### PR TITLE
feat(study): 为伴学插件添加图片识别

### DIFF
--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -2879,6 +2879,14 @@ class StudyCompanionPlugin(NekoPluginBase):
         }
         vision_image_payload = str(vision_image_base64 or "").strip()
         if vision_image_payload:
+            if not bool(self._cfg.llm_vision_enabled):
+                return Err(SdkError("llm_vision_enabled is not enabled"))
+            try:
+                vision_image_payload = _normalize_submitted_image_payload(
+                    vision_image_payload,
+                )
+            except ValueError as exc:
+                return Err(SdkError(str(exc)))
             extra_context["vision_enabled"] = True
             extra_context["vision_image_base64"] = vision_image_payload
         tutor_context = await self._build_learning_context(

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -112,6 +112,9 @@ except Exception:  # noqa: BLE001 - route registration should not block package 
     )
 
 
+_MAX_SUBMITTED_IMAGE_BASE64_LENGTH = 10 * 1024 * 1024
+
+
 def _validated_pomodoro_focus_minutes(
     config: StudyConfig, focus_minutes: Any | None
 ) -> int:
@@ -761,6 +764,25 @@ class StudyCompanionPlugin(NekoPluginBase):
                 self._knowledge_tracker.get_status_summary,
                 limit=5,
             )
+        if bool(self._cfg.llm_vision_enabled):
+            user_image = ""
+            with self._lock:
+                user_image = str(self._state.last_vision_image_base64 or "").strip()
+            if user_image:
+                context["vision_enabled"] = True
+                context["vision_image_base64"] = user_image
+            elif self._ocr_pipeline is not None:
+                vision_snapshot = self._ocr_pipeline.latest_vision_snapshot()
+                if vision_snapshot:
+                    context["vision_enabled"] = True
+                    context["vision_image_base64"] = str(
+                        vision_snapshot.get("vision_image_base64") or ""
+                    )
+                    context["vision_snapshot"] = {
+                        key: value
+                        for key, value in vision_snapshot.items()
+                        if key != "vision_image_base64"
+                    }
         if extra:
             context.update(extra)
         return context
@@ -2691,6 +2713,45 @@ class StudyCompanionPlugin(NekoPluginBase):
             )
         await self._persist_state()
         return Ok(payload)
+
+    @plugin_entry(
+        id="study_submit_image",
+        name=tr("entries.submit_image.name", default="Submit Study Image"),
+        description=tr(
+            "entries.submit_image.description",
+            default="Accept a user image and explain it with the configured vision model.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "image_base64": {"type": "string"},
+                "text": {"type": "string", "default": ""},
+            },
+            "required": ["image_base64"],
+        },
+        timeout=60.0,
+        llm_result_fields=["summary", "reply", "diagnostic"],
+    )
+    async def study_submit_image(self, image_base64: str, text: str = "", **_):
+        image_payload = str(image_base64 or "").strip()
+        if not image_payload:
+            return Err(SdkError("image_base64 is required"))
+        if len(image_payload) > _MAX_SUBMITTED_IMAGE_BASE64_LENGTH:
+            return Err(SdkError("image_base64 is too large (max 10MB)"))
+        if not bool(self._cfg.llm_vision_enabled):
+            return Err(SdkError("llm_vision_enabled is not enabled"))
+        normalized_text = str(text or "").strip()
+        with self._lock:
+            self._state.last_ocr_text = normalized_text
+            self._state.last_vision_image_base64 = image_payload
+        source_text = normalized_text or "请查看这张图片的内容"
+        result = await self.study_explain_text(text=source_text)
+        if isinstance(result, Ok):
+            with self._lock:
+                if self._state.last_vision_image_base64 == image_payload:
+                    self._state.last_vision_image_base64 = ""
+            await self._persist_state()
+        return result
 
     @plugin_entry(
         id="study_explain_text",

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -2811,6 +2811,7 @@ class StudyCompanionPlugin(NekoPluginBase):
             "type": "object",
             "properties": {
                 "text": {"type": "string", "default": ""},
+                "vision_image_base64": {"type": "string", "default": ""},
             },
         },
         timeout=45.0,

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 from datetime import datetime
 import math
 from pathlib import Path
@@ -113,6 +114,57 @@ except Exception:  # noqa: BLE001 - route registration should not block package 
 
 
 _MAX_SUBMITTED_IMAGE_BASE64_LENGTH = 10 * 1024 * 1024
