### PR TITLE
feat: add voice transcript bridge and plugin dispatch infrastructure

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -13,6 +13,7 @@ _install_runtime_bindings()
 
 import mimetypes
 import json
+from collections.abc import Mapping
 mimetypes.add_type("application/javascript", ".js")
 import asyncio
 import uuid
@@ -1342,9 +1343,7 @@ def _check_agent_api_gate() -> Dict[str, Any]:
     try:
         cm = get_config_manager()
         ok, reasons = cm.is_agent_api_ready()
-        # 字段名保留 is_free_version（前端/下游 gate 消费者沿用），值取 agent 维度的
-        # is_agent_free()：判 agent 是否走内置免费模型，而非 core/assist 的版本免费。
-        return {"ready": ok, "reasons": reasons, "is_free_version": cm.is_agent_free()}
+        return {"ready": ok, "reasons": reasons, "is_free_version": cm.is_free_version()}
     except Exception as e:
         return {"ready": False, "reasons": [f"Agent API check failed: {e}"], "is_free_version": False}
 
@@ -1650,6 +1649,139 @@ async def _emit_agent_status_update(lanlan_name: Optional[str] = None) -> None:
         pass
 
 
+VOICE_TRANSCRIPT_CUSTOM_EVENT_TYPE = "voice_transcript"
+VOICE_TRANSCRIPT_CUSTOM_EVENT_TIMEOUT_SECONDS = 1.0
+
+
+def _voice_bridge_noop(reason: str, **extra: object) -> Dict[str, Any]:
+    return {
+        "action": "noop",
+        "reason": str(reason or "noop"),
+        **extra,
+    }
+
+
+def _voice_transcript_request_has_text(event: Mapping[str, object] | None) -> bool:
+    if not isinstance(event, Mapping):
+        return False
+    return bool(str(event.get("transcript") or "").strip())
+
+
+def _voice_transcript_custom_event_args(event: Mapping[str, object]) -> Dict[str, object]:
+    metadata = event.get("metadata")
+    return {
+        "transcript": str(event.get("transcript") or "").strip(),
+        "lanlan_name": str(event.get("lanlan_name") or ""),
+        "metadata": dict(metadata) if isinstance(metadata, Mapping) else {},
+    }
+
+
+def _voice_bridge_action_from_dispatch_results(dispatch_results: object) -> Dict[str, Any]:
+    if not isinstance(dispatch_results, list) or not dispatch_results:
+        return _voice_bridge_noop("no_subscribers")
+
+    from plugin.plugins.study_companion.voice_contracts import (
+        arbitrate_voice_transcript_results,
+    )
+
+    arbitration_items: list[dict[str, object]] = []
+    failure_count = 0
+    for item in dispatch_results:
+        if not isinstance(item, Mapping):
+            continue
+        if not bool(item.get("success")):
+            failure_count += 1
+            continue
+        result = item.get("result")
+        if not isinstance(result, Mapping):
+            continue
+        action = str(result.get("action") or "").strip()
+        if not action:
+            continue
+        payload: Dict[str, Any] = dict(result)
+        payload["action"] = action
+        plugin_id = str(item.get("plugin_id") or "").strip()
+        if plugin_id:
+            payload.setdefault("source_plugin", plugin_id)
+        source_event_id = str(item.get("event_id") or "").strip()
+        if source_event_id:
+            payload.setdefault("source_event_id", source_event_id)
+        arbitration_items.append(
+            {
+                "plugin_id": payload.get("source_plugin") or plugin_id,
+                "event_id": payload.get("source_event_id") or source_event_id,
+                "success": True,
+                "result": payload,
+            }
+        )
+
+    if not arbitration_items:
+        return _voice_bridge_noop("no_handler_result", failures=failure_count)
+    payload = arbitrate_voice_transcript_results(arbitration_items)
+    if failure_count:
+        try:
+            existing_failures = int(payload.get("failures") or 0)
+        except (TypeError, ValueError):
+            existing_failures = 0
+        payload["failures"] = existing_failures + failure_count
+    return payload
+
+
+async def _dispatch_voice_transcript_custom_event(
+    event: Mapping[str, object],
+) -> Dict[str, Any]:
+    from plugin.server.application.plugins.dispatch_service import PluginDispatchService
+
+    dispatch_results = await PluginDispatchService().trigger_custom_event_subscribers(
+        event_type=VOICE_TRANSCRIPT_CUSTOM_EVENT_TYPE,
+        args=_voice_transcript_custom_event_args(event),
+        timeout=VOICE_TRANSCRIPT_CUSTOM_EVENT_TIMEOUT_SECONDS,
+    )
+    return _voice_bridge_action_from_dispatch_results(dispatch_results)
+
+
+async def _handle_voice_transcript_request(event: Dict[str, Any]) -> None:
+    event_id = str((event or {}).get("event_id") or "")
+    lanlan_name = (event or {}).get("lanlan_name")
+    result: Dict[str, Any] = _voice_bridge_noop("unavailable")
+
+    try:
+        if not _voice_transcript_request_has_text(event):
+            result = _voice_bridge_noop("empty_transcript")
+        elif not Modules.analyzer_enabled:
+            result = _voice_bridge_noop("agent_disabled")
+        elif not Modules.agent_flags.get("user_plugin_enabled", False):
+            result = _voice_bridge_noop("user_plugin_disabled")
+        else:
+            lifecycle_ready = bool(Modules.plugin_lifecycle_started)
+            if not lifecycle_ready:
+                lifecycle_ready = await _ensure_plugin_lifecycle_started()
+
+            if not lifecycle_ready:
+                result = _voice_bridge_noop("plugin_lifecycle_start_failed")
+            else:
+                result = await _dispatch_voice_transcript_custom_event(event)
+    except Exception as exc:
+        logger.debug(
+            "[VoiceBridge] plugin dispatch failed: event_id=%s lanlan=%s err=%s",
+            event_id,
+            lanlan_name,
+            exc,
+        )
+        result = {
+            "action": "noop",
+            "reason": "dispatch_failed",
+            "error_type": type(exc).__name__,
+        }
+
+    await _emit_main_event(
+        "voice_bridge_result",
+        lanlan_name if isinstance(lanlan_name, str) else None,
+        event_id=event_id,
+        result=result,
+    )
+
+
 async def _on_session_event(event: Dict[str, Any]) -> None:
     event_type = (event or {}).get("event_type")
     if event_type == "agent_intent_restore_signal":
@@ -1661,6 +1793,11 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
         # before the user actually opens a session. The restore helper
         # has its own once-flag, so this is safe to spam.
         await _maybe_restore_agent_intent()
