### PR TITLE
fix(ui): Electron Pet 窗口（index.html）永不进入手机模式

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -1470,7 +1470,7 @@
 
                         await window.live2dManager.loadModel(modelConfig, {
                             preferences: modelPreferences,
-                            isMobile: window.innerWidth <= 768
+                            isMobile: typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768)
                         });
                         throwIfStale();
 
@@ -1511,7 +1511,7 @@
                                 throwIfStale();
                                 defaultConfig.url = defaultPath;
                                 await window.live2dManager.loadModel(defaultConfig, {
-                                    isMobile: window.innerWidth <= 768
+                                    isMobile: typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768)
                                 });
                                 throwIfStale();
                                 if (window.LanLan1) {

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -860,7 +860,7 @@
 
                             await window.live2dManager.loadModel(newModelPath, {
                                 preferences: modelPreferences,
-                                isMobile: window.innerWidth <= 768,
+                                isMobile: typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768),
                                 suppressInitialIdle: skipIdleRestore
                             });
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -320,6 +320,11 @@
         if (isElectronChatWindow()) {
             return false;
         }
+        // index.html 的 Electron Pet 窗口同理：永不进入手机模式（黑背景 + 窄布局）。
+        // 标记 __LANLAN_IS_ELECTRON_PET__ 由 index.html 头部脚本同步注入。
+        if (window.__LANLAN_IS_ELECTRON_PET__) {
+            return false;
+        }
         return window.innerWidth <= 768;
     }
 

--- a/static/avatar-popup-common.js
+++ b/static/avatar-popup-common.js
@@ -279,8 +279,9 @@
         }
 
         // ── Step 0.5：手机端特殊处理：向下展开而非向左/向右 ──
+        // Electron Pet 窗口永不进入手机模式，统一走 canonical 谓词。
         const screenWidth = window.innerWidth;
-        const isMobile = screenWidth <= 768;
+        const isMobile = typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (screenWidth <= 768);
         const goDown = isMobile;
 
         // ── Step 1：从 popup 获取方向（取代 getButtonZone 启发式） ──

--- a/static/common_ui.js
+++ b/static/common_ui.js
@@ -18,8 +18,11 @@ let restoreChatContainerSize = null;
 let getStoredChatContainerSize = null;
 
 // 移动端检测（与 live2d.js 的 isMobileWidth 一致：基于窗口宽度）
