### PR TITLE
修复隐私模式开启后语音主动视觉仍可能发送截图的问题，并为非原生视觉分析增加并发保护，避免同一轮重复调用视觉模型

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1371,20 +1371,20 @@ class OmniRealtimeClient:
                 return description
             else:
                 logger.warning("VISION_MODEL not configured or analysis failed")
-                self._image_description = "[实时屏幕截图或相机画面]: 画面分析失败或暂时无法识别。"
-                self._image_recognized_this_turn = True
+                self._image_description = ""
+                self._image_recognized_this_turn = False
                 return ""
             
         except Exception as e:
             logger.error(f"Error analyzing image with vision model: {e}")
-            self._image_recognized_this_turn = True
-            self._image_description = f"[实时屏幕截图或相机画面]: 分析出错: {str(e)}"
+            self._image_recognized_this_turn = False
+            self._image_description = ""
             # 检测内容审查错误并发送中文提示到前端（不关闭session）
             error_str = str(e)
             if 'censorship' in error_str:
                 if self.on_status_message:
                     await self.on_status_message(json.dumps({"code": "IMAGE_BLOCKED"}))
-            return "图片识别发生严重错误！"
+            return ""
         finally:
             self._image_being_analyzed = False
     
@@ -2547,7 +2547,6 @@ class OmniRealtimeClient:
                     self._print_input_transcript = False
                     self._image_recognized_this_turn = False
                     self._image_sent_this_turn = False
-                    self._image_being_analyzed = False
                     if self.on_response_done:
                         await self.on_response_done()
                     # No-server-VAD providers (Gemini-proxy: lanlan.app+free /

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -81,6 +81,8 @@ def _ensure_gemini_sdk() -> bool:
 # Setup logger for this module
 logger = get_module_logger(__name__, "Main")
 
+_IMAGE_ANALYSIS_PENDING_DESCRIPTION = "[实时屏幕截图或相机画面正在分析中。先不要瞎编内容，可以稍等片刻。在此期间不要用搜索功能应付。等收到画面分析结果后再描述画面。]"
+
 
 # ── Proactive audio prompt cache ──────────────────────────────────────
 _PROACTIVE_AUDIO_DIR = Path(__file__).resolve().parent.parent / "static" / "proactive_audio"
@@ -312,7 +314,7 @@ class OmniRealtimeClient:
         self._image_recognized_this_turn = False
         self._image_sent_this_turn = False
         self._image_being_analyzed = False
-        self._image_description = "[实时屏幕截图或相机画面正在分析中。先不要瞎编内容，可以稍等片刻。在此期间不要用搜索功能应付。等收到画面分析结果后再描述画面。]"
+        self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
         self._latest_image_b64 = None  # Cached latest screenshot for proactive injection
         self._proactive_image_consumed = True  # Whether the cached image has been used by a proactive nudge
         self._proactive_injecting = False  # True while prompt_ephemeral is injecting audio — suppresses mic input
@@ -1371,14 +1373,18 @@ class OmniRealtimeClient:
                 return description
             else:
                 logger.warning("VISION_MODEL not configured or analysis failed")
-                self._image_description = ""
+                self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
                 self._image_recognized_this_turn = False
+                self._latest_image_b64 = None
+                self._proactive_image_consumed = True
                 return ""
             
         except Exception as e:
             logger.error(f"Error analyzing image with vision model: {e}")
             self._image_recognized_this_turn = False
-            self._image_description = ""
+            self._image_description = _IMAGE_ANALYSIS_PENDING_DESCRIPTION
+            self._latest_image_b64 = None
+            self._proactive_image_consumed = True
             # 检测内容审查错误并发送中文提示到前端（不关闭session）
             error_str = str(e)
             if 'censorship' in error_str:

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1377,8 +1377,7 @@ class OmniRealtimeClient:
             
         except Exception as e:
             logger.error(f"Error analyzing image with vision model: {e}")
-            self.image_recognized_this_turn = True
-            self._image_being_analyzed = False
+            self._image_recognized_this_turn = True
             self._image_description = f"[实时屏幕截图或相机画面]: 分析出错: {str(e)}"
             # 检测内容审查错误并发送中文提示到前端（不关闭session）
             error_str = str(e)
@@ -1386,6 +1385,8 @@ class OmniRealtimeClient:
                 if self.on_status_message:
                     await self.on_status_message(json.dumps({"code": "IMAGE_BLOCKED"}))
             return "图片识别发生严重错误！"
