### PR TITLE
fix: stabilize compact chat live captions

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -2805,6 +2805,7 @@ describe('App', () => {
         window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
           detail: {
             turnId: 'compact-caption-event-turn',
+            segmentId: 'compact-caption-event-turn:segment:1',
             text: firstCaption,
           },
         }));
@@ -2832,6 +2833,7 @@ describe('App', () => {
         window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
           detail: {
             turnId: 'compact-caption-event-turn',
+            segmentId: 'compact-caption-event-turn:segment:2',
             text: secondCaption,
           },
         }));
@@ -2845,6 +2847,71 @@ describe('App', () => {
       expect(revealedAfter.length).toBeGreaterThan(revealedBefore.length);
       expect(revealedAfter.startsWith(revealedBefore)).toBe(true);
       expect(mergedCaption.startsWith(revealedAfter)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('replaces compact caption updates for the same segment instead of repeating prefixes', async () => {
+    vi.useFakeTimers();
+    const firstCaption = '第一句。';
+    const secondPartialCaption = '第二句。';
+    const secondFullCaption = '第二句话补全。';
+    const mergedCaption = `${firstCaption} ${secondFullCaption}`;
+
+    try {
+      const { container } = render(<App chatSurfaceMode="compact" composerHidden messages={[]} />);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'compact-caption-segment-turn',
+            source: 'test',
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+          detail: {
+            turnId: 'compact-caption-segment-turn',
+            segmentId: 'compact-caption-segment-turn:segment:1',
+            text: firstCaption,
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+          detail: {
+            turnId: 'compact-caption-segment-turn',
+            segmentId: 'compact-caption-segment-turn:segment:2',
+            text: secondPartialCaption,
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+          detail: {
+            turnId: 'compact-caption-segment-turn',
+            segmentId: 'compact-caption-segment-turn:segment:2',
+            text: secondFullCaption,
+          },
+        }));
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable', {
+          detail: {
+            turnId: 'compact-caption-segment-turn',
+            source: 'test',
+          },
+        }));
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      const previewText = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(previewText).toBe(mergedCaption);
+      expect(previewText).not.toContain(`${secondPartialCaption} ${secondFullCaption}`);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -2522,7 +2522,7 @@ describe('App', () => {
     });
   });
 
