### PR TITLE
改名记录修补：主人段第二人称 + 阻止内部裸键泄漏

### DIFF
--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -1093,14 +1093,14 @@ PROFILE_RENAME_EVENT_FIELD = {
 }
 
 PROFILE_RENAME_EVENT_TEXT = {
-    "zh": "我以前的档案名是「{old_name}」，现在已经改名为「{new_name}」。以后请把「{new_name}」当作我的当前名字。",
-    "zh-TW": "我以前的檔案名是「{old_name}」，現在已經改名為「{new_name}」。以後請把「{new_name}」當作我的目前名字。",
-    "en": "My previous profile name was \"{old_name}\"; I have now changed it to \"{new_name}\". Treat \"{new_name}\" as my current name from now on.",
-    "ja": "以前の私のプロフィール名は「{old_name}」で、今は「{new_name}」に改名しました。これからは「{new_name}」を私の現在の名前として扱ってください。",
-    "ko": "내 이전 프로필 이름은 \"{old_name}\"였고, 지금은 \"{new_name}\"으로 바뀌었습니다. 앞으로는 \"{new_name}\"을 내 현재 이름으로 여기세요.",
-    "ru": "Раньше моё имя профиля было «{old_name}», теперь я сменила его на «{new_name}». С этого момента считай «{new_name}» моим текущим именем.",
-    "es": "Mi nombre de perfil anterior era \"{old_name}\"; ahora lo he cambiado a \"{new_name}\". A partir de ahora, trata \"{new_name}\" como mi nombre actual.",
-    "pt": "Meu nome de perfil anterior era \"{old_name}\"; agora mudei para \"{new_name}\". A partir de agora, trate \"{new_name}\" como meu nome atual.",
+    "zh": "我曾用名「{old_name}」，现在已经改名为「{new_name}」。以后请把「{new_name}」当作我的当前名字。",
+    "zh-TW": "我曾用名「{old_name}」，現在已經改名為「{new_name}」。以後請把「{new_name}」當作我的目前名字。",
+    "en": "I was formerly known as \"{old_name}\"; I am now called \"{new_name}\". Treat \"{new_name}\" as my current name from now on.",
+    "ja": "私はかつて「{old_name}」と呼ばれていましたが、今は「{new_name}」に改名しました。これからは「{new_name}」を私の現在の名前として扱ってください。",
+    "ko": "나는 예전에 \"{old_name}\"(으)로 불렸지만, 지금은 \"{new_name}\"(으)로 이름을 바꿨습니다. 앞으로는 \"{new_name}\"을 내 현재 이름으로 여기세요.",
+    "ru": "Раньше меня звали «{old_name}», теперь я сменила имя на «{new_name}». С этого момента считай «{new_name}» моим текущим именем.",
+    "es": "Antes me llamaba \"{old_name}\"; ahora me llamo \"{new_name}\". Trata \"{new_name}\" como mi nombre actual de ahora en adelante.",
+    "pt": "Antes eu me chamava \"{old_name}\"; agora me chamo \"{new_name}\". Trate \"{new_name}\" como meu nome atual de agora em diante.",
 }
 
 # 主人档案的改名记录走在猫娘（AI）的 persona/master section 里——读这段的是猫娘，
