### PR TITLE
fix(voice): 修复语音控制主按钮打开独立弹窗

### DIFF
--- a/static/live2d-ui-buttons.js
+++ b/static/live2d-ui-buttons.js
@@ -295,6 +295,14 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
                         return;
                     }
                 }
+
+                if (config.hasPopup && config.separatePopupTrigger) {
+                    const buttonData = this._floatingButtons && this._floatingButtons[config.id];
+                    if (buttonData && buttonData.triggerButton && typeof buttonData.triggerButton.click === 'function') {
+                        buttonData.triggerButton.click();
+                        return;
+                    }
+                }
             }
 
             if (config.id === 'screen') {
@@ -463,7 +471,7 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
                     }
 
                     if (config.id === 'mic' && window.renderFloatingMicList) {
-                        await window.renderFloatingMicList();
+                        await window.renderFloatingMicList(popup);
                         repositionPopup();
                     }
 

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -125,6 +125,14 @@ MMDManager.prototype.setupFloatingButtons = function() {
                     if (btn.dataset.active !== 'true') this.setButtonActive(config.id, true);
                     return;
                 }
+
+                if (config.hasPopup && config.separatePopupTrigger) {
+                    const buttonData = this._floatingButtons && this._floatingButtons[config.id];
+                    if (buttonData && buttonData.triggerButton && typeof buttonData.triggerButton.click === 'function') {
+                        buttonData.triggerButton.click();
+                        return;
+                    }
+                }
             }
             if (config.id === 'screen') {
                 const isRecording = window.isRecording || false;

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -147,6 +147,14 @@ VRMManager.prototype.setupFloatingButtons = function() {
                     }
                     return;
                 }
+
+                if (config.hasPopup && config.separatePopupTrigger) {
+                    const buttonData = this._floatingButtons && this._floatingButtons[config.id];
+                    if (buttonData && buttonData.triggerButton && typeof buttonData.triggerButton.click === 'function') {
+                        buttonData.triggerButton.click();
+                        return;
+                    }
+                }
             }
 
             if (config.id === 'screen') {

--- a/tests/unit/test_voice_control_popup_static.py
+++ b/tests/unit/test_voice_control_popup_static.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+UI_BUTTON_FILES = (
+    Path("static/live2d-ui-buttons.js"),
+    Path("static/vrm-ui-buttons.js"),
+    Path("static/mmd-ui-buttons.js"),
+)
+
+
+def test_voice_control_main_button_opens_existing_popup_trigger_before_toggle():
+    for path in UI_BUTTON_FILES:
+        source = path.read_text(encoding="utf-8")
+
+        popup_guard = "config.id === 'mic'"
+        popup_trigger_click = "buttonData.triggerButton.click();"
+        session_toggle = "new CustomEvent(`live2d-${config.id}-toggle`"
+
+        assert popup_guard in source, path
+        assert "config.hasPopup && config.separatePopupTrigger" in source, path
+        assert popup_trigger_click in source, path
+        assert session_toggle in source, path
+        assert source.index(popup_trigger_click) < source.index(session_toggle), path


### PR DESCRIPTION
## 概要

修复语音控制主按钮在存在独立弹窗触发器时仍走切换逻辑的问题，确保点击主麦克风按钮会优先打开已有弹窗触发器。

## 改动

- Live2D / VRM / MMD 三套悬浮按钮逻辑中，麦克风主按钮优先触发独立 popup trigger
- Live2D 麦克风弹窗渲染时传入 popup 实例，便于后续定位刷新
- 新增静态单测覆盖主按钮打开弹窗应早于 session toggle 的行为

## 测试

- 新增 `tests/unit/test_voice_control_popup_static.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了语音控制按钮的弹窗交互逻辑，确保独立弹窗触发按钮的点击事件被正确处理。

* **Tests**
  * 新增测试用例，验证语音控制主按钮的弹窗触发逻辑在切换事件前正确执行。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->