### PR TITLE
恢复紧凑聊天框字幕态的轮盘工具入口，并调整字幕文字区域宽度，避免轮盘按钮遮挡右侧文本

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -2211,7 +2211,7 @@ describe('App', () => {
     }
   });
 
-  it('renders compact input as the default entry without history or extra controls', () => {
+  it('renders compact default as a subtitle capsule with the wheel entry', () => {
     const message = parseChatMessage({
       id: 'assistant-compact-1',
       role: 'assistant',
@@ -2224,14 +2224,44 @@ describe('App', () => {
 
     expect(container.querySelector('.compact-chat-stage-body-slot')).toHaveAttribute('data-compact-stage-fallback', 'message-list');
     expect(container.querySelector('.message-list')).toBeNull();
-    expect(container.querySelector('.compact-chat-capsule-button')).toBeNull();
-    expect(container.querySelector('[data-compact-geometry-part="inputBody"]')).not.toBeNull();
-    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+    expect(container.querySelector('.compact-chat-capsule-button')).not.toBeNull();
+    expect(container.querySelector('[data-compact-geometry-part="inputBody"]')).toBeNull();
+    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent('今天想让我陪你做什么呢？');
     expect(container.querySelector('.compact-chat-entry-button')).toBeNull();
     expect(container.querySelector('.compact-chat-tool-btn')).toBeNull();
+    const actionButton = screen.getByRole('button', { name: '更多工具' });
+    expect(actionButton).toBeInTheDocument();
+    expect(actionButton.querySelector('img')).toHaveAttribute('src', '/static/icons/dropdown_arrow.png');
+    expect(container.querySelector('.compact-input-tool-fan')).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
   });
 
-  it('does not request compact input for an already-input compact surface', () => {
+  it('opens compact tools from the subtitle capsule without entering input', () => {
+    const onCompactChatStateChange = vi.fn();
+    const message = parseChatMessage({
+      id: 'assistant-compact-tool-default',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:00',
+      createdAt: 1,
+      blocks: [{ type: 'text', text: '保持字幕态，同时打开轮盘。' }],
+    });
+    const { container } = render(
+      <App
+        chatSurfaceMode="compact"
+        messages={[message]}
+        onCompactChatStateChange={onCompactChatStateChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
+
+    expect(container.querySelector('[data-compact-geometry-part="inputBody"]')).toBeNull();
+    expect(container.querySelector('.compact-chat-capsule-button')).not.toBeNull();
+    expect(container.querySelector('.compact-input-tool-fan')).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+    expect(onCompactChatStateChange).not.toHaveBeenCalledWith('input');
+  });
+
+  it('requests compact input when the single compact entry is clicked', () => {
     const onCompactChatStateChange = vi.fn();
     const message = parseChatMessage({
       id: 'assistant-compact-2',
@@ -2250,9 +2280,9 @@ describe('App', () => {
       />,
     );
 
-    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '可以先说一句你今天想做什么' }));
 
-    expect(onCompactChatStateChange).not.toHaveBeenCalledWith('input');
+    expect(onCompactChatStateChange).toHaveBeenCalledWith('input');
   });
 
   it('keeps revealing the final assistant tail after the same streaming message settles', async () => {
@@ -3060,8 +3090,37 @@ describe('App', () => {
 
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');
     expect(container.querySelector('.composer-input')).toBeNull();
-    expect(container.querySelector('.compact-input-tool-fan')).toBeNull();
+    expect(screen.getByRole('button', { name: '更多工具' })).toBeInTheDocument();
+    expect(container.querySelector('.compact-input-tool-fan')).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
     expect(onCompactChatStateChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps the compact wheel available while voice mode shows the subtitle capsule', () => {
+    const onCompactChatStateChange = vi.fn();
+    const message = parseChatMessage({
+      id: 'assistant-compact-voice-tool-entry',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:00',
+      createdAt: 1,
+      blocks: [{ type: 'text', text: '语音字幕态也可以打开轮盘。' }],
+      status: 'sent',
+    });
+    const { container } = render(
+      <App
+        chatSurfaceMode="compact"
+        composerHidden
+        messages={[message]}
+        onCompactChatStateChange={onCompactChatStateChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
+
+    expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');
+    expect(container.querySelector('.composer-input')).toBeNull();
+    expect(container.querySelector('.compact-input-tool-fan')).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+    expect(onCompactChatStateChange).not.toHaveBeenCalledWith('input');
   });
 
   it('opens compact input tools from the same right-side button without submitting', () => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -66,14 +66,19 @@ const defaultMessages: ChatMessage[] = [];
 type AvatarToolId = AvatarInteractionPayload['toolId'];
 
 function getEffectiveCompactChatState(
-  _requestedState: CompactChatState,
-  _hasVisibleChoices: boolean,
-  composerHidden: boolean,
+  requestedState: CompactChatState,
+  hasVisibleChoices: boolean,
 ): CompactChatState {
-  if (composerHidden) {
+  if (requestedState === 'input') {
+    return 'input';
+  }
+  if (hasVisibleChoices) {
+    return 'options';
+  }
+  if (requestedState === 'options') {
     return 'default';
   }
-  return 'input';
+  return requestedState;
 }
 
 const COMPACT_PREVIEW_MAX_LENGTH = 84;
@@ -1320,11 +1325,15 @@ export default function App({
     compactChoiceInteractionsAllowed && galgameModeEnabled && !choicePromptHasOptions
     && (galgameOptionsLoading || galgameOptions.length > 0);
   const compactSurfaceChoicesVisible = choicePromptHasOptions || galgameOptionsVisible;
-  const isCompactSurface = chatSurfaceMode !== 'minimized';
-  const requestedCompactChatState = compactChatState;
+  const isCompactSurface = chatSurfaceMode === 'compact';
+  const requestedCompactChatState = isCompactSurface && composerHidden && compactChatState === 'input'
+    ? 'default'
+    : compactChatState;
   const effectiveCompactChatState = isCompactSurface
-    ? getEffectiveCompactChatState(requestedCompactChatState, compactSurfaceChoicesVisible, composerHidden)
+    ? getEffectiveCompactChatState(requestedCompactChatState, compactSurfaceChoicesVisible)
     : requestedCompactChatState;
+  const compactToolFanSurfaceAvailable = isCompactSurface
+    && (effectiveCompactChatState === 'input' || effectiveCompactChatState === 'default');
   const getCompactSurfaceResizeMaxAvailableWidth = useCallback(() => {
     const desktopWindow = window as typeof window & {
       __nekoDesktopCompactLayout?: DesktopCompactChoicePlacementLayout | null;
@@ -2799,7 +2808,7 @@ export default function App({
   ]);
 
   useEffect(() => {
-    if (!isCompactSurface || effectiveCompactChatState !== 'input') {
+    if (!compactToolFanSurfaceAvailable) {
       resetCompactInputToolFanHoverBlock();
       return;
     }
@@ -2845,11 +2854,10 @@ export default function App({
   }, [
     clearCompactInputToolFanCloseTimer,
     compactInputHasPayload,
+    compactToolFanSurfaceAvailable,
     composerDisabled,
-    effectiveCompactChatState,
     isCompactInputToolPointerInHoverRegion,
     isCompactInputToolPointerInToggleHoverRegion,
-    isCompactSurface,
     openCompactInputToolFan,
     resetCompactInputToolFanHoverBlock,
     scheduleCompactInputToolFanTransientClose,
@@ -3101,17 +3109,15 @@ export default function App({
 
   useEffect(() => {
     if (!compactInputToolFanOpen) return;
-    if (!isCompactSurface || effectiveCompactChatState !== 'input' || composerHidden || composerDisabled || compactInputHasPayload) {
+    if (!compactToolFanSurfaceAvailable || composerDisabled || compactInputHasPayload) {
       closeCompactInputToolFan();
     }
   }, [
     closeCompactInputToolFan,
     compactInputHasPayload,
     compactInputToolFanOpen,
+    compactToolFanSurfaceAvailable,
     composerDisabled,
-    composerHidden,
-    effectiveCompactChatState,
-    isCompactSurface,
   ]);
 
   useEffect(() => {
@@ -3962,7 +3968,50 @@ export default function App({
     '--compact-tool-wheel-charge-second-angle': `${compactInputToolWheelChargeSecondLapAngle}deg`,
   } as CSSProperties;
 
-  const compactInputToolFanNode = isCompactSurface && effectiveCompactChatState === 'input' ? (
+  const renderCompactToolToggleButton = (allowSubmit: boolean) => {
+    const isSubmitButton = allowSubmit && compactInputHasPayload;
+    return (
+      <button
+        className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
+        ref={compactInputToolToggleRef}
+        type={isSubmitButton ? 'submit' : 'button'}
+        aria-label={isSubmitButton ? sendButtonLabel : overflowMenuAriaLabel}
+        aria-haspopup={isSubmitButton ? undefined : 'true'}
+        aria-expanded={isSubmitButton ? undefined : compactInputToolFanOpen}
+        disabled={isSubmitButton ? !canSubmit : composerDisabled}
+        onPointerDown={isSubmitButton ? undefined : (event) => {
+          event.preventDefault();
+          compactInputToolTogglePointerHandledRef.current = true;
+          toggleCompactInputToolFanByClick();
+        }}
+        onPointerEnter={isSubmitButton ? undefined : handleCompactInputToolHoverEnter}
+        onPointerLeave={isSubmitButton ? undefined : handleCompactInputToolHoverLeave}
+        onFocus={isSubmitButton ? undefined : clearCompactInputToolFanCloseTimer}
+        onBlur={isSubmitButton ? scheduleCompactInputCollapse : () => {
+          scheduleCompactInputToolFanTransientClose();
+          if (allowSubmit) {
+            scheduleCompactInputCollapse();
+          }
+        }}
+        onClick={isSubmitButton ? undefined : () => {
+          if (compactInputToolTogglePointerHandledRef.current) {
+            compactInputToolTogglePointerHandledRef.current = false;
+            return;
+          }
+          toggleCompactInputToolFanByClick();
+        }}
+      >
+        <img
+          className={isSubmitButton ? undefined : 'compact-input-tool-toggle-icon'}
+          src={isSubmitButton ? '/static/icons/send_new_icon.png' : '/static/icons/dropdown_arrow.png'}
+          alt=""
+          aria-hidden="true"
+        />
+      </button>
+    );
+  };
+
+  const compactInputToolFanNode = compactToolFanSurfaceAvailable ? (
     <div
       ref={compactInputToolFanRef}
       className="compact-input-tool-fan"
@@ -4708,64 +4757,33 @@ export default function App({
                           }
                         }}
                       />
-                      <button
-                        className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
-                        ref={compactInputToolToggleRef}
-                        type={compactInputHasPayload ? 'submit' : 'button'}
-                        aria-label={compactInputHasPayload ? sendButtonLabel : overflowMenuAriaLabel}
-                        aria-haspopup={compactInputHasPayload ? undefined : 'true'}
-                        aria-expanded={compactInputHasPayload ? undefined : compactInputToolFanOpen}
-                        disabled={compactInputHasPayload ? !canSubmit : composerDisabled}
-                        onPointerDown={compactInputHasPayload ? undefined : (event) => {
-                          event.preventDefault();
-                          compactInputToolTogglePointerHandledRef.current = true;
-                          toggleCompactInputToolFanByClick();
-                        }}
-                        onPointerEnter={compactInputHasPayload ? undefined : handleCompactInputToolHoverEnter}
-                        onPointerLeave={compactInputHasPayload ? undefined : handleCompactInputToolHoverLeave}
-                        onFocus={compactInputHasPayload ? undefined : clearCompactInputToolFanCloseTimer}
-                        onBlur={compactInputHasPayload ? scheduleCompactInputCollapse : () => {
-                          scheduleCompactInputToolFanTransientClose();
-                          scheduleCompactInputCollapse();
-                        }}
-                        onClick={compactInputHasPayload ? undefined : () => {
-                          if (compactInputToolTogglePointerHandledRef.current) {
-                            compactInputToolTogglePointerHandledRef.current = false;
-                            return;
-                          }
-                          toggleCompactInputToolFanByClick();
-                        }}
-                      >
-                        <img
-                          className={compactInputHasPayload ? undefined : 'compact-input-tool-toggle-icon'}
-                          src={compactInputHasPayload ? '/static/icons/send_new_icon.png' : '/static/icons/dropdown_arrow.png'}
-                          alt=""
-                          aria-hidden="true"
-                        />
-                      </button>
+                      {renderCompactToolToggleButton(true)}
                     </>
                   ) : (
-                    <button
-                      className="compact-chat-capsule-button"
-                      type="button"
-                      disabled={composerDisabled}
-                      onClick={() => {
-                        if (composerHidden) return;
-                        requestCompactChatState('input');
-                      }}
-                    >
-                      <span
-                        ref={compactPreviewTextRef}
-                        className="compact-chat-capsule-text"
-                        data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
+                    <>
+                      <button
+                        className="compact-chat-capsule-button"
+                        type="button"
+                        disabled={composerDisabled}
+                        onClick={() => {
+                          if (composerHidden) return;
+                          requestCompactChatState('input');
+                        }}
                       >
-                        {compactPreviewDisplayText}
-                      </span>
-                    </button>
+                        <span
+                          ref={compactPreviewTextRef}
+                          className="compact-chat-capsule-text"
+                          data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
+                        >
+                          {compactPreviewDisplayText}
+                        </span>
+                      </button>
+                      {effectiveCompactChatState === 'default' ? renderCompactToolToggleButton(false) : null}
+                    </>
                   )}
-                </div>
-                {compactInputToolFanNode}
-              </div>
+		                </div>
+		                {compactInputToolFanNode}
+		              </div>
             ) : null}
           </form>
         </footer>

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1933,6 +1933,10 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   padding: 5px 62px 5px 20px;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] {
+  padding-right: 78px;
+}
+
 .compact-chat-surface-frame::before {
   content: "";
   position: absolute;
@@ -1985,6 +1989,12 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 .compact-chat-capsule-button:disabled {
   cursor: not-allowed;
   opacity: 0.58;
+}
+
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-chat-capsule-button {
+  flex: 0 1 calc(100% - 76px);
+  width: calc(100% - 76px);
+  max-width: calc(100% - 76px);
 }
 
 .compact-chat-capsule-text {
@@ -3193,6 +3203,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   display: none;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .send-button-circle,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .send-button-circle {
   width: 42px;
   height: 42px;
@@ -3202,11 +3213,13 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   overflow: visible;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .send-button-circle img,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .send-button-circle img {
   width: 46px;
   height: 46px;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle {
   --compact-tool-toggle-hover-outset: 14px;
   position: absolute;
@@ -3218,10 +3231,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transform: none;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle:hover,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle:hover {
   transform: none;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle::before,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle::before {
   content: "";
   position: absolute;
@@ -3238,6 +3253,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle[aria-haspopup="true"],
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"] {
   background: rgba(160, 220, 255, 0.26);
   box-shadow:
@@ -3245,15 +3261,19 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle[aria-haspopup="true"]::before,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"]::before {
   opacity: 1;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle[aria-haspopup="true"]:hover::before,
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle[aria-haspopup="true"].is-open::before,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"]:hover::before,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"].is-open::before {
   transform: scale(1.08);
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle-icon,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle-icon {
   position: relative;
   z-index: 1;
@@ -3264,6 +3284,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transition: transform 0.18s ease;
 }
 
+.compact-chat-surface-frame[data-compact-chat-state="default"] .compact-input-tool-toggle.is-open .compact-input-tool-toggle-icon,
 .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle.is-open .compact-input-tool-toggle-icon {
   transform: rotate(-90deg);
 }
@@ -4115,6 +4136,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   color: rgba(202, 222, 244, 0.66);
 }
 
+[data-theme="dark"] .compact-chat-surface-frame[data-compact-chat-state="default"] .send-button-circle,
 [data-theme="dark"] .compact-chat-surface-frame[data-compact-chat-state="input"] .send-button-circle {
   background: transparent;
   box-shadow: none;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  - 优化了紧凑对话界面的默认状态显示，改进了字幕胶囊按钮与工具菜单的交互行为。
  - 增强了语音模式下的界面表现和用户交互体验。

* **Tests**
  - 更新了紧凑对话界面相关的测试用例，新增了工具菜单和语音模式下的交互覆盖验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->