### PR TITLE
feat(agent): 免费版 Agent 配额耗尽时弹前端提示（节流≤10s/次）

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -3409,6 +3409,24 @@ async def startup():
         await Modules.agent_bridge.start()
     except Exception as e:
         logger.warning(f"[Agent] Event bridge startup failed: {e}")
+    # 免费版 Agent 每日配额耗尽 → 节流通知前端弹提示（最多每 10 秒一次）。
+    # consume_agent_daily_quota 跑在 worker 线程里调这个回调，用 run_coroutine_threadsafe
+    # 把异步 ZeroMQ emit 调度回 agent_server 的事件循环；不 .result()，保持非阻塞。
+    try:
+        _quota_notify_loop = asyncio.get_running_loop()
+
+        def _notify_agent_quota_exceeded(used: int, limit: int) -> None:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    _emit_main_event("agent_quota_exceeded", None, used=used, limit=limit),
+                    _quota_notify_loop,
+                )
+            except Exception as e:
+                logger.debug("[Agent] schedule agent_quota_exceeded emit failed: %s", e)
+
+        get_config_manager().register_quota_exceeded_notifier(_notify_agent_quota_exceeded)
+    except Exception as e:
+        logger.warning(f"[Agent] register quota-exceeded notifier failed: {e}")
     # Push initial server status so frontend can render Agent popup without waiting.
     _bump_state_revision()
 

--- a/app/main_server.py
+++ b/app/main_server.py
@@ -628,6 +628,32 @@ async def _handle_agent_event(event: dict):
                 await _broadcast_to_all_connected(payload)
             return
 
+        # 免费版 Agent 每日配额耗尽：全局提示（与角色无关），广播成 status toast
+        # 到所有已连接会话。上游 config_manager 已节流（≤每 10 秒一次），这里不会刷屏。
+        # 前端已就绪：AGENT_QUOTA_EXCEEDED 在 criticalErrorCodes 里，配 i18n 文案
+        # （{{used}}/{{limit}}）走 showStatusToast。
+        if event_type == "agent_quota_exceeded":
+            import json as _json
+            status_message = _json.dumps({
+                "code": "AGENT_QUOTA_EXCEEDED",
+                "details": {
+                    "used": event.get("used", 0),
+                    "limit": event.get("limit", 300),
+                },
+            })
+            quota_payload = {"type": "status", "message": status_message}
+            mgr_for_quota = _get_session_manager(lanlan)
+            if lanlan and mgr_for_quota is not None:
+                ws_for_quota = getattr(mgr_for_quota, "websocket", None)
+                if _is_websocket_connected(ws_for_quota):
+                    try:
+                        await ws_for_quota.send_json(quota_payload)
+                    except Exception as e:
+                        logger.debug("[EventBus] agent_quota_exceeded send failed: %s", e)
+            else:
+                await _broadcast_to_all_connected(quota_payload)
+            return
+
         # Resolve target session manager; fallback to broadcast if lanlan is unknown
         mgr = _get_session_manager(lanlan)
         if not mgr and event_type == "task_update":

