### PR TITLE
build(nuitka): exclude onnxruntime.transformers from the bundle

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -278,6 +278,12 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-package=tiktoken"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=tiktoken_ext"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=onnxruntime"
+          # onnxruntime.transformers/ is a benchmark + model-conversion toolbox
+          # nothing at runtime imports (rapidocr uses only the core InferenceSession).
+          # --include-package=onnxruntime would recurse and compile the whole subtree,
+          # including a 130k+ line gpt2 benchmark C unit that crashes the C backend.
+          # Mirrors build-desktop.yml.
+          NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=onnxruntime.transformers"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=tokenizers"
 
           # Package data

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -337,6 +337,12 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-package=tiktoken"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=tiktoken_ext"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=onnxruntime"
+          # onnxruntime.transformers/ is a benchmark + model-conversion toolbox
+          # nothing at runtime imports (rapidocr uses only the core InferenceSession).
+          # --include-package=onnxruntime would recurse and compile the whole subtree,
+          # including a 130k+ line gpt2 benchmark C unit that crashes the C backend.
+          # Synced with build_nuitka.bat.
+          NUITKA_OPTS="$NUITKA_OPTS --nofollow-import-to=onnxruntime.transformers"
           NUITKA_OPTS="$NUITKA_OPTS --include-package=tokenizers"
           # bilibili_dm/bilibili_danmaku plugins import bilibili_api; compile the
           # package itself (CI previously only carried its package-data).
@@ -502,6 +508,12 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=tiktoken
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=tiktoken_ext
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=onnxruntime
+          rem onnxruntime.transformers/ is a benchmark + model-conversion toolbox
+          rem nothing at runtime imports (rapidocr uses only the core InferenceSession).
+          rem --include-package=onnxruntime would recurse and compile the whole subtree,
+          rem including a 130k+ line gpt2 benchmark C unit that crashes the C backend.
+          rem Synced with build_nuitka.bat.
+          set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=onnxruntime.transformers
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=tokenizers
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package-data=jinja2
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package-data=certifi


### PR DESCRIPTION
## Problem

`--include-package=onnxruntime` makes Nuitka recurse into the entire
`onnxruntime.transformers/` subtree — a benchmark + model-conversion
toolbox (benchmark.py, bert_perf_test.py, convert_*.py, fusion_*.py, the
gpt2 benchmark). Compiling its 130k+ line gpt2 benchmark unit crashed the
MSVC backend (D8027 / compiler out of heap).

Nothing at runtime imports `onnxruntime.transformers`: rapidocr and the
local embedding model both run inference through the core onnxruntime
`InferenceSession` (capi) only.

## Change

Add `--nofollow-import-to=onnxruntime.transformers` to both the Unix and
Windows Nuitka invocations in `.github/workflows/build-desktop.yml`,
mirroring the local (gitignored) `build_nuitka.bat`.

## Notes

CI-only build-config change; no application code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **其他变更**
  * 优化了桌面应用的构建参数（Windows 与 Unix/Linux），在编译后端时避免递归处理包含基准与模型转换工具的子模块，从而减少构建时崩溃并提升整体构建稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->