### PR TITLE
fix(chat): stabilize mobile compact chat resizing

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -122,6 +122,7 @@ const COMPACT_INPUT_TOOL_FAN_INTERACTIVE_DELAY_MS = 220;
 const COMPACT_INPUT_TOOL_FAN_TRANSIENT_CLOSE_DELAY_MS = 360;
 const COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS = 650;
 const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 430;
+const COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280;
 const COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
 const COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER = 32;
 const COMPACT_CHOICE_PLACEMENT_HYSTERESIS = 24;
@@ -318,12 +319,16 @@ type DesktopCompactChoicePlacementLayout = {
   } | null;
 };
 
-function clampCompactSurfaceResizeWidth(width: number, maxAvailableWidth: number): number {
+function clampCompactSurfaceResizeWidth(
+  width: number,
+  maxAvailableWidth: number,
+  minAvailableWidth = COMPACT_SURFACE_RESIZE_MIN_WIDTH,
+): number {
   const maxWidth = Math.max(
     0,
     Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, maxAvailableWidth - COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER),
   );
-  const minWidth = Math.min(COMPACT_SURFACE_RESIZE_MIN_WIDTH, maxWidth || COMPACT_SURFACE_RESIZE_MIN_WIDTH);
+  const minWidth = Math.min(minAvailableWidth, maxWidth || minAvailableWidth);
   return Math.round(Math.max(minWidth, Math.min(width, Math.max(minWidth, maxWidth))));
 }
 
@@ -1437,9 +1442,18 @@ export default function App({
     }
     return window.innerWidth || COMPACT_SURFACE_RESIZE_MIN_WIDTH + COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER;
   }, []);
+  const getCompactSurfaceResizeMinAvailableWidth = useCallback(() => (
+    !document.body?.classList.contains('electron-chat-window') && window.innerWidth <= 768
+      ? COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH
+      : COMPACT_SURFACE_RESIZE_MIN_WIDTH
+  ), []);
   const getClampedCompactSurfaceResizeWidth = useCallback((width: number) => (
-    clampCompactSurfaceResizeWidth(width, getCompactSurfaceResizeMaxAvailableWidth())
-  ), [getCompactSurfaceResizeMaxAvailableWidth]);
+    clampCompactSurfaceResizeWidth(
+      width,
+      getCompactSurfaceResizeMaxAvailableWidth(),
+      getCompactSurfaceResizeMinAvailableWidth(),
+    )
+  ), [getCompactSurfaceResizeMaxAvailableWidth, getCompactSurfaceResizeMinAvailableWidth]);
   const getClampedCompactSurfaceResizeWidthForSide = useCallback((
     side: CompactSurfaceResizeSide,
     width: number,
@@ -1465,11 +1479,15 @@ export default function App({
         ? resizeState.anchorRightScreen - areaLeft
         : areaRight - resizeState.anchorLeftScreen;
       if (Number.isFinite(maxWidth) && maxWidth > 0) {
-        return clampCompactSurfaceResizeWidth(width, maxWidth + COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER);
+        return clampCompactSurfaceResizeWidth(
+          width,
+          maxWidth + COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER,
+          getCompactSurfaceResizeMinAvailableWidth(),
+        );
       }
     }
     return getClampedCompactSurfaceResizeWidth(width);
-  }, [getClampedCompactSurfaceResizeWidth]);
+  }, [getCompactSurfaceResizeMinAvailableWidth, getClampedCompactSurfaceResizeWidth]);
   const getCurrentCompactSurfaceWidth = useCallback(() => {
     const rectWidth = compactInputShellRef.current?.getBoundingClientRect().width;
     if (Number.isFinite(rectWidth) && rectWidth && rectWidth > 0) {
@@ -1481,8 +1499,8 @@ export default function App({
     if (Number.isFinite(cssWidth) && cssWidth > 0) {
       return getClampedCompactSurfaceResizeWidth(cssWidth);
     }
-    return COMPACT_SURFACE_RESIZE_MIN_WIDTH;
-  }, [getClampedCompactSurfaceResizeWidth]);
+    return getCompactSurfaceResizeMinAvailableWidth();
+  }, [getCompactSurfaceResizeMinAvailableWidth, getClampedCompactSurfaceResizeWidth]);
   const compactSurfaceEffectiveWidth = isCompactSurface
     && compactSurfaceResizeWidth !== null
     ? getClampedCompactSurfaceResizeWidth(compactSurfaceResizeWidth)

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -125,6 +125,7 @@ const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 430;
 const COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280;
 const COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
 const COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER = 32;
+const COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER = 16;
 const COMPACT_CHOICE_PLACEMENT_HYSTERESIS = 24;
 const COMPOSER_OPTION_MARQUEE_MIN_DISTANCE = 6;
 const COMPOSER_OPTION_MARQUEE_MIN_DURATION_MS = 1400;
@@ -323,10 +324,11 @@ function clampCompactSurfaceResizeWidth(
   width: number,
   maxAvailableWidth: number,
   minAvailableWidth = COMPACT_SURFACE_RESIZE_MIN_WIDTH,
+  viewportGutter = COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER,
 ): number {
   const maxWidth = Math.max(
     0,
-    Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, maxAvailableWidth - COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER),
+    Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, maxAvailableWidth - viewportGutter),
   );
   const minWidth = Math.min(minAvailableWidth, maxWidth || minAvailableWidth);
   return Math.round(Math.max(minWidth, Math.min(width, Math.max(minWidth, maxWidth))));