--- a/tests/unit/test_agent_quota_notify.py
+++ b/tests/unit/test_agent_quota_notify.py
@@ -1,0 +1,107 @@
+"""免费版 Agent 配额耗尽 → 前端提示通知器的回归测试。
+
+锁住两件事：
+  1. 节流语义：配额耗尽信号在 `_quota_notify_interval_s` 窗口内最多触发一次回调，
+     过窗口后可再触发一次（对应"每 10 秒最多给一次提示"）。
+  2. 卡点接线：免费版配额耗尽时 `consume_agent_daily_quota` 会触发已注册的回调。
+
+历史背景：配额耗尽的"提示"原本走 app-agent.js 的 modal（maybeShowAgentQuotaExceededModal），
+依赖前端文本匹配人类可读短语；后端把信号退化成机器码 AGENT_QUOTA_EXCEEDED 后匹配不上、提示消失。
+现改为后端在唯一卡点直接按 code 触发节流通知 → status toast，不再依赖脆弱的文本匹配。
+"""
+
+import time
+
+import pytest
+
+from utils import config_manager as cm_module
+from utils.config_manager import ConfigManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_quota_notify_state():
+    """隔离类级节流/回调状态，避免测试间（以及与真实运行时）串扰。"""
+    saved_notifier = ConfigManager._quota_exceeded_notifier
+    saved_last = ConfigManager._quota_notify_last_monotonic
+    ConfigManager._quota_exceeded_notifier = None
+    ConfigManager._quota_notify_last_monotonic = 0.0
+    try:
+        yield
+    finally:
+        ConfigManager._quota_exceeded_notifier = saved_notifier
+        ConfigManager._quota_notify_last_monotonic = saved_last
+
+
+def test_quota_notifier_throttled_to_one_per_interval():
+    """节流：窗口内连撞多次只通知 1 次；过窗口后再通知 1 次。"""
+    calls = []
+    ConfigManager.register_quota_exceeded_notifier(lambda used, limit: calls.append((used, limit)))
+    cm = ConfigManager.__new__(ConfigManager)  # 只用到类级状态，无需 config_dir
+
+    for _ in range(5):
+        cm._maybe_notify_quota_exceeded(300, 300)
+    assert calls == [(300, 300)], "窗口内应只通知一次"
+
+    # 把"上次通知时间"推到节流窗口之外，模拟过了 interval
+    ConfigManager._quota_notify_last_monotonic = time.monotonic() - (ConfigManager._quota_notify_interval_s + 1)
+    cm._maybe_notify_quota_exceeded(300, 300)
+    assert calls == [(300, 300), (300, 300)], "过窗口后应再通知一次"
+
+    cm._maybe_notify_quota_exceeded(300, 300)
+    assert len(calls) == 2, "新窗口内再撞不应重复通知"
+
+
+def test_quota_notifier_noop_without_registration():
+    """没注册回调时应安静返回、不抛错。"""
+    cm = ConfigManager.__new__(ConfigManager)
+    cm._maybe_notify_quota_exceeded(300, 300)  # 不应抛异常
+
+
+def test_quota_notifier_swallows_callback_error():
+    """回调自身抛错不应冒泡到配额消费路径。"""
+    def _boom(used, limit):
+        raise RuntimeError("notifier boom")
+
+    ConfigManager.register_quota_exceeded_notifier(_boom)
+    cm = ConfigManager.__new__(ConfigManager)
+    cm._maybe_notify_quota_exceeded(300, 300)  # 不应抛异常
+
+
+def test_consume_agent_daily_quota_triggers_notifier_on_exhaustion(tmp_path, monkeypatch):
+    """卡点回归：免费版配额耗尽时 consume_agent_daily_quota 触发通知器一次。"""
+    calls = []
+    ConfigManager.register_quota_exceeded_notifier(lambda used, limit: calls.append((used, limit)))
+
+    cm = ConfigManager.__new__(ConfigManager)
+    cm.config_dir = tmp_path
+    cm.project_config_dir = tmp_path
+    cm.app_name = "N.E.K.O"
+    cm._verbose = False
+    monkeypatch.setattr(cm, "is_free_version", lambda: True)
+    monkeypatch.setattr(cm, "ensure_config_directory", lambda: None)
+    monkeypatch.setattr(ConfigManager, "_free_agent_daily_limit", 0)
+
+    ok, info = cm.consume_agent_daily_quota(source="regression_test")
+
+    assert ok is False, "limit=0 时任何一次消费都应耗尽"
+    assert info["limited"] is True
+    assert calls == [(0, 0)], "耗尽应触发通知器一次，携带 (used, limit)"
+
+
+def test_consume_non_free_version_never_notifies(tmp_path, monkeypatch):
+    """非免费版不计配额、不通知（早退路径）。"""
+    calls = []
+    ConfigManager.register_quota_exceeded_notifier(lambda used, limit: calls.append((used, limit)))
+
+    cm = ConfigManager.__new__(ConfigManager)
+    cm.config_dir = tmp_path
+    cm.project_config_dir = tmp_path
+    cm.app_name = "N.E.K.O"
+    cm._verbose = False
+    monkeypatch.setattr(cm, "is_free_version", lambda: False)
+    monkeypatch.setattr(ConfigManager, "_free_agent_daily_limit", 0)
+
+    ok, info = cm.consume_agent_daily_quota(source="regression_test")
+
+    assert ok is True, "非免费版应放行"
+    assert calls == [], "非免费版不应触发通知器"

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import threading
 import asyncio
+import time
 import math
 import uuid
 from datetime import date
@@ -860,6 +861,12 @@ class ConfigManager:
     _agent_quota_lock = threading.Lock()
     _selected_root_unavailable_recovery_override_roots: set[str] = set()
     _free_agent_daily_limit = 300 # 免费配额并非只在本地实施，本地计算是为了减少无效请求、节约网络带宽。
+    # 配额耗尽时给前端弹提示的节流：与 _agent_quota_lock 不同的锁，避免在持有配额锁时重入。
+    # notifier 由 agent_server 在启动时注册（进程级），收到耗尽信号最多每 _quota_notify_interval_s 秒触发一次。
+    _quota_notify_lock = threading.Lock()
+    _quota_notify_interval_s = 10.0
+    _quota_notify_last_monotonic = 0.0
+    _quota_exceeded_notifier = None
     ROOT_STATE_VERSION = 1
     CLOUDSAVE_LOCAL_STATE_VERSION = 1
     CHARACTER_TOMBSTONES_STATE_VERSION = 1
@@ -3846,6 +3853,32 @@ class ConfigManager:
         """本地 Agent 试用配额计数文件路径。"""
         return self.config_dir / "agent_quota.json"
 
