### PR TITLE
fix(docker): 修复 embedding 模型下载触发 HF 429 导致 Docker Build 失败

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,6 +41,12 @@ config/user_preferences.json
 config/voice_storage.json
 N.E.K.O/
 
+# Embedding model weights: the image downloads the pinned revision in
+# docker/Dockerfile's pre-copy layer (step 5b), so the later `COPY . /app` must
+# not drag a developer's locally-prepared (possibly stale/partial) copy over the
+# verified download. Also trims build-context upload size.
+data/embedding_models
+
 # Build artifacts
 build/
 dist/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,6 +119,34 @@ RUN mkdir -p /root/.config/uv && \
       'url = "https://pypi.tuna.tsinghua.edu.cn/simple/"' \
       > /root/.config/uv/uv.toml
 
+# 5b. Bundle the local embedding model BEFORE copying the source tree.
+# Keying this layer on the model ARGs + the downloader script alone — instead of
+# on every source change via the `COPY . /app` below — keeps it cached across
+# commits, so it only re-downloads when the pin changes. Previously this sat
+# AFTER `COPY . /app`, re-ran on every commit, and kept tripping huggingface.co's
+# per-IP rate limit (HTTP 429), failing the build. The build context excludes
+# data/embedding_models, so the later `COPY . /app` does not clobber these
+# weights. Pure-stdlib downloader run on the system python3 (the uv venv is not
+# built yet); honors the proxy ARGs. repo+revision are pinned identically to
+# .github/workflows/build-desktop.yml so every build path resolves the same
+# on-disk profile. Standard image ships only the int8 variant (the runtime
+# `auto` default) to stay lightweight; the full image bundles fp32 too.
+ARG EMBEDDING_MODEL_REPO=jinaai/jina-embeddings-v5-text-nano-retrieval
+ARG EMBEDDING_MODEL_REVISION=ac5d898c8d382b17167c33e5c8af644a3519b47d
+ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
+COPY scripts/prepare_embedding_model.py /app/scripts/prepare_embedding_model.py
+RUN cd /app && \
+    if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
+    if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
+    python3 scripts/prepare_embedding_model.py \
+        --repo "$EMBEDDING_MODEL_REPO" \
+        --revision "$EMBEDDING_MODEL_REVISION" \
+        --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \
+        --output-root data/embedding_models \
+        --variant int8 && \
+    unset http_proxy && \
+    unset https_proxy
+
 # 6. Copy N.E.K.O. project from local build context (with correct ownership)
 COPY --chown=neko:neko . /app
 
@@ -138,28 +166,6 @@ RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
     uv sync --frozen && \
-    unset http_proxy && \
-    unset https_proxy
-
-# 8b. Bundle the local embedding model so vectors work out-of-the-box (offline).
-# Without this the image ships no weights and EmbeddingService sticky-disables
-# at first load (NO_MODEL_FILE) — vector recall / fact dedup silently degrade.
-# repo+revision are pinned identically to .github/workflows/build-desktop.yml so
-# every build path resolves the same on-disk profile. Standard image ships only
-# the int8 variant (the runtime `auto` default) to stay lightweight; the full
-# image bundles fp32 too. Pure-stdlib downloader; needs network (honors proxy ARGs).
-ARG EMBEDDING_MODEL_REPO=jinaai/jina-embeddings-v5-text-nano-retrieval
-ARG EMBEDDING_MODEL_REVISION=ac5d898c8d382b17167c33e5c8af644a3519b47d
-ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
-RUN cd /app && \
-    if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
-    if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    uv run --no-sync python scripts/prepare_embedding_model.py \
-        --repo "$EMBEDDING_MODEL_REPO" \
-        --revision "$EMBEDDING_MODEL_REVISION" \
-        --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \
-        --output-root data/embedding_models \
-        --variant int8 && \
     unset http_proxy && \
     unset https_proxy
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -190,6 +190,34 @@ RUN mkdir -p /root/.config/uv && \
       'url = "https://pypi.tuna.tsinghua.edu.cn/simple/"' \
       > /root/.config/uv/uv.toml
 