@@ -1119,14 +1119,14 @@ PROFILE_RENAME_EVENT_FIELD_MASTER = {
 }
 
 PROFILE_RENAME_EVENT_TEXT_MASTER = {
-    "zh": "档案名已从「{old_name}」改为「{new_name}」，当前名字是「{new_name}」。",
-    "zh-TW": "檔案名已從「{old_name}」改為「{new_name}」，目前名字是「{new_name}」。",
-    "en": "The profile name was changed from \"{old_name}\" to \"{new_name}\"; the current name is \"{new_name}\".",
-    "ja": "プロフィール名は「{old_name}」から「{new_name}」に変更されました。現在の名前は「{new_name}」です。",
-    "ko": "프로필 이름이 \"{old_name}\"에서 \"{new_name}\"(으)로 변경되었습니다. 현재 이름은 \"{new_name}\"입니다.",
-    "ru": "Имя профиля изменено с «{old_name}» на «{new_name}»; текущее имя — «{new_name}».",
-    "es": "El nombre de perfil cambió de \"{old_name}\" a \"{new_name}\"; el nombre actual es \"{new_name}\".",
-    "pt": "O nome de perfil foi alterado de \"{old_name}\" para \"{new_name}\"; o nome atual é \"{new_name}\".",
+    "zh": "曾用名「{old_name}」，现在的名字是「{new_name}」。",
+    "zh-TW": "曾用名「{old_name}」，現在的名字是「{new_name}」。",
+    "en": "Formerly known as \"{old_name}\"; the current name is \"{new_name}\".",
+    "ja": "かつての名前は「{old_name}」で、現在の名前は「{new_name}」です。",
+    "ko": "예전 이름은 \"{old_name}\"였고, 현재 이름은 \"{new_name}\"입니다.",
+    "ru": "Прежнее имя — «{old_name}», текущее имя — «{new_name}».",
+    "es": "Nombre anterior: \"{old_name}\"; nombre actual: \"{new_name}\".",
+    "pt": "Nome anterior: \"{old_name}\"; nome atual: \"{new_name}\".",
 }
 
 

--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -1104,28 +1104,29 @@ PROFILE_RENAME_EVENT_TEXT = {
 }
 
 # 主人档案的改名记录走在猫娘（AI）的 persona/master section 里——读这段的是猫娘，
-# 改名的是对面的用户，所以这里**禁止用第一人称**（否则猫娘会以为是自己改了名）。
-# 统一用第二人称「你」直接称呼用户，既消除人称歧义，也避开「主人/master」这类物化称呼。
+# 改名的是对面的用户。第一人称「我」会让猫娘以为是自己改了名，第二人称「你」又读着
+# 别扭，所以这里**去掉人称**，用中性陈述，和 master section 里其它无人称字段（昵称/
+# 性别…）的语气对齐。
 PROFILE_RENAME_EVENT_FIELD_MASTER = {
-    "zh": "你的改名记录",
-    "zh-TW": "你的改名紀錄",
-    "en": "Your Profile Rename Record",
-    "ja": "あなたの改名記録",
-    "ko": "당신의 프로필 이름 변경 기록",
-    "ru": "Запись о смене имени твоего профиля",
-    "es": "Tu registro de cambio de nombre de perfil",
-    "pt": "Seu registro de mudança de nome do perfil",
+    "zh": "改名记录",
+    "zh-TW": "改名紀錄",
+    "en": "Profile Rename Record",
+    "ja": "改名記録",
+    "ko": "프로필 이름 변경 기록",
+    "ru": "Запись о смене имени профиля",
+    "es": "Registro de cambio de nombre de perfil",
+    "pt": "Registro de mudança de nome do perfil",
 }
 
 PROFILE_RENAME_EVENT_TEXT_MASTER = {
-    "zh": "你以前的档案名是「{old_name}」，现在已经改名为「{new_name}」。以后请把「{new_name}」当作你的当前名字。",
-    "zh-TW": "你以前的檔案名是「{old_name}」，現在已經改名為「{new_name}」。以後請把「{new_name}」當作你的目前名字。",
-    "en": "Your previous profile name was \"{old_name}\"; it has now been changed to \"{new_name}\". Treat \"{new_name}\" as your current name from now on.",
-    "ja": "以前のあなたのプロフィール名は「{old_name}」で、今は「{new_name}」に改名されました。これからは「{new_name}」をあなたの現在の名前として扱ってください。",
-    "ko": "당신의 이전 프로필 이름은 \"{old_name}\"였고, 지금은 \"{new_name}\"으로 바뀌었습니다. 앞으로는 \"{new_name}\"을 당신의 현재 이름으로 여기세요.",
-    "ru": "Раньше твоё имя профиля было «{old_name}», теперь оно изменено на «{new_name}». С этого момента считай «{new_name}» твоим текущим именем.",
-    "es": "Tu nombre de perfil anterior era \"{old_name}\"; ahora se ha cambiado a \"{new_name}\". A partir de ahora, trata \"{new_name}\" como tu nombre actual.",
-    "pt": "Seu nome de perfil anterior era \"{old_name}\"; agora foi alterado para \"{new_name}\". A partir de agora, trate \"{new_name}\" como seu nome atual.",
+    "zh": "档案名已从「{old_name}」改为「{new_name}」，当前名字是「{new_name}」。",
+    "zh-TW": "檔案名已從「{old_name}」改為「{new_name}」，目前名字是「{new_name}」。",
+    "en": "The profile name was changed from \"{old_name}\" to \"{new_name}\"; the current name is \"{new_name}\".",
+    "ja": "プロフィール名は「{old_name}」から「{new_name}」に変更されました。現在の名前は「{new_name}」です。",
+    "ko": "프로필 이름이 \"{old_name}\"에서 \"{new_name}\"(으)로 변경되었습니다. 현재 이름은 \"{new_name}\"입니다.",
+    "ru": "Имя профиля изменено с «{old_name}» на «{new_name}»; текущее имя — «{new_name}».",
+    "es": "El nombre de perfil cambió de \"{old_name}\" a \"{new_name}\"; el nombre actual es \"{new_name}\".",
+    "pt": "O nome de perfil foi alterado de \"{old_name}\" para \"{new_name}\"; o nome atual é \"{new_name}\".",
 }
 
 
