### PR TITLE
fix(memory): recall_memory 弱模型健壮性 + 首次调用即时占位语音

### DIFF
--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -3029,6 +3029,31 @@ RECALL_MEMORY_TOOL_NO_RESULT = {
     "pt": "Nenhuma memória relevante encontrada.",
 }
 
+# 同时给了 query 和 time 却 0 命中时返回这条——提示模型放宽过滤条件，
+# 用「只带时间」或「只带 query」再查一次，而不是直接当作没有记忆放弃。
+RECALL_MEMORY_TOOL_NO_RESULT_LOOSEN = {
+    "zh": "在该时间范围内没有找到匹配「{query}」的记忆。建议放宽过滤条件重试一次：要么只用 time（按时间回溯该时段的记忆），要么只用 query（不限时间地语义检索）。",
+    "en": "No memory matched \"{query}\" within that time range. Try loosening the filter and querying once more: either with time only (recall memories from that period) or with query only (semantic search without a time limit).",
+    "ja": "その時間範囲で「{query}」に一致する記憶は見つかりませんでした。フィルタを緩めてもう一度試してください：time だけ（その期間の記憶を回想）か、query だけ（時間制限なしの意味検索）のどちらかで。",
+    "ko": "해당 시간 범위에서 \"{query}\"에 일치하는 기억을 찾지 못했습니다. 필터를 완화해 다시 시도해 보세요: time만 사용(해당 기간의 기억 회상)하거나 query만 사용(시간 제한 없는 의미 검색)하세요.",
+    "ru": "В этом диапазоне времени не нашлось воспоминаний по запросу «{query}». Попробуйте ослабить фильтр и запросить ещё раз: либо только time (вспомнить воспоминания за тот период), либо только query (семантический поиск без ограничения по времени).",
+    "es": "No se encontró ninguna memoria que coincidiera con \"{query}\" en ese rango de tiempo. Prueba a aflojar el filtro y consultar de nuevo: con solo time (recordar memorias de ese período) o con solo query (búsqueda semántica sin límite de tiempo).",
+    "pt": "Nenhuma memória correspondeu a \"{query}\" nesse intervalo de tempo. Tente afrouxar o filtro e consultar novamente: apenas com time (recordar memórias daquele período) ou apenas com query (busca semântica sem limite de tempo).",
+}
+
+# 本轮首次调用 recall_memory 时立即喂给 TTS 的占位语音，填补检索 + 多轮
+# 工具调用的空窗，避免冷场。只进 TTS，不进前端气泡 / 不进对话历史。带省略号
+# 让 http_sentence normalizer 当作完整句子立即 flush 合成，不与随后的正文黏连。
+RECALL_MEMORY_TOOL_FILLER = {
+    "zh": "让我回忆一下哦……",
+    "en": "Let me recall that for a moment...",
+    "ja": "ちょっと思い出してみるね……",
+    "ko": "잠깐 떠올려 볼게……",
+    "ru": "Дай-ка вспомню…",
+    "es": "Déjame recordar un momento...",
+    "pt": "Deixa eu lembrar um pouquinho...",
+}
+
 # 召回到 N 条记忆时的总览首句；后面接渲染条目，每条按
 # ``[tier/entity] text  (事件日期, 相对标签)`` 格式（tier/entity 是英文
 # enum，不翻译；text 是原始记忆内容，按用户拍板"不翻译"；时间锚点优先

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -80,6 +80,13 @@ from config.prompts.prompts_memory import (
     RECALL_MEMORY_TOOL_FOUND_HEADER,
 )
 
+# recall 占位语音用的合成 worker-sid 后缀。仅用于在 TTS worker 层把 filler 切成
+# 一段独立 utterance（见 _emit_recall_filler_tts）；``send_speech`` 在发往前端前会
+# 把它剥掉、归一回本轮 turn sid。否则在「把 request-id 透传进音频事件」的 provider
+# （如 minimax 的 ("__audio__", sid, ...) 路径）下，filler 音频会带着合成 sid 到前端，
+# 用户打断时前端按 turn sid 匹配不到 filler chunk，barge-in 取消不掉 filler。
+_RECALL_FILLER_SID_SUFFIX = "::recall-filler"
+
 
 # 内部 item 渲染时的视觉标记。状态信息已在外层 SYSTEM_NOTIFICATION_TASK_ACTIVE
 # 表达，emoji 仅作快速视觉识别用。
@@ -1204,7 +1211,7 @@ class LLMSessionManager:
                 return False
             if not (self.tts_ready and self.tts_thread and self.tts_thread.is_alive()):
                 return False
-            filler_sid = f"{turn_sid}::recall-filler"
+            filler_sid = f"{turn_sid}{_RECALL_FILLER_SID_SUFFIX}"
             self._enqueue_tts_text_chunk(filler_sid, text)
             # flush 这段独立 utterance。用 filler_sid 而非 turn sid，所以**不**触碰
             # 本轮 _tts_done_queued_for_turn——正文之后仍按正常 turn-end 流程 flush。
@@ -6941,6 +6948,11 @@ class LLMSessionManager:
         try:
             if self.websocket and hasattr(self.websocket, 'client_state') and self.websocket.client_state == self.websocket.client_state.CONNECTED:
                 effective_speech_id = speech_id if speech_id is not None else self.current_speech_id
