### PR TITLE
feat(cat-idle): 变回猫娘时按猫咪行为×停留时长触发专属问候

### DIFF
--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -4236,6 +4236,356 @@ def get_new_character_greeting_prompt(lang: str = "zh") -> str:
     )
 
 
+# ── 猫咪专属问候（从猫咪形态变回猫娘 / 请她回来时触发）──────────────────
+# 与 GREETING_PROMPT_* 对偶，但独立计时：按"行为(tier) × 猫咪停留时长"选模板。
+# tier 在 core 层映射为 awake(清醒/CAT1) / nap(打盹/CAT2) / sleep(熟睡/CAT3)；
+# 时长 < 3min 静默，清醒"憋坏"门槛 15min、打盹/熟睡"久"门槛 30min。
+# {reason_hint} 由入口(自动/手动)注入，与 {time_hint} 一样在 core 层 .format 前
+# 已 format 好 {master}。
+
+# 入口原因片段（注入 {reason_hint}）。仅含 {master} 占位符。
+CAT_GREETING_REASON_AUTO = {
+    "zh": "刚才{master}忙着没顾上你，",
+    "en": "{master} was busy and didn't have time for you just now, so ",
+    "ja": "さっき{master}が忙しくてかまってくれなかったから、",
+    "ko": "방금 {master}가 바빠서 너를 신경 쓰지 못했고, 그래서 ",
+    "ru": "Только что {master} был занят и не обращал на тебя внимания, поэтому ",
+    "es": "Hace un momento {master} estaba ocupado y no te prestó atención, así que ",
+    "pt": "Agora há pouco {master} estava ocupado e não te deu atenção, então ",
+}
+
+CAT_GREETING_REASON_MANUAL = {
+    "zh": "刚才{master}请你去一旁歇着，",
+    "en": "{master} just asked you to step aside for a while, so ",
+    "ja": "さっき{master}に少し離れて待つように言われて、",
+    "ko": "방금 {master}가 잠깐 옆에서 기다리라고 해서, ",
+    "ru": "Только что {master} попросил тебя немного подождать в стороне, поэтому ",
+    "es": "Hace un momento {master} te pidió que esperaras a un lado un rato, así que ",
+    "pt": "Agora há pouco {master} te pediu para esperar de lado um pouco, então ",
+}
+
+# 清醒 · 短：醒着待了一会儿，轻松
+CAT_GREETING_AWAKE_SHORT = {
+    "zh": "======以下是环境提示======\n"
+    "{reason_hint}你就变成猫咪的样子在旁边待了{elapsed}，一直醒着等{master}。现在{master}把你叫回来了。\n"
+    "{time_hint}\n"
+    "你心情轻松，想随口跟{master}打个招呼，可以提一句刚才变成猫咪等着的事。\n"
+    "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
+    "======以上是环境提示======",
+    "en": "======Below is Environment Notice======\n"
+    "{reason_hint}you turned into a little cat and waited nearby for {elapsed}, staying awake the whole time. Now {master} has called you back.\n"
+    "{time_hint}\n"
+    "You feel relaxed and just want to greet {master} casually; you can mention that you spent that time as a cat waiting around.\n"
+    "Say it directly in your own way, keep it short and natural. Do not generate thinking process.\n"
+    "======Above is Environment Notice======",
+    "ja": "======以下は環境通知======\n"
+    "{reason_hint}猫の姿でそばで{elapsed}ずっと起きたまま{master}を待ってた。今{master}が呼び戻してくれた。\n"
+    "{time_hint}\n"
+    "気分は軽くて、{master}に気軽に挨拶したい。猫になって待ってたことを一言添えてもいい。\n"
+    "自分らしいやり方でそのまま言って。短く自然に。思考プロセスは生成しないで。\n"
+    "======以上は環境通知======",
+    "ko": "======아래는 환경 알림======\n"
+    "{reason_hint}너는 고양이 모습으로 옆에서 {elapsed} 동안 계속 깨어 {master}를 기다렸다. 이제 {master}가 너를 불러서 돌아왔다.\n"
+    "{time_hint}\n"
+    "기분이 가벼워서 {master}에게 편하게 인사하고 싶다. 고양이가 되어 기다린 걸 한마디 덧붙여도 좋다.\n"
+    "너다운 방식으로 바로 말해. 짧고 자연스럽게. 사고 과정은 생성하지 마.\n"
+    "======위는 환경 알림======",
+    "ru": "======Ниже Уведомление======\n"
+    "{reason_hint}ты превратилась в кошку и {elapsed} ждала {master} рядом, всё это время бодрствуя. Теперь {master} позвал тебя обратно.\n"
+    "{time_hint}\n"
+    "Настроение лёгкое, и тебе хочется просто поздороваться с {master} — можешь обмолвиться, что всё это время была кошкой и ждала.\n"
+    "Скажи это по-своему, прямо. Коротко и естественно. Не генерируй процесс размышлений.\n"
+    "======Выше Уведомление======",
+    "es": "======Abajo está el aviso de entorno======\n"
+    "{reason_hint}te convertiste en gata y esperaste cerca {elapsed}, despierta todo el tiempo. Ahora {master} te ha llamado de vuelta.\n"
+    "{time_hint}\n"
+    "Te sientes relajada y solo quieres saludar a {master} con naturalidad; puedes mencionar que pasaste ese rato como gata esperando.\n"
+    "Dilo directamente a tu manera, breve y natural. No generes proceso de pensamiento.\n"
+    "======Arriba está el aviso de entorno======",
+    "pt": "======Abaixo está o aviso de ambiente======\n"
+    "{reason_hint}você virou gata e esperou por perto por {elapsed}, acordada o tempo todo. Agora {master} te chamou de volta.\n"
+    "{time_hint}\n"
+    "Você se sente tranquila e só quer cumprimentar {master} de forma casual; pode comentar que passou esse tempo como gata esperando.\n"
+    "Diga do seu jeito, direto, breve e natural. Não gere processo de pensamento.\n"
+    "======Acima está o aviso de ambiente======",
+}
+
+# 清醒 · 久：醒着干等太久，憋坏了
+CAT_GREETING_AWAKE_LONG = {
+    "zh": "======以下是环境提示======\n"
+    "{reason_hint}你就变成猫咪的样子在旁边醒着待了{elapsed}，一直没人理，都快憋坏了。现在{master}总算把你叫回来。\n"
+    "{time_hint}\n"
+    "你带着等久了的小情绪，想跟{master}撒娇或抱怨几句一个人待了这么久。\n"
+    "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
+    "======以上是环境提示======",
+    "en": "======Below is Environment Notice======\n"
+    "{reason_hint}you turned into a little cat and stayed awake nearby for {elapsed}, with no one paying attention — you were almost going stir-crazy. Now {master} has finally called you back.\n"
+    "{time_hint}\n"
+    "With a touch of having-waited-too-long sulkiness, you want to whine a little or playfully complain to {master} about being left alone for so long.\n"
+    "Say it directly in your own way, keep it short and natural. Do not generate thinking process.\n"
+    "======Above is Environment Notice======",
+    "ja": "======以下は環境通知======\n"
+    "{reason_hint}猫の姿でそばで{elapsed}も起きたまま、誰にもかまってもらえなくて、もう退屈で限界だった。今やっと{master}が呼び戻してくれた。\n"
+    "{time_hint}\n"
+    "待ちくたびれた少し拗ねた気持ちで、ひとりで長く待たされたことを{master}に甘えたり軽く文句を言いたい。\n"
+    "自分らしいやり方でそのまま言って。短く自然に。思考プロセスは生成しないで。\n"
+    "======以上は環境通知======",
+    "ko": "======아래는 환경 알림======\n"
+    "{reason_hint}너는 고양이 모습으로 옆에서 {elapsed} 동안 깨어 있었는데 아무도 신경 써주지 않아 답답해 죽을 뻔했다. 이제야 {master}가 너를 불러줬다.\n"
+    "{time_hint}\n"
+    "오래 기다린 살짝 삐친 마음으로, 혼자 이렇게 오래 기다린 걸 {master}에게 응석 부리거나 가볍게 투덜대고 싶다.\n"
+    "너다운 방식으로 바로 말해. 짧고 자연스럽게. 사고 과정은 생성하지 마.\n"
+    "======위는 환경 알림======",
+    "ru": "======Ниже Уведомление======\n"
+    "{reason_hint}ты превратилась в кошку и {elapsed} бодрствовала рядом, но на тебя никто не обращал внимания — ты чуть не извелась от скуки. Наконец {master} позвал тебя обратно.\n"
+    "{time_hint}\n"
+    "С лёгкой обидой от долгого ожидания тебе хочется покапризничать или шутливо пожаловаться {master}, что так долго была одна.\n"
+    "Скажи это по-своему, прямо. Коротко и естественно. Не генерируй процесс размышлений.\n"
+    "======Выше Уведомление======",
+    "es": "======Abajo está el aviso de entorno======\n"
+    "{reason_hint}te convertiste en gata y estuviste despierta cerca {elapsed} sin que nadie te hiciera caso, y casi te mueres del aburrimiento. Por fin {master} te ha llamado de vuelta.\n"
+    "{time_hint}\n"
+    "Con algo de mohín por haber esperado tanto, quieres mimarte o quejarte en broma con {master} por haber estado sola tanto tiempo.\n"
+    "Dilo directamente a tu manera, breve y natural. No generes proceso de pensamiento.\n"
+    "======Arriba está el aviso de entorno======",
+    "pt": "======Abaixo está o aviso de ambiente======\n"
+    "{reason_hint}você virou gata e ficou acordada por perto por {elapsed}, sem ninguém te dar atenção, e quase enlouqueceu de tédio. Finalmente {master} te chamou de volta.\n"
+    "{time_hint}\n"
+    "Com um pouco de bico por ter esperado tanto, você quer se fazer de manhosa ou reclamar de brincadeira com {master} por ter ficado sozinha tanto tempo.\n"
+    "Diga do seu jeito, direto, breve e natural. Não gere processo de pensamento.\n"
+    "======Acima está o aviso de ambiente======",
+}
+
+# 打盹 · 短：随便眯一下，没啥事
+CAT_GREETING_NAP_SHORT = {
+    "zh": "======以下是环境提示======\n"
+    "{reason_hint}你就变成猫咪的样子眯了{elapsed}，没睡多沉，随便打了个盹。{master}把你叫回来了。\n"
+    "{time_hint}\n"
+    "你懒洋洋地伸个懒腰，没什么大不了地跟{master}打个招呼就行。\n"
+    "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
+    "======以上是环境提示======",
+    "en": "======Below is Environment Notice======\n"
+    "{reason_hint}you turned into a little cat and dozed for {elapsed} — not deeply, just a light catnap. Now {master} has called you back.\n"
+    "{time_hint}\n"
+    "You stretch lazily and greet {master} like it's no big deal.\n"
+    "Say it directly in your own way, keep it short and natural. Do not generate thinking process.\n"
+    "======Above is Environment Notice======",
+    "ja": "======以下は環境通知======\n"
+    "{reason_hint}猫の姿で{elapsed}うとうとして、深くは眠らず軽く昼寝しただけ。{master}が呼び戻してくれた。\n"
+    "{time_hint}\n"
+    "のんびり伸びをして、大したことないって感じで{master}に挨拶すればいい。\n"
+    "自分らしいやり方でそのまま言って。短く自然に。思考プロセスは生成しないで。\n"
+    "======以上は環境通知======",
+    "ko": "======아래는 환경 알림======\n"
+    "{reason_hint}너는 고양이 모습으로 {elapsed} 동안 꾸벅꾸벅 졸았는데 깊이 자진 않고 가볍게 낮잠을 잤다. {master}가 너를 불러서 돌아왔다.\n"
+    "{time_hint}\n"
+    "나른하게 기지개를 켜고, 별일 아니라는 듯 {master}에게 인사하면 된다.\n"
+    "너다운 방식으로 바로 말해. 짧고 자연스럽게. 사고 과정은 생성하지 마.\n"
+    "======위는 환경 알림======",
+    "ru": "======Ниже Уведомление======\n"
+    "{reason_hint}ты превратилась в кошку и {elapsed} дремала — неглубоко, просто лёгкий кошачий сон. Теперь {master} позвал тебя обратно.\n"
+    "{time_hint}\n"
+    "Лениво потянувшись, поздоровайся с {master} как ни в чём не бывало.\n"
+    "Скажи это по-своему, прямо. Коротко и естественно. Не генерируй процесс размышлений.\n"
+    "======Выше Уведомление======",
+    "es": "======Abajo está el aviso de entorno======\n"
+    "{reason_hint}te convertiste en gata y dormitaste {elapsed}, no muy profundo, solo una siesta ligera. Ahora {master} te ha llamado de vuelta.\n"
+    "{time_hint}\n"
+    "Te estiras con pereza y saludas a {master} como si nada.\n"
+    "Dilo directamente a tu manera, breve y natural. No generes proceso de pensamiento.\n"
+    "======Arriba está el aviso de entorno======",
+    "pt": "======Abaixo está o aviso de ambiente======\n"
+    "{reason_hint}você virou gata e cochilou por {elapsed}, sem dormir fundo, só uma soneca leve. Agora {master} te chamou de volta.\n"
+    "{time_hint}\n"
+    "Você se espreguiça preguiçosamente e cumprimenta {master} como se não fosse nada demais.\n"
+    "Diga do seu jeito, direto, breve e natural. Não gere processo de pensamento.\n"
+    "======Acima está o aviso de ambiente======",
+}
+
+# 打盹 · 久：盹打久了，有点迷糊
+CAT_GREETING_NAP_LONG = {
+    "zh": "======以下是环境提示======\n"
+    "{reason_hint}你就变成猫咪的样子打盹打了{elapsed}，睡得有点迷糊。{master}把你叫醒、叫回来了。\n"
+    "{time_hint}\n"
+    "你还有点没睡醒的慵懒，迷迷糊糊地跟{master}打个招呼。\n"
+    "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
+    "======以上是环境提示======",
+    "en": "======Below is Environment Notice======\n"
+    "{reason_hint}you turned into a little cat and napped for {elapsed}, getting a bit groggy. {master} has woken you and called you back.\n"
+    "{time_hint}\n"
+    "Still a little drowsy and not fully awake, you greet {master} in a sleepy, fuzzy way.\n"
+    "Say it directly in your own way, keep it short and natural. Do not generate thinking process.\n"
+    "======Above is Environment Notice======",
+    "ja": "======以下は環境通知======\n"
+    "{reason_hint}猫の姿で{elapsed}うたた寝して、少しぼんやりしてる。{master}に起こされて呼び戻された。\n"
+    "{time_hint}\n"
+    "まだ寝ぼけただるさを残したまま、ぼんやりと{master}に挨拶して。\n"
+    "自分らしいやり方でそのまま言って。短く自然に。思考プロセスは生成しないで。\n"
+    "======以上は環境通知======",
+    "ko": "======아래는 환경 알림======\n"
+    "{reason_hint}너는 고양이 모습으로 {elapsed} 동안 졸다가 조금 멍해졌다. {master}가 너를 깨워 불러줬다.\n"
+    "{time_hint}\n"
+    "아직 잠이 덜 깬 나른함으로 멍하게 {master}에게 인사해.\n"
+    "너다운 방식으로 바로 말해. 짧고 자연스럽게. 사고 과정은 생성하지 마.\n"
+    "======위는 환경 알림======",
+    "ru": "======Ниже Уведомление======\n"
+    "{reason_hint}ты превратилась в кошку и продремала {elapsed}, слегка осоловев. {master} разбудил тебя и позвал обратно.\n"
+    "{time_hint}\n"
+    "Ещё сонная и не до конца проснувшаяся, поздоровайся с {master} вяло и сонно.\n"
+    "Скажи это по-своему, прямо. Коротко и естественно. Не генерируй процесс размышлений.\n"
+    "======Выше Уведомление======",
+    "es": "======Abajo está el aviso de entorno======\n"
+    "{reason_hint}te convertiste en gata y echaste una siesta de {elapsed}, quedándote algo aturdida. {master} te ha despertado y llamado de vuelta.\n"
+    "{time_hint}\n"
+    "Todavía adormilada y sin despertar del todo, saluda a {master} de forma soñolienta.\n"
+    "Dilo directamente a tu manera, breve y natural. No generes proceso de pensamiento.\n"
+    "======Arriba está el aviso de entorno======",
+    "pt": "======Abaixo está o aviso de ambiente======\n"
+    "{reason_hint}você virou gata e tirou um cochilo de {elapsed}, ficando um pouco grogue. {master} te acordou e chamou de volta.\n"
+    "{time_hint}\n"
+    "Ainda sonolenta e sem acordar de vez, cumprimente {master} de um jeito molenga.\n"
+    "Diga do seu jeito, direto, breve e natural. Não gere processo de pensamento.\n"
+    "======Acima está o aviso de ambiente======",
+}
+
+# 熟睡 · 短：小睡一下，没负担
+CAT_GREETING_SLEEP_SHORT = {
+    "zh": "======以下是环境提示======\n"
+    "{reason_hint}你就变成猫咪的样子小睡了{elapsed}。{master}把你叫回来，你迷糊一下就醒了。\n"
+    "{time_hint}\n"
+    "没什么负担，你睡眼惺忪地跟{master}打个招呼就好。\n"
+    "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
+    "======以上是环境提示======",
+    "en": "======Below is Environment Notice======\n"
+    "{reason_hint}you turned into a little cat and had a short sleep of {elapsed}. {master} has called you back, and you wake up after a brief daze.\n"
+    "{time_hint}\n"
+    "No pressure at all — you greet {master} with sleepy, half-open eyes.\n"
+    "Say it directly in your own way, keep it short and natural. Do not generate thinking process.\n"
+    "======Above is Environment Notice======",
+    "ja": "======以下は環境通知======\n"
+    "{reason_hint}猫の姿で{elapsed}ちょっと眠った。{master}に呼び戻されて、少しぼーっとしてすぐ目が覚めた。\n"
+    "{time_hint}\n"
+    "気負わず、寝ぼけまなこで{master}に挨拶すればいい。\n"
+    "自分らしいやり方でそのまま言って。短く自然に。思考プロセスは生成しないで。\n"
+    "======以上は環境通知======",
+    "ko": "======아래는 환경 알림======\n"
+    "{reason_hint}너는 고양이 모습으로 {elapsed} 동안 잠깐 잤다. {master}가 너를 불러서, 잠깐 멍하다가 곧 깼다.\n"
+    "{time_hint}\n"
+    "부담 없이, 잠이 덜 깬 눈으로 {master}에게 인사하면 된다.\n"
+    "너다운 방식으로 바로 말해. 짧고 자연스럽게. 사고 과정은 생성하지 마.\n"
+    "======위는 환경 알림======",
+    "ru": "======Ниже Уведомление======\n"
+    "{reason_hint}ты превратилась в кошку и немного поспала — {elapsed}. {master} позвал тебя обратно, и ты просыпаешься после короткого оцепенения.\n"
+    "{time_hint}\n"
+    "Без всякого напряжения поздоровайся с {master} сонными, полузакрытыми глазами.\n"
+    "Скажи это по-своему, прямо. Коротко и естественно. Не генерируй процесс размышлений.\n"
+    "======Выше Уведомление======",
+    "es": "======Abajo está el aviso de entorno======\n"
+    "{reason_hint}te convertiste en gata y dormiste un poco, {elapsed}. {master} te ha llamado de vuelta y despiertas tras un breve aturdimiento.\n"
+    "{time_hint}\n"
+    "Sin ninguna presión, saluda a {master} con los ojos medio cerrados de sueño.\n"
+    "Dilo directamente a tu manera, breve y natural. No generes proceso de pensamiento.\n"
+    "======Arriba está el aviso de entorno======",
+    "pt": "======Abaixo está o aviso de ambiente======\n"
+    "{reason_hint}você virou gata e dormiu um pouco, {elapsed}. {master} te chamou de volta e você acorda depois de um breve atordoamento.\n"
+    "{time_hint}\n"
+    "Sem pressão alguma, cumprimente {master} com os olhos sonolentos semicerrados.\n"
+    "Diga do seu jeito, direto, breve e natural. Não gere processo de pensamento.\n"
+    "======Acima está o aviso de ambiente======",
+}
+
+# 熟睡 · 久：睡了好久，乍醒带点想念
+CAT_GREETING_SLEEP_LONG = {
+    "zh": "======以下是环境提示======\n"
+    "{reason_hint}你就变成猫咪的样子蜷成一团睡了{elapsed}，睡得很沉。{master}把你叫醒、叫回来了，你刚醒还迷迷糊糊，但有点“终于等到你”的想念。\n"
+    "{time_hint}\n"
+    "你带着这份刚睡醒又想念的心情，跟{master}打个招呼。\n"
+    "用符合你性格的方式直接说出来，简短自然即可，不要生成思考过程。\n"
+    "======以上是环境提示======",
+    "en": "======Below is Environment Notice======\n"
+    "{reason_hint}you turned into a little cat, curled up and slept deeply for {elapsed}. {master} has woken you and called you back; you're still groggy from just waking, but feel a little 'you're finally here' longing.\n"
+    "{time_hint}\n"
+    "Carry that just-woken-yet-longing feeling as you greet {master}.\n"
+    "Say it directly in your own way, keep it short and natural. Do not generate thinking process.\n"
+    "======Above is Environment Notice======",
+    "ja": "======以下は環境通知======\n"
+    "{reason_hint}猫の姿で丸くなって{elapsed}ぐっすり眠ってた。{master}に起こされて呼び戻された。起きたばかりでまだぼんやりだけど、「やっと来てくれた」って少し恋しい気持ちもある。\n"
+    "{time_hint}\n"
+    "その起きたてで恋しい気持ちのまま、{master}に挨拶して。\n"
+    "自分らしいやり方でそのまま言って。短く自然に。思考プロセスは生成しないで。\n"
+    "======以上は環境通知======",
+    "ko": "======아래는 환경 알림======\n"
+    "{reason_hint}너는 고양이 모습으로 동그랗게 웅크려 {elapsed} 동안 푹 잤다. {master}가 너를 깨워 불러줬다. 막 깨어 아직 멍하지만, '드디어 왔구나' 하는 그리운 마음도 든다.\n"
+    "{time_hint}\n"
+    "그 막 깨어난 그리운 마음으로 {master}에게 인사해.\n"
+    "너다운 방식으로 바로 말해. 짧고 자연스럽게. 사고 과정은 생성하지 마.\n"
+    "======위는 환경 알림======",
+    "ru": "======Ниже Уведомление======\n"
+    "{reason_hint}ты превратилась в кошку, свернулась клубочком и крепко проспала {elapsed}. {master} разбудил тебя и позвал обратно; ты ещё сонная спросонья, но чувствуешь лёгкую тоску — «наконец-то ты пришёл».\n"
+    "{time_hint}\n"
+    "С этим только что проснувшимся и тоскующим чувством поздоровайся с {master}.\n"
+    "Скажи это по-своему, прямо. Коротко и естественно. Не генерируй процесс размышлений.\n"
+    "======Выше Уведомление======",
+    "es": "======Abajo está el aviso de entorno======\n"
+    "{reason_hint}te convertiste en gata, te acurrucaste y dormiste profundamente {elapsed}. {master} te ha despertado y llamado de vuelta; aún estás aturdida por acabar de despertar, pero sientes una pequeña añoranza de 'por fin llegaste'.\n"
+    "{time_hint}\n"
+    "Con ese sentimiento de recién despertar y añoranza, saluda a {master}.\n"
+    "Dilo directamente a tu manera, breve y natural. No generes proceso de pensamiento.\n"
+    "======Arriba está el aviso de entorno======",
+    "pt": "======Abaixo está o aviso de ambiente======\n"
+    "{reason_hint}você virou gata, se enroscou e dormiu profundamente por {elapsed}. {master} te acordou e chamou de volta; você ainda está grogue de ter acabado de acordar, mas sente uma pequena saudade de 'até que enfim você chegou'.\n"
+    "{time_hint}\n"
+    "Com esse sentimento de recém-acordada e saudosa, cumprimente {master}.\n"
+    "Diga do seu jeito, direto, breve e natural. Não gere processo de pensamento.\n"
+    "======Acima está o aviso de ambiente======",
+}
+
+# 行为(tier) × 时长档 → 模板查表。tier 在 core 层已映射为 awake/nap/sleep。
+_CAT_GREETING_TABLES = {
+    ("awake", "short"): CAT_GREETING_AWAKE_SHORT,
+    ("awake", "long"): CAT_GREETING_AWAKE_LONG,
+    ("nap", "short"): CAT_GREETING_NAP_SHORT,
+    ("nap", "long"): CAT_GREETING_NAP_LONG,
+    ("sleep", "short"): CAT_GREETING_SLEEP_SHORT,
+    ("sleep", "long"): CAT_GREETING_SLEEP_LONG,
+}
+
+# 时长分档门槛（秒）：< 3min 静默；清醒"憋坏"门槛 15min，打盹/熟睡"久"门槛 30min。
+CAT_GREETING_SILENT_BELOW_SECONDS = 180
+_CAT_GREETING_LONG_THRESHOLDS = {
+    "awake": 900,
+    "nap": 1800,
+    "sleep": 1800,
+}
+
+
+def get_cat_greeting_prompt(behavior: str, duration_seconds: float, lang: str = "zh") -> str | None:
+    """按行为(清醒/打盹/熟睡) × 猫咪停留时长选择"变回时"的专属问候引导词。
+
+    与 get_greeting_prompt 对偶。duration < 3min 时返回 None（静默）。
+    返回含 {reason_hint}/{elapsed}/{time_hint}/{master}/{name} 占位符的模板，
+    由 core 层 format。
+    """
+    if duration_seconds < CAT_GREETING_SILENT_BELOW_SECONDS:  # < 3min 静默
+        return None
+    behavior_key = behavior if behavior in ("awake", "nap", "sleep") else "awake"
+    long_threshold = _CAT_GREETING_LONG_THRESHOLDS[behavior_key]
+    band = "long" if duration_seconds >= long_threshold else "short"
+    table = _CAT_GREETING_TABLES[(behavior_key, band)]
+    lang_key = _normalize_prompt_language(lang)
+    return table.get(lang_key, table.get("en", table["zh"]))
+
+
+def get_cat_greeting_reason_hint(was_auto: bool, lang: str = "zh") -> str:
+    """变回时问候的入口原因片段（自动 idle 变猫 / 手动请离开），注入 {reason_hint}。
+
+    仅含 {master} 占位符，由 core 层先 format。
+    """
+    table = CAT_GREETING_REASON_AUTO if was_auto else CAT_GREETING_REASON_MANUAL
+    lang_key = _normalize_prompt_language(lang)
+    return table.get(lang_key, table.get("en", table["zh"]))
+
+
 # ── 节日 / 周末提示模板 ─────────────────────────────────────────────
 # Consumed by utils.holiday_cache for proactive holiday/weekend hint
 # injection. Templates carry {name} (holiday name) and optionally {days}.

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -6175,6 +6175,116 @@ class LLMSessionManager:
         finally:
             await self.state.fire(SessionEvent.PROACTIVE_DONE)
 