@@ -1159,7 +1160,7 @@ def render_profile_rename_event_context(
 
     entity="neko"：写进猫娘自己的 section，用第一人称「我」。
     entity="master"：写进猫娘 persona 的 master section，读者是猫娘、改名的是用户，
-    因此用第二人称「你」直接称呼用户，避免第一人称把用户的改名误当成猫娘自己的。
+    因此去掉人称用中性陈述，避免第一人称把用户的改名误当成猫娘自己的。
     """
     lang_key = _normalize_memory_prompt_lang(lang)
     if str(entity or "").strip().lower() == "master":

--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -1103,6 +1103,31 @@ PROFILE_RENAME_EVENT_TEXT = {
     "pt": "Meu nome de perfil anterior era \"{old_name}\"; agora mudei para \"{new_name}\". A partir de agora, trate \"{new_name}\" como meu nome atual.",
 }
 
+# 主人档案的改名记录走在猫娘（AI）的 persona/master section 里——读这段的是猫娘，
+# 改名的是对面的用户，所以这里**禁止用第一人称**（否则猫娘会以为是自己改了名）。
+# 统一用第二人称「你」直接称呼用户，既消除人称歧义，也避开「主人/master」这类物化称呼。
+PROFILE_RENAME_EVENT_FIELD_MASTER = {
+    "zh": "你的改名记录",
+    "zh-TW": "你的改名紀錄",
+    "en": "Your Profile Rename Record",
+    "ja": "あなたの改名記録",
+    "ko": "당신의 프로필 이름 변경 기록",
+    "ru": "Запись о смене имени твоего профиля",
+    "es": "Tu registro de cambio de nombre de perfil",
+    "pt": "Seu registro de mudança de nome do perfil",
+}
+
+PROFILE_RENAME_EVENT_TEXT_MASTER = {
+    "zh": "你以前的档案名是「{old_name}」，现在已经改名为「{new_name}」。以后请把「{new_name}」当作你的当前名字。",
+    "zh-TW": "你以前的檔案名是「{old_name}」，現在已經改名為「{new_name}」。以後請把「{new_name}」當作你的目前名字。",
+    "en": "Your previous profile name was \"{old_name}\"; it has now been changed to \"{new_name}\". Treat \"{new_name}\" as your current name from now on.",
+    "ja": "以前のあなたのプロフィール名は「{old_name}」で、今は「{new_name}」に改名されました。これからは「{new_name}」をあなたの現在の名前として扱ってください。",
+    "ko": "당신의 이전 프로필 이름은 \"{old_name}\"였고, 지금은 \"{new_name}\"으로 바뀌었습니다. 앞으로는 \"{new_name}\"을 당신의 현재 이름으로 여기세요.",
+    "ru": "Раньше твоё имя профиля было «{old_name}», теперь оно изменено на «{new_name}». С этого момента считай «{new_name}» твоим текущим именем.",
+    "es": "Tu nombre de perfil anterior era \"{old_name}\"; ahora se ha cambiado a \"{new_name}\". A partir de ahora, trata \"{new_name}\" como tu nombre actual.",
+    "pt": "Seu nome de perfil anterior era \"{old_name}\"; agora foi alterado para \"{new_name}\". A partir de agora, trate \"{new_name}\" como seu nome atual.",
+}
+
 
 def _normalize_memory_prompt_lang(lang: str | None) -> str:
     """归一化记忆 prompt 本地化 key，保留繁中分支。"""
@@ -1128,12 +1153,22 @@ def render_profile_rename_event_context(
     lang: str | None,
     old_name: str,
     new_name: str,
+    entity: str = "neko",
 ) -> tuple[str, str]:
-    """渲染给 AI 的一人称改名记录，返回 (字段名, 内容)。"""
+    """渲染改名记录，返回 (字段名, 内容)。
+
+    entity="neko"：写进猫娘自己的 section，用第一人称「我」。
+    entity="master"：写进猫娘 persona 的 master section，读者是猫娘、改名的是用户，
+    因此用第二人称「你」直接称呼用户，避免第一人称把用户的改名误当成猫娘自己的。
+    """
     lang_key = _normalize_memory_prompt_lang(lang)
+    if str(entity or "").strip().lower() == "master":
+        field_dict, text_dict = PROFILE_RENAME_EVENT_FIELD_MASTER, PROFILE_RENAME_EVENT_TEXT_MASTER
+    else:
+        field_dict, text_dict = PROFILE_RENAME_EVENT_FIELD, PROFILE_RENAME_EVENT_TEXT
     return (
-        _loc(PROFILE_RENAME_EVENT_FIELD, lang_key),
-        _loc(PROFILE_RENAME_EVENT_TEXT, lang_key).format(
+        _loc(field_dict, lang_key),
+        _loc(text_dict, lang_key).format(
             old_name=str(old_name or "").strip(),
             new_name=str(new_name or "").strip(),
         ),

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -521,7 +521,13 @@ class PersonaManager:
                 if isinstance(v, list):
                     v = '、'.join(str(item) for item in v)
                 entry_id = self._card_entry_id(entity, k)
-                text = f"{k}: {v}"
+                if str(k).startswith("__ai_context"):
+                    # 合成运行时上下文字段（如 __ai_context.profile_rename_events）：
+                    # value 已是自带本地化标签的完整句子，不能再前缀内部键名，
+                    # 否则裸键 "__ai_context.xxx: ..." 会原样泄漏进模型读到的 fact。
+                    text = str(v)
+                else:
+                    text = f"{k}: {v}"
                 expected.append((entry_id, text))
             return expected
 

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -521,10 +521,11 @@ class PersonaManager:
                 if isinstance(v, list):
                     v = '、'.join(str(item) for item in v)
                 entry_id = self._card_entry_id(entity, k)
-                if str(k).startswith("__ai_context"):
+                if str(k).startswith("__ai_context."):
                     # 合成运行时上下文字段（如 __ai_context.profile_rename_events）：
                     # value 已是自带本地化标签的完整句子，不能再前缀内部键名，
                     # 否则裸键 "__ai_context.xxx: ..." 会原样泄漏进模型读到的 fact。
+                    # 用带点的前缀精确匹配约定命名，避免误伤 __ai_contextual_* 这类普通键。
                     text = str(v)
                 else:
                     text = f"{k}: {v}"

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -121,6 +121,60 @@ def test_profile_rename_event_prompt_i18n_is_complete_and_first_person():
 
 
 @pytest.mark.unit
+def test_profile_rename_event_master_uses_second_person():
+    """主人改名记录进的是猫娘 persona 的 master section，读者是猫娘、
+    改名的是用户，必须第二人称「你」，绝不能第一人称「我」。"""
+    from config.prompts.prompts_memory import (
+        PROFILE_RENAME_EVENT_FIELD_MASTER,
+        PROFILE_RENAME_EVENT_TEXT_MASTER,
+        render_profile_rename_event_context,
+    )
+
+    expected_langs = {"zh", "zh-TW", "en", "ja", "ko", "ru", "es", "pt"}
+    assert set(PROFILE_RENAME_EVENT_FIELD_MASTER) == expected_langs
+    assert set(PROFILE_RENAME_EVENT_TEXT_MASTER) == expected_langs
+
+    zh_label, zh_text = render_profile_rename_event_context("zh-CN", "旧名", "新名", entity="master")
+    assert zh_label == "你的改名记录"
+    assert "你以前的档案名" in zh_text
+    assert "当作你的当前名字" in zh_text
+    assert "我以前的档案名" not in zh_text
+    assert "我的当前名字" not in zh_text
+    assert "旧名" in zh_text and "新名" in zh_text
+
+    en_label, en_text = render_profile_rename_event_context("en", "Old", "New", entity="master")
+    assert en_label == "Your Profile Rename Record"
+    assert "Your previous profile name" in en_text
+    assert "My previous profile name" not in en_text
+
+    # 缺省（neko）仍是第一人称，主人变体不影响默认行为。
+    _, neko_text = render_profile_rename_event_context("zh-CN", "旧名", "新名")
+    assert "我以前的档案名" in neko_text
+
+
+@pytest.mark.unit
+def test_master_effective_payload_rename_context_is_second_person(monkeypatch):
+    monkeypatch.setattr("utils.language_utils.get_global_language_full", lambda: "zh-CN")
+    from utils.config_manager import _build_effective_character_payload
+
+    payload = {
+        "档案名": "新主人名",
+        "_reserved": {
+            "ai_context": {
+                "rename_events": [
+                    {"type": "profile_rename", "old_name": "旧主人名", "new_name": "新主人名"},
+                ]
+            }
+        },
+    }
+    effective = _build_effective_character_payload(payload, entity="master")
+    context = effective["__ai_context.profile_rename_events"]
+    assert "你以前的档案名" in context
+    assert "我以前的档案名" not in context
+    assert "旧主人名" in context and "新主人名" in context
+
+
+@pytest.mark.unit
 def test_profile_rename_event_uses_collision_safe_synthetic_key(monkeypatch):
     monkeypatch.setattr("utils.language_utils.get_global_language_full", lambda: "zh-CN")
     from utils.config_manager import _build_effective_character_payload
@@ -441,7 +495,8 @@ async def test_rename_catgirl_moves_runtime_and_legacy_memory_storage(monkeypatc
             assert "新角色" in hidden_context
             from memory.persona import PersonaManager
             persona_md = PersonaManager().render_persona_markdown("新角色")
-            assert "__ai_context.profile_rename_events" in persona_md
+            # 合成字段的内部裸键不能泄漏进渲染给模型的 persona 文本，只保留本地化标签。
+            assert "__ai_context.profile_rename_events" not in persona_md
             assert "我的改名记录" in persona_md
             assert "我以前的档案名" in persona_md
             assert "旧角色" in persona_md
@@ -509,15 +564,20 @@ async def test_rename_master_adds_hidden_ai_context_and_master_save_preserves_it
 
             _, _, master_basic_config, _, _, _, _, _, _ = cm.get_character_data()
             hidden_context = master_basic_config["__ai_context.profile_rename_events"]
-            assert "我的改名记录" in hidden_context
-            assert "我以前的档案名" in hidden_context
+            # 主人改名记录进的是猫娘 persona 的 master section，必须第二人称「你」，
+            # 不能第一人称「我」（否则猫娘会以为是自己改了名）。
+            assert "你的改名记录" in hidden_context
+            assert "你以前的档案名" in hidden_context
+            assert "我以前的档案名" not in hidden_context
             assert old_master_name in hidden_context
             assert "新主人" in hidden_context
 
             from memory.persona import PersonaManager
             persona_md = PersonaManager().render_persona_markdown(current_catgirl)
-            assert "__ai_context.profile_rename_events" in persona_md
-            assert "我的改名记录" in persona_md
+            # 同上：裸键不泄漏，且主人段是第二人称。
+            assert "__ai_context.profile_rename_events" not in persona_md
+            assert "你的改名记录" in persona_md
+            assert "我的改名记录" not in persona_md
             assert old_master_name in persona_md
             assert "新主人" in persona_md
 

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -121,9 +121,10 @@ def test_profile_rename_event_prompt_i18n_is_complete_and_first_person():
 
 
 @pytest.mark.unit
-def test_profile_rename_event_master_uses_second_person():
+def test_profile_rename_event_master_is_person_neutral():
     """主人改名记录进的是猫娘 persona 的 master section，读者是猫娘、
-    改名的是用户，必须第二人称「你」，绝不能第一人称「我」。"""
+    改名的是用户。第一人称会让猫娘误以为是自己改名，所以这里去掉人称、
+    用中性陈述，既不能出现「我」也不带「你」。"""
     from config.prompts.prompts_memory import (
         PROFILE_RENAME_EVENT_FIELD_MASTER,
         PROFILE_RENAME_EVENT_TEXT_MASTER,
@@ -135,17 +136,16 @@ def test_profile_rename_event_master_uses_second_person():
     assert set(PROFILE_RENAME_EVENT_TEXT_MASTER) == expected_langs
 
     zh_label, zh_text = render_profile_rename_event_context("zh-CN", "旧名", "新名", entity="master")
-    assert zh_label == "你的改名记录"
-    assert "你以前的档案名" in zh_text
-    assert "当作你的当前名字" in zh_text
-    assert "我以前的档案名" not in zh_text
-    assert "我的当前名字" not in zh_text
+    assert zh_label == "改名记录"
     assert "旧名" in zh_text and "新名" in zh_text
+    # 去人称：既无第一人称「我」也无第二人称「你」。
+    assert "我" not in zh_text
+    assert "你" not in zh_text
 
     en_label, en_text = render_profile_rename_event_context("en", "Old", "New", entity="master")
-    assert en_label == "Your Profile Rename Record"
-    assert "Your previous profile name" in en_text
-    assert "My previous profile name" not in en_text
+    assert en_label == "Profile Rename Record"
+    assert "Old" in en_text and "New" in en_text
+    assert "My " not in en_text and "Your " not in en_text
 
     # 缺省（neko）仍是第一人称，主人变体不影响默认行为。
     _, neko_text = render_profile_rename_event_context("zh-CN", "旧名", "新名")
@@ -153,7 +153,7 @@ def test_profile_rename_event_master_uses_second_person():
 
 
 @pytest.mark.unit
-def test_master_effective_payload_rename_context_is_second_person(monkeypatch):
+def test_master_effective_payload_rename_context_is_person_neutral(monkeypatch):
     monkeypatch.setattr("utils.language_utils.get_global_language_full", lambda: "zh-CN")
     from utils.config_manager import _build_effective_character_payload
 
@@ -169,9 +169,9 @@ def test_master_effective_payload_rename_context_is_second_person(monkeypatch):
     }
     effective = _build_effective_character_payload(payload, entity="master")
     context = effective["__ai_context.profile_rename_events"]
-    assert "你以前的档案名" in context
-    assert "我以前的档案名" not in context
     assert "旧主人名" in context and "新主人名" in context
+    assert "我" not in context
+    assert "你" not in context
 
 
 @pytest.mark.unit
@@ -564,20 +564,19 @@ async def test_rename_master_adds_hidden_ai_context_and_master_save_preserves_it
 
             _, _, master_basic_config, _, _, _, _, _, _ = cm.get_character_data()
             hidden_context = master_basic_config["__ai_context.profile_rename_events"]
-            # 主人改名记录进的是猫娘 persona 的 master section，必须第二人称「你」，
-            # 不能第一人称「我」（否则猫娘会以为是自己改了名）。
-            assert "你的改名记录" in hidden_context
-            assert "你以前的档案名" in hidden_context
-            assert "我以前的档案名" not in hidden_context
+            # 主人改名记录进的是猫娘 persona 的 master section，去掉人称用中性陈述，
+            # 既不能第一人称「我」（否则猫娘会以为是自己改了名），也不带第二人称「你」。
+            assert "改名记录" in hidden_context
+            assert "我" not in hidden_context
+            assert "你" not in hidden_context
             assert old_master_name in hidden_context
             assert "新主人" in hidden_context
 
             from memory.persona import PersonaManager
             persona_md = PersonaManager().render_persona_markdown(current_catgirl)
-            # 同上：裸键不泄漏，且主人段是第二人称。
+            # 同上：裸键不泄漏，且主人段无人称。
             assert "__ai_context.profile_rename_events" not in persona_md
-            assert "你的改名记录" in persona_md
-            assert "我的改名记录" not in persona_md
+            assert "改名记录" in persona_md
             assert old_master_name in persona_md
             assert "新主人" in persona_md
 

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -107,14 +107,14 @@ def test_profile_rename_event_prompt_i18n_is_complete_and_first_person():
 
     zh_label, zh_text = render_profile_rename_event_context("zh-CN", "旧角色", "新角色")
     assert zh_label == "我的改名记录"
-    assert "我以前的档案名" in zh_text
+    assert "我曾用名" in zh_text
     assert "旧角色" in zh_text
     assert "新角色" in zh_text
     assert "只代表改名前的历史称呼" not in zh_text
 
     en_label, en_text = render_profile_rename_event_context("en", "Old", "New")
     assert en_label == "My Profile Rename Record"
-    assert "My previous profile name" in en_text
+    assert "formerly known as" in en_text
     assert "Old" in en_text
     assert "New" in en_text
     assert "historical name before the rename" not in en_text
@@ -149,7 +149,7 @@ def test_profile_rename_event_master_is_person_neutral():
 
     # 缺省（neko）仍是第一人称，主人变体不影响默认行为。
     _, neko_text = render_profile_rename_event_context("zh-CN", "旧名", "新名")
-    assert "我以前的档案名" in neko_text
+    assert "我曾用名" in neko_text
 
 
 @pytest.mark.unit
@@ -204,7 +204,7 @@ def test_profile_rename_event_uses_collision_safe_synthetic_key(monkeypatch):
     assert effective["我的改名记录"] == "用户自己写的字段"
     hidden_context = effective["__ai_context.profile_rename_events"]
     assert "我的改名记录" in hidden_context
-    assert "我以前的档案名" in hidden_context
+    assert "我曾用名" in hidden_context
     assert "旧角色" in hidden_context
     assert "临时角色" in hidden_context
     assert "新角色" in hidden_context
@@ -218,7 +218,7 @@ def test_profile_rename_event_uses_collision_safe_synthetic_key(monkeypatch):
         for key, value in effective_with_internal_collision.items()
         if key.startswith("__ai_context.profile_rename_events.")
     ]
