### PR TITLE
[codex] 添加学习伴侣 Neko 命令桥接

### DIFF
--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -136,6 +136,7 @@ from .entry_tutor_question_entries import _TutorQuestionEntriesMixin
 from .entry_tutor_answer_entries import _TutorAnswerEntriesMixin
 from .entry_tutor_summary_entries import _TutorSummaryEntriesMixin
 from .entry_ocr_entries import _OcrEntriesMixin
+from .entry_neko_commands import _NekoCommandsMixin
 
 
 @neko_plugin
@@ -164,6 +165,7 @@ class StudyCompanionPlugin(
     _TutorAnswerEntriesMixin,
     _TutorSummaryEntriesMixin,
     _OcrEntriesMixin,
+    _NekoCommandsMixin,
     NekoPluginBase,
 ):
     def __init__(self, ctx):
@@ -203,6 +205,9 @@ class StudyCompanionPlugin(
         self._memory_habit_bridge: MemoryHabitBridge | None = None
         self._event_bus: StudyEventBus | None = None
         self._review_due_task: asyncio.Task[None] | None = None
+        self._command_queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
+        self._command_worker_task: asyncio.Task[None] | None = None
+        self._interruptible_task: asyncio.Task[None] | None = None
 
     @lifecycle(id="startup")
     async def startup(self, **_):
@@ -287,6 +292,8 @@ class StudyCompanionPlugin(
             self._sync_doc_export_entry()
             await self._persist_state()
             self._start_review_due_task()
+            if self._event_bus is not None:
+                await self._subscribe_neko_commands()
             status_payload = await asyncio.to_thread(self._status_payload)
             return Ok({"status": STATUS_READY, "result": status_payload})
         except asyncio.CancelledError:

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -208,6 +208,9 @@ class StudyCompanionPlugin(
         self._command_queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
         self._command_worker_task: asyncio.Task[None] | None = None
         self._interruptible_task: asyncio.Task[None] | None = None
+        self._neko_command_transport: Any | None = None
+        self._neko_command_handler: Any | None = None
+        self._neko_command_watcher: Any | None = None
 
     @lifecycle(id="startup")
     async def startup(self, **_):
@@ -307,6 +310,7 @@ class StudyCompanionPlugin(
             return Err(SdkError("failed to start study_companion"))
 
     async def _cleanup_after_failed_startup(self) -> None:
+        await self._unsubscribe_neko_commands()
         await self._cancel_review_due_task()
         agent = self._agent
         self._agent = None
@@ -345,6 +349,7 @@ class StudyCompanionPlugin(
 
     @lifecycle(id="shutdown")
     async def shutdown(self, **_):
+        await self._unsubscribe_neko_commands()
         await self._cancel_review_due_task()
         try:
             self.unregister_dynamic_entry("study_export_notes")

--- a/plugin/plugins/study_companion/entry_neko_commands.py
+++ b/plugin/plugins/study_companion/entry_neko_commands.py
@@ -77,6 +77,17 @@ def _fmt_mode_changed_for_neko(*, new_mode: str, transition_phrase: str) -> str:
 
 class _NekoCommandsMixin:
     async def _subscribe_neko_commands(self) -> None:
+        await self._unsubscribe_neko_commands()
+        if await self._subscribe_neko_command_transport():
+            return
+        if await self._subscribe_neko_command_bus():
+            return
+        self.logger.warning(
+            "startup: message-plane transport unavailable for {}",
+            _NEKO_COMMAND_TOPIC,
+        )
+
+    async def _subscribe_neko_command_transport(self) -> bool:
         transport = None
         for ctx in (
             self.ctx,
@@ -88,17 +99,149 @@ class _NekoCommandsMixin:
                 break
         subscribe = getattr(transport, "subscribe", None)
         if not callable(subscribe):
-            self.logger.warning(
-                "startup: message-plane transport unavailable for {}",
-                _NEKO_COMMAND_TOPIC,
-            )
-            return
-        result = subscribe(_NEKO_COMMAND_TOPIC, self._on_neko_command)
+            return False
+        handler = self._on_neko_command
+        result = subscribe(_NEKO_COMMAND_TOPIC, handler)
         if inspect.isawaitable(result):
             result = await result
         if isinstance(result, Err):
             self.logger.warning(
                 "startup: failed to subscribe {}: {}",
+                _NEKO_COMMAND_TOPIC,
+                result.error,
+            )
+            return False
+        self._neko_command_transport = transport
+        self._neko_command_handler = handler
+        return True
+
+    async def _subscribe_neko_command_bus(self) -> bool:
+        bus = getattr(getattr(self.ctx, "bus", None), "messages", None)
+        get_messages = getattr(bus, "get", None)
+        if not callable(get_messages):
+            return False
+        try:
+            messages = get_messages(max_count=100)
+            if inspect.isawaitable(messages):
+                messages = await messages
+            watch = getattr(messages, "watch", None)
+            if not callable(watch):
+                return False
+            watcher = watch(self.ctx, bus="messages", debounce_ms=0)
+            loop = asyncio.get_running_loop()
+
+            def _on_messages_added(delta: Any) -> None:
+                self._dispatch_neko_command_messages(delta, loop)
+
+            watcher.subscribe(on="add")(_on_messages_added)
+            watcher.start()
+        except Exception as exc:
+            self.logger.warning(
+                "startup: failed to subscribe {} via messages bus: {}",
+                _NEKO_COMMAND_TOPIC,
+                exc,
+            )
+            return False
+        self._neko_command_watcher = watcher
+        return True
+
+    def _dispatch_neko_command_messages(
+        self, delta: Any, loop: asyncio.AbstractEventLoop
+    ) -> None:
+        for record in getattr(delta, "added", ()) or ():
+            payload = self._extract_neko_command_payload(record)
+            if payload is None:
+                continue
+
+            def _create_task(command_payload: dict[str, Any] = payload) -> None:
+                asyncio.create_task(self._on_neko_command(command_payload))
+
+            try:
+                loop.call_soon_threadsafe(_create_task)
+            except RuntimeError:
+                self.logger.warning(
+                    "neko command bus callback ignored after event loop closed"
+                )
+
+    @staticmethod
+    def _extract_neko_command_payload(record: Any) -> dict[str, Any] | None:
+        metadata = getattr(record, "metadata", None)
+        description = getattr(record, "description", "")
+        raw = getattr(record, "raw", None)
+        candidates: list[tuple[Any, Any]] = []
+        if isinstance(metadata, dict):
+            candidates.append(
+                (metadata.get("topic") or description, metadata.get("payload"))
+            )
+        if isinstance(raw, dict):
+            raw_metadata = raw.get("metadata")
+            if isinstance(raw_metadata, dict):
+                candidates.append(
+                    (
+                        raw_metadata.get("topic") or raw.get("description"),
+                        raw_metadata.get("payload"),
+                    )
+                )
+            raw_payload = raw.get("payload")
+            if isinstance(raw_payload, dict):
+                payload_metadata = raw_payload.get("metadata")
+                if isinstance(payload_metadata, dict):
+                    candidates.append(
+                        (
+                            payload_metadata.get("topic")
+                            or raw_payload.get("description"),
+                            payload_metadata.get("payload"),
+                        )
+                    )
+        for topic, payload in candidates:
+            if str(topic or "").strip() == _NEKO_COMMAND_TOPIC and isinstance(
+                payload, dict
+            ):
+                return dict(payload)
+        return None
+
+    async def _unsubscribe_neko_commands(self) -> None:
+        watcher = getattr(self, "_neko_command_watcher", None)
+        self._neko_command_watcher = None
+        if watcher is not None:
+            stop = getattr(watcher, "stop", None)
+            if callable(stop):
+                try:
+                    stop()
+                except Exception as exc:
+                    self.logger.warning(
+                        "shutdown: failed to stop {} messages bus watcher: {}",
+                        _NEKO_COMMAND_TOPIC,
+                        exc,
+                    )
+
+        transport = getattr(self, "_neko_command_transport", None)
+        handler = getattr(self, "_neko_command_handler", None)
+        self._neko_command_transport = None
+        self._neko_command_handler = None
+        if transport is None or handler is None:
+            return
+        unsubscribe = getattr(transport, "unsubscribe", None)
+        if not callable(unsubscribe):
+            self.logger.warning(
+                "shutdown: message-plane transport cannot unsubscribe {}",
+                _NEKO_COMMAND_TOPIC,
+            )
+            return
+        try:
+            result = unsubscribe(_NEKO_COMMAND_TOPIC, handler)
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as exc:
+            self.logger.warning(
+                "shutdown: failed to unsubscribe {}: {}",
+                _NEKO_COMMAND_TOPIC,
+                exc,
+            )
+            return
+        if isinstance(result, Err):
+            self.logger.warning(
+                "shutdown: failed to unsubscribe {}: {}",
                 _NEKO_COMMAND_TOPIC,
                 result.error,
             )

--- a/plugin/plugins/study_companion/entry_neko_commands.py
+++ b/plugin/plugins/study_companion/entry_neko_commands.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+from plugin.sdk.plugin import Err, Ok, SdkError
+
+from .constants import MODE_COMPANION, MODE_INTERACTIVE, MODE_TEACHING
+from .entry_common import _plugin_lock
+
+
+_NEKO_COMMAND_TOPIC = "neko.study_command"
+
+_NEKO_COMMAND_HANDLERS: dict[str, str] = {
+    "explain_current": "_handle_neko_explain_current",
+    "quiz_me": "_handle_neko_quiz_me",
+    "show_progress": "_handle_neko_show_progress",
+    "start_review": "_handle_neko_start_review",
+    "change_mode": "_handle_neko_change_mode",
+}
+
+
+def _fmt_explain_current_for_neko(*, text: str, explanation: str) -> str:
+    return f"[伴学·概念解释]\n原文: {text}\n\n{explanation}"
+
+
+def _fmt_quiz_for_neko(*, topic: str, question: str) -> str:
+    header = f"[伴学·随堂测验] 主题: {topic}" if topic else "[伴学·随堂测验]"
+    return f"{header}\n\n{question}"
+
+
+def _fmt_progress_for_neko(
+    *, items: list[dict[str, Any]], due_count: int, session_questions: int
+) -> str:
+    if not items:
+        return "[伴学·学习进度] 暂无掌握度数据。"
+    lines = [f"[伴学·学习进度] 本次已答 {session_questions} 题"]
+    for item in items:
+        lines.append(f"  {item['topic']}: {float(item['mastery']):.0%}")
+    if due_count > 0:
+        lines.append(f"待复习卡片: {due_count} 张")
+    return "\n".join(lines)
+
+
+def _fmt_review_start_for_neko(
+    *, due_items: list[dict[str, Any]], deck_id: str, due_count: int
+) -> str:
+    deck_info = f"（牌组: {deck_id}）" if deck_id else ""
+    top_topics: list[str] = []
+    for item in due_items[:5]:
+        deck = item.get("deck") if isinstance(item.get("deck"), dict) else {}
+        name = str(deck.get("name") or "")
+        if name and name not in top_topics:
+            top_topics.append(name)
+    topic_list = "、".join(top_topics[:5]) if top_topics else "综合"
+    limit_note = (
+        f"\n先展示前 {len(due_items)} 张。" if due_count > len(due_items) else ""
+    )
+    return (
+        f"[伴学·复习提醒] {due_count} 张卡片待复习{deck_info}{limit_note}\n"
+        f"涉及: {topic_list}\n"
+        f"现在开始复习吗？"
+    )
+
+
+def _fmt_mode_changed_for_neko(*, new_mode: str, transition_phrase: str) -> str:
+    mode_labels = {
+        MODE_COMPANION: "伴读模式",
+        MODE_INTERACTIVE: "互动模式",
+        MODE_TEACHING: "教学模式",
+    }
+    label = mode_labels.get(new_mode, new_mode)
+    phrase = f"\n{transition_phrase}" if transition_phrase else ""
+    return f"[伴学·模式切换] 已切换至「{label}」{phrase}"
+
+
+class _NekoCommandsMixin:
+    async def _subscribe_neko_commands(self) -> None:
+        transport = None
+        for ctx in (
+            self.ctx,
+            getattr(self.ctx, "_host_ctx", None),
+            getattr(self, "_host_ctx", None),
+        ):
+            transport = getattr(ctx, "transport", None)
+            if transport is not None:
+                break
+        subscribe = getattr(transport, "subscribe", None)
+        if not callable(subscribe):
+            self.logger.warning(
+                "startup: message-plane transport unavailable for {}",
+                _NEKO_COMMAND_TOPIC,
+            )
+            return
+        result = subscribe(_NEKO_COMMAND_TOPIC, self._on_neko_command)
+        if inspect.isawaitable(result):
+            result = await result
+        if isinstance(result, Err):
+            self.logger.warning(
+                "startup: failed to subscribe {}: {}",
+                _NEKO_COMMAND_TOPIC,
+                result.error,
+            )
+
+    async def _on_neko_command(self, payload: dict[str, Any]):
+        if self._event_bus is None:
+            return Err(SdkError("Neko communication is not enabled"))
+        if not isinstance(payload, dict):
+            self.logger.warning("_on_neko_command received invalid payload")
+            return Err(SdkError("invalid command payload"))
+        cmd = str(payload.get("command") or "").strip()
+        if not cmd:
+            self.logger.warning("_on_neko_command received empty command")
+            return Err(SdkError("empty command"))
+
+        handler_name = _NEKO_COMMAND_HANDLERS.get(cmd)
+        if handler_name is None:
+            self.logger.warning("_on_neko_command unknown command: {}", cmd)
+            return Err(SdkError(f"unknown command: {cmd}"))
+
+        handler = getattr(self, handler_name, None)
+        if handler is None:
+            self.logger.error("_on_neko_command handler not found: {}", handler_name)
+            return Err(SdkError(f"handler not found: {handler_name}"))
+
+        try:
+            await handler(payload)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.logger.exception("_on_neko_command handler failed: {}", cmd)
+            return Err(SdkError(f"handler failed: {cmd}: {exc}"))
+        return Ok(None)
+
+    async def _handle_neko_explain_current(self, payload: dict[str, Any]) -> None:
+        text = ""
+        if self._ocr_pipeline is not None:
+            try:
+                snapshot = await asyncio.to_thread(self._ocr_pipeline.capture_snapshot)
+                text = str(getattr(snapshot, "text", "") or "").strip()
+            except Exception:
+                self.logger.exception("explain_current: OCR snapshot failed")
+
+        if not text:
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=5,
+                text="[伴学] 当前屏幕无可识别的文字内容。",
+            )
+            return
+
+        try:
+            result = await self.study_explain_text(text=text[:2000])
+        except Exception:
+            self.logger.exception("explain_current: study_explain_text failed")
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=5,
+                text="[伴学] 抱歉，概念解释请求处理失败，请稍后再试。",
+            )
+            return
+
+        if isinstance(result, Ok):
+            reply = result.value if isinstance(result.value, dict) else {}
+            explanation = str(
+                reply.get("explanation") or reply.get("reply") or result.value or ""
+            )
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=5,
+                text=_fmt_explain_current_for_neko(
+                    text=text[:300], explanation=explanation
+                ),
+            )
+            return
+
+        self.logger.warning(
+            "explain_current: study_explain_text failed: {}",
+            getattr(result, "error", result),
+        )
+        await self._push_neko_command_message(
+            visibility=[],
+            ai_behavior="respond",
+            priority=5,
+            text="[伴学] 抱歉，概念解释请求处理失败，请稍后再试。",
+        )
+
+    async def _handle_neko_quiz_me(self, payload: dict[str, Any]) -> None:
+        topic = str(payload.get("topic") or "").strip()
+        text = str(payload.get("text") or "").strip()
+        async with _plugin_lock(self._lock):
+            has_cached_ocr = bool(self._state.last_ocr_text.strip())
+        if not topic and not text and not has_cached_ocr:
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=5,
+                text="[伴学] 请指定题目主题或当前屏幕有可识别内容。",
+            )
+            return
+
+        question_text = text or topic
+        try:
+            result = await self.study_generate_question(text=question_text, topic=topic)
+        except Exception:
+            self.logger.exception("quiz_me: study_generate_question failed")
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=5,
+                text="[伴学] 抱歉，题目生成请求处理失败，请稍后再试。",
+            )
+            return
+
+        if isinstance(result, Ok):
+            reply = result.value if isinstance(result.value, dict) else {}
+            question = str(
+                reply.get("question") or reply.get("reply") or result.value or ""
+            )
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=5,
+                text=_fmt_quiz_for_neko(topic=topic, question=question),
+            )
+            return
+
+        self.logger.warning(
+            "quiz_me: study_generate_question failed: {}",
+            getattr(result, "error", result),
+        )
+        await self._push_neko_command_message(
+            visibility=[],
+            ai_behavior="respond",
+            priority=5,
+            text="[伴学] 抱歉，题目生成请求处理失败，请稍后再试。",
+        )
+
+    async def _handle_neko_show_progress(self, payload: dict[str, Any]) -> None:
+        topic = str(payload.get("topic") or "").strip()
+        progress_items: list[dict[str, Any]] = []
+        if topic:
+            topic_row = await asyncio.to_thread(self._store.get_topic, topic)
+            if topic_row is None:
+                topic_row = await asyncio.to_thread(
+                    self._store.find_topic_by_name, topic
+                )
+            topic_id = str((topic_row or {}).get("id") or topic).strip()
+            mastery = await asyncio.to_thread(
+                self._knowledge_tracker.get_mastery, topic_id
+            )
+            if topic_row is not None or mastery > 0:
+                progress_items.append(
+                    {
+                        "topic": str((topic_row or {}).get("name") or topic),
+                        "mastery": mastery,
+                    }
+                )
+        else:
+            overview = await asyncio.to_thread(
+                self._store.list_mastery_overview, limit=10
+            )
+            for entry in overview or []:
+                progress_items.append(
+                    {
+                        "topic": entry.get("topic_name") or entry.get("topic_id") or "",
+                        "mastery": entry.get("mastery") or 0.0,
+                    }
+                )
+
+        due_count = 0
+        if self._memory_deck_store is not None:
+            try:
+                due_count = await asyncio.to_thread(
+                    self._memory_deck_store.count_due_reviews
+                )
+            except Exception:
+                self.logger.exception("show_progress: count_due_reviews failed")
+
+        progress_items = [
+            item for item in progress_items if str(item.get("topic") or "").strip()
+        ]
+        progress_items.sort(
+            key=lambda item: float(item.get("mastery") or 0.0), reverse=True
+        )
+        session_questions = await self._read_neko_session_answer_count()
+        await self._push_neko_command_message(
+            visibility=[],
+            ai_behavior="read",
+            priority=2,
+            text=_fmt_progress_for_neko(
+                items=progress_items,
+                due_count=int(due_count or 0),
+                session_questions=session_questions,
+            ),
+        )
+
+    async def _handle_neko_start_review(self, payload: dict[str, Any]) -> None:
+        deck_id = str(payload.get("deck_id") or "").strip()
+        if self._memory_deck_store is None:
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=3,
+                text="[伴学] 记忆卡片系统未就绪。",
+            )
+            return
+
+        try:
+            due_count = await asyncio.to_thread(
+                self._memory_deck_store.count_due_reviews, deck_id=deck_id
+            )
+            due_items = await asyncio.to_thread(
+                self._memory_deck_store.due_reviews, deck_id=deck_id, limit=20
+            )
+        except Exception:
+            self.logger.exception("start_review: due_reviews failed")
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=3,
+                text="[伴学] 抱歉，复习卡片查询失败，请稍后再试。",
+            )
+            return
+
+        if not due_items:
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=3,
+                text="[伴学] 太棒了，当前没有到期卡片需要复习！",
+            )
+            return
+
+        await self._push_neko_command_message(
+            visibility=[],
+            ai_behavior="respond",
+            priority=3,
+            text=_fmt_review_start_for_neko(
+                due_items=due_items,
+                deck_id=deck_id,
+                due_count=int(due_count or len(due_items)),
+            ),
+        )
+
+    async def _handle_neko_change_mode(self, payload: dict[str, Any]) -> None:
+        mode = str(payload.get("mode") or "").strip()
+        if mode not in (MODE_COMPANION, MODE_INTERACTIVE, MODE_TEACHING):
+            self.logger.warning("change_mode: invalid mode: {}", mode)
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="read",
+                priority=1,
+                text=f"[伴学] 不支持的模式: {mode}",
+            )
+            return
+
+        try:
+            result = await self.study_set_mode(mode=mode, reason="neko_command")
+        except Exception as exc:
+            self.logger.exception("change_mode: study_set_mode failed")
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="respond",
+                priority=1,
+                text=f"[伴学] 抱歉，模式切换失败：{exc}",
+            )
+            raise
+
+        if isinstance(result, Ok):
+            reply = result.value if isinstance(result.value, dict) else {}
+            await self._push_neko_command_message(
+                visibility=[],
+                ai_behavior="read",
+                priority=1,
+                text=_fmt_mode_changed_for_neko(
+                    new_mode=mode,
+                    transition_phrase=str(reply.get("transition_phrase") or ""),
+                ),
+            )
+            return
+
+        self.logger.warning(
+            "change_mode: study_set_mode failed: {}",
+            getattr(result, "error", result),
+        )
+        error = getattr(result, "error", result)
+        await self._push_neko_command_message(
+            visibility=[],
+            ai_behavior="respond",
+            priority=1,
+            text=f"[伴学] 抱歉，模式切换失败：{error}",
+        )
+        raise RuntimeError(f"study_set_mode failed: {error}")
+
+    async def _read_neko_session_answer_count(self) -> int:
+        lock = getattr(self, "_lock", None)
+        if hasattr(lock, "__aenter__"):
+            async with lock:
+                return self._neko_session_answer_count_unlocked()
+        if hasattr(lock, "__enter__"):
+            return await asyncio.to_thread(self._read_neko_session_answer_count_sync)
+        return self._neko_session_answer_count_unlocked()
+
+    def _read_neko_session_answer_count_sync(self) -> int:
+        with self._lock:
+            return self._neko_session_answer_count_unlocked()
+
+    def _neko_session_answer_count_unlocked(self) -> int:
+        try:
+            return int(self._state.session_summary_seed.get("answer_count") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    async def _push_neko_command_message(
+        self,
+        *,
+        visibility: list[str],
+        ai_behavior: str,
+        priority: int,
+        text: str,
+    ) -> None:
+        result = self.ctx.push_message(
+            visibility=visibility,
+            ai_behavior=ai_behavior,
+            priority=priority,
+            parts=[{"type": "text", "text": text}],
+            source="study_companion",
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        if isinstance(result, Err):
+            raise RuntimeError(f"neko command push_message failed: {result.error}")
+        if isinstance(result, dict) and result.get("ok") is False:
+            raise RuntimeError(
+                f"neko command push_message failed: {result.get('error') or result}"
+            )
+
+
+__all__ = ["_NekoCommandsMixin"]

--- a/plugin/plugins/study_companion/entry_pomodoro_entries.py
+++ b/plugin/plugins/study_companion/entry_pomodoro_entries.py
@@ -122,12 +122,22 @@ class _PomodoroEntriesMixin:
                     if goal_id
                     else {}
                 )
+                status_config = status.get("config")
+                status_focus_minutes = (
+                    status_config.get("focus_minutes")
+                    if isinstance(status_config, dict)
+                    else None
+                )
                 supervision.on_focus_start(
                     goal=goal or {},
                     planned_minutes=float(
-                        status.get("config", {}).get("focus_minutes")
-                        or focus_minutes
-                        or 0
+                        status_focus_minutes
+                        if status_focus_minutes is not None
+                        else (
+                            focus_minutes
+                            if focus_minutes is not None
+                            else planned_focus_minutes
+                        )
                     ),
                 )
             return Ok(build_pomodoro_status_payload(status))

--- a/plugin/plugins/study_companion/entry_status_entries.py
+++ b/plugin/plugins/study_companion/entry_status_entries.py
@@ -85,7 +85,12 @@ class _StatusEntriesMixin:
             default="Return whether memory deck habit integration is available.",
         ),
         input_schema={"type": "object", "properties": {}},