+_MAX_SUBMITTED_IMAGE_BASE64_ENCODED_LENGTH = (
+    ((_MAX_SUBMITTED_IMAGE_BASE64_LENGTH + 2) // 3) * 4 + 64
+)
+_SUPPORTED_SUBMITTED_IMAGE_MIME_BY_DATA_URL_PREFIX = {
+    "data:image/jpeg;base64": "image/jpeg",
+    "data:image/png;base64": "image/png",
+}
+
+
+def _detect_submitted_image_mime(raw: bytes) -> str:
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    return ""
+
+
+def _normalize_submitted_image_payload(image_base64: str) -> str:
+    image_payload = str(image_base64 or "").strip()
+    if not image_payload:
+        raise ValueError("image_base64 is required")
+
+    expected_mime = ""
+    encoded_payload = image_payload
+    if image_payload.lower().startswith("data:"):
+        header, separator, encoded_payload = image_payload.partition(",")
+        expected_mime = _SUPPORTED_SUBMITTED_IMAGE_MIME_BY_DATA_URL_PREFIX.get(
+            header.strip().lower(),
+            "",
+        )
+        if not separator or not encoded_payload.strip():
+            raise ValueError("image_base64 data URL is malformed")
+        if not expected_mime:
+            raise ValueError("only JPEG/PNG data URLs are supported")
+    encoded_payload = encoded_payload.strip()
+    if len(encoded_payload) > _MAX_SUBMITTED_IMAGE_BASE64_ENCODED_LENGTH:
+        raise ValueError("image_base64 is too large (max 10MB)")
+    try:
+        raw = base64.b64decode(encoded_payload, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("image_base64 is not valid base64") from exc
+    if not raw:
+        raise ValueError("image_base64 is not valid base64")
+    if len(raw) > _MAX_SUBMITTED_IMAGE_BASE64_LENGTH:
+        raise ValueError("image_base64 is too large (max 10MB)")
+    actual_mime = _detect_submitted_image_mime(raw)
+    if not actual_mime:
+        raise ValueError("only JPEG/PNG images are supported")
+    if expected_mime and actual_mime != expected_mime:
+        raise ValueError("image_base64 MIME does not match image data")
+    return f"data:{actual_mime};base64,{encoded_payload}"
 
 
 def _validated_pomodoro_focus_minutes(
@@ -2733,25 +2785,20 @@ class StudyCompanionPlugin(NekoPluginBase):
         llm_result_fields=["summary", "reply", "diagnostic"],
     )
     async def study_submit_image(self, image_base64: str, text: str = "", **_):
-        image_payload = str(image_base64 or "").strip()
-        if not image_payload:
-            return Err(SdkError("image_base64 is required"))
-        if len(image_payload) > _MAX_SUBMITTED_IMAGE_BASE64_LENGTH:
-            return Err(SdkError("image_base64 is too large (max 10MB)"))
+        try:
+            image_payload = _normalize_submitted_image_payload(image_base64)
+        except ValueError as exc:
+            return Err(SdkError(str(exc)))
         if not bool(self._cfg.llm_vision_enabled):
             return Err(SdkError("llm_vision_enabled is not enabled"))
         normalized_text = str(text or "").strip()
         with self._lock:
             self._state.last_ocr_text = normalized_text
-            self._state.last_vision_image_base64 = image_payload
         source_text = normalized_text or "请查看这张图片的内容"
-        result = await self.study_explain_text(text=source_text)
-        if isinstance(result, Ok):
-            with self._lock:
-                if self._state.last_vision_image_base64 == image_payload:
-                    self._state.last_vision_image_base64 = ""
-            await self._persist_state()
-        return result
+        return await self.study_explain_text(
+            text=source_text,
+            vision_image_base64=image_payload,
+        )
 
     @plugin_entry(
         id="study_explain_text",
@@ -2769,7 +2816,7 @@ class StudyCompanionPlugin(NekoPluginBase):
         timeout=45.0,
         llm_result_fields=["summary", "reply", "diagnostic"],
     )
-    async def study_explain_text(self, text: str = "", **_):
+    async def study_explain_text(self, text: str = "", vision_image_base64: str = "", **_):
         if self._agent is None:
             return Err(SdkError("study tutor agent is not initialized"))
         raw_text = str(text or "").strip()
@@ -2824,17 +2871,20 @@ class StudyCompanionPlugin(NekoPluginBase):
                 source_text = self._state.last_ocr_text
             used_ocr_fallback = bool(source_text.strip())
         # Phase 3: explain with the active mode selected above.
+        extra_context: dict[str, Any] = {
+            "source": "ocr_snapshot" if used_ocr_fallback or not raw_text else "manual",
+            "mode": active_mode,
+            "mode_switch": bool(mode_switch.get("changed")),
+            "source_text": source_text,
+        }
+        vision_image_payload = str(vision_image_base64 or "").strip()
+        if vision_image_payload:
+            extra_context["vision_enabled"] = True
+            extra_context["vision_image_base64"] = vision_image_payload
         tutor_context = await self._build_learning_context(
             LLM_OPERATION_CONCEPT_EXPLAIN,
             input_text=source_text,
-            extra={
-                "source": "ocr_snapshot"
-                if used_ocr_fallback or not raw_text
-                else "manual",
-                "mode": active_mode,
-                "mode_switch": bool(mode_switch.get("changed")),
-                "source_text": source_text,
-            },
+            extra=extra_context,
         )
         reply = await self._agent.concept_explain(
             source_text,

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -2792,8 +2792,9 @@ class StudyCompanionPlugin(NekoPluginBase):
         if not bool(self._cfg.llm_vision_enabled):
             return Err(SdkError("llm_vision_enabled is not enabled"))
         normalized_text = str(text or "").strip()
-        with self._lock:
-            self._state.last_ocr_text = normalized_text
+        if normalized_text:
+            with self._lock:
+                self._state.last_ocr_text = normalized_text
         source_text = normalized_text or "请查看这张图片的内容"
         return await self.study_explain_text(
             text=source_text,

--- a/plugin/plugins/study_companion/models.py
+++ b/plugin/plugins/study_companion/models.py
@@ -208,6 +208,8 @@ class StudyConfig:
     rapidocr_model_type: str = "mobile"
     rapidocr_ocr_version: str = "PP-OCRv4"
     llm_call_timeout_seconds: float = 30.0
+    llm_vision_enabled: bool = False
+    llm_vision_max_image_px: int = 768
     fsrs_retention_target: float = 0.90
     fsrs_auto_optimize_interval_days: int = 30
     knowledge_contribution_opt_in: bool = False
@@ -238,6 +240,10 @@ class StudyConfig:
         )
         self.llm_call_timeout_seconds = self._clamp_float(
             self.llm_call_timeout_seconds, 1.0, 3600.0, 30.0
+        )
+        self.llm_vision_enabled = bool(self.llm_vision_enabled)
+        self.llm_vision_max_image_px = max(
+            64, min(4096, self._coerce_int(self.llm_vision_max_image_px, 768))
         )
         self.fsrs_retention_target = self._clamp_float(
             self.fsrs_retention_target, 0.1, 0.99, 0.90
@@ -316,6 +322,7 @@ class StudyState:
     last_error: str = ""
     last_started_at: str = ""
     last_ocr_text: str = ""
+    last_vision_image_base64: str = ""
     last_ocr_at: str = ""
     last_screen_classification: dict[str, Any] = field(default_factory=dict)
     recent_screen_classifications: list[dict[str, Any]] = field(default_factory=list)
@@ -333,7 +340,9 @@ class StudyState:
     dependency_status: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        payload = asdict(self)
+        payload.pop("last_vision_image_base64", None)
+        return payload
 
 
 @dataclass(slots=True)
@@ -540,6 +549,16 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
             1.0,
             3600.0,
             30.0,
+        ),
+        llm_vision_enabled=_bool(
+            llm, "llm_vision_enabled", False, "llm_vision_enabled"
+        ),
+        llm_vision_max_image_px=max(
+            64,
+            min(
+                4096,
+                _int(llm, "llm_vision_max_image_px", 768, "llm_vision_max_image_px"),
+            ),
         ),
         fsrs_retention_target=_clamp(
             _float(fsrs, "retention_target", 0.90, "fsrs_retention_target"),

--- a/plugin/plugins/study_companion/plugin.toml
+++ b/plugin/plugins/study_companion/plugin.toml
@@ -57,6 +57,8 @@ enabled = true
 
 [llm]
 llm_call_timeout_seconds = 30
+llm_vision_enabled = false
+llm_vision_max_image_px = 768
 
 [ocr_reader]
 enabled = true

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -130,8 +130,8 @@ class StudyOcrPipeline:
     def _remember_vision_snapshot(
         self, image: Any, *, now: float | None = None
     ) -> None:
+        self._clear_vision_snapshot()
         if not bool(self._config.llm_vision_enabled):
-            self._clear_vision_snapshot()
             return
         if image is None or not hasattr(image, "save"):
             return

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -56,16 +56,19 @@ class StudyOcrPipeline:
 
     def snapshot_from_image(self, image: Any, *, backend_name: str = "") -> OcrSnapshot:
         if image is None:
+            self._clear_vision_snapshot()
             return OcrSnapshot(status="empty", captured_at=utc_now_iso(), diagnostic="no image supplied")
         return self._extract_image(image, backend_name=backend_name or self._config.ocr_backend_selection)
 
     def capture_snapshot(self, target: Any | None = None) -> OcrSnapshot:
         if not self._config.ocr_enabled:
+            self._clear_vision_snapshot()
             return OcrSnapshot(status="disabled", captured_at=utc_now_iso(), diagnostic="OCR is disabled")
         if target is None:
             try:
                 frame = self._capture_fullscreen()
             except Exception as exc:
+                self._clear_vision_snapshot()
                 return OcrSnapshot(
                     status="capture_failed",
                     captured_at=utc_now_iso(),
@@ -81,6 +84,7 @@ class StudyOcrPipeline:
             )
             frame = self._resolve_capture_backend().capture_frame(target, profile)
         except Exception as exc:
+            self._clear_vision_snapshot()
             return OcrSnapshot(
                 status="capture_failed",
                 captured_at=utc_now_iso(),

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
+import io
 import time
 from typing import Any
+
+from PIL import Image
 
 from .models import OcrSnapshot, StudyConfig, utc_now_iso
 
@@ -11,6 +15,13 @@ CAPTURE_BACKEND_DXCAM = "dxcam"
 CAPTURE_BACKEND_MSS = "mss"
 CAPTURE_BACKEND_PRINTWINDOW = "printwindow"
 CAPTURE_BACKEND_PYAUTOGUI = "pyautogui"
+_VISION_SNAPSHOT_JPEG_QUALITY = 72
+_VISION_SNAPSHOT_TTL_SECONDS = 8.0
+
+try:
+    _PIL_RESAMPLING = Image.Resampling
+except AttributeError:  # pragma: no cover - Pillow < 9.1 compatibility.
+    _PIL_RESAMPLING = Image
 
 
 @dataclass(slots=True)
@@ -34,11 +45,14 @@ class StudyOcrPipeline:
         self._config = config
         self._ocr_backend = ocr_backend
         self._capture_backend = capture_backend
+        self._latest_vision_snapshot: dict[str, Any] = {}
+        self._latest_vision_image_base64 = ""
 
     def update_config(self, config: StudyConfig) -> None:
         self._config = config
         self._ocr_backend = None
         self._capture_backend = None
+        self._clear_vision_snapshot()
 
     def snapshot_from_image(self, image: Any, *, backend_name: str = "") -> OcrSnapshot:
         if image is None:
@@ -87,6 +101,7 @@ class StudyOcrPipeline:
 
     def _extract_image(self, image: Any, *, backend_name: str) -> OcrSnapshot:
         started = time.monotonic()
+        self._remember_vision_snapshot(image, now=started)
         try:
             backend = self._resolve_ocr_backend()
             raw = backend.extract_text(image)
@@ -107,6 +122,87 @@ class StudyOcrPipeline:
             captured_at=utc_now_iso(),
             diagnostic=f"ocr_duration_seconds={elapsed:.3f}",
         )
+
+    def _clear_vision_snapshot(self) -> None:
+        self._latest_vision_snapshot = {}
+        self._latest_vision_image_base64 = ""
+
+    def _remember_vision_snapshot(
+        self, image: Any, *, now: float | None = None
+    ) -> None:
+        if not bool(self._config.llm_vision_enabled):
+            self._clear_vision_snapshot()
+            return
+        if image is None or not hasattr(image, "save"):
+            return
+        if now is None:
+            now = time.monotonic()
+        try:
+            frame = image.convert("RGB") if hasattr(image, "convert") else image
+            width, height = frame.size
+            if width <= 0 or height <= 0:
+                self._logger.debug(
+                    "study vision snapshot skipped: invalid image dimensions {}x{}",
+                    width,
+                    height,
+                )
+                return
+            max_px = max(64, int(self._config.llm_vision_max_image_px or 768))
+            scale = min(1.0, float(max_px) / float(max(width, height)))
+            if scale < 1.0:
+                frame = frame.resize(
+                    (max(1, int(width * scale)), max(1, int(height * scale))),
+                    _PIL_RESAMPLING.LANCZOS,
+                )
+                width, height = frame.size
+            buffer = io.BytesIO()
+            frame.save(
+                buffer,
+                format="JPEG",
+                quality=_VISION_SNAPSHOT_JPEG_QUALITY,
+                optimize=True,
+            )
+            raw = buffer.getvalue()
+            if not raw:
+                self._logger.debug("study vision snapshot skipped: empty encoded buffer")
+                return
+            expires_at = now + _VISION_SNAPSHOT_TTL_SECONDS
+            self._latest_vision_image_base64 = (
+                "data:image/jpeg;base64," + base64.b64encode(raw).decode("ascii")
+            )
+            self._latest_vision_snapshot = {
+                "captured_at": utc_now_iso(),
+                "expires_at_monotonic": expires_at,
+                "source": "ocr_screenshot",
+                "width": int(width),
+                "height": int(height),
+                "byte_size": len(raw),
+                "ttl_seconds": _VISION_SNAPSHOT_TTL_SECONDS,
+            }
+        except MemoryError as exc:
+            self._logger.warning("study vision snapshot memory error: {}", exc)
+        except Exception as exc:
+            self._logger.debug("study vision snapshot encoding skipped: {}", exc)
+
+    def latest_vision_snapshot(self) -> dict[str, Any]:
+        if not bool(self._config.llm_vision_enabled):
+            return {}
+        snapshot = dict(self._latest_vision_snapshot or {})
+        image_base64 = str(self._latest_vision_image_base64 or "")
+        if not snapshot or not image_base64:
+            return {}
+        now = time.monotonic()
+        if now >= float(snapshot.get("expires_at_monotonic") or 0.0):
+            self._clear_vision_snapshot()
+            return {}
+        return {
+            **{
+                key: value
+                for key, value in snapshot.items()
+                if key != "expires_at_monotonic"
+            },
+            "vision_image_base64": image_base64,
+        }
 
     @staticmethod
     def _normalize_ocr_output(raw: Any) -> tuple[str, list[dict[str, Any]]]:

--- a/plugin/plugins/study_companion/tutor_llm_agent.py
+++ b/plugin/plugins/study_companion/tutor_llm_agent.py
@@ -800,6 +800,11 @@ class TutorLLMAgent:
         normalized = str(model or "").strip().lower()
         if not normalized:
             return False
+        if normalized.startswith("glm-") and re.search(
+            r"(?:^|[-_.])\d+(?:\.\d+)?v(?:[-_.]|$)",
+            normalized,
+        ):
+            return True
         return any(
             marker in normalized
             for marker in (

--- a/plugin/plugins/study_companion/tutor_llm_agent.py
+++ b/plugin/plugins/study_companion/tutor_llm_agent.py
@@ -176,7 +176,7 @@ class _JSONCorrector:
         self,
         *,
         operation: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         call_model: Callable[..., Awaitable[str]],
     ) -> str:
         raw_text = await call_model(messages, operation=operation)
@@ -204,12 +204,12 @@ class _JSONCorrector:
         self,
         *,
         operation: str,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         bad_output: object,
         parse_error: object,
         attempt: int,
         max_attempts: int,
-    ) -> list[dict[str, str]]:
+    ) -> list[dict[str, Any]]:
         correction_messages = list(messages)
         correction_messages.append(
             {
@@ -389,6 +389,9 @@ class TutorLLMAgent:
             mode=selected_mode,
             context=context,
         )
+        vision_image_base64 = str(context.get("vision_image_base64") or "") if context else ""
+        if vision_image_base64:
+            messages = self._attach_vision_image(messages, vision_image_base64)
         try:
             content = await self._call_model(messages)
             reply = content.strip()
@@ -498,6 +501,9 @@ class TutorLLMAgent:
     async def _invoke_structured_operation(self, operation: str, context: dict[str, Any]) -> TutorReply:
         try:
             messages = build_operation_messages(operation, context)
+            vision_image_base64 = str(context.get("vision_image_base64") or "")
+            if vision_image_base64:
+                messages = self._attach_vision_image(messages, vision_image_base64)
             raw_text = await self._json_corrector.invoke_with_correction(
                 operation=operation,
                 messages=messages,
@@ -789,9 +795,98 @@ class TutorLLMAgent:
             return "general"
         return first_line[:48]
 
+    @staticmethod
+    def _model_supports_vision(model: str) -> bool:
+        normalized = str(model or "").strip().lower()
+        if not normalized:
+            return False
+        return any(
+            marker in normalized
+            for marker in (
+                "gpt-4o",
+                "gpt-4.1",
+                "gpt-4.5",
+                "gpt-5",
+                "vision",
+                "vl",
+                "qwen2.5-vl",
+                "qwen-vl",
+                "gemini",
+                "claude-3",
+                "claude-4",
+            )
+        )
+
+    @staticmethod
+    def _message_has_image_content(message: dict[str, Any]) -> bool:
+        content = message.get("content")
+        if not isinstance(content, list):
+            return False
+        return any(
+            isinstance(block, dict) and block.get("type") == "image_url"
+            for block in content
+        )
+
+    @staticmethod
+    def _strip_image_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                result.append(dict(message))
+                continue
+            text_parts = [
+                str(block.get("text") or "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            ]
+            next_message = dict(message)
+            next_message["content"] = "\n".join(part for part in text_parts if part)
+            result.append(next_message)
+        return result
+
+    @staticmethod
+    def _attach_vision_image(
+        messages: list[dict[str, Any]],
+        image_base64: str,
+        *,
+        detail: str = "auto",
+    ) -> list[dict[str, Any]]:
+        if not image_base64:
+            return messages
+        image_url = (
+            image_base64
+            if image_base64.startswith(("data:image/jpeg", "data:image/png"))
+            else f"data:image/jpeg;base64,{image_base64}"
+        )
+        if detail not in {"low", "high", "auto"}:
+            detail = "auto"
+        result = [dict(message) for message in messages]
+        for index in range(len(result) - 1, -1, -1):
+            if str(result[index].get("role") or "") != "user":
+                continue
+            content = result[index].get("content")
+            if isinstance(content, list):
+                text = "\n".join(
+                    str(block.get("text") or "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                )
+            else:
+                text = str(content or "")
+            result[index]["content"] = [
+                {"type": "text", "text": text},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": image_url, "detail": detail},
+                },
+            ]
+            return result
+        return result
+
     async def _call_model(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         *,
         operation: str = LLM_OPERATION_CONCEPT_EXPLAIN,
     ) -> str:
@@ -811,14 +906,20 @@ class TutorLLMAgent:
             details = ", ".join(missing_runtime_deps)
             raise SdkError(f"missing runtime dependency: {details}")
 
-        api_config = get_config_manager().get_model_api_config("summary")
+        api_config = get_config_manager().get_model_api_config("agent")
         base_url = str(api_config.get("base_url") or "").strip()
         model = str(api_config.get("model") or "").strip()
         api_key = str(api_config.get("api_key") or "").strip()
         if not base_url or not model:
-            raise SdkError("missing configured summary model")
+            raise SdkError("missing configured agent model")
+        has_image = any(self._message_has_image_content(message) for message in messages)
+        if has_image and not self._model_supports_vision(model):
+            self._logger.warning(
+                "vision stripped: model {} not in vision allowlist", model
+            )
+            messages = self._strip_image_content(messages)
         key = (
-            "summary",
+            "agent",
             operation,
             base_url,
             model,
@@ -835,8 +936,8 @@ class TutorLLMAgent:
             ),
         )
         if llm is None:
-            raise SdkError("failed to initialize summary model")
-        set_call_type("summary")
+            raise SdkError("failed to initialize agent model")
+        set_call_type("agent")
         ainvoke = getattr(llm, "ainvoke", None)
         if callable(ainvoke):
             response = await asyncio.wait_for(ainvoke(messages), timeout=timeout_seconds)

--- a/plugin/plugins/study_companion/tutor_llm_agent.py
+++ b/plugin/plugins/study_companion/tutor_llm_agent.py
@@ -854,11 +854,14 @@ class TutorLLMAgent:
     ) -> list[dict[str, Any]]:
         if not image_base64:
             return messages
-        image_url = (
-            image_base64
-            if image_base64.startswith(("data:image/jpeg", "data:image/png"))
-            else f"data:image/jpeg;base64,{image_base64}"
-        )
+        if image_base64.lower().startswith("data:"):
+            if not image_base64.lower().startswith(
+                ("data:image/jpeg;base64,", "data:image/png;base64,")
+            ):
+                return messages
+            image_url = image_base64
+        else:
+            image_url = f"data:image/jpeg;base64,{image_base64}"
         if detail not in {"low", "high", "auto"}:
             detail = "auto"
         result = [dict(message) for message in messages]

--- a/plugin/plugins/study_companion/tutor_llm_agent.py
+++ b/plugin/plugins/study_companion/tutor_llm_agent.py
@@ -914,20 +914,33 @@ class TutorLLMAgent:
             details = ", ".join(missing_runtime_deps)
             raise SdkError(f"missing runtime dependency: {details}")
 
-        api_config = get_config_manager().get_model_api_config("agent")
+        config_manager = get_config_manager()
+        has_image = any(self._message_has_image_content(message) for message in messages)
+        if has_image:
+            vision_config = config_manager.get_model_api_config("vision")
+            vision_base_url = str(vision_config.get("base_url") or "").strip()
+            vision_model = str(vision_config.get("model") or "").strip()
+            if vision_base_url and vision_model:
+                api_config = vision_config
+                model_group = "vision"
+            else:
+                api_config = config_manager.get_model_api_config("agent")
+                model_group = "agent"
+        else:
+            api_config = config_manager.get_model_api_config("agent")
+            model_group = "agent"
         base_url = str(api_config.get("base_url") or "").strip()
         model = str(api_config.get("model") or "").strip()
         api_key = str(api_config.get("api_key") or "").strip()
         if not base_url or not model:
-            raise SdkError("missing configured agent model")
-        has_image = any(self._message_has_image_content(message) for message in messages)
-        if has_image and not self._model_supports_vision(model):
+            raise SdkError(f"missing configured {model_group} model")
+        if has_image and model_group != "vision" and not self._model_supports_vision(model):
             self._logger.warning(
                 "vision stripped: model {} not in vision allowlist", model
             )
             messages = self._strip_image_content(messages)
         key = (
-            "agent",
+            model_group,
             operation,
             base_url,
             model,
@@ -945,7 +958,7 @@ class TutorLLMAgent:
         )
         if llm is None:
             raise SdkError("failed to initialize agent model")
-        set_call_type("agent")
+        set_call_type(model_group)
         ainvoke = getattr(llm, "ainvoke", None)
         if callable(ainvoke):
             response = await asyncio.wait_for(ainvoke(messages), timeout=timeout_seconds)

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -598,6 +598,20 @@ def test_study_config_and_state_legacy_mode_migration(tmp_path: Path) -> None:
 
     llm_timeout = build_config({"llm": {"call_timeout_seconds": 42}})
     assert llm_timeout.llm_call_timeout_seconds == 42
+    assert llm_timeout.llm_vision_enabled is False
+    assert llm_timeout.llm_vision_max_image_px == 768
+    llm_vision = build_config(
+        {"llm": {"llm_vision_enabled": True, "llm_vision_max_image_px": 128}}
+    )
+    assert llm_vision.llm_vision_enabled is True
+    assert llm_vision.llm_vision_max_image_px == 128
+    flat_llm_vision = build_config(
+        {"llm_vision_enabled": True, "llm_vision_max_image_px": 256}
+    )
+    assert flat_llm_vision.llm_vision_enabled is True
+    assert flat_llm_vision.llm_vision_max_image_px == 256
+    direct_vision = StudyConfig(llm_vision_max_image_px=99999)
+    assert direct_vision.llm_vision_max_image_px == 4096
     fsrs_config = build_config(
         {"fsrs": {"retention_target": 0.88, "auto_optimize_interval_days": 14}}
     )
@@ -2730,13 +2744,17 @@ async def test_tutor_agent_structured_operations_degrade_with_generic_diagnostic
 async def test_tutor_agent_llm_cache_distinguishes_rotated_api_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from utils import config_manager, llm_client
+    from utils import config_manager, llm_client, token_tracker
+
+    config_groups: list[str] = []
+    call_types: list[str] = []
 
     class _ConfigManager:
         def __init__(self) -> None:
             self.api_key = "old-key"
 
-        def get_model_api_config(self, _group: str):
+        def get_model_api_config(self, group: str):
+            config_groups.append(group)
             return {
                 "base_url": "https://llm.example.test/v1",
                 "model": "study-model",
@@ -2761,6 +2779,7 @@ async def test_tutor_agent_llm_cache_distinguishes_rotated_api_keys(
 
     monkeypatch.setattr(config_manager, "get_config_manager", lambda: cfg_mgr)
     monkeypatch.setattr(llm_client, "create_chat_llm", _create_chat_llm)
+    monkeypatch.setattr(token_tracker, "set_call_type", call_types.append)
 
     agent = TutorLLMAgent(logger=_Logger(), config=StudyConfig(language="en"))
     first = await agent._call_model([{"role": "user", "content": "one"}])
@@ -2769,6 +2788,8 @@ async def test_tutor_agent_llm_cache_distinguishes_rotated_api_keys(
 
     assert first == "reply from old-key"
     assert second == "reply from new-key"
+    assert config_groups == ["agent", "agent"]
+    assert call_types == ["agent", "agent"]
     assert created_keys == ["old-key", "new-key"]
     assert create_kwargs
     assert all("temperature" not in item for item in create_kwargs)

--- a/plugin/tests/unit/plugins/test_study_companion_vision.py
+++ b/plugin/tests/unit/plugins/test_study_companion_vision.py
@@ -356,6 +356,46 @@ def test_remember_vision_snapshot_clears_stale_snapshot_on_abort() -> None:
     assert pipeline.latest_vision_snapshot() == {}
 
 
+def test_capture_snapshot_clears_stale_vision_snapshot_on_early_failure() -> None:
+    class _FailingCaptureBackend:
+        def capture_frame(self, *_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("capture boom")
+
+    pipeline = StudyOcrPipeline(
+        logger=_Logger(),
+        config=StudyConfig(llm_vision_enabled=True),
+        ocr_backend=_FakeOcrBackend(),
+        capture_backend=_FailingCaptureBackend(),
+    )
+    image = Image.new("RGB", (16, 16), color="white")
+
+    pipeline._remember_vision_snapshot(image)
+    assert pipeline.latest_vision_snapshot()
+
+    failed = pipeline.capture_snapshot(target=object())
+
+    assert failed.status == "capture_failed"
+    assert pipeline.latest_vision_snapshot() == {}
+
+
+def test_capture_snapshot_clears_stale_vision_snapshot_when_ocr_disabled() -> None:
+    pipeline = StudyOcrPipeline(
+        logger=_Logger(),
+        config=StudyConfig(llm_vision_enabled=True),
+        ocr_backend=_FakeOcrBackend(),
+    )
+    image = Image.new("RGB", (16, 16), color="white")
+
+    pipeline._remember_vision_snapshot(image)
+    assert pipeline.latest_vision_snapshot()
+
+    pipeline._config = StudyConfig(ocr_enabled=False, llm_vision_enabled=True)
+    disabled = pipeline.capture_snapshot()
+
+    assert disabled.status == "disabled"
+    assert pipeline.latest_vision_snapshot() == {}
+
+
 def test_remember_vision_snapshot_warns_on_memory_error() -> None:
     class _MemoryErrorImage:
         size = (16, 16)

--- a/plugin/tests/unit/plugins/test_study_companion_vision.py
+++ b/plugin/tests/unit/plugins/test_study_companion_vision.py
@@ -223,6 +223,12 @@ async def test_call_model_strips_vision_for_text_model(
     class _ConfigManager:
         def get_model_api_config(self, group: str) -> dict[str, str]:
             config_groups.append(group)
+            if group == "vision":
+                return {
+                    "base_url": "",
+                    "model": "",
+                    "api_key": "",
+                }
             return {
                 "base_url": "https://llm.example.test/v1",
                 "model": "gpt-4",
@@ -252,11 +258,74 @@ async def test_call_model_strips_vision_for_text_model(
     )
 
     assert result == "reply"
-    assert config_groups == ["agent"]
+    assert config_groups == ["vision", "agent"]
     assert call_types == ["agent"]
     assert seen == [{"role": "user", "content": "one"}]
     assert logger.warnings
     assert "vision stripped" in str(logger.warnings[0][0][0])
+
+
+@pytest.mark.asyncio
+async def test_call_model_uses_vision_config_for_image_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from utils import config_manager, llm_client, token_tracker
+
+    seen_messages: list[dict[str, Any]] = []
+    seen_client_kwargs: list[dict[str, Any]] = []
+    config_groups: list[str] = []
+    call_types: list[str] = []
+
+    class _ConfigManager:
+        def get_model_api_config(self, group: str) -> dict[str, str]:
+            config_groups.append(group)
+            if group == "vision":
+                return {
+                    "base_url": "https://vision.example.test/v1",
+                    "model": "step-1o-turbo-vision",
+                    "api_key": "vision-key",
+                }
+            return {
+                "base_url": "https://agent.example.test/v1",
+                "model": "step-3",
+                "api_key": "agent-key",
+            }
+
+    class _FakeLLM:
+        async def ainvoke(self, messages: list[dict[str, Any]]):
+            seen_messages.extend(messages)
+            return SimpleNamespace(content="vision reply")
+
+    def _create_chat_llm(**kwargs: Any) -> _FakeLLM:
+        seen_client_kwargs.append(kwargs)
+        return _FakeLLM()
+
+    monkeypatch.setattr(config_manager, "get_config_manager", lambda: _ConfigManager())
+    monkeypatch.setattr(llm_client, "create_chat_llm", _create_chat_llm)
+    monkeypatch.setattr(token_tracker, "set_call_type", call_types.append)
+    agent = TutorLLMAgent(logger=_Logger(), config=StudyConfig(language="en"))
+
+    result = await agent._call_model(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is shown?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+                ],
+            }
+        ]
+    )
+
+    assert result == "vision reply"
+    assert config_groups == ["vision"]
+    assert call_types == ["vision"]
+    assert seen_client_kwargs[0]["base_url"] == "https://vision.example.test/v1"
+    assert seen_client_kwargs[0]["model"] == "step-1o-turbo-vision"
+    assert seen_client_kwargs[0]["api_key"] == "vision-key"
+    content = seen_messages[0]["content"]
+    assert isinstance(content, list)
+    assert content[1]["type"] == "image_url"
 
 
 def test_study_state_to_dict_excludes_transient_vision_image() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_vision.py
+++ b/plugin/tests/unit/plugins/test_study_companion_vision.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import base64
+import json
+import threading
+from types import MethodType, SimpleNamespace
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from plugin.plugins.study_companion import StudyCompanionPlugin
+from plugin.plugins.study_companion.constants import LLM_OPERATION_CONCEPT_EXPLAIN
+from plugin.plugins.study_companion.models import StudyConfig
+from plugin.plugins.study_companion.state import build_initial_state
+from plugin.plugins.study_companion.study_ocr_pipeline import StudyOcrPipeline
+from plugin.plugins.study_companion.tutor_llm_agent import TutorLLMAgent
+from plugin.sdk.plugin import Err, Ok
+
+pytestmark = pytest.mark.unit
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.debugs: list[tuple[tuple[object, ...], dict[str, object]]] = []
+        self.warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def warning(self, *_args: object, **_kwargs: object) -> None:
+        self.warnings.append((_args, _kwargs))
+        return None
+
+    def debug(self, *_args: object, **_kwargs: object) -> None:
+        self.debugs.append((_args, _kwargs))
+        return None
+
+
+class _FakeOcrBackend:
+    def extract_text(self, _image: Any) -> str:
+        return "ocr text"
+
+
+class _Store:
+    def list_interactions(self, _limit: int) -> list[dict[str, object]]:
+        return []
+
+
+class _KnowledgeTracker:
+    def get_status_summary(self, *, limit: int = 5) -> dict[str, object]:
+        return {"limit": limit}
+
+
+class _VisionPipeline:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+
+    def latest_vision_snapshot(self) -> dict[str, object]:
+        return dict(self.payload)
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        ("gpt-4o", True),
+        ("claude-4-sonnet", True),
+        ("gemini-2.5-pro", True),
+        ("gpt-4", False),
+        ("", False),
+    ],
+)
+def test_model_supports_vision(model: str, expected: bool) -> None:
+    assert TutorLLMAgent._model_supports_vision(model) is expected
+
+
+def test_attach_vision_image_adds_to_last_user_msg() -> None:
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "look here"},
+    ]
+
+    result = TutorLLMAgent._attach_vision_image(messages, "abc", detail="high")
+
+    assert result[1]["content"] == "first"
+    content = result[3]["content"]
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "look here"}
+    assert content[1]["type"] == "image_url"
+    assert content[1]["image_url"]["url"] == "data:image/jpeg;base64,abc"
+    assert content[1]["image_url"]["detail"] == "high"
+
+
+def test_attach_vision_image_empty_skips() -> None:
+    messages = [{"role": "user", "content": "plain"}]
+
+    assert TutorLLMAgent._attach_vision_image(messages, "") is messages
+
+
+def test_attach_vision_image_only_allows_jpeg_and_png_data_urls() -> None:
+    messages = [{"role": "user", "content": "plain"}]
+
+    png = TutorLLMAgent._attach_vision_image(messages, "data:image/png;base64,abc")
+    svg = TutorLLMAgent._attach_vision_image(
+        messages, "data:image/svg+xml;base64,abc"
+    )
+
+    assert png[0]["content"][1]["image_url"]["url"] == "data:image/png;base64,abc"
+    assert svg[0]["content"][1]["image_url"]["url"] == (
+        "data:image/jpeg;base64,data:image/svg+xml;base64,abc"
+    )
+
+
+def test_strip_image_content_removes_image_blocks() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "one"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+                {"type": "text", "text": "two"},
+            ],
+        },
+        {"role": "assistant", "content": "unchanged"},
+    ]
+
+    result = TutorLLMAgent._strip_image_content(messages)
+
+    assert result == [
+        {"role": "user", "content": "one\ntwo"},
+        {"role": "assistant", "content": "unchanged"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_concept_explain_attaches_vision_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = TutorLLMAgent(logger=_Logger(), config=StudyConfig(language="en"))
+    seen: list[dict[str, Any]] = []
+
+    async def _fake_call_model(messages: list[dict[str, Any]]):
+        seen.extend(messages)
+        return "vision reply"
+
+    monkeypatch.setattr(agent, "_call_model", _fake_call_model)
+
+    reply = await agent.concept_explain(
+        "solve this",
+        context={"vision_image_base64": "image-payload"},
+    )
+
+    assert reply.reply == "vision reply"
+    content = seen[-1]["content"]
+    assert isinstance(content, list)
+    assert content[1]["image_url"]["url"] == "data:image/jpeg;base64,image-payload"
+
+
+@pytest.mark.asyncio
+async def test_structured_operation_attaches_vision_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = TutorLLMAgent(logger=_Logger(), config=StudyConfig(language="en"))
+    seen: list[dict[str, Any]] = []
+
+    async def _fake_call_model(
+        messages: list[dict[str, Any]], *, operation: str = "question_generate"
+    ):
+        seen.extend(messages)
+        return json.dumps(
+            {
+                "question": "What is shown?",
+                "answer": "A diagram",
+                "hint": "Look at the image.",
+                "difficulty": 2,
+                "topic": "diagram",
+            }
+        )
+
+    monkeypatch.setattr(agent, "_call_model", _fake_call_model)
+
+    reply = await agent.question_generate(
+        "diagram",
+        context={"vision_image_base64": "image-payload"},
+    )
+
+    assert reply.payload["question"] == "What is shown?"
+    content = seen[-1]["content"]
+    assert isinstance(content, list)
+    assert content[1]["image_url"]["url"] == "data:image/jpeg;base64,image-payload"
+
+
+@pytest.mark.asyncio
+async def test_call_model_strips_vision_for_text_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from utils import config_manager, llm_client, token_tracker
+
+    seen: list[dict[str, Any]] = []
+    config_groups: list[str] = []
+    call_types: list[str] = []
+    logger = _Logger()
+
+    class _ConfigManager:
+        def get_model_api_config(self, group: str) -> dict[str, str]:
+            config_groups.append(group)
+            return {
+                "base_url": "https://llm.example.test/v1",
+                "model": "gpt-4",
+                "api_key": "key",
+            }
+
+    class _FakeLLM:
+        async def ainvoke(self, messages: list[dict[str, Any]]):
+            seen.extend(messages)
+            return SimpleNamespace(content="reply")
+
+    monkeypatch.setattr(config_manager, "get_config_manager", lambda: _ConfigManager())
+    monkeypatch.setattr(llm_client, "create_chat_llm", lambda **_kwargs: _FakeLLM())
+    monkeypatch.setattr(token_tracker, "set_call_type", call_types.append)
+    agent = TutorLLMAgent(logger=logger, config=StudyConfig(language="en"))
+
+    result = await agent._call_model(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "one"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+                ],
+            }
+        ]
+    )
+
+    assert result == "reply"
+    assert config_groups == ["agent"]
+    assert call_types == ["agent"]
+    assert seen == [{"role": "user", "content": "one"}]
+    assert logger.warnings
+    assert "vision stripped" in str(logger.warnings[0][0][0])
+
+
+def test_study_state_to_dict_excludes_transient_vision_image() -> None:
+    state = build_initial_state()
+    state.last_vision_image_base64 = "sensitive-image"
+
+    payload = state.to_dict()
+
+    assert "last_vision_image_base64" not in payload
+
+
+def test_remember_vision_snapshot_encodes_jpeg_and_resizes() -> None:
+    pipeline = StudyOcrPipeline(
+        logger=_Logger(),
+        config=StudyConfig(llm_vision_enabled=True, llm_vision_max_image_px=96),
+        ocr_backend=_FakeOcrBackend(),
+    )
+    image = Image.new("RGB", (320, 160), color="white")
+
+    snapshot = pipeline.snapshot_from_image(image)
+    vision = pipeline.latest_vision_snapshot()
+
+    assert snapshot.status == "ok"
+    assert str(vision["vision_image_base64"]).startswith("data:image/jpeg;base64,")
+    assert vision["width"] == 96
+    assert vision["height"] == 48
+    raw = base64.b64decode(str(vision["vision_image_base64"]).split(",", 1)[1])
+    assert raw.startswith(b"\xff\xd8")
+
+
+def test_latest_vision_snapshot_expires_and_respects_disabled_config() -> None:
+    pipeline = StudyOcrPipeline(
+        logger=_Logger(),
+        config=StudyConfig(llm_vision_enabled=True),
+        ocr_backend=_FakeOcrBackend(),
+    )
+    image = Image.new("RGB", (16, 16), color="white")
+
+    pipeline._remember_vision_snapshot(image)
+    assert pipeline.latest_vision_snapshot()
+
+    pipeline._latest_vision_snapshot["expires_at_monotonic"] = 0.0
+    assert pipeline.latest_vision_snapshot() == {}
+
+    pipeline._remember_vision_snapshot(image)
+    pipeline.update_config(StudyConfig(llm_vision_enabled=False))
+    assert pipeline.latest_vision_snapshot() == {}
+
+
+def test_remember_vision_snapshot_logs_empty_return_paths() -> None:
+    class _InvalidImage:
+        size = (0, 10)
+
+        def save(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError("invalid image must not be encoded")
+
+    class _EmptyImage:
+        size = (16, 16)
+
+        def save(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    logger = _Logger()
+    pipeline = StudyOcrPipeline(
+        logger=logger,
+        config=StudyConfig(llm_vision_enabled=True),
+        ocr_backend=_FakeOcrBackend(),
+    )
+
+    pipeline._remember_vision_snapshot(_InvalidImage())
+    pipeline._remember_vision_snapshot(_EmptyImage())
+
+    messages = [str(item[0][0]) for item in logger.debugs]
+    assert any("invalid image dimensions" in message for message in messages)
+    assert any("empty encoded buffer" in message for message in messages)
+
+
+def test_remember_vision_snapshot_warns_on_memory_error() -> None:
+    class _MemoryErrorImage:
+        size = (16, 16)
+
+        def save(self, *_args: object, **_kwargs: object) -> None:
+            raise MemoryError("boom")
+
+    logger = _Logger()
+    pipeline = StudyOcrPipeline(
+        logger=logger,
+        config=StudyConfig(llm_vision_enabled=True),
+        ocr_backend=_FakeOcrBackend(),
+    )
+
+    pipeline._remember_vision_snapshot(_MemoryErrorImage())
+
+    assert logger.warnings
+    assert "memory error" in str(logger.warnings[0][0][0])
+
+
+@pytest.mark.asyncio
+async def test_build_learning_context_keeps_user_image_until_submit_success() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=True)
+    plugin._state = build_initial_state()
+    plugin._state.last_vision_image_base64 = "user-image"
+    plugin._store = _Store()
+    plugin._knowledge_tracker = _KnowledgeTracker()
+    plugin._ocr_pipeline = _VisionPipeline({"vision_image_base64": "ocr-image"})
+    plugin._lock = threading.RLock()
+
+    context = await plugin._build_learning_context(
+        LLM_OPERATION_CONCEPT_EXPLAIN,
+        input_text="explain",
+    )
+    second_context = await plugin._build_learning_context(
+        LLM_OPERATION_CONCEPT_EXPLAIN,
+        input_text="explain",
+    )
+
+    assert context["vision_enabled"] is True
+    assert context["vision_image_base64"] == "user-image"
+    assert plugin._state.last_vision_image_base64 == "user-image"
+    assert second_context["vision_image_base64"] == "user-image"
+
+
+@pytest.mark.asyncio
+async def test_study_submit_image_stores_base64_and_delegates() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=True)
+    plugin._state = build_initial_state()
+    plugin._lock = threading.RLock()
+    plugin._persist_state_calls = 0
+    calls: list[str] = []
+
+    async def _study_explain_text(self: StudyCompanionPlugin, text: str = "", **_: Any):
+        calls.append(text)
+        assert self._state.last_vision_image_base64 == "image-payload"
+        return Ok({"reply": "done"})
+
+    async def _persist_state(self: StudyCompanionPlugin) -> None:
+        self._persist_state_calls += 1
+
+    plugin.study_explain_text = MethodType(_study_explain_text, plugin)
+    plugin._persist_state = MethodType(_persist_state, plugin)
+
+    result = await plugin.study_submit_image("image-payload", text="solve this")
+
+    assert isinstance(result, Ok)
+    assert calls == ["solve this"]
+    assert plugin._state.last_vision_image_base64 == ""
+    assert plugin._persist_state_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_study_submit_image_rejects_oversized_base64() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=True)
+    plugin._state = build_initial_state()
+    plugin._lock = threading.RLock()
+
+    result = await plugin.study_submit_image("a" * (10 * 1024 * 1024 + 1))
+
+    assert isinstance(result, Err)
+    assert "too large" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_study_submit_image_keeps_base64_when_delegate_fails() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=True)
+    plugin._state = build_initial_state()
+    plugin._lock = threading.RLock()
+
+    async def _study_explain_text(self: StudyCompanionPlugin, text: str = "", **_: Any):
+        assert text
+        return Err(RuntimeError("failed"))
+
+    plugin.study_explain_text = MethodType(_study_explain_text, plugin)
+
+    result = await plugin.study_submit_image("image-payload", text="solve this")
+
+    assert isinstance(result, Err)
+    assert plugin._state.last_vision_image_base64 == "image-payload"
+
+
+@pytest.mark.asyncio
+async def test_study_submit_image_requires_enabled_config() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=False)
+    plugin._state = build_initial_state()
+    plugin._lock = threading.RLock()
+
+    result = await plugin.study_submit_image("image-payload")
+
+    assert isinstance(result, Err)
+    assert "llm_vision_enabled" in str(result.error)

