### PR TITLE
fix(chat): 退掉独立 /chat 的 full 玻璃壳，直接复用共用 compact（消除加载 full→compact 闪帧）

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -33,54 +33,27 @@
             background: transparent !important;
             overflow: hidden;
         }
-        /* Electron 独立窗口模式：React Chat 覆盖全窗口 */
+        /* Electron 独立窗口：overlay 充满窗口、当透明容器；内部 #react-chat-window-shell
+           走与首页共用的 compact 胶囊样式（static/css/index.css 里
+           body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]
+           规则集，chat.html 的 <body> 带 subtitle-web-host 故自动命中）。 */
         #react-chat-window-overlay {
             position: fixed; inset: 0;
             display: block !important;
             background: transparent !important;
         }
         #react-chat-window-backdrop { display: none !important; }
-        #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
-            position: fixed !important;
-            inset: 40px 25px 25px 20px !important;
-            width: auto !important; height: auto !important;
-            max-width: none !important; max-height: none !important;
-            transform: none !important;
-            border-radius: 22px !important;
-            background: transparent !important;
-            /* 液态边缘反光 — 顶部最亮，左次之，模拟顶光 */
-            border-top: 2px solid rgba(255, 255, 255, 0.7) !important;
-            border-left: 1px solid rgba(255, 255, 255, 0.35) !important;
-            border-right: 1px solid rgba(255, 255, 255, 0.15) !important;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.06) !important;
-            /* 外阴影 + 内高光带 */
-            box-shadow:
-                0 4px 16px rgba(12, 20, 34, 0.18),
-                0 1px 4px rgba(12, 20, 34, 0.1),
-                inset 0 2px 4px rgba(255, 255, 255, 0.5),
-                inset 0 -1px 2px rgba(255, 255, 255, 0.08) !important;
-        }
-        /* 顶栏：降低透明度 + 减小高度（原 min-height:54px + padding:10px 14px 8px） */
-        .window-topbar {
-            background: rgba(255, 255, 255, 0.35) !important;
-            min-height: 45px !important;
-            height: 45px !important;
-            padding: 0 12px !important;
-            box-sizing: border-box !important;
-        }
-        .window-topbar-actions,
-        .window-topbar-actions > * {
-            display: flex !important;
-            align-items: center !important;
-        }
-        /* 右上角四个按钮居中对齐 topbar（原 top:10px 基于 54px 高度，现适配 45px） */
-        #react-chat-window-header-actions {
-            top: 5px !important;
-        }
-        #reactChatWindowCloseButton {
-            position: relative !important;
-            top: -2px !important;
-        }
+        /* ──────────────────────────────────────────────────────────────────────
+           full 形态（覆盖全窗口的玻璃面板）已退环境，仅在此留档：
+           旧版在这里把 #react-chat-window-shell 钉成 inset:40px 的全窗口玻璃面板
+           （磨砂背景 / 四边反光边框 / 外阴影 + ::before 静态高光 + ::after 流光动画
+           + 顶栏 chrome + #react-chat-window-root 四边渐隐 mask）。因为这些规则不带
+           data-chat-surface-mode 门槛、且 overlay 又不是 hidden，页面一加载、React 还
+           没挂载时就会先画出这块空的全窗口玻璃面板，挂载后才塌成 compact —— 就是
+           "先 full 再 compact" 的那一帧。现在 shell 直接复用 index.css 的 compact 胶囊
+           规则（透明壳 + 隐藏顶栏按钮 + 去掉 ::before/::after 玻璃层），不再注入任何
+           full 形态样式/动画/mask 资源。
+           ────────────────────────────────────────────────────────────────────── */
         body.yui-guide-chat-buttons-disabled #react-chat-window-shell button,
         body.yui-guide-chat-buttons-disabled #toggle-chat-btn {
             pointer-events: none !important;
@@ -282,95 +255,11 @@
                          'Hiragino Sans', 'Malgun Gothic', sans-serif !important;
             font-weight: 400 !important;
         }