+                # recall 占位语音在 worker 层用合成 sid 切分 utterance；对前端必须归一回
+                # turn sid，否则透传 request-id 的 provider 下，filler 音频带着合成 sid，
+                # 打断时前端按 turn sid 匹配不到 → barge-in 取消不掉 filler。
+                if isinstance(effective_speech_id, str) and effective_speech_id.endswith(_RECALL_FILLER_SID_SUFFIX):
+                    effective_speech_id = effective_speech_id[: -len(_RECALL_FILLER_SID_SUFFIX)]
                 await self.websocket.send_json({
                     "type": "audio_chunk",
                     "speech_id": effective_speech_id

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2919,6 +2919,16 @@ class LLMSessionManager:
                 # 主动把管线（worker 线程 + response handler 任务）拉起来，让 worker
                 # 在检索这几秒内就绪，filler 一就绪即被 handler flush 合成播放。
                 await self.ensure_tts_pipeline_alive()
+                # 冷启动有界等待：ensure_tts_pipeline_alive 只拉起 worker/handler，
+                # 不等 __ready__。首轮 recall 紧接着 emit 时 tts_ready 可能还是 False，
+                # 导致 _emit_recall_filler_tts 直接返回 False、首轮空窗依旧。TTS 通常
+                # ~0.1s 就绪，这里给 ~1s 有界等待；超时则优雅放弃 filler（不阻塞回忆
+                # 检索主流程），由后续 recall 调用或正文兜底。
+                if not self.tts_ready:
+                    for _ in range(20):
+                        await asyncio.sleep(0.05)
+                        if self.tts_ready or self.current_speech_id != cur_sid:
+                            break
                 # 用独立 worker-sid 把 filler 作为一段完整 utterance 立即合成出声，
                 # 既能在检索空窗里马上播，又不会让正文（同 turn sid）被 worker 当成
                 # "text_done 之后的残余文本"丢弃。详见 _emit_recall_filler_tts。

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2924,10 +2924,19 @@ class LLMSessionManager:
                 # 导致 _emit_recall_filler_tts 直接返回 False、首轮空窗依旧。TTS 通常
                 # ~0.1s 就绪，这里给 ~1s 有界等待；超时则优雅放弃 filler（不阻塞回忆
                 # 检索主流程），由后续 recall 调用或正文兜底。
+                # 提前退出：sid 变化（用户打断）、worker 没起来/已挂、或已进入
+                # NO_RETRY_TTS_CODES 这类不可恢复错误时，TTS 不可能再 ready，别白等
+                # 满 1s——否则 TTS 确定失败时同轮每次 recall 都会吃满这段延迟。
                 if not self.tts_ready:
                     for _ in range(20):
+                        if (
+                            self.current_speech_id != cur_sid
+                            or not (self.tts_thread and self.tts_thread.is_alive())
+                            or getattr(self, "_last_tts_error_code", None) in NO_RETRY_TTS_CODES
+                        ):
+                            break
                         await asyncio.sleep(0.05)
-                        if self.tts_ready or self.current_speech_id != cur_sid:
+                        if self.tts_ready:
                             break
                 # 用独立 worker-sid 把 filler 作为一段完整 utterance 立即合成出声，
                 # 既能在检索空窗里马上播，又不会让正文（同 turn sid）被 worker 当成

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2912,7 +2912,6 @@ class LLMSessionManager:
         # feed_tts_chunk 因 use_tts=False 自动 no-op。
         cur_sid = self.current_speech_id
         if cur_sid and self.use_tts and getattr(self, "_recall_filler_spoken_sid", None) != cur_sid:
-            self._recall_filler_spoken_sid = cur_sid
             try:
                 # 关键：这一轮的 TTS worker 通常在正文首个 chunk 才懒启动，而
                 # recall 发生在正文之前——若此时 worker 没起，filler 只会进
@@ -2927,6 +2926,11 @@ class LLMSessionManager:
                 _filler_ok = await self._emit_recall_filler_tts(
                     _loc(RECALL_MEMORY_TOOL_FILLER, _lang), cur_sid,
                 )
+                # 仅在真正入队成功后才标记"本轮已播过"：否则（worker 未 ready 等
+                # 返回 False）会误判已预热，本轮后续 recall 不再补发 filler，且
+                # handle_text_data 的 barge-in 守卫也会按"已预热"误跳过。
+                if _filler_ok:
+                    self._recall_filler_spoken_sid = cur_sid
                 logger.debug(
                     "[recall_memory] filler TTS emitted=%s (sid=%s tts_ready=%s)",
                     _filler_ok, cur_sid, self.tts_ready,
@@ -2942,6 +2946,7 @@ class LLMSessionManager:
         if time_arg:
             post_body["time"] = time_arg
         result_payload: dict = {}
+        recall_request_ok = False  # 仅当 memory server 真正成功返回时才置真
         try:
             from utils.internal_http_client import get_internal_http_client
             client = get_internal_http_client()
@@ -2965,6 +2970,7 @@ class LLMSessionManager:
                 )
             else:
                 result_payload = resp.json()
+                recall_request_ok = True
         except Exception as exc:
             logger.warning(
                 "[recall_memory] memory_server call failed (%s: %s); "
@@ -2995,7 +3001,10 @@ class LLMSessionManager:
             # 同时带了 query 和 time 却 0 命中：八成是两个过滤条件叠加太窄
             # （时间窗口里没有语义匹配的条目）。别直接报"没有记忆"让模型放弃，
             # 提示它放宽——只留 time 或只留 query 再查一次。
-            if query and time_arg:
+            # 仅在请求**真正成功返回**时才给放宽提示：non-2xx / 异常也会落到
+            # results=[]，那是 memory server 临时故障，不该误导模型"换条件重试"
+            # 白烧刚收紧的工具迭代预算。
+            if recall_request_ok and query and time_arg:
                 return _loc(RECALL_MEMORY_TOOL_NO_RESULT_LOOSEN, _lang).format(query=query)
             return _loc(RECALL_MEMORY_TOOL_NO_RESULT, _lang)
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -75,6 +75,8 @@ from config.prompts.prompts_memory import (
     RECALL_MEMORY_TOOL_QUERY_DESCRIPTION,
     RECALL_MEMORY_TOOL_TIME_DESCRIPTION,
     RECALL_MEMORY_TOOL_NO_RESULT,
+    RECALL_MEMORY_TOOL_NO_RESULT_LOOSEN,
+    RECALL_MEMORY_TOOL_FILLER,
     RECALL_MEMORY_TOOL_FOUND_HEADER,
 )
 
@@ -1174,6 +1176,41 @@ class LLMSessionManager:
 
         return status
 
+    async def _emit_recall_filler_tts(self, text: str, turn_sid: str) -> bool:
+        """把 recall 占位语音作为一个**独立 worker utterance 立即合成播放**。
+
+        关键设计——用一个区别于本轮 turn sid 的 *worker-only* filler sid 入队，
+        随后发 ``(None, None)`` flush：
+
+        - TTS worker 把 filler 当成一段完整 utterance 立即 commit 合成出声（填补
+          检索空窗）；
+        - 之后正文用真正的 turn sid 入队时，worker 看到 ``current_speech_id != sid``
+          会自动开新 utterance 并 reset ``text_done_sent``。若 filler 复用同一个
+          turn sid，worker 的 ``sid is None`` 分支只置 ``text_done_sent=True`` 却不
+          换 sid，正文就会在 ``if text_done_sent: 丢弃残余文本`` 处被整段丢掉
+          （= 正文没声音）。用独立 sid 正是绕开这个 worker 行为。
+
+        注意：worker 内部 sid 仅用于切分 utterance；发往前端的音频仍带 core 的
+        ``self.current_speech_id``（= turn sid），所以前端看到的是同一轮连续音频，
+        无需改动前端。
+
+        未就绪时直接放弃即时 filler（返回 False），**不**退化成"塞进 pending 等
+        正文一起 flush"——那正是之前"filler 粘在正文前"的旧 bug。
+        """
+        if not self.use_tts:
+            return False
+        async with self.tts_cache_lock:
+            if self.current_speech_id != turn_sid:
+                return False
+            if not (self.tts_ready and self.tts_thread and self.tts_thread.is_alive()):
+                return False
+            filler_sid = f"{turn_sid}::recall-filler"
+            self._enqueue_tts_text_chunk(filler_sid, text)
+            # flush 这段独立 utterance。用 filler_sid 而非 turn sid，所以**不**触碰
+            # 本轮 _tts_done_queued_for_turn——正文之后仍按正常 turn-end 流程 flush。
+            self.tts_request_queue.put((None, None))
+            return True
+
     def _remember_avatar_interaction_id(self, interaction_id: str) -> None:
         if interaction_id in self._recent_avatar_interaction_id_set:
             return
@@ -1409,7 +1446,15 @@ class LLMSessionManager:
         # 如果是新消息的第一个chunk，清空TTS队列和缓存以打断之前的语音。
         # summary epilogue 触发的 TTS-only 注入 is_first_chunk=False，不会
         # 误清掉本轮已经播放/排队的 prefix 音频。
-        if is_first_chunk and self.use_tts and tts_enabled:
+        #
+        # 例外：若本轮已被 recall 占位语音（filler）预热过同一 speech_id，则
+        # 跳过这个 barge-in 清理——否则会把同轮 filler 的 pending/已合成音频一起
+        # 冲掉，使"让我回忆一下"被正文首 chunk 抹掉或粘到正文上。上一轮音频已在
+        # turn 起点（handle_new_message / _clear_tts_pipeline）清过，这里跳过安全。
+        _filler_primed_this_turn = (
+            getattr(self, "_recall_filler_spoken_sid", None) == self.current_speech_id
+        )
+        if is_first_chunk and self.use_tts and tts_enabled and not _filler_primed_this_turn:
             async with self.tts_cache_lock:
                 self.tts_pending_chunks.clear()
                 self._discard_pending_ai_voice_echo()
@@ -2853,6 +2898,35 @@ class LLMSessionManager:
             logger.debug("[recall_memory] empty-query args=%s", args_dict)
             return _loc(RECALL_MEMORY_TOOL_NO_RESULT, _lang)
 
+        # 本轮首次真正发起回忆检索时，立刻喂一段"让我回忆一下"占位语音给 TTS，
+        # 填补 hybrid_recall + 可能的多轮工具调用造成的空窗，避免猫娘那边长时间
+        # 沉默。用 current_speech_id 去重，保证一轮只播一次（模型一轮里可能连调
+        # 好几次 recall）。只进 TTS，不进前端气泡 / 不进历史；voice 模式下
+        # feed_tts_chunk 因 use_tts=False 自动 no-op。
+        cur_sid = self.current_speech_id
+        if cur_sid and self.use_tts and getattr(self, "_recall_filler_spoken_sid", None) != cur_sid:
+            self._recall_filler_spoken_sid = cur_sid
+            try:
+                # 关键：这一轮的 TTS worker 通常在正文首个 chunk 才懒启动，而
+                # recall 发生在正文之前——若此时 worker 没起，filler 只会进
+                # tts_pending_chunks，等正文来了 worker ready 才一起 flush，导致
+                # 占位语音被粘在正文前一起播、失去"填补空窗"的意义。所以这里
+                # 主动把管线（worker 线程 + response handler 任务）拉起来，让 worker
+                # 在检索这几秒内就绪，filler 一就绪即被 handler flush 合成播放。
+                await self.ensure_tts_pipeline_alive()
+                # 用独立 worker-sid 把 filler 作为一段完整 utterance 立即合成出声，
+                # 既能在检索空窗里马上播，又不会让正文（同 turn sid）被 worker 当成
+                # "text_done 之后的残余文本"丢弃。详见 _emit_recall_filler_tts。
+                _filler_ok = await self._emit_recall_filler_tts(
+                    _loc(RECALL_MEMORY_TOOL_FILLER, _lang), cur_sid,
+                )
+                logger.debug(
+                    "[recall_memory] filler TTS emitted=%s (sid=%s tts_ready=%s)",
+                    _filler_ok, cur_sid, self.tts_ready,
+                )
+            except Exception as _filler_err:
+                logger.debug("[recall_memory] filler TTS skipped: %s", _filler_err)
+
         # POST 到 memory_server。query 始终原样下传，不能因为带了 time 就清空
         # —— 下游路由：query + time → hybrid_recall(query, time_window=...) 做
         # "语义 + 时间"联合检索（窗口内按 query 排序，语义匹配保留）；只有 time
@@ -2911,6 +2985,11 @@ class LLMSessionManager:
         )
 
         if not results:
+            # 同时带了 query 和 time 却 0 命中：八成是两个过滤条件叠加太窄
+            # （时间窗口里没有语义匹配的条目）。别直接报"没有记忆"让模型放弃，
+            # 提示它放宽——只留 time 或只留 query 再查一次。
+            if query and time_arg:
+                return _loc(RECALL_MEMORY_TOOL_NO_RESULT_LOOSEN, _lang).format(query=query)
             return _loc(RECALL_MEMORY_TOOL_NO_RESULT, _lang)
 
         # 渲染：首行 i18n 总览 + 每条 markdown bullet

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1211,6 +1211,26 @@ class LLMSessionManager:
                 return False
             if not (self.tts_ready and self.tts_thread and self.tts_thread.is_alive()):
                 return False
+            # 切到 filler 的 worker-sid 之前，先处理本轮 turn_sid 可能还在管线里的
+            # pre-tool 正文（provider 先吐 content 再进 tool_calls 时会有，见
+            # _astream_openai_with_tools 的 streamed_text_buffer）。直接 _enqueue
+            # filler_sid 会让 _enqueue_tts_text_chunk 因 sid 变化 reset stripper、丢掉
+            # turn_sid 仍 pending 的文本，且 worker 换连接也会丢 server 端缓冲，造成同轮
+            # 正文缺字（Codex P2）。所以先把 stripper pending flush 出去、并用 (None,None)
+            # 把 turn_sid utterance commit 掉（worker 发 text.done 后才换 sid，不丢内容）。
+            # 仅当本轮确有 turn_sid 文本入过队（_tts_norm_speech_id == turn_sid）才触发；
+            # 模型首动作即调 recall（无 pre-tool 文本）时跳过，行为不变。
+            if self._tts_norm_speech_id == turn_sid:
+                pre_tool = self._tts_markdown_stripper.flush()
+                if pre_tool:
+                    pre_tool = self._tts_bracket_stripper.feed(pre_tool)
+                self._tts_bracket_stripper.flush()
+                if pre_tool:
+                    self.tts_request_queue.put((turn_sid, pre_tool))
+                    self._remember_pending_ai_voice_echo(turn_sid, pre_tool)
+                # 直接放 (None,None)，不走 _request_tts_done_locked，故不置
+                # _tts_done_queued_for_turn——正文/收尾仍各自正常 flush。
+                self.tts_request_queue.put((None, None))
             filler_sid = f"{turn_sid}{_RECALL_FILLER_SID_SUFFIX}"
             self._enqueue_tts_text_chunk(filler_sid, text)
             # flush 这段独立 utterance。用 filler_sid 而非 turn sid，所以**不**触碰

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1454,14 +1454,13 @@ class LLMSessionManager:
         # summary epilogue 触发的 TTS-only 注入 is_first_chunk=False，不会
         # 误清掉本轮已经播放/排队的 prefix 音频。
         #
-        # 例外：若本轮已被 recall 占位语音（filler）预热过同一 speech_id，则
-        # 跳过这个 barge-in 清理——否则会把同轮 filler 的 pending/已合成音频一起
-        # 冲掉，使"让我回忆一下"被正文首 chunk 抹掉或粘到正文上。上一轮音频已在
-        # turn 起点（handle_new_message / _clear_tts_pipeline）清过，这里跳过安全。
-        _filler_primed_this_turn = (
-            getattr(self, "_recall_filler_spoken_sid", None) == self.current_speech_id
-        )
-        if is_first_chunk and self.use_tts and tts_enabled and not _filler_primed_this_turn:
+        # 注意：这里**不**为 recall 占位语音（filler）开例外。filler 走独立 worker
+        # sid 并在检索期间就立即 flush + 经 tts_response_handler 发往前端，正文首
+        # chunk 到达时 filler 早已送达，pending / response_queue 里不再有它，清理碰
+        # 不到。反过来，这个首包清理在某些路径（如 no-server-VAD 的 response.done
+        # 只 rotate sid、不清 TTS）是下一个唯一的打断点，若为 filler 跳过会让上一轮
+        # 残留音频漏清、与新轮重叠，破坏 barge-in（Codex P1）。故保持无条件清理。
+        if is_first_chunk and self.use_tts and tts_enabled:
             async with self.tts_cache_lock:
                 self.tts_pending_chunks.clear()
                 self._discard_pending_ai_voice_echo()

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2938,7 +2938,12 @@ class LLMSessionManager:
                 # 占位语音被粘在正文前一起播、失去"填补空窗"的意义。所以这里
                 # 主动把管线（worker 线程 + response handler 任务）拉起来，让 worker
                 # 在检索这几秒内就绪，filler 一就绪即被 handler flush 合成播放。
-                await self.ensure_tts_pipeline_alive()
+                # 但 NO_RETRY_TTS_CODES（API_ARREARS / API_KEY_REJECTED 等不可恢复态）下
+                # 不要拉起：ensure_tts_pipeline_alive 直接调 _start_tts_thread，会绕过
+                # _respawn_tts_worker 的 no-retry 闸，等于同轮每次 recall 都重启一次注定
+                # 失败的 worker。此时跳过，直接走下面的早退放弃 filler。
+                if getattr(self, "_last_tts_error_code", None) not in NO_RETRY_TTS_CODES:
+                    await self.ensure_tts_pipeline_alive()
                 # 冷启动有界等待：ensure_tts_pipeline_alive 只拉起 worker/handler，
                 # 不等 __ready__。首轮 recall 紧接着 emit 时 tts_ready 可能还是 False，
                 # 导致 _emit_recall_filler_tts 直接返回 False、首轮空窗依旧。TTS 通常

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1212,6 +1212,7 @@ class OmniOfflineClient:
         )
         final_finish_reason: Optional[str] = None
         final_block_reason: Optional[str] = None
+        final_prompt_tokens: Optional[int] = None
         final_had_text = False
         async for chunk in final_stream:
             # 与常规 genai 分支对偶地采集空回复诊断：block_reason / finish_reason /
@@ -1227,7 +1228,7 @@ class OmniOfflineClient:
             if usage_meta is not None:
                 pt = getattr(usage_meta, "prompt_token_count", 0) or 0
                 if pt:
-                    self._last_prompt_tokens = pt
+                    final_prompt_tokens = pt
             candidates = getattr(chunk, "candidates", None) or []
             if not candidates:
                 continue
@@ -1243,15 +1244,19 @@ class OmniOfflineClient:
                 if text:
                     final_had_text = True
                     yield LLMStreamChunk(content=text)
+        # 统一回填本次 forced-finalize 自己的诊断值（含 prompt_tokens）。prompt_tokens
+        # 走局部变量、流结束后无条件回填：若这次被挡住/没给 usage，写回 None 而非沿用
+        # 上一轮 tool-iteration 的旧值，避免 INFO log / 上层 LLM_NO_RESPONSE 诊断串台。
         self._last_finish_reason = final_finish_reason
         self._last_block_reason = final_block_reason
+        self._last_prompt_tokens = final_prompt_tokens
         if not final_had_text:
             logger.info(
                 "OmniOfflineClient(genai): forced-finalize empty completion "
                 "finish_reason=%s block_reason=%s model=%s prompt_tokens=%s",
                 final_finish_reason, final_block_reason,
                 getattr(self, "model", None),
-                getattr(self, "_last_prompt_tokens", None),
+                final_prompt_tokens,
             )
 
     def update_max_response_length(self, max_length: int) -> None:

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -915,13 +915,14 @@ class OmniOfflineClient:
             k: v for k, v in overrides.items() if k not in ("tools", "tool_choice")
         }
         final_finish_reason: Optional[str] = None