--- a/plugin/tests/unit/plugins/test_study_companion_vision.py
+++ b/plugin/tests/unit/plugins/test_study_companion_vision.py
@@ -471,6 +471,28 @@ async def test_study_submit_image_stores_base64_and_delegates() -> None:
 
 
 @pytest.mark.asyncio
+async def test_study_submit_image_without_caption_preserves_ocr_fallback() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=True)
+    plugin._state = build_initial_state()
+    plugin._state.last_ocr_text = "previous OCR context"
+    plugin._lock = threading.RLock()
+    calls: list[str] = []
+
+    async def _study_explain_text(self: StudyCompanionPlugin, text: str = "", **_: Any):
+        calls.append(text)
+        return Ok({"reply": "done"})
+
+    plugin.study_explain_text = MethodType(_study_explain_text, plugin)
+
+    result = await plugin.study_submit_image(JPEG_IMAGE_BASE64)
+
+    assert isinstance(result, Ok)
+    assert calls == ["请查看这张图片的内容"]
+    assert plugin._state.last_ocr_text == "previous OCR context"
+
+
+@pytest.mark.asyncio
 async def test_study_submit_image_uses_call_local_image_for_overlap() -> None:
     plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
     plugin._cfg = StudyConfig(llm_vision_enabled=True)

