### PR TITLE
fix(character-card): 将角色卡列表标题星形图标及文字颜色从白色改为 #40C5F1

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -728,7 +728,7 @@ object-position: right center;
 display: flex;
 align-items: center;
 gap: 6px;
-color: #fff;
+color: #40C5F1;
 font-size: 18px;
 font-weight: 600;
 letter-spacing: 0.5px;

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -559,7 +559,7 @@
 <div class="chara-cards-header-row">
 <div class="card-info-title-area">
 <div class="card-info-header-text">
-<svg width="15" height="15" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg"><path d="M12 2 L14.5 9.5 L22 12 L14.5 14.5 L12 22 L9.5 14.5 L2 12 L9.5 9.5 Z" stroke="#7EC8E3" stroke-width="2" stroke-linejoin="round" fill="white"/></svg>
+<svg width="15" height="15" viewBox="0 0 24 24" fill="#40C5F1" xmlns="http://www.w3.org/2000/svg"><path d="M12 2 L14.5 9.5 L22 12 L14.5 14.5 L12 22 L9.5 14.5 L2 12 L9.5 9.5 Z" stroke="#7EC8E3" stroke-width="2" stroke-linejoin="round" fill="#40C5F1"/></svg>
 <span data-i18n="steam.characterCardsList">角色卡列表</span>
 </div>
 <img src="/static/icons/paw_ui.png" class="card-info-paw" alt="">


### PR DESCRIPTION
将角色卡列表标题星形图标及文字颜色从白色改为  #40C5F1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式**
  * 更新了角色卡管理页面的标题文本颜色为主题蓝色，提升视觉一致性。
  * 调整了列表页标题栏星形图标的配色方案，统一采用主题色显示。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->