+# 5b. Bundle the local embedding model BEFORE copying the source tree.
+# Keying this layer on the model ARGs + the downloader script alone — instead of
+# on every source change via the `COPY . /app` below — keeps it cached across
+# commits, so it only re-downloads when the pin changes. Previously this sat
+# AFTER `COPY . /app`, re-ran on every commit, and kept tripping huggingface.co's
+# per-IP rate limit (HTTP 429), failing the build. The build context excludes
+# data/embedding_models, so the later `COPY . /app` does not clobber these
+# weights. Pure-stdlib downloader run on the system python3 (the uv venv is not
+# built yet); honors the proxy ARGs. repo+revision are pinned identically to
+# .github/workflows/build-desktop.yml so every build path resolves the same
+# on-disk profile. `--variant both` ships int8 (the runtime `auto` default) AND
+# fp32 weights so a VECTORS_QUANTIZATION=fp32 override also works.
+ARG EMBEDDING_MODEL_REPO=jinaai/jina-embeddings-v5-text-nano-retrieval
+ARG EMBEDDING_MODEL_REVISION=ac5d898c8d382b17167c33e5c8af644a3519b47d
+ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
+COPY scripts/prepare_embedding_model.py /app/scripts/prepare_embedding_model.py
+RUN cd /app && \
+    if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
+    if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
+    python3 scripts/prepare_embedding_model.py \
+        --repo "$EMBEDDING_MODEL_REPO" \
+        --revision "$EMBEDDING_MODEL_REVISION" \
+        --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \
+        --output-root data/embedding_models \
+        --variant both && \
+    unset http_proxy && \
+    unset https_proxy
+
 # 6. Copy N.E.K.O. project from local build context (with correct ownership)
 COPY --chown=neko:neko . /app
 
@@ -210,28 +238,6 @@ RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
     uv sync --frozen && \
-    unset http_proxy && \
-    unset https_proxy
-
-# 8b. Bundle the local embedding model so vectors work out-of-the-box (offline).
-# Without this the image ships no weights and EmbeddingService sticky-disables
-# at first load (NO_MODEL_FILE) — vector recall / fact dedup silently degrade.
-# repo+revision are pinned identically to .github/workflows/build-desktop.yml so
-# every build path resolves the same on-disk profile. `--variant both` ships the
-# int8 (default) AND fp32 weights so a VECTORS_QUANTIZATION=fp32 override also
-# works. Pure-stdlib downloader; needs network (honors the proxy ARGs).
-ARG EMBEDDING_MODEL_REPO=jinaai/jina-embeddings-v5-text-nano-retrieval
-ARG EMBEDDING_MODEL_REVISION=ac5d898c8d382b17167c33e5c8af644a3519b47d
-ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
-RUN cd /app && \
-    if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
-    if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    uv run --no-sync python scripts/prepare_embedding_model.py \
-        --repo "$EMBEDDING_MODEL_REPO" \
-        --revision "$EMBEDDING_MODEL_REVISION" \
-        --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \
-        --output-root data/embedding_models \
-        --variant both && \
     unset http_proxy && \
     unset https_proxy
 

--- a/scripts/prepare_embedding_model.py
+++ b/scripts/prepare_embedding_model.py
@@ -9,9 +9,11 @@ builds all share the same on-disk layout.
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import re
+import socket
 import sys
 import time
 import urllib.error
@@ -111,16 +113,30 @@ def _download(url: str, dest: Path, *, force: bool) -> None:
             retryable = exc.code in _RETRYABLE_STATUS
             if not retryable or attempt == _MAX_ATTEMPTS:
                 raise RuntimeError(f"failed to download {url}: {exc}") from exc
-            delay = _retry_after_seconds(exc) or _backoff_seconds(attempt)
+            # Cap Retry-After too: a server-sent `Retry-After: 3600` would
+            # otherwise sleep past the job timeout instead of failing within
+            # the bounded backoff window.
+            delay = min(_retry_after_seconds(exc) or _backoff_seconds(attempt), _BACKOFF_CAP_SECONDS)
             reason = f"HTTP {exc.code}"
