### PR TITLE
导出预览窗口补齐最小化与最大化/恢复按钮；“在新窗口打开”的纯内容预览页保持原轻量关闭栏

### DIFF
--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -2085,11 +2085,10 @@
             selectInvertButton.textContent = translateLabel('chat.exportSelectInvert', 'Invert');
             copyButton.textContent = translateLabel('chat.copyToClipboard', 'Copy to Clipboard');
             openWindowButton.textContent = translateLabel('chat.previewOpenWindow', 'Open In Window');
+            setWindowControlButtonLabel(maximizeButton, 'common.maximize', 'Maximize');
             var view = doc.defaultView || null;
             if (view && view.nekoWindowControls && typeof view.nekoWindowControls.refresh === 'function') {
                 view.nekoWindowControls.refresh();
-            } else {
-                setWindowControlButtonLabel(maximizeButton, 'common.maximize', 'Maximize');
             }
         };
         window.addEventListener('localechange', localeHandler);

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -18,7 +18,6 @@
     var MAX_EXPORT_SELECTION = 100;
     var DEFAULT_USER_EXPORT_AVATAR = '/static/icons/avatar/master-avatar.png';
     var EXPORT_PREVIEW_SHELL_URL = '/static/chat-export-preview-shell.html';
-    var EXPORT_PREVIEW_SHELL_WAIT_TIMEOUT_MS = 30000;
 
     // ======================== State ========================
 
@@ -121,72 +120,6 @@
         } catch (_) {
             return EXPORT_PREVIEW_SHELL_URL;
         }
-    }
-
-    function waitForExportPreviewShell(previewWindow) {
-        return new Promise(function (resolve) {
-            if (!previewWindow || previewWindow.closed) {
-                resolve(false);
-                return;
-            }
-
-            var shellUrl = getExportPreviewShellUrl();
-            var isShellReady = function () {
-                try {
-                    var currentUrl = previewWindow.location.href;
-                    var doc = previewWindow.document;
-                    return currentUrl
-                        && currentUrl !== 'about:blank'
-                        && currentUrl.split('#')[0] === shellUrl.split('#')[0]
-                        && doc
-                        && doc.readyState
-                        && doc.readyState !== 'loading';
-                } catch (_) {
-                    return false;
-                }
-            };
-
-            var settled = false;
-            var pollTimer = null;
-            var timeoutTimer = null;
-            var onLoad = null;
-            var finish = function (ok) {
-                if (settled) return;
-                settled = true;
-                if (pollTimer) window.clearInterval(pollTimer);
-                if (timeoutTimer) window.clearTimeout(timeoutTimer);
-                if (onLoad) {
-                    try {
-                        previewWindow.removeEventListener('load', onLoad);
-                    } catch (_) {}
-                }
-                resolve(ok !== false && !!previewWindow && !previewWindow.closed);
-            };
-
-            if (isShellReady()) {
-                finish(true);
-                return;
-            }
-
-            try {
-                onLoad = function () {
-                    if (isShellReady()) finish(true);
-                };
-                previewWindow.addEventListener('load', onLoad, { once: true });
-            } catch (_) {
-                onLoad = null;
-            }
-            pollTimer = window.setInterval(function () {
-                if (!previewWindow || previewWindow.closed) {
-                    finish(false);
-                    return;
-                }
-                if (isShellReady()) finish(true);
-            }, 250);
-            timeoutTimer = window.setTimeout(function () {
-                finish(false);
-            }, EXPORT_PREVIEW_SHELL_WAIT_TIMEOUT_MS);
-        });
     }
 
     function showToast(key, fallback, duration) {
@@ -613,7 +546,7 @@
             '[data-theme="dark"] .preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}',
             '[data-theme="dark"] .preview-wrap code{background:#1f2937;}',
             '[data-theme="dark"] .preview-wrap a{color:#93c5fd;}',
-            '@media (prefers-color-scheme:dark){html,body{background:#111827;color:#e5e7eb;}.preview-wrap h1{border-color:#374151;}.preview-wrap h2{color:#cbd5e1;}.preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}.preview-wrap code{background:#1f2937;}}'
+            '@media (prefers-color-scheme:dark){html:not([data-theme]),html:not([data-theme]) body{background:#111827;color:#e5e7eb;}html:not([data-theme]) .preview-wrap h1{border-color:#374151;}html:not([data-theme]) .preview-wrap h2{color:#cbd5e1;}html:not([data-theme]) .preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}html:not([data-theme]) .preview-wrap code{background:#1f2937;}}'
         ].join('');
         return '<!DOCTYPE html><html lang="' + escapeHtml(document.documentElement.lang || 'en')
             + '"' + getPreviewThemeAttributesHtml() + '><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>'
