### PR TITLE
fix(health-check): 超时不再显示 000000，并附带 curl 退出码

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -109,7 +109,7 @@ jobs:
           API_APP_EXIT="${{ steps.check_api_app.outputs.curl_exit }}"
           API_TECH_EXIT="${{ steps.check_api_tech.outputs.curl_exit }}"
 
-          # http_code=000 时附带 curl 退出码（28=超时, 7=拒连, 6=DNS, 35=TLS）以区分故障类型
+          # curl 退出码非零（拿不到响应、即 http_code=000）时附带退出码（28=超时, 7=拒连, 6=DNS, 35=TLS）以区分故障类型
           fmt_code() {
             if [ -n "$2" ] && [ "$2" != "0" ]; then
               echo "$1, curl exit $2"

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -15,15 +15,17 @@ jobs:
       - name: Check lanlan.app (old)
         id: check_app
         run: |
+          CURL_EXIT=0
           HTTP_CODE=$(curl -s -o /tmp/resp_app.json -w "%{http_code}" \
             --max-time 30 --connect-timeout 10 \
             -X POST "https://lanlan.app/text/v1/chat/completions" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer free-access" \
             -d '{"model":"free-mini-model","messages":[{"role":"user","content":"sends some useful information"}],"max_completion_tokens":5}' \
-            2>/dev/null || echo "000")
+            2>/dev/null) || CURL_EXIT=$?
           BODY=$(cat /tmp/resp_app.json 2>/dev/null || echo "{}")
           echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
 
           if [ "$HTTP_CODE" = "200" ]; then
             if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message | has("content"))' >/dev/null 2>&1; then
@@ -39,15 +41,17 @@ jobs:
       - name: Check www.lanlan.app (new)
         id: check_api_app
         run: |
+          CURL_EXIT=0
           HTTP_CODE=$(curl -s -o /tmp/resp_api_app.json -w "%{http_code}" \
             --max-time 30 --connect-timeout 10 \
             -X POST "https://www.lanlan.app/text/v1/chat/completions" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer free-access" \
             -d '{"model":"free-mini-model","messages":[{"role":"user","content":"sends some useful information"}],"max_completion_tokens":5}' \
-            2>/dev/null || echo "000")
+            2>/dev/null) || CURL_EXIT=$?
           BODY=$(cat /tmp/resp_api_app.json 2>/dev/null || echo "{}")
           echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
 
           if [ "$HTTP_CODE" = "200" ]; then
             if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message | has("content"))' >/dev/null 2>&1; then
@@ -63,15 +67,17 @@ jobs:
       - name: Check www.lanlan.tech (new)
         id: check_api_tech
         run: |
+          CURL_EXIT=0
           HTTP_CODE=$(curl -s -o /tmp/resp_api_tech.json -w "%{http_code}" \
             --max-time 30 --connect-timeout 10 \
             -X POST "https://www.lanlan.tech/text/v1/chat/completions" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer free-access" \
             -d '{"model":"free-mini-model","messages":[{"role":"user","content":"sends some useful information"}],"max_completion_tokens":5}' \
-            2>/dev/null || echo "000")
+            2>/dev/null) || CURL_EXIT=$?
           BODY=$(cat /tmp/resp_api_tech.json 2>/dev/null || echo "{}")
           echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
+          echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
 
           if [ "$HTTP_CODE" = "200" ]; then
             if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message | has("content"))' >/dev/null 2>&1; then
@@ -99,6 +105,22 @@ jobs:
           API_APP_CODE="${{ steps.check_api_app.outputs.http_code }}"
           API_TECH_CODE="${{ steps.check_api_tech.outputs.http_code }}"
 
