### PR TITLE
修复 API 设置中辅助 API 选择免费版时仍可编辑 Key 输入框的问题，使其与核心 API 免费版行为一致

### DIFF
--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1582,6 +1582,30 @@ function toggleGptSovitsConfig() {
 
 // ==================== 结束 GPT-SoVITS v3 配置相关函数 ====================
 
+function updateAssistApiKeyInputAvailability() {
+    const assistApiSelect = document.getElementById('assistApiSelect');
+    const assistApiKeyInput = document.getElementById('assistApiKeyInput');
+    if (!assistApiSelect || !assistApiKeyInput) return;
+
+    const isFreeAssistApi = assistApiSelect.value === 'free';
+    assistApiKeyInput.disabled = isFreeAssistApi;
+    assistApiKeyInput.required = false;
+
+    if (isFreeAssistApi) {
+        const freeText = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
+        assistApiKeyInput.placeholder = freeText;
+        assistApiKeyInput.dataset.realKey = '';
+        assistApiKeyInput.value = freeText;
+        attachMaskBehavior(assistApiKeyInput);
+        return;
+    }
+
+    assistApiKeyInput.placeholder = window.t ? window.t('api.assistApiKeyPlaceholder') : '留空使用管理簿对应 Key';
+    if (isFreeVersionText(getRealKey(assistApiKeyInput))) {
+        setMaskedInput(assistApiKeyInput, '');
+    }
+}
+
 // 切换自定义API启用状态
 function toggleCustomApi(skipAutoFill) {
     const enableCustomApi = document.getElementById('enableCustomApi');
@@ -1593,13 +1617,11 @@ function toggleCustomApi(skipAutoFill) {
     const isFreeVersion = coreApiSelect && coreApiSelect.value === 'free';
 
     // 禁用或启用相关控件
-    // core=free 时只锁核心 API Key 输入（free-access 不需要用户填），
-    // 辅助 API 选择器和辅助 Key 输入保持可用，让用户能搭「免费 realtime + 付费 assist」。
-    const assistApiKeyInput = document.getElementById('assistApiKeyInput');
+    // core=free 时只锁核心 API Key 输入，辅助 Key 输入由辅助服务商自身决定。
     if (coreApiSelect) coreApiSelect.disabled = false;
     if (assistApiSelect) assistApiSelect.disabled = false;
-    if (assistApiKeyInput) assistApiKeyInput.disabled = false;
     if (apiKeyInput) apiKeyInput.disabled = isFreeVersion;
+    updateAssistApiKeyInputAvailability();
 
     // 控制自定义API容器的折叠状态
     const customApiContainer = document.getElementById('custom-api-container');
@@ -2201,8 +2223,6 @@ function updateAssistApiRecommendation() {
     const apiKeyInput = document.getElementById('apiKeyInput');
     const freeVersionHint = document.getElementById('freeVersionHint');
 
-    const assistApiKeyInput = document.getElementById('assistApiKeyInput');
-
     if (selectedCoreApi === 'free') {
         if (apiKeyInput) {
             apiKeyInput.disabled = true;
@@ -2210,11 +2230,8 @@ function updateAssistApiRecommendation() {
             apiKeyInput.required = false;
             apiKeyInput.value = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
         }
-        // 辅助 API 与核心 API 解耦：core=free 仅锁核心 API Key（免费 realtime 不需要 key），
-        // 辅助 API 选择器和辅助 Key 输入保持可用，允许「免费 realtime + 付费 assist/Agent」组合。
-        if (assistApiKeyInput) {
-            assistApiKeyInput.disabled = false;
-        }
+        // 辅助 API 与核心 API 解耦：core=free 仅锁核心 API Key，
+        // 辅助 Key 输入是否可用由辅助服务商自身决定。
         if (freeVersionHint) {
             freeVersionHint.style.display = 'inline';
         }
@@ -2248,9 +2265,6 @@ function updateAssistApiRecommendation() {
                 setMaskedInput(apiKeyInput, '');
             }
         }
-        if (assistApiKeyInput) {
-            assistApiKeyInput.disabled = false;
-        }
         if (freeVersionHint) {
             freeVersionHint.style.display = 'none';
         }
@@ -2282,6 +2296,8 @@ function updateAssistApiRecommendation() {
             });
         }
     }
+
+    updateAssistApiKeyInputAvailability();
 
     // Auto-fill core API key from book
     autoFillCoreApiKey();
@@ -2341,10 +2357,10 @@ function autoFillAssistApiKey(force) {
 
     const selectedAssistApi = assistApiSelect.value;
     if (selectedAssistApi === 'free') {
-        setMaskedInput(assistApiKeyInput, '');
-        attachMaskBehavior(assistApiKeyInput);
+        updateAssistApiKeyInputAvailability();
         return;
     }
+    updateAssistApiKeyInputAvailability();
 
     const bookKey = syncKeyFromBook(selectedAssistApi);
     // When forced (provider switch, disabling custom API, or init), clear input if no book key
@@ -3894,13 +3910,11 @@ async function initializePage() {
         if (coreApiSelect && apiKeyInput && freeVersionHint) {
             const selectedCoreApi = coreApiSelect.value;
 
-            const assistApiKeyInputInit = document.getElementById('assistApiKeyInput');
             if (selectedCoreApi === 'free') {
                 apiKeyInput.disabled = true;
                 apiKeyInput.placeholder = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
                 apiKeyInput.required = false;
                 apiKeyInput.value = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
-                if (assistApiKeyInputInit) assistApiKeyInputInit.disabled = true;
                 freeVersionHint.style.display = 'inline';
             } else {
                 apiKeyInput.disabled = false;
@@ -3909,9 +3923,9 @@ async function initializePage() {
                 if (isFreeVersionText(getRealKey(apiKeyInput))) {
                     setMaskedInput(apiKeyInput, '');
                 }
-                if (assistApiKeyInputInit) assistApiKeyInputInit.disabled = false;
                 freeVersionHint.style.display = 'none';
             }
+            updateAssistApiKeyInputAvailability();
 
             updateAssistApiRecommendation();
             autoFillCoreApiKey(true);

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -114,3 +114,31 @@ def test_tts_voice_id_not_rewritten_when_gptsovits_disabled(mock_page: Page, run
     assert payload["ttsModelId"] == "tts-1"
     assert payload["ttsVoiceId"] == "alloy"
     assert not payload["ttsVoiceId"].startswith("__gptsovits_disabled__|")
+
+
+@pytest.mark.frontend
+def test_assist_free_disables_assist_api_key_input(mock_page: Page, running_server: str):
+    """辅助 API 选择免费版时应禁用辅助 API Key 输入框。"""
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    url = f"{running_server}/api_key"
+    mock_page.goto(url)
+
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
+    mock_page.wait_for_selector("#coreApiSelect option[value='free']", state="attached", timeout=10000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='free']", state="attached", timeout=10000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='qwen']", state="attached", timeout=10000)
+
+    mock_page.select_option("#coreApiSelect", "free")
+    mock_page.select_option("#assistApiSelect", "free")
+
+    expect(mock_page.locator("#assistApiKeyInput")).to_be_disabled(timeout=5000)
+    assert mock_page.evaluate(
+        "isFreeVersionText(getRealKey(document.getElementById('assistApiKeyInput')))"
+    ) is True
+
+    mock_page.select_option("#assistApiSelect", "qwen")
+
+    expect(mock_page.locator("#assistApiKeyInput")).to_be_enabled(timeout=5000)
+    assert mock_page.evaluate(
+        "isFreeVersionText(getRealKey(document.getElementById('assistApiKeyInput')))"
+    ) is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化辅助 API 选项的用户体验：当选择免费版本时，API 密钥输入框自动禁用并显示相关提示文本，避免用户在不需要密钥的情况下尝试输入。切换回付费 API 时，输入框恢复可用状态，并自动清除无效的提示内容。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->