### PR TITLE
统一 Live2D/VRM 启动恢复与运行中拖拽的可见阈值，避免重启后把允许的半出屏位置强制拉回屏内

### DIFF
--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -1777,10 +1777,11 @@ Live2DManager.prototype._configureLoadedModel = async function(model, modelPath,
     if (!this._isLoadTokenActive(loadToken) || !model || model.destroyed) {
         return;
     }
-    // 在隐藏状态下先做一次边界校正，避免“先出现再瞬移”
+    // 在隐藏状态下先做一次边界校正，避免“先出现再瞬移”。
+    // 启动恢复必须与拖拽结束使用同一可见像素阈值，避免允许的半出屏位置被更严格地拉回屏内。
     if (typeof this._checkSnapRequired === 'function') {
         try {
-            const snapInfo = await this._checkSnapRequired(model, { threshold: 300 });
+            const snapInfo = await this._checkSnapRequired(model);
             if (snapInfo && Number.isFinite(snapInfo.targetX) && Number.isFinite(snapInfo.targetY)) {
                 model.x = snapInfo.targetX;
                 model.y = snapInfo.targetY;

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -1209,11 +1209,11 @@ class VRMManager {
             this._loadState = 'ready';
             this._isModelReadyForInteraction = true;
 
-            // 首次加载围栏：检查模型是否在屏幕外，如果是则立即校正（不动画）
+            // 首次加载围栏：与拖拽结束共用默认可见像素阈值，避免重启时把允许的半出屏位置拉回屏内。
             if (this.interaction && this.currentModel?.vrm?.scene) {
                 try {
                     const currentPos = this.currentModel.vrm.scene.position.clone();
-                    const correctedPos = this.interaction.clampModelPosition(currentPos, { minVisiblePixels: 300 });
+                    const correctedPos = this.interaction.clampModelPosition(currentPos);
                     if (!currentPos.equals(correctedPos)) {
                         this.currentModel.vrm.scene.position.copy(correctedPos);
                         console.log('[VRM Manager] 首次加载围栏已校正模型位置');

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -31,14 +31,14 @@ def test_live2d_only_display_switch_uses_edge_margin():
     assert "needsSnapBottom = overflowBottom > margin;" in source
 
 
-def test_live2d_snap_keeps_explicit_threshold_override_for_initial_placement():
+def test_live2d_initial_snap_uses_runtime_threshold():
     source = _live2d_source()
+    model_source = (PROJECT_ROOT / "static/live2d-model.js").read_text(encoding="utf-8")
 
     assert "threshold: customThreshold" in source
     assert "const margin = SNAP_CONFIG.margin;" in source
-    assert "_checkSnapRequired(model, { threshold: 300 })" in (
-        PROJECT_ROOT / "static/live2d-model.js"
-    ).read_text(encoding="utf-8")
+    assert "_checkSnapRequired(model, { threshold: 300 })" not in model_source
+    assert "const snapInfo = await this._checkSnapRequired(model);" in model_source
 
 
 def test_live2d_display_switch_still_snaps_after_window_move():

--- a/tests/unit/test_vrm_interaction_static_contracts.py
+++ b/tests/unit/test_vrm_interaction_static_contracts.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_vrm_initial_visibility_fence_uses_runtime_threshold():
+    manager_source = (PROJECT_ROOT / "static/vrm-manager.js").read_text(encoding="utf-8")
+    interaction_source = (PROJECT_ROOT / "static/vrm-interaction.js").read_text(encoding="utf-8")
+
+    assert "clampModelPosition(position, { minVisiblePixels = 200 } = {})" in interaction_source
+    assert "clampModelPosition(currentPos, { minVisiblePixels: 300 })" not in manager_source
+    assert "const correctedPos = this.interaction.clampModelPosition(currentPos);" in manager_source


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复模型初始加载时的位置校正逻辑，确保使用统一的可见像素阈值，防止允许的半屏模型被意外拉回屏内。

* **Tests**
  * 更新并新增单元测试以验证模型吸附和位置约束使用运行时阈值，确保 Live2D 和 VRM 模型的一致行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->