### PR TITLE
将辅助 API 的默认值从阿里 Qwen 改为免费版

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -666,7 +666,7 @@ def get_localized_default_characters(language: str | None = None) -> dict:
 DEFAULT_CORE_CONFIG = {
     "coreApiKey": "",
     "coreApi": "qwen",
-    "assistApi": "qwen",
+    "assistApi": "free",
     "assistApiKeyQwen": "",
     "assistApiKeyOpenai": "",
     "assistApiKeyGlm": "",

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -610,7 +610,7 @@ async def get_core_config_api():
         # 以免将不兼容的 API Key 填充到其他服务商。
         fallback_key = api_key or ''
         _core_api_provider = core_cfg.get('coreApi') or 'qwen'
-        _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
+        _assist_api_provider = core_cfg.get('assistApi') or 'free'
         _fallback_providers = {_core_api_provider, _assist_api_provider}
 
         def _fb(provider: str) -> str:
@@ -1611,7 +1611,7 @@ def _build_save_connectivity_targets(core_cfg: dict, api_config: dict) -> dict[s
         }
 
     core_provider = str(core_cfg.get("coreApi") or "qwen").strip()
-    assist_provider = str(core_cfg.get("assistApi") or "qwen").strip()
+    assist_provider = str(core_cfg.get("assistApi") or "free").strip()
     if core_provider == "free":
         assist_provider = "free"
 

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -1611,8 +1611,9 @@ def _build_save_connectivity_targets(core_cfg: dict, api_config: dict) -> dict[s
         }
 
     core_provider = str(core_cfg.get("coreApi") or "qwen").strip()
-    assist_provider = str(core_cfg.get("assistApi") or "free").strip()
-    if core_provider == "free":
+    raw_assist_provider = str(core_cfg.get("assistApi") or "").strip()
+    assist_provider = raw_assist_provider or "free"
+    if core_provider == "free" and not raw_assist_provider:
         assist_provider = "free"
 
     _add("core", core_provider)

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -268,8 +268,8 @@ class TestAssistFollowsCore:
     def test_missing_assist_defaults_to_free(self, config_manager):
         """core_config 未写 assistApi 时默认使用 free。"""
         _write_core_config(config_manager, {
-            'coreApiKey': 'free-access',
-            'coreApi': 'free',
+            'coreApiKey': 'sk-core',
+            'coreApi': 'qwen',
         })
         cfg = config_manager.get_core_config()
 

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -265,6 +265,18 @@ class TestCustomApiToggle:
 class TestAssistFollowsCore:
 
     @pytest.mark.unit
+    def test_missing_assist_defaults_to_free(self, config_manager):
+        """core_config 未写 assistApi 时默认使用 free。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'free-access',
+            'coreApi': 'free',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['assistApi'] == 'free'
+        assert cfg['OPENROUTER_URL'] == 'https://www.lanlan.tech/text/v1'
+
+    @pytest.mark.unit
     def test_free_core_defaults_assist_to_free_when_empty(self, config_manager):
         """coreApi=free + assistApi='' → 空值兜底为 free（保持免费版一键到位体验）。"""
         _write_core_config(config_manager, {

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3192,7 +3192,7 @@ class ConfigManager:
             config['CORE_API_KEY'] = core_cfg['coreApiKey']
 
         _core_api_provider = core_cfg.get('coreApi') or 'qwen'
-        _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
+        _assist_api_provider = core_cfg.get('assistApi') or 'free'
         _fallback_providers = {_core_api_provider, _assist_api_provider}
 
         def _fb(provider: str) -> str:
@@ -3286,18 +3286,17 @@ class ConfigManager:
         # 显式选择的 assistApi 一律被尊重，即使 coreApi=free。这样用户可以组合
         # 「免费实时（core=free）+ 付费文本/Agent（assist=qwen 等）」——免费 realtime
         # 端点和付费 assist 端点是独立的两条链路，没有理由把后者绑死在 free 上。
-        # 仅当用户没有显式选 assist 时，沿用 coreApi 的偏好做默认：core=free 默认 free，
-        # 其他默认 qwen。
+        # 仅当用户没有显式选 assist 时，默认使用 free，保持新用户和旧版缺字段配置一致。
         assist_api_value = core_cfg.get('assistApi')
         if not assist_api_value:
-            assist_api_value = 'free' if core_api_value == 'free' else 'qwen'
+            assist_api_value = 'free'
 
         config['assistApi'] = assist_api_value
 
         assist_profile = assist_api_profiles.get(assist_api_value)
-        if not assist_profile and assist_api_value != 'qwen':
-            logger.warning("未知的 assistApi '%s'，回退到 qwen。", assist_api_value)
-            assist_api_value = 'qwen'
+        if not assist_profile and assist_api_value != 'free':
+            logger.warning("未知的 assistApi '%s'，回退到 free。", assist_api_value)
+            assist_api_value = 'free'
             config['assistApi'] = assist_api_value
             assist_profile = assist_api_profiles.get(assist_api_value)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **配置变更**
  * 默认助理 API 提供商已由 "qwen" 更改为 "free"，前端/返回配置在缺省情况下将采用该新默认值。
  * 与默认提供商关联的连通性候选和解析逻辑随之调整，影响缺省键/端点的选择优先级。

* **测试**
  * 新增单元测试以验证当配置缺省时助理 API 会回退到 "free" 并使用对应端点。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->