-        llm_result_fields=["available", "supports_deck_goals", "supports_deck_focus"],
+        llm_result_fields=[
+            "available",
+            "supports_deck_goals",
+            "supports_deck_focus",
+            "error",
+        ],
     )
     async def study_memory_habit_status(self, **_):
         try:

--- a/plugin/plugins/study_companion/entry_tutor_explain_entries.py
+++ b/plugin/plugins/study_companion/entry_tutor_explain_entries.py
@@ -126,6 +126,15 @@ class _TutorExplainEntriesMixin:
             async with _plugin_lock(self._lock):
                 source_text = self._state.last_ocr_text
             used_ocr_fallback = bool(source_text.strip())
+        source_text = source_text.strip()
+        vision_image_payload = str(vision_image_base64 or "").strip()
+        if not source_text and not vision_image_payload:
+            return Err(
+                SdkError(
+                    "study tutor requires text or a non-empty OCR snapshot",
+                    code="MISSING_TEXT",
+                )
+            )
         # Phase 3: explain with the active mode selected above.
         try:
             extra_context: dict[str, Any] = {
@@ -136,7 +145,6 @@ class _TutorExplainEntriesMixin:
                 "mode_switch": bool(mode_switch.get("changed")),
                 "source_text": source_text,
             }
-            vision_image_payload = str(vision_image_base64 or "").strip()
             if vision_image_payload:
                 if not bool(self._cfg.llm_vision_enabled):
                     return Err(SdkError("llm_vision_enabled is not enabled"))

