### PR TITLE
fix(ci): GHCR 清理升级 dataaxiom action v1.2.0 -> v1.2.1 修第二个 404

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -42,8 +42,13 @@ jobs:
       # 会连带处理子镜像、不会对级联删除的 digest 二次删。
       - name: Delete old container versions
         # 第三方社区 action + GHCR 删除权限/token，固定到 commit SHA 防 tag 被改写。
-        # 下方 SHA 对应 v1.2.0；升级时一并更新 SHA 和行尾版本注释。
-        uses: dataaxiom/ghcr-cleanup-action@374e2028c8fb93b7219f3771cd405fab95d3dec4 # v1.2.0
+        # 下方 SHA 对应 v1.2.1；升级时一并更新 SHA 和行尾版本注释。
+        #
+        # 为什么不是 v1.2.0：v1.2.0 对级联回收只吞掉「第一个」404，删父 manifest
+        # 触发 GHCR 连带删子 digest 后，第二个已消失 digest 的 404 不被 catch，
+        # 直接 ##[error]Package not found 把 job 挂掉（每周稳定复现）。v1.2.1 的
+        # "tolerate every 404 on package version delete" 修掉这条路径。
+        uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: project-n-e-k-o


### PR DESCRIPTION
## 背景

#1497 把 GHCR 定期清理换成 manifest-aware 的 `dataaxiom/ghcr-cleanup-action`，pin 到 **v1.2.0**。但每周定时任务仍然稳定失败（最近一次：[run 26705948920](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/26705948920)）。

## 根因

删 multi-arch 父 manifest 会触发 GHCR 级联回收子 digest。action 拿开跑前的陈旧列表继续删已消失的 digest 时：

- **第一个** 404 → v1.2.0 用 try/catch 吞掉，仅 `##[warning] ... wasn't found ... ignoring this error`
- **第二个** 404（`versions/904199089`）→ 不在 catch 路径里，直接 `##[error]Package not found`，**job 挂掉**

也就是 #1497 选对了 action，但 pin 的 v1.2.0 内部对级联 404 只兜了一半。

## 修复

升级到 **v1.2.1**（上游 2026-05-25 发布，比 #1497 合并晚一天），首条 changelog 即：

> fix: tolerate **every** 404 on package version delete (was: fail on the second)

正是本仓库撞到的路径。改动仅一行：把 pin 的 commit SHA 从 v1.2.0 升到 v1.2.1，并更新行尾版本注释 + 补一段「为什么不是 v1.2.0」的说明。无其他逻辑改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更日志

* **Chores**
  * 升级了 GitHub Actions 工作流中 Docker 镜像清理工具的版本，提升清理操作的稳定性和可靠性，修复了级联清理过程中可能导致的异常问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->