+          APP_EXIT="${{ steps.check_app.outputs.curl_exit }}"
+          API_APP_EXIT="${{ steps.check_api_app.outputs.curl_exit }}"
+          API_TECH_EXIT="${{ steps.check_api_tech.outputs.curl_exit }}"
+
+          # http_code=000 时附带 curl 退出码（28=超时, 7=拒连, 6=DNS, 35=TLS）以区分故障类型
+          fmt_code() {
+            if [ -n "$2" ] && [ "$2" != "0" ]; then
+              echo "$1, curl exit $2"
+            else
+              echo "$1"
+            fi
+          }
+          APP_CODE_DISP=$(fmt_code "$APP_CODE" "$APP_EXIT")
+          API_APP_CODE_DISP=$(fmt_code "$API_APP_CODE" "$API_APP_EXIT")
+          API_TECH_CODE_DISP=$(fmt_code "$API_TECH_CODE" "$API_TECH_EXIT")
+
           ALL_HEALTHY="true"
           ANY_DOWN="false"
           for h in "$APP_HEALTHY" "$API_APP_HEALTHY" "$API_TECH_HEALTHY"; do
@@ -120,21 +142,21 @@ jobs:
           fi
 
           if [ "$APP_HEALTHY" = "true" ]; then
-            APP_STATUS=":white_check_mark: OK (HTTP $APP_CODE)"
+            APP_STATUS=":white_check_mark: OK (HTTP $APP_CODE_DISP)"
           else
-            APP_STATUS=":x: DOWN (HTTP $APP_CODE)"
+            APP_STATUS=":x: DOWN (HTTP $APP_CODE_DISP)"
           fi
 
           if [ "$API_APP_HEALTHY" = "true" ]; then
-            API_APP_STATUS=":white_check_mark: OK (HTTP $API_APP_CODE)"
+            API_APP_STATUS=":white_check_mark: OK (HTTP $API_APP_CODE_DISP)"
           else
-            API_APP_STATUS=":x: DOWN (HTTP $API_APP_CODE)"
+            API_APP_STATUS=":x: DOWN (HTTP $API_APP_CODE_DISP)"
           fi
 
           if [ "$API_TECH_HEALTHY" = "true" ]; then
-            API_TECH_STATUS=":white_check_mark: OK (HTTP $API_TECH_CODE)"
+            API_TECH_STATUS=":white_check_mark: OK (HTTP $API_TECH_CODE_DISP)"
           else
-            API_TECH_STATUS=":x: DOWN (HTTP $API_TECH_CODE)"
+            API_TECH_STATUS=":x: DOWN (HTTP $API_TECH_CODE_DISP)"
           fi
 
           # 只在有故障时 @everyone


### PR DESCRIPTION
@
## 问题

`Server Health Check` 在 lanlan.app (US, old) 连不上时，Discord 报警里 HTTP code 显示成 `000000`。

## 根因

curl 用 `-w "%{http_code}"` 时拿不到响应本就会输出 `000`（不带换行）；原来后面又跟了 `|| echo "000"`，curl 非 0 退出时再补打一遍 → `000` + `000` = **`000000`**。

## 改动

- 去掉冗余的 `|| echo "000"`，`HTTP_CODE` 现在就是干净的 `000`。
- 改用 `|| CURL_EXIT=$?` 在抓退出码的同时吞掉 errexit —— GitHub Actions 的 bash 默认 `set -eo pipefail`，若只删 fallback 不做这步，curl 超时会让整个 step 直接红掉、走不到写 output。
- 新增 `curl_exit` step output；Discord 通知失败时附带退出码，例如 `:x: DOWN (HTTP 000, curl exit 28)`，便于一眼区分故障类型：**28=超时 / 7=拒连 / 6=DNS / 35=TLS**。
- 健康（200）时显示不变，仍是 `OK (HTTP 200)`。

> 注：本次实测 lanlan.app (US, old) 确实连不上（返回 000），www 两个新域名 200 健康。老域名是否退役是另一个决定，本 PR 不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 健康检查现会捕获命令执行的退出码，通知中展示可包含退出码的组合状态码，便于诊断。
  * 通知文案升级，服务器状态从单一 HTTP 码改为显示带退出码的组合码。

* **Bug修复**
  * 移除在失败场景下写入占位 HTTP 码的行为，避免误导性的状态显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->