--- a/plugin/plugins/study_companion/entry_tutor_question_entries.py
+++ b/plugin/plugins/study_companion/entry_tutor_question_entries.py
@@ -44,6 +44,14 @@ class _TutorQuestionEntriesMixin:
             async with self._lock:
                 source_text = self._state.last_ocr_text
             used_ocr_fallback = bool(source_text.strip())
+        source_text = source_text.strip()
+        if not source_text:
+            return Err(
+                SdkError(
+                    "study tutor requires text or a non-empty OCR snapshot",
+                    code="MISSING_TEXT",
+                )
+            )
         async with self._lock:
             active_mode = self._state.active_mode
         tutor_context = await self._build_learning_context(

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -2125,7 +2125,7 @@ async def test_study_explain_text_detects_mode_intent_and_continues_when_content
 
 
 @pytest.mark.asyncio
-async def test_study_explain_text_explain_intent_without_content_keeps_empty_input_guidance(
+async def test_study_explain_text_explain_intent_without_content_returns_err(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     runtime_root = tmp_path / "runtime"
@@ -2146,10 +2146,38 @@ async def test_study_explain_text_explain_intent_without_content_keeps_empty_inp
         async with plugin._lock:
             plugin._state.last_ocr_text = ""
         explain_empty = await plugin.study_explain_text("explain")
-        assert isinstance(explain_empty, Ok)
-        assert explain_empty.value["input_text"] == ""
-        assert explain_empty.value["diagnostic"] == "empty_input"
-        assert explain_empty.value["intent"]["kind"] == "concept_explain"
+        assert isinstance(explain_empty, Err)
+        assert "requires text" in str(explain_empty.error)
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_study_generate_question_without_content_returns_err(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(runtime_root))
+    ctx = _Ctx(
+        tmp_path,
+        {
+            "study": {"language": "en", "default_mode": MODE_COMPANION},
+            "ocr_reader": {"enabled": True},
+            "rapidocr": {"lang_type": "ch"},
+        },
+    )
+    plugin = StudyCompanionPlugin(ctx)
+    result = await plugin.startup()
+    assert isinstance(result, Ok)
+    plugin._agent = _FakeTutorAgent()
+
+    try:
+        async with plugin._lock:
+            plugin._state.last_ocr_text = ""
+        question_empty = await plugin.study_generate_question()
+
+        assert isinstance(question_empty, Err)
+        assert "requires text" in str(question_empty.error)
     finally:
         await plugin.shutdown()
 
@@ -3051,6 +3079,48 @@ async def test_study_pomodoro_start_offloads_blocking_operations(
     assert to_thread_calls == ["status", "start", "get_goal"]
     assert supervision.goal == {"id": "goal-1", "title": "read"}
     assert supervision.planned_minutes == 30.0
+
+
+@pytest.mark.asyncio
+async def test_study_pomodoro_start_uses_validated_focus_minutes_as_supervision_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Habits:
+        def get_goal(self, goal_id: str) -> dict[str, object]:
+            return {"id": goal_id}
+
+    class _Timer:
+        def status(self) -> dict[str, object]:
+            return {"state": "idle", "current_focus_session": {}}
+
+        def start(self, **_kwargs) -> dict[str, object]:
+            return {"state": "focusing", "current_focus_session": {"id": "focus-4"}}
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.planned_minutes = -1.0
+
+        def on_focus_start(
+            self, *, goal: dict[str, object], planned_minutes: float
+        ) -> None:
+            self.planned_minutes = planned_minutes
+
+    async def _to_thread(func, /, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(study_companion_module.asyncio, "to_thread", _to_thread)
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._cfg = StudyConfig()
+    plugin._habit_store = _Habits()
+    plugin._checkin_manager = object()
+    plugin._pomodoro_timer = _Timer()
+    plugin._supervision = supervision
+
+    status = await plugin.study_pomodoro_start(goal_id="goal-1")
+
+    assert isinstance(status, Ok)
+    assert supervision.planned_minutes == 25.0
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_study_companion_neko_commands.py
+++ b/plugin/tests/unit/plugins/test_study_companion_neko_commands.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -206,6 +207,31 @@ def _texts(ctx: _Ctx) -> list[str]:
 def _last_push(ctx: _Ctx) -> dict[str, object]:
     assert ctx.pushed_messages
     return ctx.pushed_messages[-1]
+
+
+async def _wait_until(predicate, *, timeout: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    assert predicate()
+
+
+async def _wait_for_text(ctx: _Ctx, needle: str, *, timeout: float = 2.0) -> str:
+    found = ""
+
+    def _has_text() -> bool:
+        nonlocal found
+        for text in _texts(ctx):
+            if needle in text:
+                found = text
+                return True
+        return False
+
+    await _wait_until(_has_text, timeout=timeout)
+    return found
 
 
 async def _started_plugin(
@@ -596,6 +622,98 @@ async def test_subscribe_neko_commands_handles_missing_host_ctx(
     finally:
         plugin._host_ctx = host_ctx
         await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_neko_commands_uses_messages_bus_without_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _Record:
+        metadata = {
+            "topic": "neko.study_command",
+            "payload": {"command": "show_progress"},
+        }
+        description = "neko.study_command"
+        raw = {}
+
+    class _Delta:
+        added = (_Record(),)
+
+    class _Watcher:
+        def __init__(self) -> None:
+            self.callback = None
+            self.started = False
+            self.stopped = False
+
+        def subscribe(self, *, on: str = "add"):
+            def _decorator(callback):
+                self.callback = callback
+                return callback
+
+            return _decorator
+
+        def start(self):
+            self.started = True
+            return self
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    class _MessageList:
+        def __init__(self, watcher: _Watcher) -> None:
+            self.watcher = watcher
+
+        def watch(self, *_args, **_kwargs):
+            return self.watcher
+
+    class _Messages:
+        def __init__(self, watcher: _Watcher) -> None:
+            self.watcher = watcher
+
+        async def get(self, **_kwargs):
+            return _MessageList(self.watcher)
+
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(runtime_root))
+    watcher = _Watcher()
+    ctx = _Ctx(tmp_path)
+    delattr(ctx, "transport")
+    ctx.bus = SimpleNamespace(messages=_Messages(watcher))
+    plugin = StudyCompanionPlugin(ctx)
+    result = await plugin.startup()
+    try:
+        assert isinstance(result, Ok)
+        assert watcher.started
+        assert plugin._neko_command_watcher is not None
+
+        assert watcher.callback is not None
+        watcher.callback(_Delta())
+
+        await _wait_for_text(ctx, "暂无掌握度数据")
+    finally:
+        await plugin.shutdown()
+    assert watcher.stopped
+
+
+@pytest.mark.asyncio
+async def test_shutdown_unsubscribes_neko_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    closed = False
+    try:
+        handlers = ctx.transport._handlers.get("neko.study_command", [])
+        assert handlers == [plugin._neko_command_handler]
+
+        await plugin.shutdown()
+        closed = True
+
+        assert "neko.study_command" not in ctx.transport._handlers
+        assert plugin._neko_command_transport is None
+        assert plugin._neko_command_handler is None
+    finally:
+        if not closed:
+            await plugin.shutdown()
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_study_companion_neko_commands.py
+++ b/plugin/tests/unit/plugins/test_study_companion_neko_commands.py
@@ -1,0 +1,695 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from plugin.plugins.study_companion import StudyCompanionPlugin
+from plugin.plugins.study_companion.constants import (
+    MODE_COMPANION,
+    MODE_INTERACTIVE,
+)
+from plugin.plugins.study_companion.models import OcrSnapshot, StudyConfig, TutorReply
+from plugin.sdk.plugin import Err, Ok
+from plugin.sdk.shared.transport.message_plane import MessagePlaneTransport
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+        self.errors: list[tuple[tuple[object, ...], dict[str, object]]] = []
+        self.exceptions: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        self.warnings.append((args, kwargs))
+        return None
+
+    def error(self, *args, **kwargs):
+        self.errors.append((args, kwargs))
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+    def exception(self, *args, **kwargs):
+        self.exceptions.append((args, kwargs))
+        return None
+
+
+class _Ctx:
+    plugin_id = "study_companion"
+    metadata = {}
+    bus = None
+    run_id = ""
+
+    def __init__(
+        self,
+        plugin_dir: Path,
+        config: dict[str, object] | None = None,
+        *,
+        transport: MessagePlaneTransport | None = None,
+    ) -> None:
+        self.logger = _Logger()
+        self.config_path = plugin_dir / "plugin.toml"
+        self.config_path.write_text(
+            "[plugin]\nid='study_companion'\n", encoding="utf-8"
+        )
+        self._config = config or {"study": {"language": "en"}}
+        self._effective_config = {
+            "plugin": {"store": {"enabled": True}, "database": {"enabled": False}},
+            "plugin_state": {"backend": "memory"},
+        }
+        self.transport = transport or MessagePlaneTransport(plugin_ctx=None)
+        self.pushed_messages: list[dict[str, object]] = []
+        self.status_updates: list[dict[str, object]] = []
+        self.run_updates: list[dict[str, object]] = []
+
+    async def get_own_config(self, timeout: float = 5.0):
+        return {"config": self._config}
+
+    async def get_own_base_config(self, timeout: float = 5.0):
+        return {"config": self._config}
+
+    async def get_own_profiles_state(self, timeout: float = 5.0):
+        return {"profiles": [], "active": None}
+
+    async def get_own_profile_config(self, profile_name: str, timeout: float = 5.0):
+        return {"profile_name": profile_name, "config": self._config}
+
+    async def get_own_effective_config(
+        self, profile_name: str | None = None, timeout: float = 5.0
+    ):
+        return {"config": self._config}
+
+    async def update_own_config(self, updates, timeout: float = 10.0):
+        self._config = {**self._config, **dict(updates or {})}
+        return {"config": self._config}
+
+    async def query_plugins(self, filters, timeout: float = 5.0):
+        return {"plugins": []}
+
+    async def trigger_plugin_event(self, **kwargs):
+        return {}
+
+    async def get_system_config(self, timeout: float = 5.0):
+        return {}
+
+    async def query_memory(self, bucket_id: str, query: str, timeout: float = 5.0):
+        return {"items": []}
+
+    async def run_update(self, **kwargs):
+        self.run_updates.append(dict(kwargs))
+        return {"ok": True}
+
+    async def run_update_async(self, **kwargs):
+        self.run_updates.append(dict(kwargs))
+        return {"ok": True}
+
+    async def export_push(self, **kwargs):
+        return {"ok": True}
+
+    async def finish(self, **kwargs):
+        return {"ok": True}
+
+    def push_message(self, **kwargs):
+        self.pushed_messages.append(dict(kwargs))
+        return {"ok": True}
+
+    def update_status(self, status):
+        self.status_updates.append(dict(status))
+
+
+class _FakeStudyOcrPipeline:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def capture_snapshot(self) -> OcrSnapshot:
+        return OcrSnapshot(text=self.text, status="ok", backend="fake")
+
+
+class _FakeTutorAgent:
+    def __init__(self) -> None:
+        self.explain_inputs: list[str] = []
+        self.question_inputs: list[tuple[str, str]] = []
+
+    def update_config(self, config: StudyConfig) -> None:
+        self._config = config
+
+    async def concept_explain(
+        self,
+        text: str,
+        *,
+        mode: str = MODE_COMPANION,
+        context: dict[str, object] | None = None,
+    ) -> TutorReply:
+        self.explain_inputs.append(text)
+        return TutorReply(
+            operation="concept_explain",
+            input_text=text,
+            reply=f"Explained: {text}",
+            created_at="2026-05-11T00:00:00Z",
+        )
+
+    async def question_generate(
+        self,
+        text: str,
+        *,
+        mode: str = MODE_COMPANION,
+        context: dict[str, object] | None = None,
+    ) -> TutorReply:
+        topic = str((context or {}).get("topic_hint") or "general")
+        self.question_inputs.append((text, topic))
+        return TutorReply(
+            operation="question_generate",
+            input_text=text,
+            reply=f"Question about {topic}",
+            payload={"question": f"What is {topic}?", "topic": topic},
+            created_at="2026-05-11T00:00:00Z",
+        )
+
+    async def knowledge_track(
+        self,
+        *,
+        mode: str = MODE_COMPANION,
+        context: dict[str, object] | None = None,
+    ) -> TutorReply:
+        return TutorReply(
+            operation="knowledge_track",
+            input_text=str((context or {}).get("input_text") or ""),
+            reply="derivatives",
+            payload={"topic": "derivatives"},
+            created_at="2026-05-11T00:00:00Z",
+        )
+
+    async def shutdown(self) -> None:
+        return None
+
+
+def _texts(ctx: _Ctx) -> list[str]:
+    texts: list[str] = []
+    for message in ctx.pushed_messages:
+        if message.get("source") != "study_companion":
+            continue
+        parts = message.get("parts") or []
+        if parts:
+            texts.append(str(parts[0].get("text") or ""))
+    return texts
+
+
+def _last_push(ctx: _Ctx) -> dict[str, object]:
+    assert ctx.pushed_messages
+    return ctx.pushed_messages[-1]
+
+
+async def _started_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    config: dict[str, object] | None = None,
+) -> tuple[StudyCompanionPlugin, _Ctx]:
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(runtime_root))
+    ctx = _Ctx(tmp_path, config)
+    plugin = StudyCompanionPlugin(ctx)
+    result = await plugin.startup()
+    assert isinstance(result, Ok)
+    return plugin, ctx
+
+
+def _seed_mastery(plugin: StudyCompanionPlugin) -> None:
+    plugin._store.ensure_topic(
+        topic_id="derivatives",
+        name="Derivatives",
+        subject="math",
+        chapter="calculus",
+    )
+    plugin._knowledge_tracker.on_answer(
+        topic_id="derivatives",
+        question={"question": "What is d/dx x^2?", "answer": "2x"},
+        user_answer="2x",
+        eval_result={"verdict": "correct", "score": 1.0},
+        mode=MODE_COMPANION,
+        session_id="unit-test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_neko_explain_current_pushes_with_ocr_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin._agent = _FakeTutorAgent()
+    plugin._ocr_pipeline = _FakeStudyOcrPipeline("Derivative rules")
+    try:
+        result = await plugin._on_neko_command({"command": "explain_current"})
+
+        assert isinstance(result, Ok)
+        assert any("[伴学·概念解释]" in text for text in _texts(ctx))
+        assert any("Derivative rules" in text for text in _texts(ctx))
+        assert _last_push(ctx)["visibility"] == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_explain_current_no_ocr_pushes_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin._ocr_pipeline = _FakeStudyOcrPipeline("")
+    try:
+        result = await plugin._on_neko_command({"command": "explain_current"})
+
+        assert isinstance(result, Ok)
+        assert any("当前屏幕无可识别的文字内容" in text for text in _texts(ctx))
+        assert _last_push(ctx)["visibility"] == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_quiz_me_with_topic_generates_question(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin._agent = _FakeTutorAgent()
+    try:
+        result = await plugin._on_neko_command(
+            {"command": "quiz_me", "topic": "derivatives"}
+        )
+
+        assert isinstance(result, Ok)
+        assert any("[伴学·随堂测验]" in text for text in _texts(ctx))
+        assert any("What is derivatives?" in text for text in _texts(ctx))
+        assert _last_push(ctx)["visibility"] == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_quiz_me_without_input_uses_cached_ocr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    agent = _FakeTutorAgent()
+    plugin._agent = agent
+    async with plugin._lock:
+        plugin._state.last_ocr_text = "Cached Newton law"
+    try:
+        result = await plugin._on_neko_command({"command": "quiz_me"})
+
+        assert isinstance(result, Ok)
+        assert agent.question_inputs[0][0] == "Cached Newton law"
+        assert any("[伴学·随堂测验]" in text for text in _texts(ctx))
+        assert _last_push(ctx)["visibility"] == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_quiz_me_no_input_pushes_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        result = await plugin._on_neko_command({"command": "quiz_me"})
+
+        assert isinstance(result, Ok)
+        assert any("请指定题目主题" in text for text in _texts(ctx))
+        assert _last_push(ctx)["visibility"] == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_show_progress_returns_mastery_overview(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        _seed_mastery(plugin)
+        async with plugin._lock:
+            plugin._state.session_summary_seed = {"answer_count": 2}
+
+        result = await plugin._on_neko_command({"command": "show_progress"})
+
+        assert isinstance(result, Ok)
+        assert any("[伴学·学习进度]" in text for text in _texts(ctx))
+        assert any("Derivatives" in text for text in _texts(ctx))
+        assert ctx.pushed_messages[-1]["ai_behavior"] == "read"
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_show_progress_filtered_by_topic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        _seed_mastery(plugin)
+
+        result = await plugin._on_neko_command(
+            {"command": "show_progress", "topic": "Derivatives"}
+        )
+
+        assert isinstance(result, Ok)
+        assert any("Derivatives" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_show_progress_keeps_zero_mastery_topic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        plugin._store.ensure_topic(
+            topic_id="limits",
+            name="Limits",
+            subject="math",
+            chapter="calculus",
+        )
+
+        result = await plugin._on_neko_command(
+            {"command": "show_progress", "topic": "Limits"}
+        )
+
+        assert isinstance(result, Ok)
+        assert any("Limits: 0%" in text for text in _texts(ctx))
+        assert not any("暂无掌握度数据" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_show_progress_empty_when_no_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        result = await plugin._on_neko_command({"command": "show_progress"})
+
+        assert isinstance(result, Ok)
+        assert any("暂无掌握度数据" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_start_review_returns_due_items(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        deck = plugin._memory_deck_store.create_deck(
+            name="Exam Words", deck_type="word", language="en"
+        )
+        plugin._memory_deck_store.add_word(
+            deck_id=deck["id"],
+            word="abandon",
+            meaning="give up",
+        )
+
+        result = await plugin._on_neko_command({"command": "start_review"})
+
+        assert isinstance(result, Ok)
+        assert any("[伴学·复习提醒]" in text for text in _texts(ctx))
+        assert ctx.pushed_messages[-1]["priority"] == 3
+        assert _last_push(ctx)["visibility"] == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_start_review_reports_total_due_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _MemoryDeckStore:
+        def count_due_reviews(self, *, deck_id: str = "") -> int:
+            return 25
+
+        def due_reviews(self, *, deck_id: str = "", limit: int = 20):
+            return [
+                {"deck": {"name": f"Deck {index}"}}
+                for index in range(min(20, limit))
+            ]
+
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin._memory_deck_store = _MemoryDeckStore()  # type: ignore[assignment]
+    try:
+        result = await plugin._on_neko_command({"command": "start_review"})
+
+        assert isinstance(result, Ok)
+        assert any("25 张卡片待复习" in text for text in _texts(ctx))
+        assert any("先展示前 20 张" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_start_review_no_due_pushes_congrats(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        result = await plugin._on_neko_command({"command": "start_review"})
+
+        assert isinstance(result, Ok)
+        assert any("当前没有到期卡片" in text for text in _texts(ctx))
+        assert _last_push(ctx)["visibility"] == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_change_mode_switches_and_confirms(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        result = await plugin._on_neko_command(
+            {"command": "change_mode", "mode": MODE_INTERACTIVE}
+        )
+
+        assert isinstance(result, Ok)
+        assert plugin._state.active_mode == MODE_INTERACTIVE
+        assert any("[伴学·模式切换]" in text for text in _texts(ctx))
+        assert ctx.pushed_messages[-1]["ai_behavior"] == "read"
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_change_mode_propagates_set_mode_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+
+    async def _fail_set_mode(**_kwargs):
+        return Err(RuntimeError("mode store failed"))
+
+    plugin.study_set_mode = _fail_set_mode  # type: ignore[method-assign]
+    try:
+        result = await plugin._on_neko_command(
+            {"command": "change_mode", "mode": MODE_INTERACTIVE}
+        )
+
+        assert isinstance(result, Err)
+        assert any("模式切换失败" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_change_mode_rejects_invalid_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        result = await plugin._on_neko_command(
+            {"command": "change_mode", "mode": "invalid"}
+        )
+
+        assert isinstance(result, Ok)
+        assert any("不支持的模式" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_on_neko_command_unknown_silently_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin.logger = ctx.logger
+    try:
+        result = await plugin._on_neko_command({"command": "unknown"})
+
+        assert isinstance(result, Err)
+        assert not _texts(ctx)
+        assert any("unknown command" in str(args[0]) for args, _ in ctx.logger.warnings)
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_on_neko_command_empty_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin.logger = ctx.logger
+    try:
+        result = await plugin._on_neko_command({"command": ""})
+
+        assert isinstance(result, Err)
+        assert not _texts(ctx)
+        assert any("empty command" in str(args[0]) for args, _ in ctx.logger.warnings)
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_not_called_when_communication_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    transport = MessagePlaneTransport(plugin_ctx=None)
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(runtime_root))
+    ctx = _Ctx(
+        tmp_path,
+        {"study_companion": {"communication": {"enabled": False}}},
+        transport=transport,
+    )
+    plugin = StudyCompanionPlugin(ctx)
+    result = await plugin.startup()
+    try:
+        assert isinstance(result, Ok)
+        assert "neko.study_command" not in transport._handlers
+        command_result = await plugin._on_neko_command({"command": "show_progress"})
+        assert isinstance(command_result, Err)
+        assert ctx.pushed_messages == []
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_neko_commands_handles_missing_host_ctx(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    host_ctx = getattr(plugin, "_host_ctx", None)
+    if hasattr(plugin, "_host_ctx"):
+        delattr(plugin, "_host_ctx")
+    try:
+        ctx.transport._handlers.pop("neko.study_command", None)
+        await plugin._subscribe_neko_commands()
+
+        assert "neko.study_command" in ctx.transport._handlers
+    finally:
+        plugin._host_ctx = host_ctx
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_is_logged_not_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin.logger = ctx.logger
+
+    async def _fail(_payload: dict[str, object]) -> None:
+        raise RuntimeError("boom")
+
+    plugin._handle_neko_quiz_me = _fail  # type: ignore[method-assign]
+    try:
+        result = await plugin._on_neko_command({"command": "quiz_me", "topic": "math"})
+
+        assert isinstance(result, Err)
+        assert any(
+            "handler failed" in str(args[0]) for args, _ in ctx.logger.exceptions
+        )
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_push_neko_command_message_raises_on_err_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+
+    def _fail_push(**_kwargs):
+        return Err(RuntimeError("push failed"))
+
+    ctx.push_message = _fail_push  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match="push_message failed"):
+            await plugin._push_neko_command_message(
+                visibility=["chat"],
+                ai_behavior="respond",
+                priority=5,
+                text="hello",
+            )
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_command_roundtrip_explain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin._agent = _FakeTutorAgent()
+    plugin._ocr_pipeline = _FakeStudyOcrPipeline("Limits and continuity")
+    try:
+        result = await ctx.transport.publish(
+            "neko.study_command", {"command": "explain_current"}
+        )
+
+        assert isinstance(result, Ok)
+        assert any("Limits and continuity" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_command_roundtrip_quiz(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    plugin._agent = _FakeTutorAgent()
+    try:
+        result = await ctx.transport.publish(
+            "neko.study_command", {"command": "quiz_me", "topic": "limits"}
+        )
+
+        assert isinstance(result, Ok)
+        assert any("What is limits?" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_neko_command_roundtrip_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin, ctx = await _started_plugin(tmp_path, monkeypatch)
+    try:
+        _seed_mastery(plugin)
+
+        result = await ctx.transport.publish(
+            "neko.study_command", {"command": "show_progress"}
+        )
+
+        assert isinstance(result, Ok)
+        assert any("[伴学·学习进度]" in text for text in _texts(ctx))
+    finally:
+        await plugin.shutdown()


### PR DESCRIPTION
## 摘要

实现学习伴侣 Neko 通信方案第 4 阶段：Neko 现在可以通过消息平面主题 `neko.study_command` 向插件侧发送学习命令。

## 变更内容

- 新增 `_NekoCommandsMixin`，包含命令分发表和以下命令处理器：
  - `explain_current`
  - `quiz_me`
  - `show_progress`
  - `start_review`
  - `change_mode`
- 在 `StudyCompanionPlugin` 中注册该 mixin，并在通信能力启用时于启动阶段订阅 `neko.study_command`。
- 将命令 mixin 保持在学习伴侣插件根层，避免这个 PR 新增另一个 `plugin_entries` 子级到父级的依赖。
- 增加第 5 阶段占位字段，为后续命令队列/打断支持预留，但本 PR 不消费这些字段。
- 为新的命令桥接补充聚焦的单元测试与往返测试覆盖。
- 针对评审反馈做加固：包括 `_host_ctx` 访问、推送消息 `Err` 处理、异步处理器内的加锁读取、导出范围，以及内部 Neko 命令上下文的直接聊天可见性。

## 原因

第 1-3 阶段已经覆盖插件到 Neko 的事件投递。第 4 阶段补齐反向通道，让 Neko 侧可以请求学习伴侣插件解释当前屏幕、生成题目、汇报进度、开始复习或切换学习模式，而不需要把这些行为加入主应用层。

命令处理保留在学习伴侣插件应用层，`__init__.py` 只负责接入 mixin 和启动订阅。这样可以让 Neko 命令协议贴近它所控制的插件行为，并把队列/打断语义留给计划中的第 5 阶段 PR。

推送的命令内容使用 `visibility=[]`，因此结构化/插件兜底文本会作为 LLM 上下文，而不是直接渲染到聊天 UI 中。

## 验证

- `python -m ruff check plugin/plugins/study_companion/entry_neko_commands.py plugin/plugins/study_companion/__init__.py plugin/tests/unit/plugins/test_study_companion_neko_commands.py`
- `python -m py_compile plugin/plugins/study_companion/entry_neko_commands.py plugin/plugins/study_companion/__init__.py plugin/tests/unit/plugins/test_study_companion_neko_commands.py`
- `python -m pytest plugin/tests/unit/plugins/test_study_companion_neko_commands.py -q`（`20 passed`）
- 学习伴侣相关单元测试套件（`301 passed`）
- `git diff --check`
- GitNexus staged `detect_changes`：低风险，无受影响流程

本地没有运行完整仓库 pytest，因为它会收集 5523 个测试，包括前端、E2E 和 Playwright 覆盖；本 PR 已使用第 4 阶段相关的后端/插件测试范围完成验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CodeRabbit 摘要

* **新功能**
  * 新增 neko 命令系统，支持概念解释、随堂测验、学习进度、复习提醒与学习模式切换。
* **修复**
  * 更稳健的 Pomodoro 启动监督参数处理；缺失/空文本路径改为返回明确错误提示。
* **测试**
  * 新增大量单元测试（覆盖多命令、边界与错误场景，约 27 个用例）。
* **其他**
  * 学习状态接口增加可返回的 error 字段；文本输入统一 trim 校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->