-        except urllib.error.URLError as exc:
-            # Connection reset / DNS / timeout — transient, worth a retry.
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            socket.timeout,
+            ConnectionError,
+            http.client.IncompleteRead,
+        ) as exc:
+            # Transient network failures. urlopen()'s timeout only covers the
+            # connect phase and wraps connect errors in URLError, but a stall
+            # during response.read() of a large ONNX file surfaces as
+            # socket.timeout / TimeoutError / IncompleteRead — none of which
+            # subclass URLError, so they must be caught explicitly or they would
+            # abort the build on the first attempt instead of retrying.
             if tmp.exists():
                 tmp.unlink()
             if attempt == _MAX_ATTEMPTS:
                 raise RuntimeError(f"failed to download {url}: {exc}") from exc
             delay = _backoff_seconds(attempt)
-            reason = str(exc.reason)
+            reason = str(getattr(exc, "reason", exc)) or exc.__class__.__name__
 
         print(
             f"[embedding-model] attempt {attempt}/{_MAX_ATTEMPTS} for {url} "

--- a/scripts/prepare_embedding_model.py
+++ b/scripts/prepare_embedding_model.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -21,6 +22,16 @@ from pathlib import Path
 DEFAULT_PROFILE_ID = "local-text-retrieval-v1"
 DEFAULT_OUTPUT_ROOT = Path("data") / "embedding_models"
 PREPARED_MARKER = ".prepared.json"
+
+# Download resilience. huggingface.co rate-limits by source IP, and the Docker
+# build runs several arch/variant jobs from a shared proxy egress, so a single
+# urlopen routinely hit HTTP 429 and killed the whole build with no recovery.
+# Retry transient failures (429 / 5xx / connection errors) with exponential
+# backoff, honoring a numeric Retry-After when the server sends one.
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+_MAX_ATTEMPTS = 5
+_BACKOFF_BASE_SECONDS = 2.0
+_BACKOFF_CAP_SECONDS = 60.0
 # 40-char lowercase hex git SHA. Tags / branch refs / short SHAs are rejected
 # so the profile id stays a strict compatibility contract — anything that can
 # move under our feet, even tags (which can be force-pushed), is excluded.
@@ -51,6 +62,27 @@ def _iter_files(variant: str) -> list[str]:
     return list(FILES_BY_VARIANT[variant])
 
 
+def _retry_after_seconds(exc: urllib.error.HTTPError) -> float | None:
+    """Return the Retry-After delay in seconds, if the server sent a numeric one.
+
+    Only the delta-seconds form is honored. The HTTP-date form is valid per spec
+    but rare from huggingface.co; rather than parse dates we fall back to plain
+    exponential backoff for it.
+    """
+    headers = getattr(exc, "headers", None)
+    raw = headers.get("Retry-After") if headers else None
+    if not raw:
+        return None
+    raw = raw.strip()
+    if raw.isdigit():
+        return float(raw)
+    return None
+
+
+def _backoff_seconds(attempt: int) -> float:
+    return min(_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)), _BACKOFF_CAP_SECONDS)
+
+
 def _download(url: str, dest: Path, *, force: bool) -> None:
     if dest.exists() and dest.stat().st_size > 0 and not force:
         print(f"[embedding-model] keep existing {dest}")
@@ -59,20 +91,42 @@ def _download(url: str, dest: Path, *, force: bool) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     tmp = dest.with_suffix(dest.suffix + ".tmp")
     print(f"[embedding-model] download {url}")
