### PR TITLE
security(csrf): 把 8 个裸奔的本地变更端点接入 _validate_local_mutation_request (#1479 Step 1)

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1060,6 +1060,10 @@ async def get_pending_notices():
 @router.post("/pending-notices/ack")
 async def ack_pending_notices(request: Request):
     """前端展示完通知后调用，仅删除 cursor 以内的通知（游标确认，避免 TOCTOU）。"""
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     from main_logic.core import drain_prominent_notices
     try:
         body = await _read_json_object(request)
@@ -3093,6 +3097,10 @@ async def emotion_analysis(request: Request):
     - 根据置信度自动调整情绪类别，当置信度较低时将情绪设置为 neutral，提升结果可靠性
     - 将分析结果推送到监控系统（如果提供了 lanlan_name），实现与前端的实时交互和展示
     """
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     try:
         _config_manager = get_config_manager()
         data = await request.json()
@@ -3238,7 +3246,7 @@ async def emotion_analysis(request: Request):
 
 
 @router.post('/steam/set-achievement-status/{name}')
-async def set_achievement_status(name: str):
+async def set_achievement_status(name: str, request: Request):
     """
     设置Steam成就状态接口
     func:
@@ -3248,6 +3256,10 @@ async def set_achievement_status(name: str):
     - 若未解锁，尝试设置成就，若成功则返回成功，否则等待1秒后重试一次
     - 最多重试10次，若仍失败则返回错误，提示可能的配置问题
     """
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     steamworks = get_steamworks()
     if steamworks is not None:
         try:
@@ -3296,6 +3308,10 @@ async def update_playtime(request: Request):
     """
     更新游戏时长统计（PLAY_TIME_SECONDS）
     """
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     steamworks = get_steamworks()
     if steamworks is not None:
         try:
@@ -4519,6 +4535,10 @@ async def proactive_chat(request: Request):
     """
     主动搭话：两阶段架构 — Phase 1 合并 LLM（web筛选+music/meme关键词，1次调用），Phase 2 结合人设生成搭话
     """
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     try:
         _config_manager = get_config_manager()
         session_manager = get_session_manager()
@@ -7267,6 +7287,10 @@ async def proactive_music_played_through(request: Request):
     通道字段清空，从而让 _compute_source_weights 不再把"刚刚共享过音乐"
     继续计入对 music 通道的衰减惩罚——完整播放是用户对该通道最强的正向反馈。
     """
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     try:
         data = await request.json()
     except Exception:
@@ -7291,14 +7315,14 @@ async def proactive_music_played_through(request: Request):
 async def translate_text_api(request: Request):
     """
     翻译文本API（供前端字幕模块使用）
-    
+
     请求格式:
     {
         "text": "要翻译的文本",
         "target_lang": "目标语言代码 ('zh', 'en', 'ja', 'ko')",
         "source_lang": "源语言代码 (可选，为null时自动检测)"
     }
-    
+
     响应格式:
     {
         "success": true/false,
@@ -7307,6 +7331,10 @@ async def translate_text_api(request: Request):
         "target_lang": "目标语言代码"
     }
     """
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     try:
         data = await request.json()
         text = data.get('text', '').strip()
@@ -7387,9 +7415,13 @@ async def get_personal_dynamics(request: Request):
     """
     获取个性化内容数据
     """
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     from utils.web_scraper import fetch_personal_dynamics, format_personal_dynamics
     try:
-        
+
         data = await request.json()
         limit = data.get('limit', 10)
         

--- a/static/achievement_manager.js
+++ b/static/achievement_manager.js
@@ -164,11 +164,14 @@
                 console.log(`尝试解锁成就: ${achievementName} - ${ACHIEVEMENTS[achievementName].description}`);
 
                 // 调用Steam API
+                const achHeaders = { 'Content-Type': 'application/json' };
+                const sec = window.nekoLocalMutationSecurity;
+                if (sec && typeof sec.getMutationHeaders === 'function') {
+                    try { Object.assign(achHeaders, await sec.getMutationHeaders()); } catch (_) { }
+                }
                 const response = await fetch(`/api/steam/set-achievement-status/${achievementName}`, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    }
+                    headers: achHeaders
                 });
 
                 if (response.ok) {
@@ -256,11 +259,14 @@
 
                 try {
                     // 调用后端 API 更新 Steam 统计，发送实际经过的秒数
+                    const playtimeHeaders = { 'Content-Type': 'application/json' };
+                    const sec = window.nekoLocalMutationSecurity;
+                    if (sec && typeof sec.getMutationHeaders === 'function') {
+                        try { Object.assign(playtimeHeaders, await sec.getMutationHeaders()); } catch (_) { }
+                    }
                     const response = await fetch('/api/steam/update-playtime', {
                         method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
+                        headers: playtimeHeaders,
                         body: JSON.stringify({
                             seconds: elapsedSeconds
                         })

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -542,9 +542,14 @@
     mod.analyzeEmotion = async function analyzeEmotion(text) {
         console.log(window.t('console.analyzeEmotionCalled'), text);
         try {
+            var emotionHeaders = { 'Content-Type': 'application/json' };
+            var sec = window.nekoLocalMutationSecurity;
+            if (sec && typeof sec.getMutationHeaders === 'function') {
+                try { Object.assign(emotionHeaders, await sec.getMutationHeaders()); } catch (_) { }
+            }
             var response = await fetch('/api/emotion/analysis', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: emotionHeaders,
                 body: JSON.stringify({
                     text: text,
                     lanlan_name: window.lanlan_config.lanlan_name

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -784,9 +784,14 @@
                 // 在 propensity / restricted_screen_only / 抖动 sleep 这一整套门
                 // 之前就早退；语音 scheduler 自己也是固定 baseInterval 不带 backoff。
                 // 既然两边都不读，发了也是冗余字段。
+                var voiceProactiveHeaders = { 'Content-Type': 'application/json' };
+                var voiceProactiveSec = window.nekoLocalMutationSecurity;
+                if (voiceProactiveSec && typeof voiceProactiveSec.getMutationHeaders === 'function') {
+                    try { Object.assign(voiceProactiveHeaders, await voiceProactiveSec.getMutationHeaders()); } catch (_) { }
+                }
                 var resp = await fetch('/api/proactive_chat', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: voiceProactiveHeaders,
                     body: JSON.stringify({
                         lanlan_name: lanlanName,
                         enabled_modes: voiceModes,
@@ -1057,11 +1062,14 @@
                 return;
             }
 
+            var proactiveHeaders = { 'Content-Type': 'application/json' };
+            var proactiveSec = window.nekoLocalMutationSecurity;
+            if (proactiveSec && typeof proactiveSec.getMutationHeaders === 'function') {
+                try { Object.assign(proactiveHeaders, await proactiveSec.getMutationHeaders()); } catch (_) { }
+            }
             var response = await fetch('/api/proactive_chat', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
+                headers: proactiveHeaders,
                 body: JSON.stringify(requestBody)
             });
             // HTTP 409 = server try_start_proactive 因并发拒绝（AI 还在响应上一轮 /

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -806,8 +806,15 @@
                 // 本次请求**根本没真正发起**一次 proactive，标 'pass' 走上游"不计数"
                 // 分支自行 schedule，否则 _voiceProactiveNoResponseCount 会被白白消耗
                 // 一格、最坏 5 次 server 忙就触发"连续 5 轮无回复，停止主动搭话"。
-                if (resp.status === 409) {
-                    console.log('[ProactiveChat] 语音模式 server 并发拒绝 (409)，不消耗 attempt');
+                //
+                // HTTP 403 = CSRF/Origin 守卫拒绝（CodeRabbit on PR #1530）。
+                // 启动竞速下 page_config token 可能还没注入，前端会被一次性
+                // 拒绝；和 409 同语义——server 没真正跑过 phase1/2 LLM、没消耗
+                // 上下文。当 attempt 算会让 _voiceProactiveNoResponseCount 在
+                // token bootstrap 完成前就消耗光，触发"5 轮无回复，停止主动搭话"。
+                if (resp.status === 409 || resp.status === 403) {
+                    console.log('[ProactiveChat] 语音模式 server 拒绝 ('
+                        + resp.status + ')，不消耗 attempt');
                     S._voiceProactiveLastResult = 'pass';
                     return false;
                 }
@@ -1081,8 +1088,15 @@
             // 节奏整体往后拉，跟 server 实际状态正交、用户体验上变成"server 越忙、AI
             // 越沉默"。这里 requestSent 故意不翻 true、return false 让上游识别为"没
             // 真发"、下一轮按 base interval 重排，不动 level。
-            if (response.status === 409) {
-                console.log('[ProactiveChat] server 并发拒绝 (409)，不消耗 backoff attempt');
+            //
+            // HTTP 403 = CSRF/Origin 守卫拒绝（CodeRabbit on PR #1530）。token
+            // bootstrap 还没完成前的启动竞速窗口会撞到这个；语义同 409——server
+            // 没跑业务逻辑、没消耗资源。当 attempt 计入 backoff 会让"刚开机
+            // 几秒里 token 没就位"被惩罚性升级，跟 server 实际负载/用户活动
+            // 状态正交。下一轮 token 通常已到位，按 base interval 重排即可。
+            if (response.status === 409 || response.status === 403) {
+                console.log('[ProactiveChat] server 拒绝 ('
+                    + response.status + ')，不消耗 backoff attempt');
                 return false;
             }
             requestSent = true;

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -145,6 +145,31 @@
         } catch (_) { /* ignore */ }
     }
 
+    /**
+     * Was this 403 produced by ``_validate_local_mutation_request``
+     * (i.e. CSRF/Origin guard), or by something else (future business
+     * rule, reverse proxy, WAF, …)? The unified-guard contract is
+     * ``error_code === "csrf_validation_failed"`` (see
+     * ``static/app-prompt-shared.js`` 520-541 and
+     * ``static/universal-tutorial-manager.js`` 120-134).
+     *
+     * Only the CSRF case warrants the ``refreshToken()`` + retry-once
+     * recovery path; treating *every* 403 as benign-and-skip means a
+     * token-expired heartbeat looks identical to a "real" 403 and the
+     * caller never recovers — proactive chat would silently stall until
+     * a full page reload (CodeRabbit Major on PR #1530).
+     */
+    async function _proactiveIsCsrfValidationFailure(resp) {
+        if (!resp || resp.status !== 403) return false;
+        try {
+            var cloned = typeof resp.clone === 'function' ? resp.clone() : resp;
+            var body = await cloned.json();
+            return Boolean(body && body.error_code === 'csrf_validation_failed');
+        } catch (_) {
+            return false;
+        }
+    }
+
     function _isChatInputElement(element) {
         if (!element || element.nodeType !== 1 || typeof element.matches !== 'function') {
             return false;
@@ -784,34 +809,59 @@
                 // 在 propensity / restricted_screen_only / 抖动 sleep 这一整套门
                 // 之前就早退；语音 scheduler 自己也是固定 baseInterval 不带 backoff。
                 // 既然两边都不读，发了也是冗余字段。
-                var voiceProactiveHeaders = { 'Content-Type': 'application/json' };
                 var voiceProactiveSec = window.nekoLocalMutationSecurity;
-                if (voiceProactiveSec && typeof voiceProactiveSec.getMutationHeaders === 'function') {
-                    try { Object.assign(voiceProactiveHeaders, await voiceProactiveSec.getMutationHeaders()); } catch (_) { }
-                }
-                var resp = await fetch('/api/proactive_chat', {
-                    method: 'POST',
-                    headers: voiceProactiveHeaders,
-                    body: JSON.stringify({
-                        lanlan_name: lanlanName,
-                        enabled_modes: voiceModes,
-                        voice_mode: true,
-                        // mini-game 邀请的用户级 toggle；后端 _maybe_deliver_mini_game_invite
-                        // 与 source-driven sources 解耦，不进 enabled_modes 数组。
-                        mini_game_invite_enabled: !!S.proactiveMiniGameInviteEnabled
-                    })
+                var voiceProactiveBody = JSON.stringify({
+                    lanlan_name: lanlanName,
+                    enabled_modes: voiceModes,
+                    voice_mode: true,
+                    // mini-game 邀请的用户级 toggle；后端 _maybe_deliver_mini_game_invite
+                    // 与 source-driven sources 解耦，不进 enabled_modes 数组。
+                    mini_game_invite_enabled: !!S.proactiveMiniGameInviteEnabled
                 });
+
+                async function _sendVoiceProactive() {
+                    var hdrs = { 'Content-Type': 'application/json' };
+                    if (voiceProactiveSec && typeof voiceProactiveSec.getMutationHeaders === 'function') {
+                        try { Object.assign(hdrs, await voiceProactiveSec.getMutationHeaders()); } catch (_) { }
+                    }
+                    return fetch('/api/proactive_chat', {
+                        method: 'POST',
+                        headers: hdrs,
+                        body: voiceProactiveBody,
+                    });
+                }
+
+                var resp = await _sendVoiceProactive();
+
+                // CSRF-403 retry-once: 只在 error_code === 'csrf_validation_failed'
+                // 时调 refreshToken() + 重试一次。其它 403（业务规则、反代、WAF）走
+                // 真实失败分支，避免把所有 403 当 benign pass，让 token 过期后
+                // proactive 静默停摆到整页刷新为止（CodeRabbit Major on PR #1530）。
+                if (resp.status === 403
+                    && voiceProactiveSec
+                    && typeof voiceProactiveSec.refreshToken === 'function'
+                    && await _proactiveIsCsrfValidationFailure(resp)) {
+                    try {
+                        await voiceProactiveSec.refreshToken();
+                        resp = await _sendVoiceProactive();
+                    } catch (_) { /* fall through to 403 handling below */ }
+                }
+
                 // HTTP 409 = server try_start_proactive 因并发拒绝（AI 还在响应上一轮 /
                 // 另一路 proactive 已占坑，见 main_routers/system_router.py:4241-4247）。
                 // 本次请求**根本没真正发起**一次 proactive，标 'pass' 走上游"不计数"
                 // 分支自行 schedule，否则 _voiceProactiveNoResponseCount 会被白白消耗
                 // 一格、最坏 5 次 server 忙就触发"连续 5 轮无回复，停止主动搭话"。
                 //
-                // HTTP 403 = CSRF/Origin 守卫拒绝（CodeRabbit on PR #1530）。
-                // 启动竞速下 page_config token 可能还没注入，前端会被一次性
-                // 拒绝；和 409 同语义——server 没真正跑过 phase1/2 LLM、没消耗
-                // 上下文。当 attempt 算会让 _voiceProactiveNoResponseCount 在
-                // token bootstrap 完成前就消耗光，触发"5 轮无回复，停止主动搭话"。
+                // HTTP 403 csrf_validation_failed = 统一守卫拒绝。refresh+retry 仍失败
+                // 时归入"server 拒绝"分支：token bootstrap 真没完成 / 配置错位的
+                // 启动竞速窗口跟 409 同语义（server 早退、没跑业务）。当 attempt 算
+                // 会让 _voiceProactiveNoResponseCount 在 token bootstrap 完成前就
+                // 消耗光，触发"5 轮无回复，停止主动搭话"。
+                //
+                // 非 csrf 的 403（业务规则 / 反代 / WAF）会跳过上面的 retry，落到这里
+                // ——也按"不消耗 attempt"处理：这些路径在 proactive 语义里同样表示
+                // "server 没真正跑业务"，把它们计入 attempt 既无重试帮助又会污染调度。
                 if (resp.status === 409 || resp.status === 403) {
                     console.log('[ProactiveChat] 语音模式 server 拒绝 ('
                         + resp.status + ')，不消耗 attempt');
@@ -1069,16 +1119,37 @@
                 return;
             }
 
-            var proactiveHeaders = { 'Content-Type': 'application/json' };
             var proactiveSec = window.nekoLocalMutationSecurity;
-            if (proactiveSec && typeof proactiveSec.getMutationHeaders === 'function') {
-                try { Object.assign(proactiveHeaders, await proactiveSec.getMutationHeaders()); } catch (_) { }
+            var proactiveBody = JSON.stringify(requestBody);
+
+            async function _sendProactive() {
+                var hdrs = { 'Content-Type': 'application/json' };
+                if (proactiveSec && typeof proactiveSec.getMutationHeaders === 'function') {
+                    try { Object.assign(hdrs, await proactiveSec.getMutationHeaders()); } catch (_) { }
+                }
+                return fetch('/api/proactive_chat', {
+                    method: 'POST',
+                    headers: hdrs,
+                    body: proactiveBody,
+                });
             }
-            var response = await fetch('/api/proactive_chat', {
-                method: 'POST',
-                headers: proactiveHeaders,
-                body: JSON.stringify(requestBody)
-            });
+
+            var response = await _sendProactive();
+
+            // CSRF-403 retry-once: 只在 error_code === 'csrf_validation_failed'
+            // 时调 refreshToken() + 重试一次。其它 403 走真实失败分支，避免把所有
+            // 403 当 benign pass，让 token 过期后 proactive 静默停摆（CodeRabbit
+            // Major on PR #1530）。
+            if (response.status === 403
+                && proactiveSec
+                && typeof proactiveSec.refreshToken === 'function'
+                && await _proactiveIsCsrfValidationFailure(response)) {
+                try {
+                    await proactiveSec.refreshToken();
+                    response = await _sendProactive();
+                } catch (_) { /* fall through to 403 handling below */ }
+            }
+
             // HTTP 409 = server try_start_proactive 因并发拒绝（AI 还在响应上一轮 /
             // 另一路 proactive 已占坑，见 main_routers/system_router.py:4241-4247）。
             // 本次请求**根本没真正发起**一次 proactive——server 在 claim 那一步就早退
@@ -1089,11 +1160,11 @@
             // 越沉默"。这里 requestSent 故意不翻 true、return false 让上游识别为"没
             // 真发"、下一轮按 base interval 重排，不动 level。
             //
-            // HTTP 403 = CSRF/Origin 守卫拒绝（CodeRabbit on PR #1530）。token
-            // bootstrap 还没完成前的启动竞速窗口会撞到这个；语义同 409——server
-            // 没跑业务逻辑、没消耗资源。当 attempt 计入 backoff 会让"刚开机
-            // 几秒里 token 没就位"被惩罚性升级，跟 server 实际负载/用户活动
-            // 状态正交。下一轮 token 通常已到位，按 base interval 重排即可。
+            // HTTP 403 csrf_validation_failed = 统一守卫拒绝（refresh+retry 后仍失败）。
+            // 跟 409 同语义——server 没跑业务逻辑、没消耗资源；非 csrf 的 403（业务
+            // 规则 / 反代 / WAF）会跳过上面的 retry 落到这里，同样按"不消耗 attempt"
+            // 处理，避免把"刚开机几秒里 token 没就位 / 部署中间态"惩罚性升级
+            // backoff。下一轮 token 通常已到位，按 base interval 重排即可。
             if (response.status === 409 || response.status === 403) {
                 console.log('[ProactiveChat] server 拒绝 ('
                     + response.status + ')，不消耗 backoff attempt');

--- a/static/app.js
+++ b/static/app.js
@@ -361,11 +361,28 @@ window.addEventListener('load', async () => {
                 if (sec && typeof sec.getMutationHeaders === 'function') {
                     try { Object.assign(ackHeaders, await sec.getMutationHeaders()); } catch (_) { }
                 }
-                await fetch('/api/pending-notices/ack', {
-                    method: 'POST',
-                    headers: ackHeaders,
-                    body: JSON.stringify({ cursor }),
-                }).catch(() => { });
+                // 不能静默 .catch —— CodeRabbit on PR #1530 指出：如果 ACK
+                // 因为 token 还没注入返了 403，原来的 `.catch(() => {})` 会
+                // 当成成功，但后端没真正 drain cursor，下次启动还会再弹同一批。
+                // 显式检查 response.ok + 在失败时 console.warn，让"下次启动
+                // GET /api/pending-notices 仍带这批 → 再 ACK 一次"自然成为
+                // 重试路径，不在这里硬塞 retry/queue 复杂度。
+                try {
+                    const ackResp = await fetch('/api/pending-notices/ack', {
+                        method: 'POST',
+                        headers: ackHeaders,
+                        body: JSON.stringify({ cursor }),
+                    });
+                    if (!ackResp.ok) {
+                        console.warn(
+                            '[pending-notices/ack] backend rejected ack '
+                            + 'with HTTP ' + ackResp.status
+                            + '; notices will be re-shown on next page load',
+                        );
+                    }
+                } catch (e) {
+                    console.warn('[pending-notices/ack] ack request failed:', e);
+                }
             }
         } catch (_) { }
     })();

--- a/static/app.js
+++ b/static/app.js
@@ -356,9 +356,14 @@ window.addEventListener('load', async () => {
                 // 先全部入队（不 await），让 UI 能感知队列长度以显示"下一个"按钮
                 const promises = notices.filter(Boolean).map(n => window.showProminentNotice(n));
                 await Promise.all(promises);
+                const ackHeaders = { 'Content-Type': 'application/json' };
+                const sec = window.nekoLocalMutationSecurity;
+                if (sec && typeof sec.getMutationHeaders === 'function') {
+                    try { Object.assign(ackHeaders, await sec.getMutationHeaders()); } catch (_) { }
+                }
                 await fetch('/api/pending-notices/ack', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: ackHeaders,
                     body: JSON.stringify({ cursor }),
                 }).catch(() => { });
             }

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -915,16 +915,25 @@
         lastMusicPlayedThroughKey = trackKey;
         lastMusicPlayedThroughAt = now;
         const lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
-        try {
-            fetch('/api/proactive/music_played_through', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    lanlan_name: lanlanName,
-                    track: track ? { name: track.name, artist: track.artist, url: track.url } : null
-                })
-            }).catch(() => { /* 后端不可达不影响播放体验 */ });
-        } catch (e) { /* fetch 不可用：忽略 */ }
+        // fire-and-forget：用 async IIFE 包一层，让 getMutationHeaders 能 await
+        // 但不阻塞外层调用方（aplayer 'ended' 回调本身不关心后端是否成功）。
+        (async () => {
+            const playedHeaders = { 'Content-Type': 'application/json' };
+            const sec = window.nekoLocalMutationSecurity;
+            if (sec && typeof sec.getMutationHeaders === 'function') {
+                try { Object.assign(playedHeaders, await sec.getMutationHeaders()); } catch (_) { }
+            }
+            try {
+                await fetch('/api/proactive/music_played_through', {
+                    method: 'POST',
+                    headers: playedHeaders,
+                    body: JSON.stringify({
+                        lanlan_name: lanlanName,
+                        track: track ? { name: track.name, artist: track.artist, url: track.url } : null
+                    })
+                });
+            } catch (_) { /* 后端不可达不影响播放体验 */ }
+        })();
     }
 
     // 全局监听管理

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -384,9 +384,14 @@ async function processIncrementalTranslationQueue(requestSnapId) {
         if (requestSnapId !== incrementalRequestId) return;
 
         var targetLanguage = userLanguage !== null ? userLanguage : 'zh';
+        var translateHeaders = { 'Content-Type': 'application/json' };
+        var translateSec = window.nekoLocalMutationSecurity;
+        if (translateSec && typeof translateSec.getMutationHeaders === 'function') {
+            try { Object.assign(translateHeaders, await translateSec.getMutationHeaders()); } catch (_) { }
+        }
         var response = await fetch('/api/translate', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: translateHeaders,
             body: JSON.stringify({
                 text: textToTranslate,
                 target_lang: targetLanguage,

--- a/tests/unit/test_uncovered_endpoints_csrf.py
+++ b/tests/unit/test_uncovered_endpoints_csrf.py
@@ -1,0 +1,99 @@
+"""CSRF/Origin canary tests for previously-unguarded local mutation endpoints.
+
+These endpoints used to be `@router.post` with no `_validate_local_mutation_request`
+gate. The security follow-up (issue #1479) brought them under the unified guard.
+This file guarantees the guard stays wired up: each endpoint must reject a
+request with no Origin and no CSRF token with 403 + ``csrf_validation_failed``.
+
+We intentionally do NOT exercise the happy path here — that would require
+mocking Steamworks / session_manager / LLM / translation backends, which is
+out of scope. The negative path alone is enough to detect anyone accidentally
+removing the guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from main_routers import system_router as system_router_module
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_memory_server():
+    """Override repo-level autouse fixture; router-only tests don't need it."""
+    yield
+
+
+@pytest.fixture
+def unauthenticated_client():
+    """Client that sends NO Origin and NO X-CSRF-Token — the guard's null
+    inputs. Use this to verify each protected endpoint rejects with 403.
+    """
+    app = FastAPI()
+    app.include_router(system_router_module.router)
+    with TestClient(app) as client:
+        yield client
+
+
+# Each entry: (endpoint path, method-specific kwargs).
+# Use POSTs only — these are mutation endpoints.
+UNCOVERED_ENDPOINTS: list[tuple[str, dict]] = [
+    ("/api/pending-notices/ack", {"json": {"cursor": 0}}),
+    ("/api/emotion/analysis", {"json": {"text": "hello"}}),
+    ("/api/steam/set-achievement-status/PLAY_GAME", {}),
+    ("/api/steam/update-playtime", {"json": {"seconds": 10}}),
+    ("/api/proactive_chat", {"json": {"lanlan_name": "Yui"}}),
+    ("/api/proactive/music_played_through", {"json": {"lanlan_name": "Yui"}}),
+    ("/api/translate", {"json": {"text": "hello", "target_lang": "zh"}}),
+    ("/api/personal_dynamics", {"json": {"limit": 5}}),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("endpoint,kwargs", UNCOVERED_ENDPOINTS)
+def test_endpoint_rejects_request_without_csrf_and_origin(
+    unauthenticated_client, endpoint: str, kwargs: dict
+):
+    """No Origin, no CSRF token → 403 ``csrf_validation_failed``.
+
+    Canary against future regressions: anyone removing the guard from one of
+    these endpoints will see this test fail with a clear endpoint path.
+    """
+    response = unauthenticated_client.post(endpoint, **kwargs)
+    assert response.status_code == 403, (
+        f"{endpoint} should reject unauthenticated POST with 403, "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+    body = response.json()
+    assert body.get("error_code") == "csrf_validation_failed", (
+        f"{endpoint} should return csrf_validation_failed error code, "
+        f"got: {body}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("endpoint,kwargs", UNCOVERED_ENDPOINTS)
+def test_endpoint_rejects_request_with_wrong_csrf_token(
+    unauthenticated_client, endpoint: str, kwargs: dict
+):
+    """Same-origin browser request but wrong CSRF token → 403.
+
+    Covers the realistic attacker scenario: a malicious page running in the
+    same origin context (e.g., a compromised localhost dev server on the same
+    port range) that can read Origin but not the per-instance CSRF token.
+    """
+    response = unauthenticated_client.post(
+        endpoint,
+        headers={
+            "Origin": "http://testserver",
+            "X-CSRF-Token": "wrong-token-not-the-real-one",
+        },
+        **kwargs,
+    )
+    assert response.status_code == 403, (
+        f"{endpoint} should reject wrong-CSRF POST with 403, "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+    assert response.json().get("error_code") == "csrf_validation_failed"


### PR DESCRIPTION
## Summary

跟进 [#1479](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1479) **Step 1**。在 [#1477](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1477) 把 activity_signal 临时同源校验落地之后，仓库里还有 8 个 browser-facing 的 POST 端点没接入 `_validate_local_mutation_request` 统一守卫——任何跑在用户浏览器里的 drive-by 页面都能直接对它们发 POST。本 PR 把它们一次性收口。

- **后端**：8 个 handler 头部加 `_validate_local_mutation_request(request)`：
  - `/api/pending-notices/ack`、`/api/emotion/analysis`、`/api/steam/set-achievement-status/{name}`（顺便补上缺失的 `request: Request` 参数）、`/api/steam/update-playtime`、`/api/proactive_chat`、`/api/proactive/music_played_through`、`/api/translate`、`/api/personal_dynamics`
- **前端**：对应 7 个调用方改成走 `window.nekoLocalMutationSecurity.getMutationHeaders()` 注入 `X-CSRF-Token` —— [app.js](static/app.js)（pending-notices/ack）、[app-buttons.js](static/app-buttons.js)（emotion/analysis）、[achievement_manager.js](static/achievement_manager.js) ×2（steam）、[app-proactive.js](static/app-proactive.js) ×2（proactive_chat 语音 + 常规）、[music_ui.js](static/music_ui.js)（music_played_through，用 async IIFE 保留 fire-and-forget 语义）、[subtitle.js](static/subtitle.js)（translate）。每个调用点都做了 `if (sec && getMutationHeaders)` 的兜底，即使 `app-prompt-shared.js` 尚未加载也不会抛错（会被后端拒绝但不破坏页面）。
- **测试**：[tests/unit/test_uncovered_endpoints_csrf.py](tests/unit/test_uncovered_endpoints_csrf.py) 用 `parametrize` 给这 8 个端点各打 2 条 canary（无 Origin 无 token → 403；同源但 token 不匹配 → 403），共 16 个 case 全部通过；现有 tutorial_prompt / screenshot / activity_signal / music_played_through_reset 测试无 regression（133 passed）。

## 范围说明

- `/api/personal_dynamics` 目前没有任何前端调用方，是 dead code，但仍接入守卫——未来如果有人复活这个端点，至少默认是受保护的。删除决定单独跟进，不在本 PR 范围。
- 本 PR 只补"缺失的守卫"，**不动 `/api/activity_signal` 自身**（它仍用自定义 Origin gate，无 CSRF），那是 Step 2 的工作。
- 不引入新的配置项 / feature flag —— `_validate_local_mutation_request` 现有的"有 Origin 必须有 CSRF / 无 Origin 放行"规则在所有新接入端点上都直接生效。

## Test plan

- [x] `pytest tests/unit/test_uncovered_endpoints_csrf.py -v` — 16/16 passed
- [x] `pytest tests/unit/test_tutorial_prompt_router.py tests/unit/test_system_screenshot_router.py tests/unit/test_activity_signal_router.py tests/unit/test_music_played_through_reset.py` — 117/117 passed（验证无 regression）
- [ ] 手动验证：本地起服，浏览器触发音乐播放完毕 / 主动搭话 / 字幕翻译 / 成就解锁 / 通知 ack 流程，确认不被 403 拒绝
- [ ] 跨源攻击模拟：用 `curl -H 'Origin: https://evil.com' -X POST http://localhost:48911/api/proactive_chat ...` 确认收到 403 + `csrf_validation_failed`

---
Co-Authored-By: Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 强化多个本地变更型 POST 接口的请求验证，统一执行 CSRF/Origin 校验，提升安全性（通知确认、情感分析、成就/时长上报、主动对话、音乐上报、翻译、个人动态等）。
* **New Features**
  * 客户端请求在可用时会合并额外的安全请求头；主动对话在遇到特定 403 错误时会尝试一次刷新并重试，改进鲁棒性。
* **Documentation**
  * 调整了翻译接口的请求格式说明文字（无逻辑变更）。
* **Tests**
  * 新增针对上述端点的 CSRF/Origin 验证测试覆盖。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->