### PR TITLE
fix(deps): 去重 Linux 上的 Xlib，统一用 python-xlib（block python3-xlib）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,17 @@ pyncm-async = { path = "./deps/pyncm_async-1.8.1-py3-none-any.whl" }
 # headless variant (declared in [dependency-groups] galgame) ends up in .venv.
 # Both wheels expose the same `cv2` module name, so rapidocr's `import cv2`
 # works against either.
+#
+# python3-xlib (0.15, a stale 2016 py3 fork that pyautogui/mouseinfo pin) and
+# python-xlib (0.33, the maintained fork we depend on directly for galgame_plugin
+# X11 enumeration) both install into the same `Xlib` import namespace — having
+# both means whichever lands last wins, a latent Linux import hazard. We block
+# python3-xlib so the single, modern python-xlib provides `Xlib` for everyone;
+# its API is a strict superset, so pyautogui's `from Xlib...` resolves fine.
 [tool.uv]
 override-dependencies = [
     "opencv-python ; sys_platform == 'never'",
+    "python3-xlib ; sys_platform == 'never'",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -318,6 +318,7 @@ portalocker==2.10.1
     # via
     #   browser-use
     #   bubus
+    #   n-e-k-o
 posthog==7.8.6
     # via browser-use
 prompt-toolkit==3.0.52
@@ -1128,7 +1129,11 @@ python-multipart==0.0.20
     # via
     #   mcp
     #   n-e-k-o
-python3-xlib==0.15 ; sys_platform == 'linux'
+python-xlib==0.33 ; sys_platform == 'linux'
+    # via
+    #   n-e-k-o
+    #   pywinauto
+python3-xlib==0.15 ; sys_platform == 'never'
     # via
     #   mouseinfo
     #   pyautogui
@@ -1148,6 +1153,7 @@ pyyaml==6.0.2
     # via
     #   bilibili-api-python
     #   huggingface-hub
+    #   n-e-k-o
 pyzmq==27.1.0
     # via n-e-k-o
 qrcode==8.2
@@ -1208,6 +1214,7 @@ six==1.17.0
     #   markdownify
     #   posthog
     #   python-dateutil
+    #   python-xlib
     #   pywinauto
 smart-open==7.5.0
     # via audiolab

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "opencv-python", marker = "sys_platform == 'never'" }]
+overrides = [
+    { name = "opencv-python", marker = "sys_platform == 'never'" },
+    { name = "python3-xlib", marker = "sys_platform == 'never'" },
+]
 
 [[package]]
 name = "aiofiles"
@@ -1321,7 +1324,7 @@ version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyperclip" },
-    { name = "python3-xlib", marker = "sys_platform == 'linux'" },
+    { name = "python3-xlib", marker = "sys_platform == 'never'" },
     { name = "rubicon-objc", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/fa/b2ba8229b9381e8f6381c1dcae6f4159a7f72349e414ed19cfbbd1817173/MouseInfo-0.1.3.tar.gz", hash = "sha256:2c62fb8885062b8e520a3cce0a297c657adcc08c60952eb05bc8256ef6f7f6e7", size = 10850, upload-time = "2020-03-27T21:20:10.136Z" }
@@ -1880,7 +1883,7 @@ dependencies = [
     { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
     { name = "pyscreeze" },
-    { name = "python3-xlib", marker = "sys_platform == 'linux'" },
+    { name = "python3-xlib", marker = "sys_platform == 'never'" },
     { name = "pytweening" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/ff/cdae0a8c2118a0de74b6cf4cbcdcaf8fd25857e6c3f205ce4b1794b27814/PyAutoGUI-0.9.54.tar.gz", hash = "sha256:dd1d29e8fd118941cb193f74df57e5c6ff8e9253b99c7b04f39cfc69f3ae04b2", size = 61236, upload-time = "2023-05-24T20:11:32.972Z" }


### PR DESCRIPTION
## 背景

`uv.lock` 在 Linux 平台同时锁定了两个 Xlib 发行版：

| 包 | 版本 | 来源 | 说明 |
|---|---|---|---|
| `python-xlib` | 0.33 | **项目直接依赖**（`pyproject.toml`，galgame_plugin X11 窗口枚举）+ pywinauto | 现代维护版 |
| `python3-xlib` | 0.15 | pyautogui / mouseinfo pin | 2016 年的老 py3 fork |

两者都安装到**同一个 `Xlib` import 命名空间**，Linux 上同时装会互相覆盖（谁后装谁赢），是潜在 import 隐患。

这是 [#1525](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1525)（移除 py-cpuinfo）的 review 里 CodeRabbit 标出的**既有问题**，与 py-cpuinfo 无关，故单独成 PR。

## 改动

照搬仓库里已有的 `opencv-python` override 写法（`[tool.uv].override-dependencies` 用 `sys_platform == 'never'` marker），把 `python3-xlib` block 掉：

```toml
override-dependencies = [
    "opencv-python ; sys_platform == 'never'",
    "python3-xlib ; sys_platform == 'never'",   # 新增
]
```

这样单一的 `python-xlib` 给所有消费者提供 `Xlib`。`uv lock` 后 Linux 只解析出 python-xlib；`requirements.txt` 同步（python3-xlib 标为 `; sys_platform == 'never'`，永不安装，与 opencv-python 一致）。

## 为什么保 python-xlib 而非 python3-xlib

- `python-xlib` 是项目**直接声明**的依赖（galgame X11），且是上游维护中的现代版；`python3-xlib` 0.15 是停更老 fork。
- `python-xlib` 0.33 的 API 是 `python3-xlib` 0.15 的**严格超集**，新版 pyautogui 本身也已迁到 python-xlib。
- 静态确认两边用法都是标准 Xlib API：本项目 `from Xlib import X / display`（[window_scanner_linux.py](plugin/plugins/galgame_plugin/window_scanner_linux.py)、ocr_capture_backends/_helpers.py），pyautogui X11 后端 `from Xlib.display import Display` 等，python-xlib 全部提供。

## 验证

- `uv lock` 重解析：Linux 只剩 python-xlib，python3-xlib 全部依赖边变 `sys_platform == 'never'`。
- `uv export` 同步 requirements.txt，diff 仅涉及 xlib（py-cpuinfo 未触及，归 #1525）。
- 静态确认 pyautogui / galgame_plugin 的 Xlib import 路径均为 python-xlib 提供的标准 API。
- ⚠️ 未在真机 Linux 上跑（开发机是 Windows）；建议 Linux desktop build CI 过一遍 `uv sync` + galgame 插件 X11 路径冒烟。

> [!NOTE]
> 与 #1525 都会改 `uv.lock` / `requirements.txt`，但本 PR 从 `main` 切出、未含 py-cpuinfo 改动；两者先后合并时 lock/requirements 可能需一次 `uv lock` 重生成消解，pyproject 改的是不同 section（[tool.uv] vs [project.dependencies]），不冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了项目依赖配置，解决了相关依赖包之间的命名空间冲突，防止了潜在的导入错误。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->