### PR TITLE
压缩持续失败时用受保护的后台分段压缩兜底，防上下文无限增长

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -3400,6 +3400,11 @@ async def _run_backup_compress(lanlan_name: str, snapshot: list, detailed: bool)
         #    主路径压掉 / 被清空就返回 'moot' 丢弃（白做）。
         async with _get_settle_lock(lanlan_name):
             status = await recent_history_manager.merge_backup_memo(lanlan_name, snapshot, result[0])
+        if status == 'failed':
+            # 合并落盘失败 → 没真正写成功，bump 退避（不清），下次再试。
+            attempts = await _record_compress_backup_failure(lanlan_name, snapshot)
+            logger.info(f"[CompressBackup] {lanlan_name} 后台压缩合并落盘失败，退避计数 → {attempts}")
+            return
         # 'merged' 或 'moot' 都说明这段积压已处理 / 已过时，清退避计数。
         await _clear_compress_backup_failure(lanlan_name)
         logger.info(f"[CompressBackup] {lanlan_name} 后台压缩完成：{status}")

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -1366,7 +1366,7 @@ async def _periodic_idle_maintenance_loop():
                         )
                         try:
                             # 传空消息列表仅触发压缩逻辑
-                            await recent_history_manager.update_history([], name, detailed=True)
+                            await recent_history_manager.update_history([], name, detailed=True, on_compress_done=_on_compress_done)
                             logger.info(f"[IdleMaint] {name}: 历史记录压缩完成")
                         except Exception as e:
                             logger.warning(f"[IdleMaint] {name}: 历史记录压缩失败: {e}")
@@ -3348,6 +3348,113 @@ async def _record_review_failure(lanlan_name: str, snapshot: list) -> int:
     return state['review_fail_attempts']
 
 
+# ── best-effort 后台压缩（主路径 compress 失败时兜底）─────────────────────
+# 真根因：主路径压缩走 LLM 耗时数秒~数十秒，限流抖动 / 偶发失败 → #1629 跳过
+# 保留完整历史、下轮重试。但若持续失败，历史一直压不掉、越积越多。这里在主路径
+# 压缩失败时起一个受保护的一次性后台任务尽力压（基于快照、不被对话打断；压完用
+# fingerprint 对齐合并回写）。主路径某轮成功 → cancel 在跑的后台。失败退避复用
+# review 的 Gate 6 模式，防 summary 模型持续故障时每轮起一个注定失败的任务空烧。
+compress_backup_tasks: dict[str, asyncio.Task] = {}
+
+
+async def _record_compress_backup_failure(lanlan_name: str, snapshot: list) -> int:
+    """记一次后台压缩失败到退避计数并返回累计次数。输入 fingerprint 变了先归零
+    （每段积压各享独立预算，不跨输入累积），与 _record_review_failure 对偶。"""
+    from memory.recent import build_review_fingerprint
+    state = _maint_state.setdefault(lanlan_name, {})
+    cur_fp = build_review_fingerprint(snapshot)
+    if state.get('compress_backup_fail_fp') != cur_fp:
+        state['compress_backup_fail_attempts'] = 0
+    state['compress_backup_fail_attempts'] = (state.get('compress_backup_fail_attempts', 0) or 0) + 1
+    state['compress_backup_fail_fp'] = cur_fp
+    await _asave_maint_state()
+    return state['compress_backup_fail_attempts']
+
+
+async def _clear_compress_backup_failure(lanlan_name: str) -> None:
+    """清后台压缩失败退避计数（主路径成功 / 后台成功或白做时调）。"""
+    state = _maint_state.setdefault(lanlan_name, {})
+    if state.get('compress_backup_fail_attempts') or state.get('compress_backup_fail_fp'):
+        state['compress_backup_fail_attempts'] = 0
+        state['compress_backup_fail_fp'] = None
+        await _asave_maint_state()
+
+
+async def _run_backup_compress(lanlan_name: str, snapshot: list, detailed: bool):
+    """后台跑 best-effort 压缩：compress 在锁外（LLM 耗时，不阻塞其它端点），
+    merge 在 _get_settle_lock 内（快，串行化对该角色 history 的写）。"""
+    try:
+        # 1) 压缩（锁外）。compress_history 内部按输入大小自动分段，避免输入过大超时。
+        try:
+            result = await recent_history_manager.compress_history(snapshot, lanlan_name, detailed)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[CompressBackup] {lanlan_name} 后台压缩抛异常，按失败处理: {e}")
+            result = None
+        if result is None:
+            attempts = await _record_compress_backup_failure(lanlan_name, snapshot)
+            logger.info(f"[CompressBackup] {lanlan_name} 后台压缩失败，退避计数 → {attempts}")
+            return
+        # 2) 合并写回（锁内，快）。merge_backup_memo 用 fingerprint 对齐，积压已被
+        #    主路径压掉 / 被清空就返回 'moot' 丢弃（白做）。
+        async with _get_settle_lock(lanlan_name):
+            status = await recent_history_manager.merge_backup_memo(lanlan_name, snapshot, result[0])
+        # 'merged' 或 'moot' 都说明这段积压已处理 / 已过时，清退避计数。
+        await _clear_compress_backup_failure(lanlan_name)
+        logger.info(f"[CompressBackup] {lanlan_name} 后台压缩完成：{status}")
+    except asyncio.CancelledError:
+        logger.info(f"[CompressBackup] {lanlan_name} 后台压缩被取消（主路径已成功）")
+    except Exception as e:
+        logger.error(f"[CompressBackup] {lanlan_name} 后台压缩后处理出错: {e}")
+    finally:
+        cur = asyncio.current_task()
+        if compress_backup_tasks.get(lanlan_name) is cur:
+            compress_backup_tasks.pop(lanlan_name, None)
+
+
+async def _on_compress_done(lanlan_name: str, snapshot: list, ok: bool, detailed: bool):
+    """update_history 压缩结束回调（recent.py 注入）。
+    ok=True（主路径压成功）→ cancel 在跑的后台兜底 + 清退避；
+    ok=False（主路径压失败）→ 起一个受保护的后台兜底压缩（若无在跑、未被退避挡）。
+
+    本回调只 spawn / cancel task，不 await 后台 LLM——它可能在 _get_settle_lock
+    内被调（/renew、/settle），绝不能阻塞。"""
+    if ok:
+        task = compress_backup_tasks.get(lanlan_name)
+        if task is not None and not task.done():
+            task.cancel()
+        await _clear_compress_backup_failure(lanlan_name)
+        return
+    # ok=False：主路径压缩失败 → 起后台兜底
+    if not snapshot:
+        return
+    existing = compress_backup_tasks.get(lanlan_name)
+    if existing is not None and not existing.done():
+        return  # in-flight：同角色已有后台压缩在跑，不重复起
+    # 失败退避（Gate 6 模式）：连续失败 ≥ N 且输入未变 → dead-letter，不再起，
+    # 防 summary 模型持续故障时每轮都起一个注定失败的后台任务空烧。
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.recent import build_review_fingerprint
+    state = _maint_state.setdefault(lanlan_name, {})
+    fail_attempts = state.get('compress_backup_fail_attempts', 0) or 0
+    if fail_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+        cur_fp = build_review_fingerprint(snapshot)
+        if state.get('compress_backup_fail_fp') == cur_fp:
+            logger.debug(
+                f"[CompressBackup] {lanlan_name} 失败退避 dead-letter"
+                f"（连续失败 {fail_attempts} 次且输入未变），跳过"
+            )
+            return
+        # 输入变了 → 旧计数过期，复位放行
+        state['compress_backup_fail_attempts'] = 0
+        state['compress_backup_fail_fp'] = None
+        await _asave_maint_state()
+    task = _spawn_background_task(_run_backup_compress(lanlan_name, list(snapshot), detailed))
+    compress_backup_tasks[lanlan_name] = task
+    logger.info(f"[CompressBackup] {lanlan_name} 主路径压缩失败，已起后台兜底压缩任务")
+
+
 async def _run_review_in_background(
     lanlan_name: str, snapshot: list, cancel_event: asyncio.Event,
 ):
@@ -3827,7 +3934,7 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
         if _has_human_messages(input_history):
             await _aclear_review_clean(lanlan_name)
         logger.info(f"[MemoryServer] 收到 {lanlan_name} 的对话历史处理请求，消息数: {len(input_history)}")
-        await recent_history_manager.update_history(input_history, lanlan_name)
+        await recent_history_manager.update_history(input_history, lanlan_name, on_compress_done=_on_compress_done)
         # 旧模块已禁用（性能不足）：
         # await settings_manager.extract_and_update_settings(input_history, lanlan_name)
         # await semantic_manager.store_conversation(uid, input_history, lanlan_name)