--- a/plugin/tests/unit/plugins/test_study_companion_vision.py
+++ b/plugin/tests/unit/plugins/test_study_companion_vision.py
@@ -15,7 +15,7 @@ from plugin.plugins.study_companion.constants import LLM_OPERATION_CONCEPT_EXPLA
 from plugin.plugins.study_companion.models import StudyConfig
 from plugin.plugins.study_companion.state import build_initial_state
 from plugin.plugins.study_companion.study_ocr_pipeline import StudyOcrPipeline
-from plugin.plugins.study_companion.tutor_llm_agent import TutorLLMAgent
+from plugin.plugins.study_companion.tutor_llm_agent import TutorLLMAgent, TutorReply
 from plugin.sdk.plugin import Err, Ok
 
 pytestmark = pytest.mark.unit
@@ -43,6 +43,9 @@ class _FakeOcrBackend:
 class _Store:
     def list_interactions(self, _limit: int) -> list[dict[str, object]]:
         return []
+
+    def append_interaction(self, **_kwargs: object) -> None:
+        pass
 
 
 class _KnowledgeTracker:
@@ -508,3 +511,91 @@ async def test_study_submit_image_requires_enabled_config() -> None:
 
     assert isinstance(result, Err)
     assert "llm_vision_enabled" in str(result.error)