+        final_prompt_tokens: Optional[int] = None
         async for chunk in self.llm.astream(messages, **final_overrides):
             if chunk.finish_reason:
                 final_finish_reason = chunk.finish_reason
             if chunk.usage_metadata:
                 pt = chunk.usage_metadata.get("prompt_tokens")
                 if pt:
-                    self._last_prompt_tokens = pt
+                    final_prompt_tokens = pt
             # 与常规 tool-loop 路径一致：不向下游转发 thinking 模型的纯
             # reasoning chunk（有 reasoning_content、无 content / tool delta /
             # finish / usage）。stream_text 在首个 yield 的 chunk 上记 TTFT，
@@ -935,7 +936,11 @@ class OmniOfflineClient:
             ):
                 continue
             yield chunk
+        # prompt_tokens 走局部变量、流结束后无条件回填（与 genai 路径同口径）：这次
+        # forced-finalize 没给 usage 时写回 None，而非沿用上一轮 tool-iteration 的旧
+        # 值，避免上层 empty-completion 诊断串台。
         self._last_finish_reason = final_finish_reason
+        self._last_prompt_tokens = final_prompt_tokens
 
     async def _astream_genai_with_tools(self, messages, **overrides):
         """google-genai streaming with tool support. Yields

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -528,7 +528,7 @@ class OmniOfflineClient:
         master_name: str = "",
         on_tool_call: Optional[OnToolCallCallback] = None,
         tool_definitions: Optional[List[ToolDefinition]] = None,
-        max_tool_iterations: int = 6,
+        max_tool_iterations: int = 3,
         enable_long_response_summary: bool = False,
     ):
         # Use base_url directly without conversion
@@ -904,9 +904,26 @@ class OmniOfflineClient:
                 continue
             return
         logger.warning(
-            "OmniOfflineClient: tool iteration cap %d reached, stopping",
+            "OmniOfflineClient: tool iteration cap %d reached; forcing final answer without tools",
             self.max_tool_iterations,
         )
+        # Forced-finalize：工具轮次封顶后，去掉 tools 再调一次，逼模型基于已
+        # 积累的 tool 结果给出最终文本。否则弱模型在 finish_reason=tool_calls
+        # 上死循环到封顶后整轮静默，上游只能报"未产生文本回复"，用户那边就
+        # 表现为不回话。去掉 tools 后模型无法再发起调用，必须输出文本。
+        final_overrides = {
+            k: v for k, v in overrides.items() if k not in ("tools", "tool_choice")
+        }
+        final_finish_reason: Optional[str] = None
+        async for chunk in self.llm.astream(messages, **final_overrides):
+            if chunk.finish_reason:
+                final_finish_reason = chunk.finish_reason
+            if chunk.usage_metadata:
+                pt = chunk.usage_metadata.get("prompt_tokens")
+                if pt:
+                    self._last_prompt_tokens = pt
+            yield chunk
+        self._last_finish_reason = final_finish_reason
 
     async def _astream_genai_with_tools(self, messages, **overrides):
         """google-genai streaming with tool support. Yields
