### PR TITLE
security(csrf): activity_signal 收编进 _validate_local_mutation_request + 前端 403 退避 (#1479 Step 2)

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -7354,6 +7354,50 @@ async def translate_text_api(request: Request):
             "target_lang": "zh"
         }
 
+# ========== 个性化内容接口 ==========
+
+@router.post('/personal_dynamics')
+async def get_personal_dynamics(request: Request):
+    """
+    获取个性化内容数据
+    """
+    from utils.web_scraper import fetch_personal_dynamics, format_personal_dynamics
+    try:
+
+        data = await request.json()
+        limit = data.get('limit', 10)
+
+        # 获取个性化内容
+        personal_content = await fetch_personal_dynamics(limit=limit)
+
+        if not personal_content['success']:
+            return JSONResponse({
+                "success": False,
+                "error": "无法获取个性化内容",
+                "detail": personal_content.get('error', '未知错误')
+            }, status_code=500)
+
+        # 格式化内容用于前端显示
+        formatted_content = format_personal_dynamics(personal_content)
+
+        return JSONResponse({
+            "success": True,
+            "data": {
+                "raw": personal_content,
+                "formatted": formatted_content,
+                "platforms": [k for k in personal_content.keys() if k not in ('success', 'error', 'region')]
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"获取个性化内容失败: {e}")
+        return JSONResponse({
+            "success": False,
+            "error": "服务器内部错误",
+            "detail": str(e)
+        }, status_code=500)
+
+
 # Self-register the mini-game-invite keyword matcher with main_logic's
 # event bus. Same rationale as plugin/core/state.py: ``main_logic.core``
 # previously imported this function directly (a layering inversion);

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4249,20 +4249,24 @@ async def push_activity_signal(request: Request):
 
     Auth:
 
-    * Origin-present same-origin gate (zero-frontend-cost defence,
-      suggested by CodeRabbit on PR #1477): when the request carries an
-      ``Origin`` / ``Referer`` header AND that origin isn't in
-      ``_get_allowed_local_origins`` (which always includes the current
-      ``request.base_url``), reject with 403. Browser-mediated requests
-      always carry ``Origin`` for POST, so this single check blocks
-      cross-site drive-by JS without breaking ``curl`` / Electron's
-      same-origin renderer / native scripts (no Origin → allowed).
+    * Unified ``_validate_local_mutation_request`` guard (issue #1479
+      Step 2): same Origin + ``X-CSRF-Token`` contract every other
+      browser-facing mutation endpoint uses (tutorial-prompt,
+      screenshot, autostart-prompt, …). Replaces PR #1477's interim
+      Origin-only gate. Same-origin Electron renderers and browser
+      tabs send ``X-CSRF-Token`` via
+      ``window.nekoLocalMutationSecurity`` (token is exposed by
+      ``GET /api/config/page_config``); curl / Electron main-process /
+      native scripts that don't run the token bootstrap are now
+      rejected because *CSRF ≠ authentication* — pushing activity
+      from outside the same browsing context isn't a supported path
+      (see ``docs/design/security/local-mutation-auth.md`` for the
+      threat model). The guard already rejects ``Origin: null`` /
+      opaque origins because ``_normalize_origin_value`` returns
+      ``""`` for them, which then fails the membership check.
     * Per-lanlan 5s rate limit below + the tracker's per-character
-      lookup raise spam cost and bound the impact even if Origin
-      validation passes.
-    * A stricter CSRF token mechanism (parity with screenshot endpoints)
-      is tracked for a follow-up security-hardening PR; the threat
-      model write-up lives in issue #1023.
+      lookup raise spam cost and bound the impact even if the guard
+      somehow passes.
 
     Body fields (all optional except ``lanlan_name``):
       * ``lanlan_name`` (required) — which character's tracker to update
@@ -4272,44 +4276,14 @@ async def push_activity_signal(request: Request):
       * ``cpu_avg_30s`` — float in ``[0, 100]``, rolling CPU average
       * ``gpu_utilization`` — float in ``[0, 100]``, primary GPU utilisation
 
-    Returns 200 on success, 400 on malformed payload, 404 if
-    ``lanlan_name`` isn't registered, 429 if pushed faster than
-    ``_EXTERNAL_SIGNAL_MIN_INTERVAL`` (5s), 503 if the character's
-    tracker hasn't initialised yet.
+    Returns 200 on success, 400 on malformed payload, 403 on
+    Origin/CSRF rejection, 404 if ``lanlan_name`` isn't registered,
+    429 if pushed faster than ``_EXTERNAL_SIGNAL_MIN_INTERVAL`` (5s),
+    503 if the character's tracker hasn't initialised yet.
     """
-    # ── Origin-present same-origin gate ────────────────────────────
-    # When the request carries an Origin (or Referer fallback) but it's
-    # not in our allowed-origins set, refuse — that's the drive-by CSRF
-    # signature. Missing Origin means a non-browser caller (curl, Node,
-    # native script) which we explicitly allow because there's no
-    # mandatory CSRF token yet. Same-origin browser requests pass
-    # naturally because their Origin matches ``request.base_url``,
-    # which ``_get_allowed_local_origins`` always includes.
-    #
-    # Opaque-origin guard (Codex F5 on PR #1477): browsers send the
-    # literal string ``"null"`` as Origin for sandboxed iframes,
-    # ``file://`` pages, and certain extension contexts. ``urlsplit``
-    # parses "null" into an empty scheme/netloc which
-    # ``_normalize_origin_value`` turns into ``""`` — without this
-    # check that bypasses to the no-Origin "allowed" branch. We
-    # explicitly reject the raw "null" string before normalisation, on
-    # both Origin and Referer (the latter is our fallback).
-    raw_origin = (request.headers.get("origin") or "").strip().lower()
-    raw_referer = (request.headers.get("referer") or "").strip().lower()
-    if raw_origin == "null" or raw_referer == "null":
-        return _json_no_store_response(
-            {"success": False, "error": "origin not allowed"},
-            status_code=403,
-        )
-
-    request_origin = _get_request_origin(request)
-    if request_origin:
-        allowed = _get_allowed_local_origins(request)
-        if request_origin not in allowed:
-            return _json_no_store_response(
-                {"success": False, "error": "origin not allowed"},
-                status_code=403,
-            )
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
 
     try:
         data = await request.json()
@@ -7379,50 +7353,6 @@ async def translate_text_api(request: Request):
             "source_lang": "unknown",
             "target_lang": "zh"
         }
-
-# ========== 个性化内容接口 ==========
-
-@router.post('/personal_dynamics')
-async def get_personal_dynamics(request: Request):
-    """
-    获取个性化内容数据
-    """
-    from utils.web_scraper import fetch_personal_dynamics, format_personal_dynamics
-    try:
-        
-        data = await request.json()
-        limit = data.get('limit', 10)
-        
-        # 获取个性化内容
-        personal_content = await fetch_personal_dynamics(limit=limit)
-        
-        if not personal_content['success']:
-            return JSONResponse({
-                "success": False,
-                "error": "无法获取个性化内容",
-                "detail": personal_content.get('error', '未知错误')
-            }, status_code=500)
-        
-        # 格式化内容用于前端显示
-        formatted_content = format_personal_dynamics(personal_content)
-        
-        return JSONResponse({
-            "success": True,
-            "data": {
-                "raw": personal_content,
-                "formatted": formatted_content,
-                "platforms": [k for k in personal_content.keys() if k not in ('success', 'error', 'region')]
-            }
-        })
-        
-    except Exception as e:
-        logger.error(f"获取个性化内容失败: {e}")
-        return JSONResponse({
-            "success": False,
-            "error": "服务器内部错误",
-            "detail": str(e)
-        }, status_code=500)
-
 
 # Self-register the mini-game-invite keyword matcher with main_logic's
 # event bus. Same rationale as plugin/core/state.py: ``main_logic.core``

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4281,8 +4281,19 @@ async def push_activity_signal(request: Request):
     429 if pushed faster than ``_EXTERNAL_SIGNAL_MIN_INTERVAL`` (5s),
     503 if the character's tracker hasn't initialised yet.
     """
-    validation_error = _validate_local_mutation_request(request)
+    # ``error_defaults`` so the 403 body includes ``success: false``
+    # alongside the unified guard's ``ok/error_code`` fields — keeps
+    # the contract consistent with this endpoint's other error
+    # branches (existing frontend / tests grep ``success``). Also
+    # apply ``_set_no_store_headers`` since the rest of this handler's
+    # responses use that and a cached 403 would mask post-bootstrap
+    # success on the next tick (CodeRabbit Minor on PR #1532).
+    validation_error = _validate_local_mutation_request(
+        request,
+        error_defaults={"success": False},
+    )
     if validation_error is not None:
+        _set_no_store_headers(validation_error)
         return validation_error
 
     try:

--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -170,6 +170,35 @@
         return {};
     }
 
+    /**
+     * Read a 403 response body and decide whether the rejection came
+     * from ``_validate_local_mutation_request`` (i.e. CSRF/Origin
+     * guard) vs. any other 403 — business rule, downstream service,
+     * future role-based check, etc. Mirrors the contract in
+     * ``static/app-prompt-shared.js`` 436-541 and
+     * ``static/universal-tutorial-manager.js`` 120-134: only
+     * ``error_code === "csrf_validation_failed"`` triggers the
+     * refresh / retry / stop-the-heartbeat path (CodeRabbit Major on
+     * PR #1532).
+     *
+     * ``resp.clone()`` so the caller can still read the original body
+     * if they need to (and so the original ``Response.bodyUsed`` flag
+     * doesn't trip on a second consumer).
+     */
+    async function isCsrfValidationFailure(resp) {
+        if (!resp || resp.status !== 403) return false;
+        try {
+            var cloned = typeof resp.clone === 'function' ? resp.clone() : resp;
+            var body = await cloned.json();
+            return Boolean(body && body.error_code === 'csrf_validation_failed');
+        } catch (_) {
+            // Non-JSON 403 body / parse failure → not a unified-guard
+            // rejection; treat as a generic 403 (could be a reverse
+            // proxy / WAF / future business rule).
+            return false;
+        }
+    }
+
     async function pushOnce(lanlanName) {
         // Set the in-flight latch BEFORE the bridge read so two ticks
         // can't both clear the ``if (inFlight)`` check while one is
@@ -227,21 +256,32 @@
             }
 
             var resp = await sendOnce();
+            // CodeRabbit Major on PR #1532: only the unified-guard's
+            // ``csrf_validation_failed`` rejection should drive the
+            // refresh / retry / stop-the-heartbeat path. Other 403s
+            // (future business rules, reverse proxy, WAF, …) need to
+            // go through the generic-failure branch instead.
+            var isCsrf403 = await isCsrfValidationFailure(resp);
 
-            // 403 retry-once: the page_config token bootstrap might not
-            // have completed on the very first heartbeat tick. Try
-            // refreshing the cached token and resending before
-            // counting this toward the stop-the-heartbeat threshold.
-            // Do NOT retry on the *second* 403 of the same call —
-            // that means the token's genuinely unavailable, not a
-            // race, and a tight retry loop would just double the
+            // CSRF-403 retry-once: the page_config token bootstrap
+            // might not have completed on the very first heartbeat
+            // tick. Try refreshing the cached token and resending
+            // before counting this toward the stop-the-heartbeat
+            // threshold. Do NOT retry on the *second* 403 of the same
+            // call — that means the token's genuinely unavailable,
+            // not a race, and a tight retry loop would just double the
             // 403 rate.
-            if (resp.status === 403) {
+            if (isCsrf403) {
                 var sec = window.nekoLocalMutationSecurity;
                 if (sec && typeof sec.refreshToken === 'function') {
                     try {
                         await sec.refreshToken();
                         resp = await sendOnce();
+                        // Re-classify after retry — a successful retry
+                        // turns this from a CSRF-403 into 200 / 4xx /
+                        // 5xx, and we want the rest of this function
+                        // to treat it that way.
+                        isCsrf403 = await isCsrfValidationFailure(resp);
                     } catch (_) { /* fall through to 403 handling below */ }
                 }
             }
@@ -257,21 +297,29 @@
                 return;
             }
 
-            if (resp.status === 403) {
+            // Any non-CSRF response (any 200/4xx/5xx that isn't
+            // ``csrf_validation_failed``) breaks the *consecutive*
+            // CSRF streak — without this, alternating CSRF-403 / 500
+            // / non-CSRF-403 sequences would still trip the
+            // stop-the-heartbeat threshold (Codex P2 on PR #1532).
+            if (!isCsrf403) {
+                consecutiveCsrfFailures = 0;
+            }
+
+            if (isCsrf403) {
                 // CSRF/Origin gate rejected us — different failure
                 // mode from 5xx (transient backend issue, retry) or
-                // 4xx-business (skip). 403 means our request shape
-                // can't make it past the guard; spinning forever just
-                // burns cycles. Track separately and stop the
-                // heartbeat after MAX_CONSECUTIVE_CSRF_FAILURES so the
-                // tracker degrades cleanly to its local collector
-                // instead of looking up at silent 403s forever.
+                // 4xx-business (skip). Spinning forever just burns
+                // cycles. Track separately and stop the heartbeat
+                // after MAX_CONSECUTIVE_CSRF_FAILURES so the tracker
+                // degrades cleanly to its local collector instead of
+                // looking up at silent 403s forever.
                 consecutiveCsrfFailures++;
                 if (consecutiveCsrfFailures <= LOG_FAILURE_QUIET_THRESHOLD) {
                     console.warn(
-                        '[activity-signal] push rejected with 403 '
-                        + '(CSRF/Origin); token may not be granted '
-                        + 'yet — will retry.',
+                        '[activity-signal] push rejected with '
+                        + 'csrf_validation_failed; token may not be '
+                        + 'granted yet — will retry.',
                     );
                 }
                 if (consecutiveCsrfFailures >= MAX_CONSECUTIVE_CSRF_FAILURES
@@ -280,9 +328,10 @@
                     console.error(
                         '[activity-signal] '
                         + consecutiveCsrfFailures
-                        + ' consecutive 403s — heartbeat stopped to '
-                        + 'avoid silent spin. Tracker will fall back '
-                        + 'to its local collector (degraded mode on '
+                        + ' consecutive csrf_validation_failed '
+                        + 'rejections — heartbeat stopped to avoid '
+                        + 'silent spin. Tracker will fall back to its '
+                        + 'local collector (degraded mode on '
                         + 'non-Windows / remote backends). To '
                         + 'diagnose: verify '
                         + '``window.nekoLocalMutationSecurity`` is '
@@ -294,20 +343,13 @@
                 return;
             }
 
-            // Non-403 response (4xx-business / 5xx / 429 / etc) — the
-            // server is reachable and the CSRF guard let us past, so
-            // the *consecutive* 403 streak is broken. Without this,
-            // an alternating sequence like 403, 500, 403, 500, ...
-            // would accumulate 6 lifetime 403s and trip the
-            // stop-the-heartbeat threshold even though none of them
-            // were truly consecutive (Codex P2 on PR #1532).
-            consecutiveCsrfFailures = 0;
-
-            // 429 = rate-limited (we're heartbeating too fast somehow — shouldn't
-            // happen with the 5s interval, but if it does we just skip).
-            // 404 = lanlan_name not registered yet (boot race) — silent.
-            // 503 = tracker not yet initialised (boot race) — silent.
-            // Anything else: count toward failure log throttle.
+            // Generic failure path:
+            //   429 = rate-limited (we're heartbeating too fast somehow — shouldn't
+            //       happen with the 5s interval, but if it does we just skip).
+            //   404 = lanlan_name not registered yet (boot race) — silent.
+            //   503 = tracker not yet initialised (boot race) — silent.
+            //   Other 4xx (including non-CSRF 403s like reverse-proxy rejects)
+            //       and 5xx → count toward generic failure log throttle.
             if (resp.status !== 429 && resp.status !== 404 && resp.status !== 503) {
                 consecutiveFailures++;
                 if (consecutiveFailures <= LOG_FAILURE_QUIET_THRESHOLD) {

--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -294,6 +294,15 @@
                 return;
             }
 
+            // Non-403 response (4xx-business / 5xx / 429 / etc) — the
+            // server is reachable and the CSRF guard let us past, so
+            // the *consecutive* 403 streak is broken. Without this,
+            // an alternating sequence like 403, 500, 403, 500, ...
+            // would accumulate 6 lifetime 403s and trip the
+            // stop-the-heartbeat threshold even though none of them
+            // were truly consecutive (Codex P2 on PR #1532).
+            consecutiveCsrfFailures = 0;
+
             // 429 = rate-limited (we're heartbeating too fast somehow — shouldn't
             // happen with the 5s interval, but if it does we just skip).
             // 404 = lanlan_name not registered yet (boot race) — silent.
@@ -308,6 +317,11 @@
                 }
             }
         } catch (e) {
+            // Network error / fetch threw — we never heard back from
+            // the server, so this is NOT a CSRF rejection. Don't let
+            // network blips contribute to the 403 streak (Codex P2 on
+            // PR #1532).
+            consecutiveCsrfFailures = 0;
             consecutiveFailures++;
             if (consecutiveFailures <= LOG_FAILURE_QUIET_THRESHOLD) {
                 console.warn('[activity-signal] push exception:', e);

--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -38,11 +38,22 @@
     // After this many consecutive failures, throttle the log spam (we
     // keep retrying, just stop printing every time).
     var LOG_FAILURE_QUIET_THRESHOLD = 3;
+    // After this many consecutive 403s (CSRF/Origin rejections), STOP
+    // the heartbeat — not throttle it, stop it. Issue #1479 / wehos:
+    // a 5s heartbeat that 403s forever is a silent permanent
+    // degradation (tracker falls back to local collector but nothing
+    // visible alerts the user, and we're burning HTTP cycles for
+    // nothing). 6 ticks × 5s = 30s = 2× the tracker TTL — enough room
+    // for the page_config token bootstrap to win any boot-time race
+    // before we give up.
+    var MAX_CONSECUTIVE_CSRF_FAILURES = 6;
     var ENDPOINT = '/api/activity_signal';
 
     var heartbeatTimer = null;
     var inFlight = false;            // re-entrancy guard if the previous POST is still running
     var consecutiveFailures = 0;
+    var consecutiveCsrfFailures = 0; // dedicated counter for 403 — separate from generic failures so transient 5xx don't trip the stop-the-heartbeat gate
+    var heartbeatStoppedDueToCsrf = false; // sticky flag: once we give up, don't auto-restart on visibilitychange
     var hasLoggedBridgeMissing = false;
 
     function resolveLanlanName() {
@@ -141,6 +152,24 @@
         }
     }
 
+    /**
+     * Resolve the X-CSRF-Token header from
+     * ``window.nekoLocalMutationSecurity`` (set up by
+     * ``static/app-prompt-shared.js`` after fetching
+     * ``/api/config/page_config``). Returns ``{}`` if the helper is
+     * missing or throws — the backend will then reject with 403 and
+     * the caller's retry path handles it.
+     */
+    async function getCsrfMutationHeaders() {
+        try {
+            var sec = window.nekoLocalMutationSecurity;
+            if (sec && typeof sec.getMutationHeaders === 'function') {
+                return await sec.getMutationHeaders();
+            }
+        } catch (_) { /* fall through */ }
+        return {};
+    }
+
     async function pushOnce(lanlanName) {
         // Set the in-flight latch BEFORE the bridge read so two ticks
         // can't both clear the ``if (inFlight)`` check while one is
@@ -180,22 +209,91 @@
                 return;
             }
             payload.lanlan_name = lanlanName;
-            var resp = await fetch(ENDPOINT, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
-                cache: 'no-store',
-                // Don't keep the page alive on close just for the heartbeat.
-                keepalive: false,
-            });
+            var body = JSON.stringify(payload);
+
+            async function sendOnce() {
+                var csrfHeaders = await getCsrfMutationHeaders();
+                return fetch(ENDPOINT, {
+                    method: 'POST',
+                    headers: Object.assign(
+                        { 'Content-Type': 'application/json' },
+                        csrfHeaders,
+                    ),
+                    body: body,
+                    cache: 'no-store',
+                    // Don't keep the page alive on close just for the heartbeat.
+                    keepalive: false,
+                });
+            }
+
+            var resp = await sendOnce();
+
+            // 403 retry-once: the page_config token bootstrap might not
+            // have completed on the very first heartbeat tick. Try
+            // refreshing the cached token and resending before
+            // counting this toward the stop-the-heartbeat threshold.
+            // Do NOT retry on the *second* 403 of the same call —
+            // that means the token's genuinely unavailable, not a
+            // race, and a tight retry loop would just double the
+            // 403 rate.
+            if (resp.status === 403) {
+                var sec = window.nekoLocalMutationSecurity;
+                if (sec && typeof sec.refreshToken === 'function') {
+                    try {
+                        await sec.refreshToken();
+                        resp = await sendOnce();
+                    } catch (_) { /* fall through to 403 handling below */ }
+                }
+            }
+
             if (resp.ok) {
-                if (consecutiveFailures > 0) {
+                if (consecutiveFailures > 0 || consecutiveCsrfFailures > 0) {
                     console.info('[activity-signal] recovered after '
-                        + consecutiveFailures + ' failure(s)');
+                        + (consecutiveFailures + consecutiveCsrfFailures)
+                        + ' failure(s)');
                 }
                 consecutiveFailures = 0;
+                consecutiveCsrfFailures = 0;
                 return;
             }
+
+            if (resp.status === 403) {
+                // CSRF/Origin gate rejected us — different failure
+                // mode from 5xx (transient backend issue, retry) or
+                // 4xx-business (skip). 403 means our request shape
+                // can't make it past the guard; spinning forever just
+                // burns cycles. Track separately and stop the
+                // heartbeat after MAX_CONSECUTIVE_CSRF_FAILURES so the
+                // tracker degrades cleanly to its local collector
+                // instead of looking up at silent 403s forever.
+                consecutiveCsrfFailures++;
+                if (consecutiveCsrfFailures <= LOG_FAILURE_QUIET_THRESHOLD) {
+                    console.warn(
+                        '[activity-signal] push rejected with 403 '
+                        + '(CSRF/Origin); token may not be granted '
+                        + 'yet — will retry.',
+                    );
+                }
+                if (consecutiveCsrfFailures >= MAX_CONSECUTIVE_CSRF_FAILURES
+                    && !heartbeatStoppedDueToCsrf) {
+                    heartbeatStoppedDueToCsrf = true;
+                    console.error(
+                        '[activity-signal] '
+                        + consecutiveCsrfFailures
+                        + ' consecutive 403s — heartbeat stopped to '
+                        + 'avoid silent spin. Tracker will fall back '
+                        + 'to its local collector (degraded mode on '
+                        + 'non-Windows / remote backends). To '
+                        + 'diagnose: verify '
+                        + '``window.nekoLocalMutationSecurity`` is '
+                        + 'exposed and ``GET /api/config/page_config``'
+                        + ' returns ``autostart_csrf_token``.',
+                    );
+                    stop();
+                }
+                return;
+            }
+
             // 429 = rate-limited (we're heartbeating too fast somehow — shouldn't
             // happen with the 5s interval, but if it does we just skip).
             // 404 = lanlan_name not registered yet (boot race) — silent.
@@ -222,6 +320,17 @@
     function start() {
         if (heartbeatTimer !== null) {
             return; // already running
+        }
+        if (heartbeatStoppedDueToCsrf) {
+            // We previously gave up after MAX_CONSECUTIVE_CSRF_FAILURES.
+            // ``visibilitychange`` would normally restart the timer
+            // when the tab comes back; suppress that here so a hidden
+            // → visible flip doesn't undo the explicit stop. A page
+            // reload starts the heartbeat fresh (sticky flag is
+            // module-scoped, not persisted), which is the right
+            // recovery path because that's also when the
+            // ``nekoLocalMutationSecurity`` helper re-bootstraps.
+            return;
         }
         if (!hasBridge()) {
             if (!hasLoggedBridgeMissing) {

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -354,6 +354,13 @@ def test_no_origin_no_csrf_blocked_with_403(monkeypatch):
     same browsing context isn't a supported deployment shape (see the
     threat model in ``docs/design/security/local-mutation-auth.md``).
     Same shape as every other browser-facing mutation endpoint now.
+
+    Body contract (CodeRabbit Minor on PR #1532): the 403 must carry
+    both ``ok: false`` + ``error_code`` (unified guard shape) AND
+    ``success: false`` (this endpoint's historical shape). Cache must
+    be ``no-store`` to match the rest of activity_signal's responses,
+    or a transient bootstrap-window 403 could get cached and mask a
+    later post-bootstrap success.
     """
     mgr, tracker = _build_mgr()
     client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
@@ -364,7 +371,13 @@ def test_no_origin_no_csrf_blocked_with_403(monkeypatch):
     )
 
     assert resp.status_code == 403, resp.text
-    assert resp.json().get("error_code") == "csrf_validation_failed"
+    body = resp.json()
+    assert body.get("error_code") == "csrf_validation_failed"
+    assert body.get("success") is False, (
+        "activity_signal 403 must keep success:false for backward "
+        f"compatibility with the rest of this endpoint's contract; got {body!r}"
+    )
+    assert "no-store" in resp.headers.get("Cache-Control", "").lower()
     tracker.push_external_system_signal.assert_not_called()
 
 

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -382,6 +382,35 @@ def test_no_origin_no_csrf_blocked_with_403(monkeypatch):
 
 
 @pytest.mark.unit
+def test_no_origin_with_valid_csrf_still_blocked(monkeypatch):
+    """Valid CSRF token alone (no Origin) must not bypass the guard.
+
+    Distinguishes the *Origin AND CSRF* contract from a hypothetical
+    "token-only" relaxation: a non-browser caller that somehow obtained
+    the CSRF token (e.g., by reading the user's running browser's
+    DevTools) still can't push activity signals if it skips the Origin
+    header. Without this canary a future refactor could accidentally
+    weaken the guard to "token alone is enough" and the rest of the
+    suite would still pass (CodeRabbit Nitpick on PR #1532).
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
+        headers={"X-CSRF-Token": "test-csrf-token"},
+    )
+
+    assert resp.status_code == 403, resp.text
+    body = resp.json()
+    assert body.get("error_code") == "csrf_validation_failed"
+    assert body.get("success") is False
+    assert "no-store" in resp.headers.get("Cache-Control", "").lower()
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
 def test_same_origin_with_valid_csrf_accepted(monkeypatch):
     """Matching Origin + valid CSRF token → push goes through.
 

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -7,6 +7,9 @@ the tracker in remote / cross-platform deployments where the Python
 backend can't read foreground-window / idle / CPU / GPU directly.
 
 Coverage focus:
+  * Auth → ``_validate_local_mutation_request`` guard fires before any
+    business logic (issue #1479 Step 2: unified CSRF + Origin gate
+    replaces PR #1477's interim Origin-only check).
   * Happy path → tracker is called with the right kwargs.
   * Validation → 400 on bad shapes, 404 / 503 on missing tracker.
   * Rate limit → 429 with ``Retry-After`` when pushed too fast.
@@ -26,6 +29,14 @@ from main_routers import system_router as system_router_module
 
 
 ACTIVITY_SIGNAL_ENDPOINT = "/api/activity_signal"
+
+# TestClient's default base URL is ``http://testserver``; the unified
+# guard's allowed-origin set always includes ``request.base_url``, so
+# this Origin passes ``_get_allowed_local_origins`` automatically.
+_AUTH_HEADERS = {
+    "Origin": "http://testserver",
+    "X-CSRF-Token": "test-csrf-token",
+}
 
 
 def _build_mgr(*, has_tracker: bool = True):
@@ -49,19 +60,40 @@ def _isolate_throttle_state():
     system_router_module._ACTIVITY_SIGNAL_THROTTLE.clear()
 
 
-def _build_client(monkeypatch, mgr_map: dict):
+@pytest.fixture(autouse=True)
+def _fixed_csrf_token(monkeypatch):
+    """Pin AUTOSTART_CSRF_TOKEN so ``_AUTH_HEADERS`` is the matching token.
+
+    The real config uses a per-instance random token; tests need a fixed
+    value to predictably authenticate happy-path requests. Same trick
+    ``test_system_screenshot_router.py`` uses.
+    """
+    monkeypatch.setattr(
+        system_router_module, "AUTOSTART_CSRF_TOKEN", "test-csrf-token",
+    )
+    yield
+
+
+def _build_client(monkeypatch, mgr_map: dict, *, authenticated: bool = True):
     """TestClient with ``get_session_manager`` monkey-patched.
 
     ``mgr_map`` is the same dict shape returned in production
     (lanlan_name → mgr-like object). Pass an empty dict to simulate
     "no characters registered".
+
+    ``authenticated`` (default True): inject the matching Origin +
+    X-CSRF-Token on every request so happy-path tests don't have to
+    repeat them. Set to False when exercising the guard itself.
     """
     monkeypatch.setattr(
         system_router_module, "get_session_manager", lambda: mgr_map,
     )
     app = FastAPI()
     app.include_router(system_router_module.router)
-    return TestClient(app)
+    client = TestClient(app)
+    if authenticated:
+        client.headers.update(_AUTH_HEADERS)
+    return client
 
 
 # ── happy path ────────────────────────────────────────────────────────
@@ -305,43 +337,104 @@ def test_field_validation_400s(monkeypatch, payload, expected_error_fragment):
     tracker.push_external_system_signal.assert_not_called()
 
 
-# ── Origin-present same-origin gate ──────────────────────────────────
+# ── Unified CSRF + Origin guard (issue #1479 Step 2) ─────────────────
+# These tests exercise ``_validate_local_mutation_request`` as plumbed
+# into the activity_signal endpoint. They INTENTIONALLY use
+# ``authenticated=False`` so the guard's negative paths are observable.
 
 
 @pytest.mark.unit
-def test_no_origin_header_accepted(monkeypatch):
-    """``curl`` / Node / native scripts send no Origin → must be allowed.
+def test_no_origin_no_csrf_blocked_with_403(monkeypatch):
+    """No Origin AND no CSRF token → 403 ``csrf_validation_failed``.
 
-    The Origin gate is intentionally permissive in the no-Origin case
-    because:
-      - Browsers always send Origin on POST (since the 2024-ish spec
-        update), so missing Origin reliably means non-browser caller
-      - Mandatory CSRF tokens would block legitimate native callers
-        without a clean path forward; defer to follow-up PR
+    Differs from PR #1477's interim Origin-only gate, which let
+    no-Origin callers (curl / Electron main-process / native scripts)
+    push freely. The unified guard rejects those too — *CSRF is not
+    authentication*, but pushing activity signals from outside the
+    same browsing context isn't a supported deployment shape (see the
+    threat model in ``docs/design/security/local-mutation-auth.md``).
+    Same shape as every other browser-facing mutation endpoint now.
     """
     mgr, tracker = _build_mgr()
-    client = _build_client(monkeypatch, {"Aria": mgr})
-
-    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria", "idle_seconds": 0})
-
-    assert resp.status_code == 200, resp.text
-    tracker.push_external_system_signal.assert_called_once()
-
-
-@pytest.mark.unit
-def test_same_origin_browser_request_accepted(monkeypatch):
-    """Browser fetch with matching Origin (== ``request.base_url``) passes."""
-    mgr, tracker = _build_mgr()
-    client = _build_client(monkeypatch, {"Aria": mgr})
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
 
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
         json={"lanlan_name": "Aria", "idle_seconds": 0},
-        headers={"Origin": "http://testserver"},  # TestClient's base_url
+    )
+
+    assert resp.status_code == 403, resp.text
+    assert resp.json().get("error_code") == "csrf_validation_failed"
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+def test_same_origin_with_valid_csrf_accepted(monkeypatch):
+    """Matching Origin + valid CSRF token → push goes through.
+
+    The TestClient's default base_url is ``http://testserver``, which
+    ``_get_allowed_local_origins`` always adds to the allowed set. With
+    the matching ``X-CSRF-Token``, the guard returns None and the
+    handler runs normally.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
+        headers={
+            "Origin": "http://testserver",
+            "X-CSRF-Token": "test-csrf-token",
+        },
     )
 
     assert resp.status_code == 200, resp.text
     tracker.push_external_system_signal.assert_called_once()
+
+
+@pytest.mark.unit
+def test_same_origin_without_csrf_blocked(monkeypatch):
+    """Matching Origin but missing CSRF token → 403.
+
+    This is the threat the unified guard exists to cover (and PR
+    #1477's Origin-only gate did *not* cover): a malicious same-origin
+    context (e.g., a compromised browser extension injecting fetch
+    into the page) that has the right Origin but can't read the
+    per-instance CSRF token.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
+        headers={"Origin": "http://testserver"},
+    )
+
+    assert resp.status_code == 403, resp.text
+    assert resp.json().get("error_code") == "csrf_validation_failed"
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+def test_same_origin_with_wrong_csrf_blocked(monkeypatch):
+    """Matching Origin but WRONG CSRF token → 403 (constant-time compare)."""
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
+        headers={
+            "Origin": "http://testserver",
+            "X-CSRF-Token": "wrong-token-not-the-real-one",
+        },
+    )
+
+    assert resp.status_code == 403, resp.text
+    assert resp.json().get("error_code") == "csrf_validation_failed"
+    tracker.push_external_system_signal.assert_not_called()
 
 
 @pytest.mark.unit
@@ -353,66 +446,49 @@ def test_same_origin_browser_request_accepted(monkeypatch):
 def test_cross_site_origin_blocked_with_403(monkeypatch, evil_origin):
     """Drive-by browser fetch from off-origin page → 403.
 
-    This is the threat that the Origin gate exists to block: a
-    malicious page on attacker.com calling our endpoint via fetch().
-    Browser always sends Origin = the page's origin; since that's not
-    our base_url, we reject before tracker dispatch.
+    The CSRF token wouldn't help an attacker because they can't read it
+    cross-origin, but Origin alone is enough to reject — make sure the
+    guard fires before any business code runs.
     """
     mgr, tracker = _build_mgr()
-    client = _build_client(monkeypatch, {"Aria": mgr})
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
 
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
         json={"lanlan_name": "Aria", "idle_seconds": 0},
-        headers={"Origin": evil_origin},
+        headers={
+            "Origin": evil_origin,
+            # Even if the attacker guesses the token they're still
+            # off-origin → reject.
+            "X-CSRF-Token": "test-csrf-token",
+        },
     )
 
     assert resp.status_code == 403, resp.text
-    assert "origin" in resp.json()["error"].lower()
-    tracker.push_external_system_signal.assert_not_called()
-
-
-@pytest.mark.unit
-def test_referer_used_when_no_origin(monkeypatch):
-    """``_get_request_origin`` falls back to Referer when Origin absent.
-
-    Drive-by CSRF mitigation must work even when an attacker omits
-    Origin (some older clients / browser bugs do this) — Referer is
-    the practical fallback, and our helper already implements it.
-    """
-    mgr, tracker = _build_mgr()
-    client = _build_client(monkeypatch, {"Aria": mgr})
-
-    # Referer from off-origin page → should still block
-    resp = client.post(
-        ACTIVITY_SIGNAL_ENDPOINT,
-        json={"lanlan_name": "Aria", "idle_seconds": 0},
-        headers={"Referer": "https://evil.com/some/path"},
-    )
-
-    assert resp.status_code == 403
+    assert resp.json().get("error_code") == "csrf_validation_failed"
     tracker.push_external_system_signal.assert_not_called()
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("header_name,opaque_value", [
     ("Origin", "null"),
-    ("Origin", "NULL"),  # case-insensitive
-    ("Referer", "null"),  # Referer fallback also rejects "null"
+    ("Origin", "NULL"),
+    ("Referer", "null"),
 ])
 def test_opaque_origin_null_rejected(monkeypatch, header_name, opaque_value):
-    """``Origin: null`` (and Referer: null) from sandboxed iframes / file://
-    contexts must be 403, not fall through to the no-Origin allow path.
+    """``Origin: null`` / ``Referer: null`` from opaque-origin contexts → 403.
 
-    Codex P1 (F5 on PR #1477): browsers emit the literal string "null"
-    for opaque origins. ``urlsplit("null")`` parses into empty scheme +
-    netloc → ``_normalize_origin_value`` returns "" → the no-Origin
-    allow branch fires, bypassing the gate. Without an explicit raw
-    check, ``<iframe sandbox>`` on attacker.com could fetch our
-    endpoint and spoof signals.
+    Browsers emit literal ``"null"`` as Origin for sandboxed iframes,
+    ``file://`` pages, and certain extension contexts. The unified
+    guard handles this naturally: ``_normalize_origin_value("null")``
+    returns ``""`` (urlsplit yields empty scheme), so the membership
+    check fails. With no CSRF token in the request, the guard rejects
+    before anything else runs. The combined ``has_valid_csrf AND
+    has_valid_origin`` rule means even a malicious sandbox carrying
+    *some* string in X-CSRF-Token can't bypass it.
     """
     mgr, tracker = _build_mgr()
-    client = _build_client(monkeypatch, {"Aria": mgr})
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
 
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
@@ -421,22 +497,23 @@ def test_opaque_origin_null_rejected(monkeypatch, header_name, opaque_value):
     )
 
     assert resp.status_code == 403, resp.text
-    assert "origin" in resp.json()["error"].lower()
+    assert resp.json().get("error_code") == "csrf_validation_failed"
     tracker.push_external_system_signal.assert_not_called()
 
 
 @pytest.mark.unit
-def test_unparseable_origin_treated_as_absent(monkeypatch):
-    """Garbage Origin (can't parse scheme/host) → treated as no-Origin.
+def test_unparseable_origin_blocked(monkeypatch):
+    """Garbage Origin (can't parse scheme/host) → 403, not allowed.
 
-    Mirrors screenshot-router test
-    ``test_interactive_screenshot_blocks_browser_requests_with_unparseable_origin``
-    inverted: unparseable means "we can't tell where this came from",
-    so we fall through to the no-Origin path (allow). The endpoint's
-    rate limit + lanlan_name lookup still bound impact.
+    Differs from PR #1477's interim behaviour which would have
+    fallen through to the no-Origin allow branch. Under the unified
+    guard ``_normalize_origin_value`` returns ``""`` for unparseable
+    input, the membership check fails, and without a valid CSRF token
+    we reject. This closes a fingerprinting / probing vector where an
+    attacker could send garbage Origins to detect endpoint existence.
     """
     mgr, tracker = _build_mgr()
-    client = _build_client(monkeypatch, {"Aria": mgr})
+    client = _build_client(monkeypatch, {"Aria": mgr}, authenticated=False)
 
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
@@ -444,9 +521,9 @@ def test_unparseable_origin_treated_as_absent(monkeypatch):
         headers={"Origin": "not a url"},
     )
 
-    # Origin couldn't be normalised → counts as no Origin → allowed
-    assert resp.status_code == 200, resp.text
-    tracker.push_external_system_signal.assert_called_once()
+    assert resp.status_code == 403, resp.text
+    assert resp.json().get("error_code") == "csrf_validation_failed"
+    tracker.push_external_system_signal.assert_not_called()
 
 
 @pytest.mark.unit
@@ -538,7 +615,8 @@ def test_nan_and_infinity_rejected(monkeypatch, field, bad_token):
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
         content=body,
-        headers={"Content-Type": "application/json"},
+        # TestClient defaults to no extra headers; merge our auth headers in.
+        headers={"Content-Type": "application/json", **_AUTH_HEADERS},
     )
 
     assert resp.status_code == 400, resp.text


### PR DESCRIPTION
## Summary

跟进 [#1479](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1479) **Step 2**。[PR #1477](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1477) 给 `/api/activity_signal` 落地了"带 Origin 的同源校验"作为临时加固；本 PR 把它接入和其它本地变更端点同一套 `_validate_local_mutation_request` 守卫，并修复 wehos [在 issue 评论里指出的「静默永久降级」隐患](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1479#issuecomment-3325000000)。

## 后端 [`main_routers/system_router.py`](main_routers/system_router.py:4280)

- 删除 ~30 行自定义 Origin-only gate（含 \"null\" 显式拒绝、跨源拒绝两段）
- 替换为单行 `_validate_local_mutation_request(request)` 调用，统一错误码 `csrf_validation_failed` / 403，和 screenshot / tutorial-prompt / autostart-prompt 等端点行为一致
- 更新 handler docstring 解释新 auth 语义；强调 **CSRF ≠ authentication** 边界 —— 无 Origin 的非浏览器调用方（curl / Electron 主进程 / native 脚本）从此被拒绝，是预期的（这些 caller 不该 push activity signal，详见 Step 3 的文档）

## 前端 [`static/app-activity-signal.js`](static/app-activity-signal.js)

- **注入 token**：新增 `getCsrfMutationHeaders()` helper 走 `window.nekoLocalMutationSecurity.getMutationHeaders()` 注入 `X-CSRF-Token`。同源 Electron 渲染器走 `GET /api/config/page_config` 拿 token，零额外 IPC
- **首次 403 → refresh + retry once**：覆盖 page_config bootstrap 还没完成的启动竞速窗口
- **403 退避**：新增 `consecutiveCsrfFailures` + `heartbeatStoppedDueToCsrf`：连续 `MAX_CONSECUTIVE_CSRF_FAILURES = 6 ticks (30s, 2× tracker TTL)` 次 403 后 `stop()` 心跳并打一条 `console.error` 说明降级原因 + 排查指引
- **sticky stop**：`start()` early return 阻止 `visibilitychange` 自动重启心跳，要恢复必须 page reload（同时 token bootstrap 会重做）
- **区分 CSRF 失败 vs 后端故障**：普通 5xx 仍走原有 `consecutiveFailures`，不计入 CSRF stop 阈值（守卫拒绝跟临时故障的语义不同）

## 测试 [`tests/unit/test_activity_signal_router.py`](tests/unit/test_activity_signal_router.py)

- 重构 `_build_client(authenticated=True/False)`：happy path 自动注入 Origin + X-CSRF-Token；守卫负路径用 `authenticated=False`
- **4 个新守卫测试**：no-Origin no-CSRF blocked / same-origin with valid CSRF accepted / same-origin without CSRF blocked / same-origin with wrong CSRF blocked
- 改造原 Origin gate 测试断言：`error_code → \"csrf_validation_failed\"`
- 行为反转测试：`test_no_origin_no_csrf_blocked_with_403` / `test_unparseable_origin_blocked`（无 Origin / 无效 Origin 现在被拒绝，CSRF ≠ auth 边界）
- **68/68 测试通过**

## 关于 wehos 评论中的「跨三仓上线时序坑」

- Electron 同源渲染器实际是「有 Origin」分支，token 走 `page_config` 模板注入，**不需要** NEKO-PC preload 桥额外暴露 token
- 即使遇到老版本前端 + 新版本后端的中间态，前端的 6 次 403 退避会让心跳干净退出，tracker 走本地采集器降级，不再静默自旋

## 范围

- 本 PR **只动 activity_signal 一个端点**；其它端点的 CSRF 收编在 [PR #1530](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1530)（Step 1）
- 不引入 `NEKO_REQUIRE_CSRF_FOR_ORIGIN` / `NEKO_REQUIRE_CSRF_FOR_NO_ORIGIN` 配置项 —— `_validate_local_mutation_request` 现有规则已足够；如果未来 remote 模式真的需要更细粒度，再加 flag
- 文档化（威胁模型、规则矩阵、CSRF ≠ 鉴权边界）放在 Step 3

## Test plan

- [x] `pytest tests/unit/test_activity_signal_router.py -v` — 68/68 passed
- [ ] 本地起服务，触发 5s 心跳，确认带 token 时 200；删 token cookie / 改坏 `window.nekoLocalMutationSecurity.peekCachedToken()` 模拟 403 ≥ 6 次，确认心跳停止 + 控制台显眼 error
- [ ] 跨源攻击模拟：`curl -H 'Origin: https://evil.com' -X POST http://localhost:48911/api/activity_signal -d '{}'` 确认收到 403 `csrf_validation_failed`

---
Co-Authored-By: Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加模块自注册钩子以容忍可预期缺失的小游戏邀请关键词模块。

* **改进**
  * 统一并强化本地变更的 CSRF/Origin 验证流程，失败返回一致的 403 响应并避免不当放行。
  * 前端心跳机制新增对连续统一 CSRF 拒绝的检测、限次重试与粘性停止逻辑，避免误触恢复并区分非 CSRF 错误。

* **修复**
  * 精简个性化动态接口错误处理，移除通用异常兜底，错误路径返回更明确的响应结构。

* **测试**
  * 更新与扩展鉴权相关的单元测试用例以覆盖新验证策略与失败场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->