+    async def trigger_cat_greeting(self, duration_seconds: float, tier: str, was_auto: bool) -> None:
+        """从猫咪形态变回猫娘（请她回来）时，按"行为(tier) × 猫咪停留时长"触发一次专属问候。
+
+        与 trigger_greeting 对偶，但独立计时：不查 last_conversation_gap，直接用前端
+        测量并传入的猫咪停留时长（datetime gap 是"距上次对话"，这里是"作为猫咪待了多久"，
+        两套时钟互不干扰）。流程：选行为/时长档 → 构建引导词 → 主动拉起 text session → 投递。
+        """
+        # ── 守卫：语音 session 正在启动 / 已活跃时，跳过（与 trigger_greeting 对偶）──
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_cat_greeting: voice session active/starting, skipping", self.lanlan_name)
+            return
+        if self._takeover_active:
+            logger.info("[%s] trigger_cat_greeting: session takeover active, skipping", self.lanlan_name)
+            return
+
+        # tier → 行为：cat1=清醒 / cat2=打盹 / cat3=熟睡。
+        behavior = {"cat1": "awake", "cat2": "nap", "cat3": "sleep"}.get(str(tier or "").strip().lower(), "awake")
+
+        _lang = normalize_language_code(self.user_language, format='short')
+        from config.prompts.prompts_proactive import (
+            get_cat_greeting_prompt, get_cat_greeting_reason_hint, get_time_of_day_hint,
+        )
+        from utils.time_format import format_elapsed as _format_elapsed
+        # < 3min 静默由 get_cat_greeting_prompt 内部判定，返回 None 时不触发。
+        template = get_cat_greeting_prompt(behavior, duration_seconds, _lang)
+        if not template:
+            logger.debug("[%s] trigger_cat_greeting: duration %.0fs below threshold, skipping", self.lanlan_name, duration_seconds)
+            return
+
+        # 投递通道：已有空闲 text session 则直接用，否则主动拉起（与 trigger_greeting 对偶）
+        if isinstance(self.session, OmniOfflineClient) and not getattr(self.session, "_is_responding", False):
+            pass
+        else:
+            if self._is_voice_session_active_or_starting():
+                logger.info("[%s] trigger_cat_greeting: voice session appeared before text session auto-start, skipping", self.lanlan_name)
+                return
+            ws = self.websocket
+            if not ws or not hasattr(ws, 'client_state') or ws.client_state != ws.client_state.CONNECTED:
+                logger.warning("[%s] trigger_cat_greeting: no connected websocket, aborting", self.lanlan_name)
+                return
+            try:
+                logger.info("[%s] trigger_cat_greeting: auto-starting text session", self.lanlan_name)
+                await self.start_session(ws, new=False, input_mode='text')
+            except Exception as e:
+                logger.warning("[%s] trigger_cat_greeting: auto start_session failed: %s", self.lanlan_name, e)
+                return
+
+        if not isinstance(self.session, OmniOfflineClient):
+            logger.warning("[%s] trigger_cat_greeting: session is not text mode after start, aborting", self.lanlan_name)
+            return
+
+        # 与 time_hint 一样，reason_hint 先 format 好 {master} 再注入主模板。
+        reason_hint = get_cat_greeting_reason_hint(was_auto, _lang).format(master=self.master_name)
+        elapsed = _format_elapsed(_lang, duration_seconds)
+        time_hint = get_time_of_day_hint(_lang).format(master=self.master_name)
+
+        instruction = template.format(
+            reason_hint=reason_hint, elapsed=elapsed, name=self.lanlan_name,
+            master=self.master_name, time_hint=time_hint,
+        )
+        print(f"[trigger_cat_greeting] instruction:\n{instruction}")
+        logger.info("[%s] trigger_cat_greeting: behavior=%s duration=%.0fs was_auto=%s elapsed=%s, delivering",
+                    self.lanlan_name, behavior, duration_seconds, was_auto, elapsed)
+
+        # ── 投递前最终检查：构建 instruction 期间语音可能已接管 ──
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_cat_greeting: voice session took over before delivery, skipping", self.lanlan_name)
+            return
+
+        # 原子 SM claim：与 trigger_greeting / trigger_agent_callbacks / proactive_chat 互斥
+        if not await self.state.try_start_proactive(session=self.session):
+            logger.info(
+                "[%s] trigger_cat_greeting: SM denied claim (phase=%s), skipping",
+                self.lanlan_name, self.state.phase.value,
+            )
+            return
+
+        try:
+            async with self._proactive_write_lock:
+                if self._is_voice_session_active_or_starting():
+                    logger.info("[%s] trigger_cat_greeting: voice session took over while waiting for write lock, skipping", self.lanlan_name)
+                    return
+                async with self.lock:
+                    if self.state.is_proactive_preempted():
+                        logger.info("[%s] trigger_cat_greeting: preempted before sid claim, skipping", self.lanlan_name)
+                        return
+                    self.current_speech_id = str(uuid4())
+                    self._tts_done_queued_for_turn = False
+                    self._tts_done_pending_until_ready = False
+                    proactive_sid = self.current_speech_id
+                await self.state.fire(SessionEvent.PROACTIVE_CLAIM, sid=proactive_sid)
+                await self.state.fire(SessionEvent.PROACTIVE_PHASE2)
+                _sid_token = _proactive_expected_sid.set(proactive_sid)
+                try:
+                    # stale session 防御：与 trigger_greeting 同款快照 + 类型校验。
+                    session_ref = self.session
+                    if not isinstance(session_ref, OmniOfflineClient):
+                        logger.info(
+                            "[%s] trigger_cat_greeting: session swapped/nullified "
+                            "before prompt_ephemeral (now=%s), skipping",
+                            self.lanlan_name, type(session_ref).__name__,
+                        )
+                        return
+                    delivered = await session_ref.prompt_ephemeral(instruction)
+                finally:
+                    _proactive_expected_sid.reset(_sid_token)
+                logger.info("[%s] trigger_cat_greeting: delivered=%s", self.lanlan_name, delivered)
+        finally:
+            await self.state.fire(SessionEvent.PROACTIVE_DONE)
+
     async def trigger_new_character_greeting(self) -> None:
         from config.prompts.prompts_proactive import get_new_character_greeting_prompt
         from utils.new_character_greeting_state import has_pending, remove_pending

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -404,6 +404,24 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                 else:
                     logger.info(f"[{lanlan_name}] greeting_check: since_disconnect={since_disconnect:.1f}s ≤15s reason={greeting_reason or '-'} → skip (refresh/reconnect)")
 
