### PR TITLE
修复核心 API 为免费版时，空的非免费辅助 API Key 被错误回填为 free-access 的问题

### DIFF
--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -603,14 +603,21 @@ async def get_core_config_api():
             api_key = core_config.get('CORE_API_KEY','')
             # 创建空的配置对象用于返回默认值
             core_cfg = {}
+            runtime_core_api_provider = core_config.get('CORE_API_TYPE') or ''
+            runtime_assist_api_provider = core_config.get('assistApi') or ''
+        else:
+            runtime_core_api_provider = ''
+            runtime_assist_api_provider = ''
         
         # 旧版本 core_config.json 可能只有 coreApiKey 而没有各 assistApiKey* 字段，
         # 需要与 ConfigManager.get_core_config() 保持一致的回退逻辑，
         # 但只能回退到与 coreApi / assistApi 匹配的服务商，
         # 以免将不兼容的 API Key 填充到其他服务商。
         fallback_key = api_key if api_key != 'free-access' else ''
-        _core_api_provider = core_cfg.get('coreApi') or 'qwen'
-        _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
+        _core_api_provider = core_cfg.get('coreApi') or runtime_core_api_provider or 'qwen'
+        _assist_api_provider = core_cfg.get('assistApi') or runtime_assist_api_provider
+        if not _assist_api_provider:
+            _assist_api_provider = 'free' if _core_api_provider == 'free' else 'qwen'
         _fallback_providers = {_core_api_provider, _assist_api_provider}
 
         def _fb(provider: str) -> str:

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -608,7 +608,7 @@ async def get_core_config_api():
         # 需要与 ConfigManager.get_core_config() 保持一致的回退逻辑，
         # 但只能回退到与 coreApi / assistApi 匹配的服务商，
         # 以免将不兼容的 API Key 填充到其他服务商。
-        fallback_key = api_key or ''
+        fallback_key = api_key if api_key != 'free-access' else ''
         _core_api_provider = core_cfg.get('coreApi') or 'qwen'
         _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
         _fallback_providers = {_core_api_provider, _assist_api_provider}

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -315,6 +315,33 @@ class TestAssistFollowsCore:
         assert cfg.get('IS_FREE_VERSION') is True
 
     @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_get_core_config_api_defaults_empty_assist_to_free_for_free_core(self, monkeypatch):
