### PR TITLE
fix(llm): 非流式收口剥离 Qwen3.5/3.6 泄漏进 content 的思考链

### DIFF
--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -20,7 +20,7 @@ import httpx
 
 from config import OPENCLAW_MAGIC_INTENT_MAX_TOKENS
 from utils.file_utils import robust_json_loads
-from utils.llm_client import create_chat_llm
+from utils.llm_client import create_chat_llm, strip_thinking_segments
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
 
@@ -458,7 +458,10 @@ class OpenClawAdapter:
 
     @staticmethod
     def _strip_reasoning_trace(text: str) -> str:
-        cleaned = re.sub(r"<think>.*?</think>", "", str(text or ""), flags=re.IGNORECASE | re.DOTALL).strip()
+        # Shared stripper handles both paired <think>...</think> and the
+        # Qwen3.5/3.6 dangling-</think> leak shape; ReAct line filtering below
+        # is openclaw-specific and stays here.
+        cleaned = strip_thinking_segments(text)
         if not cleaned:
             return ""
 

--- a/tests/unit/test_strip_thinking_segments.py
+++ b/tests/unit/test_strip_thinking_segments.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""``strip_thinking_segments`` — defensive chain-of-thought removal for
+non-streaming replies.
+
+Background: qwen3-vl-* route reasoning to the ``reasoning_content`` field
+(``content`` stays clean), but the Qwen3.5/3.6 hybrid models never populate
+``reasoning_content`` over the OpenAI-compatible endpoint — the whole
+chain-of-thought lands in ``content`` with only a *dangling* ``</think>`` (no
+opening tag) before the real answer. A paired-tag regex can't catch that;
+these cases pin the dangling-close behavior plus the well-formed and
+passthrough cases.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from utils.llm_client import strip_thinking_segments
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # 1) Qwen3.5 leak: implicit-open thinking + lone </think> + answer.
+        ("用户让我描述图片。草稿2更准确简洁。\n</think>\n\n这张图片包含一个红色的矩形。",
+         "这张图片包含一个红色的矩形。"),
+        # 2) Well-formed paired block.
+        ("<think>reason here</think>final answer", "final answer"),
+        # 3) <thinking> long-form variant, paired.
+        ("<thinking>step 1\nstep 2</thinking>\nDone.", "Done."),
+        # 4) Multiple paired blocks.
+        ("<think>a</think>X<think>b</think>Y", "XY"),
+        # 5) Clean reply (qwen3-vl path) passes through untouched.
+        ("图中左侧是一个红色矩形，右侧是一个蓝色圆形。",
+         "图中左侧是一个红色矩形，右侧是一个蓝色圆形。"),
+        # 6) Multiline reasoning before the dangling close (real probe shape).
+        ("1. 识别主体\n2. 组织语言\n精简一下：\n</think>\n\n答案在这里", "答案在这里"),
+        # 7) Case-insensitive close tag.
+        ("thinking...</THINK>answer", "answer"),
+        # 8) Empty / falsy inputs.
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_strip(raw, expected):
+    assert strip_thinking_segments(raw) == expected
+
+
+def test_no_answer_after_dangling_close_yields_empty():
+    """Pure-thinking reply with a trailing close tag → nothing left."""
+    assert strip_thinking_segments("just reasoning, no answer\n</think>") == ""
+
+
+def test_plain_text_with_no_tags_is_identity():
+    txt = "这是一段普通回复，没有任何思考标签，应原样返回。"
+    assert strip_thinking_segments(txt) == txt

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -12,10 +12,51 @@ from __future__ import annotations
 
 import contextvars
 import json as _json
+import re
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Union
 
 from openai import AsyncOpenAI, OpenAI
+
+
+# ────────────────────────────────────────────────────────────────
+# Reasoning-trace stripping (non-streaming defensive cleanup)
+# ────────────────────────────────────────────────────────────────
+# Well-formed <think>...</think> / <thinking>...</thinking> blocks.
+_THINK_PAIRED_RE = re.compile(r"<think(?:ing)?\s*>.*?</think(?:ing)?\s*>", re.IGNORECASE | re.DOTALL)
+# A *dangling* close tag with no matching open. This is the Qwen3.5/3.6
+# OpenAI-compat leak shape: unlike qwen3-vl-* (which route reasoning to the
+# ``reasoning_content`` field), the 3.5/3.6 hybrid models never populate
+# ``reasoning_content`` — the whole chain-of-thought lands in ``content`` with
+# only a lone ``</think>`` (implicit open) separating it from the real answer.
+# A paired-tag regex alone can't catch this; we strip everything up to and
+# including the first unmatched close tag.
+_THINK_DANGLING_CLOSE_RE = re.compile(r"^.*?</think(?:ing)?\s*>", re.IGNORECASE | re.DOTALL)
+_THINK_ANY_CLOSE_RE = re.compile(r"</think(?:ing)?\s*>", re.IGNORECASE)
+
+
+def strip_thinking_segments(text: str | None) -> str:
+    """Remove leaked chain-of-thought from a *non-streaming* model reply.
+
+    Handles two shapes:
+      1. Well-formed ``<think>...</think>`` blocks (any count).
+      2. Qwen3.5/3.6 leak: reasoning dumped into ``content`` with only a
+         dangling ``</think>`` (no opening tag) before the answer.
+
+    Conservative — only acts when a think tag is present, so clean replies
+    (qwen3-vl-*, gpt, claude, etc.) pass through untouched. Streaming is *not*
+    covered here on purpose: when the chain-of-thought arrives token-by-token
+    in ``delta.content`` with no delimiter there's nothing reliable to strip.
+    """
+    if not text:
+        return text or ""
+    s = str(text)
+    # 1) drop well-formed blocks first
+    s = _THINK_PAIRED_RE.sub("", s)
+    # 2) any close tag still present is unmatched → preceding text is thinking
+    if _THINK_ANY_CLOSE_RE.search(s):
+        s = _THINK_DANGLING_CLOSE_RE.sub("", s, count=1)
+    return s.strip()
 
 
 # ────────────────────────────────────────────────────────────────
