### PR TITLE
fix(memory): 杀软仍删 embeddings.py 的真因是 py-cpuinfo 的 CPUID shellcode 子进程，改用 numpy __cpu_features__

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -103,8 +103,9 @@ jobs:
         shell: bash
         run: |
           uv venv .venv
-          # Embedding runtime deps (onnxruntime, tokenizers, py-cpuinfo) are
-          # in [project.dependencies] now — plain `uv sync` covers both the
+          # Embedding runtime deps (onnxruntime, tokenizers; CPU SIMD detect
+          # reads numpy's __cpu_features__, no py-cpuinfo) are in
+          # [project.dependencies] now — plain `uv sync` covers both the
           # build-time prepare step and the bundled runtime.
           # `--group galgame` adds rapidocr-onnxruntime + opencv-python-headless
           # for the bundled OCR backend; pyproject's [tool.uv].override-dependencies

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -112,8 +112,9 @@ jobs:
         shell: bash
         run: |
           uv venv .venv
-          # Embedding runtime deps (onnxruntime, tokenizers, py-cpuinfo) are
-          # in [project.dependencies] now — plain `uv sync` covers both the
+          # Embedding runtime deps (onnxruntime, tokenizers; CPU SIMD detect
+          # reads numpy's __cpu_features__, no py-cpuinfo) are in
+          # [project.dependencies] now — plain `uv sync` covers both the
           # build-time prepare step and the bundled runtime.
           # `--group galgame` adds rapidocr-onnxruntime + opencv-python-headless
           # for the bundled OCR backend; pyproject's [tool.uv].override-dependencies

--- a/docs/deployment/embedding-models.md
+++ b/docs/deployment/embedding-models.md
@@ -10,7 +10,7 @@ Do not store the concrete upstream model name in config or memory cache fields. 
 
 ## Development Setup
 