+        finally:
+            self._image_being_analyzed = False
     
     async def stream_image(self, image_b64: str, *, bypass_rate_limit: bool = False) -> None:
         """Stream raw image data to the API.
@@ -1403,6 +1404,11 @@ class OmniRealtimeClient:
         try:
             # Models without native vision (step, free on lanlan.tech) — first frame triggers VISION_MODEL analysis
             if '实时屏幕截图或相机画面正在分析中' in self._image_description and not self._supports_native_image:
+                # 非原生视觉后端只需要本轮第一帧做分析；后续高频帧直接丢弃，避免并发刷爆 VISION_MODEL。
+                async with self._image_lock:
+                    if self._image_recognized_this_turn or self._image_being_analyzed:
+                        return
+                    self._image_being_analyzed = True
                 await self._analyze_image_with_vision_model(image_b64)
                 return
             
@@ -2541,6 +2547,7 @@ class OmniRealtimeClient:
                     self._print_input_transcript = False
                     self._image_recognized_this_turn = False
                     self._image_sent_this_turn = False
+                    self._image_being_analyzed = False
                     if self.on_response_done:
                         await self.on_response_done()
                     # No-server-VAD providers (Gemini-proxy: lanlan.app+free /

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -71,6 +71,24 @@
     let _wasLeaderLastTick = null; // 用于 leader 状态切换时主动 reschedule
     let _chatInputSlowdownUntil = 0;
 
+    function isProactiveVisionEnabledNow() {
+        // 跨窗口时 leader 可能还没收到 storage 事件；以 localStorage 的最新保存值兜底。
+        try {
+            const raw = localStorage.getItem('project_neko_settings');
+            if (raw) {
+                const settings = JSON.parse(raw);
+                if (settings && typeof settings.proactiveVisionEnabled === 'boolean') {
+                    return settings.proactiveVisionEnabled;
+                }
+            }
+        } catch (_) { }
+
+        if (typeof window.proactiveVisionEnabled !== 'undefined') {
+            return !!window.proactiveVisionEnabled;
+        }
+        return !!S.proactiveVisionEnabled;
+    }
+
     function isHomeTutorialFeatureSuppressed() {
         try {
             const controller = window.NekoHomeTutorialFeatureController;
@@ -1617,6 +1635,10 @@
      */
     async function sendOneProactiveVisionFrame() {
         try {
+            if (!isProactiveVisionEnabledNow() || !S.isRecording) {
+                stopProactiveVisionDuringSpeech();
+                return;
+            }
             if (!S.socket || S.socket.readyState !== WebSocket.OPEN) return;
 
             var dataUrl = null;
@@ -1650,6 +1672,10 @@
                 }
             }
 
+            if (!isProactiveVisionEnabledNow() || !S.isRecording) {
+                stopProactiveVisionDuringSpeech();
+                return;
+            }
             if (dataUrl && S.socket && S.socket.readyState === WebSocket.OPEN) {
                 S.socket.send(JSON.stringify({
                     action: 'stream_data',
@@ -1684,13 +1710,13 @@
         }
 
         // 仅在条件满足时启动：已开启主动视觉 && 正在录音 && 未手动屏幕共享
-        if (!S.proactiveVisionEnabled || !S.isRecording) return;
+        if (!isProactiveVisionEnabledNow() || !S.isRecording) return;
         var screenButton = document.getElementById('screenButton');
         if (screenButton && screenButton.classList.contains('active')) return; // 手动共享时不启动
 
         S.proactiveVisionFrameTimer = setInterval(async function () {
             // 在每次执行前再做一次检查，避免竞态
-            if (!S.proactiveVisionEnabled || !S.isRecording || isGoodbyeActive()) {
+            if (!isProactiveVisionEnabledNow() || !S.isRecording || isGoodbyeActive()) {
                 stopProactiveVisionDuringSpeech();
                 return;
             }
@@ -1894,14 +1920,16 @@
             return;
         }
 
+        var privacyBlocksVision = !isProactiveVisionEnabledNow();
+
         // 如果正在录音（语音模式），流可能正在被使用，不释放
-        if (S.isRecording) {
+        if (S.isRecording && !privacyBlocksVision) {
             console.log('[主动视觉] 语音模式活跃中，不释放流');
             return;
         }
 
         // 如果主动搭话+主动视觉Chat仍活跃，保留流
-        if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled) {
+        if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled && !privacyBlocksVision) {
             console.log('[主动视觉] 主动搭话视觉仍活跃，不释放流');
             return;
         }

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -479,7 +479,7 @@
             !S.proactiveVideoChatEnabled && !S.proactivePersonalChatEnabled &&
             !S.proactiveMusicEnabled && !S.proactiveMemeEnabled &&
             !S.proactiveMiniGameInviteEnabled) {
-            return S.proactiveVisionEnabled;
+            return isProactiveVisionEnabledNow();
         }
 
         // 如果只选择了个人动态搭话，需要同时开启个人动态
@@ -818,7 +818,7 @@
             if (S.isRecording) {
                 var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
                 var voiceModes = [];
-                if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled && S.proactiveVisionEnabled) {
+                if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled && isProactiveVisionEnabledNow()) {
                     voiceModes.push('vision');
                 }
                 console.log('[ProactiveChat] 语音模式快速路径，modes: [' + voiceModes.join(', ') + ']');
@@ -897,7 +897,7 @@
             // 收集所有启用的搭话方式
             // 视觉搭话：需要同时开启主动搭话和自主视觉
             // 同时触发 vision 和 window 模式
-            if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled && S.proactiveVisionEnabled) {
+            if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled && isProactiveVisionEnabledNow()) {
                 availableModes.push('vision');
                 availableModes.push('window');
             }
@@ -1034,7 +1034,7 @@
 
                 // await 期间用户可能切换模式，重新过滤可用模式
                 var latestModes = [];
-                if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled && S.proactiveVisionEnabled) {
+                if (S.proactiveVisionChatEnabled && S.proactiveChatEnabled && isProactiveVisionEnabledNow()) {
                     latestModes.push('vision', 'window');
                 }
                 if (S.proactiveNewsChatEnabled && S.proactiveChatEnabled) {

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -1034,7 +1034,6 @@
             screenButton().disabled = false;
             stopButton().disabled = true;
             resetSessionButton().disabled = false;
-            window.showStatusToast(window.t ? window.t('app.speaking') : '正在语音...', 2000);
 
             // 移除active类
             screenButton().classList.remove('active');

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -174,8 +174,9 @@
                 var idleTime = Date.now() - S.screenCaptureStreamLastUsed;
                 if (idleTime >= IDLE_TIMEOUT) {
                     // 主动视觉活跃时，不释放屏幕流（避免 macOS 反复弹窗 getDisplayMedia）
-                    var proactiveVisionActive = S.proactiveVisionEnabled ||
-                        (S.proactiveVisionChatEnabled && S.proactiveChatEnabled);
+                    var proactiveVisionActive = S.proactiveVisionEnabled && (
+                        S.isRecording || (S.proactiveVisionChatEnabled && S.proactiveChatEnabled)
+                    );
                     var isManualScreenShare = screenButton() && screenButton().classList.contains('active');
                     if (proactiveVisionActive && !isManualScreenShare) {
                         console.log('[屏幕流闲置] 主动视觉活跃中，跳过释放并续约定时器');
@@ -994,8 +995,9 @@
         stopScreening();
 
         // 判断主动视觉是否活跃
-        var proactiveVisionActive = S.proactiveVisionEnabled ||
-            (S.proactiveVisionChatEnabled && S.proactiveChatEnabled);
+        var proactiveVisionActive = S.proactiveVisionEnabled && (
+            S.isRecording || (S.proactiveVisionChatEnabled && S.proactiveChatEnabled)
+        );
 
         // 条件释放流
         if (forceRelease || !proactiveVisionActive) {

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -38,6 +38,25 @@
     // 「没见过 branch 」当首启代名——升级用户也都没见过 branch，那个口径会误伤他们的
     // 既有偏好。offline 首启错过 branch 时 marker 留着，下次在线再补
     const _FIRST_LAUNCH_PENDING_KEY = '_neko_first_launch_branch_pending';
+    const _SHARED_SETTINGS_KEYS = [
+        'proactiveChatEnabled',
+        'proactiveVisionEnabled',
+        'proactiveVisionChatEnabled',
+        'proactiveNewsChatEnabled',
+        'proactiveVideoChatEnabled',
+        'proactivePersonalChatEnabled',
+        'proactiveMusicEnabled',
+        'proactiveMemeEnabled',
+        'proactiveMiniGameInviteEnabled',
+        'mergeMessagesEnabled',
+        'focusModeEnabled',
+        'avatarReactionBubbleEnabled',
+        'proactiveChatInterval',
+        'proactiveVisionInterval',
+        'textGuardMaxLength',
+        'renderQuality',
+        'targetFrameRate'
+    ];
 
     function getDefaultRenderQuality() {
         return S.renderQuality || 'medium';
@@ -71,6 +90,74 @@
             settings.userLanguage = S.userLanguage;
         }
         return settings;
+    }
+
+    function applySharedRuntimeSettings(settings) {
+        if (!settings || typeof settings !== 'object') return false;
+        let changed = false;
+        _SHARED_SETTINGS_KEYS.forEach((key) => {
+            if (!Object.prototype.hasOwnProperty.call(settings, key)) return;
+            if (S[key] !== settings[key]) {
+                S[key] = settings[key];
+                changed = true;
+            }
+        });
+        if (Object.prototype.hasOwnProperty.call(settings, 'userLanguage')) {
+            S.userLanguage = settings.userLanguage;
+            changed = true;
+        }
+        if (changed && S.renderQuality) {
+            window.cursorFollowPerformanceLevel = U.mapRenderQualityToFollowPerf(S.renderQuality);
+        }
+        return changed;
+    }
+
+    function isManualScreenShareActive() {
+        try {
+            const button = document.getElementById('screenButton');
+            return !!(button && button.classList.contains('active'));
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function stopVisionAfterPrivacyEnabled() {
+        if (S.proactiveVisionEnabled !== false) return;
+
+        try {
+            if (typeof window.stopProactiveVisionDuringSpeech === 'function') {
+                window.stopProactiveVisionDuringSpeech();
+            }
+        } catch (error) {
+            console.warn('[app-settings] 停止语音主动视觉失败:', error);
+        }
+
+        if (isManualScreenShareActive()) return;
+
+        try {
+            if (typeof window.stopScreening === 'function') {
+                window.stopScreening();
+            }
+        } catch (error) {
+            console.warn('[app-settings] 停止屏幕发送循环失败:', error);
+        }
+
+        try {
+            if (S.screenCaptureStream && typeof S.screenCaptureStream.getTracks === 'function') {
+                S.screenCaptureStream.getTracks().forEach((track) => {
+                    try { track.stop(); } catch (_) { }
+                });
+            }
+        } catch (error) {
+            console.warn('[app-settings] 释放隐私模式屏幕流失败:', error);
+        } finally {
+            S.screenCaptureStream = null;
+            S.screenCaptureStreamLastUsed = null;
+            if (S.screenCaptureStreamIdleTimer) {
+                clearTimeout(S.screenCaptureStreamIdleTimer);
+                S.screenCaptureStreamIdleTimer = null;
+            }
+        }
     }
 
     /**
@@ -314,6 +401,7 @@
         S.textGuardMaxLength = currentTextGuardMaxLength;
         S.renderQuality = currentRenderQuality;
         S.targetFrameRate = currentTargetFrameRate;
+        stopVisionAfterPrivacyEnabled();
         // 同步字幕设置到共享状态
         S.subtitleEnabled = currentSubtitleEnabled;
         S.userLanguage = currentUserLanguage;
@@ -672,6 +760,20 @@
     }
 
     // ======================== 初始化调用 ========================
+
+    window.addEventListener('storage', function (event) {
+        if (event.key !== 'project_neko_settings' || !event.newValue) return;
+        try {
+            const settings = JSON.parse(event.newValue);
+            const changed = applySharedRuntimeSettings(settings);
+            stopVisionAfterPrivacyEnabled();
+            if (changed && typeof window.scheduleProactiveChat === 'function') {
+                window.scheduleProactiveChat();
+            }
+        } catch (error) {
+            console.warn('[app-settings] 跨窗口设置同步失败:', error);
+        }
+    });
 
     // 加载设置
     loadSettings();

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -102,7 +102,10 @@
                 changed = true;
             }
         });
-        if (Object.prototype.hasOwnProperty.call(settings, 'userLanguage')) {
+        if (
+            Object.prototype.hasOwnProperty.call(settings, 'userLanguage') &&
+            S.userLanguage !== settings.userLanguage
+        ) {
             S.userLanguage = settings.userLanguage;
             changed = true;
         }

--- a/tests/unit/test_video_session.py
+++ b/tests/unit/test_video_session.py
@@ -150,6 +150,29 @@ async def test_non_native_vision_fallback():
 
 
 @pytest.mark.unit
+async def test_non_native_failed_vision_clears_cached_frame(monkeypatch):
+    client = _make_client("step-realtime", supports_native_image=False)
+    client._image_description = "实时屏幕截图或相机画面正在分析中"
+
+    async def fake_analyze_image_with_vision_model(**_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "utils.screenshot_utils.analyze_image_with_vision_model",
+        fake_analyze_image_with_vision_model,
+    )
+
+    await client.stream_image(DUMMY_IMAGE_B64)
+
+    assert client._image_recognized_this_turn is False
+    assert client._latest_image_b64 is None
+    assert client._proactive_image_consumed is True
+    assert "正在分析中" in client._image_description
+
+    await client.close()
+
+
+@pytest.mark.unit
 def test_livestream_free_supports_native_vision():
     """Livestream 主播自建 server_prefix 上游同为 Gemini 系，free 路应被判定为原生视觉，
     哪怕 base_url 既不含 lanlan.app 也不含 lanlan.tech（已被派生为自建地址）。"""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改进视觉分析的异常与并发控制，异常时清理分析状态并防止高频帧重复触发分析，避免残留或重复分析。
  * 收紧屏幕分享空闲判定，修复因判定过宽导致的流保留/释放不一致，移除多余的“正在语音”提示。

* **新功能**
  * 引入跨窗口优先读取的主动视觉开关获取方式，实时感知设置变更并用于触发与发送保护。
  * 保存设置时自动执行隐私相关的视觉流停止与同步清理。

* **Tests**
  * 新增单元测试覆盖非原生视觉失败时清理缓存与状态的行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->