@@ -3872,7 +3979,7 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
         logger.info(f"[MemoryServer] renew: 收到 {lanlan_name} 的对话历史处理请求，消息数: {len(input_history)}")
         # 首轮摘要带锁：阻塞 /new_dialog 直到摘要+时间戳写入完成
         async with _get_settle_lock(lanlan_name):
-            await recent_history_manager.update_history(input_history, lanlan_name, detailed=True)
+            await recent_history_manager.update_history(input_history, lanlan_name, detailed=True, on_compress_done=_on_compress_done)
             await time_manager.astore_conversation(uid, input_history, lanlan_name)
 
         # 以下操作在锁外执行，不阻塞 /new_dialog
@@ -3908,7 +4015,7 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
         async with _get_settle_lock(lanlan_name):
             if input_history:
                 await time_manager.astore_conversation(uid, input_history, lanlan_name)
-            await recent_history_manager.update_history([], lanlan_name, detailed=True)
+            await recent_history_manager.update_history([], lanlan_name, detailed=True, on_compress_done=_on_compress_done)
 
         if input_history:
             await _spawn_outbox_post_turn_signals(lanlan_name, input_history)

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -3395,6 +3395,10 @@ async def _run_backup_compress(lanlan_name: str, snapshot: list, detailed: bool)
         if result is None:
             attempts = await _record_compress_backup_failure(lanlan_name, snapshot)
             logger.info(f"[CompressBackup] {lanlan_name} 后台压缩失败，退避计数 → {attempts}")
+            # best-effort 也没压成 → 实在不行才丢：若历史仍超硬上限，裁剪最旧未压缩
+            # 原文兜底（锁内串行化写）。暂时性失败时后台会成功、走不到这里。
+            async with _get_settle_lock(lanlan_name):
+                await recent_history_manager.enforce_hard_cap(lanlan_name)
             return
         # 2) 合并写回（锁内，快）。merge_backup_memo 用 fingerprint 对齐，积压已被
         #    主路径压掉 / 被清空就返回 'moot' 丢弃（白做）。
@@ -3450,6 +3454,10 @@ async def _on_compress_done(lanlan_name: str, snapshot: list, ok: bool, detailed
                 f"[CompressBackup] {lanlan_name} 失败退避 dead-letter"
                 f"（连续失败 {fail_attempts} 次且输入未变），跳过"
             )
+            # dead-letter：后台已救不回 → 此时才裁剪兜底（实在不行才丢）。不 acquire
+            # settle lock：本回调可能已在 /renew·/settle 的锁内被调（重入会死锁）；
+            # enforce_hard_cap 是 best-effort 写。
+            await recent_history_manager.enforce_hard_cap(lanlan_name)
             return
         # 输入变了 → 旧计数过期，复位放行
         state['compress_backup_fail_attempts'] = 0

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1075,6 +1075,22 @@ RECENT_PER_MESSAGE_MAX_TOKENS = 500
 - 上游：用户/AI 的原始对话文本，正常一轮 30-500 token，长贴可能数 KB。
 - 截断策略：保留头尾各 250 token，中段用 "…[省略中段]…" 替换。"""
 
+RECENT_COMPRESS_INPUT_BUDGET_TOKENS = 8000
+"""后台 best-effort 压缩的单段输入 token 预算（分段阈值）。
+- 用途：待压积压渲染成文本后若超过此值，compress_history 走分段
+  map-reduce——切成每段 ≤ 此值的小段分别压成中间摘要，再 reduce 成最终
+  备忘录，减小单次 LLM 输入、避免输入过大导致超时。未超此值的正常压缩
+  走原一次性路径，行为不变。
+- 上游：积压对话渲染文本的 token 数。"""
+
+RECENT_HARD_CAP_TOKENS = 60000
+"""recent 历史的硬上限（最终兜底，平时不触发）。
+- 用途：压缩持续失败（如持续 429，best-effort 后台也救不回）导致历史
+  一直压不掉、无限膨胀时，update_history 保留完整历史前若总 token 超过
+  此值，丢弃最旧的未压缩对话原文，保留近期若干条 + 备忘录，保证 prompt
+  有界。设得很大，只作最后防线。
+- 上游：未被压缩而累积的 recent 历史 token 数。"""
+
 # ---- Memory: reflection ----
 REFLECTION_TEXT_MAX_TOKENS = 150
 """单条 reflection 文本的 soft cap。