@@ -758,7 +691,7 @@
     }
 
     function getPreviewThemeAttributesHtml() {
-        return isDarkTheme() ? ' data-theme="dark" class="dark"' : '';
+        return isDarkTheme() ? ' data-theme="dark" class="dark"' : ' data-theme="light"';
     }
 
     function applyPreviewThemeToDocument(doc) {
@@ -767,7 +700,7 @@
             doc.documentElement.setAttribute('data-theme', 'dark');
             doc.documentElement.classList.add('dark');
         } else {
-            doc.documentElement.removeAttribute('data-theme');
+            doc.documentElement.setAttribute('data-theme', 'light');
             doc.documentElement.classList.remove('dark');
         }
     }
@@ -2531,12 +2464,10 @@
 
         if (isExistingWindow) {
             disposePreviewModal(false);
-        } else {
-            var shellReady = await waitForExportPreviewShell(previewWindow);
-            if (!shellReady) {
-                return null;
-            }
         }
+        try {
+            if (typeof previewWindow.stop === 'function') previewWindow.stop();
+        } catch (_) {}
         state.previewWindow = previewWindow;
         var doc = previewWindow.document;
         doc.open();
@@ -2704,8 +2635,8 @@
             + '::-webkit-scrollbar-thumb:hover{background:rgba(140,140,140,0.6);}'
             + '::-webkit-scrollbar-corner{background:transparent;}'
             + '@media (prefers-color-scheme:dark){'
-            + '::-webkit-scrollbar-thumb{background:rgba(200,200,200,0.25);}'
-            + '::-webkit-scrollbar-thumb:hover{background:rgba(200,200,200,0.4);}'
+            + 'html:not([data-theme])::-webkit-scrollbar-thumb,html:not([data-theme]) ::-webkit-scrollbar-thumb{background:rgba(200,200,200,0.25);}'
+            + 'html:not([data-theme])::-webkit-scrollbar-thumb:hover,html:not([data-theme]) ::-webkit-scrollbar-thumb:hover{background:rgba(200,200,200,0.4);}'
             + '}'
             + '</style>';
         return scrollbarCss

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -146,12 +146,12 @@
             };
 
             var settled = false;
-            var timer = null;
+            var pollTimer = null;
             var onLoad = null;
             var finish = function (ok) {
                 if (settled) return;
                 settled = true;
-                if (timer) window.clearTimeout(timer);
+                if (pollTimer) window.clearInterval(pollTimer);
                 if (onLoad) {
                     try {
                         previewWindow.removeEventListener('load', onLoad);
@@ -167,16 +167,19 @@
 
             try {
                 onLoad = function () {
-                    finish(isShellReady());
+                    if (isShellReady()) finish(true);
                 };
                 previewWindow.addEventListener('load', onLoad, { once: true });
             } catch (_) {
-                finish(false);
-                return;
+                onLoad = null;
             }
-            timer = window.setTimeout(function () {
-                finish(isShellReady());
-            }, 1500);
+            pollTimer = window.setInterval(function () {
+                if (!previewWindow || previewWindow.closed) {
+                    finish(false);
+                    return;
+                }
+                if (isShellReady()) finish(true);
+            }, 250);
         });
     }
 
@@ -2493,9 +2496,6 @@
         } else {
             var shellReady = await waitForExportPreviewShell(previewWindow);
             if (!shellReady) {
-                try {
-                    previewWindow.close();
-                } catch (_) {}
                 return null;
             }
         }

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -18,6 +18,7 @@
     var MAX_EXPORT_SELECTION = 100;
     var DEFAULT_USER_EXPORT_AVATAR = '/static/icons/avatar/master-avatar.png';
     var EXPORT_PREVIEW_SHELL_URL = '/static/chat-export-preview-shell.html';
+    var EXPORT_PREVIEW_SHELL_WAIT_TIMEOUT_MS = 30000;
 
     // ======================== State ========================
 
