### PR TITLE
修复主动搭话屏幕标签泄漏

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1729,22 +1729,41 @@ def _parse_unified_phase1_result(text: str) -> dict:
 _PROACTIVE_LEGAL_SOURCE_TAGS = frozenset({"CHAT", "WEB", "PASS", "MUSIC", "MEME"})
 _PROACTIVE_SCREEN_TAG_LEAKS = frozenset({"SCREEN", "SCREENSHOT", "VISION", "WINDOW"})
 _PROACTIVE_BRACKET_TAG_RE = re.compile(r"^\[([A-Za-z][A-Za-z0-9_-]{0,31})\]\s*")
+_PROACTIVE_LEGAL_TAG_RE = re.compile(r"^\[(CHAT|WEB|PASS|MUSIC|MEME)\]\s*", re.IGNORECASE)
 
 
-def _strip_proactive_screen_tag_leak(text: str) -> str:
-    """Remove accidental screen-source tags such as ``[Screen]`` from Phase 2 text."""
+def _strip_proactive_screen_tag_leak(text: str) -> tuple[str, str]:
+    """剥离 Phase 2 文本里误写的屏幕来源标签（如 ``[Screen]``）。
+
+    主动搭话屏幕-only 场景下模型偶尔把屏幕来源当成首行标签吐出来。这类标签语义上
+    就是"在聊屏幕里看到的东西"= 普通搭话，统一归一成 ``CHAT``。
+
+    返回 ``(cleaned_text, recovered_source_tag)``：
+    - 命中已知屏幕泄漏标签 → 剥掉它。若其后紧跟合法来源标签（``[Screen][CHAT]``
+      这类组合）则一并剥掉并采用该真实 tag，否则按 ``CHAT`` 兜底。
+    - 未命中（无标签 / 合法标签 / 未知标签）→ 原样返回，recovered 为空串，
+      交回调用方既有的无 tag 处理（格式自救 regen / drop）。
+
+    标签匹配大小写不敏感。
+    """
     if not text:
-        return ""
+        return "", ""
     leading_len = len(text) - len(text.lstrip())
     leading = text[:leading_len]
     body = text[leading_len:]
     match = _PROACTIVE_BRACKET_TAG_RE.match(body)
     if not match:
-        return text
+        return text, ""
     tag = match.group(1).upper()
     if tag in _PROACTIVE_LEGAL_SOURCE_TAGS or tag not in _PROACTIVE_SCREEN_TAG_LEAKS:
-        return text
-    return leading + body[match.end():].lstrip()
+        return text, ""
+    rest = body[match.end():].lstrip()
+    # 兼容 [Screen][CHAT] 组合：泄漏标签后若紧跟合法来源标签，剥掉并采用真实 tag
+    # （否则该 [CHAT] 字面会作为正文漏给 TTS）；没有则按 CHAT 兜底。
+    legal = _PROACTIVE_LEGAL_TAG_RE.match(rest)
+    if legal:
+        return leading + rest[legal.end():].lstrip(), legal.group(1).upper()
+    return leading + rest, "CHAT"
 
 
 def _lookup_link_by_title(title: str, all_links: list[dict]) -> dict | None:
@@ -6341,7 +6360,9 @@ async def proactive_chat(request: Request):
                                 source_tag = tag_match.group(1).upper()
                                 cleaned = cleaned[tag_match.end():]
                             else:
-                                cleaned = _strip_proactive_screen_tag_leak(cleaned)
+                                cleaned, _leak_tag = _strip_proactive_screen_tag_leak(cleaned)
+                                if _leak_tag:
+                                    source_tag = _leak_tag
                             tag_parsed = True
                             
                             if source_tag == 'PASS' or '[PASS]' in cleaned.upper():
@@ -6399,7 +6420,9 @@ async def proactive_chat(request: Request):
                 source_tag = tag_match.group(1).upper()
                 cleaned = cleaned[tag_match.end():]
             else:
-                cleaned = _strip_proactive_screen_tag_leak(cleaned)
+                cleaned, _leak_tag = _strip_proactive_screen_tag_leak(cleaned)
+                if _leak_tag:
+                    source_tag = _leak_tag
             if source_tag == 'PASS' or '[PASS]' in cleaned.upper():
                 aborted = True
             elif cleaned.strip():
@@ -6457,7 +6480,9 @@ async def proactive_chat(request: Request):
                     _fix_tag = _ftm.group(1).upper()
                     _fc = _fc[_ftm.end():]
                 else:
-                    _fc = _strip_proactive_screen_tag_leak(_fc)
+                    _fc, _leak_tag = _strip_proactive_screen_tag_leak(_fc)
+                    if _leak_tag:
+                        _fix_tag = _leak_tag
                 if _fix_tag and _fix_tag != "PASS" and _fc.strip() and "[PASS]" not in _fc.upper():
                     source_tag = _fix_tag
                     full_text = _fc.strip()