+// Electron Pet 窗口（index.html）永不进入手机模式：优先走 canonical 谓词
+//（live2d-core.js 定义的 window.isMobileWidth 已感知 __LANLAN_IS_ELECTRON_PET__）。
 function uiIsMobileWidth() {
-    return window.innerWidth <= 768;
+    if (typeof window.isMobileWidth === 'function') return window.isMobileWidth();
+    return !window.__LANLAN_IS_ELECTRON_PET__ && window.innerWidth <= 768;
 }
 
 function isCollapsed() {

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -651,16 +651,18 @@ html #chat-container {
 /* ===== 移动端暗色模式适配 ===== */
 @media only screen and (max-width: 768px) {
 
-  html[data-theme="dark"],
-  html[data-theme="dark"] body {
+  /* Electron Pet 窗口（html/body 带 lanlan-pet-mode）排除：它需要透明背景
+     透出桌面，绝不能在暗色下被刷成黑色。 */
+  html[data-theme="dark"]:not(.lanlan-pet-mode),
+  html[data-theme="dark"]:not(.lanlan-pet-mode) body {
     background: #000 !important;
   }
 
-  [data-theme="dark"] #chat-content-wrapper {
+  html[data-theme="dark"]:not(.lanlan-pet-mode) #chat-content-wrapper {
     background: rgba(25, 25, 25, 0.6);
   }
 
-  [data-theme="dark"] #text-input-area {
+  html[data-theme="dark"]:not(.lanlan-pet-mode) #text-input-area {
     background: rgba(40, 40, 40, 0.55);
     border-top: 1px solid rgba(255, 255, 255, 0.06);
   }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2533,13 +2533,13 @@ body.react-chat-window-dragging {
 
 @media only screen and (max-width: 768px) {
 
-    /* 手机端背景设为黑色 */
-    html,
-    body {
+    /* 手机端背景设为黑色（Electron Pet 窗口除外：html/body 都带 lanlan-pet-mode） */
+    html:not(.lanlan-pet-mode),
+    body:not(.lanlan-pet-mode) {
         background: #000 !important;
     }
 
-    #live2d-container {
+    :where(body:not(.lanlan-pet-mode)) #live2d-container {
         position: fixed;
         right: 0;
         bottom: 0;
@@ -2548,7 +2548,7 @@ body.react-chat-window-dragging {
         z-index: 5;
     }
 
-    #chat-container {
+    :where(body:not(.lanlan-pet-mode)) #chat-container {
         width: 90vw;
         left: 5vw;
         bottom: 10px;
@@ -2561,12 +2561,12 @@ body.react-chat-window-dragging {
         box-shadow: none;
     }
 
-    #chat-header {
+    :where(body:not(.lanlan-pet-mode)) #chat-header {
         height: 40px;
         font-size: 0.9rem;
     }
 
-    #chat-content-wrapper {
+    :where(body:not(.lanlan-pet-mode)) #chat-content-wrapper {
         padding: 12px;
         padding-top: 44px;
         /* 禁用内容区过渡，避免折叠时对子元素产生影响 */
@@ -2575,7 +2575,7 @@ body.react-chat-window-dragging {
         /* Fluent 背景层 */
     }
 
-    #text-input-area {
+    :where(body:not(.lanlan-pet-mode)) #text-input-area {
         padding: 8px;
         /* 输入区不参与任何过渡动画 */
         transition: none !important;
@@ -2586,73 +2586,73 @@ body.react-chat-window-dragging {
     }
 
     /* 输入区内部元素也不参与过渡，避免细微跳动 */
-    #text-input-row,
-    #textInputBox,
-    #button-group {
+    :where(body:not(.lanlan-pet-mode)) #text-input-row,
+    :where(body:not(.lanlan-pet-mode)) #textInputBox,
+    :where(body:not(.lanlan-pet-mode)) #button-group {
         transition: none !important;
     }
 
-    #textInputBox {
+    :where(body:not(.lanlan-pet-mode)) #textInputBox {
         font-size: 0.9rem;
         /* 移动端：按钮纵向排列，高度匹配按钮组总高度 */
         height: 92px;
     }
 
-    #button-group {
+    :where(body:not(.lanlan-pet-mode)) #button-group {
         gap: 4px;
     }
 
-    #textSendButton,
-    #screenshotButton {
+    :where(body:not(.lanlan-pet-mode)) #textSendButton,
+    :where(body:not(.lanlan-pet-mode)) #screenshotButton {
         padding: 6px 12px;
         font-size: 0.8rem;
         min-width: 70px;
     }
 