@@ -475,18 +516,18 @@ class ChatOpenAI:
         # message=None 的合法响应，直接 .message.content 会 NoneType 崩溃。
         choice = resp.choices[0] if resp.choices else None
         msg = choice.message if choice else None
-        content = getattr(msg, "content", None)
+        content = strip_thinking_segments(getattr(msg, "content", None))
         usage_dict = resp.usage.model_dump() if resp.usage else {}
-        return LLMResponse(content=content or "", response_metadata={"token_usage": usage_dict})
+        return LLMResponse(content=content, response_metadata={"token_usage": usage_dict})
 
     def invoke(self, messages: Any, **overrides: Any) -> LLMResponse:
         """Sync twin of ``ainvoke``. See its docstring for ``overrides``."""
         resp = self._client.chat.completions.create(**self._params(messages, **overrides))
         choice = resp.choices[0] if resp.choices else None
         msg = choice.message if choice else None
-        content = getattr(msg, "content", None)
+        content = strip_thinking_segments(getattr(msg, "content", None))
         usage_dict = resp.usage.model_dump() if resp.usage else {}
-        return LLMResponse(content=content or "", response_metadata={"token_usage": usage_dict})
+        return LLMResponse(content=content, response_metadata={"token_usage": usage_dict})
 
     # --- raw-resp invoke (for callers needing reasoning_content / raw choices) ---
 


### PR DESCRIPTION
## 背景

排查"qwen 图片模型思考过程泄漏到正文"的问题。用百炼真实 key 跑了 6 模型 × 流式/非流式 × `enable_thinking` 三态的矩阵，结论是两个阵营：

| 模型 | thinking 默认 | 开 thinking 时推理落点 | content |
|---|---|---|---|
| `qwen3-vl-plus/flash/max` | 关 | `reasoning_content`（或开不了，报 thinking_budget） | 永远干净 |
| `qwen-plus`（老文本） | 关 | `reasoning_content` | 干净 |
| **`qwen3.5-plus`（新混合，能吃图）** | **开** | **`reasoning_content` 恒空，思考直接进 `content`** | **脏** |

`qwen3.5-plus` 非流式实测原文：`content` = `'...草稿2更准确简洁。\n</think>\n\n这张图片包含...'`，`reasoning_content` 为空。整段思考 + 一个**无开标签的孤立 `</think>`** + 真答案全塞 `content`。这就解释了之前的困惑：

- **"没有 `<think>` 标签"** → 只有无头 `</think>`，`<think>...</think>` 正则抓不到。
- **"似乎和非流式有关"** → 非流式 `ainvoke` 把【思考+`</think>`+答案】整团塞 `content`；流式路径本想靠 `chunk.reasoning_content` 分流，但该字段恒空，分流空转。

同 [QwenLM/Qwen3.6#26](https://github.com/QwenLM/Qwen3.6/issues/26) 描述一致。

## 改动

- 新增共享 `strip_thinking_segments()`（`utils/llm_client.py`）：删成对 `<think>…</think>` + 切掉无头 `</think>` 之前的思考；干净回复原样透传。
- 挂在 `ChatOpenAI.ainvoke`/`invoke` 非流式唯一收口处（`astream` 读 `reasoning_content` 的对偶位置）——一处覆盖 proactive、memory（facts/reflection/refine/recall/persona/recent 等十余处 `ainvoke`）、截图分析等所有非流式调用。流式不动。
- `brain/openclaw_adapter.py` 的 `_strip_reasoning_trace` 去重复用该函数。

## 取舍

非流式正文若**合法地**出现 `</think>` 字面量（极罕见）会被误切。考虑到这是防御性清理、qwen3.5 泄漏是高频真实问题，按维护者拍板"不怕误伤"采用此方案。

## Test plan

- [x] `tests/unit/test_strip_thinking_segments.py` 11 例（用探针抓到的真实 qwen3.5 泄漏原文）全过
- [x] `test_agent_runtime_intent` + `test_agent_rewrite_regression` 160 passed，openclaw 链无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了 LLM 模型响应的处理，防止内部推理链信息泄露到用户界面。

* **Tests**
  * 新增推理链清理功能的单元测试，覆盖多种标签格式和边界情况。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->