@@ -1162,9 +1179,37 @@ class OmniOfflineClient:
                 continue
             return
         logger.warning(
-            "OmniOfflineClient(genai): tool iteration cap %d reached",
+            "OmniOfflineClient(genai): tool iteration cap %d reached; forcing final answer without tools",
             self.max_tool_iterations,
         )
+        # Forced-finalize：与 OpenAI 路径对偶。去掉 tools 再生成一次，逼模型
+        # 基于已积累的 tool 结果输出最终文本，避免封顶后整轮静默。
+        final_cfg_kw = {k: v for k, v in gen_config_kw.items() if k != "tools"}
+        final_system_instruction, final_contents = _genai_messages_to_contents(messages)
+        if final_system_instruction:
+            final_cfg_kw["system_instruction"] = final_system_instruction
+        try:
+            final_config = types.GenerateContentConfig(**final_cfg_kw)
+            final_stream = await self._genai_client.aio.models.generate_content_stream(
+                model=self.model,
+                contents=final_contents,
+                config=final_config,
+            )
+            async for chunk in final_stream:
+                candidates = getattr(chunk, "candidates", None) or []
+                if not candidates:
+                    continue
+                cand_content = getattr(candidates[0], "content", None)
+                for part in (getattr(cand_content, "parts", None) or []):
+                    if getattr(part, "thought", False):
+                        continue
+                    text = getattr(part, "text", None) or ""
+                    if text:
+                        yield LLMStreamChunk(content=text)
+        except Exception as e:
+            # forced-finalize 失败不再 fallback / raise：已经是兜底的最后一步，
+            # 失败就只能让上游按空回复处理（与不加兜底前行为一致）。
+            logger.warning("OmniOfflineClient(genai): forced-finalize failed: %s", e)
 
     def update_max_response_length(self, max_length: int) -> None:
         """更新回复 token 上限（用户可能在对话期间修改设置）。

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1198,17 +1198,49 @@ class OmniOfflineClient:
             contents=final_contents,
             config=final_config,
         )
+        final_finish_reason: Optional[str] = None
+        final_block_reason: Optional[str] = None
+        final_had_text = False
         async for chunk in final_stream:
+            # 与常规 genai 分支对偶地采集空回复诊断：block_reason / finish_reason /
+            # prompt_tokens。否则若 forced-finalize 也被 safety / recitation /
+            # max-tokens 挡住而无文本，上层只能引用上一轮 tool-iteration 的过期
+            # finish_reason，诊断失真。
+            pf = getattr(chunk, "prompt_feedback", None)
+            if pf is not None:
+                br = getattr(pf, "block_reason", None)
+                if br:
+                    final_block_reason = str(br)
+            usage_meta = getattr(chunk, "usage_metadata", None)
+            if usage_meta is not None:
+                pt = getattr(usage_meta, "prompt_token_count", 0) or 0
+                if pt:
+                    self._last_prompt_tokens = pt
             candidates = getattr(chunk, "candidates", None) or []
             if not candidates:
                 continue
-            cand_content = getattr(candidates[0], "content", None)
+            cand = candidates[0]
+            fr = getattr(cand, "finish_reason", None)
+            if fr:
+                final_finish_reason = str(fr)
+            cand_content = getattr(cand, "content", None)
             for part in (getattr(cand_content, "parts", None) or []):
                 if getattr(part, "thought", False):
                     continue
                 text = getattr(part, "text", None) or ""
                 if text:
+                    final_had_text = True
                     yield LLMStreamChunk(content=text)
+        self._last_finish_reason = final_finish_reason
+        self._last_block_reason = final_block_reason
+        if not final_had_text:
+            logger.info(
+                "OmniOfflineClient(genai): forced-finalize empty completion "
+                "finish_reason=%s block_reason=%s model=%s prompt_tokens=%s",
+                final_finish_reason, final_block_reason,
+                getattr(self, "model", None),
+                getattr(self, "_last_prompt_tokens", None),
+            )
 
     def update_max_response_length(self, max_length: int) -> None:
         """更新回复 token 上限（用户可能在对话期间修改设置）。

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1184,32 +1184,31 @@ class OmniOfflineClient:
         )
         # Forced-finalize：与 OpenAI 路径对偶。去掉 tools 再生成一次，逼模型
         # 基于已积累的 tool 结果输出最终文本，避免封顶后整轮静默。
