### PR TITLE
feat(chat): compact 输入框拖动 + 轮盘交互增强

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -3345,7 +3345,7 @@ describe('App', () => {
     }
   });
 
-  it('closes compact input tools when pointer press follows hover open', async () => {
+  it('closes compact input tools when a tap follows hover open', async () => {
     vi.useFakeTimers();
     const originalMatchMedia = window.matchMedia;
     mockHoverCapableMatchMedia();
@@ -3356,7 +3356,9 @@ describe('App', () => {
       const actionButton = screen.getByRole('button', { name: '更多工具' });
       const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
       fireEvent.pointerEnter(actionButton, { pointerType: 'mouse' });
+      // A quick tap (press + release) toggles the hover-opened fan shut.
       fireEvent.pointerDown(actionButton, { pointerId: 8, button: 0, buttons: 1, pointerType: 'mouse' });
+      fireEvent.pointerUp(actionButton, { pointerId: 8, button: 0, pointerType: 'mouse' });
       fireEvent.pointerLeave(actionButton, { clientX: 96, clientY: 96, pointerType: 'mouse' });
 
       await act(async () => {
@@ -3370,14 +3372,25 @@ describe('App', () => {
     }
   });
 
-  it('opens compact input tools on primary pointer press', () => {
-    render(<App chatSurfaceMode="compact" compactChatState="input" />);
+  it('opens compact input tools on a primary pointer tap without requesting a drag', () => {
+    const dragRequests: Event[] = [];
+    const onDragRequest = (event: Event) => dragRequests.push(event);
+    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
+    try {
+      render(<App chatSurfaceMode="compact" compactChatState="input" />);
 
-    const actionButton = screen.getByRole('button', { name: '更多工具' });
-    const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
-    fireEvent.pointerDown(actionButton, { pointerId: 9, button: 0, buttons: 1, pointerType: 'mouse' });
+      const actionButton = screen.getByRole('button', { name: '更多工具' });
+      const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
+      // The fan now opens on release (deferred), so a press alone keeps it shut.
+      fireEvent.pointerDown(actionButton, { pointerId: 9, button: 0, buttons: 1, pointerType: 'mouse' });
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
 
-    expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+      fireEvent.pointerUp(actionButton, { pointerId: 9, button: 0, pointerType: 'mouse' });
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+      expect(dragRequests).toHaveLength(0);
+    } finally {
+      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
+    }
   });
 
   it('keeps compact tool actions disabled until the fan finishes opening', async () => {
@@ -3392,12 +3405,9 @@ describe('App', () => {
         />,
       );
 
-      fireEvent.pointerDown(screen.getByRole('button', { name: '更多工具' }), {
-        pointerId: 9,
-        button: 0,
-        buttons: 1,
-        pointerType: 'mouse',
-      });
+      const toggle = screen.getByRole('button', { name: '更多工具' });
+      fireEvent.pointerDown(toggle, { pointerId: 9, button: 0, buttons: 1, pointerType: 'mouse' });
+      fireEvent.pointerUp(toggle, { pointerId: 9, button: 0, pointerType: 'mouse' });
       const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
       const importButton = fan.querySelector('.compact-input-tool-item-import') as HTMLButtonElement;
 
@@ -4241,21 +4251,187 @@ describe('App', () => {
     expect(onCompactChatStateChange).not.toHaveBeenCalledWith('default');
   });
 
-  it('reopens compact input tools after closing them from the tool toggle pointer press', () => {
+  it('reopens compact input tools after closing them from a tool toggle tap', () => {
     render(<App chatSurfaceMode="compact" compactChatState="input" />);
 
     const actionButton = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
     const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
     expect(actionButton).not.toBeNull();
 
-    fireEvent.pointerDown(actionButton, { pointerId: 21, button: 0, buttons: 1, pointerType: 'mouse' });
+    const tapToggle = (pointerId: number) => {
+      fireEvent.pointerDown(actionButton, { pointerId, button: 0, buttons: 1, pointerType: 'mouse' });
+      fireEvent.pointerUp(actionButton, { pointerId, button: 0, pointerType: 'mouse' });
+    };
+
+    tapToggle(21);
     expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
 
-    fireEvent.pointerDown(actionButton, { pointerId: 22, button: 0, buttons: 1, pointerType: 'mouse' });
+    tapToggle(22);
     expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
 
-    fireEvent.pointerDown(actionButton, { pointerId: 23, button: 0, buttons: 1, pointerType: 'mouse' });
+    tapToggle(23);
     expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+  });
+
+  it('requests a surface drag on a long-press of the tool toggle without opening the fan', async () => {
+    vi.useFakeTimers();
+    const dragRequests: CustomEvent[] = [];
+    const onDragRequest = (event: Event) => dragRequests.push(event as CustomEvent);
+    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
+    try {
+      render(<App chatSurfaceMode="compact" compactChatState="input" />);
+
+      const actionButton = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
+      const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
+
+      fireEvent.pointerDown(actionButton, {
+        pointerId: 31,
+        button: 0,
+        buttons: 1,
+        pointerType: 'mouse',
+        clientX: 100,
+        clientY: 50,
+        screenX: 512,
+        screenY: 360,
+      });
+      expect(dragRequests).toHaveLength(0);
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(320);
+      });
+
+      expect(dragRequests).toHaveLength(1);
+      expect(dragRequests[0].detail).toMatchObject({ screenX: 512, screenY: 360 });
+      // The wheel stays shut so the surface drag starts clean.
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+
+      // Releasing after the hold must not toggle the wheel back open.
+      fireEvent.pointerUp(actionButton, { pointerId: 31, button: 0, pointerType: 'mouse' });
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+    } finally {
+      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels the tool toggle tap and drag when the pointer moves before the hold fires', async () => {
+    vi.useFakeTimers();
+    const dragRequests: Event[] = [];
+    const onDragRequest = (event: Event) => dragRequests.push(event);
+    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
+    try {
+      render(<App chatSurfaceMode="compact" compactChatState="input" />);
+
+      const actionButton = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
+      const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
+
+      // Touch never hover-opens the fan, so this isolates the gesture itself.
+      fireEvent.pointerDown(actionButton, {
+        pointerId: 41,
+        buttons: 1,
+        pointerType: 'touch',
+        clientX: 100,
+        clientY: 50,
+      });
+      fireEvent.pointerMove(actionButton, {
+        pointerId: 41,
+        buttons: 1,
+        pointerType: 'touch',
+        clientX: 130,
+        clientY: 50,
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      fireEvent.pointerUp(actionButton, { pointerId: 41, pointerType: 'touch' });
+
+      expect(dragRequests).toHaveLength(0);
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+    } finally {
+      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
+      vi.useRealTimers();
+    }
+  });
+
+  it('signals fan-open solid state to the desktop shell on open and close', () => {
+    const openStates: Array<boolean | undefined> = [];
+    const onOpenState = (event: Event) => openStates.push((event as CustomEvent).detail?.open);
+    window.addEventListener('neko:compact-tool-fan-open-state-change', onOpenState);
+    try {
+      render(<App chatSurfaceMode="compact" compactChatState="input" />);
+      const actionButton = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
+      const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
+
+      const tapToggle = (pointerId: number) => {
+        fireEvent.pointerDown(actionButton, { pointerId, button: 0, buttons: 1, pointerType: 'mouse' });
+        fireEvent.pointerUp(actionButton, { pointerId, button: 0, pointerType: 'mouse' });
+      };
+
+      tapToggle(51);
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+      expect(openStates).toContain(true);
+
+      tapToggle(52);
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+      expect(openStates[openStates.length - 1]).toBe(false);
+    } finally {
+      window.removeEventListener('neko:compact-tool-fan-open-state-change', onOpenState);
+    }
+  });
+
+  it('focuses the input on a quick tap of an input-box edge band', () => {
+    render(<App chatSurfaceMode="compact" compactChatState="input" />);
+    const band = document.body.querySelector('.compact-input-edge-band-left') as HTMLElement;
+    const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
+    expect(band).not.toBeNull();
+    // Drop the auto-focus so the tap is what re-focuses.
+    act(() => { input.blur(); });
+    expect(input).not.toHaveFocus();
+
+    fireEvent.pointerDown(band, { pointerId: 61, button: 0, buttons: 1, pointerType: 'mouse', clientX: 10, clientY: 27 });
+    fireEvent.pointerUp(band, { pointerId: 61, button: 0, pointerType: 'mouse' });
+
+    expect(input).toHaveFocus();
+  });
+
+  it('requests a surface drag on a long-press of an input-box edge band without focusing the input', async () => {
+    vi.useFakeTimers();
+    const dragRequests: CustomEvent[] = [];
+    const onDragRequest = (event: Event) => dragRequests.push(event as CustomEvent);
+    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
+    try {
+      render(<App chatSurfaceMode="compact" compactChatState="input" />);
+      const band = document.body.querySelector('.compact-input-edge-band-left') as HTMLElement;
+      const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
+      act(() => { input.blur(); });
+
+      fireEvent.pointerDown(band, {
+        pointerId: 62,
+        button: 0,
+        buttons: 1,
+        pointerType: 'mouse',
+        clientX: 10,
+        clientY: 27,
+        screenX: 300,
+        screenY: 500,
+      });
+      expect(dragRequests).toHaveLength(0);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(320);
+      });
+      expect(dragRequests).toHaveLength(1);
+      expect(dragRequests[0].detail).toMatchObject({ screenX: 300, screenY: 500 });
+
+      fireEvent.pointerUp(band, { pointerId: 62, button: 0, pointerType: 'mouse' });
+      // A long-press is a drag, not a tap — it must not focus the input.
+      expect(input).not.toHaveFocus();
+    } finally {
+      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
+      vi.useRealTimers();
+    }
   });
 
   it('uses hover for enter and leave while click only toggles compact input tools', async () => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -104,6 +104,11 @@ const COMPACT_INPUT_TOOL_WHEEL_CHARGE_MAX_STEPS = COMPACT_INPUT_TOOL_WHEEL_CHARG
 const COMPACT_INPUT_TOOL_WHEEL_CHARGE_RELEASE_STEP_MS = 36;
 const COMPACT_INPUT_TOOL_WHEEL_CENTER_X = 116;
 const COMPACT_INPUT_TOOL_WHEEL_CENTER_Y = 116;
+// Drag-to-rotate sensitivity scalar (arc = radius * angleDelta), NOT a layout
+// value. Kept at 91.92 so the rotate-by-drag feel is unchanged even though the
+// visual orbit radius (--compact-tool-wheel-orbit-radius in styles.css) was
+// halved — the angle itself is measured from real geometry, this only scales
+// how much angular travel counts as one step.
 const COMPACT_INPUT_TOOL_WHEEL_ORBIT_RADIUS = 91.92;
 const COMPACT_INPUT_TOOL_WHEEL_HOVER_RADIUS = 116;
 const COMPACT_INPUT_TOOL_WHEEL_ANGLE_MIN_RADIUS = 16;
@@ -111,6 +116,13 @@ const COMPACT_INPUT_TOOL_TOGGLE_HOVER_OUTSET = 14;
 const COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE = 48;
 const COMPACT_INPUT_TOOL_FAN_INTERACTIVE_DELAY_MS = 220;
 const COMPACT_INPUT_TOOL_FAN_TRANSIENT_CLOSE_DELAY_MS = 360;
+// Long-press to grab and drag the whole compact surface (the OS window-move
+// runs in the desktop preload; see neko:compact-surface-drag-request). Hold this
+// long without moving more than the tolerance. Shared by the dropdown-arrow
+// toggle and the input-box edge bands; a quick tap on either does its own thing
+// (toggle opens the tool wheel; an edge band focuses the input) on release.
+const COMPACT_INPUT_SURFACE_LONG_PRESS_MS = 320;
+const COMPACT_INPUT_SURFACE_LONG_PRESS_MOVE_TOLERANCE = 10;
 const COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS = 650;
 const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 430;
 const COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
@@ -220,6 +232,16 @@ type CompactToolWheelChargeState = {
   direction: 1 | -1 | null;
   sameDirectionSteps: number;
   chargeSteps: number;
+};
+
+type CompactToolTogglePressState = {
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startScreenX: number;
+  startScreenY: number;
+  longPressFired: boolean;
+  canceledTap: boolean;
 };
 
 type CompactToolWheelDragPoint = {
@@ -1125,6 +1147,10 @@ export default function App({
   const compactInputToolWheelSuppressClickRef = useRef(false);
   const compactInputToolWheelScrollDeltaRef = useRef(0);
   const compactInputToolTogglePointerHandledRef = useRef(false);
+  const compactInputToolTogglePressRef = useRef<CompactToolTogglePressState | null>(null);
+  const compactInputToolToggleLongPressTimerRef = useRef<number | null>(null);
+  const compactInputEdgePressRef = useRef<CompactToolTogglePressState | null>(null);
+  const compactInputEdgeLongPressTimerRef = useRef<number | null>(null);
   const compactInputToolFanPositionSyncRef = useRef<(() => void) | null>(null);
   const compactInputToolFanCloseTimerRef = useRef<number | null>(null);
   const compactInputToolFanInteractiveTimerRef = useRef<number | null>(null);
@@ -2360,6 +2386,19 @@ export default function App({
     }));
   }, []);
 
+  // Tell the desktop shell to keep the whole wheel region solid while the fan is
+  // open, so mouse-wheel scrolling responds across the entire circle (not only
+  // over the icon buttons). Released when the fan closes. See preload
+  // neko:compact-tool-fan-open-state-change.
+  const dispatchCompactToolFanOpenState = useCallback((open: boolean) => {
+    window.dispatchEvent(new CustomEvent('neko:compact-tool-fan-open-state-change', {
+      detail: {
+        open,
+        timestamp: Date.now(),
+      },
+    }));
+  }, []);
+
   const scheduleCompactInputToolWheelDragGuardRelease = useCallback(() => {
     clearCompactInputToolWheelDragGuardTimer();
     compactInputToolWheelDragGuardTimerRef.current = window.setTimeout(() => {
@@ -2400,6 +2439,7 @@ export default function App({
     compactInputToolFanPositionSyncRef.current?.();
     compactInputToolFanOpenRef.current = false;
     setCompactInputToolFanOpen(false);
+    dispatchCompactToolFanOpenState(false);
     if (!options?.afterClose) return;
     const desktopWindow = window as Window & {
       __nekoDesktopCompactLayout?: {
@@ -2418,6 +2458,7 @@ export default function App({
     clearCompactInputToolWheelFastAnimationTimer,
     clearCompactInputToolWheelChargeReleaseTimer,
     dispatchCompactToolWheelDragState,
+    dispatchCompactToolFanOpenState,
     resetCompactInputToolWheelCharge,
     setCompactInputToolFanInteractiveState,
   ]);
@@ -2472,6 +2513,7 @@ export default function App({
     updateCompactInputToolFanPosition();
     compactInputToolFanOpenRef.current = true;
     setCompactInputToolFanOpen(true);
+    dispatchCompactToolFanOpenState(true);
     compactInputToolFanInteractiveTimerRef.current = window.setTimeout(() => {
       compactInputToolFanInteractiveTimerRef.current = null;
       if (!compactInputToolFanOpenIntentRef.current) return;
@@ -2482,6 +2524,7 @@ export default function App({
     clearCompactInputToolFanInteractiveTimer,
     compactInputHasPayload,
     composerDisabled,
+    dispatchCompactToolFanOpenState,
     setCompactInputToolFanInteractiveState,
     updateCompactInputToolFanPosition,
   ]);
@@ -2572,6 +2615,156 @@ export default function App({
     compactInputToolFanSuppressHoverUntilLeaveRef.current = false;
     openCompactInputToolFan('click');
   }, [closeCompactInputToolFanFromUserClick, openCompactInputToolFan]);
+
+  const clearCompactInputToolToggleLongPressTimer = useCallback(() => {
+    if (compactInputToolToggleLongPressTimerRef.current !== null) {
+      window.clearTimeout(compactInputToolToggleLongPressTimerRef.current);
+      compactInputToolToggleLongPressTimerRef.current = null;
+    }
+  }, []);
+
+  // Ask the desktop shell to grab and drag the whole compact surface. Only the
+  // preload/main process can move the native window; the page just signals it.
+  // Mirrors neko:compact-tool-wheel-drag-state-change as a one-shot request.
+  const dispatchCompactSurfaceDragRequest = useCallback((screenX: number, screenY: number) => {
+    window.dispatchEvent(new CustomEvent('neko:compact-surface-drag-request', {
+      detail: {
+        screenX,
+        screenY,
+        timestamp: Date.now(),
+      },
+    }));
+  }, []);
+
+  // Long-press on the dropdown-arrow toggle = grab the surface; quick tap = open
+  // the tool wheel on release (deferred so a press-and-hold never flashes it open).
+  const handleCompactInputToolTogglePointerDown = useCallback((event: ReactPointerEvent) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    event.preventDefault();
+    clearCompactInputToolToggleLongPressTimer();
+    // Fresh gesture: drop any stale click-suppression left by a prior press
+    // whose trailing click never arrived (so keyboard activation still toggles).
+    compactInputToolTogglePointerHandledRef.current = false;
+    compactInputToolTogglePressRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startScreenX: event.screenX,
+      startScreenY: event.screenY,
+      longPressFired: false,
+      canceledTap: false,
+    };
+    try {
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    } catch (_) {}
+    compactInputToolToggleLongPressTimerRef.current = window.setTimeout(() => {
+      compactInputToolToggleLongPressTimerRef.current = null;
+      const press = compactInputToolTogglePressRef.current;
+      if (!press || press.longPressFired || press.canceledTap) return;
+      press.longPressFired = true;
+      // Close the wheel (a hover may have opened it) so the drag starts clean.
+      closeCompactInputToolFanFromUserClick();
+      dispatchCompactSurfaceDragRequest(press.startScreenX, press.startScreenY);
+    }, COMPACT_INPUT_SURFACE_LONG_PRESS_MS);
+  }, [
+    clearCompactInputToolToggleLongPressTimer,
+    closeCompactInputToolFanFromUserClick,
+    dispatchCompactSurfaceDragRequest,
+  ]);
+
+  const handleCompactInputToolTogglePointerMove = useCallback((event: ReactPointerEvent) => {
+    const press = compactInputToolTogglePressRef.current;
+    if (!press || press.pointerId !== event.pointerId || press.longPressFired) return;
+    const dx = event.clientX - press.startClientX;
+    const dy = event.clientY - press.startClientY;
+    if (Math.hypot(dx, dy) > COMPACT_INPUT_SURFACE_LONG_PRESS_MOVE_TOLERANCE) {
+      // Moved before the hold fired: not a tap, not a long-press — do nothing.
+      press.canceledTap = true;
+      clearCompactInputToolToggleLongPressTimer();
+    }
+  }, [clearCompactInputToolToggleLongPressTimer]);
+
+  const finishCompactInputToolTogglePress = useCallback((event: ReactPointerEvent, options?: { canceled?: boolean }) => {
+    const press = compactInputToolTogglePressRef.current;
+    if (!press || press.pointerId !== event.pointerId) return;
+    clearCompactInputToolToggleLongPressTimer();
+    try {
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    } catch (_) {}
+    compactInputToolTogglePressRef.current = null;
+    // Swallow the trailing click for any pointer-driven gesture; keyboard
+    // activation has no press record and still toggles through onClick.
+    compactInputToolTogglePointerHandledRef.current = true;
+    if (press.longPressFired) return;
+    if (options?.canceled || press.canceledTap) return;
+    toggleCompactInputToolFanByClick();
+  }, [clearCompactInputToolToggleLongPressTimer, toggleCompactInputToolFanByClick]);
+
+  useEffect(() => () => clearCompactInputToolToggleLongPressTimer(), [clearCompactInputToolToggleLongPressTimer]);
+
+  // Input-box edge bands: same long-press-to-drag gesture as the arrow, but a
+  // quick tap focuses the input for typing instead of toggling the wheel. These
+  // bands overlay only the rim; the uncovered center keeps native press-to-type.
+  const clearCompactInputEdgeLongPressTimer = useCallback(() => {
+    if (compactInputEdgeLongPressTimerRef.current !== null) {
+      window.clearTimeout(compactInputEdgeLongPressTimerRef.current);
+      compactInputEdgeLongPressTimerRef.current = null;
+    }
+  }, []);
+
+  const handleCompactInputEdgePointerDown = useCallback((event: ReactPointerEvent) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    event.preventDefault();
+    clearCompactInputEdgeLongPressTimer();
+    compactInputEdgePressRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startScreenX: event.screenX,
+      startScreenY: event.screenY,
+      longPressFired: false,
+      canceledTap: false,
+    };
+    try {
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    } catch (_) {}
+    compactInputEdgeLongPressTimerRef.current = window.setTimeout(() => {
+      compactInputEdgeLongPressTimerRef.current = null;
+      const press = compactInputEdgePressRef.current;
+      if (!press || press.longPressFired || press.canceledTap) return;
+      press.longPressFired = true;
+      dispatchCompactSurfaceDragRequest(press.startScreenX, press.startScreenY);
+    }, COMPACT_INPUT_SURFACE_LONG_PRESS_MS);
+  }, [clearCompactInputEdgeLongPressTimer, dispatchCompactSurfaceDragRequest]);
+
+  const handleCompactInputEdgePointerMove = useCallback((event: ReactPointerEvent) => {
+    const press = compactInputEdgePressRef.current;
+    if (!press || press.pointerId !== event.pointerId || press.longPressFired) return;
+    const dx = event.clientX - press.startClientX;
+    const dy = event.clientY - press.startClientY;
+    if (Math.hypot(dx, dy) > COMPACT_INPUT_SURFACE_LONG_PRESS_MOVE_TOLERANCE) {
+      press.canceledTap = true;
+      clearCompactInputEdgeLongPressTimer();
+    }
+  }, [clearCompactInputEdgeLongPressTimer]);
+
+  const finishCompactInputEdgePress = useCallback((event: ReactPointerEvent, options?: { canceled?: boolean }) => {
+    const press = compactInputEdgePressRef.current;
+    if (!press || press.pointerId !== event.pointerId) return;
+    clearCompactInputEdgeLongPressTimer();
+    try {
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+    } catch (_) {}
+    compactInputEdgePressRef.current = null;
+    if (press.longPressFired) return;
+    if (options?.canceled || press.canceledTap) return;
+    // Quick tap on the rim → focus the input for typing.
+    if (!composerDisabled) {
+      compactInputRef.current?.focus();
+    }
+  }, [clearCompactInputEdgeLongPressTimer, composerDisabled]);
+
+  useEffect(() => () => clearCompactInputEdgeLongPressTimer(), [clearCompactInputEdgeLongPressTimer]);
 
   const rotateCompactInputToolWheel = useCallback((direction: 1 | -1) => {
     setCompactInputToolWheelIndex(current => (
@@ -4008,11 +4201,10 @@ export default function App({
       aria-haspopup={compactToolToggleActsAsSubmit ? undefined : 'true'}
       aria-expanded={compactToolToggleActsAsSubmit ? undefined : compactInputToolFanOpen}
       disabled={compactToolToggleActsAsSubmit ? !canSubmit : composerDisabled}
-      onPointerDown={compactToolToggleActsAsSubmit ? undefined : (event) => {
-        event.preventDefault();
-        compactInputToolTogglePointerHandledRef.current = true;
-        toggleCompactInputToolFanByClick();
-      }}
+      onPointerDown={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolTogglePointerDown}
+      onPointerMove={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolTogglePointerMove}
+      onPointerUp={compactToolToggleActsAsSubmit ? undefined : (event) => finishCompactInputToolTogglePress(event)}
+      onPointerCancel={compactToolToggleActsAsSubmit ? undefined : (event) => finishCompactInputToolTogglePress(event, { canceled: true })}
       onPointerEnter={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverEnter}
       onPointerLeave={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverLeave}
       onFocus={compactToolToggleActsAsSubmit ? undefined : clearCompactInputToolFanCloseTimer}
@@ -4786,6 +4978,18 @@ export default function App({
                           }
                         }}
                       />
+                      <div className="compact-input-edge-bands" aria-hidden="true">
+                        {(['top', 'bottom', 'left', 'right'] as const).map((side) => (
+                          <div
+                            key={side}
+                            className={`compact-input-edge-band compact-input-edge-band-${side}`}
+                            onPointerDown={handleCompactInputEdgePointerDown}
+                            onPointerMove={handleCompactInputEdgePointerMove}
+                            onPointerUp={(event) => finishCompactInputEdgePress(event)}
+                            onPointerCancel={(event) => finishCompactInputEdgePress(event, { canceled: true })}
+                          />
+                        ))}
+                      </div>
                       {compactInputToolToggleButton}
                     </>
                   ) : (

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1964,6 +1964,57 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   z-index: 2;
 }
 
+/* Input-box edge bands: the rim defers interaction to release — a quick tap
+   focuses the input, a long-press drags the whole surface. Left/right are wide
+   grips (40px); top/bottom are thin (5px) since the box is only 54px tall. The
+   container has no pointer surface, so the uncovered center keeps native
+   press-to-type + caret placement. Sits above the textarea (z-index 2) but
+   below the arrow toggle (z-index 5), which keeps its own gesture. */
+.compact-chat-surface-frame > .compact-input-edge-bands {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+.compact-input-edge-band {
+  position: absolute;
+  pointer-events: auto;
+  background: transparent;
+  cursor: text;
+  touch-action: none;
+  -webkit-app-region: no-drag;
+}
+
+.compact-input-edge-band-left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 40px;
+}
+
+.compact-input-edge-band-right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 40px;
+}
+
+.compact-input-edge-band-top {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 5px;
+}
+
+.compact-input-edge-band-bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 5px;
+}
+
 .compact-chat-capsule-button {
   display: flex;
   align-items: center;
@@ -3218,6 +3269,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   z-index: 5;
   isolation: isolate;
   -webkit-app-region: no-drag;
+  /* Long-press grabs the surface for dragging; keep touch gestures from being
+     reinterpreted as a pan/scroll (which would pointercancel the hold). */
+  touch-action: none;
   transform: none;
 }
 
@@ -3275,6 +3329,11 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   --compact-tool-button-size: 38px;
   --compact-tool-fan-hit-outset: 52px;
   --compact-tool-wheel-hover-radius: 116px;
+  /* Orbit radius = how far the tool icons sit from the arrow center (visual
+     only). Halved from the original 91.92px to pull the wheel in tighter. The
+     drag-rotate sensitivity scalar in App.tsx is intentionally left at 91.92 so
+     rotate-by-drag feel is unchanged. */
+  --compact-tool-wheel-orbit-radius: 45.96px;
   --compact-tool-fan-focus-x: var(--compact-tool-wheel-hover-radius);
   --compact-tool-fan-focus-y: var(--compact-tool-wheel-hover-radius);
   --compact-tool-wheel-center-x: var(--compact-tool-wheel-hover-radius);
@@ -3496,7 +3555,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="-2"] {
   opacity: 1;
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(107.35deg) translateX(91.92px) rotate(-107.35deg) scale(0.86);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(107.35deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(-107.35deg) scale(0.86);
   pointer-events: auto;
 }
 
@@ -3516,25 +3575,25 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="-1"] {
   opacity: 1;
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(75.82deg) translateX(91.92px) rotate(-75.82deg) scale(0.98);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(75.82deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(-75.82deg) scale(0.98);
   pointer-events: auto;
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="0"] {
   opacity: 1;
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(45deg) translateX(91.92px) rotate(-45deg) scale(1.04);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(45deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(-45deg) scale(1.04);
   pointer-events: auto;
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="1"] {
   opacity: 1;
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(14.18deg) translateX(91.92px) rotate(-14.18deg) scale(0.98);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(14.18deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(-14.18deg) scale(0.98);
   pointer-events: auto;
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="2"] {
   opacity: 1;
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(-17.35deg) translateX(91.92px) rotate(17.35deg) scale(0.86);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(-17.35deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(17.35deg) scale(0.86);
   pointer-events: auto;
 }
 
@@ -3560,15 +3619,15 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden"] {
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(45deg) translateX(18.38px) rotate(-45deg) scale(0.56);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(45deg) translateX(calc(var(--compact-tool-wheel-orbit-radius) * 0.2)) rotate(-45deg) scale(0.56);
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden-forward"] {
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(-48.51deg) translateX(91.92px) rotate(48.51deg) scale(0.56);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(-48.51deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(48.51deg) scale(0.56);
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] .compact-input-tool-item[data-compact-tool-wheel-slot="hidden-backward"] {
-  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(138.51deg) translateX(91.92px) rotate(-138.51deg) scale(0.56);
+  transform: translate(var(--compact-tool-wheel-center-x), var(--compact-tool-wheel-center-y)) rotate(138.51deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(-138.51deg) scale(0.56);
 }
 
 .compact-input-tool-fan .composer-tool-btn img {


### PR DESCRIPTION
## 改了什么（react-neko-chat 页面侧）

compact 模式下围绕"输入框更好拖、轮盘更顺手"的一组交互增强：

1. **长按拖动整个输入框**
   - 右侧展开箭头：长按 ~320ms（不移动）→ 发 `neko:compact-surface-drag-request` 拖动整窗；快速点击改为**松手展开**工具轮盘（deferred，避免长按时轮盘闪一下）。
   - 输入框四边**边缘带**（左右各 40px、上下各 5px）：轻点=聚焦输入、长按=拖动、移动取消；中心区（默认 350×44）保持**按下立即输入 + 原生光标定位**。边缘带是透明 overlay，盖在 textarea 之上、箭头之下，中心不盖。

2. **工具轮盘轨道半径砍半**：`91.92 → 45.96px`（CSS 变量化 `--compact-tool-wheel-orbit-radius`）。拖动旋转的灵敏度系数保持不变、与视觉解耦。

3. **轮盘滚轮整圈响应**：轮盘打开时发 `neko:compact-tool-fan-open-state-change`，让桌面壳把轮盘圆收为单 rect 实心，鼠标滚轮在整圈都能切换，而非只在图标按钮上。

## 桌面壳依赖（lanlan_frd）

真正"挪 OS 窗口"和"原生整圆实心"只能由 Electron preload 做。本 PR 是**页面侧**：派发上述事件。事件无人消费时**全部惰性降级**——纯浏览器/旧壳下：半径变化、松手展开、边缘带轻点聚焦照常生效；长按拖窗、整圈滚轮需配套的 `lanlan_frd/preload-chat-react.js` 改动（单独处理）。

## 验证

- typecheck 干净；vitest **148 passed**（新增箭头长按/松手展开、边缘带轻点聚焦/长按拖拽、fan-open 信号等用例）；`npm run build` 通过。
- 浏览器实测 `elementFromPoint`：中心=textarea、左右/下=边缘带、箭头盖在右带之上、中心 350×44；轮盘图标实测距圆心 46px。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **New Features**
  * 紧凑输入模式新增长按手势，支持拖动整个输入表面。
  * 改进工具扇打开/关闭状态同步至宿主。
  * 优化输入框边缘带的交互识别，支持快速点击聚焦和长按拖拽。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->