### PR TITLE
fix(chat): enable compact surface body drag

### DIFF
--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -86,11 +86,13 @@
    - `.compact-chat-surface-shell`
    - `.compact-chat-surface-frame`
    - `data-compact-geometry-owner="surface"`
-   - `data-compact-geometry-item="capsule" | "input" | "dragHandle" | "resizeHandle" | "toolFan" | "history" | "historyHandle" | "choice"`
+   - `data-compact-geometry-item="capsule" | "input" | "resizeHandle" | "toolFan" | "history" | "historyHandle" | "choice"`
    - `data-compact-geometry-part="capsuleBody" | "inputBody"`
+   - `data-compact-drag-surface="true"` 声明 compact 对话框本体 surface；整体拖拽只指这个本体，不包含历史、工具轮盘、选项层等浮层。
+   - `data-compact-no-drag="true"` 声明 textarea、工具按钮、resize、历史、选项等真实控件和浮层排除拖拽。
 6. 早期 `.compact-chat-capsule-shell` / `.compact-chat-input-shell` 已不是当前主体事实，后续文档和实现不要再按这两个旧类名设计。
 7. `.compact-chat-surface-frame` 是同一个 54px 高的本体：`default/options` 内放 capsule button，`input` 内放 textarea 和右侧工具/发送按钮。
-8. 蓝线拖拽手柄是 `.compact-chat-drag-handle`，带 `data-compact-drag-handle="true"`，必须保留。
+8. 旧蓝线拖拽手柄 `.compact-chat-drag-handle` / `data-compact-drag-handle="true"` 已删除，不应恢复；对话框本体拖拽走 `data-compact-drag-surface` / `data-compact-no-drag`。
 9. 左右缩放手柄是 `.compact-chat-resize-handle-left/right`，通过 `neko:compact-surface-resize-request` 与宿主同步宽度。
 10. 工具转轮通过 portal 挂到 `document.body`，并以 `data-compact-geometry-item="toolFan"` 进入 geometry。
 11. 历史层由 `CompactExportHistoryPanel` 挂载到 `app-shell` 内，锚点是 `.compact-export-history-anchor`，并以 `data-compact-geometry-item="history"` 进入 geometry。
@@ -142,7 +144,7 @@
    - `window.__nekoDesktopCompactExternalBall`
 3. 桌面 compact surface 的 BrowserWindow bounds 由页面 surface geometry、history drag carrier bounds 和 workArea 共同派生。
 4. 最小化 ball 按外部 ball window 思路承载，不应和 surface 绑在同一个大透明窗口里。
-5. Native Wayland 下 `[data-compact-drag-handle="true"]` 需要走 `-webkit-app-region: drag`，不能强行走全局 cursor polling。
+5. Native Wayland 下 compact 对话框本体拖拽需要让 `[data-compact-drag-surface="true"]` 走 `-webkit-app-region: drag`，并用 `[data-compact-no-drag="true"]` 排除真实控件和浮层；不能强行走全局 cursor polling。
 6. 桌面历史拖拽已有桥接状态：
    - `window.__nekoDesktopCompactHistoryDragState`
    - `window.__nekoDesktopCompactHistoryPointerPassthrough`
@@ -220,13 +222,14 @@
 
 Surface island 包含：
 
-1. `.compact-chat-surface-frame` 本体。
-2. 蓝线拖拽手柄。
-3. 左右 resize 手柄。
-4. ChoicePrompt / GalGame options。
-5. 工具转轮。
-6. 内联历史 / 导出历史层。
-7. 历史拖拽视觉层。
+1. `.compact-chat-surface-frame` 本体，同时也是 compact 对话框本体拖拽 surface。
+2. 左右 resize 手柄。
+3. ChoicePrompt / GalGame options。
+4. 工具转轮。
+5. 内联历史 / 导出历史层。
+6. 历史拖拽视觉层。
+
+旧蓝线拖拽手柄不再属于 surface island；compact 对话框本体拖拽由 `.compact-chat-surface-frame` 声明承担。
 
 定位：
 
@@ -238,7 +241,7 @@ Surface island 包含：
 
 命中：
 
-1. 只有可见本体、输入、选项、工具、历史滚动区、历史控件、拖拽层、蓝线和 resize 手柄可命中。
+1. 只有可见本体、输入、选项、工具、历史滚动区、历史控件、拖拽层和 resize 手柄可命中。
 2. 透明包裹层必须穿透。
 3. 关闭态、空态、未加载态不能留下透明但吃事件的大矩形。
 4. 历史气泡之间、气泡左右留白等非对话透明区应尽量 passthrough，尤其是桌面端。
@@ -249,7 +252,7 @@ Surface island 包含：
 2. ChoicePrompt / GalGame 选项应在历史层上方。
 3. 工具转轮在输入器上方。
 4. 历史拖拽视觉层在 history/source 之上，但不应污染普通命中。
-5. 蓝线在 surface 本体上方，但不能扩大成大命中面。
+5. 旧蓝线不再参与层级；本体拖拽命中不能扩大成大透明面。
 
 ## Compact Ball Island
 
@@ -260,7 +263,7 @@ Ball island 包含最小化小球视觉与点击区域。
 1. ball 基于模型 bounds 位于模型左侧。
 2. ball 使用 viewport/workArea clamp，不能出屏。
 3. 没有模型 bounds 时才使用 fallback，并视为降级路径。
-4. ball 不随蓝线拖拽移动。
+4. ball 不随 compact surface 本体拖拽移动。
 5. ball 不读取 compact surface localStorage。
 6. ball 不参与 surface bounds 计算。
 7. 桌面端优先由独立 ball window 承载，不和 surface 之间生成大透明命中区域。
@@ -288,9 +291,8 @@ Compact Interaction Geometry 是紧凑态的根合同。所有可见、可点、
 4. `history`
 5. `historyHandle`
 6. `toolFan`
-7. `dragHandle`
-8. `resizeHandle`
-9. `ball`
+7. `resizeHandle`
+8. `ball`
 
 规则：
 
@@ -299,7 +301,7 @@ Compact Interaction Geometry 是紧凑态的根合同。所有可见、可点、
 3. surface 和 ball 之间不能通过一个大透明矩形相连。
 4. 子组件允许视觉浮出父 DOM，但浮出的可见区域必须注册进 geometry。
 5. 新增 compact 浮层时，同步补 DOM 身份、geometry item、hit 策略、native bounds 和验证项。
