### PR TITLE
修复角色卡自定义字段在 UI 中因数字 key 被优先枚举导致的排序错乱，新增字段创建顺序元数据并在加载、保存、预览和自动保存中统一按创建…

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -50,6 +50,7 @@ CHARACTER_SYSTEM_RESERVED_FIELDS = (
     "mmd_idle_animation",
     "mmd_idle_animations",
     "touch_set",
+    "_field_order",
 )
 
 CHARACTER_WORKSHOP_RESERVED_FIELDS = (
@@ -79,6 +80,7 @@ def get_character_reserved_fields() -> tuple[str, ...]:
 RESERVED_FIELD_SCHEMA = {
     "voice_id": str,
     "system_prompt": str,
+    "field_order": list,
     "persona_override": {
         "preset_id": str,
         "selected_at": str,

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1119,6 +1119,65 @@ def _filter_mutable_catgirl_fields(data: dict) -> dict:
     }
 
 
+def _normalize_catgirl_field_order(order, available_fields: list[str]) -> list[str]:
+    """按显式顺序排列普通设定字段，并把遗漏字段按当前存储顺序补在末尾。"""
+    available = {str(key) for key in available_fields}
+    result: list[str] = []
+    seen: set[str] = set()
+
+    if isinstance(order, list):
+        for raw_key in order:
+            key = str(raw_key or "").strip()
+            if not key or key in seen or key not in available:
+                continue
+            result.append(key)
+            seen.add(key)
+
+    for raw_key in available_fields:
+        key = str(raw_key or "").strip()
+        if key and key not in seen:
+            result.append(key)
+            seen.add(key)
+    return result
+
+
+def _extract_catgirl_field_order_payload(raw_data: dict) -> list[str] | None:
+    """读取前端提交的字段顺序；没有显式顺序时返回 None。"""
+    if not isinstance(raw_data, dict):
+        return None
+    raw_order = raw_data.get("_field_order")
+    if isinstance(raw_order, list):
+        return [str(item or "").strip() for item in raw_order]
+    reserved = raw_data.get("_reserved")
+    if isinstance(reserved, dict) and isinstance(reserved.get("field_order"), list):
+        return [str(item or "").strip() for item in reserved["field_order"]]
+    return None
+
+
+def _sync_catgirl_field_order(catgirl_data: dict, requested_order: list[str] | None = None) -> None:
+    """维护普通设定字段的创建顺序，避免数字 key 被 JS 枚举规则提前。"""
+    if not isinstance(catgirl_data, dict):
+        return
+    available_fields = [
+        str(key)
+        for key in catgirl_data.keys()
+        if key not in CHARACTER_RESERVED_FIELD_SET
+    ]
+    if requested_order is None:
+        requested_order = get_reserved(catgirl_data, "field_order", default=None)
+    field_order = _normalize_catgirl_field_order(requested_order, available_fields)
+    set_reserved(catgirl_data, "field_order", field_order)
+
+
+def _flatten_catgirl_for_response(catgirl_data: dict) -> dict:
+    """展开保留字段前补上字段顺序，供前端按创建顺序渲染。"""
+    if not isinstance(catgirl_data, dict):
+        return catgirl_data
+    data = copy.deepcopy(catgirl_data)
+    _sync_catgirl_field_order(data)
+    return flatten_reserved(data)
+
+
 def _build_minimax_request_prefix(prefix: str, provider_label: str) -> tuple[str, str]:
     """将用户输入的前缀规范化为 MiniMax 可接受的安全前缀。"""
     import uuid
@@ -1517,7 +1576,7 @@ async def get_characters(request: Request):
         # COMPAT(v1->v2): 前端仍依赖旧平铺字段，接口层按需展开。
         for cat_name, cat_data in list(characters_data['猫娘'].items()):
             if isinstance(cat_data, dict):
-                characters_data['猫娘'][cat_name] = flatten_reserved(cat_data)
+                characters_data['猫娘'][cat_name] = _flatten_catgirl_for_response(cat_data)
 
     # 尝试从请求参数或请求头获取用户语言
     user_language = request.query_params.get('language')
@@ -3271,6 +3330,7 @@ async def add_catgirl(request: Request):
     if err:
         return JSONResponse({'success': False, 'error': err}, status_code=400)
     data = _filter_mutable_catgirl_fields(raw_data)
+    requested_field_order = _extract_catgirl_field_order_payload(raw_data)
     data['档案名'] = str(profile_name).strip()
 
     _config_manager = get_config_manager()
@@ -3298,6 +3358,7 @@ async def add_catgirl(request: Request):
                 catgirl_data[k] = v
 
     characters['猫娘'][key] = catgirl_data
+    _sync_catgirl_field_order(catgirl_data, requested_field_order)
     # 默认走 free preset：非 free / 非 lanlan.tech 通道由 LLMSessionManager 现有 gate 清空 self.voice_id，不会泄漏给其他 TTS provider。
     # 从 free_voices['cuteGirl'] 读以避免硬编码漂移；缺失时回退到首个非空预设，再回退到旧版默认值。
     default_free_voice_id = _get_new_catgirl_default_voice_id()
@@ -3355,6 +3416,7 @@ async def update_catgirl(name: str, request: Request):
             )
 
     data = _filter_mutable_catgirl_fields(raw_data)
+    requested_field_order = _extract_catgirl_field_order_payload(raw_data)
     _config_manager = get_config_manager()
     characters = await _config_manager.aload_characters()
     if name not in characters.get('猫娘', {}):
@@ -3399,6 +3461,8 @@ async def update_catgirl(name: str, request: Request):
     # 兼容前端自动修复：若请求中带有 model_type，则同步写入保留字段。
     if model_type_in_payload and requested_model_type:
         set_reserved(characters['猫娘'][name], 'avatar', 'model_type', requested_model_type)
+
+    _sync_catgirl_field_order(characters['猫娘'][name], requested_field_order)
 
     await _config_manager.asave_characters(characters)
 
@@ -5139,6 +5203,7 @@ async def get_character_cards():
             try:
                 data = await read_json_async(file_path)
                 if data and data.get('name'):
+                    _sync_catgirl_field_order(data)
                     return {
                         'id': filename[:-11],  # 去掉 .chara.json 后缀
                         'name': data['name'],

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1164,7 +1164,9 @@ def _sync_catgirl_field_order(catgirl_data: dict, requested_order: list[str] | N
         if key not in CHARACTER_RESERVED_FIELD_SET
     ]
     if requested_order is None:
-        requested_order = get_reserved(catgirl_data, "field_order", default=None)
+        # 也认顶层 _field_order：工坊上传卡的顺序存在顶层（上传时 _reserved 被剥离），
+        # 只读 _reserved.field_order 会漏掉它而退回 JSON key 枚举顺序（数字 key 被提前）。
+        requested_order = _extract_catgirl_field_order_payload(catgirl_data)
     field_order = _normalize_catgirl_field_order(requested_order, available_fields)
     set_reserved(catgirl_data, "field_order", field_order)
 

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -5294,6 +5294,15 @@ async def sync_workshop_character_cards(
                                 if k not in skip_keys and v is not None:
                                     catgirl_data[k] = v
 
+                            # 字段创建顺序元数据被当作保留字段过滤掉了，这里复用 characters_router 的逻辑
+                            # 把它提回 _reserved.field_order；否则订阅同步到的工坊卡会丢失显式顺序，
+                            # 数字 key 自定义字段会在安装后再次按对象枚举顺序乱序。
+                            from main_routers.characters_router import (
+                                _extract_catgirl_field_order_payload as _extract_field_order,
+                                _sync_catgirl_field_order as _sync_field_order,
+                            )
+                            _sync_field_order(catgirl_data, _extract_field_order(chara_data))
+
                             # 工坊角色首次导入时强制清空 voice_id（当前工坊 voice_id 尚未适配）。
                             # 仅影响新增角色；已存在角色会在上面的分支直接跳过。
                             set_reserved(catgirl_data, 'voice_id', '')

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -5019,6 +5019,13 @@ async def sync_workshop_character_cards(
     Returns:
         dict: {"added": int, "backfilled_faces": int, "skipped": int, "errors": int}
     """
+    # 复用 characters_router 的字段顺序 helper：函数级 lazy import，既避免顶层 router→router 依赖，
+    # 又只在每次同步开始导入一次，不在每个 .chara.json 上重复走 import 路径。
+    from main_routers.characters_router import (
+        _extract_catgirl_field_order_payload as _extract_field_order,
+        _sync_catgirl_field_order as _sync_field_order,
+    )
+
     added_count = 0
     backfilled_face_count = 0
     skipped_count = 0
@@ -5294,13 +5301,9 @@ async def sync_workshop_character_cards(
                                 if k not in skip_keys and v is not None:
                                     catgirl_data[k] = v
 
-                            # 字段创建顺序元数据被当作保留字段过滤掉了，这里复用 characters_router 的逻辑
-                            # 把它提回 _reserved.field_order；否则订阅同步到的工坊卡会丢失显式顺序，
+                            # 字段创建顺序元数据被当作保留字段过滤掉了，这里把它提回 _reserved.field_order
+                            # （helper 在函数开头一次性导入）；否则订阅同步到的工坊卡会丢失显式顺序，
                             # 数字 key 自定义字段会在安装后再次按对象枚举顺序乱序。
-                            from main_routers.characters_router import (
-                                _extract_catgirl_field_order_payload as _extract_field_order,
-                                _sync_catgirl_field_order as _sync_field_order,
-                            )
                             _sync_field_order(catgirl_data, _extract_field_order(chara_data))
 
                             # 工坊角色首次导入时强制清空 voice_id（当前工坊 voice_id 尚未适配）。

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -147,14 +147,18 @@ function getStoredCharacterFieldOrder(rawData) {
         });
 }
 
-function getOrderedCharacterFieldKeys(rawData, hiddenFields = []) {
+function getOrderedCharacterFieldKeys(rawData, hiddenFields = [], options = {}) {
     if (!rawData || typeof rawData !== 'object') return [];
+    // 渲染自定义字段时要剔除系统保留名（live2d/model_type 等）；但工坊导入 scanCharaFile 需要保留这些
+    // 模型字段，只按调用方传入的 hiddenFields 过滤，故用此开关让调用方决定是否额外剔除保留名。
+    const { skipReservedNames = true } = options;
     const hidden = new Set((hiddenFields || []).map(normalizeCharacterFieldName).filter(Boolean));
     const seen = new Set();
     const keys = [];
     const addKey = (rawKey) => {
         const key = normalizeCharacterFieldName(rawKey);
-        if (!key || seen.has(key) || hidden.has(key) || isCharacterReservedFieldName(key)) return;
+        if (!key || seen.has(key) || hidden.has(key)) return;
+        if (skipReservedNames && isCharacterReservedFieldName(key)) return;
         const value = rawData[key];
         if (value === null || value === undefined) return;
         seen.add(key);
@@ -2887,7 +2891,9 @@ async function scanCharaFile(filePath, itemId, itemTitle) {
             const skipKeys = ['档案名', ...RESERVED_FIELDS];
 
             const fieldOrder = [];
-            getOrderedCharacterFieldKeys(charaData, skipKeys).forEach(key => {
+            // 工坊导入要保留 live2d/model_type/vrm 等模型字段（仅靠 skipKeys 过滤工坊元数据），
+            // 不能套用渲染路径对系统保留名的剔除，否则导入卡会丢失模型绑定、开成错误或缺失的模型。
+            getOrderedCharacterFieldKeys(charaData, skipKeys, { skipReservedNames: false }).forEach(key => {
                 const value = charaData[key];
                 if (value !== undefined && value !== null && value !== '') {
                     catgirlFormat[key] = value;

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -9,6 +9,7 @@ const FRONTEND_FORCE_HIDDEN_FIELDS = [
     'live2d_item_id',
     'live2d_idle_animation',
     '_reserved',
+    '_field_order',
     'item_id',
     'idleAnimation',
     'idleAnimations',
@@ -79,6 +80,7 @@ function collectCharacterFields(form, options = {}) {
     } = options;
     const data = {};
     const seen = new Set();
+    const fieldOrder = [];
 
     Object.entries(baseData || {}).forEach(([key, value]) => {
         const normalizedKey = normalizeCharacterFieldName(key);
@@ -104,13 +106,81 @@ function collectCharacterFields(form, options = {}) {
             continue;
         }
         if (seen.has(key)) {
-            return { data, duplicateKey: key };
+            return { data, duplicateKey: key, fieldOrder };
         }
         data[key] = value;
         seen.add(key);
+        fieldOrder.push(key);
     }
 
-    return { data, duplicateKey: '' };
+    return { data, duplicateKey: '', fieldOrder };
+}
+
+const CHARACTER_FIELD_ORDER_PAYLOAD_KEY = '_field_order';
+
+function attachCharacterFieldOrderPayload(data, fieldOrder) {
+    if (!data || !Array.isArray(fieldOrder)) return data;
+    const seen = new Set();
+    data[CHARACTER_FIELD_ORDER_PAYLOAD_KEY] = fieldOrder
+        .map(normalizeCharacterFieldName)
+        .filter(key => {
+            if (!key || seen.has(key) || isCharacterReservedFieldName(key)) return false;
+            seen.add(key);
+            return true;
+        });
+    return data;
+}
+
+function getStoredCharacterFieldOrder(rawData) {
+    if (!rawData || typeof rawData !== 'object') return [];
+    const reserved = rawData._reserved && typeof rawData._reserved === 'object' ? rawData._reserved : null;
+    const order = reserved && Array.isArray(reserved.field_order)
+        ? reserved.field_order
+        : (Array.isArray(rawData[CHARACTER_FIELD_ORDER_PAYLOAD_KEY]) ? rawData[CHARACTER_FIELD_ORDER_PAYLOAD_KEY] : []);
+    const seen = new Set();
+    return order
+        .map(normalizeCharacterFieldName)
+        .filter(key => {
+            if (!key || seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+}
+
+function getOrderedCharacterFieldKeys(rawData, hiddenFields = []) {
+    if (!rawData || typeof rawData !== 'object') return [];
+    const hidden = new Set((hiddenFields || []).map(normalizeCharacterFieldName).filter(Boolean));
+    const seen = new Set();
+    const keys = [];
+    const addKey = (rawKey) => {
+        const key = normalizeCharacterFieldName(rawKey);
+        if (!key || seen.has(key) || hidden.has(key) || isCharacterReservedFieldName(key)) return;
+        const value = rawData[key];
+        if (value === null || value === undefined) return;
+        seen.add(key);
+        keys.push(key);
+    };
+
+    // 数字形式的对象 key 会被浏览器提前枚举，优先使用后端保存的显式顺序。
+    getStoredCharacterFieldOrder(rawData).forEach(addKey);
+    Object.keys(rawData).forEach(addKey);
+    return keys;
+}
+
+function setLocalRawDataFieldOrder(rawData, fieldOrder) {
+    if (!rawData || typeof rawData !== 'object' || !Array.isArray(fieldOrder)) return rawData;
+    const reserved = rawData._reserved && typeof rawData._reserved === 'object'
+        ? rawData._reserved
+        : (rawData._reserved = {});
+    const seen = new Set();
+    reserved.field_order = fieldOrder
+        .map(normalizeCharacterFieldName)
+        .filter(key => {
+            if (!key || seen.has(key) || isCharacterReservedFieldName(key) || rawData[key] === undefined) return false;
+            seen.add(key);
+            return true;
+        });
+    return rawData;
 }
 
 function loadCharacterReservedFieldsConfig() {
@@ -2816,12 +2886,15 @@ async function scanCharaFile(filePath, itemId, itemTitle) {
             // 跳过的字段：档案名（已处理）、保留字段
             const skipKeys = ['档案名', ...RESERVED_FIELDS];
 
-            // 添加所有非保留字段
-            for (const [key, value] of Object.entries(charaData)) {
-                if (!skipKeys.includes(key) && value !== undefined && value !== null && value !== '') {
+            const fieldOrder = [];
+            getOrderedCharacterFieldKeys(charaData, skipKeys).forEach(key => {
+                const value = charaData[key];
+                if (value !== undefined && value !== null && value !== '') {
                     catgirlFormat[key] = value;
+                    fieldOrder.push(key);
                 }
-            }
+            });
+            attachCharacterFieldOrderPayload(catgirlFormat, fieldOrder);
 
             // 重要：如果角色卡有 live2d 字段，需要同时保存 live2d_item_id
             // 这样首页加载时才能正确构建工坊模型的路径
@@ -3001,7 +3074,7 @@ function getNextCharacterCardId() {
     return maxId + 1;
 }
 
-function buildLocalCatgirlRawData(catgirlName, submittedData) {
+function buildLocalCatgirlRawData(catgirlName, submittedData, fieldOrder) {
     const cards = Array.isArray(window.characterCards) ? window.characterCards : [];
     const existingIdx = findCharacterCardIndexByName(catgirlName);
     const previousRawData = existingIdx >= 0 && cards[existingIdx]?.rawData && typeof cards[existingIdx].rawData === 'object'
@@ -3024,6 +3097,9 @@ function buildLocalCatgirlRawData(catgirlName, submittedData) {
             nextRawData[key] = value;
         }
     });
+    if (Array.isArray(fieldOrder)) {
+        setLocalRawDataFieldOrder(nextRawData, fieldOrder);
+    }
     return nextRawData;
 }
 
@@ -5347,7 +5423,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
     // 自定义字段
     const ALL_RESERVED = typeof getWorkshopHiddenFields === 'function' ? ['档案名', ...getWorkshopHiddenFields()] : ['档案名'];
     const renderedCustomFields = new Set();
-    Object.keys(cat).forEach(k => {
+    getOrderedCharacterFieldKeys(cat, ALL_RESERVED).forEach(k => {
         const normalizedKey = normalizeCharacterFieldName(k);
         if (!normalizedKey || ALL_RESERVED.includes(normalizedKey) || renderedCustomFields.has(normalizedKey)) return;
         const val = cat[k];
@@ -6519,7 +6595,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
 
         const selectedVoiceId = (form.querySelector('select[name="voice_id"]')?.value ?? '').trim();
         const previousVoiceId = form._previousVoiceId || '';
-        const { data, duplicateKey } = collectCharacterFields(form, {
+        const { data, duplicateKey, fieldOrder } = collectCharacterFields(form, {
             baseData: { '档案名': nameInput.value.trim() },
             excludeFieldNames: ['档案名', 'voice_id'],
         });
@@ -6527,6 +6603,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             showMessage(window.t ? window.t('character.fieldExists') : '该设定已存在', 'error');
             return;
         }
+        attachCharacterFieldOrderPayload(data, fieldOrder);
 
         // 如果新建猫娘已被临时保存（自动创建），则改用 PUT 更新
         const effectiveIsNew = isNew && !form._autoCreated;
@@ -6553,7 +6630,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             showMessage(result.error || (window.t ? window.t('character.saveFailed') : '保存失败'), 'error');
             return false;
         }
-        const localRawData = buildLocalCatgirlRawData(data['档案名'], data);
+        const localRawData = buildLocalCatgirlRawData(data['档案名'], data, fieldOrder);
         let savedRawDataForCache = localRawData;
         syncCharacterCardCache(data['档案名'], localRawData);
         if (form._autoCreatedDetachedName) {
@@ -6694,6 +6771,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                     ? freshData['猫娘'][data['档案名']]
                     : {};
                 savedRawDataForCache = mergeFreshCatgirlRawDataWithLocal(freshRawData, localRawData);
+                setLocalRawDataFieldOrder(savedRawDataForCache, fieldOrder);
                 syncCharacterCardCache(data['档案名'], savedRawDataForCache);
                 buildCatgirlDetailForm(data['档案名'], savedRawDataForCache, false, container);
             } catch (e) {
@@ -6702,6 +6780,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             }
         }
         await loadCharacterCards();
+        setLocalRawDataFieldOrder(savedRawDataForCache, fieldOrder);
         syncCharacterCardCache(data['档案名'], savedRawDataForCache);
         return true;
     } catch (error) {
@@ -9358,7 +9437,8 @@ function updateCardPreview() {
     container.innerHTML = '';
 
     // 遍历所有属性并动态生成显示
-    for (const [key, value] of Object.entries(rawData)) {
+    for (const key of getOrderedCharacterFieldKeys(rawData, hiddenFields)) {
+        const value = rawData[key];
         // 跳过保留字段
         if (hiddenFields.includes(key)) continue;
 
@@ -10273,7 +10353,7 @@ async function panelAutoSaveCatgirlField(input, catgirlName) {
     if (!form) return;
     const fieldName = normalizeCharacterFieldName(input.name);
     if (!fieldName || fieldName === '档案名' || fieldName === 'voice_id') return;
-    const { data, duplicateKey } = collectCharacterFields(form, {
+    const { data, duplicateKey, fieldOrder } = collectCharacterFields(form, {
         baseData: { '档案名': catgirlName },
         excludeFieldNames: ['档案名', 'voice_id'],
     });
@@ -10281,6 +10361,7 @@ async function panelAutoSaveCatgirlField(input, catgirlName) {
         showMessage(window.t ? window.t('character.fieldExists') : '该设定已存在', 'error');
         return;
     }
+    attachCharacterFieldOrderPayload(data, fieldOrder);
     try {
         const resp = await fetch('/api/characters/catgirl/' + encodeURIComponent(catgirlName), {
             method: 'PUT',
@@ -10288,7 +10369,7 @@ async function panelAutoSaveCatgirlField(input, catgirlName) {
             body: JSON.stringify(data)
         });
         if (resp.ok) {
-            syncCharacterCardCache(catgirlName, buildLocalCatgirlRawData(catgirlName, data));
+            syncCharacterCardCache(catgirlName, buildLocalCatgirlRawData(catgirlName, data, fieldOrder));
             storeOriginalValue(input);
             const allInputs = form.querySelectorAll('input, textarea');
             const sentFields = new Set(Object.keys(data));

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -7885,6 +7885,10 @@ async function handleUploadToWorkshop() {
         // 现在角色使用的是 rawData 中的数据，只覆盖 description 和 tags
         const fullCharaData = { ...rawData };
 
+        // 字段顺序是展示属性，先在删保留字段前抓住它，删完再以顶层 _field_order 挂回。
+        // 否则数字 key 的自定义字段名会被下载方按对象枚举顺序提前，复现本次修复要解决的乱序问题。
+        const workshopFieldOrder = getStoredCharacterFieldOrder(rawData);
+
         // 重要：清理系统保留字段，防止恶意数据或循环引用被上传到工坊
         // 这些字段是下载时由系统添加的元数据，不应该出现在工坊角色卡中
         // description/tags 及其中文版本是工坊上传时自动生成的，不属于角色卡原始数据
@@ -7892,6 +7896,10 @@ async function handleUploadToWorkshop() {
         const SYSTEM_RESERVED_FIELDS = getWorkshopReservedFields();
         for (const field of SYSTEM_RESERVED_FIELDS) {
             delete fullCharaData[field];
+        }
+        // 顺序元数据本身被当作系统保留字段删掉了，这里按显式顺序重新挂回，供下载方按创建顺序渲染。
+        if (workshopFieldOrder.length) {
+            attachCharacterFieldOrderPayload(fullCharaData, workshopFieldOrder);
         }
 
         // 重要：添加"档案名"字段，这是下载后解析为 characters.json key 的必需字段

--- a/static/js/reserved_fields_utils.js
+++ b/static/js/reserved_fields_utils.js
@@ -19,7 +19,7 @@ const ReservedFieldsUtils = (() => {
 
     const SYSTEM_RESERVED_FIELDS_FALLBACK = Object.freeze([
         'live2d', 'voice_id', 'system_prompt', 'model_type', 'live3d_sub_type', 'vrm', 'vrm_animation',
-        'lighting', 'vrm_rotation', 'live2d_item_id', 'live2d_idle_animation', '_reserved', 'item_id', 'idleAnimation', 'idleAnimations',
+        'lighting', 'vrm_rotation', 'live2d_item_id', 'live2d_idle_animation', '_reserved', '_field_order', 'item_id', 'idleAnimation', 'idleAnimations',
         'mmd', 'mmd_animation', 'mmd_idle_animation', 'mmd_idle_animations'
     ]);
 
@@ -27,7 +27,7 @@ const ReservedFieldsUtils = (() => {
         '原始数据', '文件路径', '创意工坊物品ID',
         'description', 'tags', 'name',
         '描述', '标签', '关键词',
-        '_reserved', 'item_id', 'idleAnimation', 'idleAnimations'
+        '_reserved', '_field_order', 'item_id', 'idleAnimation', 'idleAnimations'
     ]);
 
     const ALL_RESERVED_FIELDS_FALLBACK = Object.freeze(

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -870,8 +870,10 @@ def test_character_card_manager_keeps_numeric_field_creation_order(
 
             document.querySelector('.chara-card-item')?.click();
             await waitFor(() => document.querySelectorAll('.catgirl-panel-overlay textarea[name]').length >= 2);
+            const targetFieldNames = new Set(['喵喵喵', '1']);
             const beforeSaveOrder = Array.from(document.querySelectorAll('.catgirl-panel-overlay textarea[name]'))
-                .map(el => el.getAttribute('name'));
+                .map(el => el.getAttribute('name'))
+                .filter(name => targetFieldNames.has(name));
 
             document.querySelector('.catgirl-panel-overlay #save-button').click();
             await waitFor(() => savedBodies.length > 0);
@@ -884,8 +886,98 @@ def test_character_card_manager_keeps_numeric_field_creation_order(
         """
     )
 
-    assert state["beforeSaveOrder"][:2] == ["喵喵喵", "1"]
+    assert state["beforeSaveOrder"] == ["喵喵喵", "1"]
     assert state["savedOrder"] == ["喵喵喵", "1"]
+
+
+@pytest.mark.frontend
+def test_character_card_manager_workshop_upload_preserves_field_order(
+    mock_page: Page,
+    running_server: str,
+):
+    """上传到创意工坊会剥掉系统保留字段（含承载顺序的 _reserved），需确保字段创建顺序
+    以顶层 _field_order 幸存，否则下载方按对象枚举顺序渲染时数字 key 字段会再次乱序。"""
+    _open_character_card_manager(mock_page, running_server)
+
+    uploaded = mock_page.evaluate(
+        """
+        async () => {
+            const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            const waitFor = async (predicate, timeout = 2500) => {
+                const startedAt = Date.now();
+                while (Date.now() - startedAt < timeout) {
+                    if (predicate()) return true;
+                    await sleep(25);
+                }
+                return false;
+            };
+
+            const originalFetch = window.fetch.bind(window);
+            const uploadBodies = [];
+            window.showMessage = () => {};
+            window.showAutoSaveToast = () => {};
+            window.showAlertDialog = async () => {};
+            // 模型判定走真实逻辑会牵扯大量全局状态，这里直接放行，把断言聚焦在字段顺序上。
+            window.isDefaultModel = () => false;
+            window.isStaticDefaultLive2DModel = () => false;
+
+            window.fetch = async (input, init = {}) => {
+                const rawUrl = typeof input === 'string' ? input : input.url;
+                const url = new URL(rawUrl, window.location.origin);
+                const path = decodeURIComponent(url.pathname);
+                const method = String(init.method || 'GET').toUpperCase();
+
+                if (path === '/api/steam/workshop/prepare-upload' && method === 'POST') {
+                    uploadBodies.push(JSON.parse(init.body || '{}'));
+                    return new Response(JSON.stringify({ success: true }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                return originalFetch(input, init);
+            };
+
+            // handleUploadToWorkshop 会读页面上的描述输入框；测试页面未必挂载它，按需补一个。
+            if (!document.getElementById('character-card-description')) {
+                const descInput = document.createElement('textarea');
+                descInput.id = 'character-card-description';
+                document.body.appendChild(descInput);
+            }
+
+            const card = {
+                id: 9301,
+                name: '顺序猫',
+                originalName: '顺序猫',
+                description: '用于工坊上传顺序回归',
+                tags: [],
+                rawData: {
+                    '1': '数字字段',
+                    '喵喵喵': '文字字段',
+                    '描述': '用于工坊上传顺序回归',
+                    _reserved: { field_order: ['喵喵喵', '1'] }
+                }
+            };
+            window.characterCards = [card];
+            // expandCharacterCardSection 第一行即设置 currentCharacterCardId；后续填表副作用与本用例无关，吞掉即可。
+            try { expandCharacterCardSection(card); } catch (_) {}
+            // 放在 expand 之后，避免被其填充逻辑覆盖，保证模型校验直接通过。
+            window.currentCharacterCardModelType = 'live2d';
+            window.currentCharacterCardModel = '顺序猫模型';
+
+            await handleUploadToWorkshop();
+            await waitFor(() => uploadBodies.length > 0);
+
+            const charaData = uploadBodies.length ? uploadBodies[0].charaData : null;
+            return {
+                fieldOrder: (charaData && charaData._field_order) || null,
+                hasReserved: !!(charaData && charaData._reserved)
+            };
+        }
+        """
+    )
+
+    assert uploaded["fieldOrder"] == ["喵喵喵", "1"]
+    assert uploaded["hasReserved"] is False
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -981,6 +981,80 @@ def test_character_card_manager_workshop_upload_preserves_field_order(
 
 
 @pytest.mark.frontend
+def test_character_card_manager_scan_import_keeps_model_fields_and_order(
+    mock_page: Page,
+    running_server: str,
+):
+    """从创意工坊导入角色卡（scanCharaFile）必须保留 live2d/model_type 等模型字段，
+    同时按显式 _field_order 排列自定义字段。若误套渲染路径的系统保留名剔除，会丢掉模型绑定。"""
+    _open_character_card_manager(mock_page, running_server)
+
+    added = mock_page.evaluate(
+        """
+        async () => {
+            const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            const waitFor = async (predicate, timeout = 2500) => {
+                const startedAt = Date.now();
+                while (Date.now() - startedAt < timeout) {
+                    if (predicate()) return true;
+                    await sleep(25);
+                }
+                return false;
+            };
+
+            const originalFetch = window.fetch.bind(window);
+            const addBodies = [];
+            window.showMessage = () => {};
+            window.showAlert = () => {};
+
+            const charaJson = {
+                '档案名': '顺序猫',
+                'live2d': '测试模型',
+                'model_type': 'live2d',
+                '1': '数字字段',
+                '喵喵喵': '文字字段',
+                '_field_order': ['喵喵喵', '1']
+            };
+
+            window.fetch = async (input, init = {}) => {
+                const rawUrl = typeof input === 'string' ? input : input.url;
+                const url = new URL(rawUrl, window.location.origin);
+                const path = decodeURIComponent(url.pathname);
+                const method = String(init.method || 'GET').toUpperCase();
+
+                if (path === '/api/steam/workshop/read-file') {
+                    return new Response(JSON.stringify({ success: true, content: JSON.stringify(charaJson) }), {
+                        status: 200, headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/catgirl' && method === 'POST') {
+                    addBodies.push(JSON.parse(init.body || '{}'));
+                    return new Response(JSON.stringify({ success: true }), {
+                        status: 200, headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                return originalFetch(input, init);
+            };
+
+            await scanCharaFile('顺序猫.chara.json', '99887', '顺序猫');
+            await waitFor(() => addBodies.length > 0);
+            return addBodies[0] || null;
+        }
+        """
+    )
+
+    assert added is not None
+    # P1：模型字段必须保留，被误过滤会丢失模型绑定、开成错误或缺失的模型
+    assert added["live2d"] == "测试模型"
+    assert added["model_type"] == "live2d"
+    assert added["live2d_item_id"] == "99887"
+    # 自定义字段及其显式创建顺序一并保留
+    assert added["1"] == "数字字段"
+    assert added["喵喵喵"] == "文字字段"
+    assert added["_field_order"] == ["喵喵喵", "1"]
+
+
+@pytest.mark.frontend
 def test_character_card_manager_live2d_preview_loads_after_regression_fixes(
     mock_page: Page,
     running_server: str,

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -746,6 +746,149 @@ def test_character_card_manager_saved_new_field_survives_immediate_reopen_with_s
 
 
 @pytest.mark.frontend
+def test_character_card_manager_keeps_numeric_field_creation_order(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            const waitFor = async (predicate, timeout = 2500) => {
+                const startedAt = Date.now();
+                while (Date.now() - startedAt < timeout) {
+                    if (predicate()) return true;
+                    await sleep(25);
+                }
+                return false;
+            };
+
+            const originalFetch = window.fetch.bind(window);
+            const savedBodies = [];
+            window.showMessage = () => {};
+            window.showAutoSaveToast = () => {};
+            window.showAlertDialog = async () => {};
+
+            window.fetch = async (input, init = {}) => {
+                const rawUrl = typeof input === 'string' ? input : input.url;
+                const url = new URL(rawUrl, window.location.origin);
+                const path = decodeURIComponent(url.pathname);
+                const method = String(init.method || 'GET').toUpperCase();
+
+                if (path === '/api/characters/catgirl/顺序猫' && method === 'PUT') {
+                    savedBodies.push(JSON.parse(init.body || '{}'));
+                    return new Response(JSON.stringify({ success: true }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters' && method === 'GET') {
+                    return new Response(JSON.stringify({
+                        '主人': {},
+                        '当前猫娘': '顺序猫',
+                        '猫娘': {
+                            '顺序猫': {
+                                '1': '数字字段',
+                                '喵喵喵': '文字字段',
+                                '_reserved': { field_order: ['喵喵喵', '1'] }
+                            }
+                        }
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/current_catgirl') {
+                    return new Response(JSON.stringify({ current_catgirl: '顺序猫' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/character-card/list') {
+                    return new Response(JSON.stringify({ success: true, character_cards: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/card-faces') {
+                    return new Response(JSON.stringify({ success: true, names: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/card-metas') {
+                    return new Response(JSON.stringify({ success: true, metas: {} }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/voices') {
+                    return new Response(JSON.stringify({ voices: {}, free_voices: {}, voice_owners: {} }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/custom_tts_voices') {
+                    return new Response(JSON.stringify({ success: true, voices: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/live2d/models') {
+                    return new Response(JSON.stringify([]), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/model/vrm/models' || path === '/api/model/mmd/models') {
+                    return new Response(JSON.stringify({ success: true, models: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                return originalFetch(input, init);
+            };
+
+            window.characterCards = [{
+                id: 1,
+                name: '顺序猫',
+                originalName: '顺序猫',
+                description: '',
+                tags: [],
+                rawData: {
+                    '1': '数字字段',
+                    '喵喵喵': '文字字段',
+                    _reserved: { field_order: ['喵喵喵', '1'] }
+                }
+            }];
+            window._workshopCurrentCatgirl = '顺序猫';
+            window._cardFaceNames = new Set();
+            window._cardMetas = {};
+            renderCharaCardsView();
+
+            document.querySelector('.chara-card-item')?.click();
+            await waitFor(() => document.querySelectorAll('.catgirl-panel-overlay textarea[name]').length >= 2);
+            const beforeSaveOrder = Array.from(document.querySelectorAll('.catgirl-panel-overlay textarea[name]'))
+                .map(el => el.getAttribute('name'));
+
+            document.querySelector('.catgirl-panel-overlay #save-button').click();
+            await waitFor(() => savedBodies.length > 0);
+
+            return {
+                beforeSaveOrder,
+                savedOrder: savedBodies[0]._field_order || []
+            };
+        }
+        """
+    )
+
+    assert state["beforeSaveOrder"][:2] == ["喵喵喵", "1"]
+    assert state["savedOrder"] == ["喵喵喵", "1"]
+
+
+@pytest.mark.frontend
 def test_character_card_manager_live2d_preview_loads_after_regression_fixes(
     mock_page: Page,
     running_server: str,

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -324,6 +324,20 @@ def test_flatten_catgirl_for_response_preserves_numeric_field_creation_order():
     assert '_reserved' not in catgirl
 
 
+def test_sync_catgirl_field_order_honors_top_level_payload():
+    # 工坊上传卡的顺序存在顶层 _field_order（上传时 _reserved 被剥离）；列表/读取入口调 _sync
+    # 时不传 payload，必须认这个顶层字段，否则退回 JSON key 枚举顺序让数字 key 被提前。
+    catgirl = {
+        '1': '数字字段',
+        '喵喵喵': '文字字段',
+        '_field_order': ['喵喵喵', '1'],
+    }
+
+    characters_router_module._sync_catgirl_field_order(catgirl)
+
+    assert get_reserved(catgirl, 'field_order') == ['喵喵喵', '1']
+
+
 def test_migrate_catgirl_reserved_does_not_persist_empty_live3d_sub_type():
     catgirl = _build_characters_fixture()['猫娘']['测试角色']
     avatar = catgirl['_reserved']['avatar']

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -312,6 +312,18 @@ def test_flatten_reserved_exposes_live3d_sub_type_for_frontend_consumers():
     assert flattened['live3d_sub_type'] == 'vrm'
 
 
+def test_flatten_catgirl_for_response_preserves_numeric_field_creation_order():
+    catgirl = {
+        '喵喵喵': '文字字段',
+        '1': '数字字段',
+    }
+
+    flattened = characters_router_module._flatten_catgirl_for_response(catgirl)
+
+    assert get_reserved(flattened, 'field_order') == ['喵喵喵', '1']
+    assert '_reserved' not in catgirl
+
+
 def test_migrate_catgirl_reserved_does_not_persist_empty_live3d_sub_type():
     catgirl = _build_characters_fixture()['猫娘']['测试角色']
     avatar = catgirl['_reserved']['avatar']


### PR DESCRIPTION
…顺序渲染

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加自定义字段顺序管理，用户可在角色卡中指定并看到稳定的字段显示顺序；该顺序在保存、加载、预览和上传流程中自动保留。
* **修复**
  * 确保包含数字键的字段也能按创建/指定顺序稳定展示。
  * 修复导入/订阅/上传场景中字段顺序丢失的问题。
* **配置**
  * 增加系统保留字段以支持字段顺序的存储与回退行为。
* **测试**
  * 新增前端与单元测试覆盖字段顺序的保存、上传和渲染行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->