-    .screenshot-item {
+    :where(body:not(.lanlan-pet-mode)) .screenshot-item {
         width: 80px;
     }
 
-    .screenshot-thumbnail {
+    :where(body:not(.lanlan-pet-mode)) .screenshot-thumbnail {
         width: 80px;
         height: 60px;
     }
 
-    .chat-avatar-preview-card-body {
+    :where(body:not(.lanlan-pet-mode)) .chat-avatar-preview-card-body {
         flex-direction: column;
         align-items: stretch;
     }
 
-    .chat-avatar-preview-image-shell {
+    :where(body:not(.lanlan-pet-mode)) .chat-avatar-preview-image-shell {
         width: 78px;
         height: 78px;
         border-radius: 22px;
     }
 
-    #screenshots-title {
+    :where(body:not(.lanlan-pet-mode)) #screenshots-title {
         font-size: 0.8rem;
     }
 
-    #clear-all-screenshots {
+    :where(body:not(.lanlan-pet-mode)) #clear-all-screenshots {
         font-size: 0.7rem;
         padding: 2px 6px;
     }
 
-    .screenshot-index {
+    :where(body:not(.lanlan-pet-mode)) .screenshot-index {
         font-size: 0.65rem;
     }
 
-    .message {
+    :where(body:not(.lanlan-pet-mode)) .message {
         font-size: 0.9rem;
         max-width: 85%;
     }
 
     /* 移动端显示拍照，隐藏截图 */
-    .desktop-text {
+    :where(body:not(.lanlan-pet-mode)) .desktop-text {
         display: none;
     }
 
-    .mobile-text {
+    :where(body:not(.lanlan-pet-mode)) .mobile-text {
         display: inline;
     }
 }
@@ -2660,7 +2660,7 @@ body.react-chat-window-dragging {
 @media only screen and (max-width: 768px) {
 
     /* 移动端：折叠时容器完全透明且不拦截触摸事件 */
-    #chat-container.mobile-collapsed {
+    :where(body:not(.lanlan-pet-mode)) #chat-container.mobile-collapsed {
         width: 48px !important;
         min-width: 48px !important;
         max-width: 48px !important;
@@ -2676,14 +2676,14 @@ body.react-chat-window-dragging {
         border: none !important;
     }
 
-    #chat-container.mobile-collapsed::before {
+    :where(body:not(.lanlan-pet-mode)) #chat-container.mobile-collapsed::before {
         backdrop-filter: none !important;
         -webkit-backdrop-filter: none !important;
         background: transparent !important;
     }
 
     /* 移动端：折叠时仅切换按钮可交互 */
-    #chat-container.mobile-collapsed #toggle-chat-btn {
+    :where(body:not(.lanlan-pet-mode)) #chat-container.mobile-collapsed #toggle-chat-btn {
         pointer-events: auto !important;
         left: 8px;
         right: auto;
@@ -2693,8 +2693,8 @@ body.react-chat-window-dragging {
     }
 
     /* 移动端：折叠时隐藏输入区和音乐调节条 */
-    #chat-container.mobile-collapsed #text-input-area,
-    #chat-container.mobile-collapsed .music-player-bar {
+    :where(body:not(.lanlan-pet-mode)) #chat-container.mobile-collapsed #text-input-area,
+    :where(body:not(.lanlan-pet-mode)) #chat-container.mobile-collapsed .music-player-bar {
         display: none !important;
     }
 }
@@ -2702,12 +2702,12 @@ body.react-chat-window-dragging {
 @media only screen and (max-width: 768px) {
 
     /* 移动端：最小化仅折叠内容区，输入区常驻显示 */
-    #chat-container.minimized #text-input-area {
+    :where(body:not(.lanlan-pet-mode)) #chat-container.minimized #text-input-area {
         display: block;
     }
 
     /* 移动端：最小化时保持容器尺寸，让输入区可见可用 */
-    #chat-container.minimized {
+    :where(body:not(.lanlan-pet-mode)) #chat-container.minimized {
         width: 90vw;
         left: 5vw;
         bottom: 5px;
@@ -2725,7 +2725,7 @@ body.react-chat-window-dragging {
     /* React chat window 移动端规则仅作用于 index.html 等真正的浏览器手机端。
        chat.html 是 Electron 独立窗口（无论拖得多窄都应走 PC 逻辑），
        在 <body> 加 .electron-chat-window 从此媒体查询中排除。 */
-    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
         width: calc(100vw - 12px);
         height: auto;
         max-height: 85vh;
@@ -2739,7 +2739,7 @@ body.react-chat-window-dragging {
         overflow: hidden;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
         width: calc(100vw - 16px) !important;
         left: 8px !important;
         right: 8px;
@@ -2748,14 +2748,14 @@ body.react-chat-window-dragging {
         transform: none !important;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell #react-chat-window-root {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell #react-chat-window-root {
         height: 100%;
         flex: 1 1 auto;
         overflow: hidden;
         min-height: 0;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell .app-shell {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .app-shell {
         height: 100%;
         display: flex;
         flex-direction: column;
@@ -2766,7 +2766,7 @@ body.react-chat-window-dragging {
        overflow:hidden 保证输入区不会被消息挤出。shell 尺寸仍由
        syncMobileContentLayout() 写成显式像素（根据内容，最高 85vh；
        用户拖过顶部手柄后走 mobileUserHeight 持久化值）。 */
-    body:not(.electron-chat-window) #react-chat-window-shell .chat-window {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .chat-window {
         height: 100%;
         display: grid;
         grid-template-rows: auto 1fr auto;
@@ -2774,12 +2774,12 @@ body.react-chat-window-dragging {
         overflow: hidden;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell .chat-body {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .chat-body {
         min-height: 0;
         overflow: hidden;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell .message-list {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .message-list {
         height: 100%;
         min-height: 0;
         overflow-y: auto;
@@ -2788,35 +2788,35 @@ body.react-chat-window-dragging {
 
     /* .is-mobile-content-capped 现在不再影响布局（message-list 始终可滚），
        保留空规则以免其他位置若有依赖时出现样式回退。 */
-    body:not(.electron-chat-window) #react-chat-window-shell.is-mobile-content-capped .message-list {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-content-capped .message-list {
         overflow-y: auto;
     }
 
     /* Mobile: hide the divider between translate and jukebox plus the last tool button (jukebox)
        to reduce clutter on small screens. If the tool order changes, replace these positional
        selectors with a dedicated class or data attribute on the affected controls. */
-    body:not(.electron-chat-window) #react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2),
-    body:not(.electron-chat-window) #react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2),
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
         display: none;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn,
-    body:not(.electron-chat-window) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:hover,
-    body:not(.electron-chat-window) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:active,
-    body:not(.electron-chat-window) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:focus {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn,
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:hover,
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:active,
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:focus {
         background: transparent !important;
         pointer-events: none;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-drag-handle {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-drag-handle {
         cursor: grab;
     }
 
     /* 手机端：仅显示顶部拖拽边缘用于调整高度，隐藏其余方向 */
-    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-edge {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized) .react-chat-resize-edge {
         display: none;
     }
-    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-n {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized) .react-chat-resize-n {
         display: block;
         height: 14px;
         top: -4px;
@@ -2826,7 +2826,7 @@ body.react-chat-window-dragging {
         /* 可视拖拽指示条 */
         background: transparent;
     }
-    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-n::after {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized) .react-chat-resize-n::after {
         content: '';
         position: absolute;
         left: 50%;
@@ -2840,27 +2840,27 @@ body.react-chat-window-dragging {
 
     /* ---- 手机端最小化：50px 圆形悬浮球（与桌面端一致）----
        替代原先的全宽底部胶囊，使用圆形小球，可自由拖动 */
-    body:not(.electron-chat-window) #react-chat-window-shell.is-minimized {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-minimized {
         width: 50px !important;
         height: 50px !important;
         border-radius: 50%;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell.is-minimized #react-chat-window-drag-handle {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-minimized #react-chat-window-drag-handle {
         display: flex;
         align-items: center;
         justify-content: center;
         cursor: pointer;
     }
 
-    body:not(.electron-chat-window) #react-chat-window-shell.is-minimized .react-chat-minimized-icon {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-minimized .react-chat-minimized-icon {
         width: 100%;
         height: 100%;
         object-fit: contain;
         pointer-events: none;
     }
 
-    #chat-container.minimized::before {
+    :where(body:not(.lanlan-pet-mode)) #chat-container.minimized::before {
         backdrop-filter: none !important;
         -webkit-backdrop-filter: none !important;
         background: transparent !important;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2725,7 +2725,7 @@ body.react-chat-window-dragging {
     /* React chat window 移动端规则仅作用于 index.html 等真正的浏览器手机端。
        chat.html 是 Electron 独立窗口（无论拖得多窄都应走 PC 逻辑），
        在 <body> 加 .electron-chat-window 从此媒体查询中排除。 */
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
         width: calc(100vw - 12px);
         height: auto;
         max-height: 85vh;
@@ -2739,7 +2739,7 @@ body.react-chat-window-dragging {
         overflow: hidden;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
         width: calc(100vw - 16px) !important;
         left: 8px !important;
         right: 8px;
@@ -2748,14 +2748,14 @@ body.react-chat-window-dragging {
         transform: none !important;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell #react-chat-window-root {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell #react-chat-window-root {
         height: 100%;
         flex: 1 1 auto;
         overflow: hidden;
         min-height: 0;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .app-shell {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .app-shell {
         height: 100%;
         display: flex;
         flex-direction: column;
@@ -2766,7 +2766,7 @@ body.react-chat-window-dragging {
        overflow:hidden 保证输入区不会被消息挤出。shell 尺寸仍由
        syncMobileContentLayout() 写成显式像素（根据内容，最高 85vh；
        用户拖过顶部手柄后走 mobileUserHeight 持久化值）。 */
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .chat-window {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .chat-window {
         height: 100%;
         display: grid;
         grid-template-rows: auto 1fr auto;
@@ -2774,12 +2774,12 @@ body.react-chat-window-dragging {
         overflow: hidden;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .chat-body {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .chat-body {
         min-height: 0;
         overflow: hidden;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .message-list {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .message-list {
         height: 100%;
         min-height: 0;
         overflow-y: auto;
@@ -2788,35 +2788,35 @@ body.react-chat-window-dragging {
 
     /* .is-mobile-content-capped 现在不再影响布局（message-list 始终可滚），
        保留空规则以免其他位置若有依赖时出现样式回退。 */
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-content-capped .message-list {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-mobile-content-capped .message-list {
         overflow-y: auto;
     }
 
     /* Mobile: hide the divider between translate and jukebox plus the last tool button (jukebox)
        to reduce clutter on small screens. If the tool order changes, replace these positional
        selectors with a dedicated class or data attribute on the affected controls. */
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2),
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2),
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
         display: none;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn,
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:hover,
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:active,
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:focus {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn,
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:hover,
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:active,
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-mobile-expand-guarding .composer-tool-btn:focus {
         background: transparent !important;
         pointer-events: none;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-drag-handle {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-drag-handle {
         cursor: grab;
     }
 
     /* 手机端：仅显示顶部拖拽边缘用于调整高度，隐藏其余方向 */
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized) .react-chat-resize-edge {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-edge {
         display: none;
     }
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized) .react-chat-resize-n {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-n {
         display: block;
         height: 14px;
         top: -4px;
@@ -2826,7 +2826,7 @@ body.react-chat-window-dragging {
         /* 可视拖拽指示条 */
         background: transparent;
     }
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell:not(.is-minimized) .react-chat-resize-n::after {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-n::after {
         content: '';
         position: absolute;
         left: 50%;
@@ -2840,20 +2840,20 @@ body.react-chat-window-dragging {
 
     /* ---- 手机端最小化：50px 圆形悬浮球（与桌面端一致）----
        替代原先的全宽底部胶囊，使用圆形小球，可自由拖动 */
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-minimized {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-minimized {
         width: 50px !important;
         height: 50px !important;
         border-radius: 50%;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-minimized #react-chat-window-drag-handle {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-minimized #react-chat-window-drag-handle {
         display: flex;
         align-items: center;
         justify-content: center;
         cursor: pointer;
     }
 
-    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode))#react-chat-window-shell.is-minimized .react-chat-minimized-icon {
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell.is-minimized .react-chat-minimized-icon {
         width: 100%;
         height: 100%;
         object-fit: contain;

--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -27,7 +27,8 @@ let motionTimer = null; // 动作持续时间定时器
 let isEmotionChanging = false; // 防止快速连续点击的标志
 
 // 全局：判断是否为移动端宽度
-const isMobileWidth = () => window.innerWidth <= 768;
+// Electron Pet 窗口永不进入手机模式（本文件早于 common_ui.js 加载，故用 flag 内联判断）。
+const isMobileWidth = () => !window.__LANLAN_IS_ELECTRON_PET__ && window.innerWidth <= 768;
 
 // 口型同步参数列表常量
 // 这些参数用于控制模型的嘴部动作，在处理表情和常驻表情时需要跳过，以避免覆盖实时的口型同步

--- a/static/live2d-init.js
+++ b/static/live2d-init.js
@@ -458,7 +458,7 @@ async function initLive2DModel() {
             // 加载模型（使用事件驱动方式，在常驻表情应用完成后应用参数）
             await window.live2dManager.loadModel(targetModelPath, {
                 preferences: modelPreferences,
-                isMobile: window.innerWidth <= 768,
+                isMobile: typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768),
                 // 在常驻表情应用完成后应用参数（事件驱动，替代不可靠的 setTimeout）
                 onResidentExpressionApplied: (model) => {
                     if (modelPreferences && modelPreferences.parameters &&

--- a/static/vrm-core.js
+++ b/static/vrm-core.js
@@ -988,7 +988,8 @@ class VRMCore {
                     const screenWidth = window.innerWidth;
 
                     // 计算合适的初始缩放（参考Live2D的默认大小计算，参考 vrm.js）
-                    const isMobile = window.innerWidth <= 768;
+                    // Electron Pet 窗口永不进入手机模式，统一走 canonical 谓词。
+                    const isMobile = typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768);
                     let targetScale;
 
                     if (isMobile) {
@@ -1078,7 +1079,7 @@ class VRMCore {
                     const fov = this.manager.camera.fov * (Math.PI / 180);
                     const distance = (scaledModelHeight / 2) / Math.tan(fov / 2) / targetScreenHeight * screenHeight;
 
-                    const isMobileDevice = screenWidth <= 768;
+                    const isMobileDevice = typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (screenWidth <= 768);
                     const cameraY = center.y + (isMobileDevice ? scaledModelHeight * 0.2 : scaledModelHeight * 0.1);
                     const cameraZ = Math.abs(distance);
                     this.manager.camera.position.set(0, cameraY, cameraZ);

--- a/static/vrm-init.js
+++ b/static/vrm-init.js
@@ -99,7 +99,7 @@ window.VRM_PATHS = {
 };
 
 // 全局：判断是否为移动端宽度（如果不存在则定义，避免重复定义）
-window.isMobileWidth = window.isMobileWidth || (() => window.innerWidth <= 768);
+window.isMobileWidth = window.isMobileWidth || (() => !window.__LANLAN_IS_ELECTRON_PET__ && window.innerWidth <= 768);
 
 const isModelManagerPage = () => window.location.pathname.includes('model_manager') || document.querySelector('#vrm-model-select') !== null;
 window.vrmManager = null;

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -877,7 +877,7 @@ class VRMManager {
 
                 const screenHeight = window.innerHeight;
                 const screenWidth = window.innerWidth;
-                const isMobile = screenWidth <= 768;
+                const isMobile = typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (screenWidth <= 768);
 
                 if (isMobile) {
                     targetScale = Math.max(0.4, Math.min(0.8, screenHeight / 1800));
@@ -912,7 +912,7 @@ class VRMManager {
 
                 const screenHeight = window.innerHeight;
                 const screenWidth = window.innerWidth;
-                const isMobileDevice = screenWidth <= 768;
+                const isMobileDevice = typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (screenWidth <= 768);
 
                 const scaledModelHeight = size.y > 0 ? size.y : 1.5;
                 const targetScreenHeight = screenHeight * 0.45;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,24 @@
     <title data-i18n="app.title">Project N.E.K.O.</title>
     <!-- VRM 光照默认值：从后端注入，保证在所有 JS 之前同步可用 -->
     <script>window.VRM_DEFAULT_LIGHTING=Object.freeze({{ vrm_defaults | tojson }});</script>
+    <!-- Electron Pet 窗口标记：必须在任何样式表之前同步执行，给 <html> 打上
+         lanlan-pet-mode，让 index.css 的 (max-width:768px) 手机端规则（黑背景、
+         窄布局）整段排除掉。Electron preload 在页面脚本之前注入这些全局，所以这里
+         能同步读到；同时兜底匹配 userAgent，避免首帧黑屏闪烁。dev 浏览器（无这些
+         信号）不打标记，窄宽手机版行为保持不变。 -->
+    <script>(function () {
+        try {
+            var w = window;
+            var isElectronPet = !!(w.electronDesktopCapturer || w.electronSpatialAudio || w.electronShell)
+                || w.__NEKO_MULTI_WINDOW__ === true
+                || /Electron/i.test(navigator.userAgent || '')
+                || !!(w.process && w.process.versions && w.process.versions.electron);
+            w.__LANLAN_IS_ELECTRON_PET__ = isElectronPet;
+            if (isElectronPet) {
+                document.documentElement.classList.add('lanlan-pet-mode');
+            }
+        } catch (e) { /* 检测失败按非 Electron 处理，退回浏览器行为 */ }
+    })();</script>
     <!-- 诊断观测：必须最早加载——内部 monkey-patch setInterval/setTimeout 计数活跃
          timer，业务代码之后加载就抓不到早期注册的那些。默认关，靠
          localStorage.NEKO_DEBUG_HEALTH=1 + 刷新启用。详见 static/debug-health.js。 -->
@@ -44,6 +62,13 @@
 </head>
 
 <body class="subtitle-web-host">
+    <!-- 同步把 Electron Pet 标记补到 body（head 脚本执行时 body 尚不存在）；
+         在 chat-container 等内容解析之前执行，避免窄窗口下手机布局闪一帧。 -->
+    <script>(function () {
+        if (window.__LANLAN_IS_ELECTRON_PET__) {
+            document.body.classList.add('lanlan-pet-mode');
+        }
+    })();</script>
 
     <!-- 旧的按钮面板已迁移到浮动按钮系统（live2d.js），保留隐藏的旧按钮元素供功能触发使用 -->
     <div id="sidebar" style="display: none;">


### PR DESCRIPTION
## 问题

Electron 桌面宠物窗口加载的就是 `templates/index.html`，而它的"手机模式"（黑背景 + 奇怪布局）是**纯 CSS 按 viewport 宽度触发**的（`@media (max-width:768px)`），没有任何 JS 闸门：

- `index.css` 的媒体查询直接 `html,body{background:#000 !important}`，并把 chat 容器 / react-chat-window-shell 拉成全宽底部；
- 已有的 chat.html 独立窗口靠 `<body class="electron-chat-window">` + `body:not(.electron-chat-window)` 排除手机模式，但 Pet 窗口（index.html）没有对应标记，所以一旦窗口窄于 768px 就掉进手机布局。

## 修法（沿用既有 `electron-chat-window` 对偶约定）

**标记注入** — `templates/index.html`：head 里一段同步脚本（早于任何样式表），检测 Electron preload 注入的全局（`electronDesktopCapturer` / `electronSpatialAudio` / `electronShell` / `__NEKO_MULTI_WINDOW__`，兜底 UA 与 `process.versions.electron`），置 `window.__LANLAN_IS_ELECTRON_PET__` 并给 `<html>` 加 `lanlan-pet-mode`；body 开头再补一段给 `<body>` 加（head 执行时 body 尚不存在）。两处同步执行 → 首帧不闪黑。dev 浏览器无这些信号 → 不打标记 → 窄宽手机版行为完全不变。

**CSS 排除** — `index.css` / `dark-mode.css`：媒体查询里每条选择器加 `:where(body:not(.lanlan-pet-mode))` 前缀（`:where()` 零特异性，不改原规则优先级）；黑背景那条用 `html:not(.lanlan-pet-mode), body:not(.lanlan-pet-mode)`。原本只防 chat.html 的 21 条 `body:not(.electron-chat-window)` 升级为同时排除 Pet 窗口。

**JS 谓词** — 运行时 canonical 是 `live2d-core.js` 定义并导出的 `window.isMobileWidth`，在此加 flag 短路；`vrm-init.js` 的 `||`-fallback、`common_ui.js` 的 `uiIsMobileWidth`、`app-react-chat-window.js` 的 `isMobileWidth()` 也同步加判断。散落的 inline 宽度判断（`vrm-core` / `vrm-manager` / `avatar-popup-common` / `app-character` / `app-interpage` / `live2d-init`，影响 3D 模型缩放/相机/popup 方向）统一路由到 `window.isMobileWidth()`（用仓库既有的 `typeof window.isMobileWidth === 'function' ? ... : (innerWidth<=768)` 防御写法）。

## 刻意未改

- `app-state.js` 的 `appUtils.isMobile()` 是 UA-based（不是宽度），桌面 Electron 本就不命中。
- 教程相关宽度判断（`app-tutorial-prompt.js` / `universal-tutorial-manager.js`）保持原状——它们用宽度判断来**跳过**教程，narrow Electron 窗口跳过教程是安全方向；强行启用反而可能弹出教程遮罩/接管拖拽，超出本次"修黑背景+布局"的范围。

## 验证

- 所有改动 JS 过 `node --check`；`index.css` / `dark-mode.css` 大括号配平。
- ⚠️ **没法在 CI/浏览器里实测**：触发条件是 Electron preload 注入的全局，且 index.html 是 Jinja 模板需后端渲染。需要在 Electron 分发里实测窄窗口下 Pet 窗口不再黑屏、avatar 仍按桌面缩放。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化移动端/桌面端判定：优先使用全局判定函数以提高识别准确性
  * 修复 Electron Pet 场景不会被误判为“手机模式”，避免应用窄布局或黑背景

* **样式优化**
  * 在移动端暗色模式中排除 lanlan-pet-mode，保持 Electron Pet 窗口透明/不被刷黑
  * 收敛移动端样式规则，限定不影响 lanlan-pet-mode

* **其他**
  * 提前注入环境检测并在首帧同步 lanlan-pet-mode 类以减少闪烁

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->