@@ -6487,7 +6512,9 @@ async def proactive_chat(request: Request):
                 "message": "Phase 2 流式输出被拦截或为空"
             }))
         
-        full_text = _strip_proactive_screen_tag_leak(full_text)
+        full_text, _leak_tag = _strip_proactive_screen_tag_leak(full_text)
+        if _leak_tag and not source_tag:
+            source_tag = _leak_tag
         response_text = full_text.strip()
         # 不要把 proactive 原文写进 logger（会进日志文件 / 遥测）；只记元数据。
         # 完整原文通过 print 给开发者本地查看。
@@ -6630,7 +6657,9 @@ async def proactive_chat(request: Request):
                 regen_source_tag = _tag_m.group(1).upper()
                 _cleaned = _cleaned[_tag_m.end():]
             else:
-                _cleaned = _strip_proactive_screen_tag_leak(_cleaned)
+                _cleaned, _leak_tag = _strip_proactive_screen_tag_leak(_cleaned)
+                if _leak_tag:
+                    regen_source_tag = _leak_tag
             # regen 输出 [PASS] / 空 → 等价于"模型放弃了"，drop 而不是退回原文。
             # 显式把 ``regen_source_tag == 'PASS'`` 也算 drop（前面剥过 [TAG] 前缀，
             # _cleaned 已不含字面 "[PASS]"，但 regen_source_tag 记下了是 PASS）。

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1726,6 +1726,27 @@ def _parse_unified_phase1_result(text: str) -> dict:
     return result
 
 
