### PR TITLE
为 compact 聊天输入框中的图片附件增加独立预览视窗，使图片添加后显示在输入框下方，并匹配现有明暗主题样式;统一拖拽图片的导入行为

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5701,7 +5701,7 @@ describe('App', () => {
   it('renders pending composer attachments and removes them through callback', () => {
     const onComposerRemoveAttachment = vi.fn();
 
-    render(
+    const { container } = render(
       <App
         composerAttachments={[
           { id: 'img-1', url: 'data:image/png;base64,aaa', alt: 'Screenshot 1' },
@@ -5710,6 +5710,11 @@ describe('App', () => {
       />,
     );
 
+    const viewport = container.querySelector('.composer-attachment-viewport');
+    expect(viewport).toHaveClass('composer-attachment-viewport-compact');
+    expect(viewport).toHaveAttribute('data-compact-geometry-item', 'attachments');
+    expect(container.querySelector('.compact-chat-surface-shell .composer-attachment-viewport')).toBe(viewport);
+    expect(container.querySelector('.composer-panel > .composer-attachments')).toBeNull();
     expect(screen.getByAltText('Screenshot 1')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Remove image: Screenshot 1' }));
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4903,6 +4903,42 @@ export default function App({
       ) : null}
     </div>
   ) : null;
+  const composerAttachmentPreviewNode = composerAttachments.length > 0 ? (
+    <div
+      className={`composer-attachment-viewport${isCompactSurface ? ' composer-attachment-viewport-compact' : ''}`}
+      aria-label={composerAttachmentsAriaLabel}
+      data-compact-geometry-item={isCompactSurface ? 'attachments' : undefined}
+      data-compact-geometry-owner={isCompactSurface ? 'surface' : undefined}
+      data-compact-no-drag={isCompactSurface ? 'true' : undefined}
+    >
+      <div className="composer-attachments" role="list">
+        {composerAttachments.map((attachment) => (
+          <figure key={attachment.id} className="composer-attachment-card" role="listitem">
+            <img
+              className="composer-attachment-image"
+              src={attachment.url}
+              alt={attachment.alt || ''}
+              loading="lazy"
+            />
+            <button
+              className="composer-attachment-remove"
+              type="button"
+              aria-label={`${removeAttachmentButtonAriaLabel}: ${attachment.alt || attachment.id}`}
+              aria-disabled={composerDisabled}
+              disabled={composerDisabled}
+              onClick={() => {
+                if (!composerDisabled) {
+                  onComposerRemoveAttachment?.(attachment.id);
+                }
+              }}
+            >
+              <span className="composer-attachment-remove-icon" aria-hidden="true" />
+            </button>
+          </figure>
+        ))}
+      </div>
+    </div>
+  ) : null;
 
   const choiceLayerNode = (
     <div
@@ -5227,34 +5263,6 @@ export default function App({
           data-compact-chat-state={effectiveCompactChatState}
         >
           <div id="music-player-mount" />
-          {composerAttachments.length > 0 ? (
-            <div className="composer-attachments" aria-label={composerAttachmentsAriaLabel}>
-              {composerAttachments.map((attachment) => (
-                <figure key={attachment.id} className="composer-attachment-card">
-                  <img
-                    className="composer-attachment-image"
-                    src={attachment.url}
-                    alt={attachment.alt || ''}
-                    loading="lazy"
-                  />
-                  <button
-                    className="composer-attachment-remove"
-                    type="button"
-                    aria-label={`${removeAttachmentButtonAriaLabel}: ${attachment.alt || attachment.id}`}
-                    aria-disabled={composerDisabled}
-                    disabled={composerDisabled}
-                    onClick={() => {
-                      if (!composerDisabled) {
-                        onComposerRemoveAttachment?.(attachment.id);
-                      }
-                    }}
-                  >
-                    脳
-                  </button>
-                </figure>
-              ))}
-            </div>
-          ) : null}
           <form className="composer" onSubmit={(event) => {
             event.preventDefault();
             submitDraft();
@@ -5363,6 +5371,7 @@ export default function App({
                     </>
                   )}
                 </div>
+                {composerAttachmentPreviewNode}
                 {compactInputToolFanNode}
               </div>
             ) : null}

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1098,24 +1098,73 @@ svg {
   display: none;
 }
 
+.composer-attachment-viewport {
+  width: 100%;
+  min-width: 0;
+  padding: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(127, 144, 170, 0.22);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(242, 248, 255, 0.66));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 6px 16px rgba(65, 91, 130, 0.08);
+  backdrop-filter: blur(18px) saturate(1.16);
+  -webkit-backdrop-filter: blur(18px) saturate(1.16);
+}
+
+.composer-attachment-viewport-compact {
+  width: 100%;
+  max-width: var(--compact-surface-active-width);
+  margin-top: 6px;
+  padding: 7px 8px 6px;
+  border-color: rgba(255, 255, 255, 0.5);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.68), rgba(239, 248, 255, 0.56));
+  box-shadow:
+    0 0 0 1px rgba(208, 233, 255, 0.12),
+    0 8px 20px rgba(42, 89, 132, 0.08);
+}
+
 .composer-attachments {
   display: flex;
-  gap: 10px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  max-height: 74px;
   overflow-x: auto;
-  padding-bottom: 2px;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  padding: 1px 1px 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(96, 127, 166, 0.28) transparent;
+}
+
+.composer-attachments::-webkit-scrollbar {
+  height: 5px;
+}
+
+.composer-attachments::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.composer-attachments::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(96, 127, 166, 0.28);
 }
 
 .composer-attachment-card {
   position: relative;
-  width: 90px;
-  height: 90px;
+  width: 68px;
+  height: 68px;
   margin: 0;
   flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid rgba(127, 144, 170, 0.28);
   border-radius: 8px;
-  overflow: visible;
-  border: 2px solid #d7dde6;
-  box-shadow: 0 4px 10px rgba(89, 108, 140, 0.08);
-  background: #fff;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 4px 12px rgba(65, 91, 130, 0.1);
 }
 
 .composer-attachment-image {
@@ -1127,19 +1176,51 @@ svg {
 
 .composer-attachment-remove {
   position: absolute;
-  top: -6px;
-  right: -6px;
-  width: 20px;
-  height: 20px;
-  border: 0;
+  top: 4px;
+  right: 4px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.82);
   border-radius: 999px;
   color: #fff;
-  background: #dc3545;
+  background: rgba(34, 47, 66, 0.72);
   cursor: pointer;
-  font-size: 0.92rem;
-  font-weight: 700;
-  line-height: 1;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 3px 8px rgba(25, 38, 58, 0.22);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: background 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+}
+
+.composer-attachment-remove::before,
+.composer-attachment-remove::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  top: 50%;
+  height: 1.5px;
+  border-radius: 999px;
+  background: currentColor;
+  transform-origin: center;
+}
+
+.composer-attachment-remove::before {
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.composer-attachment-remove::after {
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.composer-attachment-remove:hover:not(:disabled) {
+  background: rgba(220, 53, 69, 0.9);
+  transform: scale(1.06);
+}
+
+.composer-attachment-remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
 }
 
 /* ===== 输入框统一容器 ===== */
@@ -1898,7 +1979,9 @@ body.electron-chat-window.subtitle-web-host > .compact-chat-choice-anchor[data-c
   --compact-surface-active-width: var(--compact-surface-resize-width, var(--compact-surface-width, 430px));
   position: relative;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
   padding-top: 4px;
   width: var(--compact-surface-active-width);
   overflow: visible;
@@ -4060,9 +4143,40 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background: rgba(28, 28, 46, 0.91);
 }
 
+[data-theme="dark"] .composer-attachment-viewport {
+  border-color: rgba(116, 187, 255, 0.18);
+  background: linear-gradient(180deg, rgba(38, 48, 68, 0.72), rgba(23, 35, 50, 0.62));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 8px 20px rgba(0, 0, 0, 0.22);
+}
+
+[data-theme="dark"] .composer-attachment-viewport-compact {
+  border-color: rgba(177, 216, 255, 0.24);
+  background: linear-gradient(180deg, rgba(31, 48, 66, 0.68), rgba(15, 29, 46, 0.6));
+  box-shadow:
+    0 0 0 1px rgba(132, 184, 236, 0.1),
+    0 8px 18px rgba(0, 0, 0, 0.18);
+}
+
+[data-theme="dark"] .composer-attachments {
+  scrollbar-color: rgba(95, 199, 255, 0.38) transparent;
+}
+
+[data-theme="dark"] .composer-attachments::-webkit-scrollbar-thumb {
+  background: rgba(95, 199, 255, 0.38);
+}
+
 [data-theme="dark"] .composer-attachment-card {
-  border-color: #444;
-  background: #2a2a3a;
+  border-color: rgba(116, 187, 255, 0.22);
+  background: rgba(33, 45, 62, 0.82);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.24);
+}
+
+[data-theme="dark"] .composer-attachment-remove {
+  border-color: rgba(222, 240, 255, 0.26);
+  background: rgba(10, 18, 30, 0.72);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.34);
 }
 
 [data-theme="dark"] .composer-tool-btn:hover {

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -209,6 +209,52 @@
         return /\.(avif|bmp|gif|heic|heif|ico|jpe?g|png|tiff?|webp)$/i.test(name);
     }
 
+    function getImageFilesFromFileList(fileList) {
+        return Array.from(fileList || []).filter(function (file) {
+            return file instanceof File && (!file.type || /^image\//i.test(file.type) || isLikelyImageFile(file));
+        });
+    }
+
+    function dataTransferHasFiles(dataTransfer) {
+        if (!dataTransfer) return false;
+        if (dataTransfer.files && dataTransfer.files.length > 0) return true;
+        if (dataTransfer.items && dataTransfer.items.length > 0) {
+            return Array.from(dataTransfer.items).some(function (item) {
+                return item && item.kind === 'file';
+            });
+        }
+        return Array.from(dataTransfer.types || []).indexOf('Files') >= 0;
+    }
+
+    function getFilesFromDataTransfer(dataTransfer) {
+        if (!dataTransfer) return [];
+        var files = Array.from(dataTransfer.files || []);
+        if (files.length > 0) return files;
+        return Array.from(dataTransfer.items || [])
+            .filter(function (item) {
+                return item && item.kind === 'file' && typeof item.getAsFile === 'function';
+            })
+            .map(function (item) {
+                return item.getAsFile();
+            })
+            .filter(function (file) {
+                return file instanceof File;
+            });
+    }
+
+    function isChatImageDropTarget(target) {
+        var targetNode = target instanceof Node ? target : null;
+        var shell = document.getElementById('react-chat-window-shell');
+        if (shell && targetNode && shell.contains(targetNode)) return true;
+        var textInputBox = S && S.dom ? S.dom.textInputBox : null;
+        if (textInputBox && targetNode && textInputBox.contains(targetNode)) return true;
+        return !!(document.body && document.body.classList.contains('electron-chat-window'));
+    }
+
+    function shouldHandleChatFileDrop(event) {
+        return !!(event && isChatImageDropTarget(event.target) && dataTransferHasFiles(event.dataTransfer));
+    }
+
     function isLikelyJpegBlob(blob) {
         if (!blob || typeof blob !== 'object') return false;
         if (/^image\/jpe?g$/i.test(blob.type || '')) return true;
@@ -483,31 +529,7 @@
                 return;
             }
 
-            Promise.allSettled(files.map(mod.importImageFileToPendingList))
-                .then(function (results) {
-                    var succeeded = 0;
-                    var failed = 0;
-                    for (var i = 0; i < results.length; i++) {
-                        if (results[i].status === 'fulfilled') {
-                            succeeded++;
-                        } else {
-                            failed++;
-                            console.error('[导入图片] 单张处理失败:', results[i].reason);
-                        }
-                    }
-                    if (succeeded > 0) {
-                        window.showStatusToast(
-                            window.t ? window.t('app.importImageAdded', { count: succeeded }) : '已添加 ' + succeeded + ' 张图片，发送时会一并带上',
-                            3000
-                        );
-                    }
-                    if (failed > 0) {
-                        window.showStatusToast(
-                            window.t ? window.t('app.importImageFailed') : '导入图片失败',
-                            4000
-                        );
-                    }
-                })
+            mod.importImageFilesToPendingList(files, { logPrefix: '[导入图片]' })
                 .finally(function () {
                     input.value = '';
                 });
@@ -530,6 +552,45 @@
             .then(function (dataUrl) {
                 mod.addScreenshotToList(dataUrl);
                 return dataUrl;
+            });
+    };
+
+    mod.importImageFilesToPendingList = function importImageFilesToPendingList(files, options) {
+        var imageFiles = getImageFilesFromFileList(files);
+        if (!imageFiles.length) {
+            window.showStatusToast(
+                window.t ? window.t('app.importImageFailed') : '导入图片失败',
+                4000
+            );
+            return Promise.resolve({ succeeded: 0, failed: 0 });
+        }
+
+        var logPrefix = options && options.logPrefix ? options.logPrefix : '[导入图片]';
+        return Promise.allSettled(imageFiles.map(mod.importImageFileToPendingList))
+            .then(function (results) {
+                var succeeded = 0;
+                var failed = 0;
+                for (var i = 0; i < results.length; i++) {
+                    if (results[i].status === 'fulfilled') {
+                        succeeded++;
+                    } else {
+                        failed++;
+                        console.error(logPrefix + ' 单张处理失败:', results[i].reason);
+                    }
+                }
+                if (succeeded > 0) {
+                    window.showStatusToast(
+                        window.t ? window.t('app.importImageAdded', { count: succeeded }) : '已添加 ' + succeeded + ' 张图片，发送时会一并带上',
+                        3000
+                    );
+                }
+                if (failed > 0) {
+                    window.showStatusToast(
+                        window.t ? window.t('app.importImageFailed') : '导入图片失败',
+                        4000
+                    );
+                }
+                return { succeeded: succeeded, failed: failed };
             });
     };
 
@@ -3099,6 +3160,28 @@
                 }
             }
         });
+
+        // 图片文件拖到聊天框时按「导入图片」处理，避免浏览器默认打开本地文件。
+        document.addEventListener('dragover', function (e) {
+            if (!shouldHandleChatFileDrop(e)) return;
+            e.preventDefault();
+            e.stopPropagation();
+            if (e.dataTransfer) {
+                e.dataTransfer.dropEffect = isHomeTutorialInteractionLocked() ? 'none' : 'copy';
+            }
+        }, true);
+
+        document.addEventListener('drop', function (e) {
+            if (!shouldHandleChatFileDrop(e)) return;
+            e.preventDefault();
+            e.stopPropagation();
+            if (isHomeTutorialInteractionLocked()) {
+                showHomeTutorialLockedToast();
+                return;
+            }
+            var files = getFilesFromDataTransfer(e.dataTransfer);
+            mod.importImageFilesToPendingList(files, { logPrefix: '[拖放图片]' });
+        }, true);
 
         mod.ensureImportImageInput();
         mod.syncPendingComposerAttachments();

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -211,7 +211,7 @@
 
     function getImageFilesFromFileList(fileList) {
         return Array.from(fileList || []).filter(function (file) {
-            return file instanceof File && (/^image\//i.test(file.type || '') || isLikelyImageFile(file));
+            return file instanceof File && (file.type === '' || isLikelyImageFile(file));
         });
     }
 

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -211,7 +211,7 @@
 
     function getImageFilesFromFileList(fileList) {
         return Array.from(fileList || []).filter(function (file) {
-            return file instanceof File && (!file.type || /^image\//i.test(file.type) || isLikelyImageFile(file));
+            return file instanceof File && (/^image\//i.test(file.type || '') || isLikelyImageFile(file));
         });
     }
 
@@ -223,7 +223,9 @@
                 return item && item.kind === 'file';
             });
         }
-        return Array.from(dataTransfer.types || []).indexOf('Files') >= 0;
+        return Array.from(dataTransfer.types || []).some(function (type) {
+            return /^files$/i.test(String(type || ''));
+        });
     }
 
     function getFilesFromDataTransfer(dataTransfer) {
@@ -556,20 +558,21 @@
     };
 
     mod.importImageFilesToPendingList = function importImageFilesToPendingList(files, options) {
-        var imageFiles = getImageFilesFromFileList(files);
+        var inputFiles = Array.from(files || []);
+        var imageFiles = getImageFilesFromFileList(inputFiles);
         if (!imageFiles.length) {
             window.showStatusToast(
                 window.t ? window.t('app.importImageFailed') : '导入图片失败',
                 4000
             );
-            return Promise.resolve({ succeeded: 0, failed: 0 });
+            return Promise.resolve({ succeeded: 0, failed: inputFiles.length });
         }
 
         var logPrefix = options && options.logPrefix ? options.logPrefix : '[导入图片]';
         return Promise.allSettled(imageFiles.map(mod.importImageFileToPendingList))
             .then(function (results) {
                 var succeeded = 0;
-                var failed = 0;
+                var failed = inputFiles.length - imageFiles.length;
                 for (var i = 0; i < results.length; i++) {
                     if (results[i].status === 'fulfilled') {
                         succeeded++;
@@ -578,13 +581,19 @@
                         console.error(logPrefix + ' 单张处理失败:', results[i].reason);
                     }
                 }
-                if (succeeded > 0) {
+                if (succeeded > 0 && failed > 0) {
+                    window.showStatusToast(
+                        window.t
+                            ? window.t('app.importImagePartial', { success: succeeded, failed: failed })
+                            : '已添加 ' + succeeded + ' 张图片，' + failed + ' 张导入失败',
+                        4000
+                    );
+                } else if (succeeded > 0) {
                     window.showStatusToast(
                         window.t ? window.t('app.importImageAdded', { count: succeeded }) : '已添加 ' + succeeded + ' 张图片，发送时会一并带上',
                         3000
                     );
-                }
-                if (failed > 0) {
+                } else if (failed > 0) {
                     window.showStatusToast(
                         window.t ? window.t('app.importImageFailed') : '导入图片失败',
                         4000

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "Text chatting",
         "capturing": "Capturing...",
         "importImageAdded": "Added {{count}} image(s); they will be sent together",
+        "importImagePartial": "Added {{success}} image(s), {{failed}} failed to import",
         "importImageFailed": "Failed to import image",
         "screenshotAdded": "Screenshot added, click send to send together",
         "screenshotFailed": "Screenshot failed",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "Chat de texto",
         "capturing": "Capturando...",
         "importImageAdded": "Se agregaron {{count}} imágenes; serán enviados juntos",
+        "importImagePartial": "Se agregaron {{success}} imágenes; {{failed}} no se pudieron importar",
         "importImageFailed": "No se pudo importar la imagen",
         "screenshotAdded": "Captura de pantalla agregada, haga clic en enviar para enviar juntos",
         "screenshotFailed": "Error en la captura de pantalla",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "テキストチャット中",
         "capturing": "スクリーンショット中...",
         "importImageAdded": "{{count}} 枚の画像を追加しました。送信時に一緒に送られます",
+        "importImagePartial": "{{success}} 枚の画像を追加しました。{{failed}} 枚の取り込みに失敗しました",
         "importImageFailed": "画像の取り込みに失敗しました",
         "screenshotAdded": "スクリーンショットを追加しました。送信をクリックして一緒に送信",
         "screenshotFailed": "スクリーンショット失敗",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "텍스트 채팅",
         "capturing": "캡처 중...",
         "importImageAdded": "이미지 {{count}}개를 추가했습니다. 전송 시 함께 보내집니다",
+        "importImagePartial": "이미지 {{success}}개를 추가했습니다. {{failed}}개는 가져오기에 실패했습니다",
         "importImageFailed": "이미지 가져오기에 실패했습니다",
         "screenshotAdded": "스크린샷이 추가되었습니다. 함께 보내려면 보내기를 클릭하세요.",
         "screenshotFailed": "스크린샷 실패",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "Bate-papo por texto",
         "capturing": "Capturando...",
         "importImageAdded": "Adicionadas imagens {{count}}; eles serão enviados juntos",
+        "importImagePartial": "Adicionadas {{success}} imagens; {{failed}} falharam ao importar",
         "importImageFailed": "Falha ao importar imagem",
         "screenshotAdded": "Captura de tela adicionada, clique em enviar para enviar juntos",
         "screenshotFailed": "Falha na captura de tela",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "Текстовый чат",
         "capturing": "Захват...",
         "importImageAdded": "Добавлено изображений: {{count}}. Они будут отправлены вместе",
+        "importImagePartial": "Добавлено изображений: {{success}}. Не удалось импортировать: {{failed}}",
         "importImageFailed": "Не удалось импортировать изображение",
         "screenshotAdded": "Скриншот добавлен, нажмите отправить",
         "screenshotFailed": "Ошибка скриншота",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "正在文本聊天中",
         "capturing": "正在截图...",
         "importImageAdded": "已添加 {{count}} 张图片，发送时会一并带上",
+        "importImagePartial": "已添加 {{success}} 张图片，{{failed}} 张导入失败",
         "importImageFailed": "导入图片失败",
         "screenshotAdded": "截图已添加，点击发送一起发送",
         "screenshotFailed": "截图失败",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2110,6 +2110,7 @@
         "textChattingShort": "正在文本聊天中",
         "capturing": "正在截圖...",
         "importImageAdded": "已新增 {{count}} 張圖片，發送時會一併帶上",
+        "importImagePartial": "已新增 {{success}} 張圖片，{{failed}} 張匯入失敗",
         "importImageFailed": "匯入圖片失敗",
         "screenshotAdded": "截圖已添加，點擊發送一起發送",
         "screenshotFailed": "截圖失敗",

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -322,7 +322,7 @@ def test_drop_image_on_chat_imports_pending_attachment_without_navigation(
     assert result["dropDefaultPrevented"] is True
     assert result["hrefAfter"] == result["hrefBefore"]
     assert result["attachmentCount"] == 1
-    assert result["attachmentUrl"].startswith("data:image/")
+    assert result["attachmentUrl"].startswith("data:image/jpeg;base64,")
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -197,23 +197,42 @@ def test_import_image_without_mime_converts_to_jpeg_attachment(
     mock_page: Page,
     running_server: str,
 ):
-    _open_react_chat_page(mock_page, running_server)
-    _install_chat_send_harness(mock_page)
+    mock_page.add_init_script(
+        "window.localStorage.setItem('neko_tutorial_settings', 'seen')"
+    )
+    mock_page.goto(f"{running_server}/chat", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost"
+        " && window.appButtons"
+        " && typeof window.appButtons.importImageFilesToPendingList === 'function'"
+    )
+    mock_page.evaluate(
+        """() => {
+            window.showStatusToast = () => {};
+            if (typeof window.reactChatWindowHost.setComposerAttachments === 'function') {
+                window.reactChatWindowHost.setComposerAttachments([]);
+            }
+        }"""
+    )
 
     import_result = mock_page.evaluate(
         """async () => {
             const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
             const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
             const file = new File([bytes], 'tiny-image', { type: '' });
-            await window.appButtons.importImageFileToPendingList(file);
+            const result = await window.appButtons.importImageFilesToPendingList([file]);
             const state = window.reactChatWindowHost.getState();
             return {
+                succeeded: result.succeeded,
+                failed: result.failed,
                 attachmentCount: state.composerAttachments.length,
                 attachmentUrl: state.composerAttachments[0] && state.composerAttachments[0].url
             };
         }"""
     )
 
+    assert import_result["succeeded"] == 1
+    assert import_result["failed"] == 0
     assert import_result["attachmentCount"] == 1
     attachment_url = import_result["attachmentUrl"]
     assert attachment_url.startswith("data:image/jpeg;base64,")

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -247,8 +247,11 @@ def test_drop_image_on_chat_imports_pending_attachment_without_navigation(
             const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
             const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
             const file = new File([bytes], 'dropped.png', { type: 'image/png' });
-            const target = document.body;
+            const target = document.querySelector('.compact-chat-surface-shell')
+                || document.querySelector('.chat-window')
+                || document.getElementById('react-chat-window-shell');
             if (!target) throw new Error('Missing chat drop target');
+            const hrefBefore = window.location.href;
 
             const createDropEvent = (type) => {
                 const transfer = {
@@ -288,6 +291,8 @@ def test_drop_image_on_chat_imports_pending_attachment_without_navigation(
             return {
                 dragoverDefaultPrevented: dragover.defaultPrevented,
                 dropDefaultPrevented: drop.defaultPrevented,
+                hrefBefore,
+                hrefAfter: window.location.href,
                 attachmentCount: state.composerAttachments.length,
                 attachmentUrl: state.composerAttachments[0] && state.composerAttachments[0].url,
             };
@@ -296,6 +301,7 @@ def test_drop_image_on_chat_imports_pending_attachment_without_navigation(
 
     assert result["dragoverDefaultPrevented"] is True
     assert result["dropDefaultPrevented"] is True
+    assert result["hrefAfter"] == result["hrefBefore"]
     assert result["attachmentCount"] == 1
     assert result["attachmentUrl"].startswith("data:image/")
 

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -220,6 +220,87 @@ def test_import_image_without_mime_converts_to_jpeg_attachment(
 
 
 @pytest.mark.frontend
+def test_drop_image_on_chat_imports_pending_attachment_without_navigation(
+    mock_page: Page,
+    running_server: str,
+):
+    mock_page.add_init_script(
+        "window.localStorage.setItem('neko_tutorial_settings', 'seen')"
+    )
+    mock_page.goto(f"{running_server}/chat", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost"
+        " && window.appButtons"
+        " && typeof window.appButtons.importImageFilesToPendingList === 'function'"
+    )
+    mock_page.evaluate(
+        """() => {
+            window.showStatusToast = () => {};
+            if (typeof window.reactChatWindowHost.setComposerAttachments === 'function') {
+                window.reactChatWindowHost.setComposerAttachments([]);
+            }
+        }"""
+    )
+
+    result = mock_page.evaluate(
+        """async () => {
+            const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
+            const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
+            const file = new File([bytes], 'dropped.png', { type: 'image/png' });
+            const target = document.body;
+            if (!target) throw new Error('Missing chat drop target');
+
+            const createDropEvent = (type) => {
+                const transfer = {
+                    files: [file],
+                    items: [{ kind: 'file', type: file.type, getAsFile: () => file }],
+                    types: ['Files'],
+                    dropEffect: 'move',
+                };
+                const event = new Event(type, { bubbles: true, cancelable: true });
+                Object.defineProperty(event, 'dataTransfer', { value: transfer });
+                return event;
+            };
+
+            const dragover = createDropEvent('dragover');
+            target.dispatchEvent(dragover);
+            const drop = createDropEvent('drop');
+            target.dispatchEvent(drop);
+
+            await new Promise((resolve, reject) => {
+                const started = Date.now();
+                const tick = () => {
+                    const state = window.reactChatWindowHost.getState();
+                    if (state.composerAttachments.length === 1) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - started > 3000) {
+                        reject(new Error('Timed out waiting for dropped image import'));
+                        return;
+                    }
+                    setTimeout(tick, 25);
+                };
+                tick();
+            });
+
+            const state = window.reactChatWindowHost.getState();
+            return {
+                dragoverDefaultPrevented: dragover.defaultPrevented,
+                dropDefaultPrevented: drop.defaultPrevented,
+                attachmentCount: state.composerAttachments.length,
+                attachmentUrl: state.composerAttachments[0] && state.composerAttachments[0].url,
+            };
+        }"""
+    )
+
+    assert result["dragoverDefaultPrevented"] is True
+    assert result["dropDefaultPrevented"] is True
+    assert result["attachmentCount"] == 1
+    assert result["attachmentUrl"].startswith("data:image/")
+
+
+@pytest.mark.frontend
 def test_import_rejects_canvas_data_url_encode_fallback(
     mock_page: Page,
     running_server: str,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -919,8 +919,23 @@ def test_chat_image_file_drop_uses_import_pipeline_and_blocks_browser_navigation
     script = APP_BUTTONS_PATH.read_text(encoding="utf-8")
 
     assert "function getImageFilesFromFileList(fileList)" in script
+    assert "return file instanceof File && (/^image\\//i.test(file.type || '') || isLikelyImageFile(file));" in script
+    assert "!file.type ||" not in script
+    assert "return /^files$/i.test(String(type || ''));" in script
     assert "mod.importImageFilesToPendingList = function importImageFilesToPendingList(files, options)" in script
-    assert "mod.importImageFilesToPendingList(files, { logPrefix: '[导入图片]' })" in script
+    assert "return Promise.resolve({ succeeded: 0, failed: inputFiles.length });" in script
+    assert "window.t('app.importImagePartial', { success: succeeded, failed: failed })" in script
+
+    change_anchor = "input.addEventListener('change', function (event) {"
+    change_block = script.split(change_anchor, 1)[1].split(
+        "mod._importImageInput = input;",
+        1,
+    )[0]
+    assert script.index("function getImageFilesFromFileList(fileList)") < script.index(change_anchor)
+    assert script.index(change_anchor) < script.index(
+        "mod.importImageFilesToPendingList = function importImageFilesToPendingList(files, options)"
+    )
+    assert "mod.importImageFilesToPendingList(files, { logPrefix: '[导入图片]' })" in change_block
 
     drag_block = script.split("document.addEventListener('dragover'", 1)[1].split(
         "document.addEventListener('drop'",

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -913,3 +913,31 @@ def test_compact_history_drop_payload_suppresses_real_send_in_voice_mode_only_at
     assert "compactHistoryDropPayloadQueue = Promise.resolve();" in script
     assert "sendCompactHistoryDropPayloadNow(payload)" in script
     assert "prepareCompactHistoryDropSubmit" in drop_block
+
+
+def test_chat_image_file_drop_uses_import_pipeline_and_blocks_browser_navigation():
+    script = APP_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    assert "function getImageFilesFromFileList(fileList)" in script
+    assert "mod.importImageFilesToPendingList = function importImageFilesToPendingList(files, options)" in script
+    assert "mod.importImageFilesToPendingList(files, { logPrefix: '[导入图片]' })" in script
+
+    drag_block = script.split("document.addEventListener('dragover'", 1)[1].split(
+        "document.addEventListener('drop'",
+        1,
+    )[0]
+    drop_block = script.split("document.addEventListener('drop'", 1)[1].split(
+        "mod.ensureImportImageInput();",
+        1,
+    )[0]
+
+    assert "shouldHandleChatFileDrop(e)" in drag_block
+    assert "e.preventDefault();" in drag_block
+    assert "e.stopPropagation();" in drag_block
+    assert "e.dataTransfer.dropEffect = isHomeTutorialInteractionLocked() ? 'none' : 'copy';" in drag_block
+
+    assert "shouldHandleChatFileDrop(e)" in drop_block
+    assert "e.preventDefault();" in drop_block
+    assert "e.stopPropagation();" in drop_block
+    assert "showHomeTutorialLockedToast();" in drop_block
+    assert "mod.importImageFilesToPendingList(files, { logPrefix: '[拖放图片]' });" in drop_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -919,7 +919,7 @@ def test_chat_image_file_drop_uses_import_pipeline_and_blocks_browser_navigation
     script = APP_BUTTONS_PATH.read_text(encoding="utf-8")
 
     assert "function getImageFilesFromFileList(fileList)" in script
-    assert "return file instanceof File && (/^image\\//i.test(file.type || '') || isLikelyImageFile(file));" in script
+    assert "return file instanceof File && (file.type === '' || isLikelyImageFile(file));" in script
     assert "!file.type ||" not in script
     assert "return /^files$/i.test(String(type || ''));" in script
     assert "mod.importImageFilesToPendingList = function importImageFilesToPendingList(files, options)" in script


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持将图片拖放到聊天框以批量导入为待发送附件，并提供导入统计反馈（部分/全部/失败提示）。

* **改进**
  * 优化待发送附件预览的紧凑布局与视觉样式（尺寸、间距、边框、阴影与毛玻璃、滚动行为）。
  * 调整附件预览的渲染位置与移除交互（更紧凑的移除按钮与禁用处理），并增强暗色模式表现。

* **本地化**
  * 增加“部分图片导入成功”多语种提示文本。

* **测试**
  * 新增与更新拖放导入及导入管线的单元和端到端测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->