### PR TITLE
修复聊天框紧凑轮盘中表情按钮选中态显示为方形的问题，让选中效果与其他轮盘按钮一致，完整覆盖外层圆形区域

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -3951,6 +3951,8 @@ describe('App', () => {
 
       expect(avatarTool.querySelector('#composer-tool-popover-compact')).toBeNull();
       expect(fan.querySelector(':scope > #composer-tool-popover-compact')).not.toBeNull();
+      expect(avatarTool).toHaveAttribute('data-compact-tool-active', 'true');
+      expect(emojiButton).toHaveClass('is-active');
 
       fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4579,7 +4579,7 @@ export default function App({
         ref={toolMenuRef}
         aria-hidden={getCompactToolWheelAriaHidden(6)}
         data-compact-tool-wheel-slot={getCompactToolWheelSlotValue(6)}
-        data-compact-tool-active={activeToolItem ? 'true' : 'false'}
+        data-compact-tool-active={toolMenuOpen || activeToolItem ? 'true' : 'false'}
       >
         <button
           className={`composer-tool-btn composer-emoji-btn${toolMenuOpen || activeToolItem ? ' is-active' : ''}`}

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3609,6 +3609,13 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   z-index: 2;
 }
 
+.compact-input-tool-fan .compact-input-tool-item-avatar > .composer-emoji-btn,
+.compact-input-tool-fan .compact-input-tool-item-avatar > .composer-emoji-btn:hover,
+.compact-input-tool-fan .compact-input-tool-item-avatar > .composer-emoji-btn.is-active {
+  background: transparent;
+  border-radius: 999px;
+}
+
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] {
   visibility: visible;
   pointer-events: auto;
@@ -4115,6 +4122,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 [data-theme="dark"] .composer-emoji-btn.is-active {
   background: rgba(68, 183, 254, 0.26);
+}
+
+[data-theme="dark"] .compact-input-tool-fan .compact-input-tool-item-avatar > .composer-emoji-btn,
+[data-theme="dark"] .compact-input-tool-fan .compact-input-tool-item-avatar > .composer-emoji-btn:hover,
+[data-theme="dark"] .compact-input-tool-fan .compact-input-tool-item-avatar > .composer-emoji-btn.is-active {
+  background: transparent;
 }
 
 [data-theme="dark"] .composer-tool-clear-btn {

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3616,6 +3616,11 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   border-radius: 999px;
 }
 
+.compact-input-tool-fan .compact-input-tool-item-avatar > .composer-emoji-btn:disabled {
+  opacity: 1;
+  cursor: inherit;
+}
+
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] {
   visibility: visible;
   pointer-events: auto;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复暗色主题下表情按钮背景覆盖问题，保证在所有主题中背景保持透明显示。

* **Style**
  * 调整紧凑输入工具轮盘中头像区域的表情按钮样式：统一透明背景、圆角与禁用态光标/不透明度处理，提升视觉一致性。

* **Tests**
  * 增加断言以验证表情按钮被激活时的状态和对应工具区域的激活标记。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->