### PR TITLE
feat(ab): 下线 proactive_interval_20s，main 默认扶正 20s，新开 proactive_interval_25s

### DIFF
--- a/main_routers/proactive_router.py
+++ b/main_routers/proactive_router.py
@@ -93,7 +93,7 @@ PROACTIVE_PRESETS: dict[str, dict[str, Any]] = {
         "proactiveMusicEnabled": True,
         "proactiveMemeEnabled": True,
         "proactiveMiniGameInviteEnabled": True,
-        "proactiveChatInterval": 15,
+        "proactiveChatInterval": 20,
         "proactiveVisionInterval": 10,
     },
     # 低打扰：保留搭话与个人动态，关掉新闻/视频/音乐等噪声源，间隔放长。

--- a/plugin/plugins/proactive_controller/__init__.py
+++ b/plugin/plugins/proactive_controller/__init__.py
@@ -125,7 +125,7 @@ class ProactiveControllerPlugin(NekoPluginBase):
         name="切换主动搭话模式",
         description=(
             "套用一组主动搭话预设。可选模式：'off'（全关，默认首次启动值）、"
-            "'normal'（推荐配置，所有源开启，间隔 15s/10s）、'focus'（低打扰，"
+            "'normal'（推荐配置，所有源开启，间隔 20s/10s）、'focus'（低打扰，"
             "仅留搭话和个人动态，间隔 60s）、'frequent'（高频，全开，间隔 5s）。"
             " 注意：预设不会改变 proactiveVisionEnabled（隐私模式）—— 那是用户绝对控制权。"
         ),

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -23,15 +23,16 @@
     // 有意义，海外默认隐私开 → 对该实验天然 no-op，A/B 差异主要体现在国内。
     const _VISION_CHAT_AB_BRANCH = 'vision_chat_default_off';
     // 海外专属 A/B 实验组分支名（与 utils/token_tracker.py 的 _TELEMETRY_BRANCHES 对齐）。
-    // 把主动搭话间隔（proactiveChatInterval）首启默认从控制组的 15s 拉长到 20s，看更慢的
-    // 搭话节奏对海外用户的影响；不动隐私 / 屏幕分享来源默认值，也没有弹窗。方向与
+    // 把主动搭话间隔（proactiveChatInterval）首启默认从新控制组的 20s 再拉长到 25s，看更慢
+    // 的搭话节奏对海外用户的影响；不动隐私 / 屏幕分享来源默认值，也没有弹窗。方向与
     // vision_chat_default_off 相反——只在海外（_isUserRegionChina() 为 false）才覆写，
     // 国内落到本组天然 no-op。两组抽签互斥（同设备只落一个 branch），但目标地区不重叠
-    // （vision 差异在国内、本组只影响海外），可同时在线。
-    const _PROACTIVE_INTERVAL_AB_BRANCH = 'proactive_interval_20s';
+    // （vision 差异在国内、本组只影响海外），可同时在线。前身 proactive_interval_20s
+    // （测 15s→20s）已下线，20s 扶正为 main 新基线。
+    const _PROACTIVE_INTERVAL_AB_BRANCH = 'proactive_interval_25s';
     // 实验组的主动搭话间隔默认值（秒）。控制组默认见 app-state.js 的
-    // DEFAULT_PROACTIVE_CHAT_INTERVAL（15s）。
-    const _PROACTIVE_INTERVAL_AB_VALUE = 20;
+    // DEFAULT_PROACTIVE_CHAT_INTERVAL（20s）。
+    const _PROACTIVE_INTERVAL_AB_VALUE = 25;
     // 「首启等 branch 决议」专属 marker：只有 localStorage 走过本 PR 的首启分支才会写
     // 「1」，branch 决议后清掉。用 marker 在不在判断「应不应该套 A/B 覆写」，避免拿
     // 「没见过 branch 」当首启代名——升级用户也都没见过 branch，那个口径会误伤他们的
@@ -562,8 +563,8 @@
                 }
                 // A/B test 覆写（海外专属）：与上方 vision 实验对称，但目标地区相反——只在
                 // 海外（!_isUserRegionChina()）真·首启时，把主动搭话间隔默认值从控制组的
-                // DEFAULT_PROACTIVE_CHAT_INTERVAL（15s）拉长到 _PROACTIVE_INTERVAL_AB_VALUE
-                // （20s）。守卫与 vision 同款：服务器无云端间隔偏好 + 用户没在 fetch 间隙手
+                // DEFAULT_PROACTIVE_CHAT_INTERVAL（20s）拉长到 _PROACTIVE_INTERVAL_AB_VALUE
+                // （25s）。守卫与 vision 同款：服务器无云端间隔偏好 + 用户没在 fetch 间隙手
                 // 动改 + 本地值仍等于控制组默认（即也没在之前 offline session 里改过）。国内
                 // 落到本组天然 no-op；与 vision_chat_default_off（差异在国内）目标地区不重
                 // 叠，可同时在线。本组只改默认值、无弹窗。

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -24,7 +24,7 @@
         SPATIAL_AUDIO_FALLOFF_RATE: 0.35,    // 超出主屏后每个 refDist 衰减比例
         SPATIAL_AUDIO_RAMP_SECONDS: 0.12,    // pan/gain 平滑过渡时长，避免突变 click
         SPATIAL_AUDIO_POLL_MS: 500,          // 位置轮询周期（兜底，事件驱动为主）