-6. `resizeHandle` / `dragHandle` 这类 aria-hidden 控件只有在 collector 明确允许时才能进入 geometry。
+6. `resizeHandle` 这类 aria-hidden 控件只有在 collector 明确允许时才能进入 geometry；旧 `dragHandle` 不再进入 geometry。
 
 ### 页面 Geometry 来源
 
@@ -446,7 +448,7 @@ Compact 当前文字是“当前轮轻提示”，不是完整历史记录、字
 5. 桌面端 compact resize / relayout 只影响 compact carrier，不再维护 full 模式窗口快照。
 6. 从 minimized 恢复 compact 时，必须恢复 compact bounds、shape、ignore-mouse-events、external ball 和 resizable 状态。
 7. Windows 展开 fallback 需要真实 resizable style toggle，不能把 `setResizable(false)` 到 `setResizable(false)` 当成 cache busting。
-8. Native Wayland compact drag handle 应保留原生 drag 策略，不走不可用的全局 cursor/window polling。
+8. Native Wayland compact 对话框本体拖拽应保留原生 drag 策略，不走不可用的全局 cursor/window polling。
 9. ReactChat 紧凑窗口必须保持在模型上方，并由 window manager / top coordinator 维护层级。
 
 ## 修改指导
@@ -480,7 +482,7 @@ Compact 当前文字是“当前轮轻提示”，不是完整历史记录、字
 3. 修改 ball 时，确认：
    - 只看模型 bounds。
    - 不读 surface position。
-   - 不被蓝线拖拽影响。
+   - 不被 compact surface 本体拖拽影响。
 4. 修改选项层时，确认：
    - 不塞回胶囊。
    - 下方不足能转到上方。
@@ -540,7 +542,7 @@ Surface：
 命中：
 
 1. compact 周围透明区域不挡后方内容点击。
-2. 可见胶囊、输入、选项、工具、历史、拖拽层、蓝线和 resize 手柄都能稳定点击。
+2. 可见胶囊、输入、选项、工具、历史、拖拽层和 resize 手柄都能稳定点击。
 3. 选项/历史关闭后不留透明命中区。
 4. 桌面端 BrowserWindow bounds / setShape / passthrough 与页面 geometry 一致。
 
@@ -589,23 +591,23 @@ Surface：
 3. 模型移动不会强行覆盖用户保存的 surface 位置。
 4. compact window 在模型上方。
 5. 从 minimized 恢复 compact 后窗口 bounds、shape、resizable 和 ball 状态恢复正确。
-6. Native Wayland 拖拽仍使用可工作的原生拖拽路径。
+6. Native Wayland 对话框本体拖拽仍使用可工作的原生拖拽路径。
 
 ## 禁止方案
 
 1. 禁止用 `HEAD` 覆盖当前工作区紧凑态改动。
-2. 禁止删除 `.compact-chat-drag-handle` 或 `data-compact-drag-handle="true"` 链路。
+2. 禁止恢复 `.compact-chat-drag-handle` 或 `data-compact-drag-handle="true"` 作为 compact 主拖拽入口；同时禁止误删历史显隐按钮和桌面壳折叠球链路。
 3. 禁止把 compact 背景加到 `#react-chat-window-shell` 这类外层透明窗口壳上。
 4. 禁止把 ball 固定到视口左下角当作模型左侧定位。
 5. 禁止让 compact surface 的持久化位置影响 ball 位置。
 6. 禁止让 ball 和 surface 共用一个大透明矩形作为桌面端最终方案。
-7. 禁止用全局粗暴 `pointer-events: none` 破坏输入、选项、工具、蓝线、历史或 ball。
+7. 禁止用全局粗暴 `pointer-events: none` 破坏输入、选项、工具、历史、历史显隐按钮或 ball。
 8. 禁止只给 textarea 加固定高度就宣称解决输入态撑高。
 9. 禁止只提高局部 `z-index` 就宣称解决模型上方层级问题。
 10. 禁止把 GalGame / ChoicePrompt 选项塞回胶囊内部来绕过裁切。
 11. 禁止选项或历史关闭后仍保留透明命中区域。
 12. 禁止为未来功能预留透明但吃事件的大空区域。
-13. 禁止让历史滚动误触发蓝线拖拽。
+13. 禁止让历史滚动误触发 compact surface 本体拖拽。
 14. 禁止让历史、选项或工具层参与 ball 定位。
 15. 禁止让视觉浮层依赖未登记的 `overflow: visible` 逃逸父容器。
 16. 禁止把 NEKO-PC 的实现限制反向改成网页端产品目标。

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -148,26 +148,32 @@ describe('App', () => {
     expect(compactStage).toHaveAttribute('data-compact-chat-state', 'input');
   });
 
