### PR TITLE
fix(voice): 切语音误等 15s（settledId）+ geo 调试 flag + VAD 微调

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(f"{APP_NAME}.{__name__}")
 # GPT-SoVITS voice_id 前缀(角色管理中使用 "gsv:<voice_id>" 格式标识 GPT-SoVITS 声音)
 GSV_VOICE_PREFIX = "gsv:"
 
+# GeoIP 区域判定的调试开关（ConfigManager._check_non_mainland 读取）：
+#   None  → 正常走真实检测（HTTP IP geo + Steam geo 双判），生产默认值
+#   True  → 强制判定为非中国大陆（走 lanlan.app 免费路径）
+#   False → 强制判定为中国大陆
+# 调试时改这里即可，不用动 config_manager 的检测逻辑；上线保持 None。
+GEOIP_FORCE_NON_MAINLAND = None
+
 # 角色档案保留字段（统一管理）
 # - system: 由系统指定功能维护，不允许通用角色编辑接口直接修改
 # - workshop: 创意工坊导入/发布流程专用，不应从外部角色卡直接透传

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -826,7 +826,7 @@ class OmniRealtimeClient:
                     "type": "semantic_vad" if "3.5" in self._model_lower else "server_vad",
                     "threshold": 0.55,
                     "prefix_padding_ms": 300,
-                    "silence_duration_ms": 600
+                    "silence_duration_ms": 650
                 },
                 "repetition_penalty": 1.2,
                 "temperature": 0.7,

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -524,6 +524,11 @@
         S.assistantTurnCompletedId = null;
         S.assistantTurnCompletionSource = null;
         S.assistantSpeechStartedTurnId = null;