+        """API 管理页读取旧配置时，core=free + assistApi='' 应回填 assist=free。"""
+        from main_routers import config_router
+
+        async def fake_read_json_async(_path):
+            return {
+                'coreApiKey': 'free-access',
+                'coreApi': 'free',
+                'assistApi': '',
+            }
+
+        class FakeConfigManager:
+            def get_runtime_config_path(self, _filename):
+                return 'core_config.json'
+
+        monkeypatch.setattr(config_router, 'read_json_async', fake_read_json_async)
+        monkeypatch.setattr(config_router, 'get_config_manager', lambda: FakeConfigManager())
+
+        response = await config_router.get_core_config_api()
+
+        assert response['success'] is True
+        assert response['coreApi'] == 'free'
+        assert response['assistApi'] == 'free'
+        assert response['assistApiKeyQwen'] == ''
+
+    @pytest.mark.unit
     def test_free_core_honors_explicit_assist(self, config_manager):
         """coreApi=free + assistApi=silicon → 显式选择被保留，agent/text 走 silicon。"""
         _write_core_config(config_manager, {

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -116,6 +116,43 @@ class TestKeybookSaveLoad:
         assert cfg['ASSIST_API_KEY_QWEN_INTL'] == 'sk-core-master'
 
     @pytest.mark.unit
+    def test_free_core_does_not_fill_paid_assist_when_key_empty(self, config_manager):
+        """core=free 时，空的非免费 assist Key 不应回退成 free-access。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'free-access',
+            'coreApi': 'free',
+            'assistApi': 'qwen',
+            'assistApiKeyQwen': '',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['CORE_API_KEY'] == 'free-access'
+        assert cfg['CORE_API_TYPE'] == 'free'
+        assert cfg['assistApi'] == 'qwen'
+        assert cfg['ASSIST_API_KEY_QWEN'] == ''
+        assert cfg['AUDIO_API_KEY'] == ''
+        assert cfg['OPENROUTER_API_KEY'] == ''
+        assert cfg['AGENT_MODEL_API_KEY'] == ''
+        conversation_cfg = config_manager.get_model_api_config('conversation')
+        assert conversation_cfg['api_key'] == ''
+
+    @pytest.mark.unit
+    def test_free_core_preserves_paid_assist_explicit_key(self, config_manager):
+        """core=free 时，显式填写的非免费 assist Key 仍应生效。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'free-access',
+            'coreApi': 'free',
+            'assistApi': 'qwen',
+            'assistApiKeyQwen': 'sk-assist-qwen',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['ASSIST_API_KEY_QWEN'] == 'sk-assist-qwen'
+        assert cfg['AUDIO_API_KEY'] == 'sk-assist-qwen'
+        assert cfg['OPENROUTER_API_KEY'] == 'sk-assist-qwen'
+        assert cfg['AGENT_MODEL_API_KEY'] == 'sk-assist-qwen'
+
+    @pytest.mark.unit
     def test_qwen_intl_uses_saved_successful_us_url(self, config_manager):
         """qwen_intl 连通性测试命中美国 URL 后，运行配置应使用该 URL。"""
         us_url = 'https://dashscope-us.aliyuncs.com/compatible-mode/v1'

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3191,8 +3191,10 @@ class ConfigManager:
         if core_cfg.get('coreApiKey'):
             config['CORE_API_KEY'] = core_cfg['coreApiKey']
 
-        _core_api_provider = core_cfg.get('coreApi') or 'qwen'
-        _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
+        _core_api_provider = core_cfg.get('coreApi') or config['CORE_API_TYPE']
+        _assist_api_provider = core_cfg.get('assistApi')
+        if not _assist_api_provider:
+            _assist_api_provider = 'free' if _core_api_provider == 'free' else 'qwen'
         _fallback_providers = {_core_api_provider, _assist_api_provider}
         _core_key_fallback = config['CORE_API_KEY'] if config['CORE_API_KEY'] != 'free-access' else ''
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3194,9 +3194,10 @@ class ConfigManager:
         _core_api_provider = core_cfg.get('coreApi') or 'qwen'
         _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
         _fallback_providers = {_core_api_provider, _assist_api_provider}
+        _core_key_fallback = config['CORE_API_KEY'] if config['CORE_API_KEY'] != 'free-access' else ''
 
         def _fb(provider: str) -> str:
-            return config['CORE_API_KEY'] if provider in _fallback_providers else ''
+            return _core_key_fallback if provider in _fallback_providers else ''
 
         config['ASSIST_API_KEY_QWEN'] = core_cfg.get('assistApiKeyQwen', '') or _fb('qwen')
         config['ASSIST_API_KEY_QWEN_INTL'] = core_cfg.get('assistApiKeyQwenIntl', '') or _fb('qwen_intl')
@@ -3322,13 +3323,13 @@ class ConfigManager:
                 config['OPENROUTER_API_KEY'] = derived_key
 
         if not config['AUDIO_API_KEY']:
-            config['AUDIO_API_KEY'] = config['CORE_API_KEY']
+            config['AUDIO_API_KEY'] = _core_key_fallback
         if not config['OPENROUTER_API_KEY']:
-            config['OPENROUTER_API_KEY'] = config['CORE_API_KEY']
+            config['OPENROUTER_API_KEY'] = _core_key_fallback
 
         # Agent API Key 回退：未显式配置时跟随辅助 API Key
         if not config.get('AGENT_MODEL_API_KEY'):
-            config['AGENT_MODEL_API_KEY'] = derived_key if derived_key else config.get('CORE_API_KEY', '')
+            config['AGENT_MODEL_API_KEY'] = config.get('OPENROUTER_API_KEY', '')
 
         # 自定义API配置映射（使用大写下划线形式的内部键，且在未提供时保留已有默认值）
         enable_custom_api = core_cfg.get('enableCustomApi', False)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复配置回退逻辑：避免占位符密钥被误填充到其他API密钥字段；当核心为免费时，助手提供者默认回退为免费，相关派生密钥回退规则更合理，确保空值不被错误继承。

* **Tests**
  * 新增用例验证免费核心场景下助手密钥与派生密钥的正确保留与回退行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->