### PR TITLE
feat(chat): 首页聊天框收敛为 compact / minimized 两态

### DIFF
--- a/docs/design/home-compact-chat-mode-design.md
+++ b/docs/design/home-compact-chat-mode-design.md
@@ -8,7 +8,7 @@
 
 本文覆盖当前分支已经落地的紧凑聊天框长期事实和维护边界，包括：
 
-1. `full / compact / minimized` 三层聊天形态。
+1. `compact / minimized` 两态聊天形态。
 2. `default / options / input` 紧凑态内部三态。
 3. 紧凑 surface、最小化 ball、选项层、工具转轮、内联历史、历史气泡拖拽与发送链路。
 4. Web、独立 `/chat`、NEKO-PC 桌面壳三端的样式、geometry、命中、bounds 和拖拽边界。
@@ -75,7 +75,7 @@
 已确认事实：
 
 1. 当前聊天 UI 以 React chat 为准；旧 `#chat-container` 只作为兼容 DOM 存在。
-2. 宿主形态是 `chatSurfaceMode: 'full' | 'compact' | 'minimized'`。
+2. 宿主形态是 `chatSurfaceMode: 'compact' | 'minimized'`（localStorage 里遗留的 `'full'` 读入时迁移为 `'compact'`）。
 3. compact 内部状态是 `compactChatState: 'default' | 'options' | 'input'`。
 4. `effectiveCompactChatState` 会在存在 ChoicePrompt / GalGame options 时把 compact 推到 `options`，不需要业务层另造状态。
 5. compact 主体 DOM 已统一为：
@@ -108,7 +108,7 @@
 2. 因此 compact surface 的 React CSS 在首页、独立 `/chat` 和 NEKO-PC 承载页上是同一份构建产物。
 3. 改 `frontend/react-neko-chat/src/*` 后必须运行 `bash build_frontend.sh`，确保 `static/react/neko-chat/neko-chat-window.css` 已同步。
 4. `static/app-react-chat-window.js` 负责：
-   - `full -> compact -> minimized -> full` 形态循环。
+   - `compact ↔ minimized` 形态切换。
    - compact surface 位置和宽度持久化。
    - `--compact-surface-left/top/width/height` 和 `--desktop-compact-surface-*` CSS 变量同步。
    - surface geometry 收集、union、hit rect、native rect 输出。
@@ -148,27 +148,24 @@
 8. 历史空白区域需要 pointer passthrough；拖拽期间必须关闭 passthrough，避免拖拽链路丢事件。
 9. Electron 透明窗口里 CSS 透明不等于点击穿透；必须同时考虑 BrowserWindow bounds、setShape/input region、页面 `pointer-events` 和 history passthrough。
 
-## 三层聊天形态
+## 两态聊天形态
 
 首页聊天框只有一条连续形态链：
 
-1. `full`
-   - 完整聊天框。
-   - 承担完整历史、完整 composer、附件和工具区域。
-2. `compact`
-   - 紧凑聊天框。
+1. `compact`
+   - 紧凑聊天框（默认）。
    - 承担当前轮预览、选项、输入、工具、内联历史、历史选择和历史拖拽发送。
-3. `minimized`
+2. `minimized`
    - 最小化小球。
    - 承担最轻入口和恢复链路。
 
 规则：
 
-1. 三者共享同一套消息、发送、附件、选项、教程和恢复语义。
-2. 三者区别是视觉密度、承载面积和原生窗口 bounds，不是业务协议分叉。
+1. 两者共享同一套消息、发送、附件、选项、教程和恢复语义。
+2. 两者区别是视觉密度、承载面积和原生窗口 bounds，不是业务协议分叉。
 3. 切换形态不能清空会话、重置选项或破坏输入状态恢复。
 4. compact surface 的用户拖动位置只影响 surface，不影响 ball。
-5. 从 compact 切回 full/minimized 时，桌面端必须恢复 bounds、shape、ignore-mouse-events、external ball 和 resizable 状态。
+5. 从 compact 切到 minimized 时，桌面端必须同步 native ball 窗口；从 minimized 恢复 compact 时，必须走 compact carrier bounds 而非旧 full 面板尺寸。
 
 ## Compact 内部三态
 
@@ -194,7 +191,7 @@
 1. `.compact-chat-surface-frame` 内切换为 textarea + 右侧按钮。
 2. 空输入且无附件时，右侧按钮是工具入口。
 3. 有文本或附件时，右侧按钮是发送。
-4. 输入态高度受控，不允许被 composer 撑成 full 面板。
+4. 输入态高度受控，不允许被 composer 撑成独立大面板。
 5. blur、发送、工具关闭后必须能自然回到展示态。
 
 ## Compact Surface 视觉合同
@@ -434,8 +431,8 @@ Compact 当前文字是“当前轮轻提示”，不是完整历史记录、字
 2. 桌面端可以用独立 ball window、BrowserWindow bounds、setShape/input region 和 pointer passthrough 实现命中与裁切。
 3. 桌面端不能因为原生窗口实现限制而把 ball 重新绑回 surface。
 4. 桌面端拖拽保存的是 surface anchor，不是 ball anchor。
-5. 桌面端 compact resize / relayout 不能污染 full 模式窗口大小。
-6. 从 compact 切回 full 或 minimized 时，必须恢复原窗口状态、shape、ignore-mouse-events、external ball 和 resizable 状态。
+5. 桌面端 compact resize / relayout 只影响 compact carrier，不再维护 full 模式窗口快照。
+6. 从 minimized 恢复 compact 时，必须恢复 compact bounds、shape、ignore-mouse-events、external ball 和 resizable 状态。
 7. Windows 展开 fallback 需要真实 resizable style toggle，不能把 `setResizable(false)` 到 `setResizable(false)` 当成 cache busting。
 8. Native Wayland compact drag handle 应保留原生 drag 策略，不走不可用的全局 cursor/window polling。
 9. ReactChat 紧凑窗口必须保持在模型上方，并由 window manager / top coordinator 维护层级。
@@ -506,7 +503,7 @@ Compact 当前文字是“当前轮轻提示”，不是完整历史记录、字
 如果改了 NEKO-PC：
 
 1. 做桌面端真实启动检查。
-2. 检查 `compact/full/minimized` 三态。
+2. 检查 `compact ↔ minimized` 两态。
 3. 检查拖拽、resize、选项、输入、工具、历史、历史拖拽、层级和点击穿透。
 4. 对照网页端目标表现确认一致。
 
@@ -514,7 +511,7 @@ Compact 当前文字是“当前轮轻提示”，不是完整历史记录、字
 
 基础形态：
 
-1. `full -> compact -> minimized -> full` 循环稳定。
+1. `compact ↔ minimized` 切换稳定。
 2. compact 默认不展示完整历史。
 3. compact 当前文字在下方 surface 内，不出现上方独立说话框。
 4. minimized ball 位于模型左侧，且不随 surface 拖拽。
@@ -525,7 +522,7 @@ Surface：
 2. 未保存位置时，默认在模型可见区域偏下。
 3. surface 不被模型压住。
 4. 打开工具、选项、历史或右侧展开栏时，surface anchor 不抖动。
-5. 左右 resize 不突破 workArea，也不污染 full bounds。
+5. 左右 resize 不突破 workArea，也不污染 legacy full bounds 存储。
 6. 玻璃背景在浅色/暗色模式下都能读清文字，且不像凸起按钮。
 
 命中：
@@ -544,7 +541,7 @@ Surface：
 
 输入：
 
-1. 输入态不会被 composer 撑成 full 面板。
+1. 输入态不会被 composer 撑成独立大面板。
 2. 长文本内部滚动。
 3. 空输入右侧按钮打开工具转轮。
 4. 有文本或附件时右侧按钮发送。
@@ -576,7 +573,7 @@ Surface：
 2. 拖拽 surface 不牵动 ball。
 3. 模型移动不会强行覆盖用户保存的 surface 位置。
 4. compact window 在模型上方。
-5. 切回 full/minimized 后窗口 bounds、shape、resizable 和 ball 状态恢复正确。
+5. 从 minimized 恢复 compact 后窗口 bounds、shape、resizable 和 ball 状态恢复正确。
 6. Native Wayland 拖拽仍使用可工作的原生拖拽路径。
 
 ## 禁止方案
@@ -604,7 +601,7 @@ Surface：
 
 后续紧凑态相关改动按以下顺序判断优先级：
 