-  it('prefers the latest assistant text for compact preview instead of echoing the latest user message', () => {
+  it('does not use historical assistant or user messages as compact speech preview text', () => {
     const assistantMessage = parseChatMessage({
       id: 'assistant-compact-priority',
       role: 'assistant',
@@ -2544,7 +2544,8 @@ describe('App', () => {
       <App chatSurfaceMode="compact" composerHidden messages={[assistantMessage, userMessage]} />,
     );
 
-    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent('先看我这边的引导内容');
+    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent('Chat content will appear here.');
+    expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('先看我这边的引导内容');
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('这是我刚刚发出的内容');
   });
 
@@ -2564,7 +2565,7 @@ describe('App', () => {
 
     const preview = container.querySelector('.compact-chat-capsule-text');
     expect(preview).toHaveAttribute('data-compact-preview-streaming', 'true');
-    expect(preview).toHaveTextContent('');
+    expect(preview?.textContent ?? '').toBe('');
   });
 
   it('falls back to revealing compact streaming text when playback state never arrives', async () => {
@@ -2583,7 +2584,7 @@ describe('App', () => {
     try {
       const { container } = render(<App chatSurfaceMode="compact" composerHidden messages={[message]} />);
 
-      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent('');
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1400);
@@ -2765,12 +2766,15 @@ describe('App', () => {
       const secondStreaming = makeBubble('assistant-compact-speech-turn-bubble-2', secondBubbleText, 'streaming', 5);
       rerender(<App chatSurfaceMode="compact" composerHidden messages={[firstSent, secondStreaming]} />);
 
-      // First tick lets the fallback safety net engage (it arms a ~700ms timer,
-      // whose state update then schedules the reveal frame); the second drives
-      // the reveal forward into the appended bubble.
+      // The same-turn append should start moving immediately from the seeded
+      // prefix instead of waiting for the fallback safety timer.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(800);
+        await vi.advanceTimersByTimeAsync(250);
       });
+      const revealedImmediately = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(revealedImmediately.length).toBeGreaterThan(revealedBefore.length);
+      expect(`${firstBubbleText} ${secondBubbleText}`.startsWith(revealedImmediately)).toBe(true);
+
       await act(async () => {
         await vi.advanceTimersByTimeAsync(8000);
       });
@@ -2778,6 +2782,69 @@ describe('App', () => {
       const revealedLater = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
       expect(revealedLater.length).toBeGreaterThan(firstBubbleText.length);
       expect(`${firstBubbleText} ${secondBubbleText}`.startsWith(revealedLater)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses compact caption events as the live same-turn display source without waiting for message bubbles', async () => {
+    vi.useFakeTimers();
+    const firstCaption = '第一句由紧凑字幕事件直接驱动显示。';
+    const secondCaption = '第二句只通过同 turn 字幕事件追加，不等待历史气泡入队。';
+
+    try {
+      const { container } = render(<App chatSurfaceMode="compact" composerHidden messages={[]} />);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'compact-caption-event-turn',
+            source: 'test',
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+          detail: {
+            turnId: 'compact-caption-event-turn',
+            text: firstCaption,
+          },
+        }));
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-caption-event-turn',
+            playbackTurnId: 'compact-caption-event-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 1,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+      });
+
+      const revealedBefore = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(revealedBefore.length).toBeGreaterThan(0);
+      expect(firstCaption.startsWith(revealedBefore)).toBe(true);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+          detail: {
+            turnId: 'compact-caption-event-turn',
+            text: secondCaption,
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250);
+      });
+
+      const revealedAfter = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      const mergedCaption = `${firstCaption} ${secondCaption}`;
+      expect(revealedAfter.length).toBeGreaterThan(revealedBefore.length);
+      expect(revealedAfter.startsWith(revealedBefore)).toBe(true);
+      expect(mergedCaption.startsWith(revealedAfter)).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -2799,7 +2866,7 @@ describe('App', () => {
     try {
       const { container } = render(<App chatSurfaceMode="compact" composerHidden messages={[message]} />);
 
-      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent('');
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
 
       act(() => {
         window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable', {
@@ -2859,6 +2926,428 @@ describe('App', () => {
       const visibleLength = container.querySelector('.compact-chat-capsule-text')?.textContent?.length ?? 0;
       expect(visibleLength).toBeGreaterThanOrEqual(7);
       expect(visibleLength).toBeLessThanOrEqual(8);
+      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
+        streamingText.slice(0, visibleLength),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores speech playback state from a different assistant turn', async () => {
+    vi.useFakeTimers();
+    const streamingText = '当前 turn 的语音播放状态才能推动这段紧凑字幕。';
+    const message = parseChatMessage({
+      id: 'assistant-compact-streaming-progress-turn',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:01',
+      createdAt: 2,
+      turnId: 'compact-current-playback-turn',
+      blocks: [{ type: 'text', text: streamingText }],
+      status: 'streaming',
+    });
+
+    try {
+      const { container } = render(<App chatSurfaceMode="compact" composerHidden messages={[message]} />);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-previous-playback-turn',
+            playbackTurnId: 'compact-previous-playback-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 5,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-current-playback-turn',
+            playbackTurnId: 'compact-current-playback-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 1,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      const visibleLength = container.querySelector('.compact-chat-capsule-text')?.textContent?.length ?? 0;
+      expect(visibleLength).toBeGreaterThan(0);
+      expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
+        streamingText.slice(0, visibleLength),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not flash the previous sentence when the next assistant sentence streams under a new turn id', async () => {
+    vi.useFakeTimers();
+    const firstSentence = '第一句话已经说完了，不能在第二句话开始时闪回来。';
+    const secondSentence = '第二句话现在开始说，紧凑字幕只能显示这句的前缀。';
+    const firstStreaming = parseChatMessage({
+      id: 'assistant-compact-segment-first',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:01',
+      createdAt: 2,
+      turnId: 'compact-first-segment-turn',
+      blocks: [{ type: 'text', text: firstSentence }],
+      status: 'streaming',
+    });
+    const firstSent = parseChatMessage({
+      ...firstStreaming,
+      status: 'sent',
+    });
+    const secondStreaming = parseChatMessage({
+      id: 'assistant-compact-segment-second',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:02',
+      createdAt: 5,
+      turnId: 'compact-second-segment-turn',
+      blocks: [{ type: 'text', text: secondSentence }],
+      status: 'streaming',
+    });
+
+    try {
+      const { container, rerender } = render(
+        <App chatSurfaceMode="compact" composerHidden messages={[firstStreaming]} />,
+      );
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-first-segment-turn',
+            playbackTurnId: 'compact-first-segment-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 1,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+      });
+      const visibleBeforeFirstSettle = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(visibleBeforeFirstSettle.length).toBeGreaterThan(0);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-ending', {
+          detail: {
+            turnId: 'compact-first-segment-turn',
+            source: 'test',
+          },
+        }));
+      });
+      rerender(<App chatSurfaceMode="compact" composerHidden messages={[firstSent]} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe(visibleBeforeFirstSettle);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'compact-second-segment-turn',
+            source: 'test',
+          },
+        }));
+      });
+      rerender(<App chatSurfaceMode="compact" composerHidden messages={[firstSent]} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
+
+      rerender(<App chatSurfaceMode="compact" composerHidden messages={[firstSent, secondStreaming]} />);
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-second-segment-turn',
+            playbackTurnId: 'compact-second-segment-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 1,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      const previewText = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(previewText).not.toContain(firstSentence.slice(0, 6));
+      expect(secondSentence.startsWith(previewText)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not use a stale streaming message from an older turn during a new-turn gap', async () => {
+    vi.useFakeTimers();
+    const previousTurnText = '上一轮残留的 streaming 气泡绝不能在新分句空窗里闪出来。';
+    const firstSentence = '当前第一句话刚说完，等待第二句话。';
+    const secondSentence = '当前第二句话开始后才可以显示这里。';
+    const stalePreviousStreaming = parseChatMessage({
+      id: 'assistant-compact-stale-previous-streaming',
+      role: 'assistant',
+      author: 'Neko',
+      time: '09:59',
+      createdAt: 1,
+      turnId: 'compact-stale-previous-turn',
+      blocks: [{ type: 'text', text: previousTurnText }],
+      status: 'streaming',
+    });
+    const firstSent = parseChatMessage({
+      id: 'assistant-compact-current-first-sent',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:01',
+      createdAt: 2,
+      turnId: 'compact-current-first-turn',
+      blocks: [{ type: 'text', text: firstSentence }],
+      status: 'sent',
+    });
+    const secondStreaming = parseChatMessage({
+      id: 'assistant-compact-current-second-streaming',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:02',
+      createdAt: 3,
+      turnId: 'compact-current-second-turn',
+      blocks: [{ type: 'text', text: secondSentence }],
+      status: 'streaming',
+    });
+
+    try {
+      const { container, rerender } = render(
+        <App chatSurfaceMode="compact" composerHidden messages={[stalePreviousStreaming, firstSent]} />,
+      );
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-ending', {
+          detail: {
+            turnId: 'compact-current-first-turn',
+            source: 'test',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
+      expect(container.querySelector('.compact-chat-capsule-text')).not.toHaveTextContent(previousTurnText);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+          detail: {
+            turnId: 'compact-current-second-turn',
+            source: 'test',
+          },
+        }));
+      });
+      rerender(<App chatSurfaceMode="compact" composerHidden messages={[stalePreviousStreaming, firstSent]} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
+      expect(container.querySelector('.compact-chat-capsule-text')).not.toHaveTextContent(previousTurnText);
+
+      rerender(<App chatSurfaceMode="compact" composerHidden messages={[stalePreviousStreaming, firstSent, secondStreaming]} />);
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-current-second-turn',
+            playbackTurnId: 'compact-current-second-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 1,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      const previewText = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(previewText).not.toContain(previousTurnText.slice(0, 8));
+      expect(secondSentence.startsWith(previewText)).toBe(true);
+      expect(previewText.length).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the same-turn compact caption merged after the turn-ending boundary', async () => {
+    vi.useFakeTimers();
+    const firstSentence = '同一轮第一句话已经结束。';
+    const secondSentence = '同一轮第二句话延迟进入队列后才应该显示。';
+    const firstStreaming = parseChatMessage({
+      id: 'assistant-compact-same-turn-first-streaming',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:01',
+      createdAt: 2,
+      turnId: 'compact-same-delayed-turn',
+      blocks: [{ type: 'text', text: firstSentence }],
+      status: 'streaming',
+    });
+    const firstSent = parseChatMessage({
+      ...firstStreaming,
+      status: 'sent',
+    });
+    const secondStreaming = parseChatMessage({
+      id: 'assistant-compact-same-turn-second-streaming',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:02',
+      createdAt: 3,
+      turnId: 'compact-same-delayed-turn',
+      blocks: [{ type: 'text', text: secondSentence }],
+      status: 'streaming',
+    });
+
+    try {
+      const { container, rerender } = render(
+        <App chatSurfaceMode="compact" composerHidden messages={[firstStreaming]} />,
+      );
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-same-delayed-turn',
+            playbackTurnId: 'compact-same-delayed-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 1,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      const visibleBeforeFirstSettle = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      expect(visibleBeforeFirstSettle.length).toBeGreaterThan(0);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-turn-ending', {
+          detail: {
+            turnId: 'compact-same-delayed-turn',
+            source: 'test',
+          },
+        }));
+      });
+      rerender(<App chatSurfaceMode="compact" composerHidden messages={[firstSent]} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe(visibleBeforeFirstSettle);
+
+      rerender(<App chatSurfaceMode="compact" composerHidden messages={[firstSent, secondStreaming]} />);
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-speech-playback-state', {
+          detail: {
+            active: true,
+            turnId: 'compact-same-delayed-turn',
+            playbackTurnId: 'compact-same-delayed-turn',
+            audioContextTime: 0,
+            playbackStartAudioTime: 0,
+            playbackEndAudioTime: 1,
+            updatedAt: Date.now(),
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      const previewText = container.querySelector('.compact-chat-capsule-text')?.textContent ?? '';
+      const mergedText = `${firstSentence} ${secondSentence}`;
+      expect(mergedText.startsWith(previewText)).toBe(true);
+      expect(previewText.length).toBeGreaterThan(0);
+      expect(container.querySelector('[data-compact-export-history-message-id="assistant-compact-same-turn-first-streaming"]')).not.toBeNull();
+      expect(container.querySelector('[data-compact-export-history-message-id="assistant-compact-same-turn-second-streaming"]')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores speech-unavailable events from a different assistant turn', async () => {
+    vi.useFakeTimers();
+    const streamingText = '当前 turn 的语音不可用事件才能触发紧凑字幕兜底。';
+    const message = parseChatMessage({
+      id: 'assistant-compact-streaming-unavailable-turn',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:01',
+      createdAt: 2,
+      turnId: 'compact-current-unavailable-turn',
+      blocks: [{ type: 'text', text: streamingText }],
+      status: 'streaming',
+    });
+
+    try {
+      const { container } = render(<App chatSurfaceMode="compact" composerHidden messages={[message]} />);
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable', {
+          detail: {
+            turnId: 'compact-previous-unavailable-turn',
+            source: 'test',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      expect(container.querySelector('.compact-chat-capsule-text')?.textContent ?? '').toBe('');
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable', {
+          detail: {
+            turnId: 'compact-current-unavailable-turn',
+            source: 'test',
+          },
+        }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      const visibleLength = container.querySelector('.compact-chat-capsule-text')?.textContent?.length ?? 0;
+      expect(visibleLength).toBeGreaterThan(0);
       expect(container.querySelector('.compact-chat-capsule-text')).toHaveTextContent(
         streamingText.slice(0, visibleLength),
       );
@@ -3181,7 +3670,7 @@ describe('App', () => {
     }
   });
 
-  it('keeps settled compact preview text bounded after streaming ends', () => {
+  it('does not use a settled assistant message as compact speech preview text', () => {
     const settledText = '这是猫娘已经说完的一整段内容，用来确认紧凑态在非流式状态下仍然保持有限预览，不重新变成长聊天框。'.repeat(3);
     const message = parseChatMessage({
       id: 'assistant-compact-settled-bounded',
@@ -3197,8 +3686,8 @@ describe('App', () => {
 
     const preview = container.querySelector('.compact-chat-capsule-text');
     expect(preview).toHaveAttribute('data-compact-preview-streaming', 'false');
-    expect(preview?.textContent?.length).toBe(84);
-    expect(preview?.textContent?.endsWith('...')).toBe(true);
+    expect(preview).toHaveTextContent('Chat content will appear here.');
+    expect(preview).not.toHaveTextContent(settledText.slice(0, 20));
   });
 
   it('keeps compact speech display active when a playing message settles from streaming to sent', async () => {
@@ -3421,7 +3910,9 @@ describe('App', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: '语音模式下不能进入输入态。' }));
+    const capsule = container.querySelector('.compact-chat-capsule-button');
+    expect(capsule).toHaveTextContent('Chat content will appear here.');
+    fireEvent.click(capsule as Element);
 
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');
     expect(container.querySelector('.composer-input')).toBeNull();

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -370,6 +370,19 @@ function normalizeCompactPreviewText(text: string): string {
     .trim();
 }
 
+function splitCompactPreviewGraphemes(text: string): string[] {
+  const segmenter = (Intl as typeof Intl & {
+    Segmenter?: new (
+      locale?: string,
+      options?: { granularity?: 'grapheme' },
+    ) => { segment(input: string): Iterable<{ segment: string }> };
+  }).Segmenter;
+  if (typeof segmenter === 'function') {
+    return Array.from(new segmenter(undefined, { granularity: 'grapheme' }).segment(text), part => part.segment);
+  }
+  return Array.from(text);
+}
+
 function getCompactSpeechRevealDuration(textLength: number, audioDuration: number): number {
   const readableDuration = textLength / COMPACT_SPEECH_REVEAL_MAX_CHARS_PER_SECOND;
   return Math.max(audioDuration, readableDuration, 0.05);
@@ -1727,6 +1740,35 @@ export default function App({
     compactSpeechVisibleLength,
     compactPreviewText,
     compactPreviewTextVisible,
+  ]);
+  const compactPreviewDisplayContent = useMemo(() => {
+    if (!compactPreviewIsStreaming || !compactPreviewDisplayText) {
+      return compactPreviewDisplayText;
+    }
+    const graphemes = splitCompactPreviewGraphemes(compactPreviewDisplayText);
+    const latestIndex = graphemes.length - 1;
+    if (latestIndex < 0) {
+      return '';
+    }
+    const prefix = graphemes.slice(0, latestIndex).join('');
+    const latestGrapheme = graphemes[latestIndex];
+    const keyPrefix = compactMessagePreview?.turnStartId || compactMessagePreview?.messageId || 'compact-preview';
+    return (
+      <>
+        {prefix}
+        <span
+          key={`${keyPrefix}:${latestIndex}:${latestGrapheme}`}
+          className="compact-chat-capsule-glyph"
+        >
+          {latestGrapheme}
+        </span>
+      </>
+    );
+  }, [
+    compactMessagePreview?.messageId,
+    compactMessagePreview?.turnStartId,
+    compactPreviewDisplayText,
+    compactPreviewIsStreaming,
   ]);
   const emojiButtonAriaLabel = i18n('chat.emojiButtonAriaLabel', 'Emoji');
   const toolIconsAriaLabel = i18n('chat.toolIconsAriaLabel', 'Tool icons');
@@ -5186,7 +5228,7 @@ export default function App({
                           data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
                           onWheel={handleCompactPreviewWheel}
                         >
-                          {compactPreviewDisplayText}
+                          {compactPreviewDisplayContent}
                         </span>
                       </button>
                       {compactInputToolToggleButton}

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -85,7 +85,6 @@ function getEffectiveCompactChatState(
   return requestedState;
 }
 
-const COMPACT_PREVIEW_MAX_LENGTH = 84;
 const COMPACT_SPEECH_REVEAL_MAX_CHARS_PER_SECOND = 8;
 const COMPACT_SPEECH_TURN_MERGE_WINDOW_MS = 12000;
 const COMPACT_SPEECH_FALLBACK_REVEAL_DELAY_MS = 700;
@@ -268,11 +267,17 @@ type CompactMessagePreview = {
   // when a genuinely new turn begins. Used to tell an appended bubble from a
   // new turn without relying on text-prefix matching.
   turnStartId: string;
+  turnId?: string;
   author: string;
   text: string;
   fullText: string;
   isStreaming: boolean;
   isAssistant: boolean;
+};
+
+type CompactCaptionState = {
+  turnId: string;
+  text: string;
 };
 
 type DesktopCompactChoicePlacementLayout = {
@@ -342,6 +347,9 @@ function persistCompactExportHistoryOpen(open: boolean) {
 
 type SpeechPlaybackState = {
   active: boolean;
+  turnId?: string | null;
+  playbackTurnId?: string | null;
+  speechId?: string | null;
   audioContextTime: number;
   playbackStartAudioTime: number;
   playbackEndAudioTime: number;
@@ -355,13 +363,6 @@ function normalizeCompactPreviewText(text: string): string {
     .trim();
 }
 
-function truncateCompactPreview(text: string, maxLength: number): string {
-  if (text.length <= maxLength) {
-    return text;
-  }
-  return `${text.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
-}
-
 function getCompactSpeechRevealDuration(textLength: number, audioDuration: number): number {
   const readableDuration = textLength / COMPACT_SPEECH_REVEAL_MAX_CHARS_PER_SECOND;
   return Math.max(audioDuration, readableDuration, 0.05);
@@ -373,6 +374,18 @@ function getEstimatedSpeechAudioTime(state: SpeechPlaybackState): number {
   }
   const elapsedSinceUpdate = Math.max(0, (Date.now() - state.updatedAt) / 1000);
   return state.audioContextTime + elapsedSinceUpdate;
+}
+
+function isSpeechPlaybackStateForCompactPreview(
+  state: SpeechPlaybackState | null,
+  preview: { turnId?: string } | null,
+): state is SpeechPlaybackState {
+  if (!state) return false;
+  const previewTurnId = preview?.turnId;
+  if (!previewTurnId) return true;
+  const stateTurnIds = [state.playbackTurnId, state.turnId].filter((value): value is string => !!value);
+  if (stateTurnIds.length === 0) return true;
+  return stateTurnIds.includes(previewTurnId);
 }
 
 function getMessageBlockPreviewText(message: ChatMessage): string {
@@ -399,7 +412,11 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
   let latestStreamingAssistantIndex = -1;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (message?.role === 'assistant' && message.status === 'streaming' && getMessageBlockPreviewText(message)) {
+    if (
+      message?.role === 'assistant'
+      && message.status === 'streaming'
+      && getMessageBlockPreviewText(message)
+    ) {
       latestStreamingAssistantIndex = index;
       break;
     }
@@ -409,10 +426,11 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
     const turnTexts: string[] = [];
     let turnAuthor = '';
     const latestStreamingMessage = messages[latestStreamingAssistantIndex];
+    const latestStreamingTurnId = latestStreamingMessage?.turnId;
     const turnMessageId = String(latestStreamingMessage?.id || 'assistant-streaming');
     // Walks backward to the earliest merged bubble, so the last assignment in
     // the loop is the turn's anchor id.
-    let turnStartId = turnMessageId;
+    let turnStartId = latestStreamingTurnId ? `assistant-turn:${latestStreamingTurnId}` : turnMessageId;
     let previousIncludedCreatedAt = typeof latestStreamingMessage?.createdAt === 'number'
       && Number.isFinite(latestStreamingMessage.createdAt)
       ? latestStreamingMessage.createdAt
@@ -423,15 +441,18 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
       if (message.role !== 'assistant') {
         break;
       }
+      if (index !== latestStreamingAssistantIndex && latestStreamingTurnId && message.turnId !== latestStreamingTurnId) {
+        break;
+      }
       if (index !== latestStreamingAssistantIndex && message.status !== 'streaming') {
         const createdAt = typeof message.createdAt === 'number' && Number.isFinite(message.createdAt)
           ? message.createdAt
           : null;
-        if (
+        if (!latestStreamingTurnId && (
           previousIncludedCreatedAt === null
           || createdAt === null
           || Math.abs(previousIncludedCreatedAt - createdAt) > COMPACT_SPEECH_TURN_MERGE_WINDOW_MS
-        ) {
+        )) {
           break;
         }
         previousIncludedCreatedAt = createdAt;
@@ -441,7 +462,9 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
       // gain text; if the anchor only moved on text-bearing bubbles it would
       // drift to a later bubble and back, re-keying the same turn as a new one
       // and replaying the caption.
-      turnStartId = String(message.id || turnMessageId);
+      if (!latestStreamingTurnId) {
+        turnStartId = String(message.id || turnMessageId);
+      }
       const text = getMessageBlockPreviewText(message);
       if (!text) continue;
       turnTexts.unshift(text);
@@ -452,6 +475,7 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
       return {
         messageId: turnMessageId || 'assistant-streaming',
         turnStartId,
+        turnId: latestStreamingTurnId,
         author: turnAuthor,
         text: turnText,
         fullText: turnText,
@@ -461,31 +485,7 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
     }
   }
 
-  let fallbackPreview: CompactMessagePreview | null = null;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (!message) continue;
-    const text = getMessageBlockPreviewText(message);
-    if (!text) continue;
-
-    const isStreamingAssistantMessage = message.role === 'assistant' && message.status === 'streaming';
-    const preview = {
-      messageId: message.id,
-      turnStartId: String(message.id),
-      author: message.author,
-      text: isStreamingAssistantMessage ? text : truncateCompactPreview(text, COMPACT_PREVIEW_MAX_LENGTH),
-      fullText: text,
-      isStreaming: isStreamingAssistantMessage,
-      isAssistant: message.role === 'assistant',
-    };
-    if (message.role === 'assistant') {
-      return preview;
-    }
-    if (!fallbackPreview) {
-      fallbackPreview = preview;
-    }
-  }
-  return fallbackPreview;
+  return null;
 }
 
 type ToolIconItem = {
@@ -1184,6 +1184,7 @@ export default function App({
   const compactSpeechLastFrameTimeRef = useRef(0);
   const compactSpeechPreviewIdRef = useRef('');
   const compactSpeechPreviewTextRef = useRef('');
+  const compactSpeechPreviewTurnIdRef = useRef('');
   // Identity of the turn the speech reveal is currently walking through (the
   // preview's turnStartId). Updated when the preview re-keys (messageId change),
   // so it holds the *previous* turn's anchor at the moment a new bubble arrives
@@ -1210,6 +1211,11 @@ export default function App({
   const [compactSpeechVisibleLength, setCompactSpeechVisibleLength] = useState(0);
   const [compactSpeechFallbackRevealActive, setCompactSpeechFallbackRevealActive] = useState(false);
   const [speechPlaybackState, setSpeechPlaybackState] = useState<SpeechPlaybackState | null>(null);
+  const [compactCaptionState, setCompactCaptionState] = useState<CompactCaptionState | null>(null);
+  const [compactAssistantStreamingGap, setCompactAssistantStreamingGap] = useState<{
+    turnId: string;
+    acceptStreaming: boolean;
+  } | null>(null);
   const [compactChoiceLayerPlacement, setCompactChoiceLayerPlacement] = useState<'above' | 'below'>('above');
   const [compactInputToolFanOpen, setCompactInputToolFanOpen] = useState(false);
   const [compactInputToolFanInteractive, setCompactInputToolFanInteractive] = useState(false);
@@ -1628,35 +1634,76 @@ export default function App({
     }
   }, [compactExportSelectedIds, compactExportSelectableIds]);
   const surfaceModeClassName = `chat-surface-mode-${chatSurfaceMode}`;
-  const compactMessagePreview = useMemo(() => getCompactMessagePreview(messages), [messages]);
-  const compactSpeechModeActive = !!compactMessagePreview?.isAssistant
+  const compactMessagePreviewFromMessages = useMemo(() => getCompactMessagePreview(messages), [messages]);
+  const compactCaptionPreview = useMemo<CompactMessagePreview | null>(() => {
+    if (!compactCaptionState?.turnId || !compactCaptionState.text) {
+      return null;
+    }
+    return {
+      messageId: `compact-caption:${compactCaptionState.turnId}`,
+      turnStartId: `compact-caption:${compactCaptionState.turnId}`,
+      turnId: compactCaptionState.turnId,
+      author: 'Neko',
+      text: compactCaptionState.text,
+      fullText: compactCaptionState.text,
+      isStreaming: true,
+      isAssistant: true,
+    };
+  }, [compactCaptionState?.text, compactCaptionState?.turnId]);
+  const compactMessagePreview = compactCaptionPreview || compactMessagePreviewFromMessages;
+  const compactMatchedSpeechPlaybackState = isSpeechPlaybackStateForCompactPreview(
+    speechPlaybackState,
+    compactMessagePreview,
+  ) ? speechPlaybackState : null;
+  const compactPreviewMatchesStreamingGap = !!compactAssistantStreamingGap
+    && !!compactMessagePreview?.isAssistant
+    && !!compactMessagePreview.isStreaming
+    && !!compactMessagePreview.turnId
+    && compactMessagePreview.turnId === compactAssistantStreamingGap.turnId;
+  const compactPreservedSpeechMatchesEndingGap = !!compactAssistantStreamingGap
+    && !compactAssistantStreamingGap.acceptStreaming
+    && !!compactSpeechPreviewTurnIdRef.current
+    && compactSpeechPreviewTurnIdRef.current === compactAssistantStreamingGap.turnId;
+  const compactSuppressAssistantFallback = !!compactAssistantStreamingGap
+    && !compactPreviewMatchesStreamingGap
+    && !compactPreservedSpeechMatchesEndingGap;
+  const compactPreservedSpeechActive = !compactMessagePreview
+    && !compactSuppressAssistantFallback
+    && !!compactSpeechPreviewIdRef.current
+    && !!compactSpeechPreviewTextRef.current;
+  const compactSpeechModeActive = compactPreservedSpeechActive
+    || (!compactSuppressAssistantFallback
+    && !!compactMessagePreview?.isAssistant
     && !!compactMessagePreview?.messageId
     && (
       compactMessagePreview.isStreaming
       || compactSpeechPreviewIdRef.current === compactMessagePreview.messageId
-    );
-  const compactSpeechPreservedText = compactSpeechModeActive && !compactMessagePreview?.isStreaming
+    ));
+  const compactSpeechPreservedText = (compactSpeechModeActive && !compactMessagePreview?.isStreaming)
     ? compactSpeechPreviewTextRef.current
     : '';
-  const compactPreviewText = compactSpeechModeActive
-    ? (
-      compactMessagePreview?.isStreaming
-        ? compactMessagePreview?.fullText || ''
-        : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
-    )
-    : compactMessagePreview?.text
-    || i18n('chat.emptyState', 'Chat content will appear here.');
+  const compactPreviewText = compactSuppressAssistantFallback
+    ? ''
+    : compactSpeechModeActive
+      ? (
+        compactMessagePreview?.isStreaming
+          ? compactMessagePreview?.fullText || ''
+          : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
+      )
+      : compactMessagePreview?.text
+      || i18n('chat.emptyState', 'Chat content will appear here.');
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewSpeechDuration = useMemo(() => {
-    if (!compactPreviewIsStreaming || !speechPlaybackState) {
+    if (!compactPreviewIsStreaming || !compactMatchedSpeechPlaybackState) {
       return null;
     }
-    const audioDuration = speechPlaybackState.playbackEndAudioTime - speechPlaybackState.playbackStartAudioTime;
+    const audioDuration = compactMatchedSpeechPlaybackState.playbackEndAudioTime
+      - compactMatchedSpeechPlaybackState.playbackStartAudioTime;
     if (!Number.isFinite(audioDuration) || audioDuration <= 0.05) {
       return null;
     }
     return getCompactSpeechRevealDuration(compactPreviewText.length, audioDuration);
-  }, [compactPreviewIsStreaming, compactPreviewText.length, speechPlaybackState]);
+  }, [compactMatchedSpeechPlaybackState, compactPreviewIsStreaming, compactPreviewText.length]);
   const compactPreviewDisplayText = useMemo(() => {
     if (!compactPreviewIsStreaming) {
       return compactPreviewTextVisible || compactPreviewText;
@@ -1747,12 +1794,94 @@ export default function App({
   }, [compactPreviewTextVisible]);
 
   useEffect(() => {
-    compactPreviewTextVisibleRef.current = compactPreviewTextVisible;
-  }, [compactPreviewTextVisible]);
-
-  useEffect(() => {
     speechPlaybackStateRef.current = speechPlaybackState;
   }, [speechPlaybackState]);
+
+  useEffect(() => {
+    const handleAssistantTurnStart = (event: Event) => {
+      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
+      const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-${Date.now()}`;
+      setCompactCaptionState(current => (
+        current?.turnId === turnId ? current : null
+      ));
+      setCompactAssistantStreamingGap({
+        turnId,
+        acceptStreaming: true,
+      });
+    };
+    const handleAssistantTurnBoundary = (event: Event) => {
+      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
+      const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-ended-${Date.now()}`;
+      setCompactAssistantStreamingGap({
+        turnId,
+        acceptStreaming: false,
+      });
+    };
+    const handleCompactCaptionUpdate = (event: Event) => {
+      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
+      const turnId = detail?.turnId ? String(detail.turnId) : '';
+      const text = detail?.text ? normalizeCompactPreviewText(String(detail.text)) : '';
+      if (!turnId || !text) {
+        return;
+      }
+      setCompactCaptionState(current => {
+        if (!current || current.turnId !== turnId) {
+          return {
+            turnId,
+            text,
+          };
+        }
+        if (text === current.text || current.text.startsWith(text)) {
+          return current;
+        }
+        const nextText = text.startsWith(current.text)
+          ? text
+          : normalizeCompactPreviewText(`${current.text} ${text}`);
+        return {
+          turnId,
+          text: nextText,
+        };
+      });
+    };
+
+    window.addEventListener('neko-assistant-turn-start', handleAssistantTurnStart);
+    window.addEventListener('neko-assistant-turn-ending', handleAssistantTurnBoundary);
+    window.addEventListener('neko-assistant-turn-end', handleAssistantTurnBoundary);
+    window.addEventListener('neko-compact-caption-update', handleCompactCaptionUpdate);
+    return () => {
+      window.removeEventListener('neko-assistant-turn-start', handleAssistantTurnStart);
+      window.removeEventListener('neko-assistant-turn-ending', handleAssistantTurnBoundary);
+      window.removeEventListener('neko-assistant-turn-end', handleAssistantTurnBoundary);
+      window.removeEventListener('neko-compact-caption-update', handleCompactCaptionUpdate);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (compactMessagePreview?.isAssistant && compactMessagePreview.isStreaming) {
+      setCompactAssistantStreamingGap(currentGap => {
+        if (!currentGap) {
+          return null;
+        }
+        if (
+          !compactMessagePreview.turnId
+          || compactMessagePreview.turnId !== currentGap.turnId
+        ) {
+          return currentGap;
+        }
+        if (!currentGap.acceptStreaming) {
+          return currentGap;
+        }
+        return null;
+      });
+    }
+  }, [
+    compactAssistantStreamingGap?.acceptStreaming,
+    compactAssistantStreamingGap?.turnId,
+    compactMessagePreview?.isAssistant,
+    compactMessagePreview?.isStreaming,
+    compactMessagePreview?.messageId,
+    compactMessagePreview?.turnId,
+  ]);
 
   useEffect(() => {
     isCompactSurfaceRef.current = isCompactSurface;
@@ -1766,12 +1895,14 @@ export default function App({
     if (compactMessagePreview?.isStreaming && compactMessagePreview.isAssistant) {
       compactSpeechPreviewIdRef.current = compactMessagePreview.messageId;
       compactSpeechPreviewTextRef.current = compactMessagePreview.fullText || compactMessagePreview.text || '';
+      compactSpeechPreviewTurnIdRef.current = compactMessagePreview.turnId || '';
     } else if (compactSpeechPreviewIdRef.current && (
-      !compactMessagePreview?.messageId
-      || compactSpeechPreviewIdRef.current !== compactMessagePreview.messageId
+      compactMessagePreview?.messageId
+      && compactSpeechPreviewIdRef.current !== compactMessagePreview.messageId
     )) {
       compactSpeechPreviewIdRef.current = '';
       compactSpeechPreviewTextRef.current = '';
+      compactSpeechPreviewTurnIdRef.current = '';
     }
   }, [
     compactMessagePreview?.fullText,
@@ -1779,9 +1910,13 @@ export default function App({
     compactMessagePreview?.isStreaming,
     compactMessagePreview?.messageId,
     compactMessagePreview?.text,
+    compactMessagePreview?.turnId,
   ]);
 
   useEffect(() => {
+    if (!compactMessagePreview && compactPreservedSpeechActive) {
+      return;
+    }
     if (compactSpeechFallbackTimerRef.current !== null) {
       window.clearTimeout(compactSpeechFallbackTimerRef.current);
       compactSpeechFallbackTimerRef.current = null;
@@ -1801,14 +1936,16 @@ export default function App({
     const seedVisibleLength = continuesPreviousTurn
       ? Math.min(compactSpeechVisibleLengthRef.current, compactPreviewText.length)
       : 0;
-    // When the same turn continues, carry the fallback-reveal driver forward.
-    // Otherwise the appended text would freeze: the fallback timer re-arms but
-    // bails whenever visibleLength > 0 (the seeded length), so nothing would
-    // drive the reveal past the seed in the no-speech-playback path. Playback
-    // state is still reset to false so a finished bubble's audio can't snap the
-    // appended text to full — the next bubble's audio (or the carried fallback)
-    // resumes the reveal from the seed.
-    const keepFallbackReveal = continuesPreviousTurn && compactSpeechFallbackRevealRef.current;
+    // When the same turn continues, keep or immediately start the fallback
+    // reveal driver so appended text continues without a 700ms idle gap. The
+    // playback state is still reset to false so a finished bubble's audio can't
+    // snap the appended text to full.
+    const sameTurnHasAppendedText = continuesPreviousTurn
+      && seedVisibleLength < compactPreviewText.length;
+    const keepFallbackReveal = continuesPreviousTurn && (
+      compactSpeechFallbackRevealRef.current
+      || sameTurnHasAppendedText
+    );
     compactSpeechRevealTurnIdRef.current = nextRevealTurnId;
 
     compactSpeechVisibleLengthRef.current = seedVisibleLength;
@@ -1818,7 +1955,7 @@ export default function App({
     compactSpeechLastFrameTimeRef.current = 0;
     setCompactSpeechVisibleLength(seedVisibleLength);
     setCompactSpeechFallbackRevealActive(keepFallbackReveal);
-  }, [compactMessagePreview?.messageId]);
+  }, [compactMessagePreview, compactMessagePreview?.messageId, compactPreservedSpeechActive]);
 
   useEffect(() => {
     if (!compactPreviewIsStreaming) {
@@ -1836,11 +1973,11 @@ export default function App({
       return;
     }
 
-    if (!speechPlaybackState?.active) {
+    if (!compactMatchedSpeechPlaybackState?.active) {
       return;
     }
-    const estimatedAudioTime = getEstimatedSpeechAudioTime(speechPlaybackState);
-    if (estimatedAudioTime >= speechPlaybackState.playbackStartAudioTime) {
+    const estimatedAudioTime = getEstimatedSpeechAudioTime(compactMatchedSpeechPlaybackState);
+    if (estimatedAudioTime >= compactMatchedSpeechPlaybackState.playbackStartAudioTime) {
       compactSpeechPlaybackStartedRef.current = true;
       if (compactSpeechFallbackTimerRef.current !== null) {
         window.clearTimeout(compactSpeechFallbackTimerRef.current);
@@ -1851,7 +1988,7 @@ export default function App({
         setCompactSpeechFallbackRevealActive(false);
       }
     }
-  }, [compactPreviewIsStreaming, speechPlaybackState]);
+  }, [compactMatchedSpeechPlaybackState, compactPreviewIsStreaming]);
 
   useEffect(() => {
     if (compactSpeechFallbackTimerRef.current !== null) {
@@ -1865,7 +2002,12 @@ export default function App({
     compactSpeechFallbackTimerRef.current = window.setTimeout(() => {
       compactSpeechFallbackTimerRef.current = null;
       const playbackState = speechPlaybackStateRef.current;
+      const playbackMatchesPreview = isSpeechPlaybackStateForCompactPreview(
+        playbackState,
+        compactMessagePreview,
+      );
       const playbackHasStarted = !!playbackState?.active
+        && playbackMatchesPreview
         && getEstimatedSpeechAudioTime(playbackState) >= playbackState.playbackStartAudioTime;
       if (
         !isCompactSurfaceRef.current
@@ -1901,11 +2043,16 @@ export default function App({
         compactSpeechFallbackTimerRef.current = null;
       }
     };
-  }, [compactPreviewIsStreaming, compactPreviewText.length, compactMessagePreview?.messageId]);
+  }, [compactMessagePreview, compactPreviewIsStreaming, compactPreviewText.length]);
 
   useEffect(() => {
-    function handleAssistantSpeechUnavailable() {
+    function handleAssistantSpeechUnavailable(event: Event) {
       if (!isCompactSurfaceRef.current || !compactPreviewIsStreaming || !compactMessagePreview?.isAssistant) {
+        return;
+      }
+      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
+      const eventTurnId = detail?.turnId ? String(detail.turnId) : '';
+      if (eventTurnId && compactMessagePreview.turnId && eventTurnId !== compactMessagePreview.turnId) {
         return;
       }
       compactSpeechFallbackRevealRef.current = true;
@@ -1918,7 +2065,7 @@ export default function App({
     return () => {
       window.removeEventListener('neko-assistant-speech-unavailable', handleAssistantSpeechUnavailable);
     };
-  }, [compactMessagePreview?.isAssistant, compactPreviewIsStreaming]);
+  }, [compactMessagePreview, compactPreviewIsStreaming]);
 
   useEffect(() => {
     if (compactSpeechAnimationFrameRef.current !== null) {
@@ -1933,7 +2080,10 @@ export default function App({
     }
 
     const tick = (frameTime: number) => {
-      const playbackState = speechPlaybackStateRef.current;
+      const playbackState = isSpeechPlaybackStateForCompactPreview(
+        speechPlaybackStateRef.current,
+        compactMessagePreview,
+      ) ? speechPlaybackStateRef.current : null;
       const fallbackReveal = compactSpeechFallbackRevealRef.current;
       const shouldContinueAfterSpeech = (compactSpeechPlaybackStartedRef.current || fallbackReveal)
         && compactSpeechVisibleLengthRef.current < compactPreviewText.length;
@@ -1997,7 +2147,13 @@ export default function App({
         compactSpeechAnimationFrameRef.current = null;
       }
     };
-  }, [compactPreviewIsStreaming, compactPreviewText.length, compactPreviewSpeechDuration, compactSpeechFallbackRevealActive]);
+  }, [
+    compactMessagePreview,
+    compactPreviewIsStreaming,
+    compactPreviewText.length,
+    compactPreviewSpeechDuration,
+    compactSpeechFallbackRevealActive,
+  ]);
 
   useEffect(() => {
     const readState = (value: unknown): SpeechPlaybackState | null => {
@@ -2010,6 +2166,9 @@ export default function App({
       const playbackEndAudioTime = Number(state.playbackEndAudioTime);
       return {
         active: !!state.active,
+        turnId: state.turnId ? String(state.turnId) : null,
+        playbackTurnId: state.playbackTurnId ? String(state.playbackTurnId) : null,
+        speechId: state.speechId ? String(state.speechId) : null,
         audioContextTime: Number.isFinite(audioContextTime) ? audioContextTime : 0,
         playbackStartAudioTime: Number.isFinite(playbackStartAudioTime) ? playbackStartAudioTime : 0,
         playbackEndAudioTime: Number.isFinite(playbackEndAudioTime) ? playbackEndAudioTime : 0,

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -277,7 +277,14 @@ type CompactMessagePreview = {
 
 type CompactCaptionState = {
   turnId: string;
+  segmentId: string;
+  lastSegmentText: string;
+  segments: Array<{
+    segmentId: string;
+    text: string;
+  }>;
   text: string;
+  isEnded?: boolean;
 };
 
 type DesktopCompactChoicePlacementLayout = {
@@ -1639,17 +1646,18 @@ export default function App({
     if (!compactCaptionState?.turnId || !compactCaptionState.text) {
       return null;
     }
+    const captionMessageId = `compact-caption:${compactCaptionState.turnId}`;
     return {
-      messageId: `compact-caption:${compactCaptionState.turnId}`,
-      turnStartId: `compact-caption:${compactCaptionState.turnId}`,
+      messageId: captionMessageId,
+      turnStartId: captionMessageId,
       turnId: compactCaptionState.turnId,
       author: 'Neko',
       text: compactCaptionState.text,
       fullText: compactCaptionState.text,
-      isStreaming: true,
+      isStreaming: !compactCaptionState.isEnded,
       isAssistant: true,
     };
-  }, [compactCaptionState?.text, compactCaptionState?.turnId]);
+  }, [compactCaptionState]);
   const compactMessagePreview = compactCaptionPreview || compactMessagePreviewFromMessages;
   const compactMatchedSpeechPlaybackState = isSpeechPlaybackStateForCompactPreview(
     speechPlaybackState,
@@ -1812,6 +1820,14 @@ export default function App({
     const handleAssistantTurnBoundary = (event: Event) => {
       const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
       const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-ended-${Date.now()}`;
+      setCompactCaptionState(current => (
+        current?.turnId === turnId
+          ? {
+            ...current,
+            isEnded: true,
+          }
+          : current
+      ));
       setCompactAssistantStreamingGap({
         turnId,
         acceptStreaming: false,
@@ -1821,25 +1837,65 @@ export default function App({
       const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
       const turnId = detail?.turnId ? String(detail.turnId) : '';
       const text = detail?.text ? normalizeCompactPreviewText(String(detail.text)) : '';
+      const rawSegmentId = detail?.segmentId ?? detail?.segmentIndex;
+      const explicitSegmentId = rawSegmentId !== undefined && rawSegmentId !== null && rawSegmentId !== ''
+        ? String(rawSegmentId)
+        : '';
       if (!turnId || !text) {
         return;
       }
       setCompactCaptionState(current => {
         if (!current || current.turnId !== turnId) {
+          const segmentId = explicitSegmentId || 'legacy-segment-0';
           return {
             turnId,
+            segmentId,
+            lastSegmentText: text,
+            segments: [{
+              segmentId,
+              text,
+            }],
             text,
           };
         }
-        if (text === current.text || current.text.startsWith(text)) {
-          return current;
-        }
-        const nextText = text.startsWith(current.text)
-          ? text
-          : normalizeCompactPreviewText(`${current.text} ${text}`);
+        const currentSegments = current.segments.length > 0
+          ? current.segments
+          : [{
+            segmentId: current.segmentId || 'legacy-segment-0',
+            text: current.lastSegmentText || current.text,
+          }];
+        const previousSegmentText = current.lastSegmentText || '';
+        const segmentId = explicitSegmentId
+          || (
+            !previousSegmentText
+            || text === previousSegmentText
+            || text.startsWith(previousSegmentText)
+            || previousSegmentText.startsWith(text)
+              ? current.segmentId
+              : `legacy-segment-${currentSegments.length}`
+          );
+        const existingSegmentIndex = currentSegments.findIndex(segment => segment.segmentId === segmentId);
+        const nextSegments = existingSegmentIndex >= 0
+          ? currentSegments.map((segment, index) => (
+            index === existingSegmentIndex
+              ? {
+                segmentId,
+                text,
+              }
+              : segment
+          ))
+          : currentSegments.concat({
+            segmentId,
+            text,
+          });
+        const nextText = normalizeCompactPreviewText(nextSegments.map(segment => segment.text).join(' '));
         return {
           turnId,
+          segmentId,
+          lastSegmentText: text,
+          segments: nextSegments,
           text: nextText,
+          isEnded: false,
         };
       });
     };

--- a/frontend/react-neko-chat/src/message-schema.test.ts
+++ b/frontend/react-neko-chat/src/message-schema.test.ts
@@ -15,6 +15,29 @@ describe('message-schema', () => {
     expect(message.blocks[0]?.type).toBe('text');
   });
 
+  it('normalizes empty turn ids while preserving non-empty turn ids', () => {
+    const baseMessage = {
+      id: 'msg-turn',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:00',
+      blocks: [{ type: 'text', text: 'hello' }],
+    };
+
+    expect(parseChatMessage({
+      ...baseMessage,
+      turnId: null,
+    }).turnId).toBeUndefined();
+    expect(parseChatMessage({
+      ...baseMessage,
+      turnId: '',
+    }).turnId).toBeUndefined();
+    expect(parseChatMessage({
+      ...baseMessage,
+      turnId: 'turn-1',
+    }).turnId).toBe('turn-1');
+  });
+
   it('rejects invalid message payloads', () => {
     expect(() => parseChatMessage({
       id: 'msg-2',

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -224,13 +224,20 @@ export const messageBlockSchema = z.discriminatedUnion('type', [
   buttonGroupBlockSchema,
 ]);
 
+const turnIdSchema = z.preprocess((value) => {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+  return value;
+}, z.string().min(1).optional());
+
 export const chatMessageSchema = z.object({
   id: z.string().min(1),
   role: z.enum(['user', 'assistant', 'system', 'tool']),
   author: z.string().min(1),
   time: z.string(),
   createdAt: z.number().finite().optional(),
-  turnId: z.string().optional(),
+  turnId: turnIdSchema,
   avatarLabel: z.string().optional(),
   avatarUrl: z.string().optional(),
   blocks: z.array(messageBlockSchema),

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -230,6 +230,7 @@ export const chatMessageSchema = z.object({
   author: z.string().min(1),
   time: z.string(),
   createdAt: z.number().finite().optional(),
+  turnId: z.string().optional(),
   avatarLabel: z.string().optional(),
   avatarUrl: z.string().optional(),
   blocks: z.array(messageBlockSchema),

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2024,6 +2024,29 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   text-overflow: clip;
 }
 
+.compact-chat-capsule-glyph {
+  display: inline;
+  white-space: pre;
+  will-change: opacity;
+  animation: compact-caption-glyph-in 90ms ease-out both;
+}
+
+@keyframes compact-caption-glyph-in {
+  from {
+    opacity: 0.58;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compact-chat-capsule-glyph {
+    animation: none;
+  }
+}
+
 .compact-chat-capsule-text::-webkit-scrollbar {
   display: none;
 }

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -102,6 +102,10 @@
         return (s || '').replace(/\r\n/g, '\n');
     }
 
+    function getCurrentAssistantTurnId() {
+        return window._nekoAssistantTurnId ? String(window._nekoAssistantTurnId) : '';
+    }
+
     // ======================== 虚拟引用（兼容 response_discarded 清理逻辑） ========================
 
     function createVirtualBubbleRef(messageId) {
@@ -132,11 +136,27 @@
             author: resolvedAuthor,
             time: timeStr || getCurrentTimeString(),
             createdAt: Date.now(),
+            turnId: role === 'assistant' && window._nekoAssistantTurnId ? String(window._nekoAssistantTurnId) : undefined,
             avatarLabel: resolvedAuthor ? String(resolvedAuthor).trim().slice(0, 1).toUpperCase() : undefined,
             avatarUrl: avatarUrl || undefined,
             blocks: [{ type: 'text', text: cleanText }],
             status: status
         };
+    }
+
+    function emitCompactCaptionUpdate(text) {
+        var cleanText = String(text || '')
+            .replace(/\[play_music:[^\]]*(\]|$)/g, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+        var turnId = window._nekoAssistantTurnId ? String(window._nekoAssistantTurnId) : '';
+        if (!turnId || !cleanText) return;
+        window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+            detail: {
+                turnId: turnId,
+                text: cleanText
+            }
+        }));
     }
 
     // ======================== 句子分割（从 app-chat.js 复刻） ========================
@@ -188,10 +208,45 @@
             ch === '\u301B' || ch === '\u301E' || ch === '\u301F';
     }
 
+    function getRealisticQueueItemText(item) {
+        if (item && typeof item === 'object' && typeof item.text !== 'undefined') {
+            return normalizeGeminiText(item.text);
+        }
+        return normalizeGeminiText(item);
+    }
+
+    function getRealisticQueueItemTurnId(item) {
+        if (item && typeof item === 'object' && item.turnId) {
+            return String(item.turnId);
+        }
+        return getCurrentAssistantTurnId();
+    }
+
+    function createRealisticQueueItem(text, turnId) {
+        return {
+            text: normalizeGeminiText(text),
+            turnId: turnId ? String(turnId) : getCurrentAssistantTurnId()
+        };
+    }
+
+    function getCommonRealisticQueueTurnId(queue) {
+        var commonTurnId = '';
+        for (var i = 0; i < queue.length; i++) {
+            var turnId = getRealisticQueueItemTurnId(queue[i]);
+            if (!turnId) return '';
+            if (!commonTurnId) {
+                commonTurnId = turnId;
+            } else if (commonTurnId !== turnId) {
+                return '';
+            }
+        }
+        return commonTurnId;
+    }
+
     function joinRealisticPendingPieces(pieces) {
         var joined = '';
         for (var i = 0; i < pieces.length; i++) {
-            var piece = normalizeGeminiText(pieces[i]).replace(/^\s+/, '').replace(/\s+$/, '');
+            var piece = getRealisticQueueItemText(pieces[i]).replace(/^\s+/, '').replace(/\s+$/, '');
             if (!piece) continue;
             if (!joined) {
                 joined = piece;
@@ -244,10 +299,14 @@
         var queue = window._realisticGeminiQueue;
         if (!Array.isArray(queue) || queue.length <= 2) return;
 
+        var queueTurnId = getCommonRealisticQueueTurnId(queue);
+        if (!queueTurnId) return;
         var queueText = joinRealisticPendingPieces(queue);
         var splitQueue = splitRealisticTextNearMiddle(queueText);
         if (splitQueue.length > 0 && splitQueue.length <= queue.length) {
-            window._realisticGeminiQueue = splitQueue;
+            window._realisticGeminiQueue = splitQueue.map(function (text) {
+                return createRealisticQueueItem(text, queueTurnId);
+            });
         }
     }
 
@@ -358,12 +417,28 @@
         }
     }
 
-    function createGeminiBubble(sentence) {
+    function createGeminiBubble(sentence, options) {
+        options = options || {};
         var host = getHost();
         var cleanSentence = (sentence || '').replace(/\[play_music:[^\]]*(\]|$)/g, '');
+        var explicitTurnId = options.turnId ? String(options.turnId) : '';
+        if (!explicitTurnId && typeof window.ensureAssistantTurnStarted === 'function') {
+            window.ensureAssistantTurnStarted('create_gemini_bubble');
+        }
         var msgId = nextReactMessageId('assistant');
         var timeStr = getCurrentTimeString();
-        var msg = buildMessage(msgId, 'assistant', getCurrentAssistantName(), timeStr, cleanSentence, 'streaming');
+        var previousTurnId = window._nekoAssistantTurnId;
+        var msg = null;
+        if (explicitTurnId) {
+            window._nekoAssistantTurnId = explicitTurnId;
+        }
+        try {
+            msg = buildMessage(msgId, 'assistant', getCurrentAssistantName(), timeStr, cleanSentence, 'streaming');
+        } finally {
+            if (explicitTurnId) {
+                window._nekoAssistantTurnId = previousTurnId || null;
+            }
+        }
 
         var appendedToHost = false;
         if (msg && host && typeof host.appendMessage === 'function') {
@@ -384,9 +459,6 @@
         window.currentTurnGeminiBubbles = window.currentTurnGeminiBubbles || [];
         window.currentTurnGeminiBubbles.push(ref);
 
-        if (typeof window.ensureAssistantTurnStarted === 'function') {
-            window.ensureAssistantTurnStarted('create_gemini_bubble');
-        }
         if (appendedToHost) {
             markAssistantVisibleResponseForAchievement();
         }
@@ -436,9 +508,12 @@
                     break;
                 }
 
-                var s = window._realisticGeminiQueue.shift();
-                if (s && (window._realisticGeminiVersion || 0) === queueVersion) {
-                    createGeminiBubble(s);
+                var item = window._realisticGeminiQueue.shift();
+                var itemText = getRealisticQueueItemText(item);
+                if (itemText && (window._realisticGeminiVersion || 0) === queueVersion) {
+                    createGeminiBubble(itemText, {
+                        turnId: getRealisticQueueItemTurnId(item)
+                    });
                     window._lastBubbleTime = Date.now();
                 }
             }
@@ -522,7 +597,11 @@
         if (!Array.isArray(queue) || queue.length === 0) return;
         // 同步创建所有待排队的 bubble
         for (var i = 0; i < queue.length; i++) {
-            try { createGeminiBubble(queue[i]); } catch (_) {}
+            try {
+                createGeminiBubble(getRealisticQueueItemText(queue[i]), {
+                    turnId: getRealisticQueueItemTurnId(queue[i])
+                });
+            } catch (_) {}
         }
         window._realisticGeminiQueue = [];
     }
@@ -605,6 +684,7 @@
             } else if (typeof window.updateSubtitleStreamingText === 'function') {
                 window.updateSubtitleStreamingText(streamingText);
             }
+            emitCompactCaptionUpdate(streamingText);
         }
 
         // ---------- gemini + realistic 模式 ----------
@@ -655,7 +735,10 @@
 
             if (splitResult.sentences.length > 0) {
                 window._realisticGeminiQueue = window._realisticGeminiQueue || [];
-                window._realisticGeminiQueue.push.apply(window._realisticGeminiQueue, splitResult.sentences);
+                var queueTurnId = getCurrentAssistantTurnId();
+                window._realisticGeminiQueue.push.apply(window._realisticGeminiQueue, splitResult.sentences.map(function (sentence) {
+                    return createRealisticQueueItem(sentence, queueTurnId);
+                }));
                 rebalanceRealisticQueueIfNeeded();
                 processRealisticQueue(window._realisticGeminiVersion || 0);
                 createdVisibleBubble = (window.currentTurnGeminiBubbles ? window.currentTurnGeminiBubbles.length : 0) > bubbleCountBefore;

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -106,6 +106,17 @@
         return window._nekoAssistantTurnId ? String(window._nekoAssistantTurnId) : '';
     }
 
+    function beginCompactCaptionSegment() {
+        var turnId = getCurrentAssistantTurnId();
+        if (window._nekoCompactCaptionSegmentTurnId !== turnId) {
+            window._nekoCompactCaptionSegmentTurnId = turnId;
+            window._nekoCompactCaptionSegmentSeq = 0;
+        }
+        window._nekoCompactCaptionSegmentSeq = (window._nekoCompactCaptionSegmentSeq || 0) + 1;
+        window._nekoCompactCaptionSegmentId = (turnId || 'no-turn') + ':segment:' + window._nekoCompactCaptionSegmentSeq;
+        return window._nekoCompactCaptionSegmentId;
+    }
+
     // ======================== 虚拟引用（兼容 response_discarded 清理逻辑） ========================
 
     function createVirtualBubbleRef(messageId) {
@@ -154,6 +165,7 @@
         window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
             detail: {
                 turnId: turnId,
+                segmentId: window._nekoCompactCaptionSegmentId || '',
                 text: cleanText
             }
         }));
@@ -651,6 +663,7 @@
                 window._structuredGeminiStreaming = false;
                 window._turnIsStructured = false;
                 window._geminiTurnEndSealed = false;
+                beginCompactCaptionSegment();
                 // Per-segment scoping for cleanup. response_discarded /
                 // user-activity-cancel 都只针对当前 in-flight response item，
                 // 不应跨段抹掉已经完成的上一段气泡 —— per-segment 才对。

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1851,6 +1851,7 @@
             author: message.author,
             time: message.time,
             createdAt: message.createdAt,
+            turnId: message.turnId,
             avatarLabel: message.avatarLabel,
             avatarUrl: message.avatarUrl,
             blocks: Array.isArray(message.blocks) ? message.blocks.map(function (block) {
@@ -1910,6 +1911,7 @@
             author: sanitizeDisplayName(message.author) || getDefaultAuthorByRole(message.role || 'assistant'),
             time: time,
             createdAt: createdAt,
+            turnId: message.turnId ? String(message.turnId) : undefined,
             avatarLabel: message.avatarLabel,
             avatarUrl: message.avatarUrl,
             blocks: Array.isArray(message.blocks) ? message.blocks : [],

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -729,6 +729,13 @@
     // 之前两边各写一份导致这次 PR 修 agent_callback `return` 时才发现行为不
     // 一致；抽成共享 helper 防止下次又单边演进。
     function flushRealisticBufferOnTurnEnd() {
+        var endingTurnId = resolveAssistantLifecycleTurnId();
+        if (endingTurnId) {
+            emitAssistantLifecycleEvent('neko-assistant-turn-ending', {
+                turnId: endingTurnId,
+                source: 'turn_end_flush'
+            });
+        }
         if (typeof window.setReactMessageStatus === 'function' && window.currentGeminiMessage) {
             window.setReactMessageStatus(window.currentGeminiMessage, 'assistant', 'sent');
         }
@@ -747,7 +754,10 @@
         var trimmed = rest.replace(/^\s+/, '').replace(/\s+$/, '');
         if (trimmed) {
             window._realisticGeminiQueue = window._realisticGeminiQueue || [];
-            window._realisticGeminiQueue.push(trimmed);
+            window._realisticGeminiQueue.push({
+                text: trimmed,
+                turnId: endingTurnId || null
+            });
             if (typeof window.processRealisticQueue === 'function') {
                 window.processRealisticQueue(window._realisticGeminiVersion || 0);
             }
@@ -910,6 +920,7 @@
 
     function ensureAssistantTurnStarted(source, serverTurnId) {
         if (S.assistantTurnId) {
+            window._nekoAssistantTurnId = S.assistantTurnId;
             clearPendingAssistantTurnStart();
             logAssistantLifecycle('ensureAssistantTurnStarted:reuse_existing', {
                 source: source || 'visible_gemini_bubble',
@@ -927,6 +938,7 @@
         S.assistantTurnId = allocateAssistantTurnId(
             serverTurnId === undefined ? S.assistantPendingTurnServerId : serverTurnId
         );
+        window._nekoAssistantTurnId = S.assistantTurnId;
         S.assistantTurnStartedAt = Date.now();
         clearPendingAssistantTurnStart();
         emitAssistantLifecycleEvent('neko-assistant-turn-start', {
@@ -964,6 +976,7 @@
         clearPendingUserActivityCancel();
         emitAssistantSpeechCancel(source || 'user_activity');
         S.assistantTurnId = null;
+        window._nekoAssistantTurnId = null;
         clearPendingAssistantTurnStart();
         S.interruptedSpeechId = interruptedSpeechId || null;
         S.pendingDecoderReset = true;
@@ -1041,6 +1054,7 @@
         emitAssistantSpeechCancel(source || 'socket_close');
         S.assistantSpeechActiveTurnId = null;
         S.assistantTurnId = null;
+        window._nekoAssistantTurnId = null;
         S.assistantTurnCompletedId = null;
         S.assistantTurnSettledId = null;
         S.assistantTurnCompletionSource = null;
@@ -1722,7 +1736,7 @@
                         console.log(window.t('console.audioChunkHeaderReceived'), response);
                     }
                     if (!S.assistantTurnId && S.assistantTurnAwaitingBubble) {
-                        ensureAssistantTurnStarted('audio_chunk_header_fallback');
+                        ensureAssistantTurnStarted('audio_chunk_header_fallback', response.turn_id);
                     }
                     var speechId = response.speech_id;
                     var shouldSkip = false;
@@ -1750,14 +1764,14 @@
 
                     S.pendingAudioChunkMetaQueue.push({
                         speechId: speechId || S.currentPlayingSpeechId || null,
-                        turnId: resolveAssistantLifecycleTurnId(),
+                        turnId: resolveAssistantLifecycleTurnId(response.turn_id),
                         shouldSkip: shouldSkip,
                         epoch: S.incomingAudioEpoch,
                         receivedAt: Date.now()
                     });
                     logAssistantLifecycle('ws:audio_chunk_header', {
                         speechId: speechId || S.currentPlayingSpeechId || null,
-                        turnId: resolveAssistantLifecycleTurnId(),
+                        turnId: resolveAssistantLifecycleTurnId(response.turn_id),
                         shouldSkip: shouldSkip,
                         epoch: S.incomingAudioEpoch
                     });
@@ -1829,6 +1843,7 @@
 
                     if (statusCode === 'TTS_CONNECTION_FAILED') {
                         emitAssistantLifecycleEvent('neko-assistant-speech-unavailable', {
+                            turnId: resolveAssistantLifecycleTurnId(response.turn_id),
                             code: statusCode,
                             details: statusDetails || null,
                             source: 'tts_status'

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1463,6 +1463,7 @@
                     }
                     if (isNewMessage || sealedContinuation) {
                         S.assistantTurnId = null;
+                        window._nekoAssistantTurnId = null;
                         S.assistantPendingTurnServerId = normalizeAssistantTurnId(response.turn_id);
                         S.assistantTurnAwaitingBubble = true;
                     }
@@ -1501,6 +1502,7 @@
                     window.invalidatePendingMusicSearch();
                     emitAssistantSpeechCancel('response_discarded');
                     S.assistantTurnId = null;
+                    window._nekoAssistantTurnId = null;
                     clearPendingAssistantTurnStart();
                     // will_retry 时后端会再发一次 LLM 请求，对外仍然是"这一轮还在跑"——
                     // 但上面的 clearPendingAssistantTurnStart 已经把 awaitingBubble /


### PR DESCRIPTION
修复紧凑聊天胶囊的实时字幕显示逻辑，确保显示内容跟随当前正在说话的 assistant turn，不再闪回历史对话或同轮前序分句。

- 新增按 turnId 绑定的紧凑字幕事件源
- 将语音播放、fallback reveal、streaming message fallback 限定到当前 turn
- 在 React 聊天桥接和 realistic 队列刷新中保留 turnId
- 覆盖旧 turn 残留、同 turn 续写、语音不可用、播放状态不匹配等场景


Related: https://github.com/Project-N-E-K-O/N.E.K.O/pull/1605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 为助手“轮次 (turnId)”引入可追踪标识，提升多轮对话与紧凑字幕的一致性。
  * 流式紧凑字幕支持同轮次实时追加与替换重复前缀，逐字显示改为基于 grapheme 的字形封装。

* **Bug 修复**
  * 阻止跨轮次的语音播放/不可用事件导致的回退或闪回，优化回放/预览匹配过滤与初始占位显示。

* **测试**
  * 增加/调整多项单元与集成测试，覆盖 turnId 归一化、预览显示与事件驱动行为。

* **样式**
  * 紧凑胶囊字形动画与无动画偏好支持。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->