+        // settled 标记随完成状态一起清：turn-start / speech-cancel / clearAudioQueue
+        // 都经由本函数，等于把 settledId 接进完整的 turn 生命周期收尾。
+        // maybeFinalizeAssistantSpeech 在调用本函数之后再设 settledId（见那里），
+        // 所以"干净收尾"路径的 settledId 不会被这里误清。
+        S.assistantTurnSettledId = null;
     }
 
     function scheduleAssistantTurnCompletionFallback(turnId, source) {
@@ -673,6 +678,11 @@
         dispatchAssistantSpeechEnd(normalizedTurnId);
         var completionSource = S.assistantTurnCompletionSource;
         clearAssistantTurnCompletion();
+        // 这一轮已干净收尾。clearAssistantTurnCompletion 刚把 completedId 清成 null，
+        // 但 assistantTurnId 仍指向本轮（要等下条用户消息才清），若不标记 settled，
+        // isAssistantTextResponseInFlight 会一直把"已说完的轮"误判成在路上 → 切语音
+        // 干等 15s。这里在清空之后再标 settled，记下"turnId 这轮已收尾"。
+        S.assistantTurnSettledId = normalizedTurnId;
         logAudioLifecycle('maybeFinalizeAssistantSpeech:completed', {
             requestedTurnId: normalizedTurnId,
             completionSource: completionSource

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -1250,7 +1250,12 @@
         // 必须靠 assistantTurnCompletedId 区分"已收尾"和"还在跑"。
         // 否则"回复跑完，用户停顿一会儿再点麦克风"会被误判成在路上，
         // 干等到 15s timeout 才进语音。
-        if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) return true;
+        // settledId：语音轮干净收尾后 completedId 会被清成 null（见 app-audio-playback
+        // 的 maybeFinalizeAssistantSpeech），仅凭 turnId !== completedId 会把"已说完的轮"
+        // 误判成在路上。settledId 标记该轮已收尾，turnId === settledId 即视为不在路上。
+        if (S.assistantTurnId
+                && S.assistantTurnId !== S.assistantTurnCompletedId
+                && S.assistantTurnId !== S.assistantTurnSettledId) return true;
         if (S.assistantTurnAwaitingBubble) return true;
         if (typeof window._lastSubmittedRequestId === 'string' && window._lastSubmittedRequestId) return true;
         // 纯截图 / 纯图片这类没有 typed text 的提交，sendTextPayloadInternal
@@ -1259,6 +1264,24 @@
         // pendingTextTurnSubmitAt 专门补这段，15s freshness 兜底防漏清。
         if (S.pendingTextTurnSubmitAt && (Date.now() - S.pendingTextTurnSubmitAt) < 15000) return true;
         return false;
+    }
+
+    // 常驻诊断：切语音卡 15s 时，靠这个快照看清是哪个 in-flight 标志没被清。
+    // 只含布尔/时间戳，无对话内容。
+    function snapshotInFlightFlags() {
+        return {
+            turnMismatch: !!(S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId),
+            awaitingBubble: !!S.assistantTurnAwaitingBubble,
+            lastReqId: !!(typeof window._lastSubmittedRequestId === 'string' && window._lastSubmittedRequestId),
+            pendingSubmitMs: S.pendingTextTurnSubmitAt ? (Date.now() - S.pendingTextTurnSubmitAt) : null,
+            // 原始 id：用来区分 turnMismatch 是"completedId 标了旧 turn"还是
+            // "assistantTurnId 被重分配给没收尾的新 turn"。
+            turnId: S.assistantTurnId,
+            completedId: S.assistantTurnCompletedId,
+            settledId: S.assistantTurnSettledId,
+            pendingServerId: S.assistantPendingTurnServerId,
+            speechActiveId: S.assistantSpeechActiveTurnId
+        };
     }
 
     function waitForAssistantTurnEnd(timeoutMs) {
@@ -1273,6 +1296,8 @@
                 resolve('not_in_flight');
                 return;
             }
+            var startedAt = Date.now();
+            console.log('[VoiceSwitch] wait start — in-flight flags:', JSON.stringify(snapshotInFlightFlags()));
             var settled = false;
             function done(reason) {
                 if (settled) return;
@@ -1280,6 +1305,9 @@
                 window.removeEventListener('neko-assistant-turn-end', onEnd);
                 clearInterval(pollTimer);
                 clearTimeout(timeoutTimer);
+                console.log('[VoiceSwitch] wait done reason=' + reason
+                    + ' elapsed=' + (Date.now() - startedAt) + 'ms — flags now:',
+                    JSON.stringify(snapshotInFlightFlags()));
                 resolve(reason);
             }
             function onEnd() { done('turn_end'); }

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -1270,7 +1270,12 @@
     // 只含布尔/时间戳，无对话内容。
     function snapshotInFlightFlags() {
         return {
-            turnMismatch: !!(S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId),
+            // 与 isAssistantTextResponseInFlight 同口径：已 settle 的轮（completedId
+            // 被清成 null 但 settledId 标了该轮）不算 mismatch，否则日志会在每条已说完
+            // 的语音轮误报 turnMismatch:true，反而误导排查。原始 id 仍单列在下方备查。
+            turnMismatch: !!(S.assistantTurnId
+                && S.assistantTurnId !== S.assistantTurnCompletedId
+                && S.assistantTurnId !== S.assistantTurnSettledId),
             awaitingBubble: !!S.assistantTurnAwaitingBubble,
             lastReqId: !!(typeof window._lastSubmittedRequestId === 'string' && window._lastSubmittedRequestId),
             pendingSubmitMs: S.pendingTextTurnSubmitAt ? (Date.now() - S.pendingTextTurnSubmitAt) : null,

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -120,6 +120,12 @@
         pendingTextTurnSubmitAt: 0,
         assistantTurnSeq: 0,
         assistantTurnCompletedId: null,
+        // 一轮干净收尾后（maybeFinalizeAssistantSpeech 成功），completedId 会被
+        // clearAssistantTurnCompletion 清成 null，但 assistantTurnId 要等下条用户
+        // 消息才清。没有这个 settled 标记的话，isAssistantTextResponseInFlight 的
+        // turnMismatch（turnId !== completedId）在每条语音回复收尾后都恒为 true，
+        // 切语音会干等满 15s。settledId 记下"这轮已收尾"，turn-start/cancel 时清。
+        assistantTurnSettledId: null,
         assistantTurnCompletionSource: null,
         assistantSpeechActiveTurnId: null,
         assistantSpeechStartedTurnId: null,

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1042,6 +1042,7 @@
         S.assistantSpeechActiveTurnId = null;
         S.assistantTurnId = null;
         S.assistantTurnCompletedId = null;
+        S.assistantTurnSettledId = null;
         S.assistantTurnCompletionSource = null;
         clearPendingAssistantTurnStart();
         S.currentPlayingSpeechId = null;

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -21,6 +21,7 @@ from config import (
     APP_NAME,
     CONFIG_FILES,
     DEFAULT_CONFIG_DATA,
+    GEOIP_FORCE_NON_MAINLAND,
     RESERVED_FIELD_SCHEMA,
 )
 from config.prompts.prompts_chara import get_lanlan_prompt, is_default_prompt
@@ -2920,6 +2921,16 @@ class ConfigManager:
 
     def _check_non_mainland(self) -> bool:
         """Dual validation: both HTTP IP geo AND Steam geo must indicate non-mainland."""
+        # 调试开关：config.GEOIP_FORCE_NON_MAINLAND 非 None 时直接返回它，绕过真实检测。
+        # 生产保持 None（走下方双判）。改 config/__init__.py 那个常量即可，不动这里。
+        if GEOIP_FORCE_NON_MAINLAND is not None:
+            print(
+                f"[GeoIP] override active: forcing non-mainland={GEOIP_FORCE_NON_MAINLAND} "
+                "(config.GEOIP_FORCE_NON_MAINLAND)",
+                file=sys.stderr,
+            )
+            return GEOIP_FORCE_NON_MAINLAND
+
         if ConfigManager._region_cache is not None:
             return ConfigManager._region_cache
 


### PR DESCRIPTION
## 概要

三个相关改动，都集中在语音/配置侧：

### 1. fix(voice): 切语音误等 15s（核心）
**现象**：文字聊天里 AI 说完后点麦克风切语音，常常干等满 15s 才进语音。

**根因**：`maybeFinalizeAssistantSpeech` 成功收尾时 `clearAssistantTurnCompletion` 把 `assistantTurnCompletedId` 清成 `null`，但 `assistantTurnId` 要等下一条用户消息才清。`isAssistantTextResponseInFlight` 仅凭 `turnId !== completedId` 判定 → **每条语音回复收尾后都被误判成"仍在途"** → `waitForAssistantTurnEnd` 等满 15s timeout。

**修复**：新增 `S.assistantTurnSettledId`，finalize 成功时标记该轮已收尾；判定加 `&& turnId !== settledId`。turn-start / cancel / clearAudioQueue / 断连重置都经 `clearAssistantTurnCompletion` 自然清掉它。

附常驻 `[VoiceSwitch]` 诊断快照（`snapshotInFlightFlags`）：仅在文字 session 点麦且 in-flight 时打印，只含布尔/时间戳/turnId，**无对话内容**，便于日后 regression 一眼定位哪个标志卡住。

### 2. chore(config): geo 调试开关改为 flag
`_check_non_mainland` 原来写死 `return True`（强制走 lanlan.app）纯调试用、易漏撤。改为读 `config.GEOIP_FORCE_NON_MAINLAND` 三态：`None`=真实检测（生产默认）、`True`/`False`=强制。下次调试改 `config/__init__.py` 一个常量即可。

### 3. fix(voice): VAD silence_duration_ms 600→650
Qwen-Omni 静音判定窗口略放宽，减少话尾被过早截断。

## 影响面
- 1 为纯前端，治实际症状，风险低。
- 2 默认 `None` = 生产行为不变。
- 3 仅一个 VAD 参数。

## 备注
本次诊断中还发现一个独立的"语音轮提前 finalize（turn-end 撞音频空档 → 口型抖动 / emotion 早触发 / 尾音孤儿）"问题，因修复横跨前后端 + ~10 个 TTS provider、回退风险不为 0 且修的是用户不易察觉的瞬时小 glitch，未纳入本 PR，已记录于 #1566。

## 测试
- [x] settledId 修复：实测点麦不再等 15s
- [x] config flag 默认 None，`import config` 正常、`config_manager` 编译通过
- [x] 全量 py_compile + node --check 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增地理位置检测的调试配置开关

* **Bug 修复**
  * 修复助手语音回合完成状态追踪，防止上一轮标记残留
  * 在断线场景中重置回合已结算状态，避免干扰新会话

* **改进**
  * 调整语音静默判定参数以优化识别体验
  * 加强文本/语音等待流程的诊断日志与快照，提升误判排查能力

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->