### PR TITLE
fix(chat): 移除 compact 态模型旁的悬浮最小化球

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -253,7 +253,6 @@
     var mobileExpandClickGuard = null;
     var mobileExpandVisualGuardTimer = 0;
     var compactMinimizeBallFrame = 0;
-    var compactMinimizeBallSnapshot = '';
     var compactSurfaceAnchorSnapshot = '';
     var compactDesktopSurfaceAnchorSnapshot = '';
     var compactInteractionGeometrySnapshot = '';
@@ -1283,9 +1282,9 @@
         });
         var surfaceRects = surfaceItems.map(function (item) { return item.nativeRect; });
         var baseSurfaceRects = baseSurfaceItems.map(function (item) { return item.nativeRect; });
-        var ballRect = isCompactHomeMinimizeBallEnabled() && !isElectronCompactExternalBallEnabled()
-            ? normalizeCompactDomRect(getCompactMinimizeBallTarget())
-            : null;
+        // compact 态不再渲染模型旁的悬浮最小化球，故不再上报其 hit/native 区域，
+        // 避免 Electron 桌面壳为一个不可见的球保留点击区域（externalBall 仍走桌面外部球）。
+        var ballRect = null;
         return {
             mode: getCurrentChatSurfaceMode(),
             compactChatState: getCurrentCompactChatState(),
@@ -1422,47 +1421,12 @@
         syncCompactInteractionGeometry();
     }
 
-    function clearCompactMinimizeBallAnchor() {
-        var shell = getShell();
-        if (!shell) return;
-        shell.style.removeProperty('--compact-minimize-ball-left');
-        shell.style.removeProperty('--compact-minimize-ball-top');
-        compactMinimizeBallSnapshot = '';
-        syncCompactInteractionGeometry();
-    }
-
-    function syncCompactMinimizeBallAnchor() {
-        var shell = getShell();
-        if (!shell) return;
-        if (!isCompactHomeMinimizeBallEnabled()) {
-            clearCompactMinimizeBallAnchor();
-            return;
-        }
-
-        var placement = getCompactMinimizeBallTarget();
-        if (!placement) {
-            clearCompactMinimizeBallAnchor();
-            return;
-        }
-
-        var snapshot = Math.round(placement.left) + ':' + Math.round(placement.top);
-        if (snapshot === compactMinimizeBallSnapshot) {
-            return;
-        }
-
-        compactMinimizeBallSnapshot = snapshot;
-        shell.style.setProperty('--compact-minimize-ball-left', Math.round(placement.left) + 'px');
-        shell.style.setProperty('--compact-minimize-ball-top', Math.round(placement.top) + 'px');
-        syncCompactInteractionGeometry();
-    }
-
     function stopCompactMinimizeBallTracking() {
         if (compactMinimizeBallFrame) {
             window.cancelAnimationFrame(compactMinimizeBallFrame);
             compactMinimizeBallFrame = 0;
         }
         compactSurfacePendingModelOpen = false;
-        clearCompactMinimizeBallAnchor();
         clearCompactSurfaceAnchor();
     }
 
@@ -1482,13 +1446,11 @@
                 return;
             }
             syncCompactSurfaceAnchor();
-            syncCompactMinimizeBallAnchor();
             syncCompactInteractionGeometry();
             compactMinimizeBallFrame = window.requestAnimationFrame(loop);
         };
 
         syncCompactSurfaceAnchor();
-        syncCompactMinimizeBallAnchor();
         syncCompactInteractionGeometry();
         compactMinimizeBallFrame = window.requestAnimationFrame(loop);
     }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1142,45 +1142,11 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     pointer-events: auto;
 }
 
