### PR TITLE
fix(ui): Electron 紧凑聊天窗暗色下窗口区域不再被刷黑

### DIFF
--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -652,9 +652,11 @@ html #chat-container {
 @media only screen and (max-width: 768px) {
 
   /* Electron Pet 窗口（html/body 带 lanlan-pet-mode）排除：它需要透明背景
-     透出桌面，绝不能在暗色下被刷成黑色。 */
+     透出桌面，绝不能在暗色下被刷成黑色。
+     Electron 紧凑聊天窗口（body.electron-chat-window）同理排除：它是透明
+     BrowserWindow，圆角胶囊外围要透出桌面/Live2D，不能被刷黑。 */
   html[data-theme="dark"]:not(.lanlan-pet-mode),
-  html[data-theme="dark"]:not(.lanlan-pet-mode) body {
+  html[data-theme="dark"]:not(.lanlan-pet-mode) body:not(.electron-chat-window) {
     background: #000 !important;
   }
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2682,9 +2682,10 @@ body.react-chat-window-dragging {
 
 @media only screen and (max-width: 768px) {
 
-    /* 手机端背景设为黑色（Electron Pet 窗口除外：html/body 都带 lanlan-pet-mode） */
+    /* 手机端背景设为黑色（Electron Pet 窗口除外：html/body 都带 lanlan-pet-mode；
+       Electron 紧凑聊天窗口 body.electron-chat-window 也排除，它要透明透出桌面） */
     html:not(.lanlan-pet-mode),
-    body:not(.lanlan-pet-mode) {
+    body:not(.lanlan-pet-mode):not(.electron-chat-window) {
         background: #000 !important;
     }
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -486,11 +486,15 @@
         }
         #neko-resize-handle:hover { opacity: 1; }
 
-        /* 暗色模式透明背景覆盖 —— dark-mode.css 的 max-width:768px 媒体查询
-           会将 html/body 背景设为 #000，但 chat 窗口宽度 400px 始终命中该查询，
-           导致透明窗口背景变黑，在圆角外围显示黑色矩形 */
-        html[data-theme="dark"],
-        html[data-theme="dark"] body {
+        /* 暗色模式透明背景覆盖 —— dark-mode.css / index.css 的 max-width:768px
+           媒体查询会将 html/body 背景设为 #000，但 chat 窗口宽度 400px 始终命中。
+           #1573 给那两条黑底加了 :not(.lanlan-pet-mode)（特异性 0,2,x），压过了
+           原本 0,1,x 的反制，导致透明窗口背景变黑、圆角外围显示黑色矩形。
+           这里同步加 :not(.lanlan-pet-mode) 把反制抬到 0,2,x：与黑底特异性持平，
+           再凭源序（本 <style> 晚于两张表）取胜，使 html 行与 body 行都赢过黑底。
+           chat 窗口 html/body 从不带 lanlan-pet-mode，:not() 恒命中、不改适用范围。 */
+        html[data-theme="dark"]:not(.lanlan-pet-mode),
+        html[data-theme="dark"]:not(.lanlan-pet-mode) body {
             background: transparent !important;
         }
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -22,7 +22,12 @@
     <script src="/static/libs/APlayer.min.js?v={{ static_asset_version }}"></script>
 
     <style>
-        html, body {
+        /* 选择器加 :not(.lanlan-pet-mode) 把特异性抬到 (0,1,1)：兜浅色主题——
+           index.css 的手机端黑底 html:not(.lanlan-pet-mode) 同为 (0,1,1) 且不分
+           主题，浅色下也命中 chat 的 <html>（暗色反制是 dark-gated 不生效）；持平后
+           凭源序（本 <style> 晚于 index.css）取胜，使 <html> 浅色下也保持透明。
+           chat 窗口 html/body 从不带 lanlan-pet-mode，:not() 恒命中、不改适用范围。 */
+        html:not(.lanlan-pet-mode), body:not(.lanlan-pet-mode) {
             margin: 0; padding: 0;
             width: 100%; height: 100%;
             background: transparent !important;


### PR DESCRIPTION
## 现象

Electron 桌面端紧凑聊天框（compact chat，路由 `/chat`，由 `templates/chat.html` 渲染，嵌在透明 `BrowserWindow`）在**暗色主题**下，圆角胶囊气泡周围整个窗口区域变成不透明纯黑，本应透出桌面 / Live2D 模型。

## 根因

回归来自 #1573（commit `3ba10ac90`）。两份移动端黑底规则在 `@media (max-width:768px)` 里把根背景刷成 `#000`：

- **(A)** `static/css/dark-mode.css` —— 暗色移动端黑底
- **(B)** `static/css/index.css` —— 手机端通用黑底（不分主题）

chat 窗口 `body` 带 `electron-chat-window`、宽度恒 `<768px`，两条恒命中。#1573 给这两条加了 `:not(.lanlan-pet-mode)`（为排除 Pet 窗口），特异性从 `(0,1,x)` 抬到 `(0,2,x)`，反而**压过了** `chat.html` 头部 `(0,1,x)` 的透明反制 → 透明窗口根背景被刷黑。同文件其余 ~21 条移动端规则都带 `body:not(.electron-chat-window)` 排除 chat，唯独这两条黑底漏加。

## 修复（与既有 `electron-chat-window` / `lanlan-pet-mode` 对偶约定一致）

1. **(A)(B) 的 body 行**加 `:not(.electron-chat-window)` → chat `body` 不再被刷黑。
2. **`chat.html` 暗色反制选择器**加 `:not(.lanlan-pet-mode)`，特异性抬到 `(0,2,x)`，与暗色黑底 `(A)` 持平后凭**源序**（inline `<style>` 晚于两张表）取胜，使 `html` 行与 `body` 行都赢过黑底。`html` 那行无法直接挂 `body:not(...)`，故需这一步兜住 `html` 元素。
3. **`chat.html` 头部无条件透明反制**（第 25 行 `html, body`）选择器加 `:not(.lanlan-pet-mode)`，特异性 `(0,0,1)→(0,1,1)`，**兜浅色主题**：(B) 不分主题、浅色下仍会刷黑 chat 的 `<html>`（暗色反制是 dark-gated，浅色不生效），持平后凭源序取胜，浅色下 `<html>` 也保持透明。

## 验收（特异性 / 源序推演）

窄窗 + `body.electron-chat-window` 下两根背景最终均为 `transparent`：

| 主题 | 元素 | 胜出规则 | 特异性 | 结果 |
|---|---|---|---|---|
| dark | `<html>` | chat 反制 `html[data-theme=dark]:not(.lanlan-pet-mode)` | (0,2,1) | transparent（平 (A)，源序胜；压 (B)） |
| dark | `<body>` | chat 反制 `…:not(.lanlan-pet-mode) body` | (0,2,2) | transparent（(A)(B) body 行已不匹配 chat） |
| light | `<html>` | chat 反制 `html:not(.lanlan-pet-mode)`（第 25 行） | (0,1,1) | transparent（平 (B)，源序胜；(A) dark-gated 不生效） |
| light | `<body>` | chat 反制 `body:not(.lanlan-pet-mode)`（第 25 行） | (0,1,1) | transparent（(B) body 行已不匹配 chat） |

## 不受影响（已确认）

- 真·手机浏览器暗/浅色仍是黑底（`body` 无 `electron-chat-window`、`html/body` 无 `lanlan-pet-mode`，三处 `:not()` 均不命中真手机端，且 `chat.html` 的 inline 反制仅 chat 窗口加载）；
- Pet 窗口（`index.html`，带 `.lanlan-pet-mode`）不变；
- `subtitle.html` / `agentHud.html` / `toast.html` 未触及。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了 Electron 紧凑聊天窗口在暗色模式或移动视图下被误应用纯黑背景的问题，恢复正确显示。

* **样式**
  * 优化并细化移动端及暗色模式下的背景/透明样式选择器逻辑，避免特定模式（如宠物模式）被不当覆盖，提升视觉兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->