### PR TITLE
Fix character card title color and chat icon visibility in dark mode

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1486,6 +1486,7 @@ svg {
 .composer-icon-button {
   --composer-icon-bubble-scale: 1;
   position: relative;
+  isolation: isolate;
   width: 46px;
   height: 46px;
   border: 0;
@@ -1513,6 +1514,7 @@ svg {
 .composer-icon-button::after {
   content: '';
   position: absolute;
+  z-index: 1;
   pointer-events: none;
 }
 
@@ -1538,6 +1540,8 @@ svg {
 }
 
 .composer-icon-button-image {
+  position: relative;
+  z-index: 2;
   width: 30px;
   height: 30px;
   object-fit: contain;
@@ -2125,10 +2129,14 @@ svg {
 
 [data-theme="dark"] .composer-icon-popover {
   background: transparent;
+  opacity: 1 !important;
+  filter: none !important;
 }
 
 [data-theme="dark"] .composer-icon-button {
   border: 0;
+  opacity: 1 !important;
+  filter: none !important;
   background:
     radial-gradient(circle at 30% 28%, rgba(104, 127, 179, 0.56) 0%, rgba(79, 100, 146, 0.46) 22%, rgba(50, 61, 93, 0.52) 72%, rgba(35, 43, 66, 0.44) 100%);
   color: #d8eaff;
@@ -2158,6 +2166,13 @@ svg {
     0 12px 26px rgba(11, 24, 47, 0.42),
     0 2px 8px rgba(37, 86, 160, 0.28),
     inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+[data-theme="dark"] .composer-icon-button-image {
+  opacity: 1 !important;
+  mix-blend-mode: normal !important;
+  image-rendering: auto;
+  filter: none !important;
 }
 
 [data-theme="dark"] .composer-translate-btn.is-active::after {

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -728,7 +728,7 @@ object-position: right center;
 display: flex;
 align-items: center;
 gap: 6px;
-color: #fff;
+color: #40C5F1;
 font-size: 18px;
 font-weight: 600;
 letter-spacing: 0.5px;

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -559,7 +559,7 @@
 <div class="chara-cards-header-row">
 <div class="card-info-title-area">
 <div class="card-info-header-text">
-<svg width="15" height="15" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg"><path d="M12 2 L14.5 9.5 L22 12 L14.5 14.5 L12 22 L9.5 14.5 L2 12 L9.5 9.5 Z" stroke="#7EC8E3" stroke-width="2" stroke-linejoin="round" fill="white"/></svg>
+<svg width="15" height="15" viewBox="0 0 24 24" fill="#40C5F1" xmlns="http://www.w3.org/2000/svg"><path d="M12 2 L14.5 9.5 L22 12 L14.5 14.5 L12 22 L9.5 14.5 L2 12 L9.5 9.5 Z" stroke="#7EC8E3" stroke-width="2" stroke-linejoin="round" fill="#40C5F1"/></svg>
 <span data-i18n="steam.characterCardsList">角色卡列表</span>
 </div>
 <img src="/static/icons/paw_ui.png" class="card-info-paw" alt="">


### PR DESCRIPTION
将角色卡列表标题星形图标及文字颜色从白色改为 #40C5F1
将深色模式下道具图标提亮

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式**
  * 改进了作曲器图标按钮在暗色模式下的显示效果，确保图标清晰可见。
  * 优化了角色卡标题栏的文字和图标颜色，统一采用项目主题色展示。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->