### PR TITLE
fix(memory): embedding 推理加 token 预算分桶，治用户粘贴长文本顶爆 RSS

### DIFF
--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -154,34 +154,67 @@ def validate_catgirl_name(name: str, allow_dots: bool = False, *, reject_reserve
     return True, ""
 
 
+# 单条消息文本上限(字符)。现场触发的内存尖峰复盘:用户从外部
+# 复制一坨长文本粘贴进 recent → 整段以单条 message 形式落盘 → 后续
+# memory pipeline 把这条当成「stale entry」喂给 embedder → batch 内
+# pad-to-longest 把激活内存顶到多 GB(虽然 embedder 侧已加 token 预算
+# 兜底,这里仍在边界堵住「单条 megablob」的入口,避免把异常大对象
+# 漫到 ndjson / db / recall 等所有下游)。32K 字符 ≈ 32K token(中文)
+# 对正常对话足够宽松(单条 5K 中文 = 一篇较长文章),又把 worst-case
+# 入站体积钉住。
+_RECENT_MESSAGE_TEXT_MAX_CHARS = 32 * 1024
+# 整个 chat payload 的累计文本上限。控制「一次粘贴 1000 条 30K 文本」
+# 这种总量攻击/误操作。2 MB 对真实长会话仍宽裕,异常体积会被打回。
+_RECENT_CHAT_TOTAL_CHARS_MAX = 2 * 1024 * 1024
+# 消息条数上限。冗余防御:即使每条都很短,几十万条也能把后续
+# scan/embed/render 全拖死。
+_RECENT_CHAT_MAX_MESSAGES = 10000
+
+
 def validate_chat_payload(chat: any) -> tuple[bool, str]:
     """
     Validate the chat payload structure.
-    
+
     Args:
         chat: The chat payload to validate
-        
+
     Returns:
         tuple: (is_valid, error_message)
     """
     if not isinstance(chat, list):
         return False, "chat 必须是一个列表"
-    
+
+    if len(chat) > _RECENT_CHAT_MAX_MESSAGES:
+        return False, f"chat 消息数 {len(chat)} 超过上限 {_RECENT_CHAT_MAX_MESSAGES}"
+
+    total_chars = 0
     for idx, item in enumerate(chat):
         if not isinstance(item, dict):
             return False, f"chat[{idx}] 必须是一个字典"
-        
+
         # Validate required 'role' key
         if 'role' not in item:
             return False, f"chat[{idx}] 缺少必需的 'role' 字段"
-        
+
         if not isinstance(item['role'], str):
             return False, f"chat[{idx}]['role'] 必须是字符串"
-        
+
         # Validate optional 'text' key if present
-        if 'text' in item and not isinstance(item['text'], str):
-            return False, f"chat[{idx}]['text'] 必须是字符串"
-    
+        if 'text' in item:
+            if not isinstance(item['text'], str):
+                return False, f"chat[{idx}]['text'] 必须是字符串"
+            text_len = len(item['text'])
+            if text_len > _RECENT_MESSAGE_TEXT_MAX_CHARS:
+                return False, (
+                    f"chat[{idx}]['text'] 长度 {text_len} 超过单条上限 "
+                    f"{_RECENT_MESSAGE_TEXT_MAX_CHARS}(粘贴超长文本请拆分)"
+                )
+            total_chars += text_len
+            if total_chars > _RECENT_CHAT_TOTAL_CHARS_MAX:
+                return False, (
+                    f"chat 累计文本超过总量上限 {_RECENT_CHAT_TOTAL_CHARS_MAX}"
+                )
+
     return True, ""
 
 

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -245,7 +245,16 @@ def decode_embedding(emb: Any):
 # would reject every freshly stamped vector forever (size mismatch),
 # pinning the worker into an infinite re-embed loop. Codex review
 # PR #1147.
-_MODEL_ID_DIM_RE = re.compile(r"-(\d+)d-(?:int8|fp32)$")
+#
+# ``-mlen<N>`` 后缀(PR #1585):tokenizer 截断长度是 embedding 输入空间的
+# 一部分 —— 同一段 2K-token 文本在 max_length=8192 下喂全量、在
+# max_length=1024 下只喂前缀,得到的向量在同一模型下也不可比。把 mlen
+# 编进 model_id,降 max_length 时旧 cache 自动失效,worker 重新 embed,
+# 避免不同 token 输入空间的向量混用做 cosine。后缀可选(``mlen<N>?``)是
+# 为了向后兼容已经在用户磁盘上的老 cache id —— 它们解析 dim 仍然成功,
+# 在 is_cached_embedding_valid 里会因为 model_id 字符串比较失败被识别
+# 为 stale,然后被 worker 重新 stamp 上带 mlen 的新 id。
+_MODEL_ID_DIM_RE = re.compile(r"-(\d+)d-(?:int8|fp32)(?:-mlen\d+)?$")
 
 
 def parse_dim_from_model_id(model_id: str | None) -> int | None:
@@ -855,15 +864,27 @@ def _resolve_quantization(
     return "int8"
 
 
-def build_model_id(profile: str, dim: int, quantization: str) -> str:
+def build_model_id(
+    profile: str, dim: int, quantization: str, max_length: int | None = None,
+) -> str:
     """Return the canonical id used in ``embedding_model_id`` cache fields.
 
-    Format: ``<profile>-<dim>d-<quant>`` (e.g.
-    ``local-text-retrieval-v1-128d-int8``).
+    Format: ``<profile>-<dim>d-<quant>`` 或 ``<profile>-<dim>d-<quant>-mlen<N>``
+    (e.g. ``local-text-retrieval-v1-128d-int8-mlen1024``).
     A change to any axis flips the id, which invalidates cached
     embeddings on the next read — same idea as ``tokenizer_identity``.
+
+    ``max_length`` 是 tokenizer 截断长度 —— Codex 在 PR #1585 指出:同段
+    长文本在 max_length=8192 / max_length=1024 下喂进 ONNX 的 token 序列
+    根本不一样,得到的向量空间也不同;不编进 id 就会让升级后旧 cache
+    "看起来还有效",跟新 query 做 cosine 比较时静默偏移召回质量。
+    None 时回退到不带 mlen 的旧格式 — 仅给老调用点(如未传 max_length
+    的 legacy 测试 fixture)做兼容,真正的 service 路径总会传。
     """
-    return f"{profile}-{dim}d-{quantization}"
+    base = f"{profile}-{dim}d-{quantization}"
+    if max_length is None:
+        return base
+    return f"{base}-mlen{max_length}"
 
 
 def _profile_exists(model_dir: str, profile_id: str) -> bool:
@@ -1100,7 +1121,12 @@ class EmbeddingService:
             or self._quantization not in ("int8", "fp32")
         ):
             return None
-        return build_model_id(self._profile_id, self._dim, self._quantization)
+        return build_model_id(
+            self._profile_id,
+            self._dim,
+            self._quantization,
+            DEFAULT_VECTORS_MAX_LENGTH,
+        )
 
     def dim(self) -> int | None:
         return self._dim

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -104,7 +104,19 @@ DEFAULT_VECTORS_MODEL_PROFILE_ID = "local-text-retrieval-v1"
 DEFAULT_VECTORS_QUANTIZATION = "auto"             # "auto" | "int8" | "fp32"
 DEFAULT_VECTORS_MIN_RAM_GB = 4.0
 DEFAULT_VECTORS_MODEL_DIR_NAME = "embedding_models"
-DEFAULT_VECTORS_MAX_LENGTH = 8192
+DEFAULT_VECTORS_MAX_LENGTH = 1024
+
+# 推理峰值上限。激活内存近似 ``batch × seq × hidden × layers``;固定
+# batch + pad-to-longest 让一条长文本就能把激活顶到上百 GB(实测:
+# 用户粘贴一段长 recent 进记忆,凛天上线那个 sweep 把 RSS 从 1.1 GB
+# 顶到 12.4 GB)。改成 token 预算 ``batch × max_len ≤ _INFER_TOKEN_BUDGET``,
+# 长文本时 batch 自动缩到 1~2 条,峰值有硬上界。
+#
+# 选 16384:在新 max_length=1024 下,一桶能放下 16 条满长(等同
+# worker BATCH_SIZE=16 的原行为),正常路径吞吐零损失;当历史数据 /
+# 测试 / 自定义 profile 把 max_length 顶到旧 8192 时也只允许 2 条
+# 一桶,峰值仍可控。"""
+_INFER_TOKEN_BUDGET = 16384
 
 # Matryoshka discrete steps supported by the default local profile.
 _DIM_STEPS = (32, 64, 128, 256, 512, 768)
@@ -1251,6 +1263,12 @@ class EmbeddingService:
         sess_opts = ort.SessionOptions()
         sess_opts.intra_op_num_threads = max(1, (os.cpu_count() or 2) // 2)
         sess_opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        # Arena 默认 True(BFCArena 只涨不还):一次性大分配后 RSS 永久
+        # 钉在高水位,把瞬时尖峰变成永久占用。我们的输入有 _INFER_TOKEN_BUDGET
+        # 兜底,峰值已可控;关掉 arena 让分配器跟实际需求走,RSS 能跌回,
+        # 也避免冷路径偶发长批次永久污染基线。代价:每次 run 重新 malloc,
+        # CPU 推理本来就 100ms+ 级,malloc 几 μs 可忽略。
+        sess_opts.enable_cpu_mem_arena = False
         self._session = ort.InferenceSession(
             model_path, sess_options=sess_opts, providers=["CPUExecutionProvider"],
         )
@@ -1267,22 +1285,72 @@ class EmbeddingService:
         encodes the dim: a 64-d cached vector and a 256-d freshly
         computed vector are NOT comparable, even though they come from
         the same checkpoint, so the cache key MUST contain the dim.
+
+        Sub-batching: ``texts`` arrives already capped by the worker's
+        ``BATCH_SIZE`` (currently 16), but pad-to-longest means a single
+        long entry can blow up activation memory for the whole batch
+        (a long blob pasted into recent → entire 16-batch padded to
+        thousands of tokens → multi-GB activations). We re-bucket here
+        by token budget ``batch × max_len ≤ _INFER_TOKEN_BUDGET``: short
+        rows still pack densely (same throughput as before for the
+        normal case), and long rows fall into smaller buckets — capping
+        the per-run activation footprint regardless of input shape.
         """
         if self._session is None or self._tokenizer is None:
             raise RuntimeError("session not loaded")
         encoded = self._tokenizer.encode_batch(texts)
-        ids = [e.ids for e in encoded]
-        mask = [e.attention_mask for e in encoded]
-        # Pad to longest. Only allocate as much as we need — model accepts
-        # variable length within its 32K context.
-        max_len = max(len(x) for x in ids)
         import numpy as np
-        ids_arr = np.zeros((len(texts), max_len), dtype=np.int64)
-        mask_arr = np.zeros((len(texts), max_len), dtype=np.int64)
+
+        input_names = {i.name for i in self._session.get_inputs()}
+        # 按长度升序桶装。排序的目的是让相近长度凑一起,避免「一条短一条长」
+        # 浪费 padding 预算。每条出桶时记录 original index,run 完按原顺序填回。
+        order = sorted(range(len(encoded)), key=lambda i: len(encoded[i].ids))
+        out: list[list[float] | None] = [None] * len(texts)
+
+        bucket_idx: list[int] = []
+        bucket_max_len = 0
+        for orig_i in order:
+            n = len(encoded[orig_i].ids)
+            new_max = max(bucket_max_len, n)
+            # 空桶必接受(哪怕单条 > budget),否则极端 max_length 配置会死锁;
+            # 非空桶按预算 flush。
+            if bucket_idx and new_max * (len(bucket_idx) + 1) > _INFER_TOKEN_BUDGET:
+                self._run_bucket(bucket_idx, encoded, input_names, out, np)
+                bucket_idx = [orig_i]
+                bucket_max_len = n
+            else:
+                bucket_idx.append(orig_i)
+                bucket_max_len = new_max
+        if bucket_idx:
+            self._run_bucket(bucket_idx, encoded, input_names, out, np)
+
+        # 桶分配按 range(len(encoded)) 全覆盖 — 任何 None 残留都是 bug
+        # 而不是「正常但失败」,所以这里 assert 而不是静默过滤(过滤会改长度,
+        # 把 zip(texts, vectors) 错位)。
+        assert all(v is not None for v in out), "bucket coverage gap"
+        return out  # type: ignore[return-value]
+
+    def _run_bucket(
+        self,
+        bucket_idx: list[int],
+        encoded: list,
+        input_names: set,
+        out: list,
+        np,
+    ) -> None:
+        """单桶的 pad → ONNX run → pool → L2-norm → 写回 ``out``。
+
+        拆出来纯粹是为了让 ``_infer_blocking`` 的桶装循环短一些;状态全
+        通过参数传,无副作用(``out`` 是按 original index 原地写)。
+        """
+        ids = [encoded[i].ids for i in bucket_idx]
+        mask = [encoded[i].attention_mask for i in bucket_idx]
+        max_len = max(len(x) for x in ids)
+        ids_arr = np.zeros((len(bucket_idx), max_len), dtype=np.int64)
+        mask_arr = np.zeros((len(bucket_idx), max_len), dtype=np.int64)
         for i, (id_row, mask_row) in enumerate(zip(ids, mask)):
             ids_arr[i, : len(id_row)] = id_row
             mask_arr[i, : len(mask_row)] = mask_row
-        input_names = {i.name for i in self._session.get_inputs()}
         feeds = {"input_ids": ids_arr}
         if "attention_mask" in input_names:
             feeds["attention_mask"] = mask_arr
@@ -1293,13 +1361,14 @@ class EmbeddingService:
         # and Matryoshka-truncate to the active dim.
         token_embeddings = outputs[0]
         last_indices = np.maximum(mask_arr.sum(axis=1) - 1, 0)
-        pooled = token_embeddings[np.arange(len(texts)), last_indices]
+        pooled = token_embeddings[np.arange(len(bucket_idx)), last_indices]
         if self._dim is not None and self._dim < pooled.shape[1]:
             pooled = pooled[:, : self._dim]
         norms = np.linalg.norm(pooled, axis=1, keepdims=True)
         norms = np.where(norms == 0, 1.0, norms)
         normalized = pooled / norms
-        return [row.tolist() for row in normalized]
+        for i, orig_i in enumerate(bucket_idx):
+            out[orig_i] = normalized[i].tolist()
 
     # ── disable bookkeeping ──────────────────────────────────────────
 

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -144,6 +144,13 @@ class _DisableReason(enum.Enum):
     # the install commands diverge.
     NO_TOKENIZERS = "tokenizers_not_importable"
     NO_MODEL_FILE = "model_file_missing"
+    # ``enable_truncation`` 失败 = tokenizer 实例存在但截断契约没能建立。
+    # 必须当成 load 失败(Codex / CodeRabbit 在 PR #1585 联合指出 P2):
+    # ``model_id`` 现在把 max_length 编进 cache id,如果继续 ready,长文本
+    # 会被「未截断」地编码、却 stamp 成 ``-mlen1024``,跟未来真的 1024 截
+    # 断的 vector 在同一 id 下混存,is_cached_embedding_valid 会判它们「同
+    # 一空间」做 cosine,召回质量静默漂移。宁可 disable 也不能错配 cache。
+    TRUNCATION_SETUP_FAILED = "tokenizer_truncation_setup_failed"
     # Default bundle is INT8. ``auto`` picks INT8 when *any* usable SIMD int8
     # path exists: AVX-VNNI (fast) OR plain AVX2 (slower but fine for our nano
     # model + small corpus). Only when BOTH are confirmed absent (SSE-only
@@ -1301,8 +1308,16 @@ class EmbeddingService:
         self._tokenizer = Tokenizer.from_file(tokenizer_path)
         try:
             self._tokenizer.enable_truncation(max_length=DEFAULT_VECTORS_MAX_LENGTH)
-        except Exception as e:  # noqa: BLE001 — old tokenizers can still run without it
-            logger.warning("EmbeddingService: tokenizer truncation setup failed: %s", e)
+        except Exception as e:  # noqa: BLE001
+            # 不能继续 ready —— 见 _DisableReason.TRUNCATION_SETUP_FAILED 注释:
+            # model_id 把 max_length 编进 cache id,truncation 没生效时长文本
+            # 会被未截断地编码、却 stamp 成 mlen1024,污染 cache 语义。让 load
+            # 失败走 disable 路径,fallback service 接管,比错配 cache 安全得多。
+            logger.warning(
+                "EmbeddingService: tokenizer truncation setup failed (max_length=%d): %s",
+                DEFAULT_VECTORS_MAX_LENGTH, e,
+            )
+            raise _DisabledError(_DisableReason.TRUNCATION_SETUP_FAILED) from e
 
     def _infer_blocking(self, texts: list[str]) -> list[list[float]]:
         """Tokenize + run ONNX session + L2-normalize + Matryoshka-trunc.

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the token-budget sub-batching in
+``EmbeddingService._infer_blocking``.
+
+背景:之前 ``_infer_blocking`` 用 pad-to-longest + 固定 batch(BATCH_SIZE=16),
+一条粘贴进 recent 的长文本会让整批 16 条都 pad 到几千 token,激活内存
+顶到多 GB(实测把 RSS 从 1.1 GB 顶到 12.4 GB)。修复改成桶装:
+``batch_size × max_len ≤ _INFER_TOKEN_BUDGET``。
+
+测试目标:
+- 桶分边界正确(满桶 vs 必须 flush)
+- 单条 token 数 > budget 时仍能跑(空桶必接受)
+- 输出顺序跟输入对齐(桶内按长度排序,出桶时按 original idx 还原)
+- 不依赖 onnxruntime/tokenizers/numpy(用 monkeypatched session + 假
+  encoded 对象),所以本机没装这些重依赖也能跑。
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# numpy 是 embedding service 推理必备,缺失就 skip——跟现有
+# test_embeddings_fallback.py 的态度一致(测试只跑在能真测的环境)。
+np = pytest.importorskip("numpy")
+
+
+class _FakeEncoded:
+    """模拟 tokenizers.Encoding 接口的最小对象。只用 ids / attention_mask。"""
+    def __init__(self, n_tokens: int):
+        self.ids = list(range(1, n_tokens + 1))
+        self.attention_mask = [1] * n_tokens
+
+
+class _FakeSession:
+    """模拟 ort.InferenceSession.run:返回固定 hidden_dim 的 token embeddings。
+
+    记录每次 run 的 (batch_size, seq_len),让测试断言桶分行为。
+    """
+    HIDDEN = 32  # 测试用小 hidden,跟生产 256/768 无关
+
+    def __init__(self):
+        self.calls: list[tuple[int, int]] = []
+
+    def get_inputs(self):
+        # 只暴露 input_ids 一个入口,跳过 attention_mask / token_type_ids
+        # 分支(那部分单独有 prod 路径覆盖,这里专注桶分)。
+        inp = types.SimpleNamespace(name="input_ids")
+        return [inp]
+
+    def run(self, output_names, feeds):
+        ids = feeds["input_ids"]
+        batch, seq = ids.shape
+        self.calls.append((batch, seq))
+        # 返回 (batch, seq, hidden) — 每个 token embedding 用 row idx 当
+        # 特征值,这样输出能区分行,后续断言可以验证顺序对齐。
+        out = np.zeros((batch, seq, self.HIDDEN), dtype=np.float32)
+        for i in range(batch):
+            out[i, :, 0] = float(ids[i, 0])  # 每行首 token id 编码进 hidden[0]
+        return [out]
+
+
+@pytest.fixture
+def service_with_fake_session(monkeypatch):
+    """返回一个 EmbeddingService 实例,session/tokenizer 已被 monkeypatch。
+
+    用 ``object.__new__`` 跳过 ``__init__``,避免被 config_manager / 文件
+    路径 / RAM 检测等副作用拖累——我们只想测 _infer_blocking 的桶分。
+    """
+    # 必须在这里 import,而不是文件顶层:onnxruntime 不一定装,顶层
+    # import memory.embeddings 会触发 _build_default_service 的 import
+    # 链(虽然 service 是 lazy 的,但模块顶层 import 还是会跑)。所以
+    # importorskip 一下,让没装 ort 的环境干净 skip。
+    pytest.importorskip("tokenizers")  # _build_default_service 需要,但
+    # 我们不真走那条路;importorskip 只是兜底。
+    embeddings = pytest.importorskip("memory.embeddings")
+    svc = object.__new__(embeddings.EmbeddingService)
+    fake_sess = _FakeSession()
+    svc._session = fake_sess
+    svc._tokenizer = object()  # 占位,只要不是 None 就行(不会被调到)
+    svc._dim = None  # 不做 Matryoshka 截断
+    return svc, fake_sess, embeddings
+
+
+def _run_with_lengths(svc, fake_sess, embeddings_mod, lengths):
+    """直接喂预 tokenized 的 encoded 列表给 _run_bucket / _infer_blocking
+    走桶分。绕过 tokenizer.encode_batch,直接 monkeypatch tokenizer。
+    """
+    encoded = [_FakeEncoded(n) for n in lengths]
+    svc._tokenizer = types.SimpleNamespace(encode_batch=lambda texts: encoded)
+    # texts 列表只起占位作用,长度跟 encoded 对齐就行
+    texts = ["x"] * len(lengths)
+    return svc._infer_blocking(texts)
+
+
+def test_short_batch_runs_in_single_bucket(service_with_fake_session):
+    """全部短文本(总和远小于 budget)→ 一个桶搞定,行为等同旧 fast path。"""
+    svc, sess, emb = service_with_fake_session
+    out = _run_with_lengths(svc, sess, emb, [10, 12, 15, 8])
+    assert len(out) == 4
+    assert len(sess.calls) == 1
+    batch, seq = sess.calls[0]
+    assert batch == 4
+    assert seq == 15  # pad 到桶内最长
+
+
+def test_long_entries_split_into_multiple_buckets(service_with_fake_session):
+    """16 条全顶 1024 token → 16×1024=16384 正好等于 budget 16384,装得下;
+    再多一条就拆桶。验证桶分按 ``batch × max_len ≤ budget`` 触发。"""
+    svc, sess, emb = service_with_fake_session
+    lengths = [1024] * 17
+    out = _run_with_lengths(svc, sess, emb, lengths)
+    assert len(out) == 17
+    # 第一桶 16 条 × 1024 = 16384 = budget,刚好装下;第 17 条独占第二桶
+    assert len(sess.calls) == 2
+    batches = sorted(c[0] for c in sess.calls)
+    assert batches == [1, 16]
+
+
+def test_single_overlong_entry_still_runs(service_with_fake_session):
+    """单条 > budget 时,空桶必接受(否则永远 flush 不出去)。"""
+    svc, sess, emb = service_with_fake_session
+    out = _run_with_lengths(svc, sess, emb, [emb._INFER_TOKEN_BUDGET + 1000])
+    assert len(out) == 1
+    assert len(sess.calls) == 1
+    batch, seq = sess.calls[0]
+    assert batch == 1
+    assert seq == emb._INFER_TOKEN_BUDGET + 1000
+
+
+def test_mixed_length_preserves_original_order(service_with_fake_session):
+    """桶内按长度排序,但 _infer_blocking 必须按 original idx 还原输出顺序,
+    否则 zip(texts, vectors) 错位会让缓存键全错。"""
+    svc, sess, emb = service_with_fake_session
+    # 5 条混合长度:用首 token id(=1)区分每行,验证顺序
+    lengths = [50, 5, 100, 8, 200]
+    out = _run_with_lengths(svc, sess, emb, lengths)
+    assert len(out) == 5
+    # 每行 hidden[0] 应当 = ids[0] = 1(_FakeEncoded 的 ids 起 1),
+    # L2-norm 后 = 1/||v||。我们只验证输出对应输入是非 None 的有限值,
+    # 顺序对齐由 out[orig_i] 赋值机制保证(单测断言的是「不漏不错位」)。
+    assert all(v is not None for v in out)
+    assert all(len(v) == _FakeSession.HIDDEN for v in out)
+
+
+def test_one_long_entry_does_not_pollute_short_batch(service_with_fake_session):
+    """关键回归用例:一条 8000 token + 15 条 100 token 不应该让 15 条短的
+    一起 pad 到 8000(那正是修复前的内存炸点)。"""
+    svc, sess, emb = service_with_fake_session
+    lengths = [100] * 15 + [8000]
+    out = _run_with_lengths(svc, sess, emb, lengths)
+    assert len(out) == 16
+    # 至少一个桶的 seq_len < 8000(短文本桶),验证长文本被隔离
+    max_seqs = [c[1] for c in sess.calls]
+    assert min(max_seqs) <= 100, (
+        f"短文本不应被长文本带飞 padding: {sess.calls}"
+    )
+    # 长文本必须独占一桶 batch=1,否则同桶其他条目又被拖到 8000
+    long_calls = [c for c in sess.calls if c[1] >= 8000]
+    assert long_calls and all(c[0] == 1 for c in long_calls)
+
+
+def test_empty_input_returns_empty(service_with_fake_session):
+    svc, sess, emb = service_with_fake_session
+    out = _run_with_lengths(svc, sess, emb, [])
+    assert out == []
+    assert sess.calls == []

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -16,7 +16,6 @@
 """
 from __future__ import annotations
 
-import sys
 import types
 
 import pytest

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -222,6 +222,71 @@ def test_parse_dim_handles_both_id_formats():
     assert embeddings.parse_dim_from_model_id("foo-bar-128d-fp32-mlen8192") == 128
 
 
+def test_truncation_failure_aborts_load_with_distinct_reason():
+    """`enable_truncation` 失败时 _load_session_blocking 必须 raise
+    _DisabledError(TRUNCATION_SETUP_FAILED),而不是 ready 后继续 stamp
+    错配的 mlen cache id(Codex + CodeRabbit 在 PR #1585 联合指出的 P2)。
+
+    跑法:monkeypatch Tokenizer.from_file 返回一个 enable_truncation 抛错
+    的假 tokenizer,然后调 _load_session_blocking,断言它 raises 正确的
+    DisabledError + reason。session 创建那段也 monkeypatch 掉避免依赖
+    真模型文件。
+    """
+    embeddings = pytest.importorskip("memory.embeddings")
+    # 准备假 service 实例(同前)
+    svc = object.__new__(embeddings.EmbeddingService)
+    svc._profile_id = "test-profile"
+    svc._model_dir = "/nonexistent"  # 路径检查会过(monkeypatch 掉)
+    svc._quantization = "int8"
+    svc._dim = 256
+
+    # monkeypatch 文件检查 + onnxruntime + tokenizers,只让 enable_truncation
+    # 失败那一步成为决定性 failure。
+    import sys as _sys
+    monkey = {}
+
+    def fake_nonempty(_path):
+        return True
+    monkey["_is_nonempty_file"] = embeddings._is_nonempty_file
+    embeddings._is_nonempty_file = fake_nonempty
+
+    # 伪 ort 模块
+    fake_ort = types.SimpleNamespace(
+        SessionOptions=lambda: types.SimpleNamespace(
+            intra_op_num_threads=0,
+            graph_optimization_level=0,
+            enable_cpu_mem_arena=True,
+        ),
+        InferenceSession=lambda *a, **kw: object(),
+        GraphOptimizationLevel=types.SimpleNamespace(ORT_ENABLE_ALL=0),
+    )
+    monkey["onnxruntime"] = _sys.modules.get("onnxruntime")
+    _sys.modules["onnxruntime"] = fake_ort
+
+    # 伪 tokenizers:from_file 返回一个 enable_truncation 必抛的对象
+    class _BadTokenizer:
+        def enable_truncation(self, **_):
+            raise RuntimeError("simulated truncation failure")
+    fake_tk_mod = types.SimpleNamespace(
+        Tokenizer=types.SimpleNamespace(from_file=lambda _: _BadTokenizer()),
+    )
+    monkey["tokenizers"] = _sys.modules.get("tokenizers")
+    _sys.modules["tokenizers"] = fake_tk_mod
+
+    try:
+        with pytest.raises(embeddings._DisabledError) as exc_info:
+            svc._load_session_blocking()
+        assert exc_info.value.reason == embeddings._DisableReason.TRUNCATION_SETUP_FAILED
+    finally:
+        # 还原 monkeypatch
+        embeddings._is_nonempty_file = monkey["_is_nonempty_file"]
+        for k in ("onnxruntime", "tokenizers"):
+            if monkey[k] is None:
+                _sys.modules.pop(k, None)
+            else:
+                _sys.modules[k] = monkey[k]
+
+
 def test_old_cache_id_invalidated_after_max_length_change():
     """端到端:max_length 从 8192 降到 1024 时,老 cache row(id 含 mlen8192)
     应被 ``is_cached_embedding_valid`` 判为 stale,触发 worker 重新 embed。

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -166,3 +166,55 @@ def test_empty_input_returns_empty(service_with_fake_session):
     out = _run_with_lengths(svc, sess, emb, [])
     assert out == []
     assert sess.calls == []
+
+
+# ── Codex PR #1585 P2:max_length 进 model_id 防止跨截断长度复用 cache ──
+
+def test_build_model_id_includes_max_length_when_provided():
+    """新调用必须把 max_length 编进 id 末尾,这样降 max_length 时旧 cache
+    会因 id 字符串不等被 ``is_cached_embedding_valid`` 判为 stale。"""
+    embeddings = pytest.importorskip("memory.embeddings")
+    mid = embeddings.build_model_id("local-text-retrieval-v1", 256, "int8", 1024)
+    assert mid == "local-text-retrieval-v1-256d-int8-mlen1024"
+
+
+def test_build_model_id_omits_max_length_when_none():
+    """legacy 调用(没传 max_length)保留旧格式 —— 不破坏老测试 fixture。"""
+    embeddings = pytest.importorskip("memory.embeddings")
+    mid = embeddings.build_model_id("local-text-retrieval-v1", 128, "fp32")
+    assert mid == "local-text-retrieval-v1-128d-fp32"
+
+
+def test_parse_dim_handles_both_id_formats():
+    """parse_dim_from_model_id 必须同时解析老格式(磁盘上已有 cache)和
+    新格式(新写入)。否则升级时老 cache 全部解析失败 → 全部判 stale →
+    一次大规模重 embed,虽不致命但浪费 CPU。"""
+    embeddings = pytest.importorskip("memory.embeddings")
+    # 老格式
+    assert embeddings.parse_dim_from_model_id("local-text-retrieval-v1-256d-int8") == 256
+    # 新格式
+    assert embeddings.parse_dim_from_model_id("local-text-retrieval-v1-256d-int8-mlen1024") == 256
+    assert embeddings.parse_dim_from_model_id("foo-bar-128d-fp32-mlen8192") == 128
+
+
+def test_old_cache_id_invalidated_after_max_length_change():
+    """端到端:max_length 从 8192 降到 1024 时,老 cache row(id 含 mlen8192)
+    应被 ``is_cached_embedding_valid`` 判为 stale,触发 worker 重新 embed。
+    这是 Codex P2 的核心防御点 —— 否则新 query(1024 截前缀)会跟老
+    embedding(8192 截全量)做 cosine,得到偏移的相似度。"""
+    embeddings = pytest.importorskip("memory.embeddings")
+    old_id = "local-text-retrieval-v1-256d-int8-mlen8192"
+    new_id = "local-text-retrieval-v1-256d-int8-mlen1024"
+    # 构造一个看似有效的 cache row(填上 256-d 的假 base64 vector)
+    import base64, struct
+    fake_vec = base64.b64encode(struct.pack(f"<{256}e", *([0.1] * 256))).decode()
+    entry = {
+        "embedding": fake_vec,
+        "embedding_text_sha256": embeddings._embedding_text_sha256("hello"),
+        "embedding_model_id": old_id,
+    }
+    # 同样的 text,但运行时 model_id 已经升级 → 应该 stale
+    assert not embeddings.is_cached_embedding_valid(entry, "hello", new_id)
+    # sanity:同 id 仍然有效(不是把所有 cache 都误杀)
+    entry_match = dict(entry, embedding_model_id=new_id)
+    assert embeddings.is_cached_embedding_valid(entry_match, "hello", new_id)

--- a/tests/unit/test_embedding_token_budget.py
+++ b/tests/unit/test_embedding_token_budget.py
@@ -36,6 +36,16 @@ class _FakeSession:
     """模拟 ort.InferenceSession.run:返回固定 hidden_dim 的 token embeddings。
 
     记录每次 run 的 (batch_size, seq_len),让测试断言桶分行为。
+
+    关键设计:每行根据 ids[i, 0] 选一个**唯一的非零维度**打成 1.0,其余
+    维度为 0。这样:
+
+    - L2 归一化后向量保持「在该维度上是单位向量」(方向可区分,不会被
+      normalize 塌成同一个方向)— CodeRabbit 在 PR #1585 指出原来用
+      「单维度上的不同幅值」做区分,过 norm 后全变成 [1, 0, ..., 0],
+      错位也能通过断言。
+    - 测试可以用 ``argmax`` 直接读回 marker 维度,反推 sample → output
+      的映射,验证桶装-还原没把 idx 搞错位。
     """
     HIDDEN = 32  # 测试用小 hidden,跟生产 256/768 无关
 
@@ -52,11 +62,12 @@ class _FakeSession:
         ids = feeds["input_ids"]
         batch, seq = ids.shape
         self.calls.append((batch, seq))
-        # 返回 (batch, seq, hidden) — 每个 token embedding 用 row idx 当
-        # 特征值,这样输出能区分行,后续断言可以验证顺序对齐。
         out = np.zeros((batch, seq, self.HIDDEN), dtype=np.float32)
         for i in range(batch):
-            out[i, :, 0] = float(ids[i, 0])  # 每行首 token id 编码进 hidden[0]
+            # marker ∈ [1, HIDDEN-1],避开 0 让 argmax 唯一;ids 从 1 起、
+            # mod (HIDDEN-1) + 1 保证落进合法区间。
+            marker = ((int(ids[i, 0]) - 1) % (self.HIDDEN - 1)) + 1
+            out[i, :, marker] = 1.0
         return [out]
 
 
@@ -67,12 +78,10 @@ def service_with_fake_session(monkeypatch):
     用 ``object.__new__`` 跳过 ``__init__``,避免被 config_manager / 文件
     路径 / RAM 检测等副作用拖累——我们只想测 _infer_blocking 的桶分。
     """
-    # 必须在这里 import,而不是文件顶层:onnxruntime 不一定装,顶层
-    # import memory.embeddings 会触发 _build_default_service 的 import
-    # 链(虽然 service 是 lazy 的,但模块顶层 import 还是会跑)。所以
-    # importorskip 一下,让没装 ort 的环境干净 skip。
-    pytest.importorskip("tokenizers")  # _build_default_service 需要,但
-    # 我们不真走那条路;importorskip 只是兜底。
+    # ``object.__new__`` 绕过 __init__,fixture 既不走 _build_default_service
+    # 也不走 _load_session_blocking — tokenizers / onnxruntime 都不需要。
+    # 顶层 ``import memory.embeddings`` 本身是纯 Python 模块加载(没有
+    # 副作用 import 重依赖),importorskip 一下兜底罕见的打包剥离场景。
     embeddings = pytest.importorskip("memory.embeddings")
     svc = object.__new__(embeddings.EmbeddingService)
     fake_sess = _FakeSession()
@@ -85,8 +94,15 @@ def service_with_fake_session(monkeypatch):
 def _run_with_lengths(svc, fake_sess, embeddings_mod, lengths):
     """直接喂预 tokenized 的 encoded 列表给 _run_bucket / _infer_blocking
     走桶分。绕过 tokenizer.encode_batch,直接 monkeypatch tokenizer。
+
+    给每个 encoded 注入唯一首 token id(1, 2, 3, ...),跟 _FakeSession
+    的 marker 维度方案配合 — argmax(output[i]) 直接还原"第 i 个槽对应
+    哪个原始样本",顺序回归用例才有真断言力。
     """
     encoded = [_FakeEncoded(n) for n in lengths]
+    for i, enc in enumerate(encoded, start=1):
+        if enc.ids:
+            enc.ids[0] = i  # 注入稳定 marker;后续 token 仍是 dummy
     svc._tokenizer = types.SimpleNamespace(encode_batch=lambda texts: encoded)
     # texts 列表只起占位作用,长度跟 encoded 对齐就行
     texts = ["x"] * len(lengths)
@@ -130,17 +146,27 @@ def test_single_overlong_entry_still_runs(service_with_fake_session):
 
 def test_mixed_length_preserves_original_order(service_with_fake_session):
     """桶内按长度排序,但 _infer_blocking 必须按 original idx 还原输出顺序,
-    否则 zip(texts, vectors) 错位会让缓存键全错。"""
+    否则 zip(texts, vectors) 错位会让缓存键全错。
+
+    断言机制:_FakeSession.run 给每行在 marker=ids[i,0] 维度上打 1.0(L2
+    归一化后该维度仍是单位向量、其余维度 0),所以 argmax(out[i]) ==
+    marker 维度,而 _run_with_lengths 给样本 i 注入 ids[0]=i+1 — 因此
+    output 顺序正确时,argmax 序列必须是 [1, 2, 3, 4, 5](mod HIDDEN-1
+    后)。错位 / 漏填都会被这个断言抓到。
+    """
     svc, sess, emb = service_with_fake_session
-    # 5 条混合长度:用首 token id(=1)区分每行,验证顺序
     lengths = [50, 5, 100, 8, 200]
     out = _run_with_lengths(svc, sess, emb, lengths)
     assert len(out) == 5
-    # 每行 hidden[0] 应当 = ids[0] = 1(_FakeEncoded 的 ids 起 1),
-    # L2-norm 后 = 1/||v||。我们只验证输出对应输入是非 None 的有限值,
-    # 顺序对齐由 out[orig_i] 赋值机制保证(单测断言的是「不漏不错位」)。
     assert all(v is not None for v in out)
     assert all(len(v) == _FakeSession.HIDDEN for v in out)
+    # 输入样本 i(0-indexed)注入的 first-token-id 是 i+1,marker 维度 =
+    # ((i+1 - 1) % (HIDDEN-1)) + 1 = (i % 31) + 1。
+    expected_markers = [(i % (_FakeSession.HIDDEN - 1)) + 1 for i in range(5)]
+    actual_markers = [max(range(len(v)), key=v.__getitem__) for v in out]
+    assert actual_markers == expected_markers, (
+        f"输出顺序跟输入错位了: expected {expected_markers}, got {actual_markers}"
+    )
 
 
 def test_one_long_entry_does_not_pollute_short_batch(service_with_fake_session):

--- a/tests/unit/test_recent_chat_payload_caps.py
+++ b/tests/unit/test_recent_chat_payload_caps.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``validate_chat_payload`` size caps.
+
+背景:``/recent_file/save`` 接收用户粘贴进 recent 的整段对话,之前
+``validate_chat_payload`` 只校验结构(list of {role, text:str}),对
+单条 text 长度 / 总量 / 条数都没有上限。用户复制一坨长文本粘贴进来 →
+原样写盘 → 后续 memory pipeline 喂给 embedder → 触发 batch padding 内
+存炸点(已在 embedder 侧加 token-budget 兜底,这里加入边界硬上限,
+避免异常大对象漫到 ndjson / db / recall 等所有下游)。
+"""
+from __future__ import annotations
+
+from main_routers.memory_router import (
+    _RECENT_CHAT_MAX_MESSAGES,
+    _RECENT_CHAT_TOTAL_CHARS_MAX,
+    _RECENT_MESSAGE_TEXT_MAX_CHARS,
+    validate_chat_payload,
+)
+
+
+def test_normal_payload_passes():
+    chat = [
+        {"role": "user", "text": "你好"},
+        {"role": "ai", "text": "你好,有什么可以帮你的?"},
+    ]
+    ok, err = validate_chat_payload(chat)
+    assert ok, err
+
+
+def test_rejects_oversized_single_message():
+    """单条 text > 32K 字符 → 拒收。这是堵掉「粘贴一大坨」的主入口。"""
+    chat = [{"role": "user", "text": "x" * (_RECENT_MESSAGE_TEXT_MAX_CHARS + 1)}]
+    ok, err = validate_chat_payload(chat)
+    assert not ok
+    assert "单条上限" in err
+
+
+def test_accepts_at_limit_single_message():
+    """边界值:正好等于上限的 text 应当通过(off-by-one 守护)。"""
+    chat = [{"role": "user", "text": "x" * _RECENT_MESSAGE_TEXT_MAX_CHARS}]
+    ok, err = validate_chat_payload(chat)
+    assert ok, err
+
+
+def test_rejects_total_chars_overflow():
+    """每条都不超单条上限,但累计超 2MB → 拒收(总量攻击防御)。"""
+    # 单条 30K,要超过 2MB 需要 ~70 条
+    per_msg = _RECENT_MESSAGE_TEXT_MAX_CHARS - 1000  # < single cap
+    n = (_RECENT_CHAT_TOTAL_CHARS_MAX // per_msg) + 2  # 保证超总量
+    chat = [{"role": "user", "text": "x" * per_msg} for _ in range(n)]
+    ok, err = validate_chat_payload(chat)
+    assert not ok
+    assert "累计" in err or "总量" in err
+
+
+def test_rejects_too_many_messages():
+    """条数超 10000 → 拒收(冗余防御,即使每条都短)。"""
+    chat = [{"role": "user", "text": "a"} for _ in range(_RECENT_CHAT_MAX_MESSAGES + 1)]
+    ok, err = validate_chat_payload(chat)
+    assert not ok
+    assert "消息数" in err
+
+
+def test_structural_validation_still_works():
+    """加上限不影响原有结构校验。"""
+    ok, err = validate_chat_payload("not a list")
+    assert not ok
+    assert "列表" in err
+
+    ok, err = validate_chat_payload([{"text": "no role"}])
+    assert not ok
+    assert "role" in err
+
+    ok, err = validate_chat_payload([{"role": 123}])
+    assert not ok
+    assert "字符串" in err
+
+    ok, err = validate_chat_payload([{"role": "user", "text": 123}])
+    assert not ok
+    assert "字符串" in err
+
+
+def test_empty_payload_passes():
+    ok, err = validate_chat_payload([])
+    assert ok, err
+
+
+def test_text_field_optional():
+    """没 text 字段的 message 应当通过(原行为)。"""
+    chat = [{"role": "system"}]
+    ok, err = validate_chat_payload(chat)
+    assert ok, err


### PR DESCRIPTION
## 现场复盘

用户复制粘贴一段长文本进 recent，导入触发后台 embedding backfill。worker 凑 16 条一批，pad-to-longest 把整批撑到 8192 token，ONNX 推理瞬时激活 ~12 GB。

实测数据（来自 `/api/debug/health` ring buffer）：

| t | RSS | CPU | task list 变化 |
|---|---|---|---|
| 63s | 1.1 GB | 0% | 楼兰姑娘 在线 |
| 363s | **12.4 GB** | **400%**（吃满 4 核）| `SyncConnector-凛天` 出现 = 第二角色记忆导入触发 |
| 463s | 12.4 GB | 4% | 平台化 |

之后几分钟内 RSS 自然回落 — 是「一次性尖峰」不是永久泄漏（用户实测确认）。

## 根因

`_infer_blocking` 是固定 batch + pad-to-longest：

```python
max_len = max(len(x) for x in ids)      # 一条长文本就 = 8192
ids_arr = np.zeros((len(texts), max_len), dtype=np.int64)
outputs = self._session.run(None, feeds)  # batch 16 × seq 8192 = 几 GB 激活
```

正常 persona/reflection/facts 最长 534 字符，根本喂不出 8K — 但用户粘贴的长 recent 段会绕过所有上游 cap（`/recent_file/save` 入口零长度校验），直接以单条 entry 形式喂给 embedder 触发炸点。

## 修复（三层兜底）

1. **`_infer_blocking` 改桶装**：`batch × max_len ≤ _INFER_TOKEN_BUDGET`（16384）。短文本仍打成 16 条满桶吞吐不损；长文本自动缩到 1-2 条一桶，**峰值激活有硬上界**。
2. **`DEFAULT_VECTORS_MAX_LENGTH` 8192 → 1024**。记忆召回用不到 8K blob，砍激活基线 8×。
3. **关 ORT CPU mem arena**（`enable_cpu_mem_arena=False`）。BFCArena 只涨不还，会把瞬时尖峰变永久占用；关掉让 RSS 跟实际需求回落。
4. **`/recent_file/save` 入口加大小上限**：单条 32K 字符 / 总量 2MB / 条数 10K，边界堵掉「粘贴 megablob」灌入下游。

## Test plan

- [x] 新增 6 个桶分单测（边界值、单条超 budget、顺序保持、关键回归用例「一条长文不能把短文带飞」）→ 14/14 PASS
- [x] 新增 8 个 payload 上限单测 → 14/14 PASS
- [x] `tests/unit/test_embeddings_fallback.py` + `tests/unit/test_memory_recall.py` 回归 → 43/43 PASS
- [x] `tests/unit/test_character_memory_regression.py` + `tests/frontend/test_memory_browser.py` 回归 → 78/78 PASS
- [ ] 现场复现：粘贴长文进 recent，监控 `/api/debug/health` 的 `rss_mb` 是否还跳

## Tradeoff

- `_INFER_TOKEN_BUDGET=16384` 在新 `max_length=1024` 下 = 16×1024，跟原行为完全一致（正常路径零吞吐损失）
- 旧数据 / 自定义 profile 把 max_length 顶到 8192 时只允许 2 条一桶，吞吐降一半但避免炸内存
- 关 arena 的代价：每次 run 重新 malloc 几 μs。CPU 推理本来就 100ms+ 级，可忽略

## Files

- `memory/embeddings.py` — 桶装 `_infer_blocking` + `_run_bucket` + 三处 config knob
- `main_routers/memory_router.py` — `validate_chat_payload` 加大小上限
- `tests/unit/test_embedding_token_budget.py` — 新
- `tests/unit/test_recent_chat_payload_caps.py` — 新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增强聊天消息输入验证：新增单条文本长度、累计字符上限和消息数量上限，超限返回明确失败信息。

* **性能**
  * 优化嵌入推理的分桶与批次策略，降低长文本推理时的内存峰值与驻留行为；关闭部分运行时内存 arena 以减少 RSS 滞留。

* **兼容性**
  * 嵌入模型标识可包含截断长度，区分不同截断策略的缓存并触发重建。

* **测试**
  * 新增单元测试覆盖消息校验、嵌入 token-budget 分桶行为、截断失败处理和缓存一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->