### PR TITLE
fix(session): 去重早退补发 session_started，修 greeting 竞态卡死

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3972,24 +3972,29 @@ class LLMSessionManager:
             # 直接静默 return，但前端的 start_session 在 await 一个 session_started
             # ack——若它撞在这里被去重，ack 永远不来，前端 15s 后超时并卡死（用户
             # 在 greeting 出现前抢发消息触发的竞态：greeting 先把 in-flight 占住，
-            # 而它完成时发的 ack 又早于前端开始 await，前端两头落空）。改为：等
-            # in-flight 那次启动落定，复用其结果给本请求补一个 ack——成功补
-            # session_started、失败补 session_failed，让前端正常收口而不是干等超时。
-            # 仅作用于这条"本就会超时"的去重死路，不碰任何正常单次启动路径。
-            logger.warning("⚠️ Session正在启动中，等待 in-flight 启动 ready 后给本请求补发 session_started")
-            _dedup_input_mode = self._starting_input_mode or input_mode
-            _waited = 0.0
-            while self._starting_session_count > 0 and not self.session_ready and _waited < 14.0:
-                await asyncio.sleep(0.05)
-                _waited += 0.05
-            if self.session_ready and self.session and self.is_active:
-                await self.send_session_started(_dedup_input_mode)
-            # 仅在 in-flight 启动确认 ready 时补发 session_started。**不**在此发
-            # session_failed：in-flight 那次启动可能还在跑、稍后才成功，而前端把
-            # session_failed 当终态（reject start + 触发 end_session），过早发会把
-            # 本会在 15s 客户端窗口内成功的启动打断（Codex P1）。失败通知交由
-            # in-flight 启动自身的失败路径处理；in-flight 真挂了则维持原有的前端
-            # 超时兜底，不比改动前更差。
+            # 而它完成时发的 ack 又早于前端开始 await，前端两头落空）。
+            #
+            # 仅对**同模式**的去重请求补发 ack：in-flight 启的是它自己的模式，
+            # 跨模式（如 greeting 拉 text、另一路同刻请求 audio）若复用 in-flight 的
+            # session_started(text)，前端会按 text 切 UI、收口 promise，而用户要的
+            # audio 会话根本没起（CodeRabbit）。跨模式时维持原静默 return（与改动前
+            # 完全一致，不更差）。
+            if (self._starting_input_mode or input_mode) == input_mode:
+                logger.warning("⚠️ Session正在启动中，等待 in-flight 启动 ready 后给本请求补发 session_started")
+                _waited = 0.0
+                while self._starting_session_count > 0 and not self.session_ready and _waited < 14.0:
+                    await asyncio.sleep(0.05)
+                    _waited += 0.05
+                if self.session_ready and self.session and self.is_active:
+                    await self.send_session_started(input_mode)
+                # 仅在 in-flight 启动确认 ready 时补发 session_started。**不**在此发
+                # session_failed：in-flight 那次启动可能还在跑、稍后才成功，而前端把
+                # session_failed 当终态（reject start + 触发 end_session），过早发会把
+                # 本会在 15s 客户端窗口内成功的启动打断（Codex P1）。失败通知交由
+                # in-flight 启动自身的失败路径处理；in-flight 真挂了则维持原有的前端
+                # 超时兜底，不比改动前更差。
+            else:
+                logger.warning("⚠️ Session正在启动中（跨模式重复请求），忽略")
             return
 
         # 标记正在启动（使用计数器，避免并发 start_session 的 finally 互相覆盖）

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -529,6 +529,12 @@ logger = get_module_logger(__name__, "Main")
 IDLE_SESSION_RESET_THRESHOLD_SECONDS = 1800
 IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS = 60
 
+# 前端文本会话 start_session 等 session_started 的硬超时（static/app-buttons.js
+# 的 setTimeout(..., 15000)）。start_session 去重路径等 in-flight 启动落定后给
+# 本请求补发 ack 时，等待上限绑到这个值：超过前端这个超时再补发 session_started
+# 已无意义（前端早已 reject 并发 end_session），故以它为有意义窗口的天然上界。
+FRONTEND_START_SESSION_TIMEOUT_SECONDS = 15.0
+
 # 主动搭话（proactive）调用 prompt_ephemeral 时设置的 sid 期望值。
 # 目的：prompt_ephemeral 内部通过 on_text_delta=handle_text_data 回调 enqueue TTS，
 # 中间可能被用户输入抢占（user stream_text 清 queue + 换 current_speech_id）。
@@ -3985,13 +3991,14 @@ class LLMSessionManager:
                 # 不拿 session_ready 当谓词：它可能还残留上一个 session 的 True
                 # （in-flight start 要过几个 await 才把它重置），那样循环会被直接
                 # 跳过、在 in-flight 还没真正起好时就误发 started 假阳性（Codex P1）。
