### PR TITLE
fix(chat): 拖拽 compact surface 后吞掉补发的 click

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -22,6 +22,7 @@
     var loadedPromise = null;
     var mounted = false;
     var dragState = null;
+    var suppressDragReleaseClick = false;
     var resizeState = null;
     var minimized = false;
     var savedShellSize = null;
@@ -1555,6 +1556,29 @@
     function blockMobileExpandSyntheticPointerEvent(event) {
         if (!shouldBlockMobileExpandClick(event)) return;
         // 手机端触摸展开后浏览器会补发同坐标鼠标事件；从 mousedown 起吞掉，避免按钮出现按压反馈。
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof event.stopImmediatePropagation === 'function') {
+            event.stopImmediatePropagation();
+        }
+    }
+
+    // Web 宿主下用鼠标拖拽 surface 本体后，浏览器仍会在 mouseup 落点补发一次
+    // click（mousedown 的 preventDefault 不取消 click）。落点若是胶囊按钮会被误判为
+    // 点击而展开输入框。拖拽真正移动过(moved)时 arm 此守卫，吞掉紧随其后的那一次
+    // click。click 与 mouseup 同任务同步派发，setTimeout(…,0) 必在其后清旗，既兜底
+    // 「落点无 click」也不会误吞之后无关的点击。touch 路径已在 touchstart
+    // preventDefault 阶段抑制了合成 click，不经此守卫。
+    function armDragReleaseClickGuard() {
+        suppressDragReleaseClick = true;
+        window.setTimeout(function () {
+            suppressDragReleaseClick = false;
+        }, 0);
+    }
+
+    function consumeDragReleaseClickGuard(event) {
+        if (!suppressDragReleaseClick) return;
+        suppressDragReleaseClick = false;
         event.preventDefault();
         event.stopPropagation();
         if (typeof event.stopImmediatePropagation === 'function') {
@@ -4847,6 +4871,11 @@
         dragState = null;
         document.body.classList.remove('react-chat-window-dragging');
 
+        // 移动过的拖拽不该再变成点击：吞掉 mouseup 落点补发的那一次 click。
+        if (wasMoved) {
+            armDragReleaseClickGuard();
+        }
+
         // 最小化状态下，未发生拖拽移动 → 视为点击，恢复窗口
         // 但 suppressClick=true（如教程接管强制中断）时不触发，避免误展开
         if (minimized && !wasMoved && !opts.suppressClick) {
@@ -5277,6 +5306,7 @@
         document.addEventListener('mousedown', blockMobileExpandSyntheticPointerEvent, true);
         document.addEventListener('mouseup', blockMobileExpandSyntheticPointerEvent, true);
         document.addEventListener('click', blockMobileExpandSyntheticPointerEvent, true);
+        document.addEventListener('click', consumeDragReleaseClickGuard, true);
         bindDragging();
         createResizeEdges();
         bindResizing();

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -510,6 +510,48 @@ def test_compact_surface_drag_uses_declared_surface_and_no_drag_exclusions():
     assert "compactSurface: true" in touch_block
 
 
+def test_moved_drag_suppresses_trailing_release_click():
+    # 移动过的拖拽（含 compact surface 本体拖拽）松开后，浏览器会在 mouseup 落点
+    # 补发一次 click；落点若是胶囊按钮会被误判为点击而展开输入框。守卫在 moved
+    # 时 arm，并在 document capture 阶段吞掉紧随的那一次 click。
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    assert "var suppressDragReleaseClick = false;" in script
+
+    stop_block = script.split("function stopDrag(options)", 1)[1].split(
+        "function bindDragging()",
+        1,
+    )[0]
+    assert "if (wasMoved) {" in stop_block
+    assert "armDragReleaseClickGuard();" in stop_block
+
+    arm_block = script.split("function armDragReleaseClickGuard()", 1)[1].split(
+        "function consumeDragReleaseClickGuard",
+        1,
+    )[0]
+    assert "suppressDragReleaseClick = true;" in arm_block
+    # setTimeout(…, 0) 兜底清旗：click 同任务先消费，无 click 时也不残留误吞后续点击。
+    assert "window.setTimeout(function () {" in arm_block
+    assert "suppressDragReleaseClick = false;" in arm_block
+
+    consume_block = script.split("function consumeDragReleaseClickGuard(event)", 1)[1].split(
+        "function getOverlay()",
+        1,
+    )[0]
+    assert "if (!suppressDragReleaseClick) return;" in consume_block
+    assert "suppressDragReleaseClick = false;" in consume_block
+    assert "event.preventDefault();" in consume_block
+    assert "event.stopPropagation();" in consume_block
+
+    # capture 阶段挂载，且排在 mobile 展开守卫之后（保留既有行为优先级）。
+    assert "document.addEventListener('click', consumeDragReleaseClickGuard, true);" in script
+    listeners_block = script.split(
+        "document.addEventListener('click', blockMobileExpandSyntheticPointerEvent, true);",
+        1,
+    )[1]
+    assert "document.addEventListener('click', consumeDragReleaseClickGuard, true);" in listeners_block
+
+
 def test_desktop_compact_layout_change_resets_anchor_only_when_base_surface_changes():
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 背景

[#1611](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1611) 的 codex 评审提了个 P2：web 宿主下用鼠标掴住 compact 胶囊本体拖动、再在胶囊上松开，仍会触发胶囊 `onClick` 误切到输入模式。作者当时把它先送到单独 PR 设计「drag release suppress click」策略，这就是那个 PR。

## Root cause

`static/app-react-chat-window.js` 的 surface 拖拽：
- document capture 的 `mousedown` 里 `startDrag({compactSurface:true})` + `preventDefault()`，但 **mousedown 的 preventDefault 不会取消随后的 `click`**。
- `mouseup` 直接把 `stopDrag` 当 handler（`options` 实为 MouseEvent），所以鼠标路径只记录 `moved`，从不抑制 click。
- touch 路径无此问题：`touchstart` 阶段已 `preventDefault()`，合成 click 根本不发。

## 改动

- 新增 `suppressDragReleaseClick` 标志 + `armDragReleaseClickGuard()` / `consumeDragReleaseClickGuard()`，与既有 `mobileExpandClickGuard` 家族对偶，但不受 `isMobileWidth()` 限制（web 宿主全幅生效）。
- `stopDrag` 中 `wasMoved` 时 arm；`document` capture 段的 `click` 监听吞掉紧随其后的那一次（排在 mobile 展开守卫之后，保留既有优先级）。
- `setTimeout(0)` 兜底清旗：`click` 与 `mouseup` 同任务同步派发、必在定时器前消费；落点没 click 时旗标也不残留，不会误吞后续无关点击。

范围按 review 讨论定为「moved 的所有拖拽都 arm」——「动过的拖拽不该再变成 click」语义最干净，header 拖拽侧无实害。

## 对偶行为

- 拖动后松开（moved）→ 吞掉补发 click → 不切输入 ✅
- 原地点胶囊（未 moved）→ 不 arm → 照常打开输入 ✅
- Electron：surface `mousedown` 路径 `isElectronChatWindow()` early-return，无影响
- touch：合成 click 已被 `touchstart` preventDefault 抑制，不经此守卫

## 测试

- 新增静态契约测试 `test_moved_drag_uses_...`（`tests/unit/test_react_chat_window_static.py::test_moved_drag_suppresses_trailing_release_click`），通过；原 surface-drag 契约测试仍通过；`node --check` 语法 OK。
- ⚠️ 未做实机三上下文（index 宽屏 / 窄宽手机 / chat.html Electron）行为验证——需 compact 模式起完整 app，建议合并前在主仓库手动确认「拖动松开不开输入 / 原地点开输入」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了拖拽操作后点击事件被误识别的问题，防止拖拽释放位置被错误触发点击行为。

* **Tests**
  * 添加了单元测试以验证拖拽操作后点击事件的正确处理机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->