-Install project dependencies (includes `onnxruntime`, `tokenizers`, and `py-cpuinfo`):
+Install project dependencies (includes `onnxruntime` and `tokenizers`; CPU SIMD capability is read from numpy's `__cpu_features__`, so no `py-cpuinfo` is needed):
 
 ```bash
 uv sync

--- a/docs/ja/deployment/embedding-models.md
+++ b/docs/ja/deployment/embedding-models.md
@@ -10,7 +10,7 @@ local-text-retrieval-v1
 
 ## 開発環境の準備
 
-プロジェクト依存関係をインストールします（`onnxruntime` / `tokenizers` / `py-cpuinfo` を含む）：
+プロジェクト依存関係をインストールします（`onnxruntime` / `tokenizers` を含む。CPU SIMD 機能は numpy の `__cpu_features__` から読み取るため `py-cpuinfo` は不要）：
 
 ```bash
 uv sync

--- a/docs/zh-CN/deployment/embedding-models.md
+++ b/docs/zh-CN/deployment/embedding-models.md
@@ -10,7 +10,7 @@ local-text-retrieval-v1
 
 ## 开发环境准备
 
-安装项目主依赖（已包含 `onnxruntime`、`tokenizers`、`py-cpuinfo`）：
+安装项目主依赖（已包含 `onnxruntime`、`tokenizers`；CPU SIMD 能力改读 numpy 的 `__cpu_features__`，不再需要 `py-cpuinfo`）：
 
 ```bash
 uv sync

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -291,7 +291,7 @@ def detect_total_ram_gb() -> float | None:
 # no inline machine code, no AV heuristic match.
 #
 # Conservative: a "yes" from the table is authoritative (confirmed=True);
-# an "I don't know" falls through to py-cpuinfo / /proc/cpuinfo flags so
+# an "I don't know" falls through to numpy CPU features / /proc/cpuinfo so
 # brand-new microarchitectures aren't false-negatived just because the
 # table predates them.
 _INTEL_VNNI_MIN_MODEL_FAMILY_6 = 0x97  # Alder Lake — also covers Raptor,
@@ -393,7 +393,7 @@ def _vnni_via_family_model() -> tuple[bool, bool]:
     Returns ``(has_vnni, confirmed)``. ``confirmed=True`` means the
     family/model fell inside (or strictly below) a known range and the
     answer is final. ``(False, False)`` means the table doesn't know —
-    let the caller fall through to py-cpuinfo / ``/proc/cpuinfo``.
+    let the caller fall through to numpy CPU features / ``/proc/cpuinfo``.
 
     Replaces the deleted CPUID shellcode probe. Strictly less precise
     in one direction (brand-new microarchitectures that ship before the
@@ -410,8 +410,8 @@ def _vnni_via_family_model() -> tuple[bool, bool]:
         # All Intel client microarchitectures shipping AVX-VNNI live in
         # Family 6 with model >= Alder Lake's 0x97. Earlier Family-6
         # parts that carry AVX512-VNNI (Ice Lake server, Tiger/Rocket
-        # Lake, Sapphire Rapids) are detected by py-cpuinfo's
-        # ``avx512_vnni`` flag and don't need enumeration here.
+        # Lake, Sapphire Rapids) are detected by numpy's ``AVX512VNNI``
+        # feature flag and don't need enumeration here.
         if family == 6 and model >= _INTEL_VNNI_MIN_MODEL_FAMILY_6:
             return True, True
     elif vendor == "AuthenticAMD":
@@ -431,7 +431,7 @@ def _vnni_via_family_model() -> tuple[bool, bool]:
                     return False, True
             # An unmapped Family-19h model (e.g. a future stepping not
             # yet covered by AMD's published groupings) stays
-            # inconclusive so py-cpuinfo's flag list can have a try
+            # inconclusive so numpy's feature map can have a try
             # instead of silently picking the wrong path.
             return False, False
         # Family < 0x19 covers Zen 1 / Zen 2 (0x17), Excavator (0x15) and
@@ -440,37 +440,92 @@ def _vnni_via_family_model() -> tuple[bool, bool]:
     return False, False
 
 
-def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
-    """x86 INT8 fast path = AVX-VNNI (or AVX512-VNNI).
+def _numpy_cpu_features() -> dict | None:
+    """Read numpy's runtime CPU SIMD feature map, or None if unavailable.
 
-    Detection order (no-shellcode):
+    numpy probes CPU features in its compiled C core at import (for kernel
+    dispatch) and exposes the result as ``__cpu_features__`` — a plain
+    ``{feature_name: bool}`` dict. We read it instead of calling py-cpuinfo
+    because py-cpuinfo detects features by allocating an *executable* memory
+    page and running inline CPUID machine code inside a ``multiprocessing``
+    child (its ``ASM`` class: VirtualAlloc → VirtualProtect(PAGE_EXECUTE) →
+    CFUNCTYPE → call). That is the exact VirtualAlloc+shellcode pattern
+    PR #1437 stripped out of *this* module — Huorong's heuristic scanner
+    flags it as ``Trojan/Python.ShellLoader`` and quarantines this file (it's
+    the module on the import stack when py-cpuinfo's cpuid subprocess fires,
+    which is why the AV report blames ``embeddings.py`` running under
+    ``multiprocessing.spawn``). numpy's detection is pure compiled C — no
+    user-space RWX page, no subprocess — so the heuristic has nothing to
+    bite, and numpy is already a hard dependency we import for inference.
+
+    Returns None on exotic builds where the private attribute is gone, so
+    callers fall through to ``/proc/cpuinfo`` (Linux) or stay inconclusive.
+    """
+    import warnings
+    # numpy >= 2.0 renamed the private module ``numpy.core`` → ``numpy._core``
+    # and warns on the old path; try the new spelling first, suppress the
+    # DeprecationWarning on the legacy one for numpy 1.x.
+    for modpath in ("numpy._core._multiarray_umath",
+                    "numpy.core._multiarray_umath"):
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                mod = __import__(modpath, fromlist=["__cpu_features__"])
+            feats = getattr(mod, "__cpu_features__", None)
+            if isinstance(feats, dict) and feats:
+                return feats
+        except Exception:
+            continue
+    return None
+
+
+def _np_feature(feats: dict, *needles: str) -> bool:
+    """Case-insensitive substring test against numpy's CPU feature map.
+
+    numpy's ``__cpu_features__`` keys are stable upper-case spellings today
+    (``AVX2`` / ``AVX512VNNI`` / ``ASIMDDP``), but we case-fold and match a
+    substring so a future numpy that re-cases or lightly renames a key (e.g.
+    ``AVX512_VNNI``) still resolves — the same forgiving stance the old
+    py-cpuinfo ``any("vnni" in flag)`` search had. Returns True when *any*
+    needle matches a present key whose value is truthy.
+
+    ``"vnni"`` also matches Knights-Mill ``AVX5124VNNIW`` (a different,
+    extinct instruction set), but that part still carries AVX512 so int8
+    kernels run fine on it anyway — the resulting "pick int8" decision is the
+    right one, so the loose match costs nothing.
+    """
+    lowered = [n.lower() for n in needles]
+    return any(
+        v and any(n in k.lower() for n in lowered)
+        for k, v in feats.items()
+    )
+
+
+def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
+    """x86 INT8 fast path = AVX-VNNI (client) or AVX512-VNNI (server).
+
+    Detection order (no shellcode, no subprocess):
       1. CPU family/model lookup (:func:`_vnni_via_family_model`) — the
          only path that authoritatively answers for Alder-Lake+ Intel
-         client CPUs on Windows, where py-cpuinfo's backend silently
-         omits ``avx_vnni`` from its flag list.
-      2. ``py-cpuinfo`` flags — primary path on Linux / macOS and the
-         fallback on Windows for AVX512-VNNI parts (Cascade / Ice
-         Lake-server / Sapphire Rapids) which py-cpuinfo handles
-         correctly.
-      3. ``/proc/cpuinfo`` on Linux — text parse if py-cpuinfo failed.
+         *client* CPUs, whose AVX-VNNI flag numpy's feature map does not
+         track (it only carries the AVX512 variant).
+      2. numpy ``__cpu_features__`` "vnni" match — server VNNI parts
+         (Cascade / Ice Lake-SP / Sapphire Rapids, key ``AVX512VNNI``).
+         Client AVX-VNNI parts are all Alder-Lake+ and already answered
+         authoritatively by (1).
+      3. ``/proc/cpuinfo`` on Linux — text parse if numpy's map is gone.
 
     Returns ``(has_vnni, absence_confirmed)``. ``absence_confirmed=False``
-    means no path could read CPU flags — the caller stays optimistic and
-    picks INT8 in that case (consistent with the ARM branch).
+    means no source could read CPU features — the caller stays optimistic
+    and picks INT8 in that case (consistent with the ARM branch).
     """
     has_vnni, confirmed = _vnni_via_family_model()
     if confirmed:
         return has_vnni, True
 
-    try:
-        import cpuinfo  # type: ignore
-        flags = cpuinfo.get_cpu_info().get("flags", []) or []
-        # Empty flags (e.g. some virtualised hosts) is *not* a confirmed
-        # absence — fall through so /proc/cpuinfo can have a try.
-        if flags:
-            return any("vnni" in f for f in flags), True
-    except Exception:
-        pass
+    feats = _numpy_cpu_features()
+    if feats is not None:
+        return _np_feature(feats, "vnni"), True
 
     if platform.system() == "Linux":
         try:
@@ -488,20 +543,19 @@ def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
 def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
     """ARM64 INT8 fast path = ARMv8.2-A NEON sdot/udot (``asimddp`` feature).
 
-    Per-OS strategy:
+    Strategy (no shellcode, no subprocess):
 
       * macOS — Apple Silicon (M1+) universally has dotprod; Apple has
         never shipped an ARM Mac without it, so we short-circuit to
         ``(True, True)``.
-      * Windows — use the canonical
-        ``IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE)``
-        kernel API. Modern Snapdragon X / 8cx have dotprod, but first-gen
-        Windows-on-ARM (Snapdragon 835, ~2017) is ARMv8-A and lacks it —
-        assuming support there would silently enable a slow INT8 path.
-      * Linux — check the ``asimddp`` / ``dotprod`` feature flag (cpuinfo
-        first, ``/proc/cpuinfo`` ``Features`` line as fallback). The ARM
-        SBC ecosystem still includes plenty of Cortex-A53 / A57 / A72
-        cores that predate dotprod (Raspberry Pi 3 class).
+      * Any OS — numpy ``__cpu_features__['ASIMDDP']`` is the primary
+        source (compiled C probe, cross-platform incl. Windows-on-ARM).
+      * Linux fallback — ``/proc/cpuinfo`` ``Features`` line if numpy's
+        map is unavailable. The ARM SBC ecosystem still has plenty of
+        Cortex-A53 / A57 / A72 cores that predate dotprod (Pi-3 class).
+      * Windows fallback — ``IsProcessorFeaturePresent`` kernel32 API (a
+        documented call, not executable-memory injection) if numpy's map
+        is unavailable.
 
     Returns ``(has_dotprod, absence_confirmed)``. Inconclusive cases let
     ``auto`` quantization still pick int8 without claiming a definitive
@@ -510,6 +564,23 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
     system = platform.system()
     if system == "Darwin":
         return True, True
+
+    feats = _numpy_cpu_features()
+    if feats is not None:
+        return _np_feature(feats, "asimddp", "dotprod"), True
+
+    if system == "Linux":
+        try:
+            # ARM Linux /proc/cpuinfo uses "Features" (capital F), not "flags".
+            with open("/proc/cpuinfo", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("Features") and (
+                        "asimddp" in line or "dotprod" in line
+                    ):
+                        return True, True
+            return False, True
+        except Exception:
+            return False, False
 
     if system == "Windows":
         try:
@@ -530,29 +601,6 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
             # inconclusive rather than wrong in either direction.
             return True, False
 
-    if system == "Linux":
-        try:
-            import cpuinfo  # type: ignore
-            flags = cpuinfo.get_cpu_info().get("flags", []) or []
-            if flags:
-                # py-cpuinfo surfaces ARM features under the same "flags" key.
-                return any(f in ("asimddp", "dotprod") for f in flags), True
-        except Exception:
-            # py-cpuinfo not installed / failed on this ARM host — fall
-            # through to the /proc/cpuinfo probe below.
-            pass
-        try:
-            # ARM Linux /proc/cpuinfo uses "Features" (capital F), not "flags".
-            with open("/proc/cpuinfo", encoding="utf-8") as f:
-                for line in f:
-                    if line.startswith("Features") and (
-                        "asimddp" in line or "dotprod" in line
-                    ):
-                        return True, True
-            return False, True
-        except Exception:
-            return False, False
-
     # Unknown OS on ARM64 — modern ARM64 almost certainly has dotprod,
     # but we can't confirm.
     return True, False
@@ -570,8 +618,8 @@ def _log_int8_fast_path_decision(has_vnni: bool, confirmed: bool) -> None:
 
     Triaging "why are my vectors disabled?" needs to know whether
     detection was authoritative (the family/model table or a CPU that
-    truly lacks VNNI) or just inconclusive (sandboxed host, missing
-    py-cpuinfo, exotic arch). Including the vendor/family/model in the
+    truly lacks VNNI) or just inconclusive (exotic build with no numpy
+    feature map, unknown arch). Including the vendor/family/model in the
     log lets us extend the lookup table for future microarchitectures
     based on real reports instead of guesses.
 
@@ -643,11 +691,12 @@ def detect_avx2_details() -> tuple[bool, bool]:
     ~2× SSE throughput) — fine for our nano model + small corpus. Below AVX2
     (SSE-only) int8 would be too slow to auto-enable.
 
-    Unlike VNNI, ``avx2`` *is* reliably reported by py-cpuinfo's CPUID probe on
-    Windows (the VNNI Windows gap was specific to the ``avx_vnni`` flag), so we
-    don't need the family/model table here. ``absence_confirmed=False`` means
-    no source could read CPU flags — caller stays optimistic (picks int8),
-    matching the VNNI-inconclusive policy.
+    Source is numpy ``__cpu_features__['AVX2']`` (compiled C probe) rather
+    than py-cpuinfo, whose CPUID probe allocates an executable page and runs
+    machine code in a multiprocessing child — the VirtualAlloc+shellcode
+    pattern Huorong quarantines as ShellLoader (see :func:`_numpy_cpu_features`).
+    ``absence_confirmed=False`` means no source could read CPU features —
+    caller stays optimistic (picks int8), matching the VNNI-inconclusive policy.
     """
     if platform.machine().lower() in ("arm64", "aarch64"):
         # On ARM the only tier boundary we act on is dotprod — it plays VNNI's
@@ -659,17 +708,9 @@ def detect_avx2_details() -> tuple[bool, bool]:
         # (Cortex-A53/A57/A72, Pi-3 class) still disable under auto, exactly as
         # before. The AVX2 broadening is x86-only. (Codex P2 on PR #1482.)
         return _detect_int8_fast_path_arm()
-    try:
-        import cpuinfo  # type: ignore
-        flags = cpuinfo.get_cpu_info().get("flags", []) or []
-        if flags:
-            return ("avx2" in flags), True
-    except Exception:  # noqa: BLE001
-        # cpuinfo not installed / CPUID probe failed / empty flags. Don't fail
-        # hard — fall through to the /proc/cpuinfo parse (Linux) or to the
-        # inconclusive (False, False) return, where auto stays optimistic and
-        # still picks int8. Same degrade-don't-disable stance as VNNI detect.
-        pass
+    feats = _numpy_cpu_features()
+    if feats is not None:
+        return _np_feature(feats, "avx2"), True
     if platform.system() == "Linux":
         try:
             with open("/proc/cpuinfo", encoding="utf-8") as f:

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -548,14 +548,21 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
       * macOS — Apple Silicon (M1+) universally has dotprod; Apple has
         never shipped an ARM Mac without it, so we short-circuit to
         ``(True, True)``.
-      * Any OS — numpy ``__cpu_features__['ASIMDDP']`` is the primary
-        source (compiled C probe, cross-platform incl. Windows-on-ARM).
-      * Linux fallback — ``/proc/cpuinfo`` ``Features`` line if numpy's
-        map is unavailable. The ARM SBC ecosystem still has plenty of
+      * numpy ``__cpu_features__`` "asimddp" — but its *trustworthiness is
+        OS-dependent*. numpy only runtime-probes ARM features (HWCAP) on
+        Linux/BSD; on Windows it falls back to compile-time baseline macros,
+        so a win-arm64 wheel's conservative baseline reports ``ASIMDDP=False``
+        even on dotprod-capable Snapdragon X. We therefore trust a numpy
+        *positive* on any OS, but a numpy *negative* only on Linux. A Windows
+        numpy-negative is NOT confirmed — it falls through to the kernel
+        probe below (Codex P1 on PR #1525, restoring PR #1394's intent).
+      * Linux fallback — ``/proc/cpuinfo`` ``Features`` line if numpy's map
+        is unavailable. The ARM SBC ecosystem still has plenty of
         Cortex-A53 / A57 / A72 cores that predate dotprod (Pi-3 class).
-      * Windows fallback — ``IsProcessorFeaturePresent`` kernel32 API (a
-        documented call, not executable-memory injection) if numpy's map
-        is unavailable.
+      * Windows — ``IsProcessorFeaturePresent`` kernel32 API (a documented
+        call, not executable-memory injection). Its 0 return is ambiguous
+        (lacks dotprod OR old Win build that returns 0 for unknown feature
+        ids), reported as inconclusive so ``auto`` stays optimistic.
 
     Returns ``(has_dotprod, absence_confirmed)``. Inconclusive cases let
     ``auto`` quantization still pick int8 without claiming a definitive
@@ -566,8 +573,13 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
         return True, True
 
     feats = _numpy_cpu_features()
-    if feats is not None:
-        return _np_feature(feats, "asimddp", "dotprod"), True
+    if feats is not None and _np_feature(feats, "asimddp", "dotprod"):
+        # Positive is authoritative on any OS — the flag is only set when the
+        # feature is genuinely present.
+        return True, True
+    if feats is not None and system == "Linux":
+        # numpy runtime-probes ARM HWCAP on Linux, so a negative is reliable.
+        return False, True
 
     if system == "Linux":
         try:
@@ -586,7 +598,9 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
         try:
             import ctypes
             # PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE = 43 — the canonical
-            # Win32 feature constant for ARMv8.2 dotprod instructions.
+            # Win32 feature constant for ARMv8.2 dotprod instructions. This
+            # is the path numpy's compile-time-baseline negative can't be
+            # trusted to replace.
             if ctypes.windll.kernel32.IsProcessorFeaturePresent(43):
                 return True, True
             # 0 from this API is ambiguous: the CPU truly lacks dotprod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,12 @@ dependencies = [
   # utils/tokenize.py and wires render-time counting.
   "tiktoken>=0.7.0",
   "cachetools>=5.3",
-  # Local memory embeddings (memory/embeddings.py): ONNX + tokenizer + CPU flags
+  # Local memory embeddings (memory/embeddings.py): ONNX + tokenizer. CPU
+  # SIMD detection reads numpy's __cpu_features__ (compiled-C probe) — we do
+  # NOT use py-cpuinfo, whose CPUID probe runs VirtualAlloc+shellcode in a
+  # multiprocessing child that Huorong quarantines as Trojan.ShellLoader.
   "onnxruntime",
   "tokenizers",
-  "py-cpuinfo>=9.0.0",
   # Cross-platform screen capture used by galgame_plugin and potentially other
   # plugins (mss is also a candidate for brain/computer_use). Tiny (<1MB).
   "mss",

--- a/requirements.txt
+++ b/requirements.txt
@@ -318,6 +318,7 @@ portalocker==2.10.1
     # via
     #   browser-use
     #   bubus
+    #   n-e-k-o
 posthog==7.8.6
     # via browser-use
 prompt-toolkit==3.0.52
@@ -338,8 +339,6 @@ psutil==7.2.2
     # via
     #   browser-use
     #   n-e-k-o
-py-cpuinfo==9.0.0
-    # via n-e-k-o
 pyasn1==0.6.1
     # via
     #   pyasn1-modules
@@ -1128,6 +1127,10 @@ python-multipart==0.0.20
     # via
     #   mcp
     #   n-e-k-o
+python-xlib==0.33 ; sys_platform == 'linux'
+    # via
+    #   n-e-k-o
+    #   pywinauto
 python3-xlib==0.15 ; sys_platform == 'linux'
     # via
     #   mouseinfo
@@ -1148,6 +1151,7 @@ pyyaml==6.0.2
     # via
     #   bilibili-api-python
     #   huggingface-hub
+    #   n-e-k-o
 pyzmq==27.1.0
     # via n-e-k-o
 qrcode==8.2
@@ -1208,6 +1212,7 @@ six==1.17.0
     #   markdownify
     #   posthog
     #   python-dateutil
+    #   python-xlib
     #   pywinauto
 smart-open==7.5.0
     # via audiolab

--- a/uv.lock
+++ b/uv.lock
@@ -1390,7 +1390,6 @@ dependencies = [
     { name = "pillow" },
     { name = "portalocker" },
     { name = "psutil" },
-    { name = "py-cpuinfo" },
     { name = "pyautogui" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'" },
     { name = "pyncm-async" },
@@ -1462,7 +1461,6 @@ requires-dist = [
     { name = "pillow" },
     { name = "portalocker", specifier = ">=2.10.1" },
     { name = "psutil", specifier = ">=7.0.0" },
-    { name = "py-cpuinfo", specifier = ">=9.0.0" },
     { name = "pyautogui" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'" },
     { name = "pyncm-async", path = "deps/pyncm_async-1.8.1-py3-none-any.whl" },
@@ -1837,15 +1835,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
-name = "py-cpuinfo"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景 / 现象

火绒仍把 `memory/embeddings.py` 删掉，报毒 `Trojan/Python.ShellLoader.i`。报毒进程命令行是 `multiprocessing.spawn.spawn_main ... --multiprocessing-fork`，操作类型「执行」。

PR #1437 已经删掉了**本模块手写的** `VirtualAlloc(PAGE_EXECUTE) + 内联 CPUID 机器码 + CFUNCTYPE` shellcode，换成了 family/model 查表。但它漏了一刀。

## 真因

`embeddings.py` 还在两处调 **`cpuinfo.get_cpu_info()`**（py-cpuinfo）：

- `_detect_int8_fast_path_x86`（VNNI 查表 inconclusive 时的兜底）
- `detect_avx2_details`（x86 上**每次启动无条件**调）

而 py-cpuinfo 的 `cpuinfo.py` 里有个 `ASM` 类，干的是和 #1437 删掉的**一模一样**的事——`VirtualAlloc → VirtualProtect(PAGE_EXECUTE) → CFUNCTYPE → 跑 CPUID 机器码`，而且专门把这段放进 `multiprocessing.Process` 子进程跑（怕探测崩了连累主进程）。

这正好对上报毒的两个特征：
- 命令行的 `spawn_main --multiprocessing-fork` ← py-cpuinfo 的 cpuid 子进程
- 病毒路径指向 `embeddings.py` ← 触发该子进程时它在 import 栈上

**= #1437 把 shellcode 从前门赶出去，又通过 `import cpuinfo` 从后门请了回来。** #1482 新增的 AVX2 检测把触发从「偶发」变成「必中」。

## 改动

把三处 `cpuinfo.get_cpu_info()` 全部换成 **numpy 的 `__cpu_features__`**：

- numpy 在编译期 C 核心探测 CPU 特性并暴露成 `{特性: bool}` dict。**纯编译 C，无用户态 RWX 页、无子进程**，杀软启发式无物可咬。numpy 本就是硬依赖、本文件已 import。
- `AVX2` / `AVX512VNNI` / ARM `ASIMDDP` numpy 全有；客户端 `AVX-VNNI`（Alder Lake+）numpy 不暴露，但本来就由 family/model 查表权威覆盖（在 numpy 之前命中）。
- 新增 `_np_feature()`：大小写不敏感的子串匹配，抗 numpy 改名/改大小写，沿用旧 cpuinfo `any("vnni" in flag)` 的宽松语义。
- ARM Windows 那处 `ctypes.windll.kernel32` 降级为「numpy 拿不到时才走」的兜底。
- py-cpuinfo 现为纯死依赖，从 `pyproject.toml` / `uv.lock` / `requirements.txt` 移除，同步更新 2 个 CI workflow 注释与三语 docs。

## 为什么不回退（重点）

决策逻辑三件套 `_auto_int8_or_none` / `_resolve_quantization` / family-model 查表**一行未动**，只换了「特性从哪读」。numpy 和 py-cpuinfo 读的是同一个 CPUID 硬件位。

| 档位 | 决策 | 说明 |
|---|---|---|
| Alder/Zen4+ (有 VNNI) | int8 开 | 查表命中，不到 numpy |
| **Haswell..CometLake / Zen1-3 (无 VNNI 有 AVX2)** | **int8 开** | **#1482 救的核心档，命脉是 AVX2 位** |
| 服务器 AVX512-VNNI (Cascade/Ice Lake-SP) | int8 开 + 走快路 | 查表 inconclusive → numpy 命中 vnni |
| SSE-only 老 U | 禁用 | 同改前 |
| numpy 特性拿不到 | 乐观 int8 | 与旧「cpuinfo 失败」策略一致 |

AVX2 位 numpy 不可能误报——numpy 自己靠它决定是否走 AVX2 算子内核。子进程依赖消失后，对 #1482 那批用户反而更可靠（旧路径依赖被火绒杀的子进程跑成功）。

## 验证

- 本机（Alder Lake+）：py-cpuinfo flags 与 numpy `__cpu_features__` 对同一硬件位读数一致（AVX2 都 True）。
- 模拟 Zen3（family 0x19 model 0x21 Cezanne）+ numpy AVX2=True → `int8` 开。
- 模拟 Cascade Lake（family6 model 0x55）查表 inconclusive → numpy vnni 命中 → 走快路。
- 模拟 ARM Linux：ASIMDDP=True → `(True,True)`；False → `(False,True)` 禁用。
- `_np_feature` 大小写/改名/值=False/AVX2 不误匹配 AVX512 全部正确。
- `cpuinfo` 确认完全不再被 import；嵌入/召回相关 93 单测全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新了多语言的嵌入模型部署与开发环境说明，移除了对旧依赖的安装指引并明确使用 numpy 提供的 CPU 特性读取方式。

* **维护**
  * 精简并调整了依赖清单，移除 py-cpuinfo 相关条目并同步项目配置与构建说明。
  * 更新 CI 工作流注释，说明嵌入运行时的 CPU 特性检测改为基于 numpy；对外接口与行为签名未改变。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->