-                # 20s 仅为防 in-flight 异常永不归零的兜底安全阀，非功能时序。
+                # 等待上限绑前端的 start_session 超时：超过它再补发 ack 已无意义
+                # （前端早已 reject + end_session），故以它为窗口上界兼防挂安全阀。
                 _waited = 0.0
-                while self._starting_session_count > 0 and _waited < 20.0:
+                while self._starting_session_count > 0 and _waited < FRONTEND_START_SESSION_TIMEOUT_SECONDS:
                     await asyncio.sleep(0.05)
                     _waited += 0.05
                 # 仅当 in-flight 真正落定（count 归 0、即循环是「落定退出」而非
-                # 「20s 超时退出」）且会话确实活跃时才补发 session_started（与
+                # 「超时退出」）且会话确实活跃时才补发 session_started（与
                 # in-flight 自身发的那条幂等，前端 resolver 一次性）。若是超时退出
                 # （count 仍 >0、in-flight 没结束），self.session/is_active 在 restart
                 # 流程里可能是上一个 session 残留的 True，补发会是假阳性（Codex P1），

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3976,16 +3976,20 @@ class LLMSessionManager:
             # in-flight 那次启动落定，复用其结果给本请求补一个 ack——成功补
             # session_started、失败补 session_failed，让前端正常收口而不是干等超时。
             # 仅作用于这条"本就会超时"的去重死路，不碰任何正常单次启动路径。
-            logger.warning("⚠️ Session正在启动中，等待 in-flight 启动落定后给本请求补发 ack")
+            logger.warning("⚠️ Session正在启动中，等待 in-flight 启动 ready 后给本请求补发 session_started")
             _dedup_input_mode = self._starting_input_mode or input_mode
             _waited = 0.0
-            while self._starting_session_count > 0 and not self.session_ready and _waited < 12.0:
+            while self._starting_session_count > 0 and not self.session_ready and _waited < 14.0:
                 await asyncio.sleep(0.05)
                 _waited += 0.05
             if self.session_ready and self.session and self.is_active:
                 await self.send_session_started(_dedup_input_mode)
-            else:
-                await self.send_session_failed(_dedup_input_mode)
+            # 仅在 in-flight 启动确认 ready 时补发 session_started。**不**在此发
+            # session_failed：in-flight 那次启动可能还在跑、稍后才成功，而前端把
+            # session_failed 当终态（reject start + 触发 end_session），过早发会把
+            # 本会在 15s 客户端窗口内成功的启动打断（Codex P1）。失败通知交由
+            # in-flight 启动自身的失败路径处理；in-flight 真挂了则维持原有的前端
+            # 超时兜底，不比改动前更差。
             return
 
         # 标记正在启动（使用计数器，避免并发 start_session 的 finally 互相覆盖）

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3990,11 +3990,14 @@ class LLMSessionManager:
                 while self._starting_session_count > 0 and _waited < 20.0:
                     await asyncio.sleep(0.05)
                     _waited += 0.05
-                # in-flight 落定后看**真实状态**：起好了才补发 session_started（与
-                # in-flight 自身发的那条幂等，前端 resolver 一次性）。**不**发
-                # session_failed——in-flight 可能仍在跑/或其失败路径已通知前端，过早
-                # 发 failed 会被前端当终态打断本会成功的启动（Codex 前一条 P1）。
-                if self.session and self.is_active:
+                # 仅当 in-flight 真正落定（count 归 0、即循环是「落定退出」而非
+                # 「20s 超时退出」）且会话确实活跃时才补发 session_started（与
+                # in-flight 自身发的那条幂等，前端 resolver 一次性）。若是超时退出
+                # （count 仍 >0、in-flight 没结束），self.session/is_active 在 restart
+                # 流程里可能是上一个 session 残留的 True，补发会是假阳性（Codex P1），
+                # 故一律不发。也**不**发 session_failed——in-flight 可能仍在跑/或其
+                # 失败路径已通知前端，过早发 failed 会被前端当终态打断本会成功的启动。
+                if self._starting_session_count == 0 and self.session and self.is_active:
                     await self.send_session_started(input_mode)
             else:
                 logger.warning("⚠️ Session正在启动中（跨模式重复请求），忽略")

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3968,7 +3968,24 @@ class LLMSessionManager:
             return
         # 检查是否正在启动中
         if self._starting_session_count > 0:
