### PR TITLE
fix(chat): 工具轮盘原点可拖动 compact 文本框 + 输入态左侧握把

### DIFF
--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -90,6 +90,7 @@
    - `data-compact-geometry-part="capsuleBody" | "inputBody"`
    - `data-compact-drag-surface="true"` 声明 compact 对话框本体 surface；整体拖拽只指这个本体，不包含历史、工具轮盘、选项层等浮层。
    - `data-compact-no-drag="true"` 声明 textarea、工具按钮、resize、历史、选项等真实控件和浮层排除拖拽。
+   - 工具轮盘 toggle / fan 原点仍是 `data-compact-no-drag`（宿主命中判定不自动起拖），但 App.tsx 在原点按下并移动超阈值时额外派发 `neko:compact-surface-drag-grab`（带按下点 client/screen 坐标），让宿主以该点为锚启动本体拖拽——使轮盘中心兼作「按住拖动文本框」把手；点按仍展开/关闭轮盘、悬停展开保留、轮盘边缘拖动仍旋转。拖动后补发的 click 用独立的 origin suppress 标志吞掉（不能复用 wheel suppress，轮盘关闭 effect 会清它）。Wayland 走原生 app-region 拖拽，事件式起拖不适用。
 6. 早期 `.compact-chat-capsule-shell` / `.compact-chat-input-shell` 已不是当前主体事实，后续文档和实现不要再按这两个旧类名设计。
 7. `.compact-chat-surface-frame` 是同一个 54px 高的本体：`default/options` 内放 capsule button，`input` 内放 textarea 和右侧工具/发送按钮。
 8. 旧蓝线拖拽手柄 `.compact-chat-drag-handle` / `data-compact-drag-handle="true"` 已删除，不应恢复；对话框本体拖拽走 `data-compact-drag-surface` / `data-compact-no-drag`。
@@ -121,6 +122,7 @@
    - surface geometry 收集、union、hit rect、native rect 输出。
    - 最小化 ball 的独立定位和 geometry。
    - resize session、desktop resize active 和 layout-change 事件。
+   - 监听 `neko:compact-surface-drag-grab`（来自 React 工具轮盘原点拖拽），非 Electron 时以事件坐标为锚启动 compact surface 本体拖拽（复用既有 startDrag/全局 mousemove/mouseup 与落点 click 守卫）。Electron 由 `preload-chat-react.js` 监听同一事件改走原生窗口拖拽。
 5. `static/app-buttons.js` 是发送桥之一。compact history 文本发送必须带清晰 session / request 语义，不能让已有 composer 附件在 deferred send 中被误带上。
 6. 语音模式 / `composerHidden` 下的 history drop 只保留前端拖拽、命中和收束动效；真实发送必须在 `sendCompactHistoryDropPayload` 边界跳过，不能通过改 React 拖拽 phase 或样式来伪装。
 

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -4435,6 +4435,34 @@ describe('App', () => {
     }
   });
 