+        # 不吞异常：与 OpenAI 路径一致，让 SDK 调用失败原样向上抛，由 stream_text /
+        # prompt_ephemeral 现成的 retry / 状态上报 / response_discarded 清泡泡逻辑
+        # 接管。若在这里 try/except 成 warning，就把真实失败伪装成"空回复"，弱模型
+        # 超限后反而可能重回静音态，与本兜底目标冲突。
         final_cfg_kw = {k: v for k, v in gen_config_kw.items() if k != "tools"}
         final_system_instruction, final_contents = _genai_messages_to_contents(messages)
         if final_system_instruction:
             final_cfg_kw["system_instruction"] = final_system_instruction
-        try:
-            final_config = types.GenerateContentConfig(**final_cfg_kw)
-            final_stream = await self._genai_client.aio.models.generate_content_stream(
-                model=self.model,
-                contents=final_contents,
-                config=final_config,
-            )
-            async for chunk in final_stream:
-                candidates = getattr(chunk, "candidates", None) or []
-                if not candidates:
+        final_config = types.GenerateContentConfig(**final_cfg_kw)
+        final_stream = await self._genai_client.aio.models.generate_content_stream(
+            model=self.model,
+            contents=final_contents,
+            config=final_config,
+        )
+        async for chunk in final_stream:
+            candidates = getattr(chunk, "candidates", None) or []
+            if not candidates:
+                continue
+            cand_content = getattr(candidates[0], "content", None)
+            for part in (getattr(cand_content, "parts", None) or []):
+                if getattr(part, "thought", False):
                     continue