@@ -147,11 +148,13 @@
 
             var settled = false;
             var pollTimer = null;
+            var timeoutTimer = null;
             var onLoad = null;
             var finish = function (ok) {
                 if (settled) return;
                 settled = true;
                 if (pollTimer) window.clearInterval(pollTimer);
+                if (timeoutTimer) window.clearTimeout(timeoutTimer);
                 if (onLoad) {
                     try {
                         previewWindow.removeEventListener('load', onLoad);
@@ -180,6 +183,9 @@
                 }
                 if (isShellReady()) finish(true);
             }, 250);
+            timeoutTimer = window.setTimeout(function () {
+                finish(false);
+            }, EXPORT_PREVIEW_SHELL_WAIT_TIMEOUT_MS);
         });
     }
 
@@ -601,10 +607,16 @@
             '.preview-wrap img{max-width:100%;height:auto;border-radius:6px;margin:0.5em 0;}',
             '.preview-wrap a{color:#2563eb;text-decoration:none;}',
             '.preview-wrap a:hover{text-decoration:underline;}',
+            '[data-theme="dark"],[data-theme="dark"] body{background:#111827;color:#e5e7eb;}',
+            '[data-theme="dark"] .preview-wrap h1{border-color:#374151;}',
+            '[data-theme="dark"] .preview-wrap h2{color:#cbd5e1;}',
+            '[data-theme="dark"] .preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}',
+            '[data-theme="dark"] .preview-wrap code{background:#1f2937;}',
+            '[data-theme="dark"] .preview-wrap a{color:#93c5fd;}',
             '@media (prefers-color-scheme:dark){html,body{background:#111827;color:#e5e7eb;}.preview-wrap h1{border-color:#374151;}.preview-wrap h2{color:#cbd5e1;}.preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}.preview-wrap code{background:#1f2937;}}'
         ].join('');
         return '<!DOCTYPE html><html lang="' + escapeHtml(document.documentElement.lang || 'en')
-            + '"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>'
+            + '"' + getPreviewThemeAttributesHtml() + '><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>'
             + escapeHtml(translateLabel('chat.exportFileTitle', 'Project N.E.K.O Conversation Export'))
             + '</title><style>' + css + '</style></head><body><div class="preview-wrap">'
             + bodyHtml + '</div></body></html>';
@@ -743,6 +755,21 @@
     function isDarkTheme() {
         return document.documentElement
             && document.documentElement.getAttribute('data-theme') === 'dark';
+    }
+
+    function getPreviewThemeAttributesHtml() {
+        return isDarkTheme() ? ' data-theme="dark" class="dark"' : '';
+    }
+
+    function applyPreviewThemeToDocument(doc) {
+        if (!doc || !doc.documentElement) return;
+        if (isDarkTheme()) {
+            doc.documentElement.setAttribute('data-theme', 'dark');
+            doc.documentElement.classList.add('dark');
+        } else {
+            doc.documentElement.removeAttribute('data-theme');
+            doc.documentElement.classList.remove('dark');
+        }
     }
 
     // Canvas helpers: wrap text to a max width and return array of lines.
@@ -1819,12 +1846,13 @@
     function buildPreviewCacheKey(entries, formatId) {
         var currentFormatId = formatId || getCurrentExportFormat().id;
         var locale = document.documentElement.lang || '';
+        var theme = isDarkTheme() ? 'dark' : 'light';
         var signature = (entries || []).map(function (entry) {
             return entry.id + ':' + (entry.textContent || '').length + ':' + (entry.mediaDescriptors ? entry.mediaDescriptors.length : 0);
         }).join('|');
         var imageStyleId = currentFormatId === 'image' ? getCurrentImageExportStyle().id : '';
         var imageFormatId = currentFormatId === 'image' ? getCurrentImageExportFormat().id : '';
-        return [currentFormatId, imageStyleId, imageFormatId, locale, signature].join('::');
+        return [currentFormatId, imageStyleId, imageFormatId, locale, theme, signature].join('::');
     }
 
     function revokePreviewPayload(payload) {
@@ -2177,6 +2205,16 @@
         return document;
     }
 