+/* compact 态不再把最小化按钮渲染成模型旁的悬浮球：呼吸灯外发光会被 Electron 窗口形状裁切，
+   且球漂在角色旁观感很怪。最小化的宿主管线（按钮 DOM、toggleMinimized、折叠动画）保留，
+   compact 态下的最小化入口呈现方式后续单独设计。 */
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton {
-    position: fixed;
-    left: var(--compact-minimize-ball-left, 16px);
-    top: var(--compact-minimize-ball-top, calc(100vh - 84px));
-    right: auto;
-}
-
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton {
-    width: 50px;
-    height: 50px;
-    display: inline-flex !important;
-    visibility: visible !important;
-    opacity: 1 !important;
-    border-radius: 50%;
-    background-color: rgba(68, 183, 254, 0.15);
-    background-image: url('/static/icons/expand_icon_off_ball.png');
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
-    box-shadow: 0 0 8px rgba(68, 183, 254, 0.6);
-    animation: breathingGlow 2s ease-in-out infinite;
-    will-change: box-shadow;
-    transform: none;
-    pointer-events: auto;
-    z-index: 100001;
-}
-
-body.electron-chat-window.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton {
-    display: none !important;
-    pointer-events: none !important;
-}
-
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton:hover {
-    background-color: rgba(68, 183, 254, 0.2);
-    box-shadow: 0 0 12px rgba(68, 183, 254, 0.72);
-}
-
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton img {
-    opacity: 0;
+    display: none;
 }
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .compact-chat-surface-shell {


### PR DESCRIPTION
## 背景

react-neko-chat 处于 **compact 态**时，`#reactChatWindowMinimizeButton`（最小化按钮）被 CSS 改造成漂在猫娘模型左侧的 50px 圆 + `breathingGlow` 呼吸灯悬浮球。问题有二：

1. 球固定漂在角色旁，观感很呆。
2. 在 Electron Pet 窗口（`index.html`，body 仅 `subtitle-web-host`、无 `electron-chat-window`）里，球的发光 `box-shadow` 溢出 50px 盒子，被桌面壳的窗口 shape / native region 裁切。

结论：compact 态不该有这个球。

## 改动

| 文件 | 改动 |
|---|---|
| `static/css/index.css` | 把"按钮变球"那段样式（fixed 定位 + 呼吸灯发光 + hover + img）原地换成 `display:none`；保留 `#reactChatWindowMinimizeButton` 选择器，因为 `test_subtitle_web_host_keeps_compact_history...` 拿它当 CSS 分隔符。 |
| `static/app-react-chat-window.js` | 删球的 rAF 锚点追踪（`syncCompactMinimizeBallAnchor` / `clearCompactMinimizeBallAnchor` / `compactMinimizeBallSnapshot`）；geometry `ballRect` 恒为 `null`，不再给桌面壳留一个不可见却吃点击的球区域。 |

净 **+7 / −79**，纯删减。

## 保留的最小化管线

按钮 DOM、`click → toggleMinimized`、`setMinimized`、折叠动画落点 `getCompactMinimizeBallTarget` 全保留。**compact 态的最小化入口呈现方式留待后续单独设计。**

> ⚠️ `scheduleCompactMinimizeBallTracking` / `stopCompactMinimizeBallTracking` / `compactMinimizeBallFrame` 名字带 "Ball"，但它们其实是**整个 compact surface 定位 + geometry 上报的主 rAF 循环**（非球专用），本 PR 未动，只摘掉了循环里调用球锚点的两行。

## 三端一致性

- **index.html 宽屏/窄宽手机版**：球由被替换的那段 CSS 渲染 → 现 `display:none`，消失。
- **chat.html（Electron 聊天窗）**：本就被旧 `electron-chat-window` 规则隐藏，新规则同样覆盖，无变化。
- **Electron Pet 窗口（index.html）**：球消失，且 geometry 不再上报 `ballRect`，桌面壳不会再为不可见的球保留命中区——荧光截断问题从根上消失。

lanlan_frd（N.E.K.O.-PC）侧现在会收到 `ballRect: null`（与处理普通聊天窗口时同值，本就处理），**大概率无需改 Electron 代码**；建议确认那边没有依赖非空 `ballRect` 去建独立球窗口的残留逻辑。

## 验证

- `uv run python -m pytest tests/unit/test_react_chat_window_static.py` → **20 passed**
- grep 确认无悬空引用（`compactMinimizeBallSnapshot` / `clearCompactMinimizeBallAnchor` / `syncCompactMinimizeBallAnchor` / `--compact-minimize-ball`）。
- 不涉及 `frontend/react-neko-chat/src`，**无需 `build_frontend.sh`**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 优化紧凑模式下的点击检测准确性，移除不必要的交互区域，减少潜在的点击冲突并提升整体响应效果。
* 调整紧凑模式下最小化按钮的交互区域，防止隐藏的 UI 元素占用用户输入。
* 精简紧凑模式下的几何同步逻辑，实现更高效的交互追踪。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->