@@ -2022,6 +2038,8 @@ __all__ = [
     'RECENT_COMPRESS_THRESHOLD_ITEMS',
     'RECENT_SUMMARY_MAX_TOKENS',
     'RECENT_PER_MESSAGE_MAX_TOKENS',
+    'RECENT_COMPRESS_INPUT_BUDGET_TOKENS',
+    'RECENT_HARD_CAP_TOKENS',
     'REFLECTION_TEXT_MAX_TOKENS',
     'REFLECTION_SURFACE_TOP_K',
     'REFLECTION_SYNTHESIS_FACTS_MAX',

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -583,7 +583,13 @@ class CompressedRecentHistoryManager:
                 new_partials.append(s)
             partials = new_partials
             depth += 1
-        return "\n\n".join(partials)
+        merged = "\n\n".join(partials)
+        # reduce 缩不动 / 深度耗尽时 merged 仍可能超预算 → 硬截到预算兜底，保证
+        # 交给主体最终总结的输入有界（best-effort，丢尾部）。
+        if await acount_tokens(merged) > RECENT_COMPRESS_INPUT_BUDGET_TOKENS:
+            from utils.tokenize import atruncate_to_tokens
+            merged = await atruncate_to_tokens(merged, RECENT_COMPRESS_INPUT_BUDGET_TOKENS)
+        return merged
 
     # detailed: 保留尽可能多的细节
     async def compress_history(self, messages, lanlan_name, detailed=False):
@@ -622,18 +628,28 @@ class CompressedRecentHistoryManager:
             # 时间衰减提醒是 best-effort；失败不能挡 summary 主流程
             logger.debug(f"[RecentHistory] {lanlan_name}: stale hint 注入失败: {e}")
 
-        summary = await self._invoke_summary_llm(prompt)
-        if summary is None:
-            # 摘要失败时不生成空备忘录，避免覆盖既有 memo 或丢弃未压缩原文。
-            logger.warning(f"[RecentHistory] {lanlan_name} 摘要连续失败，跳过本轮压缩")
-            return None
-
-        if await acount_tokens(summary) > MAX_SUMMARY_TOKENS:
-            reduced = await self.further_compress(summary)
-            if reduced is None:
-                logger.warning(f"[RecentHistory] {lanlan_name} 二次压缩失败，跳过本轮压缩")
+        # Stage-1 + Stage-2 联合重试：原行为是 further_compress 失败时重试整个
+        # stage-1（stage-1 LLM 有随机性，重下一次可能直接生成 ≤MAX 的 summary 而
+        # 不必二次压缩）。重构后用有限计数循环复现该重试，同时避免原 `continue`
+        # 不计数可能导致的死循环。
+        summary = None
+        for _ in range(3):
+            s = await self._invoke_summary_llm(prompt)
+            if s is None:
+                # stage-1 连续失败：不生成空备忘录，避免覆盖既有 memo 或丢未压原文。
+                logger.warning(f"[RecentHistory] {lanlan_name} 摘要连续失败，跳过本轮压缩")
                 return None
-            summary = reduced if isinstance(reduced, str) else json.dumps(reduced, ensure_ascii=False)
+            if await acount_tokens(s) <= MAX_SUMMARY_TOKENS:
+                summary = s
+                break
+            reduced = await self.further_compress(s)
+            if reduced is not None:
+                summary = reduced if isinstance(reduced, str) else json.dumps(reduced, ensure_ascii=False)
+                break
+            # stage-2 失败 → 重试 stage-1（最多 3 轮）
+        if summary is None:
+            logger.warning(f"[RecentHistory] {lanlan_name} 二次压缩连续失败，跳过本轮压缩")
+            return None
 
         # 推进 past-block 更新锚点（best-effort）：第一次 compress 建 baseline；
         # 注入过 stale hint 表示 LLM 本轮真的更新了 past block。常规压缩不动锚点，
@@ -663,21 +679,40 @@ class CompressedRecentHistoryManager:
         直到 ≤ 上限。只在压缩持续失败、历史无限膨胀时触发（上限设很大，平时
         不触发），保证 prompt 有界。"""
         history = self.user_histories.get(lanlan_name, [])
-        if len(history) <= self.max_history_length + 1:
-            return  # 太短，不可能超大上限
+        if not history:
+            return
+        # 不用条数提前断言"不可能超上限"——几条超长原文就能顶破 token 上限。
+        # 统一交给下面按真实 token 算的 _trim 决定（_trim 内仍保证至少留近期
+        # max_history_length 条，丢不动就不丢）。
 
         from utils.tokenize import count_tokens
 
+        def _raw_tokens(msgs):
+            # 硬上限按**真实注入 prompt** 的 token 算，不能走 _render_messages_to_text
+            # （那个为压缩输入把每条截到 ≤RECENT_PER_MESSAGE_MAX_TOKENS，会严重低估
+            # 长消息、让硬上限对超长原文失效）。这里数原始 content 的 token。
+            total = 0
+            for m in msgs:
+                c = getattr(m, 'content', '')
+                if isinstance(c, list):
+                    c = ' '.join(
+                        p.get('text', '') if isinstance(p, dict) else str(p) for p in c
+                    )
+                elif not isinstance(c, str):
+                    c = str(c)
+                total += count_tokens(c)
+            return total
+
         def _trim():
-            if count_tokens(self._render_messages_to_text(history, lanlan_name)) <= RECENT_HARD_CAP_TOKENS:
+            if _raw_tokens(history) <= RECENT_HARD_CAP_TOKENS:
                 return None  # 未超，不动
             # 首条若是备忘录（已压缩的长期记忆）则保留，只丢正文里最旧的原文。
             head = [history[0]] if isinstance(history[0], SystemMessage) else []
             body = history[len(head):]
             kept = []
-            kept_tok = count_tokens(self._render_messages_to_text(head, lanlan_name)) if head else 0
+            kept_tok = _raw_tokens(head)
             for msg in reversed(body):
-                mtok = count_tokens(self._render_messages_to_text([msg], lanlan_name))
+                mtok = _raw_tokens([msg])
                 if kept and kept_tok + mtok > RECENT_HARD_CAP_TOKENS and len(kept) >= self.max_history_length:
                     break
                 kept.append(msg)
@@ -729,7 +764,10 @@ class CompressedRecentHistoryManager:
         except MaintenanceModeError:
             raise
         except Exception as e:
+            # 落盘失败 → 内存与磁盘不一致（下次 update_history reload 会回滚内存），
+            # 报 'failed' 让上层 bump 退避、不清计数，而不是谎报 'merged'。
             logger.error(f"[RecentHistory] {lanlan_name} 后台压缩合并落盘失败: {e}", exc_info=True)
+            return 'failed'
         logger.info(
             f"[RecentHistory] {lanlan_name} 后台压缩合并完成：history {len(current)}→{len(new_history)}"
         )

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -23,6 +23,8 @@ from config import (
     RECENT_SUMMARY_MAX_TOKENS,
     RECENT_PER_MESSAGE_MAX_TOKENS,
     RECENT_SUMMARY_STALE_HOURS,
+    RECENT_COMPRESS_INPUT_BUDGET_TOKENS,
+    RECENT_HARD_CAP_TOKENS,
 )
 from datetime import datetime
 
@@ -270,7 +272,7 @@ class CompressedRecentHistoryManager:
             extra_body=None,
         )
 
-    async def update_history(self, new_messages, lanlan_name, detailed=False, compress=True):
+    async def update_history(self, new_messages, lanlan_name, detailed=False, compress=True, on_compress_done=None):
         try:
             _, _, _, _, _, _, _, _, recent_log = await self._config_manager.aget_character_data()
             self.log_file_path = recent_log
@@ -311,14 +313,21 @@ class CompressedRecentHistoryManager:
 
             if compress and len(self.user_histories[lanlan_name]) > self.compress_threshold:
                 to_compress = self.user_histories[lanlan_name][:-self.max_history_length+1]
+                snapshot = list(to_compress)
                 compressed_result = await self.compress_history(to_compress, lanlan_name, detailed)
                 if compressed_result is None:
                     logger.warning(
                         f"[RecentHistory] {lanlan_name} 摘要失败，跳过本轮压缩以保留原始历史"
                     )
+                    # 持续失败兜底：保留完整历史前，若总量超硬上限则丢弃最旧未压缩原文。
+                    await self._enforce_hard_cap(lanlan_name)
+                    # best-effort：通知上层起一个受保护的后台压缩任务尽力压（主路径失败）。
+                    await self._notify_compress_done(on_compress_done, lanlan_name, snapshot, False, detailed)
                 else:
                     compressed = [compressed_result[0]]
                     self.user_histories[lanlan_name] = compressed + self.user_histories[lanlan_name][-self.max_history_length+1:]
+                    # 主路径成功 → 通知上层 cancel 在跑的后台压缩（兜底不再需要）。
+                    await self._notify_compress_done(on_compress_done, lanlan_name, snapshot, True, detailed)
         except Exception as e:
             logger.error(f"[RecentHistory] 更新历史记录时出错: {e}", exc_info=True)
 
@@ -397,12 +406,14 @@ class CompressedRecentHistoryManager:
         except Exception as e:
             logger.debug(f"[RecentHistory] {lanlan_name}: 写 recent_meta 失败: {e}")
 
-    # detailed: 保留尽可能多的细节
-    async def compress_history(self, messages, lanlan_name, detailed=False):
+    def _render_messages_to_text(self, messages, lanlan_name):
+        """把消息列表渲染成喂给摘要 LLM 的文本：每条做头尾保留截断 + role 前缀。
+
+        单条 message 文本超过 RECENT_PER_MESSAGE_MAX_TOKENS 时做头尾保留截断
+        （head=tail=半数 token）。用户长贴 / AI 偶尔写小作文都会触发；头尾各
+        保留确保问候/问题与结尾的总结/请求都不丢，中段砍掉。
+        """
         from utils.tokenize import truncate_head_tail_tokens
-        # 单条 message 文本超过 RECENT_PER_MESSAGE_MAX_TOKENS 时做头尾保留
-        # 截断（head=tail=半数 token）。用户长贴 / AI 偶尔写小作文都会触发；
-        # 头尾各保留确保问候/问题与结尾的总结/请求都不丢，中段砍掉。
         per_msg_cap = RECENT_PER_MESSAGE_MAX_TOKENS
         head_tail = per_msg_cap // 2
         name_mapping = self.name_mapping.copy()
@@ -428,53 +439,35 @@ class CompressedRecentHistoryManager:
                 joined = truncate_head_tail_tokens(joined, head_tail, head_tail)
                 line = f"{role} | {joined}"
             lines.append(line)
-        messages_text = "\n".join(lines)
+        return "\n".join(lines)
+
+    def _build_summary_prompt(self, messages_text, detailed):
+        """构建 Stage-1 摘要 prompt（不含 stale-hint 前缀；单次压缩与分段 map 共用）。
+
+        ``{MASTER_NAME}`` 是 prompt 里"保留负面反馈"段引用 master 实名的字面
+        占位符（与同 prompt 里既有的 ``%s`` 共存）。⚠️ master_name 替换**最后**
+        做：它是 user-controlled，含 ``%`` 会让先前的 ``%`` formatting 崩溃；含
+        ``%s`` 会被先前的 ``.replace("%s", ...)`` 二次替换（codex P2）。
+        """
         lang = get_global_language()
-        # ``{MASTER_NAME}`` 是 prompt 里"保留负面反馈"段引用 master 实名的字面
-        # 占位符（与同 prompt 里既有的 ``%s`` 共存：``%s`` 走 Python 格式化，
-        # ``{MASTER_NAME}`` 走显式 ``.replace``，互不干扰）。统一称呼，避免 LLM
-        # 看到 "%s 和 ai 的对话"+"用户的负面反馈" 时困惑（feedback_no_dehumanizing_terms）。
-        # ⚠️ master_name 替换**最后**做：它是 user-controlled，含 ``%`` 会让先前
-        # 的 ``%`` formatting 把它当格式符崩溃；含 ``%s`` 会被先前的
-        # ``.replace("%s", ...)`` 二次替换。先做模板自身的 ``%s`` 替换 / ``%``
-        # formatting，再注入实名（codex P2）。
         master_name = self.name_mapping['human']
         if not detailed:
-            prompt = (
+            return (
                 get_recent_history_manager_prompt(lang)
                 .replace("%s", messages_text)
                 .replace("{MASTER_NAME}", master_name)
             )
-        else:
-            prompt = (
-                (get_detailed_recent_history_manager_prompt(lang) % messages_text)
-                .replace("{MASTER_NAME}", master_name)
-            )
+        return (
+            (get_detailed_recent_history_manager_prompt(lang) % messages_text)
+            .replace("{MASTER_NAME}", master_name)
+        )
 
-        # Past block 时间衰减：距上次"实际更新 past block"超过
-        # RECENT_SUMMARY_STALE_HOURS 小时时，在 prompt 头部加一段提醒让 LLM 把
-        # 明显过时的内容挪到 summary 末尾的"较久前"段落。锚点只在 hint 真正
-        # 注入时推进（见下方 stale_hint_injected）——这样 hint 形成"每 N 小时
-        # 触发一次"的节奏，而不是"每次 compress 都看一眼"。
-        # 仅影响本次 summary 文本，不持久化到 reflection / persona。
-        stale_hint_injected = False
-        first_time_baseline = False
-        try:
-            last_past_update = await self._aread_last_past_block_update_at(lanlan_name)
-            if last_past_update is None:
-                # 第一次为该角色 compress——先建立 baseline 锚点，本轮不注入
-                # hint（首次会话还没有什么"过时"内容值得拎走）。
-                first_time_baseline = True
-            else:
-                gap_hours = (datetime.now() - last_past_update).total_seconds() / 3600.0
-                if gap_hours >= RECENT_SUMMARY_STALE_HOURS:
-                    hint = get_summary_stale_hint(lang, gap_hours)
-                    prompt = hint + "\n\n" + prompt
-                    stale_hint_injected = True
-        except Exception as e:
-            # 时间衰减提醒是 best-effort；失败不能挡 summary 主流程
-            logger.debug(f"[RecentHistory] {lanlan_name}: stale hint 注入失败: {e}")
-
+    async def _invoke_summary_llm(self, prompt):
+        """调摘要 LLM（3 次重试 + 对网络/429 指数退避），成功返回 summary 字符串，
+        失败返回 None。不含 further_compress / memo 包装 / stale 锚点——那些由
+        compress_history 主体在拿到 summary 后处理。Stage-1 单次压缩与分段 map
+        阶段共用本方法。
+        """
         retries = 0
         max_retries = 3
         while retries < max_retries:
@@ -494,32 +487,14 @@ class CompressedRecentHistoryManager:
                 # 从 JSON 字典中提取对话摘要，key 与 prompt 模板里约定的一致
                 if 'summary' in summary_json:
                     raw_summary = summary_json['summary']
-                    # Qwen 偶尔返回 list/dict 而不是字符串；强制 str-ify 后再喂
-                    # acount_tokens（不然会抛 TypeError 把整轮压缩流程崩掉）。
+                    # Qwen 偶尔返回 list/dict 而不是字符串；强制 str-ify 后再用
+                    # （不然 acount_tokens 会抛 TypeError 把整轮压缩崩掉）。
                     summary = (
                         raw_summary if isinstance(raw_summary, str)
                         else json.dumps(raw_summary, ensure_ascii=False)
                     )
                     print(f"💗摘要结果：{summary}")
-                    if await acount_tokens(summary) > MAX_SUMMARY_TOKENS:
-                        summary = await self.further_compress(summary)
-                        if summary is None:
-                            continue
-                        if not isinstance(summary, str):
-                            summary = json.dumps(summary, ensure_ascii=False)
-                    from config.prompts.prompts_sys import _loc, MEMORY_MEMO_WITH_SUMMARY
-                    memo_text = _loc(MEMORY_MEMO_WITH_SUMMARY, get_global_language()).format(summary=summary)
-                    # 推进 past-block 更新锚点（best-effort）：
-                    # - 第一次 compress：建立 baseline，让后续按 gap 触发
-                    # - 注入过 stale hint：表示 LLM 本轮真的更新了 past block
-                    # 中间没有 hint 注入的常规压缩不动锚点——这样 hint 形成稳定
-                    # 的"每 N 小时一次"节奏，而不是被频繁压缩冲掉。
-                    if first_time_baseline or stale_hint_injected:
-                        await self._awrite_last_past_block_update_at(lanlan_name)
-                    # 第二个返回值（用于上层缓存）跟 memo_text 用的 summary 保持
-                    # 一致——之前用 raw 摘要会出现"用户看到的 memo 用了 stage-2
-                    # 摘要、缓存却存了 stage-1 原文"的诡异不一致。
-                    return SystemMessage(content=memo_text), summary
+                    return summary
                 else:
                     print('💥 摘要failed: ', response_content)
                     retries += 1
@@ -537,9 +512,228 @@ class CompressedRecentHistoryManager:
                 print(f'❌ 摘要模型失败：{e}')
                 # 如果解析失败，重试
                 retries += 1
-        # 摘要失败时不生成空备忘录，避免覆盖既有 memo 或丢弃未压缩原文。
-        logger.warning(f"[RecentHistory] {lanlan_name} 摘要连续失败，跳过本轮压缩")
         return None
+
+    def _split_messages_by_budget(self, messages, lanlan_name):
+        """按渲染后累计 token 把消息切成多段，每段 ≤ RECENT_COMPRESS_INPUT_BUDGET_TOKENS。
+        不切碎单条消息（单条已被 per-message 截断到 ≤500 token）。"""
+        from utils.tokenize import count_tokens
+        budget = RECENT_COMPRESS_INPUT_BUDGET_TOKENS
+        chunks, cur, cur_tok = [], [], 0
+        for msg in messages:
+            t = count_tokens(self._render_messages_to_text([msg], lanlan_name))
+            if cur and cur_tok + t > budget:
+                chunks.append(cur)
+                cur, cur_tok = [], 0
+            cur.append(msg)
+            cur_tok += t
+        if cur:
+            chunks.append(cur)
+        return chunks
+
+    def _split_texts_by_budget(self, texts):
+        """按累计 token 把字符串列表分批，每批拼接 ≤ 预算（reduce 阶段用）。"""
+        from utils.tokenize import count_tokens
+        budget = RECENT_COMPRESS_INPUT_BUDGET_TOKENS
+        batches, cur, cur_tok = [], [], 0
+        for txt in texts:
+            tok = count_tokens(txt)
+            if cur and cur_tok + tok > budget:
+                batches.append(cur)
+                cur, cur_tok = [], 0
+            cur.append(txt)
+            cur_tok += tok
+        if cur:
+            batches.append(cur)
+        return batches
+
+    async def _segmented_compress(self, messages, lanlan_name, detailed):
+        """输入过大时的分段 map-reduce：把 messages 切段逐段总结成中间摘要，反复
+        reduce 直到拼接 ≤ 预算，返回该文本交给 compress_history 主体做最终总结。
+        任一段 LLM 失败返回 None（上层据此跳过本轮压缩）。"""
+        chunks = self._split_messages_by_budget(messages, lanlan_name)
+        partials = []
+        for chunk in chunks:
+            s = await self._invoke_summary_llm(
+                self._build_summary_prompt(self._render_messages_to_text(chunk, lanlan_name), detailed)
+            )
+            if s is None:
+                return None
+            partials.append(s)
+        logger.info(
+            f"[RecentHistory] {lanlan_name} 分段压缩：{len(messages)} 条原始消息 → {len(chunks)} 段中间摘要"
+        )
+        # 中间摘要拼接仍超预算 → 再分批合并总结，限深度防极端。
+        depth = 0
+        while (
+            len(partials) > 1
+            and await acount_tokens("\n\n".join(partials)) > RECENT_COMPRESS_INPUT_BUDGET_TOKENS
+            and depth < 3
+        ):
+            batches = self._split_texts_by_budget(partials)
+            if len(batches) >= len(partials):
+                break  # 无法再缩（单段已超预算），交给主体兜底
+            new_partials = []
+            for batch in batches:
+                s = await self._invoke_summary_llm(
+                    self._build_summary_prompt("\n\n".join(batch), detailed)
+                )
+                if s is None:
+                    return None
+                new_partials.append(s)
+            partials = new_partials
+            depth += 1
+        return "\n\n".join(partials)
+
+    # detailed: 保留尽可能多的细节
+    async def compress_history(self, messages, lanlan_name, detailed=False):
+        messages_text = self._render_messages_to_text(messages, lanlan_name)
+        # 输入过大（积压一直压不掉时会膨胀）→ 先分段 map-reduce 缩小输入，减小
+        # 单次 LLM 输入、避免输入过大导致超时。正常输入不走这条。
+        if await acount_tokens(messages_text) > RECENT_COMPRESS_INPUT_BUDGET_TOKENS:
+            reduced = await self._segmented_compress(messages, lanlan_name, detailed)
+            if reduced is None:
+                logger.warning(f"[RecentHistory] {lanlan_name} 分段压缩失败，跳过本轮压缩")
+                return None
+            messages_text = reduced
+
+        lang = get_global_language()
+        prompt = self._build_summary_prompt(messages_text, detailed)
+
+        # Past block 时间衰减：距上次"实际更新 past block"超过
+        # RECENT_SUMMARY_STALE_HOURS 小时时，在 prompt 头部加提醒让 LLM 把明显
+        # 过时的内容挪到 summary 末尾的"较久前"段落。锚点只在 hint 真正注入时
+        # 推进——这样 hint 形成"每 N 小时触发一次"的节奏，而不是每轮压缩都刷。
+        # 仅影响本次 summary 文本，不持久化到 reflection / persona。
+        stale_hint_injected = False
+        first_time_baseline = False
+        try:
+            last_past_update = await self._aread_last_past_block_update_at(lanlan_name)
+            if last_past_update is None:
+                # 第一次为该角色 compress——先建立 baseline 锚点，本轮不注入 hint。
+                first_time_baseline = True
+            else:
+                gap_hours = (datetime.now() - last_past_update).total_seconds() / 3600.0
+                if gap_hours >= RECENT_SUMMARY_STALE_HOURS:
+                    hint = get_summary_stale_hint(lang, gap_hours)
+                    prompt = hint + "\n\n" + prompt
+                    stale_hint_injected = True
+        except Exception as e:
+            # 时间衰减提醒是 best-effort；失败不能挡 summary 主流程
+            logger.debug(f"[RecentHistory] {lanlan_name}: stale hint 注入失败: {e}")
+
+        summary = await self._invoke_summary_llm(prompt)
+        if summary is None:
+            # 摘要失败时不生成空备忘录，避免覆盖既有 memo 或丢弃未压缩原文。
+            logger.warning(f"[RecentHistory] {lanlan_name} 摘要连续失败，跳过本轮压缩")
+            return None
+
+        if await acount_tokens(summary) > MAX_SUMMARY_TOKENS:
+            reduced = await self.further_compress(summary)
+            if reduced is None:
+                logger.warning(f"[RecentHistory] {lanlan_name} 二次压缩失败，跳过本轮压缩")
+                return None
+            summary = reduced if isinstance(reduced, str) else json.dumps(reduced, ensure_ascii=False)
+
+        # 推进 past-block 更新锚点（best-effort）：第一次 compress 建 baseline；
+        # 注入过 stale hint 表示 LLM 本轮真的更新了 past block。常规压缩不动锚点，
+        # 让 hint 形成稳定的"每 N 小时一次"节奏。
+        if first_time_baseline or stale_hint_injected:
+            await self._awrite_last_past_block_update_at(lanlan_name)
+
+        # 第二个返回值（用于上层缓存）跟 memo_text 用的 summary 保持一致——之前
+        # 用 raw 摘要会出现"用户看到的 memo 用 stage-2、缓存却存 stage-1"的不一致。
+        from config.prompts.prompts_sys import _loc, MEMORY_MEMO_WITH_SUMMARY
+        memo_text = _loc(MEMORY_MEMO_WITH_SUMMARY, get_global_language()).format(summary=summary)
+        return SystemMessage(content=memo_text), summary
+
+    async def _notify_compress_done(self, callback, lanlan_name, snapshot, ok, detailed):
+        """调 on_compress_done 回调（best-effort，异常吞掉不挡主流程）。
+        回调由 memory_server 注入：ok=False 起后台压缩、ok=True cancel 在跑的后台。"""
+        if callback is None:
+            return
+        try:
+            await callback(lanlan_name, snapshot, ok, detailed)
+        except Exception as e:
+            logger.debug(f"[RecentHistory] {lanlan_name} on_compress_done({ok}) 回调异常: {e}")
+
+    async def _enforce_hard_cap(self, lanlan_name):
+        """最终兜底：历史 token 超 RECENT_HARD_CAP_TOKENS 时丢弃最旧的未压缩对话
+        原文，保留首条备忘录（若有）+ 最新若干条（至少 max_history_length 条），
+        直到 ≤ 上限。只在压缩持续失败、历史无限膨胀时触发（上限设很大，平时
+        不触发），保证 prompt 有界。"""
+        history = self.user_histories.get(lanlan_name, [])
+        if len(history) <= self.max_history_length + 1:
+            return  # 太短，不可能超大上限
+
+        from utils.tokenize import count_tokens
+
+        def _trim():
+            if count_tokens(self._render_messages_to_text(history, lanlan_name)) <= RECENT_HARD_CAP_TOKENS:
+                return None  # 未超，不动
+            # 首条若是备忘录（已压缩的长期记忆）则保留，只丢正文里最旧的原文。
+            head = [history[0]] if isinstance(history[0], SystemMessage) else []
+            body = history[len(head):]
+            kept = []
+            kept_tok = count_tokens(self._render_messages_to_text(head, lanlan_name)) if head else 0
+            for msg in reversed(body):
+                mtok = count_tokens(self._render_messages_to_text([msg], lanlan_name))
+                if kept and kept_tok + mtok > RECENT_HARD_CAP_TOKENS and len(kept) >= self.max_history_length:
+                    break
+                kept.append(msg)
+                kept_tok += mtok
+            kept.reverse()
+            return head + kept
+
+        new_history = await asyncio.to_thread(_trim)
+        if new_history is not None and len(new_history) < len(history):
+            dropped = len(history) - len(new_history)
+            logger.warning(
+                f"[RecentHistory] {lanlan_name} 历史超硬上限 {RECENT_HARD_CAP_TOKENS} token，"
+                f"丢弃最旧 {dropped} 条未压缩原文以保证有界"
+            )
+            self.user_histories[lanlan_name] = new_history
+
+    async def merge_backup_memo(self, lanlan_name, snapshot, memo):
+        """后台压缩成功后，把 memo 合并回当前 history（快照对齐）。
+
+        用 snapshot 的 fingerprint 在当前 history 里定位那批积压：仍整批连续在
+        头部（capacity==len(snapshot) 且批头在 index 0）→ 替换成 [memo] + 这期间
+        新增的对话，落盘，返回 'merged'；否则（已被主路径压掉 / 被 /new_dialog
+        清空 / 头部已变）→ 丢弃返回 'moot'。
+
+        读 current 到写 new_history 之间全是同步代码（_compute_review_capacity
+        同步），asyncio 单线程下原子；落盘在写之后。调用方（memory_server）应在
+        _get_settle_lock 内调用，串行化对该角色的写。
+        """
+        current = self.user_histories.get(lanlan_name, [])
+        if not current or not snapshot:
+            return 'moot'
+        capacity, cutoff_idx = _compute_review_capacity(snapshot, current)
+        if cutoff_idx is None or capacity != len(snapshot) or (cutoff_idx - capacity + 1) != 0:
+            return 'moot'
+        new_history = [memo] + current[cutoff_idx + 1:]
+        self.user_histories[lanlan_name] = new_history
+        try:
+            assert_cloudsave_writable(
+                self._config_manager, operation="save",
+                target=f"memory/{lanlan_name}/recent.json",
+            )
+            file_path = self._ensure_path_for_character(lanlan_name)
+            await asyncio.to_thread(os.makedirs, os.path.dirname(file_path), exist_ok=True)
+            await atomic_write_json_async(
+                file_path,
+                await asyncio.to_thread(messages_to_dict, new_history),
+                indent=2, ensure_ascii=False,
+            )
+        except MaintenanceModeError:
+            raise
+        except Exception as e:
+            logger.error(f"[RecentHistory] {lanlan_name} 后台压缩合并落盘失败: {e}", exc_info=True)
+        logger.info(
+            f"[RecentHistory] {lanlan_name} 后台压缩合并完成：history {len(current)}→{len(new_history)}"
+        )
+        return 'merged'
 
     async def further_compress(self, initial_summary):
         # Stage-2 LLM 输出硬限：RECENT_SUMMARY_MAX_TOKENS + 100 余量 = 1100 token。

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -319,9 +319,12 @@ class CompressedRecentHistoryManager:
                     logger.warning(
                         f"[RecentHistory] {lanlan_name} 摘要失败，跳过本轮压缩以保留原始历史"
                     )
-                    # 持续失败兜底：保留完整历史前，若总量超硬上限则丢弃最旧未压缩原文。
-                    await self._enforce_hard_cap(lanlan_name)
                     # best-effort：通知上层起一个受保护的后台压缩任务尽力压（主路径失败）。
+                    # 硬上限裁剪**不在这里**做——否则"历史超 cap 后任何一次暂时性失败"
+                    # 都会立刻丢最旧原文，而后台压缩用的是裁剪前 snapshot → 合并失配
+                    # moot → 那批对话没被摘要就永久丢了。改由后台 best-effort 也压不成
+                    # 后再裁剪（memory_server._run_backup_compress / dead-letter 分支），
+                    # 让暂时性失败有机会被后台压成摘要保留。
                     await self._notify_compress_done(on_compress_done, lanlan_name, snapshot, False, detailed)
                 else:
                     compressed = [compressed_result[0]]
@@ -673,11 +676,11 @@ class CompressedRecentHistoryManager:
         except Exception as e:
             logger.debug(f"[RecentHistory] {lanlan_name} on_compress_done({ok}) 回调异常: {e}")
 
-    async def _enforce_hard_cap(self, lanlan_name):
+    async def enforce_hard_cap(self, lanlan_name):
         """最终兜底：历史 token 超 RECENT_HARD_CAP_TOKENS 时丢弃最旧的未压缩对话
         原文，保留首条备忘录（若有）+ 最新若干条（至少 max_history_length 条），
-        直到 ≤ 上限。只在压缩持续失败、历史无限膨胀时触发（上限设很大，平时
-        不触发），保证 prompt 有界。"""
+        直到 ≤ 上限。只在 best-effort 后台压缩也压不成、历史仍无限膨胀时由
+        memory_server 调用（上限设很大，平时不触发），保证 prompt 有界。"""
         history = self.user_histories.get(lanlan_name, [])
         if not history:
             return
@@ -728,6 +731,24 @@ class CompressedRecentHistoryManager:
                 f"丢弃最旧 {dropped} 条未压缩原文以保证有界"
             )
             self.user_histories[lanlan_name] = new_history