+    function syncPreviewWindowTheme() {
+        try {
+            if (state.previewWindow && !state.previewWindow.closed && state.previewWindow.document) {
+                applyPreviewThemeToDocument(state.previewWindow.document);
+            } else if (state.previewModal) {
+                applyPreviewThemeToDocument(getPreviewModalDocument(state.previewModal));
+            }
+        } catch (_) {}
+    }
+
     function detachPreviewHandlers(modal) {
         var modalDocument = getPreviewModalDocument(modal);
         if (state.previewEscHandler) {
@@ -2502,7 +2540,7 @@
         state.previewWindow = previewWindow;
         var doc = previewWindow.document;
         doc.open();
-        doc.write('<!DOCTYPE html><html><head><meta charset="utf-8">'
+        doc.write('<!DOCTYPE html><html lang="' + escapeHtml(document.documentElement.lang || 'en') + '"' + getPreviewThemeAttributesHtml() + '><head><meta charset="utf-8">'
             + '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
             + '<title>' + escapeHtml(previewTitle) + '</title>'
             + '<link rel="stylesheet" href="/static/css/api_key_settings.css">'
@@ -2520,8 +2558,12 @@
             + 'body.chat-export-window .chat-export-preview-window-controls{margin-left:8px;}'
             + 'body.chat-export-window .chat-export-preview-close img{pointer-events:none;}'
             + 'body.chat-export-window .chat-export-preview-body{max-height:none;}'
+            + 'html[data-theme="dark"],html[data-theme="dark"] body.chat-export-window{background:#0f172a;color:#e2e8f0;}'
+            + 'html[data-theme="dark"] body.chat-export-window .chat-export-preview-panel{background:#1e293b;color:#e2e8f0;}'
+            + 'html[data-theme="dark"] body.chat-export-window .chat-export-preview-body,html[data-theme="dark"] body.chat-export-window .chat-export-preview-frame{background:#0f172a;}'
             + '</style></head><body class="chat-export-window"></body></html>');
         doc.close();
+        applyPreviewThemeToDocument(doc);
         previewWindow.focus();
         if (!previewWindow._chatExportBeforeUnloadHandler) {
             var beforeUnloadHandler = function () {
@@ -2542,6 +2584,7 @@
             return;
         }
         var modal = ensurePreviewModal(previewWindow.document);
+        applyPreviewThemeToDocument(previewWindow.document);
 
         // Re-register localeHandler if it was removed on previous close
         if (!modal._localeHandler) {
@@ -2786,6 +2829,13 @@
             clearPreviewCache();
             renderSelectionList();
             renderControls();
+            schedulePreviewRender();
+        });
+
+        window.addEventListener('neko-theme-changed', function () {
+            syncPreviewWindowTheme();
+            if (!state.previewModal || state.previewModal.panel.hidden) return;
+            clearPreviewCache();
             schedulePreviewRender();
         });
     }

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -17,6 +17,7 @@
 
     var MAX_EXPORT_SELECTION = 100;
     var DEFAULT_USER_EXPORT_AVATAR = '/static/icons/avatar/master-avatar.png';
+    var EXPORT_PREVIEW_SHELL_URL = '/static/chat-export-preview-shell.html';
 
     // ======================== State ========================
 
@@ -111,6 +112,72 @@
             }
         });
         doc.head.appendChild(script);
+    }
+
+    function getExportPreviewShellUrl() {
+        try {
+            return new URL(EXPORT_PREVIEW_SHELL_URL, window.location.href).href;
+        } catch (_) {
+            return EXPORT_PREVIEW_SHELL_URL;
+        }
+    }
+
+    function waitForExportPreviewShell(previewWindow) {
+        return new Promise(function (resolve) {
+            if (!previewWindow || previewWindow.closed) {
+                resolve(false);
+                return;
+            }
+
+            var shellUrl = getExportPreviewShellUrl();
+            var isShellReady = function () {
+                try {
+                    var currentUrl = previewWindow.location.href;
+                    var doc = previewWindow.document;
+                    return currentUrl
+                        && currentUrl !== 'about:blank'
+                        && currentUrl.split('#')[0] === shellUrl.split('#')[0]
+                        && doc
+                        && doc.readyState
+                        && doc.readyState !== 'loading';
+                } catch (_) {
+                    return false;
+                }
+            };
+
+            var settled = false;
+            var timer = null;
+            var onLoad = null;
+            var finish = function (ok) {
+                if (settled) return;
+                settled = true;
+                if (timer) window.clearTimeout(timer);
+                if (onLoad) {
+                    try {
+                        previewWindow.removeEventListener('load', onLoad);
+                    } catch (_) {}
+                }
+                resolve(ok !== false && !!previewWindow && !previewWindow.closed);
+            };
+
+            if (isShellReady()) {
+                finish(true);
+                return;
+            }
+
+            try {
+                onLoad = function () {
+                    finish(isShellReady());
+                };
+                previewWindow.addEventListener('load', onLoad, { once: true });
+            } catch (_) {
+                finish(false);
+                return;
+            }
+            timer = window.setTimeout(function () {
+                finish(isShellReady());
+            }, 1500);
+        });
     }
 
     function showToast(key, fallback, duration) {
@@ -2413,16 +2480,24 @@
             + width + ',height=' + height + ',left=' + left + ',top=' + top;
     }
 
