### PR TITLE
bugfix(plugin): 增加多语言支持，优化插件显示文本处理

### DIFF
--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -16,8 +16,8 @@ import type {
 /**
  * 获取插件列表
  */
-export function getPlugins(): Promise<{ plugins: PluginMeta[]; message: string }> {
-  return get('/plugins')
+export function getPlugins(locale?: string): Promise<{ plugins: PluginMeta[]; message: string }> {
+  return get('/plugins', locale ? { params: { locale } } : undefined)
 }
 
 /**
@@ -141,18 +141,21 @@ function normalizeSurface(raw: any, fallbackKind: PluginUiSurface['kind'] = 'pan
  * 获取插件 UI surface 列表。优先使用未来统一 /surfaces 接口，
  * 当前后端未实现时回退到现有 /ui-info，把 static UI 归一化为 panel surface。
  */
-export async function getPluginUiSurfaces(pluginId: string): Promise<PluginUiSurface[]> {
-  const result = await getPluginUiSurfaceInfo(pluginId)
+export async function getPluginUiSurfaces(pluginId: string, locale?: string): Promise<PluginUiSurface[]> {
+  const result = await getPluginUiSurfaceInfo(pluginId, locale)
   return result.surfaces
 }
 
-export async function getPluginUiSurfaceInfo(pluginId: string): Promise<{
+export async function getPluginUiSurfaceInfo(pluginId: string, locale?: string): Promise<{
   surfaces: PluginUiSurface[]
   warnings: PluginUiWarning[]
 }> {
   const safeId = encodeURIComponent(pluginId)
   try {
-    const response = await get<{ surfaces?: any[]; warnings?: any[] } | any[]>(`/plugin/${safeId}/surfaces`)
+    const response = await get<{ surfaces?: any[]; warnings?: any[] } | any[]>(
+      `/plugin/${safeId}/surfaces`,
+      locale ? { params: { locale } } : undefined,
+    )
     const rawSurfaces = Array.isArray(response) ? response : response?.surfaces
     const rawWarnings = Array.isArray(response) ? [] : response?.warnings
     if (Array.isArray(rawSurfaces)) {

--- a/frontend/plugin-manager/src/components/plugin/PackageManagerPanel.vue
+++ b/frontend/plugin-manager/src/components/plugin/PackageManagerPanel.vue
@@ -87,7 +87,7 @@
                     <el-option
                       v-for="plugin in selectablePlugins"
                       :key="plugin.id"
-                      :label="plugin.name"
+                      :label="plugin.displayName || plugin.name"
                       :value="plugin.id"
                     />
                   </el-select>
@@ -197,7 +197,7 @@
                     <el-option
                       v-for="plugin in selectablePlugins"
                       :key="plugin.id"
-                      :label="plugin.name"
+                      :label="plugin.displayName || plugin.name"
                       :value="plugin.id"
                     />
                   </el-select>

--- a/frontend/plugin-manager/src/components/plugin/PluginCard.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginCard.vue
@@ -11,7 +11,7 @@
           <el-tag v-if="plugin.type === 'extension'" size="small" type="primary" effect="plain" class="type-tag">
             {{ t('plugins.extension') }}
           </el-tag>
-          <h3 class="plugin-name">{{ plugin.name }}</h3>
+          <h3 class="plugin-name">{{ displayText.name }}</h3>
           <StatusIndicator :status="plugin.status || 'stopped'" />
           <el-tag v-if="plugin.autoStart === false && plugin.type !== 'extension'" size="small" type="warning">
             {{ t('plugins.manualStart') }}
@@ -21,7 +21,7 @@
     </template>
 
     <div class="plugin-card-body">
-      <p class="plugin-description">{{ plugin.description || t('common.noData') }}</p>
+      <p class="plugin-description">{{ displayText.description || t('common.noData') }}</p>
 
       <PluginMetricsInline
         v-if="showMetrics"
@@ -59,6 +59,7 @@ import SourceTag from '@/components/plugin/SourceTag.vue'
 import SourceDetailRow from '@/components/plugin/SourceDetailRow.vue'
 import { useMarketVersionsStore } from '@/stores/marketVersions'
 import { hasNewerVersion } from '@/utils/version'
+import { resolvePluginDisplayText } from '@/utils/pluginDisplay'
 import type { PluginMeta, PluginInstallSourceDetailMarket } from '@/types/api'
 
 interface Props {
@@ -74,7 +75,7 @@ const props = withDefaults(defineProps<Props>(), {
   showSourceDetail: false,
 })
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const marketVersions = useMarketVersionsStore()
 
 defineEmits<{
@@ -85,6 +86,8 @@ defineEmits<{
 const entryCount = computed(() => {
   return props.plugin.entries?.length || 0
 })
+
+const displayText = computed(() => resolvePluginDisplayText(props.plugin, locale.value))
 
 /** Look up the market's latest version for this plugin, IF it was installed
  *  from the market. Returns null for non-market / unknown plugins. Callers

--- a/frontend/plugin-manager/src/components/plugin/PluginListRow.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginListRow.vue
@@ -10,7 +10,7 @@
         <div class="plugin-list-row-card__headline">
           <div class="plugin-list-row-card__heading-main">
             <el-tag size="small" effect="plain" :type="typeTagType">{{ typeLabel }}</el-tag>
-            <h3 class="plugin-list-row-card__name">{{ plugin.name }}</h3>
+            <h3 class="plugin-list-row-card__name">{{ displayText.name }}</h3>
             <StatusIndicator :status="plugin.status || 'stopped'" />
             <el-tag v-if="plugin.autoStart === false && plugin.type !== 'extension'" size="small" type="warning">
               {{ t('plugins.manualStart') }}
@@ -23,7 +23,7 @@
         </div>
 
         <p class="plugin-list-row-card__description">
-          {{ plugin.description || t('common.noData') }}
+          {{ displayText.description || t('common.noData') }}
         </p>
 
         <PluginMetricsInline
@@ -72,6 +72,7 @@ import SourceTag from '@/components/plugin/SourceTag.vue'
 import SourceDetailRow from '@/components/plugin/SourceDetailRow.vue'
 import { useMarketVersionsStore } from '@/stores/marketVersions'
 import { hasNewerVersion } from '@/utils/version'
+import { resolvePluginDisplayText } from '@/utils/pluginDisplay'
 import type { PluginMeta, PluginInstallSourceDetailMarket } from '@/types/api'
 
 interface Props {
@@ -92,10 +93,11 @@ defineEmits<{
   contextmenu: [event: MouseEvent]
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const marketVersions = useMarketVersionsStore()
 
 const entryCount = computed(() => props.plugin.entries?.length || 0)
+const displayText = computed(() => resolvePluginDisplayText(props.plugin, locale.value))
 
 const latestVersion = computed<string | null>(() => {
   const src = props.plugin.install_source

--- a/frontend/plugin-manager/src/components/plugin/PluginSelectorPanel.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginSelectorPanel.vue
@@ -98,7 +98,7 @@
                     @click.stop
                     @change="$emit('togglePlugin', plugin.id)"
                   />
-                  <span class="plugin-list-row__name">{{ plugin.name }}</span>
+                  <span class="plugin-list-row__name">{{ plugin.displayName || plugin.name }}</span>
                 </div>
               </template>
               <template v-else>
@@ -133,6 +133,7 @@ type SelectablePlugin = PluginMeta & {
   type: PluginGroupType
   enabled?: boolean
   autoStart?: boolean
+  displayName?: string
 }
 
 const props = defineProps<{

--- a/frontend/plugin-manager/src/composables/usePackageManager.ts
+++ b/frontend/plugin-manager/src/composables/usePackageManager.ts
@@ -24,6 +24,7 @@ import {
   type PluginWorkbenchItem,
   type PluginWorkbenchLayoutMode,
 } from '@/composables/usePluginWorkbench'
+import { resolvePluginDisplayText } from '@/utils/pluginDisplay'
 
 export type LayoutMode = PluginWorkbenchLayoutMode
 export type BuildMode = PluginCliBuildMode
@@ -104,23 +105,31 @@ export function usePackageManager() {
 
   const selectablePlugins = computed<SelectablePlugin[]>(() => {
     const metaById = new Map(
-      pluginStore.pluginsWithStatus.map((plugin) => [
-        plugin.id,
-        {
+      pluginStore.pluginsWithStatus.map((plugin) => {
+        const displayText = resolvePluginDisplayText(plugin, locale.value)
+        return [
+          plugin.id,
+          {
           id: plugin.id,
           name: plugin.name || plugin.id,
           description: plugin.description || '',
+          short_description: plugin.short_description,
+          displayName: displayText.name,
+          displayDescription: displayText.description,
+          displayShortDescription: displayText.shortDescription,
           version: plugin.version || '0.0.0',
           type: normalizePluginType(plugin.type),
           status: plugin.status,
           host_plugin_id: plugin.host_plugin_id,
           entries: plugin.entries || [],
+          i18n: plugin.i18n,
           runtime_enabled: plugin.runtime_enabled,
           runtime_auto_start: plugin.runtime_auto_start,
           enabled: plugin.enabled,
           autoStart: plugin.autoStart,
-        } satisfies SelectablePlugin,
-      ])
+          } satisfies SelectablePlugin,
+        ] as const
+      })
     )
 
     return localPluginIds.value.map((pluginId) => {

--- a/frontend/plugin-manager/src/composables/usePluginWorkbench.ts
+++ b/frontend/plugin-manager/src/composables/usePluginWorkbench.ts
@@ -9,6 +9,7 @@
  * 对外 API 与改造前保持一致，现有调用点（PluginList.vue、usePackageManager）零改动。
  */
 import { computed, toValue, type MaybeRefOrGetter, type WritableComputedRef } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { PluginMeta } from '@/types/api'
 import {
   useGridWorkbench,
@@ -18,6 +19,7 @@ import {
   type LayoutMode,
   type QualifierMatcher,
 } from '@/composables/useGridWorkbench'
+import { resolvePluginDisplayText } from '@/utils/pluginDisplay'
 
 export type PluginWorkbenchLayoutMode = LayoutMode
 export type PluginWorkbenchFilterMode = FilterMode
@@ -28,6 +30,9 @@ export type PluginWorkbenchItem = PluginMeta & {
   enabled?: boolean
   autoStart?: boolean
   searchIndex?: string
+  displayName?: string
+  displayDescription?: string
+  displayShortDescription?: string
 }
 
 const PLUGIN_GROUPS: readonly PluginWorkbenchGroupType[] = ['plugin', 'adapter', 'extension']
@@ -43,16 +48,20 @@ function hasUi(plugin: PluginWorkbenchItem): boolean {
 }
 
 function buildPluginSearchIndex(plugin: PluginWorkbenchItem): string {
+  const name = plugin.displayName || plugin.name
+  const description = plugin.displayDescription || plugin.description
+  const shortDescription = plugin.displayShortDescription || plugin.short_description
   const textParts = [
     plugin.id,
-    plugin.name,
-    plugin.description,
+    name,
+    description,
+    shortDescription,
     plugin.type,
     plugin.version,
     plugin.host_plugin_id,
   ]
 
-  const pinyinParts = [plugin.name, plugin.description].flatMap((value) => {
+  const pinyinParts = [name, description, shortDescription].flatMap((value) => {
     const source = value || ''
     const full = safePinyin(source, 'pinyin').replace(/\s+/g, ' ').trim()
     const initials = safePinyin(source, 'first').replace(/\s+/g, '').trim()
@@ -114,13 +123,13 @@ const pluginQualifiers: Record<string, QualifierMatcher<PluginWorkbenchItem>> = 
     return normalizeSearchPart(plugin.id).includes(value)
   },
   name(plugin, value) {
-    return normalizeSearchPart(plugin.name).includes(value)
+    return normalizeSearchPart(plugin.displayName || plugin.name).includes(value)
   },
   desc(plugin, value) {
-    return normalizeSearchPart(plugin.description).includes(value)
+    return normalizeSearchPart(plugin.displayDescription || plugin.description).includes(value)
   },
   description(plugin, value) {
-    return normalizeSearchPart(plugin.description).includes(value)
+    return normalizeSearchPart(plugin.displayDescription || plugin.description).includes(value)
   },
   host(plugin, value) {
     return normalizeSearchPart(plugin.host_plugin_id).includes(value)
@@ -160,7 +169,7 @@ const pluginQualifiers: Record<string, QualifierMatcher<PluginWorkbenchItem>> = 
   has(plugin, value) {
     switch (value) {
       case 'description':
-        return !!plugin.description?.trim()
+        return !!(plugin.displayDescription || plugin.description)?.trim()
       case 'entries':
       case 'entry':
         return (plugin.entries?.length || 0) > 0
@@ -206,11 +215,18 @@ function pluginAuthorText(plugin: PluginWorkbenchItem): string {
 export function usePluginWorkbench<
   T extends PluginMeta & { type?: string; enabled?: boolean; autoStart?: boolean; searchIndex?: string },
 >(pluginsSource: MaybeRefOrGetter<T[]>) {
+  const { locale } = useI18n()
   const normalized = computed<PluginWorkbenchItem[]>(() =>
-    toValue(pluginsSource).map((plugin) => ({
-      ...plugin,
-      type: normalizePluginType(plugin.type),
-    })),
+    toValue(pluginsSource).map((plugin) => {
+      const displayText = resolvePluginDisplayText(plugin, locale.value)
+      return {
+        ...plugin,
+        type: normalizePluginType(plugin.type),
+        displayName: displayText.name,
+        displayDescription: displayText.description,
+        displayShortDescription: displayText.shortDescription,
+      }
+    }),
   )
 
   const workbench = useGridWorkbench<PluginWorkbenchItem>(normalized, {

--- a/frontend/plugin-manager/src/stores/plugin.ts
+++ b/frontend/plugin-manager/src/stores/plugin.ts
@@ -13,6 +13,7 @@ import {
   enableExtension,
   refreshPluginsRegistry,
 } from '@/api/plugins'
+import { getLocale } from '@/i18n'
 import type { PluginMeta, PluginStatusData } from '@/types/api'
 import { PluginStatus as StatusEnum } from '@/utils/constants'
 
@@ -110,7 +111,7 @@ export const usePluginStore = defineStore('plugin', () => {
     const seq = ++fetchPluginsSeq
     pendingFetchPlugins = (async () => {
       try {
-        const response = await getPlugins()
+        const response = await getPlugins(getLocale())
         // 忽略过期响应，防止旧数据覆盖新数据
         if (seq !== fetchPluginsSeq) return
         plugins.value = response.plugins || []

--- a/frontend/plugin-manager/src/types/api.ts
+++ b/frontend/plugin-manager/src/types/api.ts
@@ -123,6 +123,7 @@ export interface PluginMeta {
   name: string
   type?: PluginType
   description: string
+  short_description?: string
   version: string
   sdk_version?: string
   sdk_recommended?: string

--- a/frontend/plugin-manager/src/utils/i18nLabel.ts
+++ b/frontend/plugin-manager/src/utils/i18nLabel.ts
@@ -32,11 +32,19 @@ export function resolvePluginI18nMessage(
   const messages = i18n?.messages
   if (!messages || !key) return fallback
 
-  const primary = String(locale).split(/[-_]/)[0]
+  const normalizedLocale = String(locale || '').trim()
+  const primary = normalizedLocale.split(/[-_]/)[0]
+  const localeLower = normalizedLocale.toLowerCase()
+  const zhCnFallback =
+    localeLower === 'zh' || localeLower.startsWith('zh-') || localeLower.startsWith('zh_')
+      ? 'zh-CN'
+      : undefined
   const candidates = [
-    locale,
-    primary && primary !== locale ? primary : undefined,
+    normalizedLocale,
+    primary && primary !== normalizedLocale ? primary : undefined,
+    zhCnFallback,
     i18n?.default_locale,
+    i18n?.default_locale?.split(/[-_]/)[0],
     'en-US',
     'en',
   ].filter((item): item is string => typeof item === 'string' && item.length > 0)

--- a/frontend/plugin-manager/src/utils/i18nLabel.ts
+++ b/frontend/plugin-manager/src/utils/i18nLabel.ts
@@ -39,12 +39,15 @@ export function resolvePluginI18nMessage(
     localeLower === 'zh' || localeLower.startsWith('zh-') || localeLower.startsWith('zh_')
       ? 'zh-CN'
       : undefined
+  const defaultLocale =
+    typeof i18n?.default_locale === 'string' ? i18n.default_locale.trim() : ''
+  const defaultPrimary = defaultLocale.split(/[-_]/)[0]
   const candidates = [
     normalizedLocale,
     primary && primary !== normalizedLocale ? primary : undefined,
     zhCnFallback,
-    i18n?.default_locale,
-    i18n?.default_locale?.split(/[-_]/)[0],
+    defaultLocale,
+    defaultPrimary && defaultPrimary !== defaultLocale ? defaultPrimary : undefined,
     'en-US',
     'en',
   ].filter((item): item is string => typeof item === 'string' && item.length > 0)

--- a/frontend/plugin-manager/src/utils/pluginDisplay.test.ts
+++ b/frontend/plugin-manager/src/utils/pluginDisplay.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePluginDisplayText } from './pluginDisplay'
+import type { PluginMeta } from '@/types/api'
+
+function pluginFixture(): PluginMeta {
+  return {
+    id: 'demo_plugin',
+    name: '默认名称',
+    description: '默认描述',
+    short_description: '默认短描述',
+    version: '0.1.0',
+    i18n: {
+      default_locale: 'zh-CN',
+      messages: {
+        'zh-CN': {
+          'plugin.name': '中文名称',
+          'plugin.description': '中文描述',
+          'plugin.short_description': '中文短描述',
+        },
+        en: {
+          'plugin.name': 'English Name',
+          'plugin.description': 'English description',
+          'plugin.short_description': 'English short description',
+        },
+      },
+    },
+  }
+}
+
+describe('resolvePluginDisplayText', () => {
+  it('resolves card text from plugin i18n for the active locale', () => {
+    expect(resolvePluginDisplayText(pluginFixture(), 'zh-CN')).toEqual({
+      name: '中文名称',
+      description: '中文描述',
+      shortDescription: '中文短描述',
+    })
+
+    expect(resolvePluginDisplayText(pluginFixture(), 'en-US')).toEqual({
+      name: 'English Name',
+      description: 'English description',
+      shortDescription: 'English short description',
+    })
+  })
+
+  it('falls back to manifest text when plugin i18n does not provide a field', () => {
+    const plugin = pluginFixture()
+    plugin.i18n = {
+      default_locale: 'zh-CN',
+      messages: {
+        en: {
+          'plugin.name': 'English Name',
+        },
+      },
+    }
+
+    expect(resolvePluginDisplayText(plugin, 'en-US')).toEqual({
+      name: 'English Name',
+      description: '默认描述',
+      shortDescription: '默认短描述',
+    })
+  })
+})

--- a/frontend/plugin-manager/src/utils/pluginDisplay.test.ts
+++ b/frontend/plugin-manager/src/utils/pluginDisplay.test.ts
@@ -87,4 +87,23 @@ describe('resolvePluginDisplayText', () => {
       shortDescription: '简体中文短描述',
     })
   })
+
+  it('ignores malformed default_locale values instead of throwing', () => {
+    const plugin = pluginFixture()
+    plugin.i18n = {
+      default_locale: 42,
+      messages: {
+        en: {
+          'plugin.name': 'English Name',
+          'plugin.description': 'English description',
+        },
+      },
+    } as any
+
+    expect(resolvePluginDisplayText(plugin, 'ko')).toEqual({
+      name: 'English Name',
+      description: 'English description',
+      shortDescription: '默认短描述',
+    })
+  })
 })

--- a/frontend/plugin-manager/src/utils/pluginDisplay.test.ts
+++ b/frontend/plugin-manager/src/utils/pluginDisplay.test.ts
@@ -59,4 +59,32 @@ describe('resolvePluginDisplayText', () => {
       shortDescription: '默认短描述',
     })
   })
+
+  it('preserves zh-CN fallback for Chinese locales before default_locale', () => {
+    const plugin = pluginFixture()
+    plugin.name = '后端已解析中文名称'
+    plugin.description = '后端已解析中文描述'
+    plugin.short_description = '后端已解析中文短描述'
+    plugin.i18n = {
+      default_locale: 'en',
+      messages: {
+        'zh-CN': {
+          'plugin.name': '简体中文名称',
+          'plugin.description': '简体中文描述',
+          'plugin.short_description': '简体中文短描述',
+        },
+        en: {
+          'plugin.name': 'English Name',
+          'plugin.description': 'English description',
+          'plugin.short_description': 'English short description',
+        },
+      },
+    }
+
+    expect(resolvePluginDisplayText(plugin, 'zh-TW')).toEqual({
+      name: '简体中文名称',
+      description: '简体中文描述',
+      shortDescription: '简体中文短描述',
+    })
+  })
 })

--- a/frontend/plugin-manager/src/utils/pluginDisplay.ts
+++ b/frontend/plugin-manager/src/utils/pluginDisplay.ts
@@ -1,0 +1,34 @@
+import type { PluginMeta } from '@/types/api'
+import { resolvePluginI18nMessage } from '@/utils/i18nLabel'
+
+export interface PluginDisplayText {
+  name: string
+  description: string
+  shortDescription: string
+}
+
+function stringFallback(value: unknown, fallback = ''): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback
+}
+
+export function resolvePluginDisplayText(plugin: PluginMeta, locale: string): PluginDisplayText {
+  const fallbackName = stringFallback(plugin.name, plugin.id)
+  const fallbackDescription = stringFallback(plugin.description)
+  const fallbackShortDescription = stringFallback(plugin.short_description, fallbackDescription)
+
+  return {
+    name: resolvePluginI18nMessage(plugin.i18n, 'plugin.name', locale, fallbackName),
+    description: resolvePluginI18nMessage(
+      plugin.i18n,
+      'plugin.description',
+      locale,
+      fallbackDescription,
+    ),
+    shortDescription: resolvePluginI18nMessage(
+      plugin.i18n,
+      'plugin.short_description',
+      locale,
+      fallbackShortDescription,
+    ),
+  }
+}

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -11,7 +11,7 @@
         <div class="card-header" data-yui-guide-id="plugin-detail-header">
           <div class="header-left" data-yui-guide-id="plugin-detail-title">
             <el-button :icon="ArrowLeft" data-yui-guide-id="plugin-detail-back" @click="goBack">{{ $t('common.back') }}</el-button>
-            <h2>{{ plugin.name }}</h2>
+            <h2>{{ pluginDisplayText.name }}</h2>
           </div>
           <div data-yui-guide-id="plugin-detail-actions">
             <PluginActions :plugin-id="pluginId" />
@@ -91,7 +91,7 @@
             <el-descriptions :column="2" border>
               <el-descriptions-item :label="$t('plugins.id')">{{ plugin.id }}</el-descriptions-item>
               <el-descriptions-item :label="$t('plugins.version')">{{ plugin.version }}</el-descriptions-item>
-              <el-descriptions-item :label="$t('plugins.description')" :span="2">{{ plugin.description || $t('common.noData') }}</el-descriptions-item>
+              <el-descriptions-item :label="$t('plugins.description')" :span="2">{{ pluginDisplayText.description || $t('common.noData') }}</el-descriptions-item>
               <el-descriptions-item :label="$t('plugins.pluginType')">
                 <el-tag size="small" :type="pluginTypeTagType">
                   {{ $t(pluginTypeText) }}
@@ -125,10 +125,10 @@
                   @click="goToPlugin(ext.id)"
                 >
                   <div class="bound-ext-info">
-                    <span class="bound-ext-name">{{ ext.name }}</span>
+                    <span class="bound-ext-name">{{ resolveDisplayText(ext).name }}</span>
                     <StatusIndicator :status="ext.status || 'pending'" />
                   </div>
-                  <p class="bound-ext-desc">{{ ext.description || $t('common.noData') }}</p>
+                  <p class="bound-ext-desc">{{ resolveDisplayText(ext).description || $t('common.noData') }}</p>
                 </el-card>
               </div>
             </div>
@@ -182,11 +182,14 @@ import HostedSurfaceFrame from '@/components/plugin/HostedSurfaceFrame.vue'
 import PluginUIFrame from '@/components/plugin/PluginUIFrame.vue'
 import { getPluginUiSurfaceInfo } from '@/api/plugins'
 import { get } from '@/api'
-import type { PluginUiSurface, PluginUiWarning } from '@/types/api'
+import { resolvePluginDisplayText, type PluginDisplayText } from '@/utils/pluginDisplay'
+import { useI18n } from 'vue-i18n'
+import type { PluginMeta, PluginUiSurface, PluginUiWarning } from '@/types/api'
 
 const route = useRoute()
 const router = useRouter()
 const pluginStore = usePluginStore()
+const { locale } = useI18n()
 
 const pluginId = computed(() => route.params.id as string)
 const activeTab = ref('info')
@@ -206,6 +209,20 @@ const hasStaticUI = ref(false)
 const plugin = computed(() => {
   return pluginStore.pluginsWithStatus.find(p => p.id === pluginId.value)
 })
+
+const emptyPluginDisplayText: PluginDisplayText = {
+  name: '',
+  description: '',
+  shortDescription: '',
+}
+
+const pluginDisplayText = computed(() => {
+  return plugin.value ? resolvePluginDisplayText(plugin.value, locale.value) : emptyPluginDisplayText
+})
+
+function resolveDisplayText(target: PluginMeta): PluginDisplayText {
+  return resolvePluginDisplayText(target, locale.value)
+}
 
 const panelSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'panel'))
 const guideSurfaces = computed(() => surfaces.value.filter((surface) => surface.kind === 'guide' || surface.kind === 'docs'))
@@ -285,7 +302,7 @@ async function fetchSurfaces() {
   const loadId = ++currentSurfaceLoadId
   const currentPluginId = pluginId.value
   try {
-    const info = await getPluginUiSurfaceInfo(currentPluginId)
+    const info = await getPluginUiSurfaceInfo(currentPluginId, locale.value)
     if (loadId !== currentSurfaceLoadId || currentPluginId !== pluginId.value) return
     surfaces.value = info.surfaces
     surfaceWarnings.value = info.warnings

--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -365,6 +365,11 @@ watch(pluginId, async () => {
     loading.value = false
   }
 })
+
+watch(locale, () => {
+  if (!plugin.value) return
+  void fetchSurfaces()
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
之前的问题原因：

插件管理页的插件卡片直接渲染 plugin.description。而这份 description 来自 /plugins 接口，后端在没有收到 locale 参数时会按系统/全局默认语言把插件描述解析成普通字符串。前端切换语言后，卡片并不会重新基于当前 UI 语言解析插件 i18n，所以描述就表现为“锁定在系统默认语言”。

处理方式：

我把插件卡片文案改成前端统一解析：新增 resolvePluginDisplayText()，从 plugin.i18n.messages 里按当前 vue-i18n 的 locale 取 plugin.name、plugin.description、plugin.short_description，没有翻译时再回退到 manifest 里的原始字段。

同时，/plugins 请求现在会带当前 locale，用于让后端继续解析 entries/list_actions 等仍由后端处理的文案；插件详情里的 surface 查询也带 locale，让 panel/guide/docs 标题跟语言走。

现在的行为：

插件管理页里已安装插件的卡片、列表行、详情基础信息、绑定扩展卡片、包管理插件选择器，以及搜索/过滤索引，都会按当前界面语言显示和匹配插件名称/描述。切换语言后，插件描述不再固定为系统默认语言；如果某个插件缺少当前语言翻译，则正常回退到插件 manifest 里的默认描述。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 插件在列表、卡片、选择面板与详情页按界面语言显示本地化名称/描述，优先展示 displayName
  * 插件面板/指南与插件列表请求随语言切换自动刷新并返回相应语言内容
  * 搜索与匹配逻辑改为基于本地化展示文本
  * 新增短描述字段以供展示

* **测试**
  * 新增本地化展示文本解析的单元测试，覆盖回退与优先级逻辑
<!-- end of auto-generated comment: release notes by coderabbit.ai -->