+        return
+    if event_type == "voice_transcript_request":
+        task = asyncio.create_task(_handle_voice_transcript_request(event))
+        Modules._background_tasks.add(task)
+        task.add_done_callback(Modules._background_tasks.discard)
         return
     if event_type == "analyze_request":
         messages = event.get("messages", [])

--- a/app/main_server.py
+++ b/app/main_server.py
@@ -121,7 +121,7 @@ try:
     from fastapi.responses import JSONResponse, Response # noqa
     from fastapi.staticfiles import StaticFiles # noqa
     from main_logic import core as core, cross_server as cross_server # noqa
-    from main_logic.agent_event_bus import MainServerAgentBridge, notify_analyze_ack, set_main_bridge # noqa
+    from main_logic.agent_event_bus import MainServerAgentBridge, notify_analyze_ack, notify_voice_bridge_result, set_main_bridge # noqa
     from fastapi.templating import Jinja2Templates # noqa
     from dataclasses import dataclass # noqa
     from typing import Any, Optional # noqa
@@ -606,6 +606,13 @@ async def _handle_agent_event(event: dict):
                 lanlan,
             )
             notify_analyze_ack(str(event.get("event_id") or ""))
+            return
+
+        if event_type == "voice_bridge_result":
+            notify_voice_bridge_result(
+                str(event.get("event_id") or ""),
+                event.get("result") if isinstance(event.get("result"), dict) else {},
+            )
             return
 
         # Agent status updates may be broadcast (lanlan_name omitted).
@@ -1641,7 +1648,6 @@ from main_routers.websocket_router import router as websocket_router # noqa
 from main_routers.workshop_router import router as workshop_router # noqa
 from main_routers.cookies_login_router import router as cookies_login_router # noqa
 from main_routers.game_router import router as game_router # noqa
-from main_routers.card_assist_router import router as card_assist_router # noqa
 from main_routers.debug_router import router as debug_router, start_watchdog as _start_debug_health_watchdog # noqa
 from main_routers.shared_state import init_shared_state, set_steamworks_initializer # noqa
 
@@ -1773,7 +1779,6 @@ app.include_router(tool_router)
 app.include_router(music_router)
 app.include_router(galgame_router)
 app.include_router(game_router)
-app.include_router(card_assist_router)
 app.include_router(capture_router)
 app.include_router(cookies_login_router) # Cookies登录相关路由，放在最后以避免与其他API路由冲突
 app.include_router(debug_router)  # 诊断观测：/api/debug/health（轻量、零侵入，详见 debug_router.py 头注释）

--- a/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
+++ b/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
@@ -1,6 +1,6 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
 import ts from 'typescript'