+    @classmethod
+    def register_quota_exceeded_notifier(cls, notifier) -> None:
+        """注册"免费版 Agent 配额耗尽"通知回调（进程级，由 agent_server 启动时注册）。
+
+        notifier(used:int, limit:int) 会在配额耗尽时被调用，**最多每 10 秒一次**（见
+        ``_maybe_notify_quota_exceeded`` 的节流）。回调本身必须非阻塞——它在持有
+        ``_agent_quota_lock`` 的临界区里被调用，通常只做一次跨线程 schedule。
+        """
+        cls._quota_exceeded_notifier = notifier
+
+    def _maybe_notify_quota_exceeded(self, used: int, limit: int) -> None:
+        """配额耗尽时节流触发已注册的前端提示回调（最多每 _quota_notify_interval_s 秒一次）。"""
+        notifier = ConfigManager._quota_exceeded_notifier
+        if notifier is None:
+            return
+        now = time.monotonic()
+        with ConfigManager._quota_notify_lock:
+            last = ConfigManager._quota_notify_last_monotonic
+            if last and (now - last) < ConfigManager._quota_notify_interval_s:
+                return
+            ConfigManager._quota_notify_last_monotonic = now
+        try:
+            notifier(used, limit)
+        except Exception as e:
+            logger.debug("配额耗尽通知回调失败: %s", e)
+
     def consume_agent_daily_quota(self, source: str = "", units: int = 1) -> tuple[bool, dict]:
         """消费 Agent 模型每日配额（仅免费版生效）。配额并非只在本地实施，本地计算是为了减少无效请求、节约网络带宽。
 
@@ -3895,6 +3928,9 @@ class ConfigManager:
 
             used = int(data.get("used", 0))
             if used + units > limit:
+                # 配额耗尽：节流通知前端弹提示（最多每 10 秒一次）。回调非阻塞，
+                # 在临界区里只做一次跨线程 schedule，不展开网络 IO。
+                self._maybe_notify_quota_exceeded(used, limit)
                 return False, {
                     "limited": True,
                     "date": today,


### PR DESCRIPTION
## 背景

免费版 brain 的后台 agent（`task_executor` / `browser_use_adapter` / `computer_use` / `deduper`）每天有 300 次本地配额。配额耗尽后，这些调用原本都在 `config_manager.consume_agent_daily_quota` 处静默 `return False`、各自停掉，**前端没有任何提示**——用户不知道为什么后台能力突然没反应了。

前端其实早就备好了 `AGENT_QUOTA_EXCEEDED` 的三件套：
- i18n 文案：`💥 免费猫爪模型今日试用次数已达上限 ({{used}}/{{limit}})，请明日再试。`（8 语言齐全）
- `app-websocket.js` 的 `criticalErrorCodes` 已包含该 code
- 走 `showStatusToast` 渲染

唯一缺的是：**后端从没把"配额耗尽"这个事件推给前端**。

## 方案

在所有 brain 模块共用的唯一卡点 `consume_agent_daily_quota` 返回 `False` 那一刻，挂一个**进程级节流通知器（最多每 10 秒一次）**：

```
consume_agent_daily_quota() 返回 False（唯一卡点）
  → _maybe_notify_quota_exceeded(used, limit)   # 进程级节流 ≥10s 才放一次
  → agent_server 注册的回调 → run_coroutine_threadsafe（非阻塞）
  → _emit_main_event("agent_quota_exceeded") → ZeroMQ
  → main_server._handle_agent_event → 广播 {"type":"status","message":'{"code":"AGENT_QUOTA_EXCEEDED",...}'}
  → 前端 showStatusToast
```

节流放在卡点的好处：全局唯一计时、4 个 brain 模块零改动、不刷屏 ZeroMQ。

## 改动

- `utils/config_manager.py`：节流状态 + `register_quota_exceeded_notifier()` + `_maybe_notify_quota_exceeded()`，挂在配额耗尽分支（与 `_agent_quota_lock` 分开的锁，避免持锁重入）
- `app/agent_server.py`：startup 注册回调，用 `run_coroutine_threadsafe` 把异步 ZeroMQ emit 调度回事件循环（不 `.result()`，非阻塞）
- `app/main_server.py`：`_handle_agent_event` 加 `agent_quota_exceeded` 分支，全局广播成 status toast

前端无需改动。

## 验证

- `py_compile` 三个文件通过
- 节流单测：连撞 5 次只通知 1 次；把计时往前推 11s 后再撞，再通知 1 次
- 卡点单测：强制免费版 + 配额上限 0，调 `consume_agent_daily_quota` → 确实触发 notifier 一次

## 行为说明

- 节流语义＝字面"最多每 10s 一次"：配额耗尽后只要还有后台 agent 在撞，就会每 10s 弹一次，直到次日配额重置。间隔常量 `_quota_notify_interval_s = 10.0`，要调改一个数即可。
- 仅免费版生效（`is_free_version()` 为真才计配额）；非免费版直接早退、零影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 当免费版代理每日配额耗尽时，向相关会话实时推送配额耗尽告警（携带已用/上限信息）。
  * 告警推送实现了进程级节流，避免短时间内重复通知。
* **测试**
  * 新增回归测试覆盖告警节流、异常吞噬与触发条件，确保通知行为稳定可靠。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->