### PR TITLE
修复语音克隆页服务商下拉菜单的地区过滤逻辑，确保国内环境只显示国内可用模型，并同步自定义下拉菜单状态

### DIFF
--- a/static/css/voice_clone.css
+++ b/static/css/voice_clone.css
@@ -559,6 +559,175 @@ body .container-header {
     box-shadow: 0 0 0 3px rgba(64, 197, 241, 0.15);
 }
 
+.api-provider-select {
+    max-width: 600px;
+    border-radius: 999px;
+}
+
+.api-provider-dropdown {
+    position: relative;
+    width: 100%;
+    max-width: 600px;
+}
+
+.api-provider-select.is-enhanced {
+    position: absolute;
+    width: 1px !important;
+    height: 1px !important;
+    opacity: 0;
+    pointer-events: none;
+    overflow: hidden;
+    clip-path: inset(50%);
+}
+
+button.api-provider-dropdown-trigger {
+    width: 100%;
+    min-height: 48px;
+    margin-top: 0;
+    padding: 10px 18px 10px 20px;
+    border-radius: 999px;
+    border: 2px solid #b3e5fc;
+    background: linear-gradient(180deg, #ffffff 0%, #f5fcff 100%);
+    color: var(--text-blue, #40C5F1);
+    font-size: 1rem;
+    font-family: 'Segoe UI', Arial, sans-serif;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+    box-sizing: border-box;
+}
+
+button.api-provider-dropdown-trigger:hover:not(:disabled) {
+    border-color: #7bd9f7;
+    box-shadow: 0 8px 20px rgba(64, 197, 241, 0.16);
+}
+
+button.api-provider-dropdown-trigger:focus-visible {
+    outline: none;
+    border-color: #40C5F1;
+    box-shadow: 0 0 0 3px rgba(64, 197, 241, 0.16);
+}
+
+button.api-provider-dropdown-trigger:active:not(:disabled) {
+    transform: translateY(1px);
+}
+
+.api-provider-dropdown-current {
+    flex: 1;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.api-provider-dropdown-current.placeholder {
+    color: #8bbfd0;
+}
+
+.api-provider-dropdown-arrow {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    background: url('/static/icons/dropdown_arrow.png') center / contain no-repeat;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+    opacity: 0.9;
+}
+
+.api-provider-dropdown.open .api-provider-dropdown-arrow {
+    transform: rotate(180deg);
+}
+
+.api-provider-dropdown.disabled button.api-provider-dropdown-trigger,
+button.api-provider-dropdown-trigger:disabled {
+    background: #f8f9fa;
+    color: #b3e5fc;
+    border-color: #e3f4ff;
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+.api-provider-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    display: none;
+    border-radius: 24px;
+    border: 1px solid #bfe8f8;
+    background: rgba(255, 255, 255, 0.98);
+    box-shadow: 0 18px 36px rgba(42, 144, 180, 0.18);
+    backdrop-filter: blur(12px);
+    overflow: hidden;
+    z-index: 95;
+    box-sizing: border-box;
+}
+
+.api-provider-dropdown.open .api-provider-dropdown-menu {
+    display: block;
+}
+
+.api-provider-dropdown-menu-scroll {
+    max-height: 320px;
+    overflow-y: auto;
+    padding: 8px;
+    box-sizing: border-box;
+    scrollbar-gutter: stable;
+}
+
+.api-provider-dropdown-menu-scroll::-webkit-scrollbar {
+    width: 6px;
+}
+
+.api-provider-dropdown-menu-scroll::-webkit-scrollbar-thumb {
+    background: rgba(64, 197, 241, 0.35);
+    border-radius: 999px;
+}
+
+button.api-provider-dropdown-option,
+.api-provider-dropdown-empty {
+    width: 100%;
+    margin-top: 0;
+    padding: 11px 14px;
+    border: none;
+    border-radius: 16px;
+    background: transparent;
+    color: var(--text-blue, #40C5F1);
+    font-size: 0.95rem;
+    font-family: 'Segoe UI', Arial, sans-serif;
+    font-weight: 500;
+    text-align: left;
+    box-sizing: border-box;
+}
+
+button.api-provider-dropdown-option {
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+button.api-provider-dropdown-option:hover:not(:disabled),
+button.api-provider-dropdown-option.selected {
+    background: linear-gradient(135deg, rgba(64, 197, 241, 0.18) 0%, rgba(64, 197, 241, 0.1) 100%);
+    color: #1b95b8;
+}
+
+button.api-provider-dropdown-option:active:not(:disabled) {
+    transform: scale(0.99);
+}
+
+button.api-provider-dropdown-option:disabled {
+    color: #b3cad3;
+    cursor: not-allowed;
+}
+
+.api-provider-dropdown-empty {
+    color: #8bbfd0;
+    cursor: default;
+}
+
 /* 按钮 - 圆角胶囊/药丸形状 */
 .btn {
     padding: 10px 20px;
@@ -967,6 +1136,7 @@ html[lang="zh-CN"] .register-voice-btn .register-text {
 
     html.neko-window-maximized .field-row input,
     html.neko-window-maximized .field-row select,
+    html.neko-window-maximized .api-provider-dropdown,
     html.neko-window-maximized .clone-input-container,
     html.neko-window-maximized .clone-method-toggle,
     html.neko-window-maximized .workshop-source-card {

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -96,6 +96,10 @@ const WORKSHOP_VOICE_PROVIDER_REGISTRY_KEYS = Object.freeze({
     minimax: 'minimax',
     minimax_intl: 'minimax_intl',
 });
+const WORKSHOP_VOICE_RESTRICTED_REGISTRY_KEYS = new Set([
+    'qwen_intl',
+    'minimax_intl',
+]);
 const workshopVoiceProviderRestrictionState = {
     loaded: false,
     loadingPromise: null,
@@ -141,11 +145,26 @@ function getWorkshopVoiceProviderRegistryKey(provider) {
 }
 
 async function checkWorkshopVoiceMainlandChinaUser() {
-    const data = await fetchWorkshopVoiceProviderJson('/api/config/steam_language', {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' }
-    });
-    return data && data.is_mainland_china === true;
+    let data = null;
+    try {
+        data = await fetchWorkshopVoiceProviderJson('/api/config/steam_language', {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' }
+        });
+    } catch (_) {
+        return true;
+    }
+
+    if (data && data.is_mainland_china === true) {
+        return true;
+    }
+
+    const ipCountry = String((data && data.ip_country) || '').trim().toUpperCase();
+    if (data && data.success === true && ipCountry && ipCountry !== 'CN') {
+        return false;
+    }
+
+    return true;
 }
 
 async function loadWorkshopVoiceProviderRestrictionState() {
@@ -159,19 +178,17 @@ async function loadWorkshopVoiceProviderRestrictionState() {
     workshopVoiceProviderRestrictionState.loadingPromise = (async () => {
         const [isMainlandChinaUser, providersResponse] = await Promise.all([
             checkWorkshopVoiceMainlandChinaUser(),
-            fetchWorkshopVoiceProviderJson('/api/config/api_providers')
+            fetchWorkshopVoiceProviderJson('/api/config/api_providers').catch(() => null)
         ]);
         let apiKeyRegistry = {};
         if (providersResponse && providersResponse.success) {
             apiKeyRegistry = providersResponse.api_key_registry || {};
-        } else {
-            throw new Error('api_providers config unavailable');
         }
         workshopVoiceProviderRestrictionState.isMainlandChinaUser = !!isMainlandChinaUser;
         workshopVoiceProviderRestrictionState.apiKeyRegistry = apiKeyRegistry;
         workshopVoiceProviderRestrictionState.loaded = true;
         return workshopVoiceProviderRestrictionState;
-    }).finally(() => {
+    })().finally(() => {
         workshopVoiceProviderRestrictionState.loadingPromise = null;
     });
 
@@ -191,7 +208,10 @@ function isWorkshopVoiceProviderRestricted(provider) {
     if (!workshopVoiceProviderRestrictionState.isMainlandChinaUser) return false;
     const registryKey = getWorkshopVoiceProviderRegistryKey(provider);
     const entry = workshopVoiceProviderRestrictionState.apiKeyRegistry[registryKey];
-    return !!(entry && entry.restricted === true);
+    if (entry && Object.prototype.hasOwnProperty.call(entry, 'restricted')) {
+        return entry.restricted === true;
+    }
+    return WORKSHOP_VOICE_RESTRICTED_REGISTRY_KEYS.has(registryKey);
 }
 
 function getFirstAvailableWorkshopVoiceProviderValue(providerSelect) {

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -496,8 +496,9 @@ async function checkVoiceCloneMainlandChinaUser() {
             method: 'GET',
             headers: { 'Content-Type': 'application/json' }
         });
-    } catch (_) {
-        return true;
+    } catch (error) {
+        console.warn('声音克隆地区检测失败，允许国际服务商:', error);
+        return false;
     }
 
     if (data && data.is_mainland_china === true) {

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -497,8 +497,8 @@ async function checkVoiceCloneMainlandChinaUser() {
             headers: { 'Content-Type': 'application/json' }
         });
     } catch (error) {
-        console.warn('声音克隆地区检测失败，允许国际服务商:', error);
-        return false;
+        console.warn('声音克隆地区检测失败，使用受限服务商策略:', error);
+        return true;
     }
 
     if (data && data.is_mainland_china === true) {

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -14,6 +14,11 @@ const VOICE_CLONE_PROVIDER_REGISTRY_KEYS = Object.freeze({
     minimax_intl: 'minimax_intl',
     elevenlabs: 'elevenlabs',
 });
+const VOICE_CLONE_RESTRICTED_REGISTRY_KEYS = new Set([
+    'qwen_intl',
+    'minimax_intl',
+    'elevenlabs',
+]);
 const VOICE_CLONE_PROVIDER_KEY_FIELDS = Object.freeze([
     ['cosyvoice', 'assistApiKeyQwen'],
     ['cosyvoice_intl', 'assistApiKeyQwenIntl'],
@@ -458,7 +463,7 @@ async function loadVoiceCloneApiConfigState(options = {}) {
         voiceCloneApiConfigState.isLocalTts = isLocalVoiceCloneServerConfigured(cfg);
         voiceCloneApiConfigState.loaded = true;
         return voiceCloneApiConfigState;
-    }).finally(() => {
+    })().finally(() => {
         voiceCloneApiConfigState.loadingPromise = null;
     });
 
@@ -485,11 +490,26 @@ function hasVoiceCloneProviderApi(provider) {
 }
 
 async function checkVoiceCloneMainlandChinaUser() {
-    const data = await fetchVoiceCloneLoaderJson('/api/config/steam_language', {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' }
-    });
-    return data && data.is_mainland_china === true;
+    let data = null;
+    try {
+        data = await fetchVoiceCloneLoaderJson('/api/config/steam_language', {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' }
+        });
+    } catch (_) {
+        return true;
+    }
+
+    if (data && data.is_mainland_china === true) {
+        return true;
+    }
+
+    const ipCountry = String((data && data.ip_country) || '').trim().toUpperCase();
+    if (data && data.success === true && ipCountry && ipCountry !== 'CN') {
+        return false;
+    }
+
+    return true;
 }
 
 async function loadVoiceCloneProviderRestrictionState() {
@@ -503,19 +523,17 @@ async function loadVoiceCloneProviderRestrictionState() {
     voiceCloneProviderRestrictionState.loadingPromise = (async () => {
         const [isMainlandChinaUser, providersData] = await Promise.all([
             checkVoiceCloneMainlandChinaUser(),
-            fetchVoiceCloneLoaderJson('/api/config/api_providers')
+            fetchVoiceCloneLoaderJson('/api/config/api_providers').catch(() => null)
         ]);
         let apiKeyRegistry = {};
         if (providersData && providersData.success) {
             apiKeyRegistry = providersData.api_key_registry || {};
-        } else {
-            throw new Error('api_providers config unavailable');
         }
         voiceCloneProviderRestrictionState.isMainlandChinaUser = !!isMainlandChinaUser;
         voiceCloneProviderRestrictionState.apiKeyRegistry = apiKeyRegistry;
         voiceCloneProviderRestrictionState.loaded = true;
         return voiceCloneProviderRestrictionState;
-    }).finally(() => {
+    })().finally(() => {
         voiceCloneProviderRestrictionState.loadingPromise = null;
     });
 
@@ -535,7 +553,10 @@ function isVoiceCloneProviderRestricted(provider) {
     if (!voiceCloneProviderRestrictionState.isMainlandChinaUser) return false;
     const registryKey = getVoiceCloneProviderRegistryKey(provider);
     const entry = voiceCloneProviderRestrictionState.apiKeyRegistry[registryKey];
-    return !!(entry && entry.restricted === true);
+    if (entry && Object.prototype.hasOwnProperty.call(entry, 'restricted')) {
+        return entry.restricted === true;
+    }
+    return VOICE_CLONE_RESTRICTED_REGISTRY_KEYS.has(registryKey);
 }
 
 function getFirstAvailableVoiceCloneProviderValue(providerSelect) {
@@ -557,6 +578,7 @@ function applyVoiceCloneProviderRestrictions(providerSelect) {
 
     const selectedOption = providerSelect.options[providerSelect.selectedIndex];
     if (selectedOption && !selectedOption.disabled && !selectedOption.hidden && selectedOption.style.display !== 'none') {
+        syncVoiceCloneSelectDropdowns(providerSelect, { rebuild: true });
         return false;
     }
 
@@ -564,7 +586,236 @@ function applyVoiceCloneProviderRestrictions(providerSelect) {
     if (fallbackValue) {
         providerSelect.value = fallbackValue;
     }
+    syncVoiceCloneSelectDropdowns(providerSelect, { rebuild: true });
     return providerSelect.value !== previousValue;
+}
+
+let voiceCloneDropdownHandlersBound = false;
+
+function getVoiceCloneDropdownPlaceholder(select) {
+    const fallbackText = window.t ? window.t('api.providerSelectPlaceholder') : '请选择服务商';
+    if (!select) return fallbackText;
+
+    const label = select.id ? document.querySelector(`label[for="${select.id}"]`) : null;
+    const labelText = label ? label.textContent?.trim() : '';
+    return labelText || fallbackText;
+}
+
+function closeVoiceCloneSelectDropdown(wrapper) {
+    if (!wrapper) return;
+
+    wrapper.classList.remove('open');
+
+    const trigger = wrapper.querySelector('.api-provider-dropdown-trigger');
+    if (trigger) {
+        trigger.setAttribute('aria-expanded', 'false');
+    }
+}
+
+function closeAllVoiceCloneSelectDropdowns(exceptWrapper = null) {
+    document.querySelectorAll('.api-provider-dropdown.open').forEach(wrapper => {
+        if (wrapper !== exceptWrapper) {
+            closeVoiceCloneSelectDropdown(wrapper);
+        }
+    });
+}
+
+function openVoiceCloneSelectDropdown(wrapper) {
+    if (!wrapper || wrapper.classList.contains('disabled')) return;
+
+    closeAllVoiceCloneSelectDropdowns(wrapper);
+    wrapper.classList.add('open');
+
+    const trigger = wrapper.querySelector('.api-provider-dropdown-trigger');
+    if (trigger) {
+        trigger.setAttribute('aria-expanded', 'true');
+    }
+}
+
+function isVoiceCloneDropdownOptionVisible(option) {
+    return !!option && !option.hidden && option.style.display !== 'none';
+}
+
+function buildVoiceCloneSelectDropdownMenu(select) {
+    if (!select) return;
+
+    const wrapper = select.closest('.api-provider-dropdown');
+    const menu = wrapper ? wrapper.querySelector('.api-provider-dropdown-menu') : null;
+    const menuScroll = menu ? menu.querySelector('.api-provider-dropdown-menu-scroll') : null;
+    if (!wrapper || !menu || !menuScroll) return;
+
+    menuScroll.innerHTML = '';
+
+    const options = Array.from(select.options).filter(isVoiceCloneDropdownOptionVisible);
+    if (options.length === 0) {
+        const emptyState = document.createElement('div');
+        emptyState.className = 'api-provider-dropdown-empty';
+        emptyState.textContent = window.t ? window.t('api.noOptionsAvailable') : '暂无可选项';
+        menuScroll.appendChild(emptyState);
+        return;
+    }
+
+    options.forEach(option => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'api-provider-dropdown-option';
+        item.setAttribute('role', 'option');
+        item.dataset.value = option.value;
+        item.textContent = option.textContent;
+
+        if (option.disabled) {
+            item.disabled = true;
+            item.setAttribute('aria-disabled', 'true');
+        }
+
+        item.addEventListener('click', event => {
+            event.preventDefault();
+
+            if (option.disabled || select.disabled || !isVoiceCloneDropdownOptionVisible(option)) {
+                return;
+            }
+
+            select.value = option.value;
+            syncVoiceCloneSelectDropdowns(select);
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+            closeVoiceCloneSelectDropdown(wrapper);
+        });
+
+        menuScroll.appendChild(item);
+    });
+}
+
+function syncVoiceCloneSelectDropdowns(targetSelect = null, { rebuild = false } = {}) {
+    const selects = targetSelect
+        ? [targetSelect]
+        : Array.from(document.querySelectorAll('.api-provider-select[data-dropdown-enhanced="true"]'));
+
+    selects.forEach(select => {
+        if (!select) return;
+
+        const wrapper = select.closest('.api-provider-dropdown');
+        const trigger = wrapper ? wrapper.querySelector('.api-provider-dropdown-trigger') : null;
+        const current = wrapper ? wrapper.querySelector('.api-provider-dropdown-current') : null;
+        const menu = wrapper ? wrapper.querySelector('.api-provider-dropdown-menu') : null;
+
+        if (!wrapper || !trigger || !current || !menu) return;
+
+        if (rebuild) {
+            buildVoiceCloneSelectDropdownMenu(select);
+        }
+
+        const selectedOption = select.options[select.selectedIndex] || null;
+        const placeholder = getVoiceCloneDropdownPlaceholder(select);
+
+        current.textContent = selectedOption && isVoiceCloneDropdownOptionVisible(selectedOption)
+            ? selectedOption.textContent
+            : placeholder;
+        current.classList.toggle('placeholder', !selectedOption || !isVoiceCloneDropdownOptionVisible(selectedOption));
+
+        trigger.disabled = !!select.disabled;
+        wrapper.classList.toggle('disabled', !!select.disabled);
+
+        menu.querySelectorAll('.api-provider-dropdown-option').forEach(item => {
+            const isSelected = item.dataset.value === select.value;
+            item.classList.toggle('selected', isSelected);
+            item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+        });
+
+        if (select.disabled) {
+            closeVoiceCloneSelectDropdown(wrapper);
+        }
+    });
+}
+
+function bindVoiceCloneDropdownGlobalHandlers() {
+    if (voiceCloneDropdownHandlersBound) return;
+
+    document.addEventListener('click', event => {
+        if (!event.target.closest('.api-provider-dropdown')) {
+            closeAllVoiceCloneSelectDropdowns();
+        }
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            closeAllVoiceCloneSelectDropdowns();
+        }
+    });
+
+    window.addEventListener('resize', () => closeAllVoiceCloneSelectDropdowns());
+
+    voiceCloneDropdownHandlersBound = true;
+}
+
+function initVoiceCloneSelectDropdown(select) {
+    if (!select || select.dataset.dropdownEnhanced === 'true' || !select.parentNode) return;
+
+    bindVoiceCloneDropdownGlobalHandlers();
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'api-provider-dropdown';
+
+    select.parentNode.insertBefore(wrapper, select);
+    wrapper.appendChild(select);
+
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'api-provider-dropdown-trigger';
+    trigger.setAttribute('aria-haspopup', 'listbox');
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-label', getVoiceCloneDropdownPlaceholder(select));
+    trigger.innerHTML = '<span class="api-provider-dropdown-current"></span><span class="api-provider-dropdown-arrow" aria-hidden="true"></span>';
+
+    const menu = document.createElement('div');
+    menu.className = 'api-provider-dropdown-menu';
+    menu.setAttribute('role', 'listbox');
+
+    const menuScroll = document.createElement('div');
+    menuScroll.className = 'api-provider-dropdown-menu-scroll';
+
+    if (select.id) {
+        menu.id = `${select.id}-menu`;
+        trigger.id = `${select.id}-dropdown-trigger`;
+        trigger.setAttribute('aria-controls', menu.id);
+    }
+
+    menu.appendChild(menuScroll);
+    wrapper.appendChild(trigger);
+    wrapper.appendChild(menu);
+
+    select.classList.add('is-enhanced');
+    select.dataset.dropdownEnhanced = 'true';
+
+    trigger.addEventListener('click', event => {
+        event.preventDefault();
+
+        if (wrapper.classList.contains('open')) {
+            closeVoiceCloneSelectDropdown(wrapper);
+        } else {
+            openVoiceCloneSelectDropdown(wrapper);
+        }
+    });
+
+    select.addEventListener('change', () => syncVoiceCloneSelectDropdowns(select));
+
+    const observer = new MutationObserver(() => {
+        syncVoiceCloneSelectDropdowns(select, { rebuild: true });
+    });
+
+    observer.observe(select, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ['disabled', 'hidden', 'style', 'label', 'value', 'selected']
+    });
+
+    syncVoiceCloneSelectDropdowns(select, { rebuild: true });
+}
+
+function initVoiceCloneSelectDropdowns() {
+    document.querySelectorAll('.api-provider-select').forEach(initVoiceCloneSelectDropdown);
+    syncVoiceCloneSelectDropdowns(null, { rebuild: true });
 }
 
 async function initVoiceCloneProviderRestrictions() {
@@ -749,6 +1000,7 @@ function updateFileDisplay() {
 
 // 监听文件选择变化
 document.addEventListener('DOMContentLoaded', () => {
+    initVoiceCloneSelectDropdowns();
     initVoiceCloneProviderRestrictions().catch(error => {
         console.warn('初始化声音克隆服务商地区过滤失败:', error);
     });
@@ -1074,7 +1326,10 @@ async function initWorkshopVoiceReference() {
         const prefixInput = document.getElementById('prefix');
         const refLanguageSelect = document.getElementById('refLanguage');
         if (prefixInput) prefixInput.value = manifest.prefix || '';
-        if (refLanguageSelect) refLanguageSelect.value = manifest.ref_language || 'ch';
+        if (refLanguageSelect) {
+            refLanguageSelect.value = manifest.ref_language || 'ch';
+            refLanguageSelect.dispatchEvent(new Event('change'));
+        }
         applyWorkshopProviderHint(manifest.provider_hint);
         updateFileDisplay();
     } catch (error) {

--- a/templates/voice_clone.html
+++ b/templates/voice_clone.html
@@ -37,8 +37,8 @@
         <div class="container-content">
             <div class="voice-register-main">
                 <div class="field-row">
-                    <label data-i18n="voice.providerLabel">语音克隆服务商</label>
-                    <select id="voiceProvider">
+                    <label for="voiceProvider" data-i18n="voice.providerLabel">语音克隆服务商</label>
+                    <select id="voiceProvider" class="api-provider-select">
                         <option value="cosyvoice" data-i18n="voice.provider.cosyvoice">阿里百炼 CosyVoice</option>
                         <option value="cosyvoice_intl" data-i18n="voice.provider.cosyvoice_intl">阿里国际版 CosyVoice</option>
                         <option value="minimax" data-i18n="voice.provider.minimax">MiniMax（国服）</option>
@@ -106,9 +106,9 @@
                 </div>
 
                 <div class="field-row">
-                    <label data-i18n="voice.refLanguage">参考音频语言（注意：不是目标音频，是您上传的参考音频的语言）</label>
+                    <label for="refLanguage" data-i18n="voice.refLanguage">参考音频语言（注意：不是目标音频，是您上传的参考音频的语言）</label>
                     <label class="hint" data-i18n="voice.refLanguageNote">选择您上传的参考音频的语言，中文以外的语言需要指定</label>
-                    <select id="refLanguage">
+                    <select id="refLanguage" class="api-provider-select">
                         <option value="ch" data-i18n="voice.lang.ch">中文</option>
                         <option value="en" data-i18n="voice.lang.en">英语</option>
                         <option value="fr" data-i18n="voice.lang.fr">法语</option>

--- a/tests/frontend/test_voice_clone.py
+++ b/tests/frontend/test_voice_clone.py
@@ -16,12 +16,12 @@ VOICE_CLONE_API_PROVIDERS_RESPONSE = {
 }
 
 
-def route_voice_clone_region_dependencies(page: Page, steam_language_payload: dict) -> None:
+def route_voice_clone_region_dependencies(page: Page, steam_language_payload: dict, steam_language_status: int = 200) -> None:
     page.add_init_script("localStorage.setItem('neko_tutorial_voice_clone', 'true');")
     page.route(
         "**/api/config/steam_language",
         lambda route: route.fulfill(
-            status=200,
+            status=steam_language_status,
             content_type="application/json",
             body=json.dumps(steam_language_payload),
         ),
@@ -136,3 +136,26 @@ def test_voice_clone_provider_dropdown_defaults_to_mainland_when_region_indeterm
         "(nodes) => nodes.map(node => node.dataset.value)"
     )
     assert values == ["cosyvoice", "minimax"]
+
+
+@pytest.mark.frontend
+def test_voice_clone_provider_dropdown_defaults_to_mainland_when_region_request_fails(mock_page: Page, running_server: str):
+    """区域请求失败时，克隆页默认隐藏受限服务商。"""
+    route_voice_clone_region_dependencies(
+        mock_page,
+        {"success": False, "error": "region unavailable"},
+        steam_language_status=503,
+    )
+
+    mock_page.goto(f"{running_server}/voice_clone")
+    mock_page.wait_for_load_state("domcontentloaded")
+    mock_page.wait_for_function(
+        """() => {
+            const select = document.querySelector('#voiceProvider');
+            if (!select) return false;
+            const visibleValues = Array.from(select.options)
+                .filter(option => !option.hidden && option.style.display !== 'none')
+                .map(option => option.value);
+            return visibleValues.join(',') === 'cosyvoice,minimax';
+        }"""
+    )

--- a/tests/frontend/test_voice_clone.py
+++ b/tests/frontend/test_voice_clone.py
@@ -1,5 +1,52 @@
+import json
+
 import pytest
 from playwright.sync_api import Page, expect
+
+
+VOICE_CLONE_API_PROVIDERS_RESPONSE = {
+    "success": True,
+    "api_key_registry": {
+        "qwen": {"config_field": "assistApiKeyQwen", "restricted": False},
+        "qwen_intl": {"config_field": "assistApiKeyQwenIntl", "restricted": True},
+        "minimax": {"config_field": "assistApiKeyMinimax", "restricted": False},
+        "minimax_intl": {"config_field": "assistApiKeyMinimaxIntl", "restricted": True},
+        "elevenlabs": {"config_field": "assistApiKeyElevenlabs", "restricted": True},
+    },
+}
+
+
+def route_voice_clone_region_dependencies(page: Page, steam_language_payload: dict) -> None:
+    page.add_init_script("localStorage.setItem('neko_tutorial_voice_clone', 'true');")
+    page.route(
+        "**/api/config/steam_language",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(steam_language_payload),
+        ),
+    )
+    page.route(
+        "**/api/config/api_providers",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(VOICE_CLONE_API_PROVIDERS_RESPONSE),
+        ),
+    )
+    page.route(
+        "**/api/config/core_api",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "success": True,
+                "enableCustomApi": False,
+                "ttsModelUrl": "",
+                "assistApiKeyQwen": "test-qwen-key",
+            }),
+        ),
+    )
 
 
 @pytest.mark.frontend
@@ -55,3 +102,37 @@ def test_voice_clone_form_validation(mock_page: Page, running_server: str):
     # Don't upload a file — just verify the form state is correct
     # The actual registration requires a real API key and audio file,
     # so we only test UI interaction here
+
+
+@pytest.mark.frontend
+def test_voice_clone_provider_dropdown_defaults_to_mainland_when_region_indeterminate(mock_page: Page, running_server: str):
+    """区域未明确识别为海外时，克隆页只展示国内可用服务商。"""
+    route_voice_clone_region_dependencies(
+        mock_page,
+        {
+            "success": False,
+            "steam_language": None,
+            "i18n_language": None,
+            "ip_country": None,
+            "is_mainland_china": False,
+        },
+    )
+
+    mock_page.goto(f"{running_server}/voice_clone")
+    mock_page.wait_for_load_state("domcontentloaded")
+    mock_page.wait_for_function(
+        """() => {
+            const select = document.querySelector('#voiceProvider');
+            if (!select) return false;
+            const visibleValues = Array.from(select.options)
+                .filter(option => !option.hidden && option.style.display !== 'none')
+                .map(option => option.value);
+            return visibleValues.join(',') === 'cosyvoice,minimax';
+        }"""
+    )
+
+    mock_page.locator("#voiceProvider-dropdown-trigger").click()
+    values = mock_page.locator("#voiceProvider-menu .api-provider-dropdown-option").evaluate_all(
+        "(nodes) => nodes.map(node => node.dataset.value)"
+    )
+    assert values == ["cosyvoice", "minimax"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入增强型下拉选择控件，改善占位、打开/关闭、可见性与键盘/点击交互。

* **改进**
  * 优化地区限制判定与容错回退，加载异常时保持可用性并同步选项状态。
  * 改善参考语音与服务商的联动与可访问性，明确 label 与下拉关联。

* **测试**
  * 新增前端测试，覆盖地区不明确或请求失败时的下拉默认行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->