-    function openExportPreviewWindow() {
+    async function openExportPreviewWindow() {
         var previewTitle = translateLabel('chat.exportPreviewTitle', 'Export Preview');
         var isExistingWindow = !!(state.previewWindow && !state.previewWindow.closed);
         var previewWindow = isExistingWindow
             ? state.previewWindow
-            : window.open('', 'neko-chat-export-preview', buildExportWindowFeatures());
+            : window.open(getExportPreviewShellUrl(), 'neko-chat-export-preview', buildExportWindowFeatures());
         if (!previewWindow) return null;
 
         if (isExistingWindow) {
             disposePreviewModal(false);
+        } else {
+            var shellReady = await waitForExportPreviewShell(previewWindow);
+            if (!shellReady) {
+                try {
+                    previewWindow.close();
+                } catch (_) {}
+                return null;
+            }
         }
         state.previewWindow = previewWindow;
         var doc = previewWindow.document;
@@ -2461,7 +2536,7 @@
     }
 
     async function openPreviewModal(previewWindow) {
-        previewWindow = previewWindow || openExportPreviewWindow();
+        previewWindow = previewWindow || await openExportPreviewWindow();
         if (!previewWindow) {
             showToast('chat.previewOpenBlocked', 'Unable to open a new preview window.', 4000);
             return;
@@ -2677,14 +2752,13 @@
             return;
         }
 
-        var previewWindow = openExportPreviewWindow();
-        if (!previewWindow) {
-            showToast('chat.previewOpenBlocked', 'Unable to open a new preview window.', 4000);
-            return;
-        }
-
         state.isPreparingPreview = true;
         try {
+            var previewWindow = await openExportPreviewWindow();
+            if (!previewWindow) {
+                showToast('chat.previewOpenBlocked', 'Unable to open a new preview window.', 4000);
+                return;
+            }
             state.allMessages = messages;
             state.selectedIds = new Set();
             clearPreviewCache();

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -59,6 +59,60 @@
         return translateText(key, fallback);
     }
 
+    function buildWindowControlCssHtml() {
+        return '<link rel="stylesheet" href="/static/css/window_controls.css">';
+    }
+
+    function buildWindowControlScriptHtml() {
+        return '<script src="/static/js/window_controls.js" defer data-neko-window-controls="1"></script>';
+    }
+
+    function buildWindowControlAssetsHtml() {
+        return buildWindowControlCssHtml() + buildWindowControlScriptHtml();
+    }
+
+    function setWindowControlButtonLabel(button, key, fallback) {
+        if (!button) return;
+        var label = translateLabel(key, fallback);
+        button.setAttribute('data-i18n-title', key);
+        button.setAttribute('data-i18n-aria', key);
+        button.setAttribute('title', label);
+        button.setAttribute('aria-label', label);
+    }
+
+    function createWindowControlButton(doc, control, key, fallback, iconClass) {
+        var button = doc.createElement('button');
+        button.type = 'button';
+        button.className = 'neko-window-control-btn';
+        button.setAttribute('data-neko-window-control', control);
+        setWindowControlButtonLabel(button, key, fallback);
+        var icon = doc.createElement('span');
+        icon.className = iconClass;
+        button.appendChild(icon);
+        return button;
+    }
+
+    function ensureWindowControlsForDocument(doc) {
+        if (!doc || !doc.head) return;
+        var view = doc.defaultView || null;
+        if (view && view.nekoWindowControls && typeof view.nekoWindowControls.init === 'function') {
+            view.nekoWindowControls.init();
+            return;
+        }
+        if (doc.querySelector('script[data-neko-window-controls="1"]')) return;
+        var script = doc.createElement('script');
+        script.src = '/static/js/window_controls.js';
+        script.defer = true;
+        script.setAttribute('data-neko-window-controls', '1');
+        script.addEventListener('load', function () {
+            var loadedView = doc.defaultView || null;
+            if (loadedView && loadedView.nekoWindowControls && typeof loadedView.nekoWindowControls.init === 'function') {
+                loadedView.nekoWindowControls.init();
+            }
+        });
+        doc.head.appendChild(script);
+    }
+
     function showToast(key, fallback, duration) {
         if (typeof window.showStatusToast !== 'function') return;
         window.showStatusToast(translateLabel(key, fallback), duration || 3000);
@@ -1797,6 +1851,31 @@
         var summary = doc.createElement('div');
         summary.className = 'chat-export-preview-summary';
 
+        var isStandaloneWindow = !!(doc.body && doc.body.classList.contains('chat-export-window'));
+        var windowControls = null;
+        var minimizeButton = null;
+        var maximizeButton = null;
+        if (isStandaloneWindow) {
+            windowControls = doc.createElement('div');
+            windowControls.className = 'neko-window-controls chat-export-preview-window-controls';
+            minimizeButton = createWindowControlButton(
+                doc,
+                'minimize',
+                'common.minimize',
+                'Minimize',
+                'neko-window-minimize-icon'
+            );
+            maximizeButton = createWindowControlButton(
+                doc,
+                'maximize',
+                'common.maximize',
+                'Maximize',
+                'neko-window-maximize-icon'
+            );
+            windowControls.appendChild(minimizeButton);
+            windowControls.appendChild(maximizeButton);
+        }
+
         var closeButton = doc.createElement('button');
         closeButton.type = 'button';
         closeButton.className = 'chat-export-preview-close close-btn';
@@ -1809,7 +1888,12 @@
 
         header.appendChild(title);
         header.appendChild(summary);
-        header.appendChild(closeButton);
+        if (windowControls) {
+            windowControls.appendChild(closeButton);
+            header.appendChild(windowControls);
+        } else {
+            header.appendChild(closeButton);
+        }
 
         var selectionSection = doc.createElement('div');
         selectionSection.className = 'chat-export-selection-section';
@@ -1916,6 +2000,8 @@
             panel: panel,
             title: title,
             summary: summary,
+            minimizeButton: minimizeButton,
+            maximizeButton: maximizeButton,
             closeButton: closeButton,
             closeIcon: closeIcon,
             selectionToolbar: selectionToolbar,
@@ -1985,9 +2071,10 @@
         openWindowButton.addEventListener('click', handleOpenWindowClick);
         downloadButton.addEventListener('click', handleDownloadClick);
 
-        // Update localized modal attributes when the app locale changes
+        // 应用语言变化时同步预览窗口文案
         var localeHandler = function () {
             closeButton.setAttribute('aria-label', translateLabel('common.close', 'Close'));
+            setWindowControlButtonLabel(minimizeButton, 'common.minimize', 'Minimize');
             title.textContent = translateLabel('chat.exportPreviewTitle', 'Export Preview');
             title.setAttribute('data-text', title.textContent);
             frame.setAttribute('title', translateLabel('chat.exportPreviewTitle', 'Export Preview'));
@@ -1998,9 +2085,19 @@
             selectInvertButton.textContent = translateLabel('chat.exportSelectInvert', 'Invert');
             copyButton.textContent = translateLabel('chat.copyToClipboard', 'Copy to Clipboard');
             openWindowButton.textContent = translateLabel('chat.previewOpenWindow', 'Open In Window');
+            var view = doc.defaultView || null;
+            if (view && view.nekoWindowControls && typeof view.nekoWindowControls.refresh === 'function') {
+                view.nekoWindowControls.refresh();
+            } else {
+                setWindowControlButtonLabel(maximizeButton, 'common.maximize', 'Maximize');
+            }
         };
         window.addEventListener('localechange', localeHandler);
         modal._localeHandler = localeHandler;
+
+        if (isStandaloneWindow) {
+            ensureWindowControlsForDocument(doc);
+        }
 
         return modal;
     }
@@ -2336,6 +2433,7 @@
             + '<title>' + escapeHtml(previewTitle) + '</title>'
             + '<link rel="stylesheet" href="/static/css/api_key_settings.css">'
             + '<link rel="stylesheet" href="/static/css/index.css">'
+            + buildWindowControlAssetsHtml()
             + '<link rel="stylesheet" href="/static/css/dark-mode.css">'
             + '<style>'
             + 'html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#f8fafc;}'
@@ -2345,6 +2443,7 @@
             + 'body.chat-export-window .chat-export-preview-header.container-header{position:sticky;top:0;z-index:100;flex-shrink:0;border-bottom:0;}'
             + 'body.chat-export-window .chat-export-preview-title{white-space:nowrap;}'
             + 'body.chat-export-window .chat-export-preview-summary{color:rgba(255,255,255,.92);font-weight:600;text-shadow:0 1px 2px rgba(0,80,140,.24);}'
+            + 'body.chat-export-window .chat-export-preview-window-controls{margin-left:8px;}'
             + 'body.chat-export-window .chat-export-preview-close img{pointer-events:none;}'
             + 'body.chat-export-window .chat-export-preview-body{max-height:none;}'
             + '</style></head><body class="chat-export-window"></body></html>');
@@ -2478,7 +2577,7 @@
         }
     }
 
