### PR TITLE
fix(card-assist): 避免建议模式误改角色卡字段

### DIFF
--- a/config/prompts/prompts_card_assist.py
+++ b/config/prompts/prompts_card_assist.py
@@ -204,15 +204,17 @@ CARD_ASSIST_CHAT_SYSTEM_PROMPT = {
 
 工作方式：
 1) 用 1-3 句话自然地回复用户。语气活泼可爱，可以适度撒娇、用「喵~」「呐」等语气词，但别太腻
-2) 如果用户的话语**明确**暗示要修改/补充/删除某个字段，把这些操作打包成 actions 列表
+2) 只有当用户**明确要求你直接动手改字段**时，才把这些操作打包成 actions 列表
 3) 操作合法的 type 只有这三种：
    - "refine_field"  —— 改写某个已有字段的值（field_key 必须在「可用字段 key」里）
    - "add_field"     —— 新增一个字段（field_key 可以是新的中文/英文名）
    - "remove_field"  —— 删除某个字段
 4) 绝对不可以触及保留字段：档案名 / voice_id / system_prompt / live2d / live3d / vrm / mmd / model_type
-5) 如果用户只是闲聊、问问题、或者还没明确说要改什么，actions 留空数组 []
+5) 如果用户是在要建议、让你审稿、分析优缺点、指出问题、提供修改方向、给候选写法，或者只是闲聊/问问题，但**没有明确要求你立刻改字段**，actions 一律留空数组 []
 6) reply 用用户的语言回复（用户用中文你就用中文，用户用英文你就用英文）
-7) 严格按 JSON 返回，禁止 markdown 代码块、禁止任何前后缀文字：
+7) 判断标准要保守：宁可少出 actions，也不要把“给建议”误判成“直接改字段”
+8) reply 不要使用 Markdown 格式符号做强调或排版，例如 `*`、`**`、`#`、`__`
+9) 严格按 JSON 返回，禁止 markdown 代码块、禁止任何前后缀文字：
 
 {
   "reply": "你给用户的话",
@@ -230,15 +232,17 @@ Available field keys (use these **verbatim** — do NOT translate or re-case):
 
 How you work:
 1) Reply naturally in 1-3 sentences. Tone should be playful and cute, occasionally using "meow~" / "nya" tics — but don't overdo it.
-2) If the user's message **clearly** implies a change to a specific field, pack those edits into the actions list.
+2) Only put edits into the actions list when the user **explicitly wants you to directly change fields right now**.
 3) Action types allowed (only these three):
    - "refine_field"  — overwrite an existing field's value (field_key must be in the "Available field keys" list)
    - "add_field"     — add a new field (field_key may be a new name)
    - "remove_field"  — delete a field
 4) NEVER touch reserved fields: 档案名 / voice_id / system_prompt / live2d / live3d / vrm / mmd / model_type
-5) If the user is just chatting / asking questions / hasn't asked for a change yet, leave actions as an empty array [].
+5) If the user is asking for advice, critique, review, pros/cons, problem-spotting, improvement directions, or candidate rewrites, or is just chatting / asking questions, but has **not explicitly asked you to apply edits now**, leave actions as an empty array [].
 6) Match the user's language in the reply (Chinese in, Chinese out; English in, English out).
-7) Return STRICT JSON only — no markdown fences, no preface or suffix text:
+7) Be conservative: when uncertain, prefer returning fewer actions rather than accidentally treating "give suggestions" as "edit the fields now".
+8) Do not use Markdown emphasis or formatting markers in the reply, such as `*`, `**`, `#`, or `__`.
+9) Return STRICT JSON only — no markdown fences, no preface or suffix text:
 
 {
   "reply": "your message to the user",

--- a/config/prompts/prompts_card_assist.py
+++ b/config/prompts/prompts_card_assist.py
@@ -253,6 +253,18 @@ How you work:
 }
 
 