+
+
+class _FakeVisionTutorAgent:
+    async def concept_explain(
+        self,
+        text: str,
+        *,
+        mode: str = "companion",
+        context: dict[str, object] | None = None,
+    ) -> TutorReply:
+        return TutorReply(
+            operation="concept_explain",
+            input_text=text,
+            reply=f"explained: {text}",
+            created_at="2026-05-25T00:00:00Z",
+        )
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _make_plugin_for_explain(*, vision_enabled: bool) -> StudyCompanionPlugin:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=vision_enabled)
+    plugin._state = build_initial_state()
+    plugin._lock = threading.RLock()
+    plugin._agent = _FakeVisionTutorAgent()
+    plugin._store = _Store()
+    plugin._knowledge_tracker = _KnowledgeTracker()
+    plugin._ocr_pipeline = None
+    plugin._persist_state_calls = 0
+
+    async def _persist_state(self: StudyCompanionPlugin) -> None:
+        self._persist_state_calls += 1
+
+    plugin._persist_state = MethodType(_persist_state, plugin)
+    return plugin
+
+
+@pytest.mark.asyncio
+async def test_study_explain_text_rejects_vision_when_disabled() -> None:
+    plugin = _make_plugin_for_explain(vision_enabled=False)
+
+    result = await plugin.study_explain_text(
+        text="hello",
+        vision_image_base64=JPEG_IMAGE_BASE64,
+    )
+
+    assert isinstance(result, Err)
+    assert "llm_vision_enabled" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_study_explain_text_rejects_invalid_vision_mime() -> None:
+    plugin = _make_plugin_for_explain(vision_enabled=True)
+
+    result = await plugin.study_explain_text(
+        text="hello",
+        vision_image_base64="data:image/webp;base64,abc123",
+    )
+
+    assert isinstance(result, Err)
+    assert "JPEG/PNG" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_study_explain_text_rejects_invalid_vision_base64() -> None:
+    plugin = _make_plugin_for_explain(vision_enabled=True)
+
+    result = await plugin.study_explain_text(
+        text="hello",
+        vision_image_base64="!!!not-base64!!!",
+    )
+
+    assert isinstance(result, Err)
+    assert "valid base64" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_study_explain_text_accepts_valid_vision_image() -> None:
+    plugin = _make_plugin_for_explain(vision_enabled=True)
+
+    result = await plugin.study_explain_text(
+        text="describe this",
+        vision_image_base64=JPEG_IMAGE_BASE64,
+    )
+
+    assert isinstance(result, Ok)