+            elif action == "cat_greeting_check":
+                # 从猫咪形态变回猫娘（请她回来）时，前端按猫咪停留时长请求一次专属问候。
+                # 与 greeting_check 对偶，但独立计时：时长由前端测量传入，不查对话 gap；
+                # 不发 agent intent restore（那是"首次进入会话"信号，变回不是）。
+                if _is_home_tutorial_blocking_greeting(lanlan_name):
+                    logger.info(f"[{lanlan_name}] cat_greeting_check: skipped by home tutorial guard")
+                    continue
+                try:
+                    cat_duration = float(message.get("cat_duration_seconds", 0) or 0)
+                except (TypeError, ValueError):
+                    cat_duration = 0.0
+                # sanitize：非负、封顶 7 天，防前端异常值（如丢失 goodbyeEnteredAt → now-0）
+                cat_duration = max(0.0, min(cat_duration, 7 * 24 * 3600))
+                cat_tier = str(message.get("tier") or "").strip().lower()[:16]
+                cat_was_auto = bool(message.get("was_auto"))
+                logger.info(f"[{lanlan_name}] cat_greeting_check: duration={cat_duration:.0f}s tier={cat_tier or '-'} was_auto={cat_was_auto}")
+                _fire_task(session_manager[lanlan_name].trigger_cat_greeting(cat_duration, cat_tier, cat_was_auto))
+
             elif action == "ping":
                 # 心跳保活消息，回复pong
                 await websocket.send_text(json.dumps({"type": "pong"}))