-                cand_content = getattr(candidates[0], "content", None)
-                for part in (getattr(cand_content, "parts", None) or []):
-                    if getattr(part, "thought", False):
-                        continue
-                    text = getattr(part, "text", None) or ""
-                    if text:
-                        yield LLMStreamChunk(content=text)
-        except Exception as e:
-            # forced-finalize 失败不再 fallback / raise：已经是兜底的最后一步，
-            # 失败就只能让上游按空回复处理（与不加兜底前行为一致）。
-            logger.warning("OmniOfflineClient(genai): forced-finalize failed: %s", e)
+                text = getattr(part, "text", None) or ""
+                if text:
+                    yield LLMStreamChunk(content=text)
 
     def update_max_response_length(self, max_length: int) -> None:
         """更新回复 token 上限（用户可能在对话期间修改设置）。

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -922,6 +922,18 @@ class OmniOfflineClient:
                 pt = chunk.usage_metadata.get("prompt_tokens")
                 if pt:
                     self._last_prompt_tokens = pt
+            # 与常规 tool-loop 路径一致：不向下游转发 thinking 模型的纯
+            # reasoning chunk（有 reasoning_content、无 content / tool delta /
+            # finish / usage）。stream_text 在首个 yield 的 chunk 上记 TTFT，
+            # 放行 reasoning-only 会把"首推理 token"误当首 token，污染封顶轮延迟埋点。
+            if (
+                getattr(chunk, "reasoning_content", None)
+                and not getattr(chunk, "content", None)
+                and not chunk.tool_call_deltas
+                and not chunk.finish_reason
+                and not chunk.usage_metadata
+            ):
+                continue
             yield chunk
         self._last_finish_reason = final_finish_reason
 

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -2129,7 +2129,9 @@ async def test_stream_text_length_guard_after_tool_call_rejects_pretool_only_rec
 @pytest.mark.asyncio
 async def test_offline_iteration_cap_breaks_runaway_loop():
     """If the model keeps requesting tools forever, we stop after