-        [data-theme="dark"] .window-topbar {
-            background: rgba(50, 50, 72, 0.35) !important;
-        }
-        /* 四边透明度渐变带：窄边（~10px），让边缘内容淡出露出高光 */
-        #react-chat-window-root {
-            -webkit-mask-image:
-                linear-gradient(to bottom, rgba(0,0,0,0.3) 0px, black 10px, black calc(100% - 10px), rgba(0,0,0,0.6) 100%),
-                linear-gradient(to right, rgba(0,0,0,0.4) 0px, black 8px, black calc(100% - 8px), rgba(0,0,0,0.4) 100%) !important;
-            -webkit-mask-composite: source-in !important;
-        }
-        body.electron-chat-window.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"] #react-chat-window-root {
-            -webkit-mask-image: none !important;
-            mask-image: none !important;
-            -webkit-mask-composite: initial !important;
-            mask-composite: initial !important;
-        }
-        @keyframes liquidFlow {
-            0%    { background-position:   0%   0%,  80%  10%,  40%  30%,  90%  50%,  20%  70%,  60%  85%,  95%  90%; }
-            12%   { background-position:  50%  15%,  20%  60%,  80%  10%,  40%  80%,  70%   5%,  10%  50%,  55%  35%; }
-            25%   { background-position:  90%  55%,  50%  90%,  15%  65%,  75%  20%,  45%  85%,  85%  15%,  20%  70%; }
-            38%   { background-position:  30%  85%,  85%  30%,  60%  95%,  10%  45%,  90%  40%,  40%  70%,  70%  10%; }
-            50%   { background-position:  70%  40%,  10%  75%,  95%  20%,  55%  90%,  15%  30%,  75%  55%,  35%  80%; }
-            63%   { background-position:  15%  70%,  65%  15%,  30%  50%,  85%  65%,  55%  95%,  25%  25%,  80%  50%; }
-            75%   { background-position:  80%  25%,  35%  85%,  70%  40%,  20%  10%,  85%  60%,  50%  90%,  10%  30%; }
-            88%   { background-position:  45%  90%,  90%  45%,  10%  75%,  60%  35%,  30%  50%,  80%  10%,  50%  65%; }
-            100%  { background-position:   0%   0%,  80%  10%,  40%  30%,  90%  50%,  20%  70%,  60%  85%,  95%  90%; }
-        }
-        /* 对角光带扫过 */
-        @keyframes lightSweep {
-            0%   { background-position: -150% -150%; }
-            100% { background-position: 250% 250%; }
-        }
-        /* 静态边缘高光层 — 在内容之下 */
-        #react-chat-window-shell:not(.is-minimized)::before {
-            content: '' !important;
-            position: absolute !important;
-            inset: 0 !important;
-            border-radius: 22px !important;
-            pointer-events: none !important;
-            z-index: 0 !important;
-            /* 边缘高光 */
-            box-shadow:
-                inset 0 2px 6px rgba(255, 255, 255, 0.5),
-                inset 0 -1px 3px rgba(255, 255, 255, 0.1),
-                inset 2px 0 4px rgba(255, 255, 255, 0.15),
-                inset -2px 0 4px rgba(255, 255, 255, 0.08) !important;
-            /* 顶部弧形高光（静态） */
-            background: linear-gradient(
-                180deg,
-                rgba(255, 255, 255, 0.25) 0%,
-                rgba(255, 255, 255, 0.08) 8%,
-                transparent 20%,
-                transparent 85%,
-                rgba(255, 255, 255, 0.04) 100%
-            ) !important;
-        }
-        /* 流动光斑层 — 三色径向渐变缓慢漂移，模拟玻璃折射
-           用 background-image 而非 background 简写，避免 !important 锁死 background-position */
-        #react-chat-window-shell:not(.is-minimized)::after {
-            content: '' !important;
-            position: absolute !important;
-            inset: 0 !important;
-            border-radius: 22px !important;
-            pointer-events: none !important;
-            z-index: 10 !important;
-            background-image:
-                radial-gradient(circle at 15% 10%, rgba(100,180,255,0.14) 0%, transparent 22%),
-                radial-gradient(circle at 75% 15%, rgba(180,140,255,0.11) 0%, transparent 20%),
-                radial-gradient(circle at 40% 35%, rgba(220,140,240,0.12) 0%, transparent 18%),
-                radial-gradient(circle at 85% 50%, rgba(120,200,255,0.13) 0%, transparent 20%),
-                radial-gradient(circle at 25% 65%, rgba(200,160,255,0.10) 0%, transparent 19%),
-                radial-gradient(circle at 60% 80%, rgba(100,190,255,0.12) 0%, transparent 21%),
-                radial-gradient(circle at 90% 85%, rgba(240,150,200,0.10) 0%, transparent 17%) !important;
-            background-size: 200% 200%, 200% 200%, 200% 200%, 200% 200%, 200% 200%, 200% 200%, 200% 200% !important;
-            background-repeat: no-repeat !important;
-            animation: liquidFlow 20s ease-in-out infinite !important;
-        }
-        /* 折叠/展开动画期间：允许 JS 控制 position/size/transform */
-        #react-chat-window-shell.is-collapsing,
-        #react-chat-window-shell.is-expanding {
-            inset: auto !important;
-            max-width: none !important; max-height: none !important;
-            border-radius: 22px !important;
-        }
-        /* 最小化态 */
-        #react-chat-window-shell.is-minimized {
-            inset: auto !important;
-            max-width: none !important; max-height: none !important;
-        }
+        /* full 形态的暗色顶栏底、#react-chat-window-root 四边渐隐 mask、liquidFlow /
+           lightSweep 玻璃流光关键帧、以及 shell 的 ::before/::after 玻璃层、
+           is-collapsing/is-expanding/is-minimized 全窗口几何复位，均随 full 形态一并
+           退环境。compact 态的最小化/折叠/展开几何由 index.css 的 subtitle-web-host
+           规则统一负责，这里不再注入 full 形态资源。 */
         /* 输入区提到光晕层之上，保持原始不透明度 */
         .composer-panel {
             position: relative !important;
@@ -659,7 +548,10 @@
     </div>
 
     <!-- React Chat（与 index.html 完全相同的 DOM 结构）-->
-    <div id="react-chat-window-overlay">
+    <!-- overlay 默认 hidden（与 index.html 一致）：在 React 挂载完成、shell 已带
+         data-chat-surface-mode="compact" 之前不渲染任何东西，避免先闪一帧 full 形态。
+         app-react-chat-window.js 的 openWindow() 会在 mountWindow() 之后置 hidden=false。 -->
+    <div id="react-chat-window-overlay" hidden>
         <div id="react-chat-window-backdrop"></div>
         <div id="react-chat-window-shell" role="dialog" aria-modal="true" aria-labelledby="react-chat-window-title">
             <div id="react-chat-window-drag-handle" aria-hidden="true"></div>

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -500,23 +500,31 @@ def test_desktop_compact_layout_change_resets_anchor_only_when_base_surface_chan
     assert "compactSurfaceAnchorSnapshot = '';" not in listener_block
 
 
-def test_electron_compact_chat_root_mask_does_not_clip_history_layer():
+def test_electron_compact_chat_retires_full_surface_chrome():
     template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
 
+    # The standalone /chat window renders the shared compact capsule (driven by
+    # static/css/index.css's `body.subtitle-web-host #react-chat-window-shell
+    # [data-chat-surface-mode="compact"]` rule set, which chat.html's
+    # subtitle-web-host body opts into) instead of a bespoke full-window glass
+    # panel. The retired full form used to paint an empty glass panel for one
+    # frame before React mounted and collapsed it to compact ("先 full 再
+    # compact" 的那一帧). chat.html must NOT re-introduce that full surface.
+    #
+    # Retired full-surface artifacts that must stay gone:
+    assert "@keyframes liquidFlow" not in template            # 玻璃流光关键帧
+    assert "@keyframes lightSweep" not in template
+    assert "-webkit-mask-image" not in template               # 全窗口 root 四边渐隐 mask
+    assert "#react-chat-window-shell:not(.is-minimized)::before" not in template
+    assert "#react-chat-window-shell:not(.is-minimized)::after" not in template
+    assert "inset: 40px 25px 25px 20px" not in template       # 全窗口 shell 几何
+
+    # The shell font tweak survives (compact still uses #react-chat-window-root).
     assert "#react-chat-window-root {" in template
-    assert (
-        'body.electron-chat-window.subtitle-web-host '
-        '#react-chat-window-shell[data-chat-surface-mode="compact"] #react-chat-window-root'
-    ) in template
-
-    compact_override_block = template.split(
-        'body.electron-chat-window.subtitle-web-host '
-        '#react-chat-window-shell[data-chat-surface-mode="compact"] #react-chat-window-root',
-        1,
-    )[1].split("@keyframes liquidFlow", 1)[0]
-
-    assert "-webkit-mask-image: none !important;" in compact_override_block
-    assert "mask-image: none !important;" in compact_override_block
+    # The overlay must start hidden so nothing paints before React mounts the
+    # compact surface — parity with templates/index.html, which is what kills the
+    # pre-mount full-form flash.
+    assert 'id="react-chat-window-overlay" hidden' in template
 
 
 def test_compact_history_controls_collapse_gives_height_back_to_history_scroll():


### PR DESCRIPTION
## 问题

Electron 加载独立 `/chat`（react-neko-chat）时，总会先闪一帧"展开形态（full）"再塌成 compact。

根因不在 React 组件（它早就只剩 `compact` / `minimized`），而在 `templates/chat.html` 自己的 `<style>`：

- chat.html 的 `<body>` 带 `subtitle-web-host`，`static/css/index.css` 早已为该 shell 写好整套 **compact 胶囊规则**（透明壳、隐藏顶栏按钮、去掉 `::before/::after` 玻璃层）。
- 但 chat.html 里还留着一套**覆盖全窗口的玻璃面板** chrome，选择器不带 `data-chat-surface-mode` 门槛、`#react-chat-window-overlay` 又没有 `hidden`。`data-chat-surface-mode="compact"` 要等 React 挂载后才写到 shell 上，所以**页面一加载、React 还没挂载时**就先画出这块空玻璃面板，挂载后才被 index.css 的 compact 规则盖住 —— 就是那一帧 `full → compact`。

这套 full chrome 与 index.css 的 compact 规则纯属**冗余且互相打架**。

## 改动

- `templates/chat.html`
  - `#react-chat-window-overlay` 加 `hidden`（与 `index.html` 一致）：挂载完成后 `app-react-chat-window.js` 的 `openWindow()` 才置 `hidden=false`，挂载前不渲染任何东西。
  - 删掉全部 full 形态资源：`#react-chat-window-shell` 的 `inset:40px` 全窗口玻璃壳（背景/边框/外阴影）、顶栏 chrome、暗色顶栏底、`#react-chat-window-root` 四边渐隐 mask、`liquidFlow`/`lightSweep` 关键帧、`::before`/`::after` 玻璃层、`is-collapsing`/`is-expanding`/`is-minimized` 全窗口几何复位。原地各留注释存档。shell 落回 index.css 的共用 compact 规则。
- `tests/unit/test_react_chat_window_static.py`
  - 原 `test_electron_compact_chat_root_mask_does_not_clip_history_layer` 把 full mask 当契约写死；改写为反向断言：full 资源（mask / liquidFlow / lightSweep / `::before` / `::after` / `inset:40px`）已退环境，且 overlay 带 `hidden`。

净删约 110 行。

保留（不属本次 full 闪帧来源）：legacy `#chat-container`（`app-*.js` 仍 `getElementById` 引用）、galgame/附件 `min-height` 兜底（compact 下被 index.css `min-height:0` 覆盖，无害）。

## 验证

- 主仓 venv 跑 `tests/unit/test_react_chat_window_static.py` 对着本分支文件：**20 passed**。
- 未改 react-neko-chat 源码，无需 `build_frontend.sh`。

## 待真机确认

独立 `/chat` 的实际观感需要在 **Electron 多窗口**里看一眼：本 PR 只删了抢 compact 的 full 壳和那一帧，让 shell 落回和首页共用的 index.css compact 规则；但 `/chat` 窗口本身的尺寸 / shape 由 N.E.K.O.-PC 侧仓的 desktop-compact-layout 负责，不在本仓范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 简化了独立聊天窗口的渲染逻辑，移除了不必要的视觉效果和动画，改善了性能。

* **测试**
  * 更新了测试用例，确保聊天窗口在新的渲染模式下正常工作，避免启动时出现闪烁现象。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->