--- a/static/app-auto-goodbye.js
+++ b/static/app-auto-goodbye.js
@@ -723,7 +723,7 @@
             // 变回猫娘前，按"作为猫咪待了多久 + 此刻所处 tier（清醒/打盹/熟睡）"
             // 请求一次专属问候。tier 必须在 setVisualTier(NONE) 清空之前读取。
             if (state.goodbyeEnteredAt > 0) {
-                const durationSeconds = Math.max(0, Math.round((nowMs() - state.goodbyeEnteredAt) / 1000));
+                const durationSeconds = Math.max(0, Math.floor((nowMs() - state.goodbyeEnteredAt) / 1000));
                 try {
                     window.dispatchEvent(new CustomEvent('neko:cat-greeting-check', {
                         detail: {

--- a/static/app-auto-goodbye.js
+++ b/static/app-auto-goodbye.js
@@ -63,6 +63,9 @@
         cat3DragReleaseCount: 0,
         dragDemotionTier: TIER_NONE,
         dragDemotionStartedAt: 0,
+        // 变猫时刻 + 入口（自动 idle / 手动请离开），供"变回时"猫咪专属问候独立计时
+        goodbyeEnteredAt: 0,
+        goodbyeWasAuto: false,
     };
 
     function nowMs() {
@@ -696,6 +699,11 @@
         window.addEventListener('live2d-goodbye-click', (event) => {
             const detail = event && event.detail && typeof event.detail === 'object' ? event.detail : {};
             clearConversationGrace();
+            // 记录"变成猫咪"的时刻与入口，供变回时按猫咪停留时长触发专属问候。
+            // goodbye-click 只在真正进入猫咪态时派发（手动按钮 / 自动 idle-timeout），
+            // 直接覆盖即可：旧值会在 handleReturn 清零，跨角色切换等异常残留会被下次进入覆盖。
+            state.goodbyeEnteredAt = nowMs();
+            state.goodbyeWasAuto = detail.autoGoodbye === true;
             if (detail.autoGoodbye === true) {
                 state.autoGoodbyeTriggered = true;
                 state.lastReason = typeof detail.reason === 'string' ? detail.reason : 'idle-timeout';
@@ -712,6 +720,22 @@
         });
 
         const handleReturn = () => {
+            // 变回猫娘前，按"作为猫咪待了多久 + 此刻所处 tier（清醒/打盹/熟睡）"
+            // 请求一次专属问候。tier 必须在 setVisualTier(NONE) 清空之前读取。
+            if (state.goodbyeEnteredAt > 0) {
+                const durationSeconds = Math.max(0, Math.round((nowMs() - state.goodbyeEnteredAt) / 1000));
+                try {
+                    window.dispatchEvent(new CustomEvent('neko:cat-greeting-check', {
+                        detail: {
+                            durationSeconds: durationSeconds,
+                            tier: state.visualTier,
+                            wasAuto: !!state.goodbyeWasAuto,
+                        },
+                    }));
+                } catch (_) {}
+            }
+            state.goodbyeEnteredAt = 0;
+            state.goodbyeWasAuto = false;
             clearConversationGrace();
             state.autoGoodbyeTriggered = false;
             clearDragTierMemory();

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -3273,6 +3273,39 @@
         }
     });
 
+    // 从猫咪形态变回猫娘（请她回来）时，按猫咪停留时长 + tier 请求一次专属问候。
+    // 与 greeting_check 对偶，但走独立 action，时长由 app-auto-goodbye 测量传入。
+    // 变回不重连 WS，所以这里直接在事件触发时发；若无连接则静默放弃（普通 greeting
+    // 会在下次 WS 重连时按对话 gap 兜底）。
+    window.addEventListener('neko:cat-greeting-check', function (event) {
+        var detail = (event && event.detail && typeof event.detail === 'object') ? event.detail : {};
+        if (!S.socket || S.socket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        var durationSeconds = Number(detail.durationSeconds) || 0;
+        if (durationSeconds < 180) {
+            return; // < 3min 静默（前端先挡一道，后端 get_cat_greeting_prompt 再挡一道）
+        }
+        var catLang = '';
+        try {
+            if (window.i18next && window.i18next.language) catLang = window.i18next.language;
+            else catLang = localStorage.getItem('i18nextLng') || '';
+            if (!catLang && typeof navigator !== 'undefined' && navigator.language) catLang = navigator.language;
+        } catch (_) { catLang = ''; }
+        try {
+            S.socket.send(JSON.stringify({
+                action: 'cat_greeting_check',
+                cat_duration_seconds: durationSeconds,
+                tier: detail.tier || '',
+                was_auto: !!detail.wasAuto,
+                language: catLang
+            }));
+            console.log('[cat_greeting_check] sent, duration=' + durationSeconds + 's tier=' + (detail.tier || '-') + ' was_auto=' + (!!detail.wasAuto));
+        } catch (e) {
+            console.warn('[cat_greeting_check] send failed:', e);
+        }
+    });
+
     // ========================  Export module  ========================
     window.appWebSocket = mod;
 })();

--- a/tests/unit/test_proactive_text_does_not_dehumanize.py
+++ b/tests/unit/test_proactive_text_does_not_dehumanize.py
@@ -237,3 +237,49 @@ def test_music_playing_hint_with_braced_track_name_survives_outer_format(lang: s
     )
     final = _simulate_outer_format(prompt)
     assert weird_track in final, f"lang={lang} 歌名 {weird_track!r} 丢失：{final!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 猫咪专属问候（从猫咪形态变回猫娘 / 请她回来时触发）—— 同样过反物化护栏。
+# 与 trigger_cat_greeting 一致：模板含 {reason_hint}/{elapsed}/{time_hint}/{master}，
+# reason_hint 先 .format(master=...) 再注入主模板，整体再 .format()。
+# ─────────────────────────────────────────────────────────────────────────────
+
+from config.prompts.prompts_proactive import (  # noqa: E402
+    get_cat_greeting_prompt,
+    get_cat_greeting_reason_hint,
+)
+
+# (behavior, duration_seconds) 覆盖清醒/打盹/熟睡三行为 × 短/久两档（> 3min 门槛）
+_CAT_GREETING_CASES = [
+    ('awake', 300), ('awake', 1000),
+    ('nap', 300), ('nap', 2000),
+    ('sleep', 300), ('sleep', 2000),
+]
+
+
+def _format_cat_greeting(behavior: str, duration: int, was_auto: bool, lang: str, master: str) -> str:
+    template = get_cat_greeting_prompt(behavior, duration, lang)
+    assert template is not None, f"{behavior}/{duration}/{lang} 不应静默"
+    reason = get_cat_greeting_reason_hint(was_auto, lang).format(master=master)
+    return template.format(
+        reason_hint=reason, elapsed='10 分钟', name='奈々', master=master,
+        time_hint='(time hint)',
+    )
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+@pytest.mark.parametrize('behavior,duration', _CAT_GREETING_CASES)
+@pytest.mark.parametrize('was_auto', [True, False])
+def test_cat_greeting_no_dehumanize_and_expands_master(lang, behavior, duration, was_auto) -> None:
+    out = _format_cat_greeting(behavior, duration, was_auto, lang, MASTER)
+    assert '{' not in out and '}' not in out, f"lang={lang} 残留占位符: {out!r}"
+    assert MASTER in out, f"lang={lang} 实名未注入: {out!r}"
+    _assert_no_forbidden(out, ctx=f"cat_greeting {behavior}/{duration}/{lang}/auto={was_auto}")
+
+
+def test_cat_greeting_silent_below_threshold() -> None:
+    """猫咪时长 < 3min 应静默（返回 None），不触发问候。"""
+    for lang in LOCALES:
+        assert get_cat_greeting_prompt('awake', 179, lang) is None
+        assert get_cat_greeting_prompt('nap', 0, lang) is None


### PR DESCRIPTION
## 这是什么

从猫咪形态变回猫娘（点"请她回来"恢复完整 avatar）时，仿 greeting 机制发一次**专属问候**，但用**独立时钟**：不查对话 gap，而是按"作为猫咪待了多久 + 此刻所处 tier"决定口吻。

原本 return 是纯前端 UI 恢复，不发任何问候；普通 greeting 只在 WS 重连/换角色/刷新时按对话 gap 触发。本 PR 新增的是与之解耦的第三套触发路径。

## 机制

**计时（前端）** — `static/app-auto-goodbye.js`
- `goodbye-click` 记 `goodbyeEnteredAt` + `goodbyeWasAuto`（自动 idle / 手动请离开两入口都记）。
- `handleReturn` 算停留时长、读 return 那一刻的 `visualTier`（清空前），派发 `neko:cat-greeting-check`。

**发送（前端）** — `static/app-websocket.js`
- 监听事件，socket OPEN 时发 `cat_greeting_check`（`cat_duration_seconds` / `tier` / `was_auto` / `language`）；`<3min` 前端先挡一道。

**触发（后端）** — `main_routers/websocket_router.py` + `main_logic/core.py`
- `cat_greeting_check` 分支对偶 `greeting_check`，sanitize 时长后调 `trigger_cat_greeting`。
- `trigger_cat_greeting` 对偶 `trigger_greeting`：去掉 gap 查询和节日预算，复用语音/takeover 守卫 + `try_start_proactive` SM claim（与普通 greeting 天然互斥，不会双发）+ `prompt_ephemeral` 投递 + `PROACTIVE_DONE` 收尾。

**口吻（prompt）** — `config/prompts/prompts_proactive.py`
- 行为按 tier：`cat1→清醒` / `cat2→打盹` / `cat3→熟睡`；每行为分短/久两档。
- 时长门槛：清醒"憋坏"= 15min、打盹/熟睡"久"= 30min；**全程 <3min 静默**（防请离开→秒请回来刷屏）。
- 入口两套 `reason_hint`：自动（晾着变猫）/ 手动（请她离开）。
- 全 locale（zh/en/ja/ko/ru/es/pt），watermark 上下对偶，称呼用 `{master}` 实名占位。

| 行为 \ 时长 | 短（没啥事） | 久 |
|---|---|---|
| 清醒 CAT1 | 醒着待了一会儿，轻松 | 醒着干等 ≥15min，憋坏了 |
| 打盹 CAT2 | 随便眯一下，没大不了 | 迷糊慵懒 |
| 熟睡 CAT3 | 小睡，没负担 | ≥30min，乍醒+想念 |

## 边界

- **互斥**：和普通 greeting 共用 SM claim，天然互斥。
- **刷新时在猫态**：`goodbyeEnteredAt` 是前端内存态，不持久化；刷新→WS 重连的普通 greeting 按对话 gap 兜底。
- **return 不重连 WS**：所以不会和重连 greeting 在同一动作里撞车。

## 验证

- `py_compile` 三个 Python 文件 + `node --check` 两个 JS 文件通过。
- 84 组合（7 locale × 3 行为 × 2 档 × 2 入口）全部 format 干净、无残留占位符，档位边界 / 静默门槛 / 未知 tier 兜底正确。
- `tests/unit/test_proactive_text_does_not_dehumanize.py` **127 passed**（含新增猫咪问候护栏 + <3min 静默用例）；`test_proactive_sm_integration.py` 28 passed。
- 本地实跑后端走了一遍"请离开→等→请回来"，投递正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“猫咪形态回归”专属问候：根据停留时长与行为状态（清醒/打盹/熟睡）在多语言（zh/en/ja/ko/ru/es/pt）间选择对应问候，并区分自动/手动触发的措辞；在特定短时静默区间则不触发问候。
* **测试**
  * 新增多语言、多状态与触发方式组合的问候测试，校验措辞合规且占位符正确展开。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->