-            logger.warning("⚠️ Session正在启动中，忽略重复请求")
+            # 另一路 start_session（典型是 greeting 的 auto-start）已在飞。早期实现
+            # 直接静默 return，但前端的 start_session 在 await 一个 session_started
+            # ack——若它撞在这里被去重，ack 永远不来，前端 15s 后超时并卡死（用户
+            # 在 greeting 出现前抢发消息触发的竞态：greeting 先把 in-flight 占住，
+            # 而它完成时发的 ack 又早于前端开始 await，前端两头落空）。改为：等
+            # in-flight 那次启动落定，复用其结果给本请求补一个 ack——成功补
+            # session_started、失败补 session_failed，让前端正常收口而不是干等超时。
+            # 仅作用于这条"本就会超时"的去重死路，不碰任何正常单次启动路径。
+            logger.warning("⚠️ Session正在启动中，等待 in-flight 启动落定后给本请求补发 ack")
+            _dedup_input_mode = self._starting_input_mode or input_mode
+            _waited = 0.0
+            while self._starting_session_count > 0 and not self.session_ready and _waited < 12.0:
+                await asyncio.sleep(0.05)
+                _waited += 0.05
+            if self.session_ready and self.session and self.is_active:
+                await self.send_session_started(_dedup_input_mode)
+            else:
+                await self.send_session_failed(_dedup_input_mode)
             return
 
         # 标记正在启动（使用计数器，避免并发 start_session 的 finally 互相覆盖）

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3980,19 +3980,22 @@ class LLMSessionManager:
             # audio 会话根本没起（CodeRabbit）。跨模式时维持原静默 return（与改动前
             # 完全一致，不更差）。
             if (self._starting_input_mode or input_mode) == input_mode:
-                logger.warning("⚠️ Session正在启动中，等待 in-flight 启动 ready 后给本请求补发 session_started")
+                logger.warning("⚠️ Session正在启动中，等 in-flight 启动落定后给本请求补发 session_started")
+                # 等 in-flight 那次启动**自己落定**（_starting_session_count 归 0）。
+                # 不拿 session_ready 当谓词：它可能还残留上一个 session 的 True
+                # （in-flight start 要过几个 await 才把它重置），那样循环会被直接
+                # 跳过、在 in-flight 还没真正起好时就误发 started 假阳性（Codex P1）。
+                # 20s 仅为防 in-flight 异常永不归零的兜底安全阀，非功能时序。
                 _waited = 0.0
-                while self._starting_session_count > 0 and not self.session_ready and _waited < 14.0:
+                while self._starting_session_count > 0 and _waited < 20.0:
                     await asyncio.sleep(0.05)
                     _waited += 0.05
-                if self.session_ready and self.session and self.is_active:
+                # in-flight 落定后看**真实状态**：起好了才补发 session_started（与
+                # in-flight 自身发的那条幂等，前端 resolver 一次性）。**不**发
+                # session_failed——in-flight 可能仍在跑/或其失败路径已通知前端，过早
+                # 发 failed 会被前端当终态打断本会成功的启动（Codex 前一条 P1）。
+                if self.session and self.is_active:
                     await self.send_session_started(input_mode)
-                # 仅在 in-flight 启动确认 ready 时补发 session_started。**不**在此发
-                # session_failed：in-flight 那次启动可能还在跑、稍后才成功，而前端把
-                # session_failed 当终态（reject start + 触发 end_session），过早发会把
-                # 本会在 15s 客户端窗口内成功的启动打断（Codex P1）。失败通知交由
-                # in-flight 启动自身的失败路径处理；in-flight 真挂了则维持原有的前端
-                # 超时兜底，不比改动前更差。
             else:
                 logger.warning("⚠️ Session正在启动中（跨模式重复请求），忽略")
             return


### PR DESCRIPTION
## Summary
- 冷启动文本会话时，greeting 的 auto-start 先占住 `_starting_session_count`；前端紧跟的 `start_session` 撞上 `core.py` 的去重早退后被**静默丢弃**，永远收不到 `session_started` ack。
- 前端 `await sessionStartPromise` 15s 后超时 → 会话卡死、后续消息全部超时（用户在 greeting 出现前抢发消息触发的竞态）。
- 修法：去重早退前**等 in-flight 启动落定**（封顶 12s，< 前端 15s 超时），复用其结果给本请求补发 ack——成功补 `session_started`、失败补 `session_failed`。仅作用于这条「本就会超时」的去重死路，不碰正常单次启动路径。

## Test plan
- [x] ws 客户端脚本驱动同一竞态序列（两个 start_session + 一条 stream_data）：修前 `session_started acks=1`（前端超时），修后 `acks=2`（前端正常 resolve），session 全程存活。
- [x] 真机文本会话验证：greeting 前抢发消息不再卡死。
- [ ] 回归：正常单次 start_session（语音/文本/刷新重连）的 ack 行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化会话并发启动去重：当重复请求与正在启动的模式一致时，客户端会最多轮询等待（最长约 15 秒）以完成正在进行的启动；若会话就绪且处于激活状态，系统会补发一次“启动成功”事件，减少前端超时或卡死风险。
  * 明确不在该去重分支发送失败事件；若检测到跨模式重复请求，仍记录告警并静默忽略请求。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->