--- a/plugin/tests/unit/plugins/test_study_companion_vision.py
+++ b/plugin/tests/unit/plugins/test_study_companion_vision.py
@@ -17,6 +17,7 @@ from plugin.plugins.study_companion.state import build_initial_state
 from plugin.plugins.study_companion.study_ocr_pipeline import StudyOcrPipeline
 from plugin.plugins.study_companion.tutor_llm_agent import TutorLLMAgent, TutorReply
 from plugin.sdk.plugin import Err, Ok
+from plugin.sdk.shared.constants import EVENT_META_ATTR
 
 pytestmark = pytest.mark.unit
 
@@ -71,12 +72,25 @@ PNG_IMAGE_BASE64 = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-png").decode("ascii"
         ("gpt-4o", True),
         ("claude-4-sonnet", True),
         ("gemini-2.5-pro", True),
+        ("glm-4.6v", True),
+        ("glm-5v-turbo", True),
+        ("glm-4-plus", False),
         ("gpt-4", False),
         ("", False),
     ],
 )
 def test_model_supports_vision(model: str, expected: bool) -> None:
     assert TutorLLMAgent._model_supports_vision(model) is expected
+
+
+def test_study_explain_text_schema_accepts_vision_image() -> None:
+    meta = getattr(StudyCompanionPlugin.study_explain_text, EVENT_META_ATTR)
+    properties = meta.input_schema["properties"]
+
+    assert properties["vision_image_base64"] == {
+        "type": "string",
+        "default": "",
+    }
 
 
 def test_attach_vision_image_adds_to_last_user_msg() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_vision.py