-    /** Build the HTML for a draggable title-bar with a close button (for frameless Electron windows). */
+    /** 构建无边框 Electron 窗口使用的自绘标题栏。 */
     function buildWindowChromeHtml(title) {
         var closeLabel = escapeHtml(translateLabel('chat.previewClose', 'Close'));
         var scrollbarCss = '<style>'
@@ -2535,9 +2634,9 @@
                 return;
             }
             var doc = payload.previewDocument;
-            // Sanitize any unsafe protocol URLs before injecting into the new window
+            // 写入新窗口前先清理不安全协议
             doc = sanitizeHtmlUrls(doc);
-            // Inject window chrome (title bar + close button) into the preview document
+            // 注入自绘标题栏并给正文留出顶部空间
             doc = doc.replace(/(<body[^>]*>)/, '$1' + chromeHtml + '<div style="padding-top:36px;">');
             doc = doc.replace(/<\/body>/, '</div></body>');
             var win = window.open('', '_blank');

--- a/static/chat-export-preview-shell.html
+++ b/static/chat-export-preview-shell.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Export Preview</title>
+</head>
+<body></body>
+</html>

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -2263,18 +2263,18 @@ html #chat-container {
 [data-theme="dark"] .chat-export-format-chip:hover,
 [data-theme="dark"] .chat-export-style-chip:hover,
 [data-theme="dark"] .chat-export-image-format-chip:hover {
-  background: rgba(99, 102, 241, 0.22);
-  border-color: #818cf8;
-  color: #e0e7ff;
+  background: rgba(56, 189, 248, 0.18);
+  border-color: #7dd3fc;
+  color: #bae6fd;
 }
 
 [data-theme="dark"] .chat-export-format-chip.is-active,
 [data-theme="dark"] .chat-export-style-chip.is-active,
 [data-theme="dark"] .chat-export-image-format-chip.is-active {
-  background: #6366f1;
-  border-color: #6366f1;
-  color: #ffffff;
-  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.45);
+  background: rgba(56, 189, 248, 0.28);
+  border-color: #38bdf8;
+  color: #e0f7ff;
+  box-shadow: 0 4px 14px rgba(56, 189, 248, 0.35);
 }
 
 [data-theme="dark"] .chat-export-selection-row:hover {
@@ -2313,23 +2313,23 @@ html #chat-container {
 }
 
 [data-theme="dark"] .chat-export-preview-action:hover:not(:disabled) {
-  background: rgba(99, 102, 241, 0.22);
-  border-color: #818cf8;
-  color: #e0e7ff;
+  background: rgba(56, 189, 248, 0.18);
+  border-color: #7dd3fc;
+  color: #bae6fd;
 }
 
 [data-theme="dark"] .chat-export-preview-action-primary {
-  background: #6366f1;
-  border-color: #6366f1;
+  background: #0ea5e9;
+  border-color: #0ea5e9;
   color: #ffffff;
-  box-shadow: 0 4px 14px rgba(99, 102, 241, 0.45);
+  box-shadow: 0 4px 14px rgba(14, 165, 233, 0.45);
 }
 
 [data-theme="dark"] .chat-export-preview-action-primary:hover:not(:disabled) {
-  background: #4f46e5;
-  border-color: #4f46e5;
+  background: #0284c7;
+  border-color: #0284c7;
   color: #ffffff;
-  box-shadow: 0 6px 18px rgba(79, 70, 229, 0.55);
+  box-shadow: 0 6px 18px rgba(2, 132, 199, 0.5);
 }
 
 /* Steam Workshop 图标保持原样（黑夜模式与白天一致） */

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2801,9 +2801,9 @@ body.chat-export-modal-open {
 }
 
 .chat-export-selection-tool:hover {
-    background: #eef2ff;
-    border-color: #818cf8;
-    color: #4338ca;
+    background: #e0f7ff;
+    border-color: #7dd3fc;
+    color: #0369a1;
 }
 
 .chat-export-selection-list {
@@ -2842,7 +2842,7 @@ body.chat-export-modal-open {
     margin-top: 3px;
     width: 16px;
     height: 16px;
-    accent-color: #6366f1;
+    accent-color: #38bdf8;
     cursor: pointer;
 }
 
@@ -2922,18 +2922,18 @@ body.chat-export-modal-open {
 .chat-export-format-chip:hover,
 .chat-export-style-chip:hover,
 .chat-export-image-format-chip:hover {
-    background: #eef2ff;
-    border-color: #818cf8;
-    color: #4338ca;
+    background: #e0f7ff;
+    border-color: #7dd3fc;
+    color: #0369a1;
 }
 
 .chat-export-format-chip.is-active,
 .chat-export-style-chip.is-active,
 .chat-export-image-format-chip.is-active {
-    background: #6366f1;
-    border-color: #6366f1;
-    color: #ffffff;
-    box-shadow: 0 4px 10px rgba(99, 102, 241, 0.35);
+    background: #dff6ff;
+    border-color: #38bdf8;
+    color: #0369a1;
+    box-shadow: 0 4px 10px rgba(56, 189, 248, 0.28);
 }
 
 /* ---------- Preview body ---------- */
@@ -3024,9 +3024,9 @@ body.chat-export-modal-open {
 }
 
 .chat-export-preview-action:hover:not(:disabled) {
-    background: #eef2ff;
-    border-color: #818cf8;
-    color: #4338ca;
+    background: #e0f7ff;
+    border-color: #7dd3fc;
+    color: #0369a1;
 }
 
 .chat-export-preview-action:disabled {
@@ -3035,17 +3035,17 @@ body.chat-export-modal-open {
 }
 
 .chat-export-preview-action-primary {
-    background: #6366f1;
-    border-color: #6366f1;
+    background: #0ea5e9;
+    border-color: #0ea5e9;
     color: #ffffff;
-    box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+    box-shadow: 0 4px 12px rgba(14, 165, 233, 0.3);
 }
 
 .chat-export-preview-action-primary:hover:not(:disabled) {
-    background: #4f46e5;
-    border-color: #4f46e5;
+    background: #0284c7;
+    border-color: #0284c7;
     color: #ffffff;
-    box-shadow: 0 6px 16px rgba(79, 70, 229, 0.4);
+    box-shadow: 0 6px 16px rgba(2, 132, 199, 0.35);
 }
 
 /* ---------- Small screens ---------- */

--- a/static/js/window_controls.js
+++ b/static/js/window_controls.js
@@ -184,6 +184,11 @@
         restoreCurrentWindowFromOpener();
     });
 
+    window.nekoWindowControls = Object.assign({}, window.nekoWindowControls || {}, {
+        init: initWindowControls,
+        refresh: refreshMaximizeState
+    });
+
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', () => {
             initWindowControls();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 预览弹窗支持窗口控制（最小化/最大化）、在独立窗口复用控件容器并响应语言切换
  * 新增独立预览壳页加载并改为异步打开流程，失败时展示提示
  * 预览主题同步增强：写入主题属性、实时同步并将主题纳入预览缓存键

* **修复**
  * 避免重复注入窗口控制资源，改进控件初始化与刷新时序
  * 优化按钮挂载与注入顺序，提升关闭/控制行为一致性

* **样式**
  * 导出交互配色由紫蓝调整为青蓝/天蓝，更新悬停/激活与阴影表现

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->