+_PROACTIVE_LEGAL_SOURCE_TAGS = frozenset({"CHAT", "WEB", "PASS", "MUSIC", "MEME"})
+_PROACTIVE_SCREEN_TAG_LEAKS = frozenset({"SCREEN", "SCREENSHOT", "VISION", "WINDOW"})
+_PROACTIVE_BRACKET_TAG_RE = re.compile(r"^\[([A-Za-z][A-Za-z0-9_-]{0,31})\]\s*")
+
+
+def _strip_proactive_screen_tag_leak(text: str) -> str:
+    """Remove accidental screen-source tags such as ``[Screen]`` from Phase 2 text."""
+    if not text:
+        return ""
+    leading_len = len(text) - len(text.lstrip())
+    leading = text[:leading_len]
+    body = text[leading_len:]
+    match = _PROACTIVE_BRACKET_TAG_RE.match(body)
+    if not match:
+        return text
+    tag = match.group(1).upper()
+    if tag in _PROACTIVE_LEGAL_SOURCE_TAGS or tag not in _PROACTIVE_SCREEN_TAG_LEAKS:
+        return text
+    return leading + body[match.end():].lstrip()
+
+
 def _lookup_link_by_title(title: str, all_links: list[dict]) -> dict | None:
     """
     根据 Phase 1 输出的标题在 all_web_links 中查找对应链接
@@ -6319,6 +6340,8 @@ async def proactive_chat(request: Request):
                             if tag_match:
                                 source_tag = tag_match.group(1).upper()
                                 cleaned = cleaned[tag_match.end():]
+                            else:
+                                cleaned = _strip_proactive_screen_tag_leak(cleaned)
                             tag_parsed = True
                             
                             if source_tag == 'PASS' or '[PASS]' in cleaned.upper():
@@ -6375,6 +6398,8 @@ async def proactive_chat(request: Request):
             if tag_match:
                 source_tag = tag_match.group(1).upper()
                 cleaned = cleaned[tag_match.end():]
+            else:
+                cleaned = _strip_proactive_screen_tag_leak(cleaned)
             if source_tag == 'PASS' or '[PASS]' in cleaned.upper():
                 aborted = True
             elif cleaned.strip():
@@ -6431,6 +6456,8 @@ async def proactive_chat(request: Request):
                 if _ftm:
                     _fix_tag = _ftm.group(1).upper()
                     _fc = _fc[_ftm.end():]
+                else:
+                    _fc = _strip_proactive_screen_tag_leak(_fc)
                 if _fix_tag and _fix_tag != "PASS" and _fc.strip() and "[PASS]" not in _fc.upper():
                     source_tag = _fix_tag
                     full_text = _fc.strip()
@@ -6460,6 +6487,7 @@ async def proactive_chat(request: Request):
                 "message": "Phase 2 流式输出被拦截或为空"
             }))
         
+        full_text = _strip_proactive_screen_tag_leak(full_text)
         response_text = full_text.strip()
         # 不要把 proactive 原文写进 logger（会进日志文件 / 遥测）；只记元数据。
         # 完整原文通过 print 给开发者本地查看。
@@ -6601,6 +6629,8 @@ async def proactive_chat(request: Request):
             if _tag_m:
                 regen_source_tag = _tag_m.group(1).upper()
                 _cleaned = _cleaned[_tag_m.end():]
+            else:
+                _cleaned = _strip_proactive_screen_tag_leak(_cleaned)
             # regen 输出 [PASS] / 空 → 等价于"模型放弃了"，drop 而不是退回原文。
             # 显式把 ``regen_source_tag == 'PASS'`` 也算 drop（前面剥过 [TAG] 前缀，
             # _cleaned 已不含字面 "[PASS]"，但 regen_source_tag 记下了是 PASS）。

--- a/tests/unit/test_proactive_phase1_pass.py
+++ b/tests/unit/test_proactive_phase1_pass.py
@@ -66,6 +66,20 @@ keyword: pass the dutchie
     assert parsed["music_pass"] is False
 
 
+def test_strip_proactive_screen_tag_leak_removes_screen_source_label():
+    cleaned = sr._strip_proactive_screen_tag_leak(
+        "[Screen]\n看这满屏的符咒，是在给那画中仙重塑筋骨？"
+    )
+
+    assert cleaned == "看这满屏的符咒，是在给那画中仙重塑筋骨？"
+
+
+def test_strip_proactive_screen_tag_leak_preserves_legal_source_tags():
+    cleaned = sr._strip_proactive_screen_tag_leak("[CHAT]\n你好呀")
+
+    assert cleaned == "[CHAT]\n你好呀"
+
+
 def test_recent_proactive_prompt_has_strong_paired_boundaries():
     lanlan = "测试娘"
     snapshot = sr._proactive_chat_history.get(lanlan)

--- a/tests/unit/test_proactive_phase1_pass.py
+++ b/tests/unit/test_proactive_phase1_pass.py
@@ -67,17 +67,44 @@ keyword: pass the dutchie
 
 
 def test_strip_proactive_screen_tag_leak_removes_screen_source_label():
-    cleaned = sr._strip_proactive_screen_tag_leak(
+    cleaned, tag = sr._strip_proactive_screen_tag_leak(
         "[Screen]\n看这满屏的符咒，是在给那画中仙重塑筋骨？"
     )
 
     assert cleaned == "看这满屏的符咒，是在给那画中仙重塑筋骨？"
+    # 已知泄漏标签统一归一成 CHAT，下游按普通搭话投递（不再误判无 tag 走 regen/drop）
+    assert tag == "CHAT"
+
+
+def test_strip_proactive_screen_tag_leak_is_case_insensitive():
+    for raw in ("[SCREEN]", "[screen]", "[ScReEn]", "[Vision]", "[window]"):
+        cleaned, tag = sr._strip_proactive_screen_tag_leak(f"{raw} 你好呀")
+        assert cleaned == "你好呀"
+        assert tag == "CHAT"
+
+
+def test_strip_proactive_screen_tag_leak_recovers_combined_legal_tag():
+    # [Screen][CHAT] 组合：剥掉泄漏标签后采用紧随其后的真实来源标签，
+    # 避免 [CHAT] 字面作为正文漏给 TTS。
+    cleaned, tag = sr._strip_proactive_screen_tag_leak("[Screen][WEB]\n看这个链接")
+
+    assert cleaned == "看这个链接"
+    assert tag == "WEB"
 
 
 def test_strip_proactive_screen_tag_leak_preserves_legal_source_tags():
-    cleaned = sr._strip_proactive_screen_tag_leak("[CHAT]\n你好呀")
+    cleaned, tag = sr._strip_proactive_screen_tag_leak("[CHAT]\n你好呀")
 
     assert cleaned == "[CHAT]\n你好呀"
+    assert tag == ""
+
+
+def test_strip_proactive_screen_tag_leak_ignores_unknown_bracket_tags():
+    # 未知 / 非屏幕泄漏标签保守放行，留给调用方既有的无 tag 处理逻辑。
+    cleaned, tag = sr._strip_proactive_screen_tag_leak("[Foo] 这不是来源标签")
+
+    assert cleaned == "[Foo] 这不是来源标签"
+    assert tag == ""
 
 
 def test_recent_proactive_prompt_has_strong_paired_boundaries():


### PR DESCRIPTION
主动搭话屏幕-only 场景下，模型可能把屏幕来源误写成 [Screen] 首行标签，并被当作正文发送。

新增屏幕来源标签清理逻辑，剥离 [Screen]、[Vision]、[Window] 等非法首行标签，同时保留 [CHAT]、[WEB]、[MUSIC]、[MEME]、[PASS] 等合法标签解析。

在流式解析、flush、格式纠正、BM25 regen 和最终投递前统一兜底清理，并增加回归测试覆盖 [Screen] 泄漏与合法标签保留。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化主动对话中来源标签的解析与恢复逻辑：在流式输出、重生成与回退路径中自动清理模型误输出的屏幕类方括号标签（如 [Screen] 等），并在必要时恢复或默认为 CHAT，减少误判与丢弃。

* **Tests**
  * 新增单元测试覆盖多种标签泄漏与恢复场景，确保解析稳健性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->