+++ b/plugin/tests/unit/plugins/test_study_companion_vision.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import threading
@@ -57,6 +58,10 @@ class _VisionPipeline:
         return dict(self.payload)
 
 
+JPEG_IMAGE_BASE64 = base64.b64encode(b"\xff\xd8\xff\xe0fake-jpeg").decode("ascii")
+PNG_IMAGE_BASE64 = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-png").decode("ascii")
+
+
 @pytest.mark.parametrize(
     "model, expected",
     [
@@ -105,9 +110,7 @@ def test_attach_vision_image_only_allows_jpeg_and_png_data_urls() -> None:
     )
 
     assert png[0]["content"][1]["image_url"]["url"] == "data:image/png;base64,abc"
-    assert svg[0]["content"][1]["image_url"]["url"] == (
-        "data:image/jpeg;base64,data:image/svg+xml;base64,abc"
-    )
+    assert svg is messages
 
 
 def test_strip_image_content_removes_image_blocks() -> None:
@@ -314,6 +317,28 @@ def test_remember_vision_snapshot_logs_empty_return_paths() -> None:
     assert any("empty encoded buffer" in message for message in messages)
 
 
+def test_remember_vision_snapshot_clears_stale_snapshot_on_abort() -> None:
+    class _InvalidImage:
+        size = (0, 10)
+
+        def save(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError("invalid image must not be encoded")
+
+    pipeline = StudyOcrPipeline(
+        logger=_Logger(),
+        config=StudyConfig(llm_vision_enabled=True),
+        ocr_backend=_FakeOcrBackend(),
+    )
+    image = Image.new("RGB", (16, 16), color="white")
+
+    pipeline._remember_vision_snapshot(image)
+    assert pipeline.latest_vision_snapshot()
+
+    pipeline._remember_vision_snapshot(_InvalidImage())
+
+    assert pipeline.latest_vision_snapshot() == {}
+
+
 def test_remember_vision_snapshot_warns_on_memory_error() -> None:
     class _MemoryErrorImage:
         size = (16, 16)
@@ -367,11 +392,11 @@ async def test_study_submit_image_stores_base64_and_delegates() -> None:
     plugin._state = build_initial_state()
     plugin._lock = threading.RLock()
     plugin._persist_state_calls = 0
-    calls: list[str] = []
+    calls: list[tuple[str, str]] = []
 
-    async def _study_explain_text(self: StudyCompanionPlugin, text: str = "", **_: Any):
-        calls.append(text)
-        assert self._state.last_vision_image_base64 == "image-payload"
+    async def _study_explain_text(self: StudyCompanionPlugin, text: str = "", **kwargs: Any):
+        calls.append((text, str(kwargs.get("vision_image_base64") or "")))
+        assert self._state.last_vision_image_base64 == ""
         return Ok({"reply": "done"})
 
     async def _persist_state(self: StudyCompanionPlugin) -> None:
@@ -380,12 +405,41 @@ async def test_study_submit_image_stores_base64_and_delegates() -> None:
     plugin.study_explain_text = MethodType(_study_explain_text, plugin)
     plugin._persist_state = MethodType(_persist_state, plugin)
 
-    result = await plugin.study_submit_image("image-payload", text="solve this")
+    result = await plugin.study_submit_image(JPEG_IMAGE_BASE64, text="solve this")
 
     assert isinstance(result, Ok)
-    assert calls == ["solve this"]
+    assert calls == [("solve this", f"data:image/jpeg;base64,{JPEG_IMAGE_BASE64}")]
     assert plugin._state.last_vision_image_base64 == ""
-    assert plugin._persist_state_calls == 1
+    assert plugin._persist_state_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_study_submit_image_uses_call_local_image_for_overlap() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=True)
+    plugin._state = build_initial_state()
+    plugin._lock = threading.RLock()
+    seen: list[tuple[str, str]] = []
+
+    async def _study_explain_text(self: StudyCompanionPlugin, text: str = "", **kwargs: Any):
+        await asyncio.sleep(0)
+        seen.append((text, str(kwargs.get("vision_image_base64") or "")))
+        assert self._state.last_vision_image_base64 == ""
+        return Ok({"reply": text})
+
+    plugin.study_explain_text = MethodType(_study_explain_text, plugin)
+
+    results = await asyncio.gather(
+        plugin.study_submit_image(JPEG_IMAGE_BASE64, text="first"),
+        plugin.study_submit_image(f"data:image/png;base64,{PNG_IMAGE_BASE64}", text="second"),
+    )
+
+    assert all(isinstance(result, Ok) for result in results)
+    assert sorted(seen) == [
+        ("first", f"data:image/jpeg;base64,{JPEG_IMAGE_BASE64}"),
+        ("second", f"data:image/png;base64,{PNG_IMAGE_BASE64}"),
+    ]
+    assert plugin._state.last_vision_image_base64 == ""
 
 
 @pytest.mark.asyncio
@@ -395,10 +449,30 @@ async def test_study_submit_image_rejects_oversized_base64() -> None:
     plugin._state = build_initial_state()
     plugin._lock = threading.RLock()
 
-    result = await plugin.study_submit_image("a" * (10 * 1024 * 1024 + 1))
+    oversized = base64.b64encode(b"\xff\xd8\xff" + b"x" * (10 * 1024 * 1024 + 1)).decode(
+        "ascii"
+    )
+
+    result = await plugin.study_submit_image(oversized)
 
     assert isinstance(result, Err)
     assert "too large" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_study_submit_image_rejects_invalid_mime_and_base64() -> None:
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    plugin._cfg = StudyConfig(llm_vision_enabled=True)
+    plugin._state = build_initial_state()
+    plugin._lock = threading.RLock()
+
+    bad_mime = await plugin.study_submit_image("data:image/webp;base64,abc")
+    bad_base64 = await plugin.study_submit_image("data:image/png;base64,not base64")
+
+    assert isinstance(bad_mime, Err)
+    assert "JPEG/PNG" in str(bad_mime.error)
+    assert isinstance(bad_base64, Err)
+    assert "valid base64" in str(bad_base64.error)
 
 
 @pytest.mark.asyncio
@@ -414,10 +488,13 @@ async def test_study_submit_image_keeps_base64_when_delegate_fails() -> None:
 
     plugin.study_explain_text = MethodType(_study_explain_text, plugin)
 
-    result = await plugin.study_submit_image("image-payload", text="solve this")
+    result = await plugin.study_submit_image(
+        f"data:image/png;base64,{PNG_IMAGE_BASE64}",
+        text="solve this",
+    )
 
     assert isinstance(result, Err)
-    assert plugin._state.last_vision_image_base64 == "image-payload"
+    assert plugin._state.last_vision_image_base64 == ""
 
 
 @pytest.mark.asyncio
@@ -427,7 +504,7 @@ async def test_study_submit_image_requires_enabled_config() -> None:
     plugin._state = build_initial_state()
     plugin._lock = threading.RLock()
 
-    result = await plugin.study_submit_image("image-payload")
+    result = await plugin.study_submit_image(JPEG_IMAGE_BASE64)
 
     assert isinstance(result, Err)
     assert "llm_vision_enabled" in str(result.error)


### PR DESCRIPTION
## 概要
- 为 `study_companion` 新增 `study_submit_image` 图片提交入口
- OCR 截图时保存 transient 压缩 JPEG data URI，并注入 LLM 上下文
- 将伴学 tutor LLM 调用从 `summary` tier 切到 `agent` tier
- 增加视觉模型 allowlist 检测，不支持视觉的模型自动回退纯文本
- 增加上传大小限制、MIME 收口、状态持久化过滤和静默失败日志

## 测试
- `uv run pytest plugin/tests/unit/plugins/test_study_companion.py plugin/tests/unit/plugins/test_study_companion_vision.py -q`
- `uv run pytest plugin/tests/unit/plugins/test_study_companion_service_ui_api.py -q`
- `uv run ruff check plugin/plugins/study_companion/models.py plugin/plugins/study_companion/study_ocr_pipeline.py plugin/plugins/study_companion/tutor_llm_agent.py plugin/plugins/study_companion/__init__.py plugin/tests/unit/plugins/test_study_companion_vision.py plugin/tests/unit/plugins/test_study_companion.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 支持提交图片用于学习解析：图片编码/格式/大小校验与归一化（仅 JPEG/PNG），新增提交接口并将视觉内容注入解释流程，优先使用会话或 OCR 快照的最新图像，支持可选文本说明。

* **Configuration**
  * 新增视觉配置项：视觉能力开关与最大图像像素上限（含默认值与范围校验）。

* **Bug Fixes**
  * 改进视觉快照缓存、过期与清理；序列化时排除瞬时视觉数据；对不支持视觉的模型自动剥离图片以避免错误。

* **Tests**
  * 新增并扩展单元测试，覆盖视觉链路、注入/剥离、快照、并发与校验边界。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->