-    try:
-        with urllib.request.urlopen(url, timeout=120) as response:
-            with tmp.open("wb") as f:
-                while True:
-                    chunk = response.read(1024 * 1024)
-                    if not chunk:
-                        break
-                    f.write(chunk)
-    except urllib.error.URLError as exc:
-        if tmp.exists():
-            tmp.unlink()
-        raise RuntimeError(f"failed to download {url}: {exc}") from exc
-    os.replace(tmp, dest)
-    print(f"[embedding-model] wrote {dest} ({dest.stat().st_size} bytes)")
+
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=120) as response:
+                with tmp.open("wb") as f:
+                    while True:
+                        chunk = response.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+            os.replace(tmp, dest)
+            print(f"[embedding-model] wrote {dest} ({dest.stat().st_size} bytes)")
+            return
+        except urllib.error.HTTPError as exc:
+            # HTTPError is a subclass of URLError, so this branch must precede it.
+            if tmp.exists():
+                tmp.unlink()
+            retryable = exc.code in _RETRYABLE_STATUS
+            if not retryable or attempt == _MAX_ATTEMPTS:
+                raise RuntimeError(f"failed to download {url}: {exc}") from exc
+            delay = _retry_after_seconds(exc) or _backoff_seconds(attempt)
+            reason = f"HTTP {exc.code}"
+        except urllib.error.URLError as exc:
+            # Connection reset / DNS / timeout — transient, worth a retry.
+            if tmp.exists():
+                tmp.unlink()
+            if attempt == _MAX_ATTEMPTS:
+                raise RuntimeError(f"failed to download {url}: {exc}") from exc
+            delay = _backoff_seconds(attempt)
+            reason = str(exc.reason)
+
+        print(
+            f"[embedding-model] attempt {attempt}/{_MAX_ATTEMPTS} for {url} "
+            f"failed ({reason}); retrying in {delay:.0f}s"
+        )
+        time.sleep(delay)
 
 
 def _verify(profile_dir: Path, files: list[str]) -> None:


### PR DESCRIPTION
## 问题

`Docker Build` workflow 近期持续失败，根因是构建镜像时下载 embedding 模型撞上 HuggingFace 按 IP 限流（HTTP 429）。

最近三次失败（`26932973108` / `26924499642` / `26923577179`）每次都精确命中同一行：

```
RuntimeError: failed to download https://huggingface.co/jinaai/jina-embeddings-v5-text-nano-retrieval/.../tokenizer.json: HTTP Error 429: Too Many Requests
```

失败链条：`scripts/prepare_embedding_model.py` 在 build 阶段从 huggingface.co 现下模型，单次 `urlopen` 无重试 → 碰 429 直接 `raise` → `build-standard (linux/amd64)` 挂 → 矩阵 fail-fast 取消 arm64 → `create-manifests` 报 `not found`。

> 旁注：apt 连 `mirrors.aliyun.com` 报 `certificate is NOT trusted` 是代理 TLS 拦截，apt 降级成 `W:` 警告用缓存索引，**不影响成败**，本 PR 不动。

## 改动

**A. 下载器加重试（治标）** — `scripts/prepare_embedding_model.py`
对 `429 / 500 / 502 / 503 / 504` 和连接错误做指数退避重试（2→4→8→16→32s，封顶 60s，最多 5 次），尊重数字型 `Retry-After`；`404` 等不可重试错误仍立即抛出。保持纯 stdlib，无新依赖。

**B. Dockerfile 层序（治本）** — `docker/Dockerfile`、`docker/Dockerfile.full`
把模型下载层从 `COPY . /app` 之后移到之前，单独 `COPY` 下载脚本并用系统 `python3` 执行（uv venv 此时还没建）。该层缓存键只依赖模型 ARG + 脚本内容，跨 commit 命中 GHA cache，不再每次 push 都打 HF。构建上下文不含 `data/embedding_models`，后续 `COPY . /app` 不会覆盖已下权重。标准镜像 `int8`、full 镜像 `both` 行为不变。

## 验证

- ✅ 重试逻辑单测：429 重试后成功 / 持续 429 耗尽抛错 / 404 不重试 / Retry-After 解析 / 退避有界，全过。
- ✅ `python -m py_compile` 语法通过。
- ⚠️ Docker Build workflow PR 不触发（设计如此），合并前会用 `workflow_dispatch --ref` 对本分支手动跑一次验证镜像能 build 通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 将本地嵌入模型的打包步骤移至镜像构建早期，使用系统 Python 下载并仅打包 int8 变体；构建后修复文件所有权并在镜像忽略规则中排除已下载模型，防止被本地上下文覆盖，减少构建上下文体积。
* **Bug Fixes**
  * 提升嵌入模型下载可靠性：加入重试、指数退避与 Retry-After 解析、临时文件清理与更明确的错误报告；移除旧的打包方式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->