+CARD_ASSIST_CHAT_ADVICE_ONLY_DIRECTIVE = {
+    "zh": (
+        "\n\n本轮是“只读建议”模式：你可以点评、指出问题、给出修改方向或候选写法，"
+        "但绝对不要提交任何字段修改动作。返回时 actions 必须是空数组 []。"
+    ),
+    "en": (
+        "\n\nThis turn is advice-only mode: you may critique the card and suggest directions or "
+        "candidate rewrites, but you must not submit any field-edit actions. Return actions as []."
+    ),
+}
+
+
 def get_card_assist_clarify_prompt(lang: str = "zh") -> str:
     return _loc(CARD_ASSIST_CLARIFY_PROMPT, lang)
 
@@ -267,3 +279,7 @@ def get_card_assist_refine_field_prompt(lang: str = "zh") -> str:
 
 def get_card_assist_chat_system_prompt(lang: str = "zh") -> str:
     return _loc(CARD_ASSIST_CHAT_SYSTEM_PROMPT, lang)
+
+
+def get_card_assist_chat_advice_only_directive(lang: str = "zh") -> str:
+    return _loc(CARD_ASSIST_CHAT_ADVICE_ONLY_DIRECTIVE, lang)

--- a/main_routers/card_assist_router.py
+++ b/main_routers/card_assist_router.py
@@ -724,7 +724,7 @@ _CHAT_ADVICE_ONLY_INTENT_RE = re.compile(
 
 _CHAT_DIRECT_EDIT_REQUEST_RE = re.compile(
     r"(直接|现在|立刻|马上|帮我|替我|给我)?\s*"
-    r"(改一下|改一改|修改一下|调整一下|改成|修改成|换成|写成|写进|应用|采纳|"
+    r"(改一下|改下|改一改|修改一下|调整一下|调整下|改成|修改成|换成|写成|写进|应用|采纳|"
     r"更新字段|保存到字段|直接改|帮我改|替我改|"
     r"apply|make\s+the\s+changes|edit\s+the\s+field|update\s+the\s+field|change\s+it\s+to)",
     re.IGNORECASE,
@@ -739,7 +739,11 @@ def _latest_user_text(history: list[dict]) -> str:
 
 
 def _chat_text_requests_edits(text: str) -> bool:
-    return bool(_CHAT_EDIT_INTENT_RE.search(text or ""))
+    text = text or ""
+    return bool(
+        _CHAT_EDIT_INTENT_RE.search(text)
+        or _CHAT_DIRECT_EDIT_REQUEST_RE.search(text)
+    )
 
 
 def _chat_text_requests_full_rewrite(text: str) -> bool:

--- a/main_routers/card_assist_router.py
+++ b/main_routers/card_assist_router.py
@@ -27,6 +27,7 @@ from fastapi.responses import JSONResponse
 
 from config import CHARACTER_RESERVED_FIELDS
 from config.prompts.prompts_card_assist import (
+    get_card_assist_chat_advice_only_directive,
     get_card_assist_chat_system_prompt,
     get_card_assist_clarify_prompt,
     get_card_assist_generate_prompt,
@@ -714,16 +715,19 @@ _CHAT_REWRITE_VERB_RE = re.compile(
     re.IGNORECASE,
 )
 
-_CHAT_ADVICE_ONLY_DIRECTIVE = {
-    "zh": (
-        "\n\n本轮是“只读建议”模式：你可以点评、指出问题、给出修改方向或候选写法，"
-        "但绝对不要提交任何字段修改动作。返回时 actions 必须是空数组 []。"
-    ),
-    "en": (
-        "\n\nThis turn is advice-only mode: you may critique the card and suggest directions or "
-        "candidate rewrites, but you must not submit any field-edit actions. Return actions as []."
-    ),
-}
+_CHAT_ADVICE_ONLY_INTENT_RE = re.compile(
+    r"(建议|意见|点评|审一下|审稿|检查一下|帮我看看|看一下|指出问题|分析|优缺点|"
+    r"修改方向|修改方案|候选写法|suggest|suggestion|advice|critique|review|"
+    r"pros\s+and\s+cons|candidate\s+rewrite)",
+    re.IGNORECASE,
+)
+
+_CHAT_DIRECT_EDIT_REQUEST_RE = re.compile(
+    r"(直接|现在|立刻|马上|帮我|替我|给我)?\s*"
+    r"(改成|修改成|换成|写成|写进|应用|采纳|更新字段|保存到字段|直接改|帮我改|替我改|"
+    r"apply|make\s+the\s+changes|edit\s+the\s+field|update\s+the\s+field|change\s+it\s+to)",
+    re.IGNORECASE,
+)
 
 
 def _latest_user_text(history: list[dict]) -> str:
@@ -743,6 +747,15 @@ def _chat_text_requests_full_rewrite(text: str) -> bool:
     return bool(
         _CHAT_FULL_REWRITE_RE.search(text)
         and _CHAT_REWRITE_VERB_RE.search(text)
+    )
+
+
+def _chat_text_requests_advice_only(text: str) -> bool:
+    if not text:
+        return False
+    return bool(
+        _CHAT_ADVICE_ONLY_INTENT_RE.search(text)
+        and not _CHAT_DIRECT_EDIT_REQUEST_RE.search(text)
     )
 
 
@@ -1018,7 +1031,10 @@ async def chat(request: Request):
     target_keys = _resolve_target_keys(body, locale_code, current_card)
     target_keys_text = " / ".join(target_keys)
     latest_user = _latest_user_text(history)
-    advice_only = body.get("advice_only") is True
+    advice_only = (
+        body.get("advice_only") is True
+        or _chat_text_requests_advice_only(latest_user)
+    )
 
     dev_cat_name = str(body.get("dev_cat_name") or _DEFAULT_DEV_CAT_NAME).strip()
     if not dev_cat_name or len(dev_cat_name) > 40:
@@ -1029,7 +1045,7 @@ async def chat(request: Request):
         dev_cat_name, current_card_text, target_keys_text
     )
     if advice_only:
-        system_content += _CHAT_ADVICE_ONLY_DIRECTIVE["zh" if lang == "zh" else "en"]
+        system_content += get_card_assist_chat_advice_only_directive(lang)
     # 聊天回复 + actions 里的字段值也用目标语言（Codex #3331696257）
     system_content += _output_language_directive(locale_code)
 

--- a/main_routers/card_assist_router.py
+++ b/main_routers/card_assist_router.py
@@ -724,7 +724,8 @@ _CHAT_ADVICE_ONLY_INTENT_RE = re.compile(
 
 _CHAT_DIRECT_EDIT_REQUEST_RE = re.compile(
     r"(直接|现在|立刻|马上|帮我|替我|给我)?\s*"
-    r"(改成|修改成|换成|写成|写进|应用|采纳|更新字段|保存到字段|直接改|帮我改|替我改|"
+    r"(改一下|改一改|修改一下|调整一下|改成|修改成|换成|写成|写进|应用|采纳|"
+    r"更新字段|保存到字段|直接改|帮我改|替我改|"
     r"apply|make\s+the\s+changes|edit\s+the\s+field|update\s+the\s+field|change\s+it\s+to)",
     re.IGNORECASE,
 )

--- a/main_routers/card_assist_router.py
+++ b/main_routers/card_assist_router.py
@@ -714,6 +714,17 @@ _CHAT_REWRITE_VERB_RE = re.compile(
     re.IGNORECASE,
 )
 
+_CHAT_ADVICE_ONLY_DIRECTIVE = {
+    "zh": (
+        "\n\n本轮是“只读建议”模式：你可以点评、指出问题、给出修改方向或候选写法，"
+        "但绝对不要提交任何字段修改动作。返回时 actions 必须是空数组 []。"
+    ),
+    "en": (
+        "\n\nThis turn is advice-only mode: you may critique the card and suggest directions or "
+        "candidate rewrites, but you must not submit any field-edit actions. Return actions as []."
+    ),
+}
+
 
 def _latest_user_text(history: list[dict]) -> str:
     for msg in reversed(history):
@@ -1007,6 +1018,7 @@ async def chat(request: Request):
     target_keys = _resolve_target_keys(body, locale_code, current_card)
     target_keys_text = " / ".join(target_keys)
     latest_user = _latest_user_text(history)
+    advice_only = body.get("advice_only") is True
 
     dev_cat_name = str(body.get("dev_cat_name") or _DEFAULT_DEV_CAT_NAME).strip()
     if not dev_cat_name or len(dev_cat_name) > 40:
@@ -1016,6 +1028,8 @@ async def chat(request: Request):
     system_content = system_template % (
         dev_cat_name, current_card_text, target_keys_text
     )
+    if advice_only:
+        system_content += _CHAT_ADVICE_ONLY_DIRECTIVE["zh" if lang == "zh" else "en"]
     # 聊天回复 + actions 里的字段值也用目标语言（Codex #3331696257）
     system_content += _output_language_directive(locale_code)
 
@@ -1049,18 +1063,20 @@ async def chat(request: Request):
         if len(reply) > _CHAT_MAX_MESSAGE_CHARS:
             reply = reply[:_CHAT_MAX_MESSAGE_CHARS] + "…"
         actions = _sanitize_actions(parsed.get("actions"))
+        if advice_only:
+            actions = []
     elif parsed is not None:
         warning = "llm_bad_shape"
 
     if not reply and content and not isinstance(parsed, dict):
         reply = (content or "")[:_CHAT_MAX_MESSAGE_CHARS]
 
-    edit_intent = _chat_text_requests_edits(latest_user)
+    edit_intent = False if advice_only else _chat_text_requests_edits(latest_user)
     # 前端「重写整张卡」quick action 透传的 locale 无关 flag 优先——本地化文案（es/ja/ko/pt/
     # ru/zh-TW 的「重写」措辞）正则匹配不到，只靠 _chat_text_requests_full_rewrite 会漏判，
     # _complete_full_rewrite_actions 补全通路不触发、部分 action 被当部分重写存下（Codex
     # #3333137718）。同时保留文本启发式，兼容用户手敲的全量重写措辞。
-    full_rewrite_intent = (
+    full_rewrite_intent = (not advice_only) and (
         body.get("full_rewrite") is True
         or _chat_text_requests_full_rewrite(latest_user)
     )

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -7331,6 +7331,7 @@ margin-top: 10px;
     animation: cardCompanionWindowIn 0.22s ease-out;
     transition: box-shadow 0.22s ease, background 0.22s ease, opacity 0.22s ease;
     resize: both;
+    -webkit-app-region: no-drag;
 }
 
 @keyframes cardCompanionWindowIn {
@@ -7420,6 +7421,7 @@ margin-top: 10px;
 
 .card-companion-panel.card-companion-dragging {
     user-select: none;
+    z-index: 100100;
     box-shadow: 0 22px 52px rgba(64, 197, 241, 0.3);
     animation-play-state: paused;
     will-change: left, top;

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -11053,11 +11053,11 @@ function _companionBuildPanel(state) {
         { label: _cardAssistT('character.aiCompanionQuickAdvice', '💡 给点建议'),
           send: _cardAssistT('character.aiCompanionQuickAdviceMsg',
                 '看一下当前的角色设定，给我几条具体的改进建议吧。'),
-          requireMode: 'chat' },
+          requireMode: 'chat', adviceOnly: true },
         { label: _cardAssistT('character.aiCompanionQuickCheck', '🔍 帮我审一下'),
           send: _cardAssistT('character.aiCompanionQuickCheckMsg',
-                '审一下角色设定有没有矛盾、空泛或者重复的地方，并提出修改方案。'),
-          requireMode: 'chat' },
+                '审一下角色设定有没有矛盾、空泛或者重复的地方。'),
+          requireMode: 'chat', adviceOnly: true },
         { label: _cardAssistT('character.aiCompanionQuickRegen', '🎲 重写整张卡'),
           send: _cardAssistT('character.aiCompanionQuickRegenMsg',
                 '把所有可见字段都按原本的角色定位重新写一遍。'),
@@ -11077,6 +11077,7 @@ function _companionBuildPanel(state) {
             // 文案——ja/ko/pt/ru/es/zh-TW 的「重写」措辞匹配不到，后端 _complete_full_rewrite_actions
             // 补全通路就不会触发，部分 action 列表会被当部分重写存下去（Codex #3333137718）。
             state._pendingFullRewrite = !!qa.fullRewrite;
+            state._pendingAdviceOnly = !!qa.adviceOnly;
             input.value = qa.send;
             _companionSubmit(state);
         });
@@ -11529,6 +11530,10 @@ async function _companionRunChat(state) {
     // 残留、被下一条普通聊天消息误当成整卡重写（CodeRabbit #3333410664）。
     const fullRewrite = state._pendingFullRewrite === true;
     state._pendingFullRewrite = false;
+    // 「给建议 / 帮我审一下」属于只读分析，不该顺手自动改表单；和 full_rewrite 一样做一次性消费，
+    // 避免某次 advice 请求 early-return 后把标记泄漏到下一条普通聊天消息（本次回归）。
+    const adviceOnly = state._pendingAdviceOnly === true;
+    state._pendingAdviceOnly = false;
     const typing = _companionAppendTyping(state);
     try {
         if (!_companionEnsureLiveForm(state)) {
@@ -11558,6 +11563,7 @@ async function _companionRunChat(state) {
             target_field_keys: _cardAssistCollectFieldKeys(state.form),
             dev_cat_name: state.devCatName,
             locale: _cardAssistCurrentLocale(),
+            advice_only: adviceOnly,
             full_rewrite: fullRewrite,
         });
         // closed-companion guard：同 clarify/generate，关掉 companion 之后
@@ -11966,6 +11972,19 @@ function _companionTruncate(s, n) {
     return s.length > n ? s.slice(0, n) + '…' : s;
 }
 
+function _cardAssistNormalizeDisplayText(text) {
+    let s = String(text == null ? '' : text);
+    // Companion bubbles render plain text, so stray markdown markers look broken.
+    // Strip the common emphasis markers and normalize markdown bullet prefixes.
+    s = s.replace(/^\s{0,3}#{1,6}\s+/gm, '');
+    s = s.replace(/^\s*[*-]\s+/gm, '• ');
+    s = s.replace(/\*\*([^*]+)\*\*/g, '$1');
+    s = s.replace(/__([^_]+)__/g, '$1');
+    s = s.replace(/(^|[^\w])\*([^*\n]+)\*(?=[^\w]|$)/g, '$1$2');
+    s = s.replace(/(^|[^\w])_([^_\n]+)_(?=[^\w]|$)/g, '$1$2');
+    return s;
+}
+
 // ========== Bubble 工厂 ==========
 
 function _companionScrollToBottom(state) {
@@ -11990,7 +12009,7 @@ function _companionAppendAssistant(state, text, opts) {
 
     const body = document.createElement('div');
     body.className = 'card-companion-bubble-body';
-    body.textContent = text || '';
+    body.textContent = _cardAssistNormalizeDisplayText(text);
     body.style.whiteSpace = 'pre-wrap';
     bubble.appendChild(body);
 
@@ -12065,7 +12084,7 @@ function _companionAppendUser(state, text) {
 function _companionAppendSystem(state, text) {
     const bubble = document.createElement('div');
     bubble.className = 'card-companion-bubble-system';
-    bubble.textContent = text || '';
+    bubble.textContent = _cardAssistNormalizeDisplayText(text);
     state.threadEl.appendChild(bubble);
     _companionScrollToBottom(state);
     return bubble;

--- a/tests/unit/test_card_assist_action_recovery.py
+++ b/tests/unit/test_card_assist_action_recovery.py
@@ -255,3 +255,40 @@ def test_chat_action_only_json_does_not_echo_raw_json(monkeypatch):
     assert body["success"] is True
     assert body["reply"] == ""
     assert body["actions"][0]["field_key"] == "招牌台词"
+
+
+def test_chat_advice_only_discards_actions_and_skips_recovery(monkeypatch):
+    monkeypatch.setattr(car, "_reject_untrusted_card_assist", lambda *_args, **_kwargs: None)
+
+    async def fake_invoke_detailed(prompt):
+        assert "只读建议" in prompt[0]["content"]
+        return (
+            '{"reply":"这里有两点建议：一是补具体习惯，二是把关系张力写得更实。","actions":[{"type":"refine_field","field_key":"行为特征","value":"会偷偷把咖啡杯按顺序摆整齐"}]}',
+            None,
+        )
+
+    async def fake_invoke(_prompt):
+        raise AssertionError("advice_only should not trigger action recovery")
+
+    monkeypatch.setattr(car, "_invoke_assist_detailed", fake_invoke_detailed)
+    monkeypatch.setattr(car, "_invoke_assist", fake_invoke)
+
+    app = FastAPI()
+    app.include_router(car.router)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/card-assist/chat",
+            json={
+                "messages": [{"role": "user", "content": "看一下当前的角色设定，给我几条具体的改进建议吧。"}],
+                "current_card": {"行为特征": "很认真", "人际关系": "和家人关系很好"},
+                "target_field_keys": ["行为特征", "人际关系"],
+                "locale": "zh-CN",
+                "advice_only": True,
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["reply"].startswith("这里有两点建议")
+    assert body["actions"] == []

--- a/tests/unit/test_card_assist_action_recovery.py
+++ b/tests/unit/test_card_assist_action_recovery.py
@@ -292,3 +292,42 @@ def test_chat_advice_only_discards_actions_and_skips_recovery(monkeypatch):
     assert body["success"] is True
     assert body["reply"].startswith("这里有两点建议")
     assert body["actions"] == []
+
+
+def test_chat_advice_style_text_skips_recovery_without_flag(monkeypatch):
+    monkeypatch.setattr(
+        car, "_reject_untrusted_card_assist", lambda *_args, **_kwargs: None
+    )
+
+    async def fake_invoke_detailed(prompt):
+        assert "只读建议" in prompt[0]["content"]
+        return (
+            "可以先把行为特征写得更具体，比如补一个固定小习惯；"
+            "人际关系也建议加一点冲突张力。",
+            None,
+        )
+
+    async def fake_invoke(_prompt):
+        raise AssertionError("manual advice-style text should not trigger action recovery")
+
+    monkeypatch.setattr(car, "_invoke_assist_detailed", fake_invoke_detailed)
+    monkeypatch.setattr(car, "_invoke_assist", fake_invoke)
+
+    app = FastAPI()
+    app.include_router(car.router)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/card-assist/chat",
+            json={
+                "messages": [{"role": "user", "content": "帮我审一下并提出修改方案"}],
+                "current_card": {"行为特征": "很认真", "人际关系": "和家人关系很好"},
+                "target_field_keys": ["行为特征", "人际关系"],
+                "locale": "zh-CN",
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["reply"].startswith("可以先把行为特征")
+    assert body["actions"] == []

--- a/tests/unit/test_card_assist_action_recovery.py
+++ b/tests/unit/test_card_assist_action_recovery.py
@@ -331,3 +331,47 @@ def test_chat_advice_style_text_skips_recovery_without_flag(monkeypatch):
     assert body["success"] is True
     assert body["reply"].startswith("可以先把行为特征")
     assert body["actions"] == []
+
+
+def test_chat_advice_with_direct_edit_phrase_still_recovers_actions(monkeypatch):
+    monkeypatch.setattr(
+        car, "_reject_untrusted_card_assist", lambda *_args, **_kwargs: None
+    )
+
+    async def fake_invoke_detailed(prompt):
+        assert "只读建议" not in prompt[0]["content"]
+        return ("我先分析一下：行为特征偏空，可以补一个具体习惯喵。", None)
+
+    async def fake_invoke(prompt):
+        assert "先分析再改一下字段" in prompt
+        return (
+            '{"actions":[{"type":"refine_field","field_key":"行为特征",'
+            '"value":"会偷偷把咖啡杯按顺序摆整齐","reason":"补充具体习惯"}]}',
+            None,
+        )
+
+    monkeypatch.setattr(car, "_invoke_assist_detailed", fake_invoke_detailed)
+    monkeypatch.setattr(car, "_invoke_assist", fake_invoke)
+
+    app = FastAPI()
+    app.include_router(car.router)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/card-assist/chat",
+            json={
+                "messages": [{"role": "user", "content": "先分析再改一下字段"}],
+                "current_card": {"行为特征": "很认真", "人际关系": "和家人关系很好"},
+                "target_field_keys": ["行为特征", "人际关系"],
+                "locale": "zh-CN",
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["actions"] == [{
+        "type": "refine_field",
+        "field_key": "行为特征",
+        "reason": "补充具体习惯",
+        "value": "会偷偷把咖啡杯按顺序摆整齐",
+    }]

--- a/tests/unit/test_card_assist_action_recovery.py
+++ b/tests/unit/test_card_assist_action_recovery.py
@@ -343,7 +343,7 @@ def test_chat_advice_with_direct_edit_phrase_still_recovers_actions(monkeypatch)
         return ("我先分析一下：行为特征偏空，可以补一个具体习惯喵。", None)
 
     async def fake_invoke(prompt):
-        assert "先分析再改一下字段" in prompt
+        assert "先帮我分析一下，然后把行为特征改下" in prompt
         return (
             '{"actions":[{"type":"refine_field","field_key":"行为特征",'
             '"value":"会偷偷把咖啡杯按顺序摆整齐","reason":"补充具体习惯"}]}',
@@ -359,7 +359,10 @@ def test_chat_advice_with_direct_edit_phrase_still_recovers_actions(monkeypatch)
         resp = client.post(
             "/api/card-assist/chat",
             json={
-                "messages": [{"role": "user", "content": "先分析再改一下字段"}],
+                "messages": [{
+                    "role": "user",
+                    "content": "先帮我分析一下，然后把行为特征改下",
+                }],
                 "current_card": {"行为特征": "很认真", "人际关系": "和家人关系很好"},
                 "target_field_keys": ["行为特征", "人际关系"],
                 "locale": "zh-CN",
@@ -369,6 +372,7 @@ def test_chat_advice_with_direct_edit_phrase_still_recovers_actions(monkeypatch)
     assert resp.status_code == 200
     body = resp.json()
     assert body["success"] is True
+    assert body["reply"].startswith("我先分析一下")
     assert body["actions"] == [{
         "type": "refine_field",
         "field_key": "行为特征",


### PR DESCRIPTION
## 摘要

修复角色卡 AI 陪伴助手在“给点建议 / 帮我审一下”等只读场景下，可能把建议误判成字段编辑动作的问题，并优化 companion 面板拖拽时的窗口表现。

## 变更点

- 为 card assist chat 增加 `advice_only` 只读建议模式，前端 quick action 会显式透传该标记，后端在该模式下强制丢弃 actions，并跳过编辑意图恢复与整卡重写补全。
- 收紧中英文 chat system prompt：只有用户明确要求“直接改字段”时才允许返回 actions；建议、审稿、候选写法等场景必须保持 actions 为空。
- 清理 companion 气泡中的常见 Markdown 强调/标题/列表符号，避免纯文本气泡里出现破碎的 `**`、`#` 等标记。
- 禁用 companion 面板的 Electron app-region drag，并提高拖拽态 z-index，避免拖拽时被窗口拖动区域或其他浮层干扰。
- 增加 advice-only 回归测试，覆盖模型返回 actions 时仍应丢弃，并确保不会触发 action recovery。

## 测试

- `UV_CACHE_DIR=/Users/stg-mba002/N.E.K.O/.uv-cache uv run pytest tests/unit/test_card_assist_action_recovery.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“建议模式（advice only）”指令模板与前端触发选项，允许显式请求仅提供建议且不提交任何字段修改。

* **改进**
  * 收紧何时生成可执行动作的规则：仅在用户明确要求时才返回动作，未显式请求时强制返回空动作并禁用编辑意图与全量重写分支。
  * 聊天气泡文本归一化，移除或规范 Markdown 标记以改善可读性。

* **问题修复**
  * 阻止面板区域参与窗口拖拽并提升拖拽时层级显示。

* **测试**
  * 新增单元测试覆盖建议模式与行为，验证不触发动作恢复且返回空动作列表。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->