@@ -1443,17 +1445,33 @@ export default function App({
     return window.innerWidth || COMPACT_SURFACE_RESIZE_MIN_WIDTH + COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER;
   }, []);
   const getCompactSurfaceResizeMinAvailableWidth = useCallback(() => (
-    !document.body?.classList.contains('electron-chat-window') && window.innerWidth <= 768
+    !document.body?.classList.contains('electron-chat-window')
+      && !document.body?.classList.contains('lanlan-pet-mode')
+      && !(window as typeof window & { __LANLAN_IS_ELECTRON_PET__?: boolean }).__LANLAN_IS_ELECTRON_PET__
+      && window.innerWidth <= 768
       ? COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH
       : COMPACT_SURFACE_RESIZE_MIN_WIDTH
+  ), []);
+  const getCompactSurfaceResizeViewportGutter = useCallback(() => (
+    !document.body?.classList.contains('electron-chat-window')
+      && !document.body?.classList.contains('lanlan-pet-mode')
+      && !(window as typeof window & { __LANLAN_IS_ELECTRON_PET__?: boolean }).__LANLAN_IS_ELECTRON_PET__
+      && window.innerWidth <= 768
+      ? COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER
+      : COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER
   ), []);
   const getClampedCompactSurfaceResizeWidth = useCallback((width: number) => (
     clampCompactSurfaceResizeWidth(
       width,
       getCompactSurfaceResizeMaxAvailableWidth(),
       getCompactSurfaceResizeMinAvailableWidth(),
+      getCompactSurfaceResizeViewportGutter(),
     )
-  ), [getCompactSurfaceResizeMaxAvailableWidth, getCompactSurfaceResizeMinAvailableWidth]);
+  ), [
+    getCompactSurfaceResizeMaxAvailableWidth,
+    getCompactSurfaceResizeMinAvailableWidth,
+    getCompactSurfaceResizeViewportGutter,
+  ]);
   const getClampedCompactSurfaceResizeWidthForSide = useCallback((
     side: CompactSurfaceResizeSide,
     width: number,
@@ -1479,15 +1497,21 @@ export default function App({
         ? resizeState.anchorRightScreen - areaLeft
         : areaRight - resizeState.anchorLeftScreen;
       if (Number.isFinite(maxWidth) && maxWidth > 0) {
+        const viewportGutter = getCompactSurfaceResizeViewportGutter();
         return clampCompactSurfaceResizeWidth(
           width,
-          maxWidth + COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER,
+          maxWidth + viewportGutter,
           getCompactSurfaceResizeMinAvailableWidth(),
+          viewportGutter,
         );
       }
     }
     return getClampedCompactSurfaceResizeWidth(width);
-  }, [getCompactSurfaceResizeMinAvailableWidth, getClampedCompactSurfaceResizeWidth]);
+  }, [
+    getCompactSurfaceResizeMinAvailableWidth,
+    getCompactSurfaceResizeViewportGutter,
+    getClampedCompactSurfaceResizeWidth,
+  ]);
   const getCurrentCompactSurfaceWidth = useCallback(() => {
     const rectWidth = compactInputShellRef.current?.getBoundingClientRect().width;
     if (Number.isFinite(rectWidth) && rectWidth && rectWidth > 0) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -511,7 +511,10 @@
 
     function getCompactSurfaceMobileWidthBounds() {
         var viewportWidth = Math.max(1, window.innerWidth || 0);
-        var viewportMax = Math.max(1, viewportWidth - COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER);
+        var viewportMax = Math.max(
+            1,
+            Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, viewportWidth - COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER)
+        );
         var minWidth = Math.min(COMPACT_SURFACE_MOBILE_MIN_WIDTH, viewportMax);
         return {
             minWidth: Math.round(minWidth),

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -243,6 +243,8 @@
     var COMPACT_MINIMIZE_BALL_AVATAR_VERTICAL_RATIO = 0.58;
     var COMPACT_SURFACE_MAX_WIDTH = 430;
     var COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
+    var COMPACT_SURFACE_MOBILE_MIN_WIDTH = 280;
+    var COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER = 16;
     var COMPACT_SURFACE_VIEWPORT_PAD_X = 16;
     var COMPACT_SURFACE_VIEWPORT_PAD_TOP = 12;
     var COMPACT_SURFACE_VIEWPORT_PAD_BOTTOM = 18;
@@ -507,7 +509,20 @@
         return false;
     }
 
+    function getCompactSurfaceMobileWidthBounds() {
+        var viewportWidth = Math.max(1, window.innerWidth || 0);
+        var viewportMax = Math.max(1, viewportWidth - COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER);
+        var minWidth = Math.min(COMPACT_SURFACE_MOBILE_MIN_WIDTH, viewportMax);
+        return {
+            minWidth: Math.round(minWidth),
+            maxWidth: Math.round(Math.max(minWidth, viewportMax))
+        };
+    }
+
     function getCompactSurfaceResizeMaxWidth() {
+        if (isMobileWidth()) {
+            return getCompactSurfaceMobileWidthBounds().maxWidth;
+        }
         return Math.max(
             COMPACT_SURFACE_MAX_WIDTH,
             Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, window.innerWidth - (COMPACT_SURFACE_VIEWPORT_PAD_X * 2))
@@ -517,15 +532,18 @@
     function getCompactSurfaceMetrics() {
         var shell = getShell();
         var rect = getCompactSurfaceBaseRect() || (shell ? normalizeCompactDomRect(shell.getBoundingClientRect()) : null);
+        var mobileWidthBounds = isMobileWidth() ? getCompactSurfaceMobileWidthBounds() : null;
         var defaultWidth = isMobileWidth()
-            ? Math.max(280, window.innerWidth - 16)
+            ? mobileWidthBounds.maxWidth
             : Math.min(COMPACT_SURFACE_MAX_WIDTH, Math.max(280, window.innerWidth - (COMPACT_SURFACE_VIEWPORT_PAD_X * 2)));
         var measuredWidth = rect && rect.width > 0 ? rect.width : 0;
         var storedWidth = loadCompactSurfaceStoredWidth();
-        var width = Math.round(Math.min(
-            Math.max(defaultWidth, measuredWidth, storedWidth || 0),
-            getCompactSurfaceResizeMaxWidth()
-        ));
+        var width = isMobileWidth() && storedWidth
+            ? storedWidth
+            : Math.round(Math.min(
+                Math.max(defaultWidth, measuredWidth, storedWidth || 0),
+                getCompactSurfaceResizeMaxWidth()
+            ));
         var height = rect && rect.height > 0 ? rect.height : COMPACT_SURFACE_DEFAULT_HEIGHT;
         return {
             width: width,
@@ -585,7 +603,10 @@
             var width = Number(parsed && parsed.width);
             if (!Number.isFinite(width) || width <= 0) return null;
             var maxWidth = getCompactSurfaceResizeMaxWidth();
-            return Math.round(Math.max(COMPACT_SURFACE_MAX_WIDTH, Math.min(width, maxWidth)));
+            var minWidth = isMobileWidth()
+                ? getCompactSurfaceMobileWidthBounds().minWidth
+                : COMPACT_SURFACE_MAX_WIDTH;
+            return Math.round(Math.max(minWidth, Math.min(width, maxWidth)));
         } catch (_) {
             return null;
         }
@@ -942,11 +963,14 @@
                 ? (currentRect.left + currentRect.width) - minLeft
                 : maxRight - currentRect.left;
         }
+        var minWidth = isMobileWidth()
+            ? getCompactSurfaceMobileWidthBounds().minWidth
+            : COMPACT_SURFACE_MAX_WIDTH;
         var maxWidth = Math.max(
-            COMPACT_SURFACE_MAX_WIDTH,
-            Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, sideMax)
+            minWidth,
+            Math.min(getCompactSurfaceResizeMaxWidth(), sideMax)
         );
-        return Math.round(Math.max(COMPACT_SURFACE_MAX_WIDTH, Math.min(width, maxWidth)));
+        return Math.round(Math.max(minWidth, Math.min(width, maxWidth)));
     }
 
     function applyCompactSurfaceResizeRequest(detail) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -5131,9 +5131,10 @@
             startDrag(event.touches[0].clientX, event.touches[0].clientY, {
                 compactSurface: true
             });
-            event.preventDefault();
-            event.stopPropagation();
-        }, { capture: true, passive: false });
+            // Do not preventDefault on touchstart: a stationary tap on the
+            // compact capsule must still synthesize click so React can enter
+            // input mode. Real drags are blocked in touchmove below.
+        }, { capture: true, passive: true });
 
         document.addEventListener('mousemove', function (event) {
             if (!dragState) return;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -3086,12 +3086,13 @@ body.react-chat-window-dragging {
     }
 
     body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
-        width: calc(100vw - 16px) !important;
-        left: 8px !important;
-        right: 8px;
+        width: var(--compact-surface-width, calc(100vw - 16px)) !important;
+        left: var(--compact-surface-left, 8px) !important;
+        right: auto;
         bottom: 8px !important;
         margin-left: 0 !important;
         transform: none !important;
+        overflow: visible;
     }
 
     body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell #react-chat-window-root {
@@ -3099,6 +3100,11 @@ body.react-chat-window-dragging {
         flex: 1 1 auto;
         overflow: hidden;
         min-height: 0;
+    }
+
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root,
+    body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .chat-window.chat-surface-mode-compact {
+        overflow: visible;
     }
 
     body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .app-shell {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1183,8 +1183,12 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     pointer-events: auto;
 }
 
+/* Compact history pass-through contract: the broad surface rule above re-enables
+   hit-testing for all surface descendants, so every transparent history wrapper
+   must be reset to none. Only visible bubbles, controls, and preview are auto. */
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-panel,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-scroll,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-scroll-content,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-message {
     pointer-events: none;

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -311,8 +311,13 @@ def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
     )[0]
 
     assert "COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280" in app_source
+    assert "COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER = 16" in app_source
     assert "getCompactSurfaceResizeMinAvailableWidth" in app_source
+    assert "getCompactSurfaceResizeViewportGutter" in app_source
+    assert "maxAvailableWidth - viewportGutter" in app_source
     assert "window.innerWidth <= 768" in app_source
+    assert "lanlan-pet-mode" in app_source
+    assert "__LANLAN_IS_ELECTRON_PET__" in app_source
     assert "COMPACT_SURFACE_MOBILE_MIN_WIDTH = 280" in script
     assert "COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER" in script
     assert "isMobileWidth() && storedWidth" in metrics_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -282,6 +282,49 @@ def test_compact_surface_resize_handles_keep_width_in_dom_geometry_contract():
     assert "right: -4px;" in styles
 
 
+def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+    styles = STATIC_INDEX_CSS_PATH.read_text(encoding="utf-8")
+    app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
+
+    mobile_compact_block = css_block(
+        styles,
+        'body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {',
+        'body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell #react-chat-window-root',
+    )
+    mobile_compact_overflow_block = css_block(
+        styles,
+        'body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root,',
+        'body:not(.electron-chat-window):where(:not(.lanlan-pet-mode)) #react-chat-window-shell .app-shell',
+    )
+    metrics_block = script.split("function getCompactSurfaceMetrics()", 1)[1].split(
+        "function clampCompactSurfacePosition(left, top, metrics)",
+        1,
+    )[0]
+    stored_width_block = script.split("function loadCompactSurfaceStoredWidth()", 1)[1].split(
+        "function saveCompactSurfacePosition",
+        1,
+    )[0]
+    resize_clamp_block = script.split("function clampCompactSurfaceResizeWidthForSide", 1)[1].split(
+        "function applyCompactSurfaceResizeRequest",
+        1,
+    )[0]
+
+    assert "COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280" in app_source
+    assert "getCompactSurfaceResizeMinAvailableWidth" in app_source
+    assert "window.innerWidth <= 768" in app_source
+    assert "COMPACT_SURFACE_MOBILE_MIN_WIDTH = 280" in script
+    assert "COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER" in script
+    assert "isMobileWidth() && storedWidth" in metrics_block
+    assert "getCompactSurfaceMobileWidthBounds().minWidth" in stored_width_block
+    assert "getCompactSurfaceMobileWidthBounds().minWidth" in resize_clamp_block
+    assert "width: var(--compact-surface-width, calc(100vw - 16px)) !important;" in mobile_compact_block
+    assert "left: var(--compact-surface-left, 8px) !important;" in mobile_compact_block
+    assert "right: auto;" in mobile_compact_block
+    assert ".chat-window.chat-surface-mode-compact" in mobile_compact_overflow_block
+    assert "overflow: visible;" in mobile_compact_overflow_block
+
+
 def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -310,7 +310,7 @@ def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
         1,
     )[0]
     mobile_width_bounds_block = script.split("function getCompactSurfaceMobileWidthBounds()", 1)[1].split(
-        "function getCompactSurfaceResizeMaxWidth",
+        "function getCompactSurfaceResizeMaxWidth()",
         1,
     )[0]
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -309,6 +309,10 @@ def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
         "function applyCompactSurfaceResizeRequest",
         1,
     )[0]