-        DEFAULT_PROACTIVE_CHAT_INTERVAL: 15, // 默认搭话间隔 (秒)
+        DEFAULT_PROACTIVE_CHAT_INTERVAL: 20, // 默认搭话间隔 (秒)；原 15s 经 proactive_interval_20s 实验扶正为新基线 20s
         DEFAULT_PROACTIVE_VISION_INTERVAL: 10, // 默认视觉间隔 (秒)
         MAX_SCREENSHOT_WIDTH: 1280,
         MAX_SCREENSHOT_HEIGHT: 720,
@@ -169,7 +169,7 @@
         isProactiveChatRunning: false,
         _proactiveSchedulerInitialized: false,
         _proactiveStartupDelayApplied: false,
-        proactiveChatInterval: 15,
+        proactiveChatInterval: 20,
         proactiveVisionFrameTimer: null,
         proactiveVisionInterval: 10,
         _lastProactiveChatScreenTime: 0,

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -348,7 +348,7 @@ function createSettingsPopupContent(manager, prefix, popup) {
 
     // 4. 主动搭话和自主视觉（角色设置已移至分隔线下方的导航菜单区域）
     const settingsToggles = [
-        { id: 'proactive-chat', label: window.t ? window.t('settings.toggles.proactiveChat') : '主动搭话', labelKey: 'settings.toggles.proactiveChat', storageKey: 'proactiveChatEnabled', hasInterval: true, intervalKey: 'proactiveChatInterval', defaultInterval: 15 },
+        { id: 'proactive-chat', label: window.t ? window.t('settings.toggles.proactiveChat') : '主动搭话', labelKey: 'settings.toggles.proactiveChat', storageKey: 'proactiveChatEnabled', hasInterval: true, intervalKey: 'proactiveChatInterval', defaultInterval: 20 },
         { id: 'proactive-vision', label: window.t ? window.t('settings.toggles.proactiveVision') : '隐私模式', labelKey: 'settings.toggles.proactiveVision', tooltipKey: 'settings.toggles.proactiveVisionTooltip', storageKey: 'proactiveVisionEnabled', hasInterval: true, intervalKey: 'proactiveVisionInterval', defaultInterval: 15, inverted: true }
     ];
 

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -385,7 +385,9 @@ _TELEMETRY_BRANCH_FILE = ".telemetry_branch"
 # A/B 池（只决定「首启默认值」实验分组；首启后用户行为已落盘、不再响应覆写，其分组
 # 归因对默认值实验无意义，分析端按真·首启样本过滤即可）：
 #   - "main"：控制组，沿用历史默认——主动搭话里的「屏幕分享来源」
-#     （proactiveVisionChatEnabled）首启默认开；隐私模式仍按地区分流。
+#     （proactiveVisionChatEnabled）首启默认开；隐私模式仍按地区分流。主动搭话间隔
+#     （proactiveChatInterval）首启默认 20s（见前端 DEFAULT_PROACTIVE_CHAT_INTERVAL；
+#     原 15s 已随 proactive_interval_20s 实验结论上移成新基线）。
 #   - "vision_chat_default_off"：实验组，把「屏幕分享来源」首启默认翻成关，并在前端
 #     检测到用户进游戏/娱乐（弹「要不要开屏幕分享搭话」）或进专注工作（弹「要不要关
 #     屏幕分享避嫌」）时一次性弹窗。注意这一组只改屏幕分享来源默认值，**不动**隐私
@@ -394,21 +396,25 @@ _TELEMETRY_BRANCH_FILE = ".telemetry_branch"
 #       地区分流（仅中国地区默认隐私关），海外默认隐私开 → 对本实验天然 no-op。抽签
 #       全地区随机，海外也会落实验组但首启覆写 / 弹窗都不生效；分析时按 locale 过滤，
 #       A/B 差异主要体现在国内。
-#   - "proactive_interval_20s"：海外专属实验组，把「主动搭话间隔」
-#     （proactiveChatInterval）首启默认从控制组 15s 拉长到 20s，看更慢的搭话节奏对
+#   - "proactive_interval_25s"：海外专属实验组，把「主动搭话间隔」
+#     （proactiveChatInterval）首启默认从新控制组 20s 再拉长到 25s，看更慢的搭话节奏对
 #     海外用户的影响。**不动**隐私模式 / 屏幕分享来源默认值，也没有弹窗。
 #       地区交互：与 vision_chat_default_off 方向相反——只在海外（前端
 #       _isUserRegionChina() 为 false）才覆写间隔默认值；国内落到本组天然 no-op。抽签
 #       全地区随机、三组互斥（同设备只落一个 branch），但 vision 实验差异在国内、本组
 #       只影响海外，目标地区不重叠，可同时在线观测。注意 _bucket_proactive_interval
-#       把 15s / 20s 都归进「10-30s」桶，所以 cohort 命中靠 branch 维度区分，不靠间隔桶。
+#       把 20s（main 新基线）/ 25s 都归进「10-30s」桶，所以 cohort 命中靠 branch 维度
+#       区分，不靠间隔桶。
 #
-# 已退役实验（老落盘值被 _read 严格校验判非法 → 下次启动按当前池随机重抽，落 main 或
-# vision_chat_default_off。都是已过首启的用户，重抽只改 telemetry 标签、不动已落盘的
-# 用户偏好，对「默认值」实验无影响，故不为其单独做确定性迁移）：
+# 已退役实验（老落盘值被 _read 严格校验判非法 → 下次启动按当前池随机重抽，落 main、
+# vision_chat_default_off 或 proactive_interval_25s。都是已过首启的用户，重抽只改
+# telemetry 标签、不动已落盘的用户偏好，对「默认值」实验无影响，故不为其单独做确定性
+# 迁移）：
 #   - "privacy_default_off_v1"（试国外隐私默认关）：前期数据效果差，已下线。
 #   - "privacy_default_off_v2"（试国内隐私默认开）：改方向去测屏幕分享来源，已下线。
-_TELEMETRY_BRANCHES: tuple = ("main", "vision_chat_default_off", "proactive_interval_20s")
+#   - "proactive_interval_20s"（试海外搭话间隔 15s→20s）：结论是 20s 更优，已把 20s
+#     扶正为 main 新基线，实验下线，改测 25s（proactive_interval_25s）。
+_TELEMETRY_BRANCHES: tuple = ("main", "vision_chat_default_off", "proactive_interval_25s")
 
 # 进程级缓存：keyed by str(config_dir)。写盘失败的环境下（只读 FS / 权限拒绝），
 # 不缓存就每次 secrets.choice 重抽，导致同一 install 的 TokenTracker 上报和


### PR DESCRIPTION
## Summary
主动搭话间隔 A/B 的一次「扶正基线 + 接力新实验」：
- **下线 `proactive_interval_20s`**：从 `_TELEMETRY_BRANCHES` 移出，挪进退役实验注释。落盘旧值会被 `_read` 严格校验判非法 → 按现池重抽，是文档化的退役行为，不加确定性迁移（符合「只测首启默认值」设计）。
- **main 搭话间隔默认 15s → 20s**（实验结论 20s 优于 15s）。四处口径全改齐，避免前端 `localIntervalMatchesControlDefault` 守卫失配导致新实验覆写不生效：
  - `static/app-state.js` `DEFAULT_PROACTIVE_CHAT_INTERVAL`（A/B 控制默认）
  - `static/app-state.js` 初始 `proactiveChatInterval`（首启 else 分支兜底值）
  - `static/avatar-ui-popup.js` 设置面板 slider fallback
  - `main_routers/proactive_router.py` `normal`「标准模式」档
  - `plugin/plugins/proactive_controller` `set_mode` 工具描述（normal 档间隔 15s→20s，对齐 preset）
- **新开 `proactive_interval_25s`**：海外专属，测 25s vs 新基线 20s，与 `vision_chat_default_off`（差异在国内）目标地区不重叠可同时在线。

## 行为影响
- 老用户（已有 saved 偏好）的搭话间隔设定不动。
- 真·首启新用户拿 20s；其中海外抽到 25s 组的拿 25s。
- 原 20s 组设备的 `.telemetry_branch` 过校验失败后按现池重抽（既定退役约定，同 `privacy_default_off` 退役）；已落盘的 20s 间隔偏好保留、恰好等于新默认。
  - ⚠️ 其中约 1/3 会重抽进 `vision_chat_default_off`。该 branch 的情境弹窗（`app-context-prompt.js`）只 gate 在 branch、不 gate 首启，故这部分老用户会开始看到一次性 vision 弹窗——这是退役重抽的固有性质（`privacy_default_off` 退役时已如此），非本 PR 新引入；实验有效性不受影响（vision 分析按真·首启过滤排除老用户）。详见 Codex P2 thread 讨论。

## Test plan
- [x] `python -m py_compile` 通过（token_tracker.py / proactive_router.py / proactive_controller）
- [x] `node --check` 通过（app-settings.js / app-state.js / avatar-ui-popup.js）
- [x] 前后端 branch 名对齐：`proactive_interval_25s`
- [ ] 主仓库手测首启：清 `project_neko_settings` + `.telemetry_branch` 写 `proactive_interval_25s` + 非中国时区 → 验证间隔默认 25s；中国时区 / main 组 → 20s

🤖 Generated with [Claude Code](https://claude.com/claude-code)