-    assert any("我以前的档案名" in str(value) for value in collision_values)
+    assert any("我曾用名" in str(value) for value in collision_values)
 
 
 @pytest.mark.unit
@@ -490,7 +490,7 @@ async def test_rename_catgirl_moves_runtime_and_legacy_memory_storage(monkeypatc
             _, _, _, effective_character_data, _, _, _, _, _ = cm.get_character_data()
             hidden_context = effective_character_data["新角色"]["__ai_context.profile_rename_events"]
             assert "我的改名记录" in hidden_context
-            assert "我以前的档案名" in hidden_context
+            assert "我曾用名" in hidden_context
             assert "旧角色" in hidden_context
             assert "新角色" in hidden_context
             from memory.persona import PersonaManager
@@ -498,7 +498,7 @@ async def test_rename_catgirl_moves_runtime_and_legacy_memory_storage(monkeypatc
             # 合成字段的内部裸键不能泄漏进渲染给模型的 persona 文本，只保留本地化标签。
             assert "__ai_context.profile_rename_events" not in persona_md
             assert "我的改名记录" in persona_md
-            assert "我以前的档案名" in persona_md
+            assert "我曾用名" in persona_md
             assert "旧角色" in persona_md
             assert "新角色" in persona_md
             assert not (Path(cm.memory_dir) / "旧角色").exists()

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -296,7 +296,7 @@ def _get_persona_override(character_payload: dict) -> dict | None:
     return override
 
 
-def _build_effective_character_payload(character_payload: dict) -> dict:
+def _build_effective_character_payload(character_payload: dict, entity: str = "neko") -> dict:
     if not isinstance(character_payload, dict):
         return {}
 
@@ -306,6 +306,7 @@ def _build_effective_character_payload(character_payload: dict) -> dict:
         for field, value in _build_ai_context_fields(
             character_payload,
             existing_fields=set(effective_payload.keys()),
+            entity=entity,
         ).items():
             effective_payload[field] = value
         return effective_payload
@@ -316,6 +317,7 @@ def _build_effective_character_payload(character_payload: dict) -> dict:
     for field, value in _build_ai_context_fields(
         character_payload,
         existing_fields=set(effective_payload.keys()),
+        entity=entity,
     ).items():
         effective_payload[field] = value
     return effective_payload
@@ -380,8 +382,13 @@ def _join_profile_rename_old_names(lang: str | None, names: list[str]) -> str:
 def _build_ai_context_fields(
     character_payload: dict,
     existing_fields: set[str] | None = None,
+    entity: str = "neko",
 ) -> dict[str, str]:
-    """把隐藏运行时事件展开成只给 prompt/记忆同步使用的合成字段。"""
+    """把隐藏运行时事件展开成只给 prompt/记忆同步使用的合成字段。
+
+    entity 区分这份 payload 是猫娘（neko）还是主人（master），决定改名记录的人称：
+    主人的记录进的是猫娘 persona 的 master section，必须第二人称，不能第一人称。
+    """
     if not isinstance(character_payload, dict):
         return {}
 
@@ -429,7 +436,7 @@ def _build_ai_context_fields(
     lines: list[str] = []
     if old_names and current_name:
         old_names_text = _join_profile_rename_old_names(lang, old_names)
-        label, text = render_profile_rename_event_context(lang, old_names_text, current_name)
+        label, text = render_profile_rename_event_context(lang, old_names_text, current_name, entity=entity)
         lines.append(f"{label}: {text}")
 
     lines.extend(legacy_lines)
@@ -2872,7 +2879,7 @@ class ConfigManager:
         character_data.setdefault('主人', deepcopy(defaults['主人']))
         character_data.setdefault('猫娘', deepcopy(defaults['猫娘']))
 
-        master_basic_config = _build_effective_character_payload(character_data.get('主人', {}))
+        master_basic_config = _build_effective_character_payload(character_data.get('主人', {}), entity="master")
         master_name = master_basic_config.get('档案名', defaults['主人']['档案名'])
 
         raw_character_data = character_data.get('猫娘') or deepcopy(defaults['猫娘'])


### PR DESCRIPTION
## 背景

承接已合并的 #1538（为主人/猫娘档案添加改名事件）。改名事件会被折叠成合成字段 `__ai_context.profile_rename_events`，经 `_build_effective_character_payload` 注入角色 payload，再由 `memory/persona.py` 的 character-card 同步写成 persona fact（`source='character_card'`, `protected=True`），最终渲染进猫娘读到的 persona 段。复查这条拼装链路发现两个问题。

## 修复

### 1. 主人档案改名记录不能用第一人称
主人的改名记录落在猫娘 persona 的 **master section**，读这段的是猫娘、改名的是用户。原先主人侧复用第一人称模板（"我以前的档案名是…"），会让猫娘把**用户**的改名误当成**自己**改了名。

- 新增 `PROFILE_RENAME_EVENT_FIELD_MASTER` / `PROFILE_RENAME_EVENT_TEXT_MASTER` 第二人称模板（8 语言全覆盖）。
- `render_profile_rename_event_context` / `_build_ai_context_fields` / `_build_effective_character_payload` 增 `entity` 参数；主人侧传 `entity="master"`，猫娘侧保持第一人称。
- 第二人称「你」同时避开「主人/master」这类物化称呼。

### 2. 内部裸键泄漏进 persona fact
persona card 同步对所有字段一律 `f"{k}: {v}"`，导致合成字段的内部键原样进入模型读到的文本：
```
__ai_context.profile_rename_events: 我的改名记录: 我以前的档案名是「X」…
```
改为：`__ai_context.*` 这类合成字段直接输出 value（已自带本地化标签），不再前缀内部键。

## 测试
- 更新两条原本断言旧行为的回归测试（裸键不再出现、主人段为第二人称）。
- 新增主人第二人称单测 + effective payload 主人段单测。
- `tests/unit/test_character_memory_regression.py` 全部 54 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为“主人/对方”改名事件添加中性表述的多语言显示变体，支持在渲染时选择主体类型（默认保持原有行为）。

* **问题修复**
  * 修复了在生成/渲染人格文本时可能泄露内部字段名或错误包含第一/第二人称的问题，输出更干净且语气正确。

* **测试**
  * 增加并调整回归测试，覆盖主人改名的中性呈现与渲染泄漏防护。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->