### PR TITLE
恢复紧凑聊天框的字幕模式，并让字幕态继续显示工具轮盘按钮；保留轮盘交互，不再通过隐藏按钮实现字幕态

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -107,11 +107,14 @@ describe('App', () => {
     props: React.ComponentProps<typeof App> = {},
   ) => render(<App compactChatState="input" {...props} />);
 
-  it('renders compact input by default when there are no messages', () => {
+  it('renders compact subtitle capsule by default while keeping the tool button visible', () => {
     render(<App />);
 
-    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
-    expect(document.body.querySelector('.compact-chat-stage-input')).not.toBeNull();
+    expect(screen.queryByPlaceholderText('Type a message...')).toBeNull();
+    expect(document.body.querySelector('.compact-chat-stage-default')).not.toBeNull();
+    expect(document.body.querySelector('.compact-chat-capsule-button')).not.toBeNull();
+    expect(screen.getByRole('button', { name: '更多工具' })).toBeInTheDocument();
+    expect(document.body.querySelector('.compact-input-tool-fan')).not.toBeNull();
   });
 
   it('exposes explicit surface mode state on the rendered shell', () => {
@@ -1747,7 +1750,7 @@ describe('App', () => {
     expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
   });
 
-  it('keeps compact input state while choices render in the shared layer', () => {
+  it('uses compact options state while choices render over the subtitle capsule', () => {
     const { container } = render(
       <App
         chatSurfaceMode="compact"
@@ -1762,9 +1765,10 @@ describe('App', () => {
       />,
     );
 
-    expect(container.querySelector('.compact-chat-stage-input')).not.toBeNull();
-    expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
+    expect(container.querySelector('.compact-chat-stage-options')).not.toBeNull();
+    expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'options');
     expect(document.body.querySelector('.compact-chat-choice-anchor')).not.toBeNull();
+    expect(container.querySelector('.compact-input-tool-toggle')).not.toBeNull();
   });
 
   it('places compact galgame options below the surface when there is enough viewport space', async () => {
@@ -2989,6 +2993,49 @@ describe('App', () => {
     }
   });
 
+  it('scrolls compact subtitle text with the mouse wheel', () => {
+    const onCompactChatStateChange = vi.fn();
+    const longText = '这是一条很长的紧凑字幕，需要通过滚轮横向查看被省略掉的后半段内容。';
+    const message = parseChatMessage({
+      id: 'assistant-compact-wheel-scroll',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:01',
+      createdAt: 2,
+      blocks: [{ type: 'text', text: longText }],
+      status: 'sent',
+    });
+
+    const { container } = render(
+      <App
+        chatSurfaceMode="compact"
+        compactChatState="default"
+        messages={[message]}
+        onCompactChatStateChange={onCompactChatStateChange}
+      />,
+    );
+    const preview = container.querySelector('.compact-chat-capsule-text') as HTMLSpanElement;
+    expect(preview).not.toBeNull();
+    Object.defineProperty(preview, 'scrollWidth', {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(preview, 'clientWidth', {
+      configurable: true,
+      value: 100,
+    });
+
+    fireEvent.wheel(preview, { deltaY: 80 });
+    expect(preview.scrollLeft).toBe(80);
+
+    fireEvent.wheel(preview, { deltaX: 240 });
+    expect(preview.scrollLeft).toBe(220);
+
+    fireEvent.wheel(preview, { deltaY: -50 });
+    expect(preview.scrollLeft).toBe(170);
+    expect(onCompactChatStateChange).not.toHaveBeenCalledWith('input');
+  });
+
   it('renders compact input as the same surface with one inline action button', () => {
     const { container } = render(<App chatSurfaceMode="compact" compactChatState="input" />);
 
@@ -3062,6 +3109,23 @@ describe('App', () => {
     expect(container.querySelector('.composer-input')).toBeNull();
     expect(container.querySelector('.compact-input-tool-fan')).toBeNull();
     expect(onCompactChatStateChange).not.toHaveBeenCalled();
+  });
+
+  it('opens compact input tools from the subtitle capsule without entering input state', () => {
+    const onCompactChatStateChange = vi.fn();
+    const { container } = render(
+      <App
+        chatSurfaceMode="compact"
+        compactChatState="default"
+        onCompactChatStateChange={onCompactChatStateChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
+
+    expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');
+    expect(document.body.querySelector('.compact-input-tool-fan')).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+    expect(onCompactChatStateChange).not.toHaveBeenCalledWith('input');
   });
 
   it('opens compact input tools from the same right-side button without submitting', () => {
@@ -4284,7 +4348,7 @@ describe('App', () => {
     }
   });
 
-  it('keeps compact input visible and delays tool fan close when desktop compact pointer leaves native hit regions', async () => {
+  it('delays tool fan close then returns empty compact input to subtitle state when desktop pointer leaves native hit regions', async () => {
     vi.useFakeTimers();
     const onCompactChatStateChange = vi.fn();
     try {
@@ -4313,7 +4377,7 @@ describe('App', () => {
       });
 
       expect(document.body.querySelector('.compact-input-tool-fan')).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
-      expect(onCompactChatStateChange).not.toHaveBeenCalledWith('default');
+      expect(onCompactChatStateChange).toHaveBeenCalledWith('default');
     } finally {
       vi.useRealTimers();
     }
@@ -4359,7 +4423,7 @@ describe('App', () => {
     expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test compact send' });
   });
 
-  it('keeps compact input open when it loses focus with no content', async () => {
+  it('returns empty compact input to subtitle state when it loses focus', async () => {
     const onCompactChatStateChange = vi.fn();
     const outsideButton = document.createElement('button');
     document.body.appendChild(outsideButton);
@@ -4382,13 +4446,13 @@ describe('App', () => {
       await new Promise((resolve) => window.setTimeout(resolve, 0));
     });
 
-    expect(onCompactChatStateChange).not.toHaveBeenCalledWith('default');
+    expect(onCompactChatStateChange).toHaveBeenCalledWith('default');
     } finally {
       outsideButton.remove();
     }
   });
 
-  it('keeps compact input open on window blur even when focus remains in the compact shell', async () => {
+  it('returns empty compact input to subtitle state on window blur even when focus remains in the compact shell', async () => {
     const onCompactChatStateChange = vi.fn();
     render(
       <App
@@ -4406,10 +4470,10 @@ describe('App', () => {
       await new Promise((resolve) => window.setTimeout(resolve, 0));
     });
 
-    expect(onCompactChatStateChange).not.toHaveBeenCalledWith('default');
+    expect(onCompactChatStateChange).toHaveBeenCalledWith('default');
   });
 
-  it('keeps compact input open when a document-level outside pointer starts with no content', async () => {
+  it('returns empty compact input to subtitle state when a document-level outside pointer starts', async () => {
     const onCompactChatStateChange = vi.fn();
     const outsideButton = document.createElement('button');
     document.body.appendChild(outsideButton);
@@ -4431,7 +4495,7 @@ describe('App', () => {
         await new Promise((resolve) => window.setTimeout(resolve, 0));
       });
 
-      expect(onCompactChatStateChange).not.toHaveBeenCalledWith('default');
+      expect(onCompactChatStateChange).toHaveBeenCalledWith('default');
     } finally {
       outsideButton.remove();
     }

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -117,6 +117,20 @@ describe('App', () => {
     expect(document.body.querySelector('.compact-input-tool-fan')).not.toBeNull();
   });
 
+  it('enters compact input from the subtitle capsule when used uncontrolled', () => {
+    const { container } = render(<App chatSurfaceMode="compact" />);
+
+    // 未受控：初始是字幕胶囊，没有输入框
+    expect(container.querySelector('.compact-chat-capsule-button')).not.toBeNull();
+    expect(container.querySelector('.composer-input')).toBeNull();
+
+    fireEvent.click(container.querySelector('.compact-chat-capsule-button') as HTMLButtonElement);
+
+    // 点击胶囊后内部 state 兜底切到输入态，输入框出现
+    expect(container.querySelector('.composer-input')).not.toBeNull();
+    expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
+  });
+
   it('exposes explicit surface mode state on the rendered shell', () => {
     const { container } = render(<App chatSurfaceMode="compact" compactChatState="input" />);
 

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -2215,7 +2215,7 @@ describe('App', () => {
     }
   });
 
-  it('renders compact input as the default entry without history or extra controls', () => {
+  it('renders compact input without history or extra controls', () => {
     const message = parseChatMessage({
       id: 'assistant-compact-1',
       role: 'assistant',
@@ -2224,7 +2224,7 @@ describe('App', () => {
       createdAt: 1,
       blocks: [{ type: 'text', text: '今天想让我陪你做什么呢？' }],
     });
-    const { container } = render(<App chatSurfaceMode="compact" messages={[message]} />);
+    const { container } = render(<App chatSurfaceMode="compact" compactChatState="input" messages={[message]} />);
 
     expect(container.querySelector('.compact-chat-stage-body-slot')).toHaveAttribute('data-compact-stage-fallback', 'message-list');
     expect(container.querySelector('.message-list')).toBeNull();
@@ -2249,6 +2249,7 @@ describe('App', () => {
     render(
       <App
         chatSurfaceMode="compact"
+        compactChatState="input"
         messages={[message]}
         onCompactChatStateChange={onCompactChatStateChange}
       />,

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -66,14 +66,23 @@ const defaultMessages: ChatMessage[] = [];
 type AvatarToolId = AvatarInteractionPayload['toolId'];
 
 function getEffectiveCompactChatState(
-  _requestedState: CompactChatState,
-  _hasVisibleChoices: boolean,
+  requestedState: CompactChatState,
+  hasVisibleChoices: boolean,
   composerHidden: boolean,
 ): CompactChatState {
   if (composerHidden) {
     return 'default';
   }
-  return 'input';
+  if (requestedState === 'input') {
+    return 'input';
+  }
+  if (hasVisibleChoices) {
+    return 'options';
+  }
+  if (requestedState === 'options') {
+    return 'default';
+  }
+  return requestedState;
 }
 
 const COMPACT_PREVIEW_MAX_LENGTH = 84;
@@ -1043,7 +1052,7 @@ export default function App({
   composerHidden = false,
   composerDisabled = false,
   chatSurfaceMode = 'compact',
-  compactChatState = 'input',
+  compactChatState = 'default',
   composerAttachments = [],
   composerAttachmentsAriaLabel = i18n('chat.pendingImagesAriaLabel', 'Pending attachments'),
   importImageButtonLabel = i18n('chat.importImage', 'Import Image'),
@@ -1930,6 +1939,21 @@ export default function App({
     }
     textNode.scrollLeft = textNode.scrollWidth;
   }, [compactPreviewDisplayText, compactPreviewIsStreaming, isCompactSurface]);
+
+  const handleCompactPreviewWheel = useCallback((event: ReactWheelEvent<HTMLSpanElement>) => {
+    const textNode = event.currentTarget;
+    const maxScrollLeft = Math.max(0, textNode.scrollWidth - textNode.clientWidth);
+    if (maxScrollLeft <= 0) return;
+
+    const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY)
+      ? event.deltaX
+      : event.deltaY;
+    if (delta === 0) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    textNode.scrollLeft = Math.max(0, Math.min(maxScrollLeft, textNode.scrollLeft + delta));
+  }, []);
 
   useEffect(() => {
     if (!isCompactSurface) return;
@@ -3021,10 +3045,10 @@ export default function App({
     clearCompactInputToolFanCloseTimer();
   }, [clearCompactInputToolFanCloseTimer]);
 
-  const collapseCompactInputIfEmpty = useCallback((options?: { ignoreFocusedShell?: boolean }) => {
+  const collapseCompactInputIfEmpty = useCallback((options?: { ignoreFocusedShell?: boolean; ignoreToolFan?: boolean }) => {
     if (!isCompactSurface) return;
     if (effectiveCompactChatState !== 'input') return;
-    if (compactInputToolFanOpen) return;
+    if (!options?.ignoreToolFan && compactInputToolFanOpen) return;
     if (draftRef.current.trim().length > 0) return;
     if (composerAttachments.length > 0) return;
     if (!options?.ignoreFocusedShell && compactExportHistoryOpen) return;
@@ -3042,12 +3066,14 @@ export default function App({
     ) {
       return;
     }
+    requestCompactChatState('default');
   }, [
     compactInputToolFanOpen,
     compactExportHistoryOpen,
     composerAttachments.length,
     effectiveCompactChatState,
     isCompactSurface,
+    requestCompactChatState,
   ]);
 
   const scheduleCompactInputCollapse = useCallback(() => {
@@ -3101,7 +3127,7 @@ export default function App({
 
   useEffect(() => {
     if (!compactInputToolFanOpen) return;
-    if (!isCompactSurface || effectiveCompactChatState !== 'input' || composerHidden || composerDisabled || compactInputHasPayload) {
+    if (!isCompactSurface || composerHidden || composerDisabled || compactInputHasPayload) {
       closeCompactInputToolFan();
     }
   }, [
@@ -3110,7 +3136,6 @@ export default function App({
     compactInputToolFanOpen,
     composerDisabled,
     composerHidden,
-    effectiveCompactChatState,
     isCompactSurface,
   ]);
 
@@ -3149,6 +3174,13 @@ export default function App({
         || compactInputToolWheelChargeReleaseActiveRef.current
       ) return;
       closeCompactInputToolFanFromDesktopOutside();
+      if (compactInputToolFanOpenRef.current) {
+        window.setTimeout(() => {
+          collapseCompactInputIfEmpty({ ignoreFocusedShell: true, ignoreToolFan: true });
+        }, COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS);
+        return;
+      }
+      collapseCompactInputIfEmpty({ ignoreFocusedShell: true, ignoreToolFan: true });
     };
 
     window.addEventListener('neko:desktop-compact-pointer-outside', handleDesktopCompactPointerOutside);
@@ -3156,6 +3188,7 @@ export default function App({
       window.removeEventListener('neko:desktop-compact-pointer-outside', handleDesktopCompactPointerOutside);
     };
   }, [
+    collapseCompactInputIfEmpty,
     closeCompactInputToolFanFromDesktopOutside,
     isCompactSurface,
   ]);
@@ -3826,6 +3859,7 @@ export default function App({
       onComposerSubmit?.({ text });
       setDraft('');
       restoreCompactExportHistoryToBottomForOutgoingMessage();
+      requestCompactChatState('default');
     } finally {
       requestAnimationFrame(() => { submittingRef.current = false; });
     }
@@ -3961,8 +3995,47 @@ export default function App({
     '--compact-tool-wheel-charge-first-angle': `${compactInputToolWheelChargeFirstLapAngle}deg`,
     '--compact-tool-wheel-charge-second-angle': `${compactInputToolWheelChargeSecondLapAngle}deg`,
   } as CSSProperties;
+  const compactToolToggleVisible = isCompactSurface && !composerHidden;
+  const compactToolToggleActsAsSubmit = effectiveCompactChatState === 'input' && compactInputHasPayload;
+  const compactInputToolToggleButton = compactToolToggleVisible ? (
+    <button
+      className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
+      ref={compactInputToolToggleRef}
+      type={compactToolToggleActsAsSubmit ? 'submit' : 'button'}
+      aria-label={compactToolToggleActsAsSubmit ? sendButtonLabel : overflowMenuAriaLabel}
+      aria-haspopup={compactToolToggleActsAsSubmit ? undefined : 'true'}
+      aria-expanded={compactToolToggleActsAsSubmit ? undefined : compactInputToolFanOpen}
+      disabled={compactToolToggleActsAsSubmit ? !canSubmit : composerDisabled}
+      onPointerDown={compactToolToggleActsAsSubmit ? undefined : (event) => {
+        event.preventDefault();
+        compactInputToolTogglePointerHandledRef.current = true;
+        toggleCompactInputToolFanByClick();
+      }}
+      onPointerEnter={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverEnter}
+      onPointerLeave={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverLeave}
+      onFocus={compactToolToggleActsAsSubmit ? undefined : clearCompactInputToolFanCloseTimer}
+      onBlur={compactToolToggleActsAsSubmit ? scheduleCompactInputCollapse : () => {
+        scheduleCompactInputToolFanTransientClose();
+        scheduleCompactInputCollapse();
+      }}
+      onClick={compactToolToggleActsAsSubmit ? undefined : () => {
+        if (compactInputToolTogglePointerHandledRef.current) {
+          compactInputToolTogglePointerHandledRef.current = false;
+          return;
+        }
+        toggleCompactInputToolFanByClick();
+      }}
+    >
+      <img
+        className={compactToolToggleActsAsSubmit ? undefined : 'compact-input-tool-toggle-icon'}
+        src={compactToolToggleActsAsSubmit ? '/static/icons/send_new_icon.png' : '/static/icons/dropdown_arrow.png'}
+        alt=""
+        aria-hidden="true"
+      />
+    </button>
+  ) : null;
 
-  const compactInputToolFanNode = isCompactSurface && effectiveCompactChatState === 'input' ? (
+  const compactInputToolFanNode = compactToolToggleVisible ? (
     <div
       ref={compactInputToolFanRef}
       className="compact-input-tool-fan"
@@ -4342,6 +4415,7 @@ export default function App({
                       try {
                         restoreCompactExportHistoryToBottomForOutgoingMessage();
                         onGalgameOptionSelect?.(option);
+                        requestCompactChatState('default');
                       } finally {
                         requestAnimationFrame(() => { submittingRef.current = false; });
                       }
@@ -4394,6 +4468,7 @@ export default function App({
                   try {
                     restoreCompactExportHistoryToBottomForOutgoingMessage();
                     onChoiceSelect?.(option, choicePrompt.source);
+                    requestCompactChatState('default');
                   } finally {
                     requestAnimationFrame(() => { submittingRef.current = false; });
                   }
@@ -4681,6 +4756,7 @@ export default function App({
                   data-compact-geometry-owner="surface"
                   data-compact-chat-state={effectiveCompactChatState}
                   data-compact-geometry-part={effectiveCompactChatState === 'input' ? 'inputBody' : 'capsuleBody'}
+                  data-compact-tool-toggle-visible={compactToolToggleVisible ? 'true' : 'false'}
                 >
                   {effectiveCompactChatState === 'input' ? (
                     <>
@@ -4708,60 +4784,30 @@ export default function App({
                           }
                         }}
                       />
-                      <button
-                        className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
-                        ref={compactInputToolToggleRef}
-                        type={compactInputHasPayload ? 'submit' : 'button'}
-                        aria-label={compactInputHasPayload ? sendButtonLabel : overflowMenuAriaLabel}
-                        aria-haspopup={compactInputHasPayload ? undefined : 'true'}
-                        aria-expanded={compactInputHasPayload ? undefined : compactInputToolFanOpen}
-                        disabled={compactInputHasPayload ? !canSubmit : composerDisabled}
-                        onPointerDown={compactInputHasPayload ? undefined : (event) => {
-                          event.preventDefault();
-                          compactInputToolTogglePointerHandledRef.current = true;
-                          toggleCompactInputToolFanByClick();
-                        }}
-                        onPointerEnter={compactInputHasPayload ? undefined : handleCompactInputToolHoverEnter}
-                        onPointerLeave={compactInputHasPayload ? undefined : handleCompactInputToolHoverLeave}
-                        onFocus={compactInputHasPayload ? undefined : clearCompactInputToolFanCloseTimer}
-                        onBlur={compactInputHasPayload ? scheduleCompactInputCollapse : () => {
-                          scheduleCompactInputToolFanTransientClose();
-                          scheduleCompactInputCollapse();
-                        }}
-                        onClick={compactInputHasPayload ? undefined : () => {
-                          if (compactInputToolTogglePointerHandledRef.current) {
-                            compactInputToolTogglePointerHandledRef.current = false;
-                            return;
-                          }
-                          toggleCompactInputToolFanByClick();
-                        }}
-                      >
-                        <img
-                          className={compactInputHasPayload ? undefined : 'compact-input-tool-toggle-icon'}
-                          src={compactInputHasPayload ? '/static/icons/send_new_icon.png' : '/static/icons/dropdown_arrow.png'}
-                          alt=""
-                          aria-hidden="true"
-                        />
-                      </button>
+                      {compactInputToolToggleButton}
                     </>
                   ) : (
-                    <button
-                      className="compact-chat-capsule-button"
-                      type="button"
-                      disabled={composerDisabled}
-                      onClick={() => {
-                        if (composerHidden) return;
-                        requestCompactChatState('input');
-                      }}
-                    >
-                      <span
-                        ref={compactPreviewTextRef}
-                        className="compact-chat-capsule-text"
-                        data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
+                    <>
+                      <button
+                        className="compact-chat-capsule-button"
+                        type="button"
+                        disabled={composerDisabled}
+                        onClick={() => {
+                          if (composerHidden) return;
+                          requestCompactChatState('input');
+                        }}
                       >
-                        {compactPreviewDisplayText}
-                      </span>
-                    </button>
+                        <span
+                          ref={compactPreviewTextRef}
+                          className="compact-chat-capsule-text"
+                          data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
+                          onWheel={handleCompactPreviewWheel}
+                        >
+                          {compactPreviewDisplayText}
+                        </span>
+                      </button>
+                      {compactInputToolToggleButton}
+                    </>
                   )}
                 </div>
                 {compactInputToolFanNode}

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1052,7 +1052,7 @@ export default function App({
   composerHidden = false,
   composerDisabled = false,
   chatSurfaceMode = 'compact',
-  compactChatState = 'default',
+  compactChatState,
   composerAttachments = [],
   composerAttachmentsAriaLabel = i18n('chat.pendingImagesAriaLabel', 'Pending attachments'),
   importImageButtonLabel = i18n('chat.importImage', 'Import Image'),
@@ -1330,7 +1330,12 @@ export default function App({
     && (galgameOptionsLoading || galgameOptions.length > 0);
   const compactSurfaceChoicesVisible = choicePromptHasOptions || galgameOptionsVisible;
   const isCompactSurface = chatSurfaceMode !== 'minimized';
-  const requestedCompactChatState = compactChatState;
+  // compactChatState 受控时跟随外部 prop；未受控（独立挂载 / 开发预览 main.tsx）时用
+  // 内部 state 兜底，让字幕胶囊点击能真正切到输入态，而不是停在胶囊里出不来喵。
+  const isCompactChatStateControlled = compactChatState !== undefined;
+  const [uncontrolledCompactChatState, setUncontrolledCompactChatState] =
+    useState<CompactChatState>('default');
+  const requestedCompactChatState = compactChatState ?? uncontrolledCompactChatState;
   const effectiveCompactChatState = isCompactSurface
     ? getEffectiveCompactChatState(requestedCompactChatState, compactSurfaceChoicesVisible, composerHidden)
     : requestedCompactChatState;
@@ -2104,8 +2109,11 @@ export default function App({
 
   const requestCompactChatState = useCallback((nextState: CompactChatState) => {
     if (!isCompactSurface) return;
+    if (!isCompactChatStateControlled) {
+      setUncontrolledCompactChatState(nextState);
+    }
     onCompactChatStateChange?.(nextState);
-  }, [isCompactSurface, onCompactChatStateChange]);
+  }, [isCompactSurface, isCompactChatStateControlled, onCompactChatStateChange]);
 
   const applyCompactSurfaceResizeWidthVar = useCallback((width: number | null) => {
     const shell = compactInputShellRef.current;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1933,6 +1933,10 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   padding: 5px 62px 5px 20px;
 }
 
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"]) {
+  padding-right: 62px;
+}
+
 .compact-chat-surface-frame::before {
   content: "";
   position: absolute;
@@ -1991,9 +1995,11 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   display: block;
   width: 100%;
   min-width: 0;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  scrollbar-width: none;
   font-size: 1.04rem;
   font-weight: 500;
   line-height: 1.35;
@@ -2003,11 +2009,9 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 
 .compact-chat-capsule-text[data-compact-preview-streaming="true"] {
   text-overflow: clip;
-  overflow-x: auto;
-  scrollbar-width: none;
 }
 
-.compact-chat-capsule-text[data-compact-preview-streaming="true"]::-webkit-scrollbar {
+.compact-chat-capsule-text::-webkit-scrollbar {
   display: none;
 }
 
@@ -3193,7 +3197,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   display: none;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .send-button-circle {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .send-button-circle {
   width: 42px;
   height: 42px;
   border-radius: 999px;
@@ -3202,12 +3206,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   overflow: visible;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .send-button-circle img {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .send-button-circle img {
   width: 46px;
   height: 46px;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle {
   --compact-tool-toggle-hover-outset: 14px;
   position: absolute;
   top: 5px;
@@ -3218,11 +3222,11 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transform: none;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle:hover {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle:hover {
   transform: none;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle::before {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle::before {
   content: "";
   position: absolute;
   inset: calc(var(--compact-tool-toggle-hover-outset) * -1);
@@ -3238,23 +3242,23 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"] {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle[aria-haspopup="true"] {
   background: rgba(160, 220, 255, 0.26);
   box-shadow:
     0 0 0 1px rgba(193, 236, 255, 0.48),
     inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"]::before {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle[aria-haspopup="true"]::before {
   opacity: 1;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"]:hover::before,
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle[aria-haspopup="true"].is-open::before {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle[aria-haspopup="true"]:hover::before,
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle[aria-haspopup="true"].is-open::before {
   transform: scale(1.08);
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle-icon {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle-icon {
   position: relative;
   z-index: 1;
   width: 46px;
@@ -3264,7 +3268,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transition: transform 0.18s ease;
 }
 
-.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-input-tool-toggle.is-open .compact-input-tool-toggle-icon {
+.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .compact-input-tool-toggle.is-open .compact-input-tool-toggle-icon {
   transform: rotate(-90deg);
 }
 
@@ -4115,7 +4119,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   color: rgba(202, 222, 244, 0.66);
 }
 
-[data-theme="dark"] .compact-chat-surface-frame[data-compact-chat-state="input"] .send-button-circle {
+[data-theme="dark"] .compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] .send-button-circle {
   background: transparent;
   box-shadow: none;
 }

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3653,6 +3653,13 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     padding: 0 18px;
   }
 
+  /* 工具轮盘按钮在字幕/选项态依旧绝对定位在右侧，需保留右侧内边距，
+     避免上面的 padding 简写把字幕文字挤到按钮下方喵 */
+  .compact-chat-surface-frame[data-compact-tool-toggle-visible="true"][data-compact-chat-state="default"],
+  .compact-chat-surface-frame[data-compact-tool-toggle-visible="true"][data-compact-chat-state="options"] {
+    padding-right: 62px;
+  }
+
   .compact-chat-surface-frame[data-compact-chat-state="input"] {
     padding: 5px 8px 5px 18px;
   }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -59,7 +59,7 @@
     var savedExpandedShellPosition = null; // last known full-surface desktop position
     var lastRestorableChatSurfaceMode = 'compact';
     var _sortKeySeq = 0; // monotonically increasing sortKey counter
-    var COMPACT_CHAT_STATES = ['input'];
+    var COMPACT_CHAT_STATES = ['default', 'options', 'input'];
     var CHAT_SURFACE_MODE_SEQUENCE = ['compact', 'minimized'];
 
     var state = {
@@ -79,7 +79,7 @@
         pendingRollbackDrafts: Object.create(null),
         rollbackDraft: '',
         _toolCursorResetKey: '',
-        compactChatState: 'input',
+        compactChatState: 'default',
         chatSurfaceMode: 'compact',
         // Off until init() reads the persisted preference post-barrier and
         // calls setGalgameModeEnabled(true) — that path fires the
@@ -108,7 +108,7 @@
     }
 
     function normalizeCompactChatState(mode) {
-        return COMPACT_CHAT_STATES.indexOf(mode) >= 0 ? mode : 'input';
+        return COMPACT_CHAT_STATES.indexOf(mode) >= 0 ? mode : 'default';
     }
 
     function getCurrentChatSurfaceMode() {
@@ -151,7 +151,7 @@
     }
 
     function resetCompactChatState() {
-        state.compactChatState = 'input';
+        state.compactChatState = 'default';
     }
 
     function shouldPersistChatSurfaceModePreference() {

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -107,10 +107,10 @@ def test_minimized_restore_uses_previous_real_surface_mode():
 
     assert "var lastRestorableChatSurfaceMode = 'compact';" in source
     assert "var CHAT_SURFACE_MODE_SEQUENCE = ['compact', 'minimized'];" in source
-    assert "var COMPACT_CHAT_STATES = ['input'];" in source
-    assert "compactChatState: 'input'," in source
-    assert "return COMPACT_CHAT_STATES.indexOf(mode) >= 0 ? mode : 'input';" in source
-    assert "state.compactChatState = 'input';" in source
+    assert "var COMPACT_CHAT_STATES = ['default', 'options', 'input'];" in source
+    assert "compactChatState: 'default'," in source
+    assert "return COMPACT_CHAT_STATES.indexOf(mode) >= 0 ? mode : 'default';" in source
+    assert "state.compactChatState = 'default';" in source
 
     next_mode_block = source.split("function getNextChatSurfaceMode(mode)", 1)[1].split(
         "function resetCompactChatState()",
@@ -333,10 +333,12 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     assert '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]' in styles
     assert "visibility: visible;" in styles
     assert (
-        '.compact-chat-surface-frame[data-compact-chat-state="input"] '
+        '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] '
         '.compact-input-tool-toggle:hover'
     ) in styles
     assert 'padding: 5px 62px 5px 20px;' in styles
+    assert '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"])' in styles
+    assert 'padding-right: 62px;' in styles
     assert 'right: 9px;' in styles
     assert "transform: none;" in styles
     assert '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden"]' in styles


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 紧凑模式下的预览文本增加鼠标滚轮横向滚动支持

* **改进**
  * 紧凑聊天默认状态改为“default”，支持 default/options/input 三种状态并优化切换与受控/非受控行为
  * 优化工具切换可见性、折叠与自动关闭时序；提交或选择后更可靠地恢复到默认态

* **样式**
  * 调整紧凑模式下工具切换相关的布局与滚动条显示样式

* **测试**
  * 扩展并调整紧凑模式交互用例，覆盖更多场景与回退逻辑验证
<!-- end of auto-generated comment: release notes by coderabbit.ai -->