-  it('renders a compact drag handle in compact input and voice capsule states only', () => {
+  it('declares compact drag surface and no-drag controls in compact states only', () => {
     const { container, rerender } = render(<App chatSurfaceMode="compact" compactChatState="input" />);
 
-    expect(container.querySelector('.compact-chat-surface-shell .compact-chat-drag-handle')).not.toBeNull();
+    expect(container.querySelector('.compact-chat-surface-shell .compact-chat-drag-handle')).toBeNull();
     expect(container.querySelectorAll('.compact-chat-surface-shell .compact-chat-resize-handle')).toHaveLength(2);
     expect(container.querySelector('.compact-chat-surface-shell')).not.toHaveAttribute('data-compact-geometry-item');
     expect(container.querySelector('[data-compact-geometry-part="inputBody"]')).toHaveAttribute('data-compact-geometry-item', 'input');
     expect(container.querySelector('[data-compact-geometry-part="inputBody"]')).toHaveAttribute('data-compact-geometry-owner', 'surface');
-    expect(container.querySelector('[data-compact-geometry-item="dragHandle"]')).toHaveAttribute('data-compact-geometry-owner', 'surface');
+    expect(container.querySelector('[data-compact-drag-surface="true"]')).toHaveAttribute('data-compact-geometry-owner', 'surface');
+    expect(container.querySelector('[data-compact-geometry-item="dragHandle"]')).toBeNull();
+    expect(container.querySelector('.composer-input')).toHaveAttribute('data-compact-no-drag', 'true');
+    expect(container.querySelector('.compact-input-tool-toggle')).toHaveAttribute('data-compact-no-drag', 'true');
     expect(container.querySelector('[data-compact-resize-side="left"]')).toHaveAttribute('data-compact-geometry-item', 'resizeHandle');
+    expect(container.querySelector('[data-compact-resize-side="left"]')).toHaveAttribute('data-compact-no-drag', 'true');
     expect(container.querySelector('[data-compact-resize-side="right"]')).toHaveAttribute('data-compact-geometry-item', 'resizeHandle');
+    expect(container.querySelector('[data-compact-resize-side="right"]')).toHaveAttribute('data-compact-no-drag', 'true');
     const stableSurfaceShell = container.querySelector('.compact-chat-surface-shell');
     const stableSurfaceFrame = container.querySelector('.compact-chat-surface-frame');
 
     rerender(<App chatSurfaceMode="compact" compactChatState="input" composerHidden />);
-    expect(container.querySelector('.compact-chat-surface-shell .compact-chat-drag-handle')).not.toBeNull();
+    expect(container.querySelector('.compact-chat-surface-shell .compact-chat-drag-handle')).toBeNull();
     expect(container.querySelectorAll('.compact-chat-surface-shell .compact-chat-resize-handle')).toHaveLength(2);
     expect(container.querySelector('.compact-chat-surface-shell')).not.toHaveAttribute('data-compact-geometry-item');
     expect(container.querySelector('[data-compact-geometry-part="capsuleBody"]')).toHaveAttribute('data-compact-geometry-item', 'capsule');
     expect(container.querySelector('[data-compact-geometry-part="capsuleBody"]')).toHaveAttribute('data-compact-geometry-owner', 'surface');
+    expect(container.querySelector('[data-compact-drag-surface="true"]')).toHaveAttribute('data-compact-geometry-part', 'capsuleBody');
     expect(container.querySelector('.compact-chat-surface-shell')).toBe(stableSurfaceShell);
     expect(container.querySelector('.compact-chat-surface-frame')).toBe(stableSurfaceFrame);
 
@@ -3643,6 +3649,7 @@ describe('App', () => {
       // A quick tap (press + release) toggles the hover-opened fan shut.
       fireEvent.pointerDown(actionButton, { pointerId: 8, button: 0, buttons: 1, pointerType: 'mouse' });
       fireEvent.pointerUp(actionButton, { pointerId: 8, button: 0, pointerType: 'mouse' });
+      fireEvent.click(actionButton);
       fireEvent.pointerLeave(actionButton, { clientX: 96, clientY: 96, pointerType: 'mouse' });
 
       await act(async () => {
@@ -3656,25 +3663,17 @@ describe('App', () => {
     }
   });
 
-  it('opens compact input tools on a primary pointer tap without requesting a drag', () => {
-    const dragRequests: Event[] = [];
-    const onDragRequest = (event: Event) => dragRequests.push(event);
-    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
-    try {
-      render(<App chatSurfaceMode="compact" compactChatState="input" />);
+  it('opens compact input tools on a primary pointer tap', () => {
+    render(<App chatSurfaceMode="compact" compactChatState="input" />);
 
-      const actionButton = screen.getByRole('button', { name: '更多工具' });
-      const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
-      // The fan now opens on release (deferred), so a press alone keeps it shut.
-      fireEvent.pointerDown(actionButton, { pointerId: 9, button: 0, buttons: 1, pointerType: 'mouse' });
-      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+    const actionButton = screen.getByRole('button', { name: '更多工具' });
+    const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
+    fireEvent.pointerDown(actionButton, { pointerId: 9, button: 0, buttons: 1, pointerType: 'mouse' });
+    expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
 
-      fireEvent.pointerUp(actionButton, { pointerId: 9, button: 0, pointerType: 'mouse' });
-      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
-      expect(dragRequests).toHaveLength(0);
-    } finally {
-      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
-    }
+    fireEvent.pointerUp(actionButton, { pointerId: 9, button: 0, pointerType: 'mouse' });
+    fireEvent.click(actionButton);
+    expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
   });
 
   it('keeps compact tool actions disabled until the fan finishes opening', async () => {
@@ -3692,6 +3691,7 @@ describe('App', () => {
       const toggle = screen.getByRole('button', { name: '更多工具' });
       fireEvent.pointerDown(toggle, { pointerId: 9, button: 0, buttons: 1, pointerType: 'mouse' });
       fireEvent.pointerUp(toggle, { pointerId: 9, button: 0, pointerType: 'mouse' });
+      fireEvent.click(toggle);
       const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
       const importButton = fan.querySelector('.compact-input-tool-item-import') as HTMLButtonElement;
 
@@ -4545,6 +4545,7 @@ describe('App', () => {
     const tapToggle = (pointerId: number) => {
       fireEvent.pointerDown(actionButton, { pointerId, button: 0, buttons: 1, pointerType: 'mouse' });
       fireEvent.pointerUp(actionButton, { pointerId, button: 0, pointerType: 'mouse' });
+      fireEvent.click(actionButton);
     };
 
     tapToggle(21);
@@ -4555,88 +4556,6 @@ describe('App', () => {
 
     tapToggle(23);
     expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
-  });
-
-  it('requests a surface drag on a long-press of the tool toggle without opening the fan', async () => {
-    vi.useFakeTimers();
-    const dragRequests: CustomEvent[] = [];
-    const onDragRequest = (event: Event) => dragRequests.push(event as CustomEvent);
-    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
-    try {
-      render(<App chatSurfaceMode="compact" compactChatState="input" />);
-
-      const actionButton = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
-      const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
-
-      fireEvent.pointerDown(actionButton, {
-        pointerId: 31,
-        button: 0,
-        buttons: 1,
-        pointerType: 'mouse',
-        clientX: 100,
-        clientY: 50,
-        screenX: 512,
-        screenY: 360,
-      });
-      expect(dragRequests).toHaveLength(0);
-      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(320);
-      });
-
-      expect(dragRequests).toHaveLength(1);
-      expect(dragRequests[0].detail).toMatchObject({ screenX: 512, screenY: 360 });
-      // The wheel stays shut so the surface drag starts clean.
-      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
-
-      // Releasing after the hold must not toggle the wheel back open.
-      fireEvent.pointerUp(actionButton, { pointerId: 31, button: 0, pointerType: 'mouse' });
-      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
-    } finally {
-      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
-      vi.useRealTimers();
-    }
-  });
-
-  it('cancels the tool toggle tap and drag when the pointer moves before the hold fires', async () => {
-    vi.useFakeTimers();
-    const dragRequests: Event[] = [];
-    const onDragRequest = (event: Event) => dragRequests.push(event);
-    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
-    try {
-      render(<App chatSurfaceMode="compact" compactChatState="input" />);
-
-      const actionButton = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
-      const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
-
-      // Touch never hover-opens the fan, so this isolates the gesture itself.
-      fireEvent.pointerDown(actionButton, {
-        pointerId: 41,
-        buttons: 1,
-        pointerType: 'touch',
-        clientX: 100,
-        clientY: 50,
-      });
-      fireEvent.pointerMove(actionButton, {
-        pointerId: 41,
-        buttons: 1,
-        pointerType: 'touch',
-        clientX: 130,
-        clientY: 50,
-      });
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(400);
-      });
-      fireEvent.pointerUp(actionButton, { pointerId: 41, pointerType: 'touch' });
-
-      expect(dragRequests).toHaveLength(0);
-      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
-    } finally {
-      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
-      vi.useRealTimers();
-    }
   });
 
   it('signals fan-open solid state to the desktop shell on open and close', () => {
@@ -4651,6 +4570,7 @@ describe('App', () => {
       const tapToggle = (pointerId: number) => {
         fireEvent.pointerDown(actionButton, { pointerId, button: 0, buttons: 1, pointerType: 'mouse' });
         fireEvent.pointerUp(actionButton, { pointerId, button: 0, pointerType: 'mouse' });
+        fireEvent.click(actionButton);
       };
 
       tapToggle(51);
@@ -4662,59 +4582,6 @@ describe('App', () => {
       expect(openStates[openStates.length - 1]).toBe(false);
     } finally {
       window.removeEventListener('neko:compact-tool-fan-open-state-change', onOpenState);
-    }
-  });
-
-  it('focuses the input on a quick tap of an input-box edge band', () => {
-    render(<App chatSurfaceMode="compact" compactChatState="input" />);
-    const band = document.body.querySelector('.compact-input-edge-band-left') as HTMLElement;
-    const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
-    expect(band).not.toBeNull();
-    // Drop the auto-focus so the tap is what re-focuses.
-    act(() => { input.blur(); });
-    expect(input).not.toHaveFocus();
-
-    fireEvent.pointerDown(band, { pointerId: 61, button: 0, buttons: 1, pointerType: 'mouse', clientX: 10, clientY: 27 });
-    fireEvent.pointerUp(band, { pointerId: 61, button: 0, pointerType: 'mouse' });
-
-    expect(input).toHaveFocus();
-  });
-
-  it('requests a surface drag on a long-press of an input-box edge band without focusing the input', async () => {
-    vi.useFakeTimers();
-    const dragRequests: CustomEvent[] = [];
-    const onDragRequest = (event: Event) => dragRequests.push(event as CustomEvent);
-    window.addEventListener('neko:compact-surface-drag-request', onDragRequest);
-    try {
-      render(<App chatSurfaceMode="compact" compactChatState="input" />);
-      const band = document.body.querySelector('.compact-input-edge-band-left') as HTMLElement;
-      const input = document.body.querySelector('.composer-input') as HTMLTextAreaElement;
-      act(() => { input.blur(); });
-
-      fireEvent.pointerDown(band, {
-        pointerId: 62,
-        button: 0,
-        buttons: 1,
-        pointerType: 'mouse',
-        clientX: 10,
-        clientY: 27,
-        screenX: 300,
-        screenY: 500,
-      });
-      expect(dragRequests).toHaveLength(0);
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(320);
-      });
-      expect(dragRequests).toHaveLength(1);
-      expect(dragRequests[0].detail).toMatchObject({ screenX: 300, screenY: 500 });
-
-      fireEvent.pointerUp(band, { pointerId: 62, button: 0, pointerType: 'mouse' });
-      // A long-press is a drag, not a tap — it must not focus the input.
-      expect(input).not.toHaveFocus();
-    } finally {
-      window.removeEventListener('neko:compact-surface-drag-request', onDragRequest);
-      vi.useRealTimers();
     }
   });
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -117,13 +117,6 @@ const COMPACT_INPUT_TOOL_TOGGLE_HOVER_OUTSET = 14;
 const COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE = 48;
 const COMPACT_INPUT_TOOL_FAN_INTERACTIVE_DELAY_MS = 220;
 const COMPACT_INPUT_TOOL_FAN_TRANSIENT_CLOSE_DELAY_MS = 360;
-// Long-press to grab and drag the whole compact surface (the OS window-move
-// runs in the desktop preload; see neko:compact-surface-drag-request). Hold this
-// long without moving more than the tolerance. Shared by the dropdown-arrow
-// toggle and the input-box edge bands; a quick tap on either does its own thing
-// (toggle opens the tool wheel; an edge band focuses the input) on release.
-const COMPACT_INPUT_SURFACE_LONG_PRESS_MS = 320;
-const COMPACT_INPUT_SURFACE_LONG_PRESS_MOVE_TOLERANCE = 10;
 const COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS = 650;
 const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 430;
 const COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
@@ -233,16 +226,6 @@ type CompactToolWheelChargeState = {
   direction: 1 | -1 | null;
   sameDirectionSteps: number;
   chargeSteps: number;
-};
-
-type CompactToolTogglePressState = {
-  pointerId: number;
-  startClientX: number;
-  startClientY: number;
-  startScreenX: number;
-  startScreenY: number;
-  longPressFired: boolean;
-  canceledTap: boolean;
 };
 
 type CompactToolWheelDragPoint = {
@@ -1166,11 +1149,6 @@ export default function App({
   const compactInputToolWheelChargeReleaseActiveRef = useRef(false);
   const compactInputToolWheelSuppressClickRef = useRef(false);
   const compactInputToolWheelScrollDeltaRef = useRef(0);
-  const compactInputToolTogglePointerHandledRef = useRef(false);
-  const compactInputToolTogglePressRef = useRef<CompactToolTogglePressState | null>(null);
-  const compactInputToolToggleLongPressTimerRef = useRef<number | null>(null);
-  const compactInputEdgePressRef = useRef<CompactToolTogglePressState | null>(null);
-  const compactInputEdgeLongPressTimerRef = useRef<number | null>(null);
   const compactInputToolFanPositionSyncRef = useRef<(() => void) | null>(null);
   const compactInputToolFanCloseTimerRef = useRef<number | null>(null);
   const compactInputToolFanInteractiveTimerRef = useRef<number | null>(null);
@@ -2749,156 +2727,6 @@ export default function App({
     openCompactInputToolFan('click');
   }, [closeCompactInputToolFanFromUserClick, openCompactInputToolFan]);
 
-  const clearCompactInputToolToggleLongPressTimer = useCallback(() => {
-    if (compactInputToolToggleLongPressTimerRef.current !== null) {
-      window.clearTimeout(compactInputToolToggleLongPressTimerRef.current);
-      compactInputToolToggleLongPressTimerRef.current = null;
-    }
-  }, []);
-
-  // Ask the desktop shell to grab and drag the whole compact surface. Only the
-  // preload/main process can move the native window; the page just signals it.
-  // Mirrors neko:compact-tool-wheel-drag-state-change as a one-shot request.
-  const dispatchCompactSurfaceDragRequest = useCallback((screenX: number, screenY: number) => {
-    window.dispatchEvent(new CustomEvent('neko:compact-surface-drag-request', {
-      detail: {
-        screenX,
-        screenY,
-        timestamp: Date.now(),
-      },
-    }));
-  }, []);
-
-  // Long-press on the dropdown-arrow toggle = grab the surface; quick tap = open
-  // the tool wheel on release (deferred so a press-and-hold never flashes it open).
-  const handleCompactInputToolTogglePointerDown = useCallback((event: ReactPointerEvent) => {
-    if (event.pointerType === 'mouse' && event.button !== 0) return;
-    event.preventDefault();
-    clearCompactInputToolToggleLongPressTimer();
-    // Fresh gesture: drop any stale click-suppression left by a prior press
-    // whose trailing click never arrived (so keyboard activation still toggles).
-    compactInputToolTogglePointerHandledRef.current = false;
-    compactInputToolTogglePressRef.current = {
-      pointerId: event.pointerId,
-      startClientX: event.clientX,
-      startClientY: event.clientY,
-      startScreenX: event.screenX,
-      startScreenY: event.screenY,
-      longPressFired: false,
-      canceledTap: false,
-    };
-    try {
-      event.currentTarget.setPointerCapture?.(event.pointerId);
-    } catch (_) {}
-    compactInputToolToggleLongPressTimerRef.current = window.setTimeout(() => {
-      compactInputToolToggleLongPressTimerRef.current = null;
-      const press = compactInputToolTogglePressRef.current;
-      if (!press || press.longPressFired || press.canceledTap) return;
-      press.longPressFired = true;
-      // Close the wheel (a hover may have opened it) so the drag starts clean.
-      closeCompactInputToolFanFromUserClick();
-      dispatchCompactSurfaceDragRequest(press.startScreenX, press.startScreenY);
-    }, COMPACT_INPUT_SURFACE_LONG_PRESS_MS);
-  }, [
-    clearCompactInputToolToggleLongPressTimer,
-    closeCompactInputToolFanFromUserClick,
-    dispatchCompactSurfaceDragRequest,
-  ]);
-
-  const handleCompactInputToolTogglePointerMove = useCallback((event: ReactPointerEvent) => {
-    const press = compactInputToolTogglePressRef.current;
-    if (!press || press.pointerId !== event.pointerId || press.longPressFired) return;
-    const dx = event.clientX - press.startClientX;
-    const dy = event.clientY - press.startClientY;
-    if (Math.hypot(dx, dy) > COMPACT_INPUT_SURFACE_LONG_PRESS_MOVE_TOLERANCE) {
-      // Moved before the hold fired: not a tap, not a long-press — do nothing.
-      press.canceledTap = true;
-      clearCompactInputToolToggleLongPressTimer();
-    }
-  }, [clearCompactInputToolToggleLongPressTimer]);
-
-  const finishCompactInputToolTogglePress = useCallback((event: ReactPointerEvent, options?: { canceled?: boolean }) => {
-    const press = compactInputToolTogglePressRef.current;
-    if (!press || press.pointerId !== event.pointerId) return;
-    clearCompactInputToolToggleLongPressTimer();
-    try {
-      event.currentTarget.releasePointerCapture?.(event.pointerId);
-    } catch (_) {}
-    compactInputToolTogglePressRef.current = null;
-    // Swallow the trailing click for any pointer-driven gesture; keyboard
-    // activation has no press record and still toggles through onClick.
-    compactInputToolTogglePointerHandledRef.current = true;
-    if (press.longPressFired) return;
-    if (options?.canceled || press.canceledTap) return;
-    toggleCompactInputToolFanByClick();
-  }, [clearCompactInputToolToggleLongPressTimer, toggleCompactInputToolFanByClick]);
-
-  useEffect(() => () => clearCompactInputToolToggleLongPressTimer(), [clearCompactInputToolToggleLongPressTimer]);
-
-  // Input-box edge bands: same long-press-to-drag gesture as the arrow, but a
-  // quick tap focuses the input for typing instead of toggling the wheel. These
-  // bands overlay only the rim; the uncovered center keeps native press-to-type.
-  const clearCompactInputEdgeLongPressTimer = useCallback(() => {
-    if (compactInputEdgeLongPressTimerRef.current !== null) {
-      window.clearTimeout(compactInputEdgeLongPressTimerRef.current);
-      compactInputEdgeLongPressTimerRef.current = null;
-    }
-  }, []);
-
-  const handleCompactInputEdgePointerDown = useCallback((event: ReactPointerEvent) => {
-    if (event.pointerType === 'mouse' && event.button !== 0) return;
-    event.preventDefault();
-    clearCompactInputEdgeLongPressTimer();
-    compactInputEdgePressRef.current = {
-      pointerId: event.pointerId,
-      startClientX: event.clientX,
-      startClientY: event.clientY,
-      startScreenX: event.screenX,
-      startScreenY: event.screenY,
-      longPressFired: false,
-      canceledTap: false,
-    };
-    try {
-      event.currentTarget.setPointerCapture?.(event.pointerId);
-    } catch (_) {}
-    compactInputEdgeLongPressTimerRef.current = window.setTimeout(() => {
-      compactInputEdgeLongPressTimerRef.current = null;
-      const press = compactInputEdgePressRef.current;
-      if (!press || press.longPressFired || press.canceledTap) return;
-      press.longPressFired = true;
-      dispatchCompactSurfaceDragRequest(press.startScreenX, press.startScreenY);
-    }, COMPACT_INPUT_SURFACE_LONG_PRESS_MS);
-  }, [clearCompactInputEdgeLongPressTimer, dispatchCompactSurfaceDragRequest]);
-
-  const handleCompactInputEdgePointerMove = useCallback((event: ReactPointerEvent) => {
-    const press = compactInputEdgePressRef.current;
-    if (!press || press.pointerId !== event.pointerId || press.longPressFired) return;
-    const dx = event.clientX - press.startClientX;
-    const dy = event.clientY - press.startClientY;
-    if (Math.hypot(dx, dy) > COMPACT_INPUT_SURFACE_LONG_PRESS_MOVE_TOLERANCE) {
-      press.canceledTap = true;
-      clearCompactInputEdgeLongPressTimer();
-    }
-  }, [clearCompactInputEdgeLongPressTimer]);
-
-  const finishCompactInputEdgePress = useCallback((event: ReactPointerEvent, options?: { canceled?: boolean }) => {
-    const press = compactInputEdgePressRef.current;
-    if (!press || press.pointerId !== event.pointerId) return;
-    clearCompactInputEdgeLongPressTimer();
-    try {
-      event.currentTarget.releasePointerCapture?.(event.pointerId);
-    } catch (_) {}
-    compactInputEdgePressRef.current = null;
-    if (press.longPressFired) return;
-    if (options?.canceled || press.canceledTap) return;
-    // Quick tap on the rim → focus the input for typing.
-    if (!composerDisabled) {
-      compactInputRef.current?.focus();
-    }
-  }, [clearCompactInputEdgeLongPressTimer, composerDisabled]);
-
-  useEffect(() => () => clearCompactInputEdgeLongPressTimer(), [clearCompactInputEdgeLongPressTimer]);
-
   const rotateCompactInputToolWheel = useCallback((direction: 1 | -1) => {
     setCompactInputToolWheelIndex(current => (
       (current + direction + COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT) % COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT
@@ -4328,14 +4156,11 @@ export default function App({
       className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
       ref={compactInputToolToggleRef}
       type={compactToolToggleActsAsSubmit ? 'submit' : 'button'}
+      data-compact-no-drag="true"
       aria-label={compactToolToggleActsAsSubmit ? sendButtonLabel : overflowMenuAriaLabel}
       aria-haspopup={compactToolToggleActsAsSubmit ? undefined : 'true'}
       aria-expanded={compactToolToggleActsAsSubmit ? undefined : compactInputToolFanOpen}
       disabled={compactToolToggleActsAsSubmit ? !canSubmit : composerDisabled}
-      onPointerDown={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolTogglePointerDown}
-      onPointerMove={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolTogglePointerMove}
-      onPointerUp={compactToolToggleActsAsSubmit ? undefined : (event) => finishCompactInputToolTogglePress(event)}
-      onPointerCancel={compactToolToggleActsAsSubmit ? undefined : (event) => finishCompactInputToolTogglePress(event, { canceled: true })}
       onPointerEnter={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverEnter}
       onPointerLeave={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverLeave}
       onFocus={compactToolToggleActsAsSubmit ? undefined : clearCompactInputToolFanCloseTimer}
@@ -4344,10 +4169,6 @@ export default function App({
         scheduleCompactInputCollapse();
       }}
       onClick={compactToolToggleActsAsSubmit ? undefined : () => {
-        if (compactInputToolTogglePointerHandledRef.current) {
-          compactInputToolTogglePointerHandledRef.current = false;
-          return;
-        }
         toggleCompactInputToolFanByClick();
       }}
     >
@@ -4368,6 +4189,7 @@ export default function App({
       aria-label={overflowMenuAriaLabel}
       data-compact-geometry-item="toolFan"
       data-compact-geometry-owner="surface"
+      data-compact-no-drag="true"
       data-compact-input-tool-fan-open={compactInputToolFanOpen ? 'true' : 'false'}
       data-compact-input-tool-fan-interactive={compactInputToolFanInteractive ? 'true' : 'false'}
       data-compact-tool-wheel-fast-animation={compactInputToolWheelFastAnimation ? 'true' : 'false'}
@@ -4711,6 +4533,7 @@ export default function App({
       ref={isCompactSurface ? compactChoiceLayerRef : undefined}
       data-compact-geometry-item={isCompactSurface ? 'choice' : undefined}
       data-compact-geometry-owner={isCompactSurface ? 'surface' : undefined}
+      data-compact-no-drag={isCompactSurface ? 'true' : undefined}
       data-choice-layer-open={compactChoiceLayerOpen ? 'true' : 'false'}
       data-chat-surface-mode={chatSurfaceMode}
       data-compact-choice-placement={isCompactSurface ? compactChoiceLayerPlacement : undefined}
@@ -4850,6 +4673,7 @@ export default function App({
       title={compactExportHistoryToggleLabel}
       data-compact-geometry-owner="surface"
       data-compact-geometry-item="historyHandle"
+      data-compact-no-drag="true"
       data-compact-history-open={compactExportHistoryOpen ? 'true' : 'false'}
       onPointerDown={handleCompactHistoryVisibilityPress}
       onPointerCancel={handleCompactHistoryVisibilityPointerCancel}
@@ -5067,17 +4891,11 @@ export default function App({
                 onBlurCapture={effectiveCompactChatState === 'input' ? scheduleCompactInputCollapse : undefined}
               >
                 <div
-                  className="compact-chat-drag-handle"
-                  data-compact-drag-handle="true"
-                  data-compact-geometry-item="dragHandle"
-                  data-compact-geometry-owner="surface"
-                  aria-hidden="true"
-                />
-                <div
                   className="compact-chat-resize-handle compact-chat-resize-handle-left"
                   data-compact-resize-side="left"
                   data-compact-geometry-item="resizeHandle"
                   data-compact-geometry-owner="surface"
+                  data-compact-no-drag="true"
                   aria-hidden="true"
                   onPointerDown={(event) => handleCompactSurfaceResizePointerDown('left', event)}
                   onPointerMove={handleCompactSurfaceResizePointerMove}
@@ -5090,6 +4908,7 @@ export default function App({
                   data-compact-resize-side="right"
                   data-compact-geometry-item="resizeHandle"
                   data-compact-geometry-owner="surface"
+                  data-compact-no-drag="true"
                   aria-hidden="true"
                   onPointerDown={(event) => handleCompactSurfaceResizePointerDown('right', event)}
                   onPointerMove={handleCompactSurfaceResizePointerMove}
@@ -5101,6 +4920,7 @@ export default function App({
                   className="compact-chat-surface-frame"
                   data-compact-geometry-item={effectiveCompactChatState === 'input' ? 'input' : 'capsule'}
                   data-compact-geometry-owner="surface"
+                  data-compact-drag-surface="true"
                   data-compact-chat-state={effectiveCompactChatState}
                   data-compact-geometry-part={effectiveCompactChatState === 'input' ? 'inputBody' : 'capsuleBody'}
                   data-compact-tool-toggle-visible={compactToolToggleVisible ? 'true' : 'false'}
@@ -5110,6 +4930,7 @@ export default function App({
                       <textarea
                         className="composer-input"
                         ref={compactInputRef}
+                        data-compact-no-drag="true"
                         placeholder={inputPlaceholder}
                         aria-label={inputPlaceholder}
                         rows={1}
@@ -5131,18 +4952,6 @@ export default function App({
                           }
                         }}
                       />
-                      <div className="compact-input-edge-bands" aria-hidden="true">
-                        {(['top', 'bottom', 'left', 'right'] as const).map((side) => (
-                          <div
-                            key={side}
-                            className={`compact-input-edge-band compact-input-edge-band-${side}`}
-                            onPointerDown={handleCompactInputEdgePointerDown}
-                            onPointerMove={handleCompactInputEdgePointerMove}
-                            onPointerUp={(event) => finishCompactInputEdgePress(event)}
-                            onPointerCancel={(event) => finishCompactInputEdgePress(event, { canceled: true })}
-                          />
-                        ))}
-                      </div>
                       {compactInputToolToggleButton}
                     </>
                   ) : (

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -2304,6 +2304,7 @@ export default function CompactExportHistoryPanel({
         data-compact-geometry-owner="surface"
         data-compact-geometry-item="history"
         data-compact-geometry-hit-scope="children"
+        data-compact-no-drag="true"
         data-compact-export-history-open="true"
         data-compact-export-history-visibility={visibilityState}
         data-compact-export-preview-open={previewOpen ? 'true' : 'false'}

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1978,57 +1978,6 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   z-index: 2;
 }
 
-/* Input-box edge bands: the rim defers interaction to release — a quick tap
-   focuses the input, a long-press drags the whole surface. Left/right are wide
-   grips (40px); top/bottom are thin (5px) since the box is only 54px tall. The
-   container has no pointer surface, so the uncovered center keeps native
-   press-to-type + caret placement. Sits above the textarea (z-index 2) but
-   below the arrow toggle (z-index 5), which keeps its own gesture. */
-.compact-chat-surface-frame > .compact-input-edge-bands {
-  position: absolute;
-  inset: 0;
-  z-index: 3;
-  pointer-events: none;
-  border-radius: inherit;
-}
-
-.compact-input-edge-band {
-  position: absolute;
-  pointer-events: auto;
-  background: transparent;
-  cursor: text;
-  touch-action: none;
-  -webkit-app-region: no-drag;
-}
-
-.compact-input-edge-band-left {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 40px;
-}
-
-.compact-input-edge-band-right {
-  top: 0;
-  bottom: 0;
-  right: 0;
-  width: 40px;
-}
-
-.compact-input-edge-band-top {
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 5px;
-}
-
-.compact-input-edge-band-bottom {
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 5px;
-}
-
 .compact-chat-capsule-button {
   display: flex;
   align-items: center;
@@ -2092,70 +2041,6 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   background: transparent;
   border-color: transparent;
   box-shadow: none;
-}
-
-.compact-chat-drag-handle {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  width: 88px;
-  height: 16px;
-  background: none;
-  border: 0;
-  cursor: grab;
-  opacity: 0;
-  pointer-events: auto;
-  transform: translateX(-50%);
-  transition: opacity 0.16s ease, transform 0.16s ease;
-  z-index: 8;
-}
-
-.compact-chat-drag-handle::before {
-  content: "";
-  position: absolute;
-  pointer-events: none;
-  top: 50%;
-  left: 50%;
-  width: 38px;
-  height: 3px;
-  background: linear-gradient(
-    90deg,
-    rgba(0, 184, 255, 0) 0%,
-    rgba(0, 184, 255, 0.72) 18%,
-    rgba(0, 196, 255, 0.88) 50%,
-    rgba(0, 184, 255, 0.72) 82%,
-    rgba(0, 184, 255, 0) 100%
-  );
-  border-radius: 999px;
-  clip-path: polygon(0 50%, 11% 0, 89% 0, 100% 50%, 89% 100%, 11% 100%);
-  transform: translate(-50%, -50%);
-  transition: width 0.16s ease, background 0.16s ease, opacity 0.16s ease;
-}
-
-.compact-chat-surface-shell:hover > .compact-chat-drag-handle,
-.compact-chat-drag-handle:hover,
-.compact-chat-drag-handle:active {
-  opacity: 1;
-}
-
-.compact-chat-drag-handle:hover {
-  transform: translateX(-50%);
-}
-
-.compact-chat-drag-handle:hover::before {
-  width: 44px;
-  background: linear-gradient(
-    90deg,
-    rgba(0, 196, 255, 0) 0%,
-    rgba(0, 196, 255, 0.82) 18%,
-    rgba(0, 210, 255, 0.96) 50%,
-    rgba(0, 196, 255, 0.82) 82%,
-    rgba(0, 196, 255, 0) 100%
-  );
-}
-
-.compact-chat-drag-handle:active {
-  cursor: grabbing;
 }
 
 .compact-chat-resize-handle {
@@ -3550,10 +3435,6 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
       rgba(0, 92, 196, 0.96) calc(360deg - var(--compact-tool-wheel-charge-second-angle)),
       rgba(0, 92, 196, 0.96) 360deg
     );
-}
-
-.compact-chat-drag-handle {
-  -webkit-app-region: no-drag;
 }
 
 .compact-input-tool-fan .compact-input-tool-item {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1017,7 +1017,7 @@
         var item = element.getAttribute('data-compact-geometry-item') || '';
         if (item === 'choice' && element.getAttribute('data-choice-layer-open') !== 'true') return false;
         if (item === 'toolFan' && element.getAttribute('data-compact-input-tool-fan-open') !== 'true') return false;
-        if (element.getAttribute('aria-hidden') === 'true' && item !== 'dragHandle' && item !== 'resizeHandle') return false;
+        if (element.getAttribute('aria-hidden') === 'true' && item !== 'resizeHandle') return false;
         var style = window.getComputedStyle ? window.getComputedStyle(element) : null;
         if (style && (style.display === 'none' || style.visibility === 'hidden')) return false;
         return true;
@@ -1140,7 +1140,6 @@
 
     function getCompactSurfaceGeometryRole(kind) {
         if (isCompactSurfaceBaseAnchorKind(kind)) return 'baseAnchor';
-        if (kind === 'dragHandle') return 'baseHit';
         return 'extraIsland';
     }
 
@@ -4776,12 +4775,10 @@
 
     var CLICK_THRESHOLD = 5; // px – 移动距离低于此值视为点击
 
-    function isCompactDragHandleTarget(target) {
-        return !!(
-            target
-            && typeof target.closest === 'function'
-            && target.closest('[data-compact-drag-handle="true"]')
-        );
+    function isCompactDragSurfaceTarget(target) {
+        if (!target || typeof target.closest !== 'function') return false;
+        if (target.closest('[data-compact-no-drag="true"]')) return false;
+        return !!target.closest('[data-compact-drag-surface="true"]');
     }
 
     function startDrag(clientX, clientY, options) {
@@ -4818,6 +4815,8 @@
         if (Math.abs(dx) > CLICK_THRESHOLD || Math.abs(dy) > CLICK_THRESHOLD) {
             dragState.moved = true;
         }
+
+        if (dragState.compactSurface && !dragState.moved) return;
 
         var left = clientX - dragState.pointerOffsetX;
         var top = clientY - dragState.pointerOffsetY;
@@ -4890,7 +4889,7 @@
         document.addEventListener('mousedown', function (event) {
             if (event.button !== 0) return;
             if (isElectronChatWindow()) return;
-            if (!isCompactDragHandleTarget(event.target)) return;
+            if (!isCompactDragSurfaceTarget(event.target)) return;
             startDrag(event.clientX, event.clientY, {
                 compactSurface: true
             });
@@ -4900,7 +4899,7 @@
 
         document.addEventListener('touchstart', function (event) {
             if (isElectronChatWindow()) return;
-            if (!isCompactDragHandleTarget(event.target)) return;
+            if (!isCompactDragSurfaceTarget(event.target)) return;
             if (!event.touches || event.touches.length === 0) return;
             startDrag(event.touches[0].clientX, event.touches[0].clientY, {
                 compactSurface: true

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -463,7 +463,7 @@ def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
     assert "function isCompactSurfaceBaseAnchorKind(kind)" in script
     assert "return kind === 'surfaceShell' || kind === 'capsule' || kind === 'input';" in script
     assert "function getCompactSurfaceGeometryRole(kind)" in script
-    assert "if (kind === 'dragHandle') return 'baseHit';" in script
+    assert "if (kind === 'dragHandle') return 'baseHit';" not in script
     assert "return 'extraIsland';" in script
     assert "item.geometryRole = getCompactSurfaceGeometryRole(item.kind);" in script
 
@@ -483,6 +483,24 @@ def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
     assert "extraIslandItems: extraIslandItems" in snapshot_block
     assert "extraIslandNativeRects:" in snapshot_block
     assert "extraIslandHitRects:" in snapshot_block
+
+
+def test_compact_surface_drag_uses_declared_surface_and_no_drag_exclusions():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    assert "function isCompactDragSurfaceTarget(target)" in script
+    assert "target.closest('[data-compact-no-drag=\"true\"]')" in script
+    assert "target.closest('[data-compact-drag-surface=\"true\"]')" in script
+    assert "function isCompactDragHandleTarget(target)" not in script
+    assert "target.closest('[data-compact-drag-handle=\"true\"]')" not in script
+    assert "if (dragState.compactSurface && !dragState.moved) return;" in script
+
+    drag_block = script.split("document.addEventListener('mousedown', function (event)", 1)[1].split(
+        "document.addEventListener('touchstart', function (event)",
+        1,
+    )[0]
+    assert "if (!isCompactDragSurfaceTarget(event.target)) return;" in drag_block
+    assert "compactSurface: true" in drag_block
 
 
 def test_desktop_compact_layout_change_resets_anchor_only_when_base_surface_changes():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -502,6 +502,13 @@ def test_compact_surface_drag_uses_declared_surface_and_no_drag_exclusions():
     assert "if (!isCompactDragSurfaceTarget(event.target)) return;" in drag_block
     assert "compactSurface: true" in drag_block
 
+    touch_block = script.split("document.addEventListener('touchstart', function (event)", 1)[1].split(
+        "document.addEventListener('mousemove', function (event)",
+        1,
+    )[0]
+    assert "if (!isCompactDragSurfaceTarget(event.target)) return;" in touch_block
+    assert "compactSurface: true" in touch_block
+
 
 def test_desktop_compact_layout_change_resets_anchor_only_when_base_surface_changes():
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
- 将 compact 聊天框拖拽入口从旧蓝线/长按请求收口为对话框本体 surface 语义。
- 为输入、工具、历史、选项和 resize 等控件声明 no-drag，保留历史显隐按钮。
- 更新设计文档、React 断言和网页宿主静态合同测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 紧凑聊天模式中将“拖拽手柄”语义替换为“拖拽表面/禁止拖拽”标记，移除边缘长按触发与独立拖拽手柄渲染。
  * 多处交互控件新增禁止拖拽标记，拖拽启动与移动阈值判定调整。

* **测试**
  * 更新并重写紧凑模式相关测试，新增验证拖拽表面与禁止拖拽区域的用例，移除若干与旧拖拽手柄和长按行为相关的断言。

* **文档**
  * 设计与验收指南同步为紧凑表面拖拽语义，移除对旧拖拽手柄的描述与禁止项调整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->