### PR TITLE
fix(test): 修复 market_bridge e2e fixture 失效的 USER_PLUGIN_CONFIG_ROOT patch（#1618 回归）

### DIFF
--- a/plugin/tests/integration/test_market_bridge_e2e.py
+++ b/plugin/tests/integration/test_market_bridge_e2e.py
@@ -173,11 +173,11 @@ def bridge_e2e_env(
 ) -> Iterator[dict[str, Any]]:
     """Build an ASGI bridge app + ISM all rooted under ``tmp_path``.
 
-    Redirects ``USER_PLUGIN_CONFIG_ROOT`` / ``USER_PLUGIN_PACKAGES_ROOT``
-    on the loaded :mod:`plugin_cli.service` module so saved packages and
-    unpacked plugins land in ``tmp_path``. Also monkeypatches the bridge's
-    own ``USER_PLUGIN_CONFIG_ROOT`` import so its upgrade path resolves
-    the correct roots.
+    Redirects the plugin root settings on :mod:`plugin.settings` so saved
+    packages and unpacked plugins land in ``tmp_path``. Both the plugin_cli
+    service and the market bridge resolve their roots through
+    ``PluginCliPathPolicy.from_settings()``, so patching the settings module
+    is enough — neither freezes the roots at import time anymore.
 
     Yields a dict with ``client`` (httpx AsyncClient), ``token``,
     ``user_root``, ``builtin_root``, ``packages_root``, ``lock_path``.
@@ -199,7 +199,10 @@ def bridge_e2e_env(
     monkeypatch.setattr(plugin_settings, "USER_PLUGIN_CONFIG_ROOT", user_root)
     monkeypatch.setattr(plugin_settings, "USER_PLUGIN_PACKAGES_ROOT", packages_root)
     monkeypatch.setattr(plugin_settings, "USER_PACKAGE_PROFILES_ROOT", profiles_root)
-    monkeypatch.setattr(market_bridge_module, "USER_PLUGIN_CONFIG_ROOT", user_root)
+    # market_bridge no longer freezes USER_PLUGIN_CONFIG_ROOT at import time; it
+    # resolves plugin roots through PluginCliPathPolicy.from_settings(), so the
+    # plugin.settings patches above are picked up without patching the module
+    # attribute (which no longer exists).
     monkeypatch.setattr(
         market_bridge_module,
         "_OAUTH_TOKEN_FILE",


### PR DESCRIPTION
## 背景

PR #1618 合并后，`market_bridge.py` 的根目录解析已改走 `PluginCliPathPolicy.from_settings()`，并删除了模块级 `USER_PLUGIN_CONFIG_ROOT` 导入。但 `bridge_e2e_env` fixture 仍保留：

```python
monkeypatch.setattr(market_bridge_module, "USER_PLUGIN_CONFIG_ROOT", user_root)
```

该属性在模块上已不存在，`monkeypatch.setattr` 默认 `raising=True`，直接抛 `AttributeError`，导致 `test_market_bridge_e2e.py` 的 **23 个用例全部在 fixture 阶段报错**。

由于该用例当前不在 PR CI 的 pytest 门禁内，这个回归没有被拦下，已随 #1618 合并进入 `main`。

## 改动

- 删掉这条失效的 `monkeypatch.setattr`。fixture 上方已 patch 的 `plugin_settings.USER_PLUGIN_CONFIG_ROOT` 会被 policy 读取——service 与 bridge 都不再在 import 期冻结根目录。
- 顺带订正 fixture docstring（不再声称 patch bridge 自己的 `USER_PLUGIN_CONFIG_ROOT` 导入）。

## 验证

基于 `main` 复现并修复后：

- `pytest plugin/tests/integration/test_market_bridge_e2e.py` → **23 passed**（修前 23 errors）
- `ruff check` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 优化了测试fixture的配置逻辑，简化了设置方式并移除了不再需要的配置项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->