+  it('keeps origin drag click suppression armed across a slow drag (no timeout clear)', () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <App chatSurfaceMode="compact" compactChatState="input" />,
+      );
+      const toggle = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
+      fireEvent.pointerDown(toggle, {
+        pointerId: 31, clientX: 100, clientY: 100, screenX: 300, screenY: 300,
+        button: 0, buttons: 1, pointerType: 'mouse',
+      });
+      fireEvent.pointerMove(toggle, {
+        pointerId: 31, clientX: 130, clientY: 110, buttons: 1, pointerType: 'mouse',
+      });
+      // 慢速拖拽：跨过任何旧的固定时长窗口（曾经的 120ms 定时器会在此误清抑制标志）。
+      vi.advanceTimersByTime(1000);
+      fireEvent.pointerUp(toggle, {
+        pointerId: 31, clientX: 130, clientY: 110, buttons: 0, pointerType: 'mouse',
+      });
+      // 释放后补发的 click 仍应被吞掉，轮盘不被误展开。
+      fireEvent.click(toggle);
+      const fan = document.body.querySelector('.compact-input-tool-fan');
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('treats a stationary tap on the tool toggle as open (no drag-grab)', () => {
     render(
       <App

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -4385,6 +4385,121 @@ describe('App', () => {
     }
   });
 
+  it('exposes a draggable left grip in compact input mode as part of the surface drag region', () => {
+    const { container, rerender } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" />,
+    );
+    const grip = container.querySelector('.compact-chat-input-drag-grip');
+    expect(grip).not.toBeNull();
+    // 握把属于本体拖拽区：自身不是 no-drag，祖先是 drag-surface，且不在任何 no-drag 子树里。
+    expect(grip).not.toHaveAttribute('data-compact-no-drag');
+    expect(grip!.closest('[data-compact-drag-surface="true"]')).not.toBeNull();
+    expect(grip!.closest('[data-compact-no-drag="true"]')).toBeNull();
+    // 仅输入态出现；胶囊态本体本身可拖，不需要单独握把。
+    rerender(<App chatSurfaceMode="compact" compactChatState="default" />);
+    expect(container.querySelector('.compact-chat-input-drag-grip')).toBeNull();
+  });
+
+  it('dispatches a compact surface drag-grab from the tool toggle when pressed and moved past threshold', () => {
+    render(
+      <App
+        chatSurfaceMode="compact"
+        compactChatState="input"
+      />,
+    );
+    const toggle = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
+    expect(toggle).not.toBeNull();
+    const grabs: Array<Record<string, number>> = [];
+    const onGrab = (event: Event) => grabs.push((event as CustomEvent).detail);
+    window.addEventListener('neko:compact-surface-drag-grab', onGrab);
+    try {
+      fireEvent.pointerDown(toggle, {
+        pointerId: 7, clientX: 100, clientY: 100, screenX: 300, screenY: 320,
+        button: 0, buttons: 1, pointerType: 'mouse',
+      });
+      fireEvent.pointerMove(toggle, {
+        pointerId: 7, clientX: 122, clientY: 108, buttons: 1, pointerType: 'mouse',
+      });
+      // 拖动超阈值 → 派发一次抓取事件，锚点用按下点（不跳变）。
+      expect(grabs).toHaveLength(1);
+      expect(grabs[0]).toMatchObject({ clientX: 100, clientY: 100, screenX: 300, screenY: 320 });
+      fireEvent.pointerUp(toggle, {
+        pointerId: 7, clientX: 122, clientY: 108, buttons: 0, pointerType: 'mouse',
+      });
+      // 拖完补发的 click 被吞掉，不应展开轮盘。
+      fireEvent.click(toggle);
+      const fan = document.body.querySelector('.compact-input-tool-fan');
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+    } finally {
+      window.removeEventListener('neko:compact-surface-drag-grab', onGrab);
+    }
+  });
+
+  it('treats a stationary tap on the tool toggle as open (no drag-grab)', () => {
+    render(
+      <App
+        chatSurfaceMode="compact"
+        compactChatState="input"
+      />,
+    );
+    const toggle = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
+    const grabs: Event[] = [];
+    const onGrab = (event: Event) => grabs.push(event);
+    window.addEventListener('neko:compact-surface-drag-grab', onGrab);
+    try {
+      fireEvent.pointerDown(toggle, {
+        pointerId: 8, clientX: 100, clientY: 100, screenX: 300, screenY: 320,
+        button: 0, buttons: 1, pointerType: 'mouse',
+      });
+      fireEvent.pointerUp(toggle, {
+        pointerId: 8, clientX: 101, clientY: 100, buttons: 0, pointerType: 'mouse',
+      });
+      expect(grabs).toHaveLength(0);
+      fireEvent.click(toggle);
+      const fan = document.body.querySelector('.compact-input-tool-fan');
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+    } finally {
+      window.removeEventListener('neko:compact-surface-drag-grab', onGrab);
+    }
+  });
+
+  it('dispatches a drag-grab from the open wheel origin and collapses the wheel', () => {
+    render(
+      <App
+        chatSurfaceMode="compact"
+        compactChatState="input"
+      />,
+    );
+    const toggle = document.body.querySelector('.compact-input-tool-toggle') as HTMLButtonElement;
+    fireEvent.click(toggle);
+    const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
+    expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+    const fanRectSpy = vi.spyOn(fan, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, right: 232, bottom: 232, width: 232, height: 232, x: 0, y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    const grabs: Array<Record<string, number>> = [];
+    const onGrab = (event: Event) => grabs.push((event as CustomEvent).detail);
+    window.addEventListener('neko:compact-surface-drag-grab', onGrab);
+    try {
+      // 在轮盘中心（origin）按下并拖动 → 移动文本框而非旋转轮盘。
+      fireEvent.pointerDown(fan, {
+        pointerId: 9, clientX: 10, clientY: 10, screenX: 210, screenY: 210,
+        button: 0, buttons: 1, pointerType: 'mouse',
+      });
+      fireEvent.pointerMove(fan, {
+        pointerId: 9, clientX: 32, clientY: 16, buttons: 1, pointerType: 'mouse',
+      });
+      expect(grabs).toHaveLength(1);
+      expect(grabs[0]).toMatchObject({ clientX: 10, clientY: 10, screenX: 210, screenY: 210 });
+      // 拖动是移动手势 → 轮盘收起。
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+    } finally {
+      window.removeEventListener('neko:compact-surface-drag-grab', onGrab);
+      fanRectSpy.mockRestore();
+    }
+  });
+
   it('keeps angular wheel drag direction while crossing behind the center', () => {
     render(
       <App

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -115,6 +115,9 @@ const COMPACT_INPUT_TOOL_WHEEL_HOVER_RADIUS = 116;
 const COMPACT_INPUT_TOOL_WHEEL_ANGLE_MIN_RADIUS = 16;
 const COMPACT_INPUT_TOOL_TOGGLE_HOVER_OUTSET = 14;
 const COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE = 48;
+// 在工具轮盘中心（toggle / fan 原点）按下后，指针移动超过此像素阈值即视为「拖动文本框」
+// 而非「点一下展开/关闭轮盘」。与宿主 surface 拖拽的 CLICK_THRESHOLD(5px) 量级一致。
+const COMPACT_INPUT_TOOL_ORIGIN_DRAG_THRESHOLD = 6;
 const COMPACT_INPUT_TOOL_FAN_INTERACTIVE_DELAY_MS = 220;
 const COMPACT_INPUT_TOOL_FAN_TRANSIENT_CLOSE_DELAY_MS = 360;
 const COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS = 650;
@@ -1148,6 +1151,20 @@ export default function App({
   const compactInputToolWheelChargeRef = useRef<CompactToolWheelChargeState>(createCompactToolWheelChargeState());
   const compactInputToolWheelChargeReleaseActiveRef = useRef(false);
   const compactInputToolWheelSuppressClickRef = useRef(false);
+  // 工具轮盘原点（toggle / fan 中心）的「按住拖动文本框」手势追踪。与轮盘旋转
+  // (compactInputToolWheelPointerRef) 互斥：原点按下时不建立旋转 pointer，旋转路径自然 no-op。
+  const compactToolOriginDragRef = useRef<{
+    pointerId: number;
+    startClientX: number;
+    startClientY: number;
+    startScreenX: number;
+    startScreenY: number;
+    moved: boolean;
+    captureTarget: Element | null;
+  } | null>(null);
+  // 专用于「拖动文本框后吞掉补发 click」的标志。独立于 compactInputToolWheelSuppressClickRef，
+  // 因为轮盘关闭 effect 会重置后者，无法跨「关闭轮盘 + 随后 click」存活。
+  const compactToolOriginSuppressClickRef = useRef(false);
   const compactInputToolWheelScrollDeltaRef = useRef(0);
   const compactInputToolFanPositionSyncRef = useRef<(() => void) | null>(null);
   const compactInputToolFanCloseTimerRef = useRef<number | null>(null);
@@ -2964,6 +2981,76 @@ export default function App({
     closeCompactInputToolFanFromUserClick();
   }, [closeCompactInputToolFanFromUserClick]);
 
+  // ── 工具轮盘原点「按住拖动文本框」手势 ────────────────────────────────────
+  // 在 toggle（轮盘关闭时）或 fan 中心（轮盘展开时，命中原点）按下后移动超阈值 → 把 surface
+  // 拖拽交给宿主（web: app-react-chat-window.js / Electron: preload-chat-react.js）经
+  // neko:compact-surface-drag-grab 接管。
+  // 点按（无移动）语义保持原样：toggle 由自身 onClick 展开/关闭；fan 原点由 onPointerDownCapture
+  // 的 markCompactToolFanOriginClickSuppressed 收起（这条收起+抑制路径不动，保证既有命中测试不回归）。
+  // 用独立的 compactToolOriginSuppressClickRef 抑制拖动后补发的 click——不能复用
+  // compactInputToolWheelSuppressClickRef，因为关闭轮盘的 effect 会把它清掉（见下方 fan 关闭 effect）。
+  const beginCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    const previous = compactToolOriginDragRef.current;
+    if (previous && previous.captureTarget && previous.captureTarget.hasPointerCapture?.(previous.pointerId)) {
+      // 兜底：上一手势没收到 pointerup（罕见）→ 释放旧捕获再重置，避免卡死。
+      try { previous.captureTarget.releasePointerCapture(previous.pointerId); } catch (_) {}
+    }
+    const captureTarget = event.currentTarget instanceof Element ? event.currentTarget : null;
+    compactToolOriginDragRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startScreenX: event.screenX,
+      startScreenY: event.screenY,
+      moved: false,
+      captureTarget,
+    };
+    try {
+      captureTarget?.setPointerCapture?.(event.pointerId);
+    } catch (_) {}
+  }, []);
+
+  const updateCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
+    const state = compactToolOriginDragRef.current;
+    if (!state || state.pointerId !== event.pointerId || state.moved) return;
+    const dx = event.clientX - state.startClientX;
+    const dy = event.clientY - state.startClientY;
+    if (Math.hypot(dx, dy) < COMPACT_INPUT_TOOL_ORIGIN_DRAG_THRESHOLD) return;
+    state.moved = true;
+    // 吞掉本次指针序列随后补发的 click，避免拖完误触发 toggle 展开 / 工具按钮；120ms 自清兜底。
+    compactToolOriginSuppressClickRef.current = true;
+    window.setTimeout(() => {
+      compactToolOriginSuppressClickRef.current = false;
+    }, 120);
+    // 拖动是「移动文本框」手势而非工具手势，收起轮盘。
+    closeCompactInputToolFan();
+    // 把 surface 拖拽交给宿主，锚点用按下点（而非当前点），避免 surface 跳变。
+    window.dispatchEvent(new CustomEvent('neko:compact-surface-drag-grab', {
+      detail: {
+        clientX: state.startClientX,
+        clientY: state.startClientY,
+        screenX: state.startScreenX,
+        screenY: state.startScreenY,
+      },
+    }));
+  }, [closeCompactInputToolFan]);
+
+  const endCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
+    const state = compactToolOriginDragRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const captureTarget = state.captureTarget;
+    compactToolOriginDragRef.current = null;
+    if (captureTarget && typeof captureTarget.releasePointerCapture === 'function') {
+      try {
+        if (captureTarget.hasPointerCapture?.(event.pointerId)) {
+          captureTarget.releasePointerCapture(event.pointerId);
+        }
+      } catch (_) {}
+    }
+    // 无移动 = 点按：toggle 交给自身 onClick；fan 原点已由 onPointerDownCapture 收起。这里不再处理。
+  }, []);
+
   useEffect(() => () => {
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
@@ -2985,6 +3072,8 @@ export default function App({
     }
 
     const handlePointerMove = (event: PointerEvent) => {
+      // 工具轮盘原点拖拽进行中时不跑悬停展开/收起逻辑，避免拖动文本框时悬停又把轮盘弹开。
+      if (compactToolOriginDragRef.current) return;
       const pointerInHoverRegion = isCompactInputToolPointerInHoverRegion(event.clientX, event.clientY, event.target);
       if (compactInputToolFanSuppressHoverUntilLeaveRef.current) {
         if (!pointerInHoverRegion) {
@@ -4163,12 +4252,21 @@ export default function App({
       disabled={compactToolToggleActsAsSubmit ? !canSubmit : composerDisabled}
       onPointerEnter={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverEnter}
       onPointerLeave={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverLeave}
+      onPointerDown={compactToolToggleActsAsSubmit ? undefined : beginCompactToolOriginDrag}
+      onPointerMove={compactToolToggleActsAsSubmit ? undefined : updateCompactToolOriginDrag}
+      onPointerUp={compactToolToggleActsAsSubmit ? undefined : endCompactToolOriginDrag}
+      onPointerCancel={compactToolToggleActsAsSubmit ? undefined : endCompactToolOriginDrag}
       onFocus={compactToolToggleActsAsSubmit ? undefined : clearCompactInputToolFanCloseTimer}
       onBlur={compactToolToggleActsAsSubmit ? scheduleCompactInputCollapse : () => {
         scheduleCompactInputToolFanTransientClose();
         scheduleCompactInputCollapse();
       }}
       onClick={compactToolToggleActsAsSubmit ? undefined : () => {
+        // 拖动文本框后补发的 click 已在 origin-drag 里置位抑制，这里消费掉，避免误展开/收起轮盘。
+        if (compactToolOriginSuppressClickRef.current) {
+          compactToolOriginSuppressClickRef.current = false;
+          return;
+        }
         toggleCompactInputToolFanByClick();
       }}
     >
@@ -4208,6 +4306,7 @@ export default function App({
       onClickCapture={(event) => {
         if (
           compactInputToolWheelSuppressClickRef.current
+          || compactToolOriginSuppressClickRef.current
           || (compactInputToolFanOpen && !compactInputToolFanInteractiveRef.current)
         ) {
           event.preventDefault();
@@ -4234,9 +4333,13 @@ export default function App({
             && localY <= COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE
           );
         if (!isOriginClick) return;
+        // 按在轮盘中心：保持原有「即时收起 + 抑制随后 click」语义（既有命中测试依赖此路径），
+        // 同时额外开启原点拖拽追踪——setPointerCapture 让 fan 关闭后仍能收到 pointermove/up，
+        // 以便检测是否要拖动文本框。stopPropagation 阻止冒泡 onPointerDown 启动轮盘旋转。
         event.preventDefault();
         event.stopPropagation();
         markCompactToolFanOriginClickSuppressed();
+        beginCompactToolOriginDrag(event);
       }}
       onPointerDown={(event) => {
         if (event.pointerType === 'mouse' && event.button !== 0) return;
@@ -4258,6 +4361,7 @@ export default function App({
             && localY <= COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE
           );
         if (isOriginClick) {
+          // 防御：通常 onPointerDownCapture 已 stopPropagation 接管原点；这里兜底维持原收起语义。
           event.preventDefault();
           event.stopPropagation();
           markCompactToolFanOriginClickSuppressed();
@@ -4287,6 +4391,10 @@ export default function App({
         } catch (_) {}
       }}
       onPointerMove={(event) => {
+        if (compactToolOriginDragRef.current) {
+          updateCompactToolOriginDrag(event);
+          return;
+        }
         updateCompactInputToolWheelDrag({
           pointerId: event.pointerId,
           clientX: event.clientX,
@@ -4298,9 +4406,17 @@ export default function App({
       }}
       onWheel={rotateCompactInputToolWheelByScroll}
       onPointerUp={(event) => {
+        if (compactToolOriginDragRef.current) {
+          endCompactToolOriginDrag(event);
+          return;
+        }
         finishCompactToolWheelPointer(event);
       }}
       onPointerCancel={(event) => {
+        if (compactToolOriginDragRef.current) {
+          endCompactToolOriginDrag(event);
+          return;
+        }
         finishCompactToolWheelPointer(event);
       }}
     >
@@ -4927,6 +5043,14 @@ export default function App({
                 >
                   {effectiveCompactChatState === 'input' ? (
                     <>
+                      {/* 输入态左侧拖拽把手：textarea / 工具按钮都是 no-drag，本握把不加 no-drag，
+                          于是落在 surface 本体拖拽区里——web/X11 经 isCompactDragSurfaceTarget、
+                          Wayland 经 frame 的 -webkit-app-region:drag 区域，均可按住拖动整个输入框。
+                          宿主 mousedown 会 preventDefault，按住把手不会让 textarea 失焦收起输入态。 */}
+                      <span
+                        className="compact-chat-input-drag-grip"
+                        aria-hidden="true"
+                      />
                       <textarea
                         className="composer-input"
                         ref={compactInputRef}

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2991,6 +2991,9 @@ export default function App({
   // compactInputToolWheelSuppressClickRef，因为关闭轮盘的 effect 会把它清掉（见下方 fan 关闭 effect）。
   const beginCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
     if (event.pointerType === 'mouse' && event.button !== 0) return;
+    // 每次新的原点按下都清掉可能残留的抑制标志（上一次拖拽若没补发 click 会留下 true），
+    // 保证本次点按/拖拽自洁——抑制只靠「拖动置位 + click 消费 / 下次按下清零」，不再用定时器。
+    compactToolOriginSuppressClickRef.current = false;
     const previous = compactToolOriginDragRef.current;
     if (previous && previous.captureTarget && previous.captureTarget.hasPointerCapture?.(previous.pointerId)) {
       // 兜底：上一手势没收到 pointerup（罕见）→ 释放旧捕获再重置，避免卡死。
@@ -3018,11 +3021,10 @@ export default function App({
     const dy = event.clientY - state.startClientY;
     if (Math.hypot(dx, dy) < COMPACT_INPUT_TOOL_ORIGIN_DRAG_THRESHOLD) return;
     state.moved = true;
-    // 吞掉本次指针序列随后补发的 click，避免拖完误触发 toggle 展开 / 工具按钮；120ms 自清兜底。
+    // 吞掉本次指针序列随后补发的 click，避免拖完误触发 toggle 展开 / 工具按钮。
+    // 一直 armed 到那次 click 被消费（或下次原点/轮盘按下清零）——不能用定时器，慢速拖拽
+    // 往往远超任何固定时长，定时器会在 release click 之前清掉、导致拖完轮盘被误开关。
     compactToolOriginSuppressClickRef.current = true;
-    window.setTimeout(() => {
-      compactToolOriginSuppressClickRef.current = false;
-    }, 120);
     // 拖动是「移动文本框」手势而非工具手势，收起轮盘。
     closeCompactInputToolFan();
     // 把 surface 拖拽交给宿主，锚点用按下点（而非当前点），避免 surface 跳变。
@@ -4372,6 +4374,8 @@ export default function App({
         clearCompactInputToolWheelChargeReleaseTimer();
         resetCompactInputToolWheelCharge();
         compactInputToolWheelSuppressClickRef.current = false;
+        // 清掉可能残留的原点拖拽抑制（上次原点拖拽若无补发 click），避免误吞这次轮盘按钮 click。
+        compactToolOriginSuppressClickRef.current = false;
         compactInputToolWheelScrollDeltaRef.current = 0;
         compactInputToolWheelDragActiveRef.current = true;
         dispatchCompactToolWheelDragState(true, event.pointerId);

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1966,7 +1966,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   content: "";
   width: 4px;
   height: 18px;
-  background-image: radial-gradient(currentColor 0.9px, transparent 1.3px);
+  background-image: radial-gradient(currentcolor 0.9px, transparent 1.3px);
   background-size: 4px 6px;
   background-position: center;
   opacity: 0.22;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1943,7 +1943,47 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 
 .compact-chat-surface-frame[data-compact-chat-state="input"] {
   gap: 0;
-  padding: 5px 62px 5px 20px;
+  padding: 5px 62px 5px 10px;
+}
+
+/* 输入态左侧拖拽把手：给一处稳定可抓的「移动文本框」区域。
+   textarea / 工具按钮是 no-drag，本握把不加 no-drag，于是属于 surface 本体拖拽区
+   （web/X11 命中判定 + Wayland 原生 -webkit-app-region:drag 都覆盖到）。
+   静息低透明、hover 提亮，沿用与左右 resize 手柄一致的「平时低调、靠近才显形」手感。 */
+.compact-chat-surface-frame[data-compact-chat-state="input"] .compact-chat-input-drag-grip {
+  flex: 0 0 12px;
+  align-self: stretch;
+  margin-right: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  touch-action: none;
+  color: #2f526b;
+}
+
+.compact-chat-input-drag-grip::before {
+  content: "";
+  width: 4px;
+  height: 18px;
+  background-image: radial-gradient(currentColor 0.9px, transparent 1.3px);
+  background-size: 4px 6px;
+  background-position: center;
+  opacity: 0.22;
+  transition: opacity 0.15s ease;
+}
+
+.compact-chat-surface-shell:hover .compact-chat-input-drag-grip::before,
+.compact-chat-input-drag-grip:active::before {
+  opacity: 0.5;
+}
+
+.compact-chat-input-drag-grip:active {
+  cursor: grabbing;
+}
+
+[data-theme="dark"] .compact-chat-surface-frame[data-compact-chat-state="input"] .compact-chat-input-drag-grip {
+  color: #e9f4ff;
 }
 
 .compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"]) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -4956,6 +4956,18 @@
         document.addEventListener('touchcancel', function (event) {
             stopDrag({ changedTouches: event.changedTouches, suppressClick: true });
         });
+
+        // React 侧工具轮盘原点「按住拖动文本框」手势：轮盘 / toggle 是 no-drag，宿主的
+        // mousedown 命中判定不会自动起拖，所以由 React 检测到拖动意图后派发该事件，这里
+        // 以按下点为锚启动 compact surface 拖拽，复用上面的全局 mousemove/mouseup（含落点
+        // click 守卫）。Electron 下由 preload-chat-react.js 用原生窗口拖拽接管，这里早退。
+        window.addEventListener('neko:compact-surface-drag-grab', function (event) {
+            if (isElectronChatWindow()) return;
+            if (getCurrentChatSurfaceMode() !== 'compact' || minimized) return;
+            var detail = event && event.detail ? event.detail : {};
+            if (!Number.isFinite(detail.clientX) || !Number.isFinite(detail.clientY)) return;
+            startDrag(detail.clientX, detail.clientY, { compactSurface: true });
+        });
     }
 
     var MIN_WIDTH = 320;


### PR DESCRIPTION
## 背景

紧凑输入态里，文本框本体 `.compact-chat-surface-frame` 虽是 `data-compact-drag-surface`，但 textarea / 工具按钮 / resize 都是 `data-compact-no-drag`，桌面鼠标又"悬停即展开轮盘、展开的轮盘盖住按钮"，导致**抓在轮盘上只能展开、拖不动文本框**。

## 改动

1. **工具轮盘原点拖拽**：在 toggle / fan 中心按下并移动超阈值（6px）时派发 `neko:compact-surface-drag-grab`（带按下点 client/screen 坐标），由宿主接管启动**既有**的 surface 本体拖拽。保留全部 `no-drag` 属性不动，所以是事件驱动、非改属性。
   - 点一下仍展开/关闭轮盘；**悬停展开、轮盘边缘旋转、charge 充能**均不回归。
   - 拖动后补发的 click 用**独立** origin-suppress 标志吞掉——不能复用 `compactInputToolWheelSuppressClickRef`，因为轮盘关闭 effect 会把它清掉。
2. **输入态左侧拖拽握把** `.compact-chat-input-drag-grip`：不加 `no-drag`，落进本体拖拽区。给 **Ubuntu Wayland**（只能靠原生 `-webkit-app-region: drag` 触发 `xdg_toplevel.move`、事件式起拖不适用）这类环境留一处稳定可抓的入口；web / X11 / Windows / Mac 也多一个显眼把手。静息低透明、hover 提亮（沿用左右 resize 手柄手感）。
3. `static/app-react-chat-window.js`：非 Electron 时监听同名事件，以按下点为锚 `startDrag(compactSurface)`，复用既有全局 mousemove/mouseup 与落点 click 守卫。

> 配套：N.E.K.O.-PC 的 `preload-chat-react.js` 监听同一事件改走原生窗口拖拽（另一个 PR）。

## 测试

- `tsc --noEmit` 干净；`vitest run` **152/152**（含新增 origin-drag / 握把契约用例，及既有 wheel / charge / no-drag / 命中态用例不回归）。
- `bash build_frontend.sh` 等价的 react-neko-chat 构建通过。
- 静态契约 `tests/unit/test_react_chat_window_static.py` 23 passed；2 个失败是历史既有（断言 `styles.css` 旋转串 / `CompactExportHistoryPanel.tsx` 命中属性，本 PR 未触及这两处，HEAD 上同样找不到那些串）。

## 待人工验收

- 三上下文：index 宽屏 / index 窄宽手机 / chat.html Electron——轮盘中心按住拖移动、点一下展开、悬停展开、边缘旋转都对，握把不挤坏输入框布局。
- Ubuntu Wayland / X11：握把（+ X11 的轮盘中心）能拖动输入框。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 紧凑聊天框可通过工具轮盘中心或左侧新增握把按住拖拽移动，并在多种宿主环境下触发窗口拖拽。

* **测试**
  * 新增多项交互测试，覆盖握把拖拽、工具轮盘行为、拖拽阈值与点击抑制场景。

* **样式**
  * 调整紧凑输入态内边距并新增握把的光标、触控与视觉样式。

* **文档**
  * 更新紧凑聊天框拖拽链路的设计文档。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->