-1. 先保护三层形态和 compact 三态的状态语义。
+1. 先保护 compact ↔ minimized 两态和 compact 内部三态的状态语义。
 2. 再保护 surface / ball 独立、geometry、命中和桌面 bounds。
 3. 再保护选项、输入、工具这些当前核心交互。
 4. 再保护内联历史 / 导出历史 / 历史拖拽发送。

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import App from './App';
+import MessageList from './MessageList';
 import { parseChatMessage, type CompactChatState } from './message-schema';
 
 describe('App', () => {
@@ -92,10 +93,26 @@ describe('App', () => {
     };
   };
 
-  it('renders the empty state when there are no messages', () => {
-    render(<App />);
+  const openCompactInputTools = async () => {
+    try {
+      vi.useFakeTimers();
+      fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(240);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  };
 
-    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+  const renderInputApp = (
+    props: React.ComponentProps<typeof App> = {},
+  ) => render(<App compactChatState="input" {...props} />);
+
+  it('renders the empty state when there are no messages', () => {
+    render(<App compactChatState="default" />);
+
+    expect(screen.getByText('Chat content will appear here.')).toBeInTheDocument();
   });
 
   it('exposes explicit surface mode state on the rendered shell', () => {
@@ -134,7 +151,7 @@ describe('App', () => {
     expect(container.querySelector('.compact-chat-surface-shell')).toBe(stableSurfaceShell);
     expect(container.querySelector('.compact-chat-surface-frame')).toBe(stableSurfaceFrame);
 
-    rerender(<App chatSurfaceMode="full" />);
+    rerender(<App chatSurfaceMode="minimized" />);
     expect(container.querySelector('.compact-chat-drag-handle')).toBeNull();
     expect(container.querySelector('.compact-chat-resize-handle')).toBeNull();
     expect(container.querySelector('[data-compact-geometry-owner="surface"]')).toBeNull();
@@ -1720,7 +1737,7 @@ describe('App', () => {
     await clickCompactExportTool();
     expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
 
-    rerender(<App chatSurfaceMode="full" messages={[message]} />);
+    rerender(<App chatSurfaceMode="minimized" messages={[message]} />);
 
     expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
     expect(container.querySelector('[data-compact-hit-region-id^="history:"]')).toBeNull();
@@ -2194,25 +2211,6 @@ describe('App', () => {
     }
   });
 
-  it('keeps compact-only state derivation out of the full surface', () => {
-    const { container } = render(
-      <App
-        chatSurfaceMode="full"
-        compactChatState="default"
-        choicePrompt={{
-          source: 'mini_game_invite',
-          options: [
-            { choice: 'accept', label: 'Accept' },
-            { choice: 'later', label: 'Later' },
-          ],
-        }}
-      />,
-    );
-
-    expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');
-    expect(container.querySelector('.composer-choice-layer')).not.toHaveClass('compact-chat-choice-anchor');
-  });
-
   it('renders compact default as a single search-like entry without history or extra controls', () => {
     const message = parseChatMessage({
       id: 'assistant-compact-1',
@@ -2544,44 +2542,6 @@ describe('App', () => {
       expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
         streamingText.slice(0, visibleLength),
       );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('does not route speech playback state into the full surface preview', async () => {
-    vi.useFakeTimers();
-    const streamingText = '完整聊天框不应该被紧凑态语音显字状态接管。';
-    const message = parseChatMessage({
-      id: 'assistant-full-speech-event-isolated',
-      role: 'assistant',
-      author: 'Neko',
-      time: '10:01',
-      createdAt: 2,
-      blocks: [{ type: 'text', text: streamingText }],
-      status: 'streaming',
-    });
-
-    try {
-      const { container } = render(<App chatSurfaceMode="full" messages={[message]} />);
-
-      act(() => {
-        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
-          detail: {
-            active: true,
-            audioContextTime: 0,
-            playbackStartAudioTime: 0,
-            playbackEndAudioTime: 1,
-            updatedAt: Date.now(),
-          },
-        }));
-      });
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(1000);
-      });
-
-      expect(container.querySelector('.compact-chat-capsule-text')).toBeNull();
-      expect(container.querySelector('.message-list')).toHaveTextContent(streamingText);
     } finally {
       vi.useRealTimers();
     }
@@ -3656,34 +3616,6 @@ describe('App', () => {
     }
   });
 
-  it('restores the full chat body and composer after leaving compact input mode', () => {
-    const { container, rerender } = render(
-      <App
-        chatSurfaceMode="compact"
-        compactChatState="input"
-        galgameModeEnabled
-        translateEnabled
-      />,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
-    expect(document.body.querySelector('.compact-input-tool-fan')).not.toBeNull();
-
-    rerender(
-      <App
-        chatSurfaceMode="full"
-        galgameModeEnabled
-        translateEnabled
-      />,
-    );
-
-    expect(container.querySelector('.chat-window')).toHaveClass('chat-surface-mode-full');
-    expect(container.querySelector('.window-topbar')).not.toBeNull();
-    expect(container.querySelector('.message-list')).not.toBeNull();
-    expect(container.querySelector('.composer-bottom-bar')).not.toBeNull();
-    expect(document.body.querySelector('.compact-input-tool-fan')).toBeNull();
-  });
-
   it('closes compact input tools on the second button click without leaving input state', () => {
     const onCompactChatStateChange = vi.fn();
     render(
@@ -3992,144 +3924,6 @@ describe('App', () => {
     expect(onCompactChatStateChange).not.toHaveBeenCalledWith('default');
   });
 
-  it('re-attaches the composer width observer after returning from compact mode', async () => {
-    vi.useFakeTimers();
-    const originalResizeObserver = globalThis.ResizeObserver;
-    const observerInstances: ResizeObserverMock[] = [];
-
-    const emitResize = (observer: ResizeObserverMock, width: number) => {
-      if (!observer.target) {
-        throw new Error('ResizeObserver target missing in test');
-      }
-      observer.callback([
-        {
-          target: observer.target,
-          contentRect: {
-            width,
-            height: 40,
-            x: 0,
-            y: 0,
-            top: 0,
-            left: 0,
-            bottom: 40,
-            right: width,
-            toJSON: () => ({}),
-          },
-        } as ResizeObserverEntry,
-      ], observer as unknown as ResizeObserver);
-    };
-
-    class ResizeObserverMock {
-      readonly callback: ResizeObserverCallback;
-      target: Element | null = null;
-
-      constructor(callback: ResizeObserverCallback) {
-        this.callback = callback;
-        observerInstances.push(this);
-      }
-
-      observe(target: Element) {
-        this.target = target;
-      }
-
-      disconnect() {}
-      unobserve() {}
-      takeRecords() { return []; }
-    }
-
-    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
-
-    try {
-      const { container, rerender } = render(<App />);
-      expect(observerInstances.length).toBeGreaterThanOrEqual(1);
-      const initialObserverCount = observerInstances.length;
-
-      rerender(<App chatSurfaceMode="compact" compactChatState="input" />);
-      rerender(<App chatSurfaceMode="full" />);
-      expect(observerInstances.length).toBeGreaterThan(initialObserverCount);
-
-      await act(async () => {
-        emitResize(observerInstances[observerInstances.length - 1], 420);
-        vi.advanceTimersByTime(300);
-      });
-
-      expect(container.querySelector('.composer-overflow-btn')).toBeNull();
-      expect(container.querySelector('.composer-galgame-btn')).not.toBeNull();
-    } finally {
-      globalThis.ResizeObserver = originalResizeObserver;
-      vi.useRealTimers();
-    }
-  });
-
-  it('re-attaches the composer width observer after returning from compact mode', async () => {
-    vi.useFakeTimers();
-    const originalResizeObserver = globalThis.ResizeObserver;
-    const observerInstances: ResizeObserverMock[] = [];
-
-    const emitResize = (observer: ResizeObserverMock, width: number) => {
-      if (!observer.target) {
-        throw new Error('ResizeObserver target missing in test');
-      }
-      observer.callback([
-        {
-          target: observer.target,
-          contentRect: {
-            width,
-            height: 40,
-            x: 0,
-            y: 0,
-            top: 0,
-            left: 0,
-            bottom: 40,
-            right: width,
-            toJSON: () => ({}),
-          },
-        } as ResizeObserverEntry,
-      ], observer as unknown as ResizeObserver);
-    };
-
-    class ResizeObserverMock {
-      readonly callback: ResizeObserverCallback;
-      target: Element | null = null;
-
-      constructor(callback: ResizeObserverCallback) {
-        this.callback = callback;
-        observerInstances.push(this);
-      }
-
-      observe(target: Element) {
-        this.target = target;
-      }
-
-      disconnect() {}
-      unobserve() {}
-      takeRecords() { return []; }
-    }
-
-    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
-
-    try {
-      const { container, rerender } = render(<App />);
-      expect(observerInstances.length).toBeGreaterThanOrEqual(1);
-      const initialObserverCount = observerInstances.length;
-
-      rerender(<App chatSurfaceMode="compact" compactChatState="input" />);
-      rerender(<App chatSurfaceMode="full" />);
-      expect(observerInstances.length).toBeGreaterThan(initialObserverCount);
-
-      await act(async () => {
-        emitResize(observerInstances[observerInstances.length - 1], 420);
-        vi.advanceTimersByTime(300);
-      });
-
-      expect(container.querySelector('.composer-overflow-btn')).toBeNull();
-      expect(container.querySelector('.composer-galgame-btn')).not.toBeNull();
-    } finally {
-      globalThis.ResizeObserver = originalResizeObserver;
-      vi.useRealTimers();
-    }
-  });
-
   it('renders grouped assistant messages with a single visible avatar', () => {
     const firstMessage = parseChatMessage({
       id: 'assistant-1',
@@ -4148,7 +3942,13 @@ describe('App', () => {
       blocks: [{ type: 'text', text: 'Second message' }],
     });
 
-    const { container } = render(<App messages={[firstMessage, secondMessage]} />);
+    const { container } = render(
+      <MessageList
+        messages={[firstMessage, secondMessage]}
+        ariaLabel="Chat messages"
+        failedStatusLabel="Failed"
+      />,
+    );
 
     expect(screen.getByText('First message')).toBeInTheDocument();
     expect(screen.getByText('Second message')).toBeInTheDocument();
@@ -4174,14 +3974,20 @@ describe('App', () => {
       status: 'failed',
     });
 
-    render(<App messages={[streamingMessage, failedMessage]} />);
+    render(
+      <MessageList
+        messages={[streamingMessage, failedMessage]}
+        ariaLabel="Chat messages"
+        failedStatusLabel="Failed"
+      />,
+    );
 
     expect(screen.getByText('Failed')).toBeInTheDocument();
   });
 
   it('submits composer text through the new submit callback', () => {
     const onComposerSubmit = vi.fn();
-    render(<App onComposerSubmit={onComposerSubmit} />);
+    renderInputApp({ onComposerSubmit });
 
     const input = screen.getByPlaceholderText('Type a message...');
     fireEvent.change(input, { target: { value: 'Test send' } });
@@ -4192,7 +3998,7 @@ describe('App', () => {
 
   it('disables composer submission while the home tutorial owns interaction', () => {
     const onComposerSubmit = vi.fn();
-    render(<App composerDisabled onComposerSubmit={onComposerSubmit} />);
+    renderInputApp({ composerDisabled: true, onComposerSubmit });
 
     const input = screen.getByPlaceholderText('Type a message...');
     expect(input).toBeDisabled();
@@ -4205,7 +4011,7 @@ describe('App', () => {
 
   it('does not render a local optimistic user bubble before the host echoes messages', () => {
     const onComposerSubmit = vi.fn();
-    render(<App onComposerSubmit={onComposerSubmit} />);
+    renderInputApp({ onComposerSubmit });
 
     const input = screen.getByPlaceholderText('Type a message...');
     fireEvent.change(input, { target: { value: 'No local optimistic bubble' } });
@@ -4216,21 +4022,22 @@ describe('App', () => {
     expect(screen.queryByText('You')).not.toBeInTheDocument();
   });
 
-  it('renders composer tool buttons and calls the React callbacks', () => {
+  it('renders composer tool buttons and calls the React callbacks', async () => {
     const onComposerImportImage = vi.fn();
     const onComposerScreenshot = vi.fn();
 
-    render(
-      <App
-        onComposerImportImage={onComposerImportImage}
-        onComposerScreenshot={onComposerScreenshot}
-      />,
-    );
+    renderInputApp({
+      onComposerImportImage,
+      onComposerScreenshot,
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Import Image' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Screenshot' }));
+    await openCompactInputTools();
 
+    fireEvent.click(document.body.querySelector('.compact-input-tool-item-import')!);
     expect(onComposerImportImage).toHaveBeenCalledTimes(1);
+
+    await openCompactInputTools();
+    fireEvent.click(document.body.querySelector('.compact-input-tool-item-screenshot')!);
     expect(onComposerScreenshot).toHaveBeenCalledTimes(1);
   });
 
@@ -4272,7 +4079,7 @@ describe('App', () => {
     expect(onComposerRemoveAttachment).not.toHaveBeenCalled();
   });
 
-  it('only emits avatar interactions when the pointer hits the avatar range', () => {
+  it('only emits avatar interactions when the pointer hits the avatar range', async () => {
     const onAvatarInteraction = vi.fn();
     const live2dContainer = document.createElement('div');
     live2dContainer.id = 'live2d-container';
@@ -4297,8 +4104,9 @@ describe('App', () => {
     });
 
     try {
-      render(<App onAvatarInteraction={onAvatarInteraction} />);
+      renderInputApp({ onAvatarInteraction });
 
+      await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
 
@@ -4323,7 +4131,7 @@ describe('App', () => {
     }
   });
 
-  it('derives different touch zones for different avatar hit areas', () => {
+  it('derives different touch zones for different avatar hit areas', async () => {
     const onAvatarInteraction = vi.fn();
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9);
     const live2dContainer = document.createElement('div');
@@ -4349,8 +4157,9 @@ describe('App', () => {
     });
 
     try {
-      render(<App onAvatarInteraction={onAvatarInteraction} />);
+      renderInputApp({ onAvatarInteraction });
 
+      await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
@@ -4380,7 +4189,7 @@ describe('App', () => {
     }
   });
 
-  it('escalates lollipop interactions from normal to burst on repeated in-range taps', () => {
+  it('escalates lollipop interactions from normal to burst on repeated in-range taps', async () => {
     const onAvatarInteraction = vi.fn();
     const live2dContainer = document.createElement('div');
     live2dContainer.id = 'live2d-container';
@@ -4405,8 +4214,9 @@ describe('App', () => {
     });
 
     try {
-      render(<App onAvatarInteraction={onAvatarInteraction} />);
+      renderInputApp({ onAvatarInteraction });
 
+      await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
 
@@ -4469,8 +4279,12 @@ describe('App', () => {
     });
 
     try {
-      const { container } = render(<App />);
+      const { container } = renderInputApp();
 
+      fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(240);
+      });
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
       fireEvent.pointerMove(window, { clientX: 150, clientY: 150 });
@@ -4508,7 +4322,7 @@ describe('App', () => {
     }
   });
 
-  it('escalates fist interactions to rapid on repeated in-range taps', () => {
+  it('escalates fist interactions to rapid on repeated in-range taps', async () => {
     const onAvatarInteraction = vi.fn();
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9);
     const live2dContainer = document.createElement('div');
@@ -4534,8 +4348,9 @@ describe('App', () => {
     });
 
     try {
-      render(<App onAvatarInteraction={onAvatarInteraction} />);
+      renderInputApp({ onAvatarInteraction });
 
+      await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
@@ -4556,7 +4371,7 @@ describe('App', () => {
     }
   });
 
-  it('does not emit avatar interactions when compact UI overlaps the avatar hit range', () => {
+  it('does not emit avatar interactions when compact UI overlaps the avatar hit range', async () => {
     const onAvatarInteraction = vi.fn();
     const live2dContainer = document.createElement('div');
     live2dContainer.id = 'live2d-container';
@@ -4591,8 +4406,9 @@ describe('App', () => {
     });
 
     try {
-      render(<App onAvatarInteraction={onAvatarInteraction} />);
+      renderInputApp({ onAvatarInteraction });
 
+      await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
       fireEvent.pointerDown(window, { button: 0, clientX: 150, clientY: 150 });
@@ -4609,9 +4425,10 @@ describe('App', () => {
     }
   });
 
-  it('selects an avatar tool from the group and clears it from the active badge', () => {
-    render(<App />);
+  it('selects an avatar tool from the group and clears it from the active badge', async () => {
+    renderInputApp();
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
 
     expect(screen.getByRole('group', { name: 'Tool icons' })).toBeInTheDocument();
@@ -4621,35 +4438,41 @@ describe('App', () => {
 
     fireEvent.click(lollipopButton);
 
+    await openCompactInputTools();
+
     const activeBadgeButton = screen.getByRole('button', { name: 'Emoji: 棒棒糖' });
     expect(activeBadgeButton).toHaveClass('is-active');
     expect(screen.queryByRole('group', { name: 'Tool icons' })).not.toBeInTheDocument();
 
     fireEvent.click(activeBadgeButton);
 
+    await openCompactInputTools();
     expect(screen.getByRole('button', { name: 'Emoji' })).toBeInTheDocument();
     expect(screen.queryByRole('group', { name: 'Tool icons' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Emoji: 棒棒糖' })).not.toBeInTheDocument();
   });
 
-  it('clears the selected avatar tool from the icon badge', () => {
-    render(<App />);
+  it('clears the selected avatar tool from the icon badge', async () => {
+    renderInputApp();
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
+    await openCompactInputTools();
     expect(screen.getByRole('button', { name: 'Emoji: 猫爪' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '恢复鼠标' }));
 
+    await openCompactInputTools();
     expect(screen.getByRole('button', { name: 'Emoji' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Emoji: 猫爪' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '恢复鼠标' })).not.toBeInTheDocument();
   });
 
-  it('emits avatar tool state changes for desktop hosts', () => {
+  it('emits avatar tool state changes for desktop hosts', async () => {
     const onAvatarToolStateChange = vi.fn();
-    render(<App onAvatarToolStateChange={onAvatarToolStateChange} />);
+    renderInputApp({ onAvatarToolStateChange });
 
     expect(onAvatarToolStateChange).toHaveBeenCalledWith(expect.objectContaining({
       active: false,
@@ -4658,6 +4481,7 @@ describe('App', () => {
     }));
 
     onAvatarToolStateChange.mockClear();
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '锤子' }));
 
@@ -4674,9 +4498,10 @@ describe('App', () => {
     }));
   });
 
-  it('anchors the desktop cursor overlay to the current pointer when a tool is activated', () => {
-    const { container } = render(<App />);
+  it('anchors the desktop cursor overlay to the current pointer when a tool is activated', async () => {
+    const { container } = renderInputApp();
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }), {
       clientX: 240,
@@ -4688,16 +4513,17 @@ describe('App', () => {
     expect((overlay as HTMLDivElement).style.transform).toBe('translate3d(201px, 274px, 0)');
   });
 
-  it('clears the tool cursor when the composer is hidden for voice mode', () => {
-    const { container, rerender } = render(<App />);
+  it('clears the tool cursor when the composer is hidden for voice mode', async () => {
+    const { container, rerender } = renderInputApp();
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
     expect(container.querySelector('.avatar-cursor-overlay')).not.toBeNull();
     expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
-    rerender(<App composerHidden />);
+    rerender(<App compactChatState="input" composerHidden />);
 
     expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
     expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
@@ -4705,16 +4531,17 @@ describe('App', () => {
     expect(document.documentElement.style.getPropertyValue('cursor')).toBe('auto');
   });
 
-  it('clears the tool cursor when the host issues a reset key', () => {
-    const { container, rerender } = render(<App />);
+  it('clears the tool cursor when the host issues a reset key', async () => {
+    const { container, rerender } = renderInputApp();
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
     expect(container.querySelector('.avatar-cursor-overlay')).not.toBeNull();
     expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
-    rerender(<App _toolCursorResetKey="voice-mode-reset-1" />);
+    rerender(<App compactChatState="input" _toolCursorResetKey="voice-mode-reset-1" />);
 
     expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
     expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
@@ -4722,10 +4549,11 @@ describe('App', () => {
     expect(document.documentElement.style.getPropertyValue('cursor')).toBe('auto');
   });
 
-  it('preserves the outside-window cursor state when the host resets a tool cursor', () => {
+  it('preserves the outside-window cursor state when the host resets a tool cursor', async () => {
     const onAvatarToolStateChange = vi.fn();
-    const { rerender } = render(<App onAvatarToolStateChange={onAvatarToolStateChange} />);
+    const { rerender } = renderInputApp({ onAvatarToolStateChange });
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
@@ -4738,7 +4566,7 @@ describe('App', () => {
     }));
 
     onAvatarToolStateChange.mockClear();
-    rerender(<App onAvatarToolStateChange={onAvatarToolStateChange} _toolCursorResetKey="voice-mode-reset-2" />);
+    rerender(<App compactChatState="input" onAvatarToolStateChange={onAvatarToolStateChange} _toolCursorResetKey="voice-mode-reset-2" />);
 
     expect(onAvatarToolStateChange).toHaveBeenCalledWith(expect.objectContaining({
       active: false,
@@ -4747,15 +4575,17 @@ describe('App', () => {
     }));
   });
 
-  it('marks the cursor back inside the host when clearing a tool from the composer', () => {
+  it('marks the cursor back inside the host when clearing a tool from the composer', async () => {
     const onAvatarToolStateChange = vi.fn();
-    render(<App onAvatarToolStateChange={onAvatarToolStateChange} />);
+    renderInputApp({ onAvatarToolStateChange });
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
     fireEvent.blur(window);
 
     onAvatarToolStateChange.mockClear();
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: '恢复鼠标' }));
 
     expect(onAvatarToolStateChange).toHaveBeenCalledWith(expect.objectContaining({
@@ -4765,9 +4595,10 @@ describe('App', () => {
     }));
   });
 
-  it('restores the native cursor while desktop system UI owns focus', () => {
-    const { container } = render(<App />);
+  it('restores the native cursor while desktop system UI owns focus', async () => {
+    const { container } = renderInputApp();
 
+    await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
@@ -4787,12 +4618,13 @@ describe('App', () => {
     expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
   });
 
-  it('uses the native cursor and clears it when leaving the Electron chat window', () => {
+  it('uses the native cursor and clears it when leaving the Electron chat window', async () => {
     (window as Window & { __NEKO_MULTI_WINDOW__?: boolean }).__NEKO_MULTI_WINDOW__ = true;
 
     try {
-      const { container } = render(<App />);
+      const { container } = renderInputApp();
 
+      await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
@@ -4812,7 +4644,7 @@ describe('App', () => {
     }
   });
 
-  it('shows the hammer secondary cursor asset on outside-range desktop clicks', () => {
+  it('shows the hammer secondary cursor asset on outside-range desktop clicks', async () => {
     const live2dContainer = document.createElement('div');
     live2dContainer.id = 'live2d-container';
     Object.defineProperty(live2dContainer, 'getClientRects', {
@@ -4836,8 +4668,9 @@ describe('App', () => {
     });
 
     try {
-      const { container } = render(<App />);
+      const { container } = renderInputApp();
 
+      await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '锤子' }));
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -9,7 +9,6 @@
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import MessageList from './MessageList';
 import CompactExportHistoryPanel, {
   COMPACT_EXPORT_SELECTION_LIMIT,
   isCompactExportMessageSelectable,
@@ -986,11 +985,11 @@ export default function App({
   inputPlaceholder = i18n('chat.textInputPlaceholder', 'Type a message...'),
   sendButtonLabel = i18n('chat.send', 'Send'),
   chatWindowAriaLabel = i18n('chat.reactWindowAriaLabel', 'Neko chat window'),
-  messageListAriaLabel = i18n('chat.messageListAriaLabel', 'Chat messages'),
-  composerToolsAriaLabel = i18n('chat.composerToolsAriaLabel', 'Composer tools'),
+  messageListAriaLabel: _messageListAriaLabel,
+  composerToolsAriaLabel: _composerToolsAriaLabel,
   composerHidden = false,
   composerDisabled = false,
-  chatSurfaceMode = 'full',
+  chatSurfaceMode = 'compact',
   compactChatState = 'default',
   composerAttachments = [],
   composerAttachmentsAriaLabel = i18n('chat.pendingImagesAriaLabel', 'Pending attachments'),
@@ -1011,7 +1010,7 @@ export default function App({
   galgameToggleButtonLabel = i18n('chat.galgameToggle', 'GalGame Mode'),
   galgameToggleButtonAriaLabel,
   galgameLoadingLabel = i18n('chat.galgameLoading', 'Generating options...'),
-  onMessageAction,
+  onMessageAction: _onMessageAction,
   onComposerImportImage,
   onComposerScreenshot,
   onComposerRemoveAttachment,
@@ -1021,7 +1020,7 @@ export default function App({
   onAvatarInteraction,
   onAvatarToolStateChange,
   onJukeboxClick,
-  onExportConversationClick,
+  onExportConversationClick: _onExportConversationClick,
   onTranslateToggle,
   onGalgameModeToggle,
   onGalgameOptionSelect,
@@ -1034,14 +1033,6 @@ export default function App({
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
   const [toolMenuOpen, setToolMenuOpen] = useState(false);
-  // Collapse the right-side tools into an overflow menu when the composer gets
-  // narrow, while preserving the exit and re-entry animations for the tool row.
-  type ComposerLayout = 'expanded' | 'collapsing' | 'compact' | 'expanding';
-  const [composerLayout, setComposerLayout] = useState<ComposerLayout>('expanded');
-  const showRightTools = composerLayout === 'expanded' || composerLayout === 'collapsing';
-  const [collapseFromWidth, setCollapseFromWidth] = useState<number | null>(null);
-  const [overflowMenuOpen, setOverflowMenuOpen] = useState(false);
-  const [composerBottomBarNode, setComposerBottomBarNode] = useState<HTMLDivElement | null>(null);
   const [activeCursorToolId, setActiveCursorToolId] = useState<string | null>(null);
   const [avatarRangeCursorVariants, setAvatarRangeCursorVariants] = useState<ToolCursorVariantState>(() => createDefaultToolCursorVariantState());
   const [outsideRangeCursorVariants, setOutsideRangeCursorVariants] = useState<ToolCursorVariantState>(() => createDefaultToolCursorVariantState());
@@ -1052,8 +1043,6 @@ export default function App({
   const [isInnerHammerEasterEggActive, setIsInnerHammerEasterEggActive] = useState(false);
   const appShellRef = useRef<HTMLElement | null>(null);
   const toolMenuRef = useRef<HTMLDivElement | null>(null);
-  const composerBottomBarRef = useRef<HTMLDivElement | null>(null);
-  const composerToolsRightRef = useRef<HTMLDivElement | null>(null);
   const compactInputShellRef = useRef<HTMLDivElement | null>(null);
   const compactInputToolToggleRef = useRef<HTMLButtonElement | null>(null);
   const compactInputToolFanRef = useRef<HTMLDivElement | null>(null);
@@ -1070,8 +1059,6 @@ export default function App({
   const compactInputToolFanInteractiveRef = useRef(false);
   const compactInputRef = useRef<HTMLTextAreaElement | null>(null);
   const compactChoiceLayerRef = useRef<HTMLDivElement | null>(null);
-  const composerLayoutRef = useRef<ComposerLayout>('expanded');
-  const overflowMenuRef = useRef<HTMLDivElement | null>(null);
   const avatarCursorOverlayRef = useRef<HTMLDivElement | null>(null);
   const hammerCursorOverlayRef = useRef<HTMLDivElement | null>(null);
   const hammerSwingTimeoutIdsRef = useRef<number[]>([]);
@@ -1262,7 +1249,7 @@ export default function App({
     compactChoiceInteractionsAllowed && galgameModeEnabled && !choicePromptHasOptions
     && (galgameOptionsLoading || galgameOptions.length > 0);
   const compactSurfaceChoicesVisible = choicePromptHasOptions || galgameOptionsVisible;
-  const isCompactSurface = chatSurfaceMode === 'compact';
+  const isCompactSurface = chatSurfaceMode !== 'minimized';
   const requestedCompactChatState = isCompactSurface && composerHidden && compactChatState === 'input'
     ? 'default'
     : compactChatState;
@@ -1329,9 +1316,7 @@ export default function App({
     && compactSurfaceResizeWidth !== null
     ? getClampedCompactSurfaceResizeWidth(compactSurfaceResizeWidth)
     : null;
-  const compactChoiceLayerOpen = !isCompactSurface
-    ? compactSurfaceChoicesVisible
-    : effectiveCompactChatState === 'options';
+  const compactChoiceLayerOpen = effectiveCompactChatState === 'options';
   const compactExportSelectedCount = compactExportSelectedIds.size;
   const compactExportSelectableMessages = useMemo(
     () => messages.filter(isCompactExportMessageSelectable),
@@ -1343,10 +1328,6 @@ export default function App({
   );
   const compactExportSelectableCount = compactExportSelectableMessages.length;
   const handleCompactExportConversationClick = useCallback(() => {
-    if (!isCompactSurface) {
-      onExportConversationClick?.();
-      return;
-    }
     setCompactExportHistoryOpen((open) => {
       const nextOpen = !open;
       persistCompactExportHistoryOpen(nextOpen);
@@ -1357,7 +1338,7 @@ export default function App({
       }
       return nextOpen;
     });
-  }, [isCompactSurface, onExportConversationClick]);
+  }, []);
   const handleCompactExportToggleMessage = useCallback((messageId: string) => {
     if (!compactExportSelectableIds.has(messageId)) return;
     setCompactExportSelectedIds((prev) => {
@@ -2479,11 +2460,6 @@ export default function App({
     clearCompactInputToolFanCloseTimer();
   }, [clearCompactInputToolFanCloseTimer]);
 
-  const handleComposerBottomBarRef = useCallback((node: HTMLDivElement | null) => {
-    composerBottomBarRef.current = node;
-    setComposerBottomBarNode(prev => (prev === node ? prev : node));
-  }, []);
-
   const collapseCompactInputIfEmpty = useCallback((options?: { ignoreFocusedShell?: boolean }) => {
     if (!isCompactSurface) return;
     if (effectiveCompactChatState !== 'input') return;
@@ -2906,100 +2882,6 @@ export default function App({
       document.removeEventListener('keydown', closeMenuOnEscape);
     };
   }, [toolMenuOpen]);
-
-  useEffect(() => {
-    composerLayoutRef.current = composerLayout;
-  }, [composerLayout]);
-
-  useEffect(() => {
-    const target = composerBottomBarNode;
-    if (!target || typeof ResizeObserver === 'undefined') return;
-    const COMPACT_THRESHOLD = 300;
-    const observer = new ResizeObserver(entries => {
-      for (const entry of entries) {
-        const wantCompact = entry.contentRect.width < COMPACT_THRESHOLD;
-        // 鍦?expanded 鈫?collapsing 杩欎竴鍒绘姄涓€涓嬪彸 4 鎸夐挳缁勭殑褰撳墠鍍忕礌瀹藉害锛?        // 鍚屼竴鎵?setState 浼氬拰 layout 鍒囨崲涓€璧?commit锛宺ender 鍑烘潵鏃?        // .is-leaving 绫诲拰 --collapse-from-width 鍙橀噺鍚屾椂鐢熸晥锛?        // CSS keyframe 灏辫兘浠庤繖涓浐瀹氬搴︽彃鍊煎埌 0銆?        // 鐢?offsetWidth 鑰岄潪 getBoundingClientRect().width锛氬墠鑰呭熀浜庡竷灞€鐩掞紝
-        // 涓嶅彈鍏ュ満 scaleX 鍔ㄧ敾褰卞搷锛涘鏋?expand 鍔ㄧ敾杩樻病璺戝畬灏卞張琚帇绐勶紝
-        if (wantCompact && composerLayoutRef.current === 'expanded' && composerToolsRightRef.current) {
-          const node = composerToolsRightRef.current;
-          const w = Math.max(node.offsetWidth, node.scrollWidth);
-          if (w > 0) setCollapseFromWidth(w);
-        }
-        setComposerLayout(prev => {
-          if (wantCompact) {
-            if (prev === 'expanded') return 'collapsing';
-            if (prev === 'expanding') return 'compact';
-            return prev;
-          } else {
-            if (prev === 'compact') return 'expanding';
-            if (prev === 'collapsing') return 'expanded';
-            return prev;
-          }
-        });
-      }
-    });
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [composerBottomBarNode]);
-
-  useEffect(() => {
-    if (isCompactSurface) {
-      setOverflowMenuOpen(false);
-      return;
-    }
-    if (!composerBottomBarNode) return;
-    if (composerBottomBarNode.getBoundingClientRect().width >= 300) {
-      setComposerLayout(prev => (
-        prev === 'compact' || prev === 'collapsing' ? 'expanded' : prev
-      ));
-    }
-  }, [composerBottomBarNode, isCompactSurface]);
-
-  // 鏀惰捣/灞曞紑鍔ㄧ敾璺戝畬鍚庡垏鍒扮ǔ鎬併€傛椂闀块渶涓?styles.css 涓殑 keyframes 瀵归綈銆?  // prefers-reduced-motion 涓?styles.css 鎶婂姩鐢昏鎴?none锛岃繖鏃惰繕绛?270/220ms
-  // 浼氳宸ュ叿鍖烘粸鐣欏湪杩囨浮鎬侊紙鎺т欢瑙嗚涓婃彁鍓嶅埌浣嶄絾 layout state 娌″垏锛夛紝
-  useEffect(() => {
-    const prefersReducedMotion =
-      typeof window !== 'undefined'
-      && typeof window.matchMedia === 'function'
-      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (composerLayout === 'collapsing') {
-      const timerId = window.setTimeout(() => {
-        setComposerLayout(prev => (prev === 'collapsing' ? 'compact' : prev));
-      }, prefersReducedMotion ? 0 : 270);
-      return () => window.clearTimeout(timerId);
-    }
-    if (composerLayout === 'expanding') {
-      const timerId = window.setTimeout(() => {
-        setComposerLayout(prev => (prev === 'expanding' ? 'expanded' : prev));
-      }, prefersReducedMotion ? 0 : 220);
-      return () => window.clearTimeout(timerId);
-    }
-    return undefined;
-  }, [composerLayout]);
-
-  useEffect(() => {
-    if (composerLayout !== 'compact') setOverflowMenuOpen(false);
-  }, [composerLayout]);
-
-  // 路路路 鑿滃崟鐨勫閮ㄧ偣鍑?/ Esc 鍏抽棴
-  useEffect(() => {
-    if (!overflowMenuOpen) return;
-    const closeOnOutsideClick = (event: MouseEvent) => {
-      const node = overflowMenuRef.current;
-      if (!node) return;
-      if (node.contains(event.target as Node)) return;
-      setOverflowMenuOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOverflowMenuOpen(false);
-    };
-    document.addEventListener('mousedown', closeOnOutsideClick);
-    document.addEventListener('keydown', closeOnEscape);
-    return () => {
-      document.removeEventListener('mousedown', closeOnOutsideClick);
-      document.removeEventListener('keydown', closeOnEscape);
-    };
-  }, [overflowMenuOpen]);
 
   useEffect(() => {
     if (!activeCursorToolId) return;
@@ -3440,153 +3322,6 @@ export default function App({
     });
     return true;
   }, [avatarToolCacheState, compactExportHistoryOpen, getCompactHistoryDesktopDropTarget, onCompactHistoryDrop, onComposerSubmit]);
-
-  const translateButtonNode = (
-    <button
-      className={`composer-tool-btn composer-translate-btn${translateEnabled ? ' is-active' : ''}`}
-      type="button"
-      aria-label={resolvedTranslateAriaLabel}
-      aria-pressed={translateEnabled}
-      title={translateButtonLabel}
-      disabled={composerDisabled}
-      onClick={() => onTranslateToggle?.()}
-    >
-      <img src="/static/icons/translate_icon.png" alt="" aria-hidden="true" />
-    </button>
-  );
-
-  const jukeboxButtonNode = (
-    <button
-      className="composer-tool-btn"
-      type="button"
-      aria-label={jukeboxButtonAriaLabel}
-      title={jukeboxButtonLabel}
-      disabled={composerDisabled}
-      onClick={() => onJukeboxClick?.()}
-    >
-      <img src="/static/icons/jukebox_icon.png" alt="" aria-hidden="true" />
-    </button>
-  );
-
-  const galgameToggleButtonNode = (
-    <button
-      className={`composer-tool-btn composer-galgame-btn${galgameModeEnabled ? ' is-active' : ''}`}
-      type="button"
-      aria-label={resolvedGalgameAriaLabel}
-      aria-pressed={galgameModeEnabled}
-      title={galgameToggleButtonLabel}
-      disabled={composerDisabled}
-      onClick={() => onGalgameModeToggle?.()}
-    >
-      <span className="composer-galgame-btn-glyph" aria-hidden="true">G</span>
-    </button>
-  );
-
-  const emojiToolMenuNode = (
-    <div className="composer-tool-menu" ref={toolMenuRef}>
-      <button
-        className={`composer-tool-btn composer-emoji-btn${toolMenuOpen || activeToolItem ? ' is-active' : ''}`}
-        type="button"
-        aria-label={selectedEmojiButtonAriaLabel}
-        title={selectedEmojiButtonAriaLabel}
-        aria-controls={toolMenuOpen ? 'composer-tool-popover' : undefined}
-        aria-expanded={toolMenuOpen}
-        disabled={composerDisabled}
-        onClick={() => {
-          if (activeToolItem) {
-            clearActiveCursorToolSelection();
-            return;
-          }
-          setToolMenuOpen(open => !open);
-        }}
-      >
-        <img
-          src={activeToolMenuVisual?.imagePath || '/static/icons/emoji_icon.png'}
-          style={activeToolItem ? {
-            transform: `translate(${activeToolMenuVisual?.offsetX ?? 0}px, ${activeToolMenuVisual?.offsetY ?? 0}px) scale(${activeToolItem.menuIconScale ?? 1})`,
-          } : undefined}
-          alt=""
-          aria-hidden="true"
-        />
-      </button>
-      {activeToolItem ? (
-        <button
-          className="composer-tool-clear-btn"
-          type="button"
-          aria-label={clearCursorToolAriaLabel}
-          title={clearCursorToolAriaLabel}
-          disabled={composerDisabled}
-          onClick={(event) => {
-            event.stopPropagation();
-            setIsCursorInsideHostWindow(true);
-            setActiveCursorToolId(null);
-            setToolMenuOpen(false);
-          }}
-        >
-          <span aria-hidden="true">脳</span>
-        </button>
-      ) : null}
-      {toolMenuOpen ? (
-        <div
-          id="composer-tool-popover"
-          className="composer-icon-popover"
-          role="group"
-          aria-label={toolIconsAriaLabel}
-        >
-          {toolIconItems.map(item => {
-            const itemLabel = getToolItemLabel(item);
-            const menuVariant = activeCursorToolId === item.id
-              ? effectiveCursorVariant
-              : 'primary';
-            const menuVisual = resolveMenuIconVisual(item, menuVariant);
-            return (
-            <button
-              key={item.id}
-              className={`composer-icon-button${activeCursorToolId === item.id ? ' is-active' : ''}`}
-              type="button"
-              aria-pressed={activeCursorToolId === item.id}
-              aria-label={itemLabel}
-              title={itemLabel}
-              disabled={composerDisabled}
-              onClick={(event) => {
-                latestPointerPositionRef.current = {
-                  x: event.clientX,
-                  y: event.clientY,
-                };
-                latestPointerTargetRef.current = event.currentTarget;
-                setIsCursorInsideHostWindow(true);
-                setIsCursorOverCompactCursorZone(true);
-                setCursorOverAvatarRange(
-                  isPointerWithinAvatarRange(event.clientX, event.clientY, avatarToolCacheState),
-                  { allowHold: true },
-                );
-                if (activeCursorToolId === item.id) {
-                  setActiveCursorToolId(null);
-                  setToolMenuOpen(false);
-                  return;
-                }
-                setAvatarRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
-                setOutsideRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
-                setActiveCursorToolId(item.id);
-                setToolMenuOpen(false);
-              }}
-            >
-              <img
-                className="composer-icon-button-image"
-                src={menuVisual.imagePath}
-                style={{
-                  transform: `translate(${menuVisual.offsetX}px, ${menuVisual.offsetY}px) scale(${item.menuIconScale ?? 1})`,
-                }}
-                alt=""
-                aria-hidden="true"
-              />
-            </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
 
   const compactFanCloseOnAction = (
     action: (() => void) | undefined,
@@ -4089,14 +3824,6 @@ export default function App({
     ? (typeof document !== 'undefined' ? createPortal(choiceLayerNode, document.body) : choiceLayerNode)
     : null;
 
-  const messageListNode = (
-    <MessageList
-      messages={messages}
-      ariaLabel={messageListAriaLabel}
-      failedStatusLabel={failedStatusLabel}
-      onAction={onMessageAction}
-    />
-  );
   const compactExportHistoryElement = isCompactSurface && compactExportHistoryOpen ? (
     <CompactExportHistoryPanel
       messages={messages}
@@ -4148,11 +3875,7 @@ export default function App({
         />
       </div>
     </section>
-  ) : (
-    <section className="chat-body">
-      {messageListNode}
-    </section>
-  );
+  ) : null;
 
   return (
     <main
@@ -4450,130 +4173,11 @@ export default function App({
                         {compactPreviewDisplayText}
                       </span>
                     </button>
-	                  )}
-		                </div>
-		                {compactInputToolFanNode}
-		              </div>
-            ) : (
-              <div
-                className="composer-input-shell"
-                data-compact-chat-state={effectiveCompactChatState}
-              >
-              <textarea
-                className="composer-input"
-                placeholder={inputPlaceholder}
-                aria-label={inputPlaceholder}
-                rows={1}
-                value={draft}
-                readOnly={composerDisabled}
-                disabled={composerDisabled}
-                onChange={(event) => { setDraft(event.target.value); }}
-                onKeyDown={(event) => {
-                  if (event.nativeEvent.isComposing) return;
-                  if (event.key === 'Enter' && !event.shiftKey) {
-                    event.preventDefault();
-                    submitDraft();
-                  }
-                }}
-              />
-              {!isCompactSurface ? choiceLayerNode : null}
-              <div
-                className="composer-bottom-bar"
-                ref={handleComposerBottomBarRef}
-              >
-                <div className="composer-bottom-tools" aria-label={composerToolsAriaLabel}>
-                  <button
-                    className="composer-tool-btn"
-                    type="button"
-                    aria-label={resolvedImportImageAriaLabel}
-                    title={importImageButtonLabel}
-                    disabled={composerDisabled}
-                    onClick={() => onComposerImportImage?.()}
-                  >
-                    <img src="/static/icons/import_image_icon.png" alt="" aria-hidden="true" />
-                  </button>
-                  <span className="composer-tool-divider" aria-hidden="true">|</span>
-                  <button
-                    className="composer-tool-btn"
-                    type="button"
-                    aria-label={resolvedScreenshotAriaLabel}
-                    title={screenshotButtonLabel}
-                    disabled={composerDisabled}
-                    onClick={() => onComposerScreenshot?.()}
-                  >
-                    <img src="/static/icons/screenshot_new_icon.png" alt="" aria-hidden="true" />
-                  </button>
-                  {/* 杩欐潯鍒嗛殧绗﹀湪 expanded / compact 涓ゆ€佷笅閮藉父椹诲悓涓€浣嶇疆锛?                      閬垮厤鍒囨崲鏃跺垎闅旂闂儊锛岃鍔ㄧ敾杩囨浮鏇撮『婊?*/}
-                  <span className="composer-tool-divider" aria-hidden="true">|</span>
-                  {showRightTools ? (
-                    <div
-                      ref={composerToolsRightRef}
-                      className={`composer-tools-right${composerLayout === 'collapsing' ? ' is-leaving' : ''}`}
-                      key="composer-tools-expanded"
-                      style={
-                        composerLayout === 'collapsing' && collapseFromWidth != null
-                          ? ({ '--collapse-from-width': `${collapseFromWidth}px` } as CSSProperties)
-                          : undefined
-                      }
-                    >
-                      {galgameToggleButtonNode}
-                      <span className="composer-tool-divider" aria-hidden="true">|</span>
-                      {translateButtonNode}
-                      <span className="composer-tool-divider" aria-hidden="true">|</span>
-                      {jukeboxButtonNode}
-                      <span className="composer-tool-divider" aria-hidden="true">|</span>
-                      {emojiToolMenuNode}
-                    </div>
-                  ) : (
-                    <div
-                      className={`composer-overflow-menu${composerLayout === 'expanding' ? ' is-leaving' : ''}`}
-                      key="composer-tools-collapsed"
-                      ref={overflowMenuRef}
-                    >
-                      <button
-                        className={`composer-tool-btn composer-overflow-btn${overflowMenuOpen ? ' is-active' : ''}`}
-                        type="button"
-                        aria-label={overflowMenuAriaLabel}
-                        title={overflowMenuAriaLabel}
-                        aria-haspopup="true"
-                        aria-expanded={overflowMenuOpen}
-                        disabled={composerDisabled}
-                        onClick={() => setOverflowMenuOpen(open => !open)}
-                      >
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                          aria-hidden="true"
-                          focusable="false"
-                        >
-                          <circle cx="6" cy="12" r="2" />
-                          <circle cx="12" cy="12" r="2" />
-                          <circle cx="18" cy="12" r="2" />
-                        </svg>
-                      </button>
-                      {overflowMenuOpen ? (
-                        <div
-                          className="composer-overflow-popover"
-                          role="group"
-                          aria-label={overflowMenuAriaLabel}
-                        >
-                          {galgameToggleButtonNode}
-                          {translateButtonNode}
-                          {jukeboxButtonNode}
-                          {emojiToolMenuNode}
-                        </div>
-                      ) : null}
-                    </div>
                   )}
                 </div>
-                <button className="send-button-circle" type="submit" aria-label={sendButtonLabel} disabled={!canSubmit}>
-                  <img src="/static/icons/send_new_icon.png" alt="" aria-hidden="true" />
-                </button>
+                {compactInputToolFanNode}
               </div>
-            </div>
-            )}
+            ) : null}
           </form>
         </footer>
       </section>

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1010,6 +1010,9 @@ export default function App({
   galgameToggleButtonLabel = i18n('chat.galgameToggle', 'GalGame Mode'),
   galgameToggleButtonAriaLabel,
   galgameLoadingLabel = i18n('chat.galgameLoading', 'Generating options...'),
+  // Retained for host API compatibility; the compact-only surface no longer
+  // renders the per-message action menu, so this handler is currently unused
+  // (the `_` prefix opts it out of unused-var lint).
   onMessageAction: _onMessageAction,
   onComposerImportImage,
   onComposerScreenshot,
@@ -1020,6 +1023,9 @@ export default function App({
   onAvatarInteraction,
   onAvatarToolStateChange,
   onJukeboxClick,
+  // Retained for host API compatibility; export lives outside the compact
+  // surface now, so this handler is currently unused (the `_` prefix opts it
+  // out of unused-var lint).
   onExportConversationClick: _onExportConversationClick,
   onTranslateToggle,
   onGalgameModeToggle,

--- a/frontend/react-neko-chat/src/message-schema.test.ts
+++ b/frontend/react-neko-chat/src/message-schema.test.ts
@@ -41,6 +41,16 @@ describe('message-schema', () => {
     expect(props.compactChatState).toBe('input');
   });
 
+  it('migrates the legacy "full" surface mode to compact instead of throwing', () => {
+    const props = parseChatWindowProps({
+      // Cast: 'full' is no longer part of the public type but mixed-version
+      // hosts can still send it; the schema must migrate rather than reject.
+      chatSurfaceMode: 'full' as unknown as 'compact',
+    });
+
+    expect(props.chatSurfaceMode).toBe('compact');
+  });
+
   it('accepts an avatar interaction callback in window props', () => {
     const onAvatarInteraction = vi.fn();
     const props = parseChatWindowProps({ onAvatarInteraction });

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -109,7 +109,7 @@ export const compactHistoryDragStatePayloadSchema = z.discriminatedUnion('active
   compactHistoryDragActiveStateSchema,
 ]);
 
-const chatSurfaceModeSchema = z.enum(['full', 'compact', 'minimized']);
+const chatSurfaceModeSchema = z.enum(['compact', 'minimized']);
 const compactChatStateSchema = z.enum(['default', 'options', 'input']);
 
 const galgameOptionSchema = z.object({

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -110,6 +110,15 @@ export const compactHistoryDragStatePayloadSchema = z.discriminatedUnion('active
 ]);
 
 const chatSurfaceModeSchema = z.enum(['compact', 'minimized']);
+// Mixed-version hosts (or any direct NekoChatWindow.mount consumer) may still
+// pass the legacy three-state value 'full' from before the home chat collapsed
+// to compact/minimized. Accept it at the parse boundary and migrate to
+// 'compact' — mirroring the localStorage migration — so the chat window keeps
+// mounting instead of throwing a ZodError. The public output stays two-state.
+const chatSurfaceModeInputSchema = z.preprocess(
+  (value) => (value === 'full' ? 'compact' : value),
+  chatSurfaceModeSchema,
+);
 const compactChatStateSchema = z.enum(['default', 'options', 'input']);
 
 const galgameOptionSchema = z.object({
@@ -264,7 +273,7 @@ export const chatWindowPropsSchema = z.object({
   exportConversationButtonAriaLabel: z.string().optional(),
   composerHidden: z.boolean().optional(),
   composerDisabled: z.boolean().optional(),
-  chatSurfaceMode: chatSurfaceModeSchema.optional(),
+  chatSurfaceMode: chatSurfaceModeInputSchema.optional(),
   compactChatState: compactChatStateSchema.optional(),
   onCompactChatStateChange: z.function()
     .args(compactChatStateSchema)

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3746,13 +3746,22 @@
                     pendingOpenAfterModelManagerHidden = true;
                     return;
                 }
+                // closeWindow 已经会重置 minimized，所以到这里通常 minimized=false
+                // 但如果外部直接调用 openWindow（未经 closeWindow），仍需处理
+                var wasMinimized = minimized;
+                if (wasMinimized) {
+                    // Opening a minimized window restores the last real surface.
+                    // Reset the logical surface BEFORE mountWindow() so React
+                    // rebuilds the compact body instead of the (blank) minimized
+                    // surface; closeWindow performs the same reset when it clears
+                    // the minimized shell.
+                    state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
+                    resetCompactChatState();
+                }
                 if (!mountWindow()) {
                     showToast(getI18nText('chat.reactWindowMountFailed', '聊天框挂载失败'), 3000);
                     return;
                 }
-                // closeWindow 已经会重置 minimized，所以到这里通常 minimized=false
-                // 但如果外部直接调用 openWindow（未经 closeWindow），仍需处理
-                var wasMinimized = minimized;
                 if (wasMinimized) {
                     // overlay 可能还隐藏，先显示再做展开动画
                     overlay.hidden = false;
@@ -3831,6 +3840,13 @@
                 shell.style.transform = 'none';
             }
             minimized = false;
+            // closeWindow clears the minimized shell directly without routing
+            // through setChatSurfaceMode, so the logical surface must be reset
+            // too. Otherwise state.chatSurfaceMode stays 'minimized' and the next
+            // openWindow() rebuilds the React props with chatSurfaceMode:
+            // 'minimized', rendering a blank body over a no-longer-minimized
+            // shell.
+            state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
             resetCompactChatState();
             savedShellSize = null;
             savedShellPosition = null;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -136,11 +136,15 @@
         }
         try {
             var raw = localStorage.getItem(CHAT_SURFACE_MODE_STORAGE_KEY);
-            if (raw === 'full') {
+            // The storage key only ever holds the restorable surface ('compact').
+            // Migrate any legacy value persisted by the old three-state build
+            // ('full') or a stray 'minimized' back to 'compact' so stale values
+            // don't linger in storage. Any other value (or first run) just
+            // resolves to 'compact' without an extra write.
+            if (raw === 'full' || raw === 'minimized') {
                 localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, 'compact');
-                return 'compact';
             }
-            return raw === 'compact' ? 'compact' : 'compact';
+            return 'compact';
         } catch (_) {
             return 'compact';
         }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -27,9 +27,9 @@
     var savedShellSize = null;
     var savedShellPosition = null; // {left, top} before minimize – used to fly back on expand
     var savedExpandedShellPosition = null; // last known full-surface desktop position
-    var lastRestorableChatSurfaceMode = 'full';
+    var lastRestorableChatSurfaceMode = 'compact';
     var _sortKeySeq = 0; // monotonically increasing sortKey counter
-    var CHAT_SURFACE_MODE_SEQUENCE = ['full', 'compact', 'minimized'];
+    var CHAT_SURFACE_MODE_SEQUENCE = ['compact', 'minimized'];
     var COMPACT_CHAT_STATES = ['default', 'options', 'input'];
 
     var state = {
@@ -49,7 +49,7 @@
         pendingRollbackDrafts: Object.create(null),
         rollbackDraft: '',
         _toolCursorResetKey: '',
-        chatSurfaceMode: 'full',
+        chatSurfaceMode: 'compact',
         compactChatState: 'default',
         // Off until init() reads the persisted preference post-barrier and
         // calls setGalgameModeEnabled(true) — that path fires the
@@ -73,7 +73,8 @@
     };
 
     function normalizeChatSurfaceMode(mode) {
-        return CHAT_SURFACE_MODE_SEQUENCE.indexOf(mode) >= 0 ? mode : 'full';
+        if (mode === 'full') return 'compact';
+        return CHAT_SURFACE_MODE_SEQUENCE.indexOf(mode) >= 0 ? mode : 'compact';
     }
 
     function normalizeCompactChatState(mode) {
@@ -110,7 +111,7 @@
     function getNextChatSurfaceMode(mode) {
         var normalized = normalizeChatSurfaceMode(mode);
         if (normalized === 'minimized') {
-            return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode) === 'compact' ? 'compact' : 'full';
+            return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
         }
         var currentIndex = CHAT_SURFACE_MODE_SEQUENCE.indexOf(normalized);
         var nextIndex = currentIndex >= 0
@@ -125,24 +126,28 @@
 
     function shouldPersistChatSurfaceModePreference() {
         // Desktop and web share the same page state contract. The caller only
-        // persists full/compact, so minimized still restores to the last real surface.
+        // persists compact only; minimized still restores to the last real surface.
         return true;
     }
 
     function readChatSurfaceModePreference() {
         if (!shouldPersistChatSurfaceModePreference()) {
-            return 'full';
+            return 'compact';
         }
         try {
             var raw = localStorage.getItem(CHAT_SURFACE_MODE_STORAGE_KEY);
-            return raw === 'compact' ? 'compact' : 'full';
+            if (raw === 'full') {
+                localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, 'compact');
+                return 'compact';
+            }
+            return raw === 'compact' ? 'compact' : 'compact';
         } catch (_) {
-            return 'full';
+            return 'compact';
         }
     }
 
     function persistChatSurfaceModePreference(mode) {
-        if (mode !== 'full' && mode !== 'compact') return;
+        if (mode !== 'compact') return;
         if (!shouldPersistChatSurfaceModePreference()) return;
         try {
             localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode);
@@ -3361,10 +3366,6 @@
             lastRestorableChatSurfaceMode = previousMode;
         }
 
-        if (!previousMinimized && previousMode === 'full') {
-            snapshotExpandedShellPositionFromShell();
-        }
-
         resetCompactChatState();
         state.chatSurfaceMode = normalized;
         persistChatSurfaceModePreference(normalized);
@@ -3374,13 +3375,6 @@
             setMinimized(nextMinimized);
         } else {
             syncChatSurfaceModeUI();
-        }
-
-        if (normalized === 'full' && previousMode === 'compact') {
-            clearCompactSurfaceAnchor();
-            clearCompactMinimizeBallAnchor();
-            restorePosition();
-            scheduleMobileContentLayout();
         }
 
         dispatchHostEvent('chat-surface-mode-change', {
@@ -3628,18 +3622,10 @@
                         restorePosition();
                         return;
                     }
-                    if (surfaceModeAfterExpand !== 'full') {
-                        syncCompactSurfaceAnchor();
+                    if (surfaceModeAfterExpand === 'minimized') {
                         return;
                     }
-                    var r = shell.getBoundingClientRect();
-                    var targetPosition = savedExpandedShellPosition || getStoredPosition();
-                    var clamped = clampPosition(targetPosition ? targetPosition.left : r.left, targetPosition ? targetPosition.top : r.top);
-                    applyPosition(clamped.left, clamped.top);
-                    rememberExpandedShellPosition(clamped.left, clamped.top);
-                    if (!window._chatAdapterActive) {
-                        persistPosition(clamped.left, clamped.top);
-                    }
+                    syncCompactSurfaceAnchor();
                 });
             };
             var onExpandEnd = function (e) {
@@ -3781,8 +3767,6 @@
                     if (getCurrentChatSurfaceMode() === 'compact') {
                         syncCompactSurfaceAnchor();
                         scheduleCompactMinimizeBallTracking();
-                    } else {
-                        restorePosition();
                     }
                     scheduleMobileContentLayout();
                 }
@@ -3939,10 +3923,6 @@
             // 最小化态下不持久化悬浮球坐标到展开态存储，
             // 否则 restorePosition 会把完整窗口放到悬浮球位置
             // 移动端坐标也不持久化，避免污染桌面端保存的位置
-            if (!minimized && !isMobileWidth() && getCurrentChatSurfaceMode() === 'full') {
-                rememberExpandedShellPosition(rect.left, rect.top);
-                persistPosition(rect.left, rect.top);
-            }
         }
 
         dragState = null;
@@ -4170,10 +4150,6 @@
                 try {
                     localStorage.setItem(MOBILE_HEIGHT_STORAGE_KEY, String(mobileUserHeight));
                 } catch (_) {}
-            } else if (getCurrentChatSurfaceMode() === 'full') {
-                persistPosition(rect.left, rect.top);
-                persistSize(rect.width, rect.height);
-                rememberExpandedShellPosition(rect.left, rect.top);
             }
         }
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -72,9 +72,34 @@ def test_close_from_minimized_preserves_compact_surface_mode():
 
     assert "state.chatSurfaceMode = 'full'" not in minimized_block
     assert "minimized = false;" in minimized_block
+    # closeWindow clears the minimized shell without routing through
+    # setChatSurfaceMode, so it must restore the logical surface to the last
+    # restorable mode. Otherwise the next openWindow() rebuilds the React props
+    # with chatSurfaceMode:'minimized' and renders a blank body.
+    assert (
+        "state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);"
+        in minimized_block
+    )
     assert "syncChatSurfaceModeUI();" in minimized_block
     assert "overlay.hidden = true;" in close_block
     assert "resetCompactChatState();" in close_block
+
+
+def test_open_from_minimized_restores_surface_mode_before_mounting():
+    source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    open_block = source.split("function openWindow()", 1)[1].split(
+        "function closeWindow()",
+        1,
+    )[0]
+    # The minimized restore branch must reset the logical surface BEFORE
+    # mountWindow() so React rebuilds the compact body instead of the blank
+    # minimized surface — symmetric with closeWindow's reset.
+    restore_assignment = (
+        "state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);"
+    )
+    assert restore_assignment in open_block
+    assert open_block.index(restore_assignment) < open_block.index("if (!mountWindow())")
 
 
 def test_minimized_restore_uses_previous_real_surface_mode():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -57,7 +57,7 @@ def test_chat_surface_mode_preference_is_shared_with_electron():
     assert "electron-chat-window" not in gate_block
     assert "return true;" in gate_block
     assert "localStorage.getItem(CHAT_SURFACE_MODE_STORAGE_KEY)" in read_block
-    assert "if (mode !== 'full' && mode !== 'compact') return;" in persist_block
+    assert "if (mode !== 'compact') return;" in persist_block
     assert "localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode)" in persist_block
 
 
@@ -80,7 +80,7 @@ def test_close_from_minimized_preserves_compact_surface_mode():
 def test_minimized_restore_uses_previous_real_surface_mode():
     source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 
-    assert "var lastRestorableChatSurfaceMode = 'full';" in source
+    assert "var lastRestorableChatSurfaceMode = 'compact';" in source
 
     next_mode_block = source.split("function getNextChatSurfaceMode(mode)", 1)[1].split(
         "function resetCompactChatState()",
@@ -101,7 +101,7 @@ def test_minimized_restore_uses_previous_real_surface_mode():
 
     assert "if (normalized === 'minimized')" in next_mode_block
     assert "lastRestorableChatSurfaceMode" in next_mode_block
-    assert "return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode) === 'compact' ? 'compact' : 'full';" in next_mode_block
+    assert "return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);" in next_mode_block
     assert "lastRestorableChatSurfaceMode = normalized;" in set_mode_block
     assert "lastRestorableChatSurfaceMode = previousMode;" in set_mode_block
     assert "lastRestorableChatSurfaceMode = normalizedChatSurfaceMode;" in set_view_props_block


### PR DESCRIPTION
## Summary

- 移除首页聊天框的 `full` 形态，只保留 `compact ↔ minimized` 两态；状态机序列改为 `['compact', 'minimized']`，默认 `compact`。
- localStorage 中遗留的 `chatSurfaceMode = 'full'` 在读取时自动迁移为 `'compact'`，只持久化 `'compact'`。
- React 侧删除 full composer 分支与 `MessageList` 接线：非 minimized 一律走 compact UI（`isCompactSurface = chatSurfaceMode !== 'minimized'`）；语音模式（`composerHidden`）下 compact 胶囊仍可见。
- 同步更新 message schema、宿主静态桥（`static/app-react-chat-window.js`）、设计文档与测试。

> 配套 Electron 侧改动见 N.E.K.O.-PC 的 PR（preload 将 `full` 归一化为 `compact` + 热键聚焦修复）。

## Changes

- `static/app-react-chat-window.js` — 两态状态机、`full→compact` 迁移、删除 full 位置 snapshot/restore 分支
- `frontend/react-neko-chat/src/App.tsx` — 移除 full UI / 独立 composer 分支
- `frontend/react-neko-chat/src/message-schema.ts` — `chatSurfaceMode` 枚举改为 `compact | minimized`
- `frontend/react-neko-chat/src/App.test.tsx` — legacy full composer 用例改测 compact input
- `tests/unit/test_react_chat_window_static.py` — 契约断言更新为只持久化 `compact`
- `docs/design/home-compact-chat-mode-design.md` — 两态形态文档

## Test plan

- [x] `npm --prefix frontend/react-neko-chat run typecheck`
- [x] `npm --prefix frontend/react-neko-chat test -- App.test.tsx` → 112 passed
- [x] `uv run pytest tests/unit/test_react_chat_window_static.py` → 16 passed
- [x] `node --check static/app-react-chat-window.js`
- [x] 人工：网页端默认 compact、两态切换、输入态、语音模式胶囊可见
- [ ] 已知遗留：左右缩放手柄手感问题（后续单独修，本 PR 不涉及）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 更新首页聊天形态设计：仅保留 compact 与 minimized，明确两态切换规则、输入态高度约束、迁移与验收要点

* **Refactor**
  * 默认界面切换为紧凑模式，移除对 full 的运行时支持；持久化/恢复与切换逻辑收敛为两态，简化展开/恢复与位置尺寸处理

* **Tests**
  * 重构测试 harness 与断言以适配紧凑输入态交互，新增兼容迁移用例以接受 legacy full 并映射为 compact
<!-- end of auto-generated comment: release notes by coderabbit.ai -->