-    ``max_tool_iterations`` LLM calls instead of looping indefinitely."""
+    ``max_tool_iterations`` tool rounds and then do ONE forced-finalize
+    call (tools removed) so the user gets a final answer instead of
+    silence."""
     from utils.llm_client import LLMStreamChunk
     from main_logic.omni_offline_client import OmniOfflineClient
     from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
@@ -2139,8 +2141,8 @@ async def test_offline_iteration_cap_breaks_runaway_loop():
 
     tool = ToolDefinition(name="loop", description="", handler=loop_tool)
 
-    # Every scripted call returns another tool_call.
-    def chunks():
+    # Every tool round returns another tool_call.
+    def loop_chunks():
         return [
             LLMStreamChunk(
                 content="",
@@ -2153,7 +2155,11 @@ async def test_offline_iteration_cap_breaks_runaway_loop():
             LLMStreamChunk(content="", finish_reason="tool_calls"),
         ]
 
-    fake_llm = _FakeLLM([chunks() for _ in range(10)])
+    # The forced-finalize call (4th) can no longer call tools → returns text.
+    final_text_chunks = [
+        LLMStreamChunk(content="最终答案", finish_reason="stop"),
+    ]
+    fake_llm = _FakeLLM([loop_chunks(), loop_chunks(), loop_chunks(), final_text_chunks])
 
     client = OmniOfflineClient.__new__(OmniOfflineClient)
     client.llm = fake_llm
@@ -2161,6 +2167,8 @@ async def test_offline_iteration_cap_breaks_runaway_loop():
     client.max_tool_iterations = 3
     client._use_genai_sdk = False
     client._genai_tools_unsupported = False
+    client._last_finish_reason = None
+    client._last_prompt_tokens = None
 
     async def handler(call: ToolCall) -> ToolResult:
         return ToolResult(call_id=call.call_id, name=call.name, output={"ok": True})
@@ -2168,11 +2176,19 @@ async def test_offline_iteration_cap_breaks_runaway_loop():
     client.on_tool_call = handler
 
     messages = [{"role": "user", "content": "loop forever"}]
-    async for _ in client._astream_with_tools(messages):
-        pass
+    streamed = ""
+    async for c in client._astream_with_tools(messages):
+        if getattr(c, "content", ""):
+            streamed += c.content
 
-    # Exactly max_tool_iterations LLM calls occurred — no infinite loop.
-    assert len(fake_llm.calls) == 3
+    # max_tool_iterations tool rounds + 1 forced-finalize call.
+    assert len(fake_llm.calls) == 4
+    # Forced-finalize streamed real text instead of leaving the turn silent.
+    assert "最终答案" in streamed
+    # The forced-finalize call must NOT advertise tools/tool_choice.
+    _final_overrides = fake_llm.calls[-1][1]
+    assert "tools" not in _final_overrides
+    assert "tool_choice" not in _final_overrides
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景
用 free-model 测试时发现：问猫娘"昨天/上周聊了啥"会**整轮无回复("似掉")**。日志显示弱模型在 `recall_memory` 上反复换措辞死循环调用，达工具迭代上限后 `finish_reason=tool_calls`、无文本产出，`OmniOfflineClient` 重试耗尽 → 整轮静音。

回忆功能本身正常（embedding ready、hybrid_recall 命中、按时间回溯生效、工具结果正常返回），问题在弱模型的工具调用行为 + 缺少兜底。

## 改动
1. **工具迭代上限 6→3 + forced-finalize**（`omni_offline_client.py`）
   封顶后不再只打 warning 静默 return，而是**去掉 tools 再调一次**，逼模型基于已积累的 tool 结果输出最终文本。openai / genai 两条路径对偶都加。
2. **time+query 0 命中时提示放宽过滤**（`core.py` + `prompts_memory.py`）
   同时带 `query` 和 `time` 却 0 命中时，返回提示让模型只用 time 或只用 query 再查一次，而不是干巴巴"没有找到相关记忆"让其直接放弃。
3. **首次调用即时占位语音**（`core.py` + `prompts_memory.py`）
   本轮首次真正发起 recall 时立即喂一段"让我回忆一下…"占位语音，填补检索空窗避免冷场。
   - 用**独立 worker-sid**(`{turn_sid}::recall-filler`)自成一段 utterance 立即 commit 合成出声；正文用真正 turn sid 入队，worker 视为新 utterance、reset `text_done`，**正文不被当 `text_done` 残余丢弃**。
   - 发往前端的音频仍带 turn sid，前端看到同一轮连续音频，**不改前端**。
   - `use_tts=False`（voice 实时模式）自动 no-op。

新增 i18n：`RECALL_MEMORY_TOOL_NO_RESULT_LOOSEN` / `RECALL_MEMORY_TOOL_FILLER`（全语种）。

## 测试
- `tests/unit/test_tool_calling.py` 更新 `test_offline_iteration_cap_breaks_runaway_loop` 覆盖 forced-finalize（3 轮工具 + 1 次去 tools 的收尾调用、产出文本、收尾调用不带 tools/tool_choice）；**56 passed**
- `scripts/check_i18n.py` 全语种 0 缺失；`scripts/check_prompt_hygiene.py` 本 PR 文件零违规
- 本地端到端验证：filler 在检索空窗里先出声、正文随后正常合成；不再"似掉"

## Test plan
- [ ] free-model 下问"昨天/上周聊了啥"：先听到"让我回忆一下…"，随后正文有声音，全程不卡死
- [ ] 强模型回归：recall 正常、无多余 filler 异常
- [ ] voice 实时模式：filler no-op，不影响原生语音

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 回忆检索新增空结果回落与放宽重试策略；首次检索且启用 TTS 时会播报仅供语音的占位填充音，避免冷场（该音不显示在对话气泡/历史）。

* **Improvements**
  * 工具调用迭代上限默认从 6 降为 3；达到上限时触发“强制终局”流，确保产出最终回答并继续流式返回结果，同时保留诊断与计量信息；向前端发送前归一化语音 ID。

* **Tests**
  * 单元测试增强，验证触发强制终局时的调用次数、最终输出及 overrides 处理。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->