@@ -189,8 +189,12 @@ function createCheckFile(entryPath, tempDir, index, surface, tomlPath) {
   const stripped = source
     .replace(/^\s*import[\s\S]*?from\s+['"](?:@neko\/plugin-ui|neko:ui)['"]\s*;?\s*/gm, '')
     .replace(/^\s*import\s+['"](?:@neko\/plugin-ui|neko:ui)['"]\s*;?\s*/gm, '')
-  const checkPath = join(tempDir, `surface-${index}.tsx`)
+  const relativeEntryPath = relative(repoRoot, entryPath)
+  const checkPath = relativeEntryPath.startsWith('..') || isAbsolute(relativeEntryPath)
+    ? join(tempDir, `surface-${index}.tsx`)
+    : join(tempDir, relativeEntryPath)
   const prefixLines = 6
+  mkdirSync(dirname(checkPath), { recursive: true })
   writeFileSync(
     checkPath,
     `/// <reference path="${hostedUiGlobalsPath}" />\nimport * as NekoUi from "@neko/plugin-ui";\nimport type { PluginSurfaceProps, HostedAction, JsonSchema, HostedApi } from "@neko/plugin-ui";\nconst { ${[
@@ -276,6 +280,7 @@ function main() {
       target: ts.ScriptTarget.ES2020,
       moduleResolution: ts.ModuleResolutionKind.Bundler,
       baseUrl: repoRoot,
+      rootDirs: [tempDir, repoRoot],
       paths: {
         '@neko/plugin-ui': ['plugin/sdk/hosted-ui'],
       },

--- a/main_logic/agent_event_bus.py
+++ b/main_logic/agent_event_bus.py
@@ -45,6 +45,9 @@ ANALYZE_PUSH_ADDR = _zmq_addr("NEKO_ZMQ_ANALYZE_PUSH_PORT", 48963)  # main -> ag
 _main_bridge_ref: Optional["MainServerAgentBridge"] = None
 _ack_waiters: dict[str, asyncio.Future] = {}
 _ack_waiters_lock = threading.Lock()
+_voice_bridge_waiters: dict[str, asyncio.Future] = {}
+_voice_bridge_waiters_resolving: set[str] = set()
+_voice_bridge_waiters_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -316,6 +319,42 @@ def notify_analyze_ack(event_id: str) -> None:
     loop.call_soon_threadsafe(_resolve)
 
 
+def notify_voice_bridge_result(event_id: str, result: Dict[str, Any]) -> None:
+    """Resolve a pending voice-bridge request sent from main_server to agent_server."""
+    if not event_id:
+        return
+    payload = result if isinstance(result, dict) else {}
+    with _voice_bridge_waiters_lock:
+        waiter = _voice_bridge_waiters.get(event_id)
+        if waiter is not None and not waiter.done():
+            _voice_bridge_waiters_resolving.add(event_id)
+        else:
+            _voice_bridge_waiters_resolving.discard(event_id)
+    if waiter is None or waiter.done():
+        return
+    loop = waiter.get_loop()
+
+    def _resolve() -> None:
+        with _voice_bridge_waiters_lock:
+            if _voice_bridge_waiters.get(event_id) is not waiter:
+                _voice_bridge_waiters_resolving.discard(event_id)
+                return
+            _voice_bridge_waiters.pop(event_id, None)
+            _voice_bridge_waiters_resolving.discard(event_id)
+        if not waiter.done():
+            waiter.set_result(payload)
+
+    try:
+        loop.call_soon_threadsafe(_resolve)
+    except RuntimeError:
+        with _voice_bridge_waiters_lock:
+            if _voice_bridge_waiters.get(event_id) is waiter:
+                if not waiter.done():
+                    waiter.cancel()
+                _voice_bridge_waiters.pop(event_id, None)
+            _voice_bridge_waiters_resolving.discard(event_id)
+
+
 # ---------------------------------------------------------------------------
 #  Layering-inversion sinks: lower layers (main_logic) emit, higher layers
 #  (plugin / main_routers) register.
@@ -492,3 +531,83 @@ async def publish_analyze_request_reliably(
             )
 
     return False
+
+
+async def publish_voice_transcript_request_reliably(
+    lanlan_name: str,
+    transcript: str,
+    *,
+    timeout_s: float = 1.2,
+    retries: int = 0,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Ask agent_server/plugins how a realtime voice transcript should be handled.
+
+    Returns a plugin-produced action payload, or ``None`` when the bridge is not
+    running or no response arrives within the bounded timeout.
+    """
+    text = str(transcript or "").strip()
+    if not text:
+        return None
+    event_id = uuid.uuid4().hex
+    loop = asyncio.get_running_loop()
+    waiter: asyncio.Future = loop.create_future()
+    with _voice_bridge_waiters_lock:
+        _voice_bridge_waiters[event_id] = waiter
+
+    try:
+        for attempt in range(max(retries, 0) + 1):
+            event = {
+                "event_type": "voice_transcript_request",
+                "event_id": event_id,
+                "lanlan_name": lanlan_name,
+                "transcript": text,
+                "metadata": dict(metadata or {}),
+                "attempt": attempt,
+            }
+            sent = await publish_session_event(event)
+            if not sent:
+                logger.debug(
+                    "[EventBus] voice_transcript_request not sent: no main bridge lanlan=%s attempt=%s",
+                    lanlan_name,
+                    attempt,
+                )
+                continue
+            try:
+                result = await asyncio.wait_for(asyncio.shield(waiter), timeout=timeout_s)
+                return result if isinstance(result, dict) else {}
+            except asyncio.TimeoutError:
+                with _voice_bridge_waiters_lock:
+                    result_is_queued = (
+                        _voice_bridge_waiters.get(event_id) is waiter
+                        and event_id in _voice_bridge_waiters_resolving
+                    )
+                if result_is_queued:
+                    try:
+                        result = await asyncio.wait_for(
+                            asyncio.shield(waiter),
+                            timeout=0.05,
+                        )
+                        return result if isinstance(result, dict) else {}
+                    except asyncio.TimeoutError:
+                        pass
+                logger.debug(
+                    "[EventBus] voice_transcript_request timed out: event_id=%s lanlan=%s attempt=%s",
+                    event_id,
+                    lanlan_name,
+                    attempt,
+                )
+                continue
+        return None
+    finally:
+        should_cancel = False
+        with _voice_bridge_waiters_lock:
+            if (
+                _voice_bridge_waiters.get(event_id) is waiter
+                and event_id not in _voice_bridge_waiters_resolving
+            ):
+                _voice_bridge_waiters.pop(event_id, None)
+                should_cancel = True
+            _voice_bridge_waiters_resolving.discard(event_id)
+        if should_cancel and not waiter.done():
+            waiter.cancel()

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -45,6 +45,7 @@ from main_logic.proactive_delivery import ProactiveDeliveryManager
 from main_logic.agent_event_bus import (
     dispatch_text_user_message,
     dispatch_user_utterance,
+    publish_voice_transcript_request_reliably,
 )
 from utils.preferences import load_global_conversation_settings, aload_global_conversation_settings
 from config import (
@@ -1966,6 +1967,75 @@ class LLMSessionManager:
             # swallowed inside the dispatcher.
             dispatch_user_utterance(bucket, event)
 
+    async def _dispatch_voice_transcript_bridge(self, transcript: str) -> str:
+        """Let plugin-side voice filters decide whether to cancel or prime context."""
+        session_snapshot = self.session
+        try:
+            result = await publish_voice_transcript_request_reliably(
+                self.lanlan_name,
+                transcript,
+                metadata={
+                    "session_type": type(session_snapshot).__name__ if session_snapshot else "",
+                    "voice_source": True,
+                },
+            )
+        except Exception as exc:
+            logger.debug("[%s] voice bridge request failed: %s", self.lanlan_name, exc)
+            return ""
+        if not isinstance(result, dict) or not result:
+            return ""
+
+        def _session_changed() -> bool:
+            if self.session is session_snapshot:
+                return False
+            logger.debug("[%s] voice bridge result ignored after session change", self.lanlan_name)
+            return True
+
+        if _session_changed():
+            return ""
+
+        action = str(result.get("action") or "").strip()
+        if action == "cancel_response":
+            if _session_changed():
+                return ""
+            cancel_response = getattr(session_snapshot, "cancel_response", None)
+            if not callable(cancel_response):
+                return ""
+            try:
+                if _session_changed():
+                    return ""
+                await cancel_response()
+                logger.debug("[%s] voice bridge cancelled current response", self.lanlan_name)
+                return action
+            except Exception as exc:
+                logger.debug("[%s] voice bridge cancel skipped/failed: %s", self.lanlan_name, exc)
+                return ""
+
+        if action == "prime_context":
+            context_text = str(result.get("context") or "").strip()
+            if not context_text:
+                return action
+            if _session_changed():
+                return ""
+            prime_context = getattr(session_snapshot, "prime_context", None)
+            if not callable(prime_context):
+                return action
+            skipped = bool(result.get("skipped", False))
+            try:
+                if _session_changed():
+                    return ""
+                await prime_context(context_text, skipped=skipped)
+                logger.debug(
+                    "[%s] voice bridge primed context len=%d skipped=%s",
+                    self.lanlan_name,
+                    len(context_text),
+                    skipped,
+                )
+            except Exception as exc:
+                logger.debug("[%s] voice bridge prime skipped/failed: %s", self.lanlan_name, exc)
+            return action
+        return action
+
     def _reset_voice_echo_suppression_cache(self) -> None:
         self._recent_ai_voice_echo_text = ''
         self._recent_ai_voice_echo_at = 0.0
@@ -2161,6 +2231,11 @@ class LLMSessionManager:
             # 即使转录为空（VAD 误触发或转录失败）也算一次"用户在发声"，
             # 维持 voice_engaged 状态。
             self._activity_tracker.on_voice_rms()
+
+        if is_voice_source and transcript_text:
+            voice_bridge_action = await self._dispatch_voice_transcript_bridge(transcript_text)
+            if voice_bridge_action == "cancel_response":
+                return
 
         if is_voice_source:
             # 仅非空转录才算"用户消息"：on_user_message 会清掉 unfinished_thread、

--- a/plugin/server/application/plugins/dispatch_service.py
+++ b/plugin/server/application/plugins/dispatch_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import math
 from collections.abc import Mapping
 from typing import Protocol, runtime_checkable
@@ -66,6 +67,54 @@ def _normalize_args(raw_args: object) -> dict[str, object]:
             )
         normalized[key] = value
     return normalized
+
+
+def _parse_event_handler_key(key: str) -> tuple[str, str, str] | None:
+    if ":" in key:
+        parts = key.split(":", 2)
+        if len(parts) == 3 and all(parts):
+            return parts[0], parts[1], parts[2]
+        return None
+    if "." in key:
+        parts = key.split(".", 1)
+        if len(parts) == 2 and all(parts):
+            return parts[0], "plugin_entry", parts[1]
+    return None
+
+
+def _find_custom_event_handlers(
+    event_type: str,
+    event_id: str = "",
+) -> list[tuple[str, str]]:
+    handlers_snapshot = state.get_event_handlers_snapshot_cached(timeout=1.0)
+    target_event_id = str(event_id or "").strip()
+    matches: set[tuple[str, str]] = set()
+    for key_obj, handler_obj in handlers_snapshot.items():
+        if not isinstance(key_obj, str):
+            continue
+        parsed = _parse_event_handler_key(key_obj)
+        if parsed is None:
+            continue
+        plugin_id, key_event_type, key_event_id = parsed
+        meta = getattr(handler_obj, "meta", None)
+        meta_event_type = getattr(meta, "event_type", None)
+        meta_event_id = getattr(meta, "id", None)
+        candidate_event_type = (
+            meta_event_type
+            if isinstance(meta_event_type, str) and meta_event_type
+            else key_event_type
+        )
+        candidate_event_id = (
+            meta_event_id
+            if isinstance(meta_event_id, str) and meta_event_id
+            else key_event_id
+        )
+        if candidate_event_type != event_type:
+            continue
+        if target_event_id and candidate_event_id != target_event_id:
+            continue
+        matches.add((plugin_id, candidate_event_id))
+    return sorted(matches)
 
 
 class PluginDispatchService:
@@ -146,3 +195,100 @@ class PluginDispatchService:
                 status_code=500,
                 details={"error_type": type(exc).__name__, "to_plugin": to_plugin},
             ) from exc
+
+    async def trigger_custom_event_subscribers(
+        self,
+        *,
+        event_type: str,
+        event_id: str = "",
+        args: object,
+        timeout: float,
+    ) -> list[dict[str, object]]:
+        if not event_type:
+            raise ServerDomainError(
+                code="INVALID_ARGUMENT",
+                message="event_type is required",
+                status_code=400,
+                details={},
+            )
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(float(timeout))
+            or float(timeout) <= 0
+        ):
+            raise ServerDomainError(
+                code="INVALID_ARGUMENT",
+                message="timeout must be a positive finite number",
+                status_code=400,
+                details={},
+            )
+
+        target_event_id = str(event_id or "").strip()
+        normalized_args = _normalize_args(args)
+        handlers = await asyncio.to_thread(
+            _find_custom_event_handlers,
+            event_type,
+            target_event_id,
+        )
+
+        async def _dispatch_handler(plugin_id: str, handler_event_id: str) -> dict[str, object]:
+            try:
+                handler_args = copy.deepcopy(normalized_args)
+                result = await asyncio.wait_for(
+                    self.trigger_custom_event(
+                        to_plugin=plugin_id,
+                        event_type=event_type,
+                        event_id=handler_event_id,
+                        args=handler_args,
+                        timeout=timeout,
+                    ),
+                    timeout=float(timeout),
+                )
+                return {
+                    "plugin_id": plugin_id,
+                    "event_id": handler_event_id,
+                    "success": True,
+                    "result": result,
+                }
+            except ServerDomainError as exc:
+                logger.warning(
+                    "trigger_custom_event_subscribers handler failed: plugin_id={}, event_type={}, event_id={}, code={}, message={}",
+                    plugin_id,
+                    event_type,
+                    handler_event_id,
+                    exc.code,
+                    exc.message,
+                )
+                return {
+                    "plugin_id": plugin_id,
+                    "event_id": handler_event_id,
+                    "success": False,
+                    "code": exc.code,
+                    "error": exc.message,
+                }
+            except Exception as exc:
+                logger.warning(
+                    "trigger_custom_event_subscribers handler crashed: plugin_id={}, event_type={}, event_id={}, err_type={}, err={}",
+                    plugin_id,
+                    event_type,
+                    handler_event_id,
+                    type(exc).__name__,
+                    str(exc),
+                )
+                return {
+                    "plugin_id": plugin_id,
+                    "event_id": handler_event_id,
+                    "success": False,
+                    "code": "PLUGIN_EVENT_DISPATCH_FAILED",
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                }
+
+        if not handlers:
+            return []
+        return list(
+            await asyncio.gather(
+                *(_dispatch_handler(plugin_id, event_id) for plugin_id, event_id in handlers)
+            )
+        )

--- a/plugin/tests/unit/server/test_plugin_dispatch_service.py
+++ b/plugin/tests/unit/server/test_plugin_dispatch_service.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from plugin.server.application.plugins import dispatch_service as dispatch_module
+from plugin.server.application.plugins.dispatch_service import PluginDispatchService
+
+pytestmark = pytest.mark.plugin_unit
+
+
+class _Host:
+    def __init__(
+        self,
+        result: dict[str, object],
+        *,
+        alive: bool = True,
+        error: Exception | None = None,
+        delay: float = 0.0,
+    ) -> None:
+        self.result = result
+        self.alive = alive
+        self.error = error
+        self.delay = delay
+        self.calls: list[tuple[str, str, dict[str, object], float]] = []
+
+    def health_check(self) -> SimpleNamespace:
+        return SimpleNamespace(alive=self.alive)
+
+    async def trigger_custom_event(
+        self,
+        *,
+        event_type: str,
+        event_id: str,
+        args: dict[str, object],
+        timeout: float,
+    ) -> dict[str, object]:
+        self.calls.append((event_type, event_id, args, timeout))
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _BarrierHost(_Host):
+    def __init__(
+        self,
+        result: dict[str, object],
+        *,
+        started: asyncio.Event,
+        peer_started: asyncio.Event,
+    ) -> None:
+        super().__init__(result)
+        self.started = started
+        self.peer_started = peer_started
+
+    async def trigger_custom_event(
+        self,
+        *,
+        event_type: str,
+        event_id: str,
+        args: dict[str, object],
+        timeout: float,
+    ) -> dict[str, object]:
+        self.calls.append((event_type, event_id, args, timeout))
+        self.started.set()
+        await asyncio.wait_for(self.peer_started.wait(), timeout=0.2)
+        return self.result
+
+
+class _MutatingHost(_Host):
+    async def trigger_custom_event(
+        self,
+        *,
+        event_type: str,
+        event_id: str,
+        args: dict[str, object],
+        timeout: float,
+    ) -> dict[str, object]:
+        metadata = args.get("metadata")
+        if isinstance(metadata, dict):
+            metadata["mutated_by"] = event_id
+        return await super().trigger_custom_event(
+            event_type=event_type,
+            event_id=event_id,
+            args=args,
+            timeout=timeout,
+        )
+
+
+def _handler(event_type: str, event_id: str) -> SimpleNamespace:
+    return SimpleNamespace(meta=SimpleNamespace(event_type=event_type, id=event_id))
+
+
+def _patch_handlers_and_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+    handlers: dict[str, SimpleNamespace],
+    hosts: dict[str, _Host],
+) -> None:
+    monkeypatch.setattr(
+        dispatch_module.state,
+        "get_event_handlers_snapshot_cached",
+        lambda timeout=1.0: handlers,
+    )
+    monkeypatch.setattr(
+        dispatch_module.state,
+        "get_plugin_hosts_snapshot_cached",
+        lambda timeout=1.0: hosts,
+    )
+
+
+@pytest.mark.asyncio
+async def test_trigger_custom_event_subscribers_dispatches_matching_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    study_host = _Host({"action": "prime_context", "context": "screen"})
+    other_host = _Host({"action": "noop"})
+    _patch_handlers_and_hosts(
+        monkeypatch,
+        {
+            "study_companion:voice_transcript:handle_transcript": _handler(
+                "voice_transcript",
+                "handle_transcript",
+            ),
+            "other_plugin:voice_transcript:other_handler": _handler(
+                "voice_transcript",
+                "other_handler",
+            ),
+            "legacy.entry": _handler("plugin_entry", "entry"),
+        },
+        {
+            "study_companion": study_host,
+            "other_plugin": other_host,
+        },
+    )
+
+    results = await PluginDispatchService().trigger_custom_event_subscribers(
+        event_type="voice_transcript",
+        args={"transcript": "Yui explain this"},
+        timeout=0.25,
+    )
+
+    assert results == [
+        {
+            "plugin_id": "other_plugin",
+            "event_id": "other_handler",
+            "success": True,
+            "result": {"action": "noop"},
+        },
+        {
+            "plugin_id": "study_companion",
+            "event_id": "handle_transcript",
+            "success": True,
+            "result": {"action": "prime_context", "context": "screen"},
+        },
+    ]
+    assert study_host.calls == [
+        (
+            "voice_transcript",
+            "handle_transcript",
+            {"transcript": "Yui explain this"},
+            0.25,
+        )
+    ]
+    assert other_host.calls == [
+        (
+            "voice_transcript",
+            "other_handler",
+            {"transcript": "Yui explain this"},
+            0.25,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_trigger_custom_event_subscribers_keeps_per_plugin_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ready_host = _Host({"action": "cancel_response"})
+    stopped_host = _Host({"action": "noop"}, alive=False)
+    _patch_handlers_and_hosts(
+        monkeypatch,
+        {
+            "alpha:voice_transcript:handle_transcript": _handler(
+                "voice_transcript",
+                "handle_transcript",
+            ),
+            "beta:voice_transcript:handle_transcript": _handler(
+                "voice_transcript",
+                "handle_transcript",
+            ),
+        },
+        {
+            "alpha": stopped_host,
+            "beta": ready_host,
+        },
+    )
+
+    results = await PluginDispatchService().trigger_custom_event_subscribers(
+        event_type="voice_transcript",
+        args={},
+        timeout=0.25,
+    )
+
+    assert results[0]["plugin_id"] == "alpha"
+    assert results[0]["event_id"] == "handle_transcript"
+    assert results[0]["success"] is False
+    assert results[0]["code"] == "PLUGIN_NOT_READY"
+    assert results[1] == {
+        "plugin_id": "beta",
+        "event_id": "handle_transcript",
+        "success": True,
+        "result": {"action": "cancel_response"},
+    }
+    assert ready_host.calls
+
+
+@pytest.mark.asyncio
+async def test_trigger_custom_event_subscribers_runs_handlers_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    alpha_started = asyncio.Event()
+    beta_started = asyncio.Event()
+    alpha_host = _BarrierHost(
+        {"action": "noop"},
+        started=alpha_started,
+        peer_started=beta_started,
+    )
+    beta_host = _BarrierHost(
+        {"action": "prime_context", "context": "ready"},
+        started=beta_started,
+        peer_started=alpha_started,
+    )
+    _patch_handlers_and_hosts(
+        monkeypatch,
+        {
+            "alpha:voice_transcript:one": _handler("voice_transcript", "one"),
+            "beta:voice_transcript:two": _handler("voice_transcript", "two"),
+        },
+        {
+            "alpha": alpha_host,
+            "beta": beta_host,
+        },
+    )
+
+    results = await PluginDispatchService().trigger_custom_event_subscribers(
+        event_type="voice_transcript",
+        args={},
+        timeout=0.25,
+    )
+
+    assert [item["plugin_id"] for item in results] == ["alpha", "beta"]
+    assert alpha_host.calls and beta_host.calls
+
+
+@pytest.mark.asyncio
+async def test_trigger_custom_event_subscribers_isolates_args_per_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    alpha_host = _MutatingHost({"action": "noop"})
+    beta_host = _Host({"action": "prime_context", "context": "ready"})
+    _patch_handlers_and_hosts(
+        monkeypatch,
+        {
+            "alpha:voice_transcript:one": _handler("voice_transcript", "one"),
+            "beta:voice_transcript:two": _handler("voice_transcript", "two"),
+        },
+        {
+            "alpha": alpha_host,
+            "beta": beta_host,
+        },
+    )
+    args = {"metadata": {"source": "voice"}, "transcript": "Yui explain this"}
+
+    results = await PluginDispatchService().trigger_custom_event_subscribers(
+        event_type="voice_transcript",
+        args=args,
+        timeout=0.25,
+    )
+
+    assert [item["plugin_id"] for item in results] == ["alpha", "beta"]
+    assert args == {"metadata": {"source": "voice"}, "transcript": "Yui explain this"}
+    assert alpha_host.calls[0][2]["metadata"] == {
+        "source": "voice",
+        "mutated_by": "one",
+    }
+    assert beta_host.calls[0][2]["metadata"] == {"source": "voice"}
+    assert alpha_host.calls[0][2] is not beta_host.calls[0][2]
+    assert alpha_host.calls[0][2]["metadata"] is not beta_host.calls[0][2]["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_trigger_custom_event_subscribers_isolates_handler_crashes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    crashing_host = _Host({"action": "noop"}, error=ValueError("bad plugin"))
+    ready_host = _Host({"action": "prime_context", "context": "ready"})
+    _patch_handlers_and_hosts(
+        monkeypatch,
+        {
+            "alpha:voice_transcript:handle_transcript": _handler(
+                "voice_transcript",
+                "handle_transcript",
+            ),
+            "beta:voice_transcript:handle_transcript": _handler(
+                "voice_transcript",
+                "handle_transcript",
+            ),
+        },
+        {
+            "alpha": crashing_host,
+            "beta": ready_host,
+        },
+    )
+
+    results = await PluginDispatchService().trigger_custom_event_subscribers(
+        event_type="voice_transcript",
+        args={},
+        timeout=0.25,
+    )
+
+    assert results[0]["plugin_id"] == "alpha"
+    assert results[0]["success"] is False
+    assert results[0]["code"] == "PLUGIN_EVENT_DISPATCH_FAILED"
+    assert results[1] == {
+        "plugin_id": "beta",
+        "event_id": "handle_transcript",
+        "success": True,
+        "result": {"action": "prime_context", "context": "ready"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_trigger_custom_event_subscribers_times_out_one_handler_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slow_host = _Host({"action": "noop"}, delay=0.2)
+    ready_host = _Host({"action": "cancel_response"})
+    _patch_handlers_and_hosts(
+        monkeypatch,
+        {
+            "alpha:voice_transcript:handle_transcript": _handler(
+                "voice_transcript",
+                "handle_transcript",
+            ),
+            "beta:voice_transcript:handle_transcript": _handler(
+                "voice_transcript",
+                "handle_transcript",
+            ),
+        },
+        {
+            "alpha": slow_host,
+            "beta": ready_host,
+        },
+    )
+
+    results = await PluginDispatchService().trigger_custom_event_subscribers(
+        event_type="voice_transcript",
+        args={},
+        timeout=0.05,
+    )
+
+    assert results[0]["plugin_id"] == "alpha"
+    assert results[0]["success"] is False
+    assert results[0]["error_type"] == "TimeoutError"
+    assert results[1] == {
+        "plugin_id": "beta",
+        "event_id": "handle_transcript",
+        "success": True,
+        "result": {"action": "cancel_response"},
+    }

--- a/tests/unit/test_agent_server_voice_bridge.py
+++ b/tests/unit/test_agent_server_voice_bridge.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_request_reports_lifecycle_start_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app import agent_server as srv
+
+    emitted: dict[str, Any] = {}
+    dispatch_called = False
+
+    async def _start_plugin_lifecycle() -> bool:
+        return False
+
+    async def _emit_main_event(event_type: str, lanlan_name: str | None, **payload: Any) -> None:
+        emitted["event_type"] = event_type
+        emitted["lanlan_name"] = lanlan_name
+        emitted["payload"] = payload
+
+    async def _dispatch_voice_transcript_custom_event(*_: Any, **__: Any) -> dict[str, Any]:
+        nonlocal dispatch_called
+        dispatch_called = True
+        return {"action": "noop", "reason": "unexpected_dispatch"}
+
+    monkeypatch.setitem(srv.Modules.agent_flags, "user_plugin_enabled", True)
+    monkeypatch.setattr(srv.Modules, "analyzer_enabled", True)
+    monkeypatch.setattr(srv.Modules, "plugin_lifecycle_started", False)
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", _start_plugin_lifecycle)
+    monkeypatch.setattr(srv, "_emit_main_event", _emit_main_event)
+    monkeypatch.setattr(
+        srv,
+        "_dispatch_voice_transcript_custom_event",
+        _dispatch_voice_transcript_custom_event,
+    )
+
+    await srv._handle_voice_transcript_request(
+        {
+            "event_id": "voice-1",
+            "lanlan_name": "Yui",
+            "transcript": "Yui explain this step",
+        }
+    )
+
+    assert dispatch_called is False
+    assert emitted["event_type"] == "voice_bridge_result"
+    assert emitted["lanlan_name"] == "Yui"
+    assert emitted["payload"]["event_id"] == "voice-1"
+    assert emitted["payload"]["result"] == {
+        "action": "noop",
+        "reason": "plugin_lifecycle_start_failed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_request_skips_plugins_when_agent_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app import agent_server as srv
+
+    emitted: dict[str, Any] = {}
+    start_called = False
+    dispatch_called = False
+
+    async def _start_plugin_lifecycle() -> bool:
+        nonlocal start_called
+        start_called = True
+        return True
+
+    async def _emit_main_event(event_type: str, lanlan_name: str | None, **payload: Any) -> None:
+        emitted["event_type"] = event_type
+        emitted["lanlan_name"] = lanlan_name
+        emitted["payload"] = payload
+
+    async def _dispatch_voice_transcript_custom_event(*_: Any, **__: Any) -> dict[str, Any]:
+        nonlocal dispatch_called
+        dispatch_called = True
+        return {"action": "noop", "reason": "unexpected_dispatch"}
+
+    monkeypatch.setitem(srv.Modules.agent_flags, "user_plugin_enabled", True)
+    monkeypatch.setattr(srv.Modules, "analyzer_enabled", False)
+    monkeypatch.setattr(srv.Modules, "plugin_lifecycle_started", False)
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", _start_plugin_lifecycle)
+    monkeypatch.setattr(srv, "_emit_main_event", _emit_main_event)
+    monkeypatch.setattr(
+        srv,
+        "_dispatch_voice_transcript_custom_event",
+        _dispatch_voice_transcript_custom_event,
+    )
+
+    await srv._handle_voice_transcript_request(
+        {
+            "event_id": "voice-disabled",
+            "lanlan_name": "Yui",
+            "transcript": "Yui explain this step",
+        }
+    )
+
+    assert start_called is False
+    assert dispatch_called is False
+    assert emitted["event_type"] == "voice_bridge_result"
+    assert emitted["lanlan_name"] == "Yui"
+    assert emitted["payload"]["event_id"] == "voice-disabled"
+    assert emitted["payload"]["result"] == {
+        "action": "noop",
+        "reason": "agent_disabled",
+    }
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_request_dispatches_custom_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app import agent_server as srv
+    from plugin.server.application.plugins.dispatch_service import PluginDispatchService
+
+    emitted: dict[str, Any] = {}
+    captured: dict[str, Any] = {}
+
+    async def _emit_main_event(event_type: str, lanlan_name: str | None, **payload: Any) -> None:
+        emitted["event_type"] = event_type
+        emitted["lanlan_name"] = lanlan_name
+        emitted["payload"] = payload
+
+    async def _trigger_custom_event_subscribers(
+        self: PluginDispatchService,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        captured.update(kwargs)
+        return [
+            {
+                "plugin_id": "study_companion",
+                "event_id": "handle_transcript",
+                "success": True,
+                "result": {
+                    "action": "prime_context",
+                    "context": "screen context",
+                },
+            }
+        ]
+
+    monkeypatch.setitem(srv.Modules.agent_flags, "user_plugin_enabled", True)
+    monkeypatch.setattr(srv.Modules, "analyzer_enabled", True)
+    monkeypatch.setattr(srv.Modules, "plugin_lifecycle_started", True)
+    monkeypatch.setattr(srv, "_emit_main_event", _emit_main_event)
+    monkeypatch.setattr(
+        PluginDispatchService,
+        "trigger_custom_event_subscribers",
+        _trigger_custom_event_subscribers,
+    )
+
+    await srv._handle_voice_transcript_request(
+        {
+            "event_id": "voice-2",
+            "lanlan_name": "Yui",
+            "transcript": "Yui explain this step",
+            "metadata": {"session_id": "s1"},
+        }
+    )
+
+    assert captured == {
+        "event_type": srv.VOICE_TRANSCRIPT_CUSTOM_EVENT_TYPE,
+        "args": {
+            "transcript": "Yui explain this step",
+            "lanlan_name": "Yui",
+            "metadata": {"session_id": "s1"},
+        },
+        "timeout": srv.VOICE_TRANSCRIPT_CUSTOM_EVENT_TIMEOUT_SECONDS,
+    }
+    assert emitted["event_type"] == "voice_bridge_result"
+    assert emitted["payload"]["event_id"] == "voice-2"
+    result = emitted["payload"]["result"]
+    assert result["action"] == "prime_context"
+    assert result["context"] == "screen context"
+    assert result["source_plugin"] == "study_companion"
+    assert result["source_event_id"] == "handle_transcript"
+
+
+def test_voice_bridge_dispatch_results_are_arbitrated() -> None:
+    from app import agent_server as srv
+
+    result = srv._voice_bridge_action_from_dispatch_results(
+        [
+            {
+                "plugin_id": "context_plugin",
+                "event_id": "prime",
+                "success": True,
+                "result": {
+                    "action": "prime_context",
+                    "context": "screen context",
+                    "priority": 100,
+                },
+            },
+            {
+                "plugin_id": "study_companion",
+                "event_id": "handle_transcript",
+                "success": True,
+                "result": {
+                    "action": "cancel_response",
+                    "reason": "ocr_overlap",
+                    "priority": -10,
+                },
+            },
+            {
+                "plugin_id": "broken",
+                "event_id": "voice",
+                "success": False,
+                "error": "timeout",
+            },
+        ]
+    )
+
+    assert result["action"] == "cancel_response"
+    assert result["reason"] == "ocr_overlap"
+    assert result["source_plugin"] == "study_companion"
+    assert result["source_event_id"] == "handle_transcript"
+    assert result["failures"] == 1

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -67,6 +67,18 @@ class _FakeActivityTracker:
         self.user_messages.append(text)
 
 
+class _FakeVoiceBridgeSession:
+    def __init__(self):
+        self.cancelled = 0
+        self.primed = []
+
+    async def cancel_response(self):
+        self.cancelled += 1
+
+    async def prime_context(self, context, *, skipped=False):
+        self.primed.append((context, skipped))
+
+
 class _FakeAliveThread:
     def is_alive(self):
         return True
@@ -320,6 +332,75 @@ async def test_takeover_dispatcher_receives_voice_echo_match_before_suppression(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bridge_result",
+    [
+        {"action": "cancel_response"},
+        {"action": "prime_context", "context": "screen context", "skipped": True},
+    ],
+)
+async def test_voice_bridge_result_is_ignored_after_session_change(
+    monkeypatch,
+    bridge_result,
+):
+    mgr = _make_manager()
+    original_session = _FakeVoiceBridgeSession()
+    replacement_session = _FakeVoiceBridgeSession()
+    mgr.session = original_session
+
+    async def fake_publish(*_args, **_kwargs):
+        mgr.session = replacement_session
+        return bridge_result
+
+    monkeypatch.setattr(
+        core_module,
+        "publish_voice_transcript_request_reliably",
+        fake_publish,
+    )
+
+    action = await core_module.LLMSessionManager._dispatch_voice_transcript_bridge(
+        mgr,
+        "Yui explain this step",
+    )
+
+    assert action == ""
+    assert original_session.cancelled == 0
+    assert original_session.primed == []
+    assert replacement_session.cancelled == 0
+    assert replacement_session.primed == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_voice_bridge_cancel_failure_does_not_report_cancel_action(monkeypatch):
+    mgr = _make_manager()
+    session = _FakeVoiceBridgeSession()
+    mgr.session = session
+
+    async def fail_cancel():
+        raise RuntimeError("session already finished")
+
+    async def fake_publish(*_args, **_kwargs):
+        return {"action": "cancel_response"}
+
+    session.cancel_response = fail_cancel
+    monkeypatch.setattr(
+        core_module,
+        "publish_voice_transcript_request_reliably",
+        fake_publish,
+    )
+
+    action = await core_module.LLMSessionManager._dispatch_voice_transcript_bridge(
+        mgr,
+        "Yui stop",
+    )
+
+    assert action == ""
+    assert session.cancelled == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_no_takeover_voice_transcript_uses_ordinary_flow():
     mgr = _make_transcript_manager()
 
@@ -336,6 +417,32 @@ async def test_no_takeover_voice_transcript_uses_ordinary_flow():
         "type": "user",
         "data": {"input_type": "transcript", "data": "普通语音"},
     }]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_voice_bridge_cancel_skips_user_context_side_effects():
+    mgr = _make_transcript_manager()
+    routed = []
+
+    async def fake_voice_bridge(text):
+        routed.append(text)
+        return "cancel_response"
+
+    mgr._dispatch_voice_transcript_bridge = fake_voice_bridge
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr,
+        "  f(x)=x^3 derivative answer is 3x^2  ",
+        is_voice_source=True,
+    )
+
+    assert routed == ["f(x)=x^3 derivative answer is 3x^2"]
+    assert mgr._activity_tracker.voice_rms_count == 1
+    assert mgr._activity_tracker.user_messages == []
+    assert mgr._session_turn_count == 0
+    mgr._publish_user_utterance_to_plugin_bus.assert_not_called()
+    assert mgr.sync_message_queue.messages == []
 
 
 @pytest.mark.unit

--- a/tests/unit/test_voice_bridge_event_bus.py
+++ b/tests/unit/test_voice_bridge_event_bus.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from main_logic import agent_event_bus
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_voice_bridge_notify_keeps_waiter_until_loop_resolves() -> None:
+    event_id = "voice-race-regression"
+    loop = asyncio.get_running_loop()
+    waiter: asyncio.Future = loop.create_future()
+    with agent_event_bus._voice_bridge_waiters_lock:
+        agent_event_bus._voice_bridge_waiters[event_id] = waiter
+        agent_event_bus._voice_bridge_waiters_resolving.discard(event_id)
+
+    try:
+        agent_event_bus.notify_voice_bridge_result(event_id, {"action": "noop"})
+
+        with agent_event_bus._voice_bridge_waiters_lock:
+            assert agent_event_bus._voice_bridge_waiters.get(event_id) is waiter
+            assert event_id in agent_event_bus._voice_bridge_waiters_resolving
+        assert not waiter.done()
+
+        await asyncio.sleep(0)
+
+        assert waiter.done()
+        assert waiter.result() == {"action": "noop"}
+        with agent_event_bus._voice_bridge_waiters_lock:
+            assert event_id not in agent_event_bus._voice_bridge_waiters
+            assert event_id not in agent_event_bus._voice_bridge_waiters_resolving
+    finally:
+        with agent_event_bus._voice_bridge_waiters_lock:
+            agent_event_bus._voice_bridge_waiters.pop(event_id, None)
+            agent_event_bus._voice_bridge_waiters_resolving.discard(event_id)
+        if not waiter.done():
+            waiter.cancel()
+
+
+def test_voice_bridge_notify_cancels_waiter_when_loop_is_closed() -> None:
+    event_id = "voice-closed-loop"
+
+    class _ClosedLoop:
+        def call_soon_threadsafe(self, _callback):
+            raise RuntimeError("event loop is closed")
+
+    class _Waiter:
+        def __init__(self):
+            self.cancelled = False
+
+        def done(self):
+            return self.cancelled
+
+        def cancel(self):
+            self.cancelled = True
+
+        def get_loop(self):
+            return _ClosedLoop()
+
+    waiter = _Waiter()
+    with agent_event_bus._voice_bridge_waiters_lock:
+        agent_event_bus._voice_bridge_waiters[event_id] = waiter
+        agent_event_bus._voice_bridge_waiters_resolving.discard(event_id)
+
+    try:
+        agent_event_bus.notify_voice_bridge_result(event_id, {"action": "noop"})
+
+        assert waiter.cancelled is True
+        with agent_event_bus._voice_bridge_waiters_lock:
+            assert event_id not in agent_event_bus._voice_bridge_waiters
+            assert event_id not in agent_event_bus._voice_bridge_waiters_resolving
+    finally:
+        with agent_event_bus._voice_bridge_waiters_lock:
+            agent_event_bus._voice_bridge_waiters.pop(event_id, None)
+            agent_event_bus._voice_bridge_waiters_resolving.discard(event_id)
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_request_returns_agent_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _Bridge:
+        async def publish_session_event(self, event: dict) -> bool:
+            captured.update(event)
+            asyncio.get_running_loop().call_soon(
+                agent_event_bus.notify_voice_bridge_result,
+                str(event["event_id"]),
+                {"action": "cancel_response"},
+            )
+            return True
+
+    monkeypatch.setattr(agent_event_bus, "_main_bridge_ref", _Bridge())
+
+    result = await agent_event_bus.publish_voice_transcript_request_reliably(
+        "Yui",
+        "hm this is 3x^2",
+        timeout_s=0.2,
+    )
+
+    assert result == {"action": "cancel_response"}
+    assert captured["event_type"] == "voice_transcript_request"
+    assert captured["lanlan_name"] == "Yui"
+    assert captured["transcript"] == "hm this is 3x^2"
+    assert agent_event_bus._voice_bridge_waiters == {}
+
+
+@pytest.mark.asyncio
+async def test_voice_transcript_request_retries_after_send_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts: list[int] = []
+
+    class _Bridge:
+        async def publish_session_event(self, event: dict) -> bool:
+            attempts.append(int(event["attempt"]))
+            if len(attempts) == 1:
+                return False
+            asyncio.get_running_loop().call_soon(
+                agent_event_bus.notify_voice_bridge_result,
+                str(event["event_id"]),
+                {"action": "prime_context", "context": "screen context"},
+            )
+            return True
+
+    monkeypatch.setattr(agent_event_bus, "_main_bridge_ref", _Bridge())
+
+    result = await agent_event_bus.publish_voice_transcript_request_reliably(
+        "Yui",
+        "Yui explain this step",
+        timeout_s=0.2,
+        retries=1,
+    )
+
+    assert attempts == [0, 1]
+    assert result == {"action": "prime_context", "context": "screen context"}
+    assert agent_event_bus._voice_bridge_waiters == {}


### PR DESCRIPTION
## 概述 (Part 1/2 — Neko 本体)

> 这是从原 PR [#1582](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1582) 拆分出的第一个 PR，包含 Neko 本体的基础设施变更。伴学插件本体变更在 [#1610](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1610)。

## 主要变更

- 新增语音转录事件桥接 (`main_logic/agent_event_bus.py`)，将实时语音转录路由到插件
- 新增插件调度服务 (`plugin/server/application/plugins/dispatch_service.py`)，支持 cancel_response / prime_context 事件契约
- 在 `agent_server.py` 中新增语音桥接动作处理
- 在 `main_server.py` 中注册语音桥接
- 补充事件总线、语音桥接、插件调度等单元/集成测试

边界设计：host 只负责转发事件和执行通用 session 操作（cancel_response、prime_context）。所有业务逻辑（过滤规则、动作定义、学习场景）留在插件层，由 Part 2 PR 提供。

## 验证

- 原 PR (1582) 的 ruff check / py_compile / pytest 全部通过
- 变更范围严格限定在 10 个文件
- 无 pyproject.toml / uv.lock 变更

## 分解说明

原 PR #1582 按 reviewer 要求拆分为两个 PR：
1. **本 PR (#1609)**：Neko 本体基础设施（voice bridge、plugin dispatch、event contracts）
2. **Part 2 (#1610)**：study_companion 插件本体（notebook、voice filter、UI、KaTeX、i18n）—— 依赖本 PR 合并后才能合并


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加语音转写功能，支持语音请求的实时处理和结果回传
  * 集成插件系统，允许插件对语音转写结果进行自定义处理和响应控制

* **优化**
  * 调整路由配置以改进服务架构
  * 增强语音转写的跨进程同步机制和可靠性

* **测试**
  * 新增语音转写、插件分发和事件总线的单元测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->