+    mobile_width_bounds_block = script.split("function getCompactSurfaceMobileWidthBounds()", 1)[1].split(
+        "function getCompactSurfaceResizeMaxWidth",
+        1,
+    )[0]
 
     assert "COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280" in app_source
     assert "COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER = 16" in app_source
@@ -320,6 +324,8 @@ def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
     assert "__LANLAN_IS_ELECTRON_PET__" in app_source
     assert "COMPACT_SURFACE_MOBILE_MIN_WIDTH = 280" in script
     assert "COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER" in script
+    assert "COMPACT_SURFACE_RESIZE_MAX_WIDTH" in mobile_width_bounds_block
+    assert "viewportWidth - COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER" in mobile_width_bounds_block
     assert "isMobileWidth() && storedWidth" in metrics_block
     assert "getCompactSurfaceMobileWidthBounds().minWidth" in stored_width_block
     assert "getCompactSurfaceMobileWidthBounds().minWidth" in resize_clamp_block
@@ -862,41 +868,43 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
 def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_through():
     styles = STATIC_INDEX_CSS_PATH.read_text(encoding="utf-8")
 
-    broad_surface_selector = (
+    compact_surface_prefix = (
         'body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):'
-        'not(.is-collapsing):not(.is-expanding) [data-compact-geometry-owner="surface"] *'
+        'not(.is-collapsing):not(.is-expanding)'
     )
-    history_anchor_selector = (
-        'body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):'
-        'not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor'
+    broad_surface_rule = (
+        f'{compact_surface_prefix} [data-compact-geometry-owner="surface"],\n'
+        f'{compact_surface_prefix} [data-compact-geometry-owner="surface"] *,\n'
+        f'{compact_surface_prefix} #reactChatWindowMinimizeButton,\n'
+        f'{compact_surface_prefix} #reactChatWindowMinimizeButton *,\n'
+        f'{compact_surface_prefix} .compact-input-tool-fan[data-compact-input-tool-fan-open="true"],\n'
+        f'{compact_surface_prefix} .compact-input-tool-fan[data-compact-input-tool-fan-open="true"] * {{\n'
+        "    pointer-events: auto;\n"
+        "}"
     )
-    history_bubble_selector = (
-        'body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):'
-        'not(.is-collapsing):not(.is-expanding) .compact-export-history-bubble'
+    history_passthrough_rule = (
+        f'{compact_surface_prefix} .compact-export-history-anchor,\n'
+        f'{compact_surface_prefix} .compact-export-history-panel,\n'
+        f'{compact_surface_prefix} .compact-export-history-scroll,\n'
+        f'{compact_surface_prefix} .compact-export-history-scroll-content,\n'
+        f'{compact_surface_prefix} .compact-export-history-message {{\n'
+        "    pointer-events: none;\n"
+        "}"
+    )
+    history_interactive_rule = (
+        f'{compact_surface_prefix} .compact-export-history-bubble,\n'
+        f'{compact_surface_prefix} .compact-export-history-controls,\n'
+        f'{compact_surface_prefix} .compact-export-preview-region {{\n'
+        "    pointer-events: auto;\n"
+        "}"
     )
 
-    assert broad_surface_selector in styles
-    assert history_anchor_selector in styles
-    assert history_bubble_selector in styles
-    assert styles.index(broad_surface_selector) < styles.index(history_anchor_selector)
-
-    passthrough_block = styles.split(history_anchor_selector, 1)[1].split(history_bubble_selector, 1)[0]
-    interactive_block = styles.split(history_bubble_selector, 1)[1].split(
-        'body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #reactChatWindowMinimizeButton',
-        1,
-    )[0]
-
-    for selector in (
-        ".compact-export-history-panel",
-        ".compact-export-history-scroll",
-        ".compact-export-history-scroll-content",
-        ".compact-export-history-message",
-    ):
-        assert selector in passthrough_block
-    assert "pointer-events: none;" in passthrough_block
-    assert ".compact-export-history-controls" in interactive_block
-    assert ".compact-export-preview-region" in interactive_block
-    assert "pointer-events: auto;" in interactive_block
+    assert broad_surface_rule in styles
+    assert history_passthrough_rule in styles
+    assert history_interactive_rule in styles
+    assert styles.index(broad_surface_rule) < styles.index(history_passthrough_rule)
+    assert styles.index(history_passthrough_rule) < styles.index(history_interactive_rule)
+    assert ".compact-export-history-scroll,\n" in history_passthrough_rule
 
 
 def test_compact_inline_export_uses_windowless_app_chat_export_api():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -552,6 +552,10 @@ def test_compact_surface_drag_uses_declared_surface_and_no_drag_exclusions():
     )[0]
     assert "if (!isCompactDragSurfaceTarget(event.target)) return;" in touch_block
     assert "compactSurface: true" in touch_block
+    assert "compact capsule must still synthesize click" in touch_block
+    assert "event.preventDefault();" not in touch_block
+    assert "event.stopPropagation();" not in touch_block
+    assert "}, { capture: true, passive: true });" in touch_block
 
 
 def test_moved_drag_suppresses_trailing_release_click():


### PR DESCRIPTION
## 概要

修复网页端手机模式下 compact 聊天框的尺寸边界、拖拽预览一致性、点击进入输入态，以及历史区域透明层阻挡页面点击/拖拽的问题。

## 主要改动

- 调整手机网页端 compact surface 的宽度上下限，避免一拖动就异常变大或占满。
- 对齐 React 预览 clamp 与宿主落地 clamp：
  - 移动端 gutter 统一为 16px。
  - 移动端最大宽度不超过共享 resize 上限 720px。
  - Electron / Electron Pet 窗口继续走桌面规则。
- 修复手机网页端点击 compact 胶囊无法进入输入态的问题。
- 恢复 compact 历史区域透明 wrapper 的点击穿透，避免透明区域阻挡下层页面点击、拖拽和触摸。
- 加硬静态测试，锁定移动端尺寸合同和历史透明区域 pointer-events 级联顺序，防止后续误改。

## 验证

- `bash build_frontend.sh`
- `node --check static/app-react-chat-window.js`
- `.venv/bin/python -m pytest tests/unit/test_react_chat_window_static.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化移动端紧凑聊天面板的宽度/缩放约束：引入移动端最小宽度与视口边距的动态回调并在裁剪链路中生效，确保小屏幕不会被裁剪过窄；恢复/限制用户存储宽度时的移动端下限并对上限作约束。

* **Style**
  * 紧凑模式改用 CSS 变量控制宽度/位置，设为 right: auto 与 overflow: visible；为导出历史层添加 pointer-events: none 以实现透传命中。

* **Tests**
  * 新增/更新单元测试，覆盖移动端宽度边界、布局变量、触控拖拽与合成点击行为（touchstart 不阻止且为 passive）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->