### PR TITLE
fix(test): 同步 compact 轮盘半径与历史命中区契约到当前源码

### DIFF
--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -353,10 +353,10 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     assert '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden"]' in styles
     assert '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden-forward"]' in styles
     assert '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden-backward"]' in styles
-    assert "rotate(107.35deg) translateX(91.92px) rotate(-107.35deg)" in styles
-    assert "rotate(-17.35deg) translateX(91.92px) rotate(17.35deg)" in styles
-    assert "rotate(-48.51deg) translateX(91.92px) rotate(48.51deg)" in styles
-    assert "rotate(138.51deg) translateX(91.92px) rotate(-138.51deg)" in styles
+    assert "rotate(107.35deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(-107.35deg)" in styles
+    assert "rotate(-17.35deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(17.35deg)" in styles
+    assert "rotate(-48.51deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(48.51deg)" in styles
+    assert "rotate(138.51deg) translateX(var(--compact-tool-wheel-orbit-radius)) rotate(-138.51deg)" in styles
     assert "translateX(83.82px)" not in wheel_block
     assert "translateX(89.74px)" not in wheel_block
     assert "translateX(92.06px)" not in wheel_block
@@ -789,8 +789,8 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "function getCompactHistoryScrollbarRect(element, parentRect)" in script
     assert "id: 'history:scrollbar'" in script
     assert "data-compact-hit-region" not in scroll_jsx_block
-    assert 'data-compact-hit-region-id={`history:message:${message.id}`}' in panel_source
-    assert 'data-compact-hit-region-id="history:controls"' in panel_source
+    assert 'data-compact-hit-region-id={historyInteractive ? `history:message:${message.id}` : undefined}' in panel_source
+    assert "data-compact-hit-region-id={historyInteractive ? 'history:controls' : undefined}" in panel_source
     assert 'data-compact-hit-region-id="history:preview"' in panel_source
 
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -307,6 +307,7 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
 
     assert "position: absolute;" in fan_block
     assert "--compact-tool-wheel-hover-radius: 116px;" in fan_block
+    assert "--compact-tool-wheel-orbit-radius: 80px;" in fan_block
     assert "--compact-tool-fan-focus-x: var(--compact-tool-wheel-hover-radius);" in fan_block
     assert "--compact-tool-fan-focus-y: var(--compact-tool-wheel-hover-radius);" in fan_block
     assert "--compact-tool-wheel-center-x: var(--compact-tool-wheel-hover-radius);" in fan_block
@@ -776,6 +777,14 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
         'className="compact-export-history-scroll-content"',
         1,
     )[0]
+    message_hit_block = panel_source.split('className="compact-export-history-bubble"', 1)[1].split(
+        'compact-export-history-check',
+        1,
+    )[0]
+    controls_hit_block = panel_source.split('className="compact-export-history-controls"', 1)[1].split(
+        'compact-export-history-controls-content',
+        1,
+    )[0]
 
     assert "pointer-events: none;" in anchor_block
     assert "pointer-events: none;" in panel_block
@@ -790,7 +799,11 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "id: 'history:scrollbar'" in script
     assert "data-compact-hit-region" not in scroll_jsx_block
     assert 'data-compact-hit-region-id={historyInteractive ? `history:message:${message.id}` : undefined}' in panel_source
+    assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in message_hit_block
+    assert "data-compact-hit-region-kind={historyInteractive ? 'message' : undefined}" in message_hit_block
     assert "data-compact-hit-region-id={historyInteractive ? 'history:controls' : undefined}" in panel_source
+    assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in controls_hit_block
+    assert "data-compact-hit-region-kind={historyInteractive ? 'controls' : undefined}" in controls_hit_block
     assert 'data-compact-hit-region-id="history:preview"' in panel_source
 
 


### PR DESCRIPTION
## 背景

`tests/unit/test_react_chat_window_static.py` 有两处断言落后于源码，导致在 clean checkout（无本地改动）上就预先失败，与近期 compact surface drag 改动无关。

## 根因（均为有意的源码改动，仅测试漏更新）

1. **轮盘半径** — `test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position`
   - slot transform 里的 `translateX(91.92px)` 在 #1599（`7512fc80e`）被抽成 CSS 变量 `var(--compact-tool-wheel-orbit-radius)`；
   - #1605（`f360def09`，"轮盘半径回调 80"）又把该变量从 `45.96px` 调成 `80px`；
   - 旋转角度始终未变。断言改为匹配变量形式。

2. **历史命中区** — `test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regions`
   - #1604（`f8e28f33d`）把历史消息气泡与操作栏的 `data-compact-hit-region-id` 用 `historyInteractive ? … : undefined` 门控，使关闭/消失中的面板不再占据命中区——与测试名称"把透明 wrapper 挡在命中区外"的意图一致，甚至是加强；
   - `history:preview` 仍是静态字面量（预览层只在可交互时挂载），保持不变。断言同步该门控。

#1599 / #1605 / #1604 改源码时都没更新这两处断言。

## 验证

```
uv run pytest tests/unit/test_react_chat_window_static.py
# 25 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 更新静态断言以匹配前端实现变化：工具扇形轮盘使用可配置半径变量并调整 transform 期望；紧凑历史面板的命中区域断言改为基于交互状态的条件表达，非交互时相关数据属性期望为空；解析面板的断言逻辑按消息与控件分别处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->