+            # 自包含落盘：本方法现在由后台 task / 回调调用（update_history 之外），
+            # 不能再依赖 update_history 的后续落盘。
+            try:
+                assert_cloudsave_writable(
+                    self._config_manager, operation="save",
+                    target=f"memory/{lanlan_name}/recent.json",
+                )
+                file_path = self._ensure_path_for_character(lanlan_name)
+                await asyncio.to_thread(os.makedirs, os.path.dirname(file_path), exist_ok=True)
+                await atomic_write_json_async(
+                    file_path,
+                    await asyncio.to_thread(messages_to_dict, new_history),
+                    indent=2, ensure_ascii=False,
+                )
+            except MaintenanceModeError:
+                raise
+            except Exception as e:
+                logger.error(f"[RecentHistory] {lanlan_name} 硬上限裁剪落盘失败: {e}", exc_info=True)
 
     async def merge_backup_memo(self, lanlan_name, snapshot, memo):
         """后台压缩成功后，把 memo 合并回当前 history（快照对齐）。

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""best-effort 后台压缩（主路径压缩失败时兜底）回归测试。
+
+主路径 update_history 压缩失败（如 RPM 限流连续失败）→ _on_compress_done(ok=False)
+起一个受保护的一次性后台压缩；主路径某轮成功 → ok=True cancel 在跑的后台。失败退避
+（复用 review 的 Gate 6 模式）防 summary 模型持续故障时每轮起注定失败的任务空烧。
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.llm_client import AIMessage, HumanMessage, SystemMessage
+
+
+def _history(n: int):
+    out = []
+    for i in range(n):
+        out.append(HumanMessage(content=f"u{i}") if i % 2 == 0 else AIMessage(content=f"a{i}"))
+    return out
+
+
+async def _cleanup_task(task):
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except BaseException:
+            pass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_compress_done_failure_spawns_backup():
+    from app import memory_server
+    name = "测试角色C"
+    snapshot = _history(6)
+    memory_server._maint_state.pop(name, None)
+    memory_server.compress_backup_tasks.pop(name, None)
+
+    async def _slow_compress(*a, **k):
+        await asyncio.sleep(30)
+
+    fake_mgr = MagicMock()
+    fake_mgr.compress_history = _slow_compress
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._on_compress_done(name, snapshot, ok=False, detailed=False)
+        task = memory_server.compress_backup_tasks.get(name)
+        assert task is not None and not task.done()  # 起了后台兜底
+        await _cleanup_task(task)
+
+    memory_server.compress_backup_tasks.pop(name, None)
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_compress_done_success_cancels_backup():
+    from app import memory_server
+    name = "测试角色C"
+    task = MagicMock()
+    task.done.return_value = False
+    memory_server.compress_backup_tasks[name] = task
+
+    with patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._on_compress_done(name, [], ok=True, detailed=False)
+
+    task.cancel.assert_called_once()  # 主路径成功 → cancel 在跑的后台
+    memory_server.compress_backup_tasks.pop(name, None)
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_compress_done_in_flight_guard():
+    from app import memory_server
+    name = "测试角色C"
+    memory_server._maint_state.pop(name, None)
+
+    existing = MagicMock()
+    existing.done.return_value = False
+    memory_server.compress_backup_tasks[name] = existing
+
+    fake_mgr = MagicMock()
+    fake_mgr.compress_history = AsyncMock(return_value=None)
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._on_compress_done(name, _history(6), ok=False, detailed=False)
+
+    # 同角色已有后台在跑 → 不重复起，仍是原 task
+    assert memory_server.compress_backup_tasks[name] is existing
+    memory_server.compress_backup_tasks.pop(name, None)
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_compress_done_deadletter_skips_spawn():
+    from app import memory_server
+    from memory.recent import build_review_fingerprint
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    name = "测试角色C"
+    snapshot = _history(6)
+    memory_server.compress_backup_tasks.pop(name, None)
+    memory_server._maint_state[name] = {
+        "compress_backup_fail_attempts": MEMORY_LIVENESS_MAX_ATTEMPTS,
+        "compress_backup_fail_fp": build_review_fingerprint(snapshot),
+    }
+
+    fake_mgr = MagicMock()
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._on_compress_done(name, snapshot, ok=False, detailed=False)
+
+    # 连续失败 ≥ N 且输入未变 → dead-letter，不再起
+    assert name not in memory_server.compress_backup_tasks
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_compress_done_deadletter_resets_when_input_changed():
+    from app import memory_server
+    from memory.recent import build_review_fingerprint
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    name = "测试角色C"
+    memory_server.compress_backup_tasks.pop(name, None)
+    # 退避计数已满，但记录的是「旧输入」的 fingerprint
+    memory_server._maint_state[name] = {
+        "compress_backup_fail_attempts": MEMORY_LIVENESS_MAX_ATTEMPTS,
+        "compress_backup_fail_fp": build_review_fingerprint(_history(4)),
+    }
+    new_snapshot = _history(8)  # 输入变了
+
+    async def _slow_compress(*a, **k):
+        await asyncio.sleep(30)
+
+    fake_mgr = MagicMock()
+    fake_mgr.compress_history = _slow_compress
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._on_compress_done(name, new_snapshot, ok=False, detailed=False)
+        # 输入变了 → 复位放行，起了后台
+        task = memory_server.compress_backup_tasks.get(name)
+        assert task is not None
+        await _cleanup_task(task)
+
+    memory_server.compress_backup_tasks.pop(name, None)
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_backup_compress_failure_bumps_backoff():
+    from app import memory_server
+    from memory.recent import build_review_fingerprint
+    name = "测试角色C"
+    snapshot = _history(6)
+    memory_server._maint_state.pop(name, None)
+
+    fake_mgr = MagicMock()
+    fake_mgr.compress_history = AsyncMock(return_value=None)
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._run_backup_compress(name, snapshot, False)
+
+    state = memory_server._maint_state[name]
+    assert state["compress_backup_fail_attempts"] == 1
+    assert state["compress_backup_fail_fp"] == build_review_fingerprint(snapshot)
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_backup_compress_merges_and_clears_backoff():
+    from app import memory_server
+    name = "测试角色C"
+    snapshot = _history(6)
+    memory_server._maint_state[name] = {"compress_backup_fail_attempts": 2}
+
+    fake_mgr = MagicMock()
+    fake_mgr.compress_history = AsyncMock(return_value=(SystemMessage(content="memo"), "memo"))
+    fake_mgr.merge_backup_memo = AsyncMock(return_value="merged")
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._run_backup_compress(name, snapshot, False)
+
+    fake_mgr.merge_backup_memo.assert_awaited_once()  # 成功 → 合并写回
+    assert not memory_server._maint_state[name].get("compress_backup_fail_attempts")  # 退避清零
+    memory_server._maint_state.pop(name, None)

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -27,7 +27,8 @@ async def _cleanup_task(task):
         task.cancel()
         try:
             await task
-        except BaseException:
+        except (asyncio.CancelledError, Exception):
+            # cleanup-only：吞掉 cancel 抛出的 CancelledError 及 task 内部任何异常
             pass
 
 

--- a/tests/unit/test_recent_compress_backup.py
+++ b/tests/unit/test_recent_compress_backup.py
@@ -113,12 +113,14 @@ async def test_on_compress_done_deadletter_skips_spawn():
     }
 
     fake_mgr = MagicMock()
+    fake_mgr.enforce_hard_cap = AsyncMock()
     with patch.object(memory_server, "recent_history_manager", fake_mgr), \
          patch.object(memory_server, "_asave_maint_state", AsyncMock()):
         await memory_server._on_compress_done(name, snapshot, ok=False, detailed=False)
 
-    # 连续失败 ≥ N 且输入未变 → dead-letter，不再起
+    # 连续失败 ≥ N 且输入未变 → dead-letter，不再起后台；但仍裁剪兜底
     assert name not in memory_server.compress_backup_tasks
+    fake_mgr.enforce_hard_cap.assert_awaited_once()
     memory_server._maint_state.pop(name, None)
 
 
@@ -165,6 +167,7 @@ async def test_run_backup_compress_failure_bumps_backoff():
 
     fake_mgr = MagicMock()
     fake_mgr.compress_history = AsyncMock(return_value=None)
+    fake_mgr.enforce_hard_cap = AsyncMock()
     with patch.object(memory_server, "recent_history_manager", fake_mgr), \
          patch.object(memory_server, "_asave_maint_state", AsyncMock()):
         await memory_server._run_backup_compress(name, snapshot, False)
@@ -172,6 +175,7 @@ async def test_run_backup_compress_failure_bumps_backoff():
     state = memory_server._maint_state[name]
     assert state["compress_backup_fail_attempts"] == 1
     assert state["compress_backup_fail_fp"] == build_review_fingerprint(snapshot)
+    fake_mgr.enforce_hard_cap.assert_awaited_once()  # 后台也压不成 → 裁剪兜底
     memory_server._maint_state.pop(name, None)
 
 

--- a/tests/unit/test_recent_compression_failure.py
+++ b/tests/unit/test_recent_compression_failure.py
@@ -184,9 +184,8 @@ def test_compress_history_returns_memo_on_success(tmp_path):
 
 
 def test_split_messages_by_budget(tmp_path, monkeypatch):
-    import memory.recent as recent_mod
     mgr, name = _make_manager(tmp_path)
-    monkeypatch.setattr(recent_mod, "RECENT_COMPRESS_INPUT_BUDGET_TOKENS", 5)
+    monkeypatch.setattr("memory.recent.RECENT_COMPRESS_INPUT_BUDGET_TOKENS", 5)
     msgs = [HumanMessage(content=f"message number {i}") for i in range(6)]
     chunks = mgr._split_messages_by_budget(msgs, name)
     assert len(chunks) >= 2
@@ -196,9 +195,8 @@ def test_split_messages_by_budget(tmp_path, monkeypatch):
 
 
 def test_compress_history_uses_segmented_path_for_large_input(tmp_path, monkeypatch):
-    import memory.recent as recent_mod
     mgr, name = _make_manager(tmp_path)
-    monkeypatch.setattr(recent_mod, "RECENT_COMPRESS_INPUT_BUDGET_TOKENS", 5)
+    monkeypatch.setattr("memory.recent.RECENT_COMPRESS_INPUT_BUDGET_TOKENS", 5)
     fake_llm = _ValidSummaryLLM("s")
     setattr(mgr, "_get_llm", lambda: fake_llm)
     _mock_summary_anchors(mgr)
@@ -211,9 +209,8 @@ def test_compress_history_uses_segmented_path_for_large_input(tmp_path, monkeypa
 
 
 def test_enforce_hard_cap_drops_oldest_keeps_memo_and_recent(tmp_path, monkeypatch):
-    import memory.recent as recent_mod
     mgr, name = _make_manager(tmp_path)
-    monkeypatch.setattr(recent_mod, "RECENT_HARD_CAP_TOKENS", 20)
+    monkeypatch.setattr("memory.recent.RECENT_HARD_CAP_TOKENS", 20)
     memo = SystemMessage(content="先前对话的备忘录: 长期记忆。")
     body = [HumanMessage(content=f"original message {i} with some length") for i in range(12)]
     mgr.user_histories[name] = [memo] + body
@@ -299,3 +296,17 @@ def test_update_history_callback_ok_true_on_success(tmp_path):
 
     _run(mgr.update_history([HumanMessage(content="new")], name, on_compress_done=_cb))
     assert calls == [(name, True)]
+
+
+def test_merge_backup_memo_reports_failed_on_write_error(tmp_path, monkeypatch):
+    mgr, name = _make_manager(tmp_path)
+    batch = [HumanMessage(content="u1"), AIMessage(content="a1"), HumanMessage(content="u2")]
+    mgr.user_histories[name] = list(batch)
+
+    async def _boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("memory.recent.atomic_write_json_async", _boom)
+
+    status = _run(mgr.merge_backup_memo(name, list(batch), SystemMessage(content="memo")))
+    assert status == "failed"  # 落盘失败必须报 failed，不能谎报 merged

--- a/tests/unit/test_recent_compression_failure.py
+++ b/tests/unit/test_recent_compression_failure.py
@@ -215,7 +215,7 @@ def test_enforce_hard_cap_drops_oldest_keeps_memo_and_recent(tmp_path, monkeypat
     body = [HumanMessage(content=f"original message {i} with some length") for i in range(12)]
     mgr.user_histories[name] = [memo] + body
 
-    _run(mgr._enforce_hard_cap(name))
+    _run(mgr.enforce_hard_cap(name))
 
     kept = mgr.user_histories[name]
     assert kept[0] is memo  # 备忘录（已压缩长期记忆）保留
@@ -228,7 +228,7 @@ def test_enforce_hard_cap_noop_when_under_budget(tmp_path):
     mgr, name = _make_manager(tmp_path)
     history = [SystemMessage(content="memo")] + [HumanMessage(content=f"m{i}") for i in range(8)]
     mgr.user_histories[name] = list(history)
-    _run(mgr._enforce_hard_cap(name))
+    _run(mgr.enforce_hard_cap(name))
     assert mgr.user_histories[name] == history  # 未超大上限，不动
 
 

--- a/tests/unit/test_recent_compression_failure.py
+++ b/tests/unit/test_recent_compression_failure.py
@@ -138,3 +138,164 @@ def test_update_history_preserves_existing_memo_when_compression_fails(tmp_path)
     assert isinstance(final[0], SystemMessage)
     assert final[0].content == old_messages[0].content
     assert final[-1].content == "new ai"
+
+
+# ── 持续失败兜底 / 分段压缩 / 后台合并 回归测试 ──────────────────────────
+
+class _ValidSummaryLLM:
+    """返回合法 JSON 摘要，模拟压缩成功。"""
+
+    def __init__(self, summary: str = "压缩后的摘要"):
+        self.calls = 0
+        self._summary = summary
+
+    async def ainvoke(self, prompt: str, **kwargs: Any) -> Any:
+        self.calls += 1
+        payload = json.dumps({"summary": self._summary}, ensure_ascii=False)
+
+        class _R:
+            content = payload
+
+        return _R()
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _mock_summary_anchors(mgr):
+    """mock past-block 锚点读写，让 compress_history 成功路径不碰磁盘 meta。"""
+    setattr(mgr, "_aread_last_past_block_update_at", lambda _n: asyncio.sleep(0, result=None))
+    setattr(mgr, "_awrite_last_past_block_update_at", lambda _n: asyncio.sleep(0, result=None))
+
+
+def test_compress_history_returns_memo_on_success(tmp_path):
+    mgr, name = _make_manager(tmp_path)
+    fake_llm = _ValidSummaryLLM("柚希今天聊了咖啡。")
+    setattr(mgr, "_get_llm", lambda: fake_llm)
+    _mock_summary_anchors(mgr)
+
+    result = _run(mgr.compress_history([HumanMessage(content="hello")], name))
+
+    assert result is not None
+    memo, summary = result
+    assert isinstance(memo, SystemMessage)
+    assert "柚希今天聊了咖啡。" in summary
+    assert fake_llm.calls == 1  # 小输入走单次路径，不分段
+
+
+def test_split_messages_by_budget(tmp_path, monkeypatch):
+    import memory.recent as recent_mod
+    mgr, name = _make_manager(tmp_path)
+    monkeypatch.setattr(recent_mod, "RECENT_COMPRESS_INPUT_BUDGET_TOKENS", 5)
+    msgs = [HumanMessage(content=f"message number {i}") for i in range(6)]
+    chunks = mgr._split_messages_by_budget(msgs, name)
+    assert len(chunks) >= 2
+    assert sum(len(c) for c in chunks) == len(msgs)  # 不丢消息
+    flat = [m for c in chunks for m in c]
+    assert [m.content for m in flat] == [m.content for m in msgs]  # 顺序保持
+
+
+def test_compress_history_uses_segmented_path_for_large_input(tmp_path, monkeypatch):
+    import memory.recent as recent_mod
+    mgr, name = _make_manager(tmp_path)
+    monkeypatch.setattr(recent_mod, "RECENT_COMPRESS_INPUT_BUDGET_TOKENS", 5)
+    fake_llm = _ValidSummaryLLM("s")
+    setattr(mgr, "_get_llm", lambda: fake_llm)
+    _mock_summary_anchors(mgr)
+
+    msgs = [HumanMessage(content=f"message number {i}") for i in range(6)]
+    result = _run(mgr.compress_history(msgs, name))
+
+    assert result is not None
+    assert fake_llm.calls > 1  # 走了分段（map 多次 + 主体最终总结）
+
+
+def test_enforce_hard_cap_drops_oldest_keeps_memo_and_recent(tmp_path, monkeypatch):
+    import memory.recent as recent_mod
+    mgr, name = _make_manager(tmp_path)
+    monkeypatch.setattr(recent_mod, "RECENT_HARD_CAP_TOKENS", 20)
+    memo = SystemMessage(content="先前对话的备忘录: 长期记忆。")
+    body = [HumanMessage(content=f"original message {i} with some length") for i in range(12)]
+    mgr.user_histories[name] = [memo] + body
+
+    _run(mgr._enforce_hard_cap(name))
+
+    kept = mgr.user_histories[name]
+    assert kept[0] is memo  # 备忘录（已压缩长期记忆）保留
+    assert len(kept) < 1 + len(body)  # 丢了最旧的原文
+    assert len(kept) >= 1 + mgr.max_history_length  # 至少保留近期 max_history_length 条
+    assert kept[-1].content == body[-1].content  # 保留的是最新的
+
+
+def test_enforce_hard_cap_noop_when_under_budget(tmp_path):
+    mgr, name = _make_manager(tmp_path)
+    history = [SystemMessage(content="memo")] + [HumanMessage(content=f"m{i}") for i in range(8)]
+    mgr.user_histories[name] = list(history)
+    _run(mgr._enforce_hard_cap(name))
+    assert mgr.user_histories[name] == history  # 未超大上限，不动
+
+
+def test_merge_backup_memo_merges_when_batch_present(tmp_path):
+    mgr, name = _make_manager(tmp_path)
+    batch = [
+        HumanMessage(content="u1"), AIMessage(content="a1"),
+        HumanMessage(content="u2"), AIMessage(content="a2"),
+    ]
+    new_during = [HumanMessage(content="during1"), AIMessage(content="during2")]
+    mgr.user_histories[name] = list(batch) + list(new_during)
+    memo = SystemMessage(content="先前对话的备忘录: 压缩结果。")
+
+    status = _run(mgr.merge_backup_memo(name, list(batch), memo))
+
+    assert status == "merged"
+    merged = mgr.user_histories[name]
+    assert merged[0] is memo
+    assert [m.content for m in merged[1:]] == [m.content for m in new_during]  # 期间新增保留
+
+
+def test_merge_backup_memo_moot_when_batch_gone(tmp_path):
+    mgr, name = _make_manager(tmp_path)
+    batch = [HumanMessage(content="u1"), AIMessage(content="a1"), HumanMessage(content="u2")]
+    # current 已被主路径压成 memo + 近期，batch 不在头部
+    mgr.user_histories[name] = [SystemMessage(content="已压缩"), HumanMessage(content="recent")]
+
+    status = _run(mgr.merge_backup_memo(name, list(batch), SystemMessage(content="memo")))
+
+    assert status == "moot"
+    assert mgr.user_histories[name][0].content == "已压缩"  # current 不动
+
+
+def test_update_history_callback_ok_false_on_failure(tmp_path):
+    mgr, name = _make_manager(tmp_path)
+    msgs = [HumanMessage(content=f"m{i}") for i in range(7)]
+    _write_recent(mgr.log_file_path[name], msgs)
+
+    async def _fail(*a, **k):
+        return None
+    setattr(mgr, "compress_history", _fail)
+
+    calls = []
+
+    async def _cb(ln, snap, ok, detailed):
+        calls.append((ln, ok))
+
+    _run(mgr.update_history([HumanMessage(content="new")], name, on_compress_done=_cb))
+    assert calls == [(name, False)]
+
+
+def test_update_history_callback_ok_true_on_success(tmp_path):
+    mgr, name = _make_manager(tmp_path)
+    msgs = [HumanMessage(content=f"m{i}") for i in range(7)]
+    _write_recent(mgr.log_file_path[name], msgs)
+
+    async def _ok(*a, **k):
+        return (SystemMessage(content="memo"), "memo")
+    setattr(mgr, "compress_history", _ok)
+
+    calls = []
+
+    async def _cb(ln, snap, ok, detailed):
+        calls.append((ln, ok))
+
+    _run(mgr.update_history([HumanMessage(content="new")], name, on_compress_done=_cb))
+    assert calls == [(name, True)]


### PR DESCRIPTION
## 背景

#1629 修了"压缩失败覆盖空备忘录"的数据丢失 bug，改成"失败跳过本轮、保留完整历史、下轮重试"，正好兜住**暂时性**失败（如 RPM 限流抖一下，下轮恢复）。

但**持续性**失败没兜住：压缩一直成不了 → 历史一直压不掉、越积越多 → 注入主模型的 prompt 无限膨胀（最终撑爆 context / 成本飙升）。几种原因互相独立、都 valid：

- **持续 429**（RPM 限流，真实发生过）：重试/退避无效（外部约束）。
- **超时 / 输入过大**：积压越大单次输入越大越易超时（恶性循环）。
- **并发覆盖**：`/process` 调 `update_history` 不持 `_get_settle_lock`（`/renew`·`/settle`·`/cache` 都持），压缩 await LLM 数十秒期间被后续对话重载磁盘覆盖，压缩白做。

## 方案（best effort → 实在不行才丢）

1. **主路径就地压（#1629，不变）**：失败跳过、保留历史、下轮重试。
2. **best-effort 后台压缩**：主路径压缩失败 → 起一个受保护的一次性后台任务尽力压。
   - 受保护：基于历史快照跑（不被对话打断），压完用 fingerprint 快照对齐原子合并写回（复用 `review_history` 的 `_compute_review_capacity`）——积压还在原位就替换成备忘录、保留这期间新增的对话；被主路径压掉/清空就丢弃（moot）。`compress` 在 `_get_settle_lock` 外（LLM 耗时不阻塞其它端点）、`merge` 在锁内（快，串行化写）。
   - 治超时：输入超 `RECENT_COMPRESS_INPUT_BUDGET_TOKENS` 就分段 map-reduce，减小单次 LLM 输入。
   - 一次性、不常驻；同角色 in-flight 只一个；主路径某轮成功就 cancel 它；失败退避复用 Gate6 模式防 summary 模型持续故障时空烧。
3. **最终兜底硬上限**：历史超 `RECENT_HARD_CAP_TOKENS`（设很大，平时不触发，只兜持续 429 这类 best-effort 也救不回的场景）→ 丢弃最旧的未压缩对话原文，保留近期若干条 + 备忘录，保证有界。

## 改动
- `memory/recent.py`：`compress_history` 重构出可复用 helper（`_render_messages_to_text` / `_build_summary_prompt` / `_invoke_summary_llm`，单次路径行为不变）+ 输入过大时分段压缩；`update_history` 加 `on_compress_done` 钩子；新增 `merge_backup_memo`（快照对齐合并）、`_enforce_hard_cap`（兜底裁剪）。
- `app/memory_server.py`：`_on_compress_done` 回调（失败起后台 / 成功 cancel + 清退避）+ `_run_backup_compress` 编排 + `compress_backup_tasks` in-flight 去重 + Gate6 失败退避；4 个压缩调用点接线。
- `config/__init__.py`：`RECENT_COMPRESS_INPUT_BUDGET_TOKENS`（8000）、`RECENT_HARD_CAP_TOKENS`（60000）。

## 测试
`tests/unit/test_recent_compression_failure.py`（扩展）+ `tests/unit/test_recent_compress_backup.py`（新增）：分段切分/路径、硬上限裁剪、快照合并（merged/moot）、回调 ok 真假、后台退避/in-flight/dead-letter/复位。`uv run pytest tests/unit/ -k "compress or recent or backoff or review or stale or temporal or memo or summary"` → 416 passed。

Relates to #1629。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 主路径压缩失败时启动受保护后台兜底任务，成功则取消；增加失败退避与 dead‑letter，避免无效重试并在必要时触发硬裁剪保障内存边界。

* **新特性**
  * 大输入支持按 token 预算分段汇总与合并以提高压缩稳健性；新增近期历史相关可配置项以便调优。

* **测试**
  * 新增单元测试覆盖后台兜底、退避、合并与硬上限行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->