### PR TITLE
将音乐播放器移入紧凑聊天记录面板，随聊天记录收起显示但保留挂载点，避免重新展开后消失；同步调整播放器样式，并修复音量条在透明窗口中点击穿透…

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -389,8 +389,10 @@ describe('App', () => {
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region', 'true');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-id', 'history:message:assistant-history-1');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-kind', 'message');
-    expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
-    expect(container.querySelector('.compact-export-history-panel #music-player-mount')).not.toBeNull();
+    expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
+    expect(container.querySelector('.composer-panel #music-player-mount')).not.toBeNull();
+    expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
+    expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-music-player-mount', 'compact-history');
     expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-id', 'history:music-player');
     expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-kind', 'music');
     expect(container.querySelector('.compact-export-history-controls')).toBeNull();
@@ -449,7 +451,9 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'closing');
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-open', 'false');
-      expect(container.querySelector('.compact-export-history-panel #music-player-mount')).not.toBeNull();
+      expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
+      expect(container.querySelector('.composer-panel #music-player-mount')).not.toBeNull();
+      expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
       expect(container.querySelector('[data-compact-hit-region-id^="history:"]')).toBeNull();
 
       fireEvent.click(container.querySelector<HTMLButtonElement>('.compact-history-visibility-handle')!);
@@ -506,10 +510,15 @@ describe('App', () => {
       expect(handle).not.toBeNull();
       expect(handle).toHaveAttribute('aria-expanded', 'false');
       expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
+      expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
+      expect(container.querySelector('.composer-panel #music-player-mount')).not.toBeNull();
 
       fireEvent.pointerDown(handle!, { pointerType: 'mouse', button: 0 });
       expect(handle).toHaveAttribute('aria-expanded', 'true');
       expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
+      expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
+      expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
+      expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-music-player-mount', 'compact-history');
       expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBe('true');
       expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
 
@@ -1926,7 +1935,8 @@ describe('App', () => {
 
     expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
     expect(container.querySelector('[data-compact-hit-region-id^="history:"]')).toBeNull();
-    expect(container.querySelector('#music-player-mount')).toBeNull();
+    expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
+    expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
     expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBeNull();
 
     rerender(<App chatSurfaceMode="compact" compactChatState="input" messages={[message]} />);

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -386,12 +386,13 @@ describe('App', () => {
     expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
     expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-geometry-hit-scope', 'children');
     expect(container.querySelector('.compact-export-history-anchor')).not.toHaveAttribute('data-compact-hit-region');
-    expect(container.querySelector('.compact-export-history-scroll')).toHaveAttribute('data-compact-hit-region', 'true');
-    expect(container.querySelector('.compact-export-history-scroll')).toHaveAttribute('data-compact-hit-region-id', 'history:scroll');
-    expect(container.querySelector('.compact-export-history-scroll')).toHaveAttribute('data-compact-hit-region-kind', 'scroll');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region', 'true');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-id', 'history:message:assistant-history-1');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-kind', 'message');
+    expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
+    expect(container.querySelector('.compact-export-history-panel #music-player-mount')).not.toBeNull();
+    expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-id', 'history:music-player');
+    expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-kind', 'music');
     expect(container.querySelector('.compact-export-history-controls')).toBeNull();
     expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('data-compact-geometry-item', 'historyHandle');
     expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('aria-expanded', 'true');
@@ -433,6 +434,7 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('aria-disabled', 'true');
       expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('tabindex', '-1');
       expect(container.querySelector('.compact-export-history-bubble')).not.toHaveAttribute('data-compact-hit-region');
+      expect(container.querySelector('.compact-export-history-music-mount')).not.toHaveAttribute('data-compact-hit-region');
       expect(container.querySelector('.compact-export-history-controls')).toHaveAttribute('aria-disabled', 'true');
       expect(container.querySelector('.compact-export-history-controls')).not.toHaveAttribute('data-compact-hit-region');
       container.querySelectorAll<HTMLButtonElement>('.compact-export-history-control').forEach((button) => {
@@ -444,12 +446,17 @@ describe('App', () => {
         await vi.advanceTimersByTimeAsync(COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS);
       });
 
-      expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
+      expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
+      expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'closing');
+      expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-open', 'false');
+      expect(container.querySelector('.compact-export-history-panel #music-player-mount')).not.toBeNull();
       expect(container.querySelector('[data-compact-hit-region-id^="history:"]')).toBeNull();
 
       fireEvent.click(container.querySelector<HTMLButtonElement>('.compact-history-visibility-handle')!);
       expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'open');
+      expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-open', 'true');
+      expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-id', 'history:music-player');
       expect(container.querySelector('.compact-export-history-controls')).toHaveAttribute('data-compact-hit-region-id', 'history:controls');
       expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('aria-expanded', 'true');
       expect(exportButton).toHaveAttribute('aria-pressed', 'true');
@@ -1919,6 +1926,7 @@ describe('App', () => {
 
     expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
     expect(container.querySelector('[data-compact-hit-region-id^="history:"]')).toBeNull();
+    expect(container.querySelector('#music-player-mount')).toBeNull();
     expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBeNull();
 
     rerender(<App chatSurfaceMode="compact" compactChatState="input" messages={[message]} />);

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1288,7 +1288,6 @@ export default function App({
   const [compactExportAutoScrollToBottom, setCompactExportAutoScrollToBottom] = useState(true);
   const compactSurfaceResizeStateRef = useRef<CompactSurfaceResizeState | null>(null);
   const compactHistoryVisibilitySuppressClickRef = useRef(false);
-  const compactExportHistoryUnmountTimerRef = useRef<number | null>(null);
   const submittingRef = useRef(false);
   const lastRollbackKeyRef = useRef('');
   const lastToolCursorResetKeyRef = useRef('');
@@ -1546,31 +1545,17 @@ export default function App({
     [compactExportSelectableMessages],
   );
   const compactExportSelectableCount = compactExportSelectableMessages.length;
-  const clearCompactExportHistoryUnmountTimer = useCallback(() => {
-    if (compactExportHistoryUnmountTimerRef.current === null) return;
-    window.clearTimeout(compactExportHistoryUnmountTimerRef.current);
-    compactExportHistoryUnmountTimerRef.current = null;
-  }, []);
   const openCompactExportHistory = useCallback(() => {
-    clearCompactExportHistoryUnmountTimer();
     setCompactExportHistoryMounted(true);
     setCompactExportHistoryOpen(true);
     persistCompactExportHistoryOpen(true);
     setCompactExportAutoScrollToBottom(true);
-  }, [clearCompactExportHistoryUnmountTimer]);
+  }, []);
   const closeCompactExportHistory = useCallback(() => {
-    clearCompactExportHistoryUnmountTimer();
     setCompactExportHistoryOpen(false);
     persistCompactExportHistoryOpen(false);
     setCompactExportPreviewOpen(false);
-    compactExportHistoryUnmountTimerRef.current = window.setTimeout(() => {
-      setCompactExportHistoryMounted(false);
-      compactExportHistoryUnmountTimerRef.current = null;
-    }, COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS);
-  }, [clearCompactExportHistoryUnmountTimer]);
-  useEffect(() => () => {
-    clearCompactExportHistoryUnmountTimer();
-  }, [clearCompactExportHistoryUnmountTimer]);
+  }, []);
   const handleCompactHistoryVisibilityToggle = useCallback(() => {
     if (compactExportHistoryOpen) {
       closeCompactExportHistory();
@@ -5371,7 +5356,6 @@ export default function App({
           data-chat-surface-mode={chatSurfaceMode}
           data-compact-chat-state={effectiveCompactChatState}
         >
-          <div id="music-player-mount" />
           <form className="composer" onSubmit={(event) => {
             event.preventDefault();
             submitDraft();

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5356,6 +5356,7 @@ export default function App({
           data-chat-surface-mode={chatSurfaceMode}
           data-compact-chat-state={effectiveCompactChatState}
         >
+          <div id="music-player-mount" className="composer-music-player-mount" />
           <form className="composer" onSubmit={(event) => {
             event.preventDefault();
             submitDraft();

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -2343,7 +2343,7 @@ export default function CompactExportHistoryPanel({
         data-compact-geometry-item="history"
         data-compact-geometry-hit-scope="children"
         data-compact-no-drag="true"
-        data-compact-export-history-open="true"
+        data-compact-export-history-open={historyInteractive ? 'true' : 'false'}
         data-compact-export-history-visibility={visibilityState}
         data-compact-export-preview-open={previewOpen ? 'true' : 'false'}
         data-compact-export-under-choice={choiceLayerAbove ? 'true' : 'false'}
@@ -2439,6 +2439,13 @@ export default function CompactExportHistoryPanel({
                 </div>
               ) : null}
             </div>
+            <div
+              id="music-player-mount"
+              className="compact-export-history-music-mount"
+              data-compact-hit-region={historyInteractive ? 'true' : undefined}
+              data-compact-hit-region-id={historyInteractive ? 'history:music-player' : undefined}
+              data-compact-hit-region-kind={historyInteractive ? 'music' : undefined}
+            />
             {controlsOpen ? (
               <div
                 className="compact-export-history-controls"

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -2440,8 +2440,8 @@ export default function CompactExportHistoryPanel({
               ) : null}
             </div>
             <div
-              id="music-player-mount"
               className="compact-export-history-music-mount"
+              data-music-player-mount="compact-history"
               data-compact-hit-region={historyInteractive ? 'true' : undefined}
               data-compact-hit-region-id={historyInteractive ? 'history:music-player' : undefined}
               data-compact-hit-region-kind={historyInteractive ? 'music' : undefined}

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1093,7 +1093,7 @@ svg {
   min-width: 0;
 }
 
-/* Hide empty music-player-mount so it doesn't occupy a grid row */
+/* 空播放器挂载点不占用布局行。 */
 #music-player-mount:empty {
   display: none;
 }
@@ -2362,6 +2362,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-scroll,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-controls,
+.compact-export-history-anchor.under-choice-prompt .compact-export-history-music-mount,
 .compact-export-history-anchor.under-choice-prompt .compact-export-preview-region {
   opacity: 0.32;
   filter: blur(1.5px);
@@ -2371,6 +2372,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-bubble,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-empty {
+  pointer-events: none;
+}
+
+.compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper {
+  opacity: 0;
+  visibility: hidden;
   pointer-events: none;
 }
 
@@ -2460,10 +2467,17 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .compact-export-history-controls,
+.compact-export-history-anchor[data-compact-export-history-visibility="closing"] .compact-export-history-music-mount,
 .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .compact-export-preview-region {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+
+.compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 @keyframes compact-history-message-enter {
@@ -2924,6 +2938,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 .compact-export-history-controls,
+.compact-export-history-music-mount,
 .compact-export-preview-region {
   display: flex;
   align-items: center;
@@ -2940,6 +2955,138 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   -webkit-backdrop-filter: blur(8px) saturate(1.08);
   pointer-events: auto;
   -webkit-app-region: no-drag;
+}
+
+.compact-export-history-music-mount {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 0 6px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
+}
+
+.compact-export-history-music-mount:empty {
+  display: none;
+}
+
+/* 历史面板内播放器：覆盖独立播放器的深色样式，贴合聊天记录的玻璃质感。 */
+#music-player-mount.compact-export-history-music-mount > .music-player-bar {
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 7px 8px;
+  gap: 8px;
+  border: 1px solid rgba(100, 184, 255, 0.2);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(237, 248, 255, 0.74));
+  color: #273042;
+  box-shadow: 0 8px 18px rgba(22, 48, 84, 0.1);
+  backdrop-filter: blur(10px) saturate(1.08);
+  -webkit-backdrop-filter: blur(10px) saturate(1.08);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-cover {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(52, 100, 148, 0.18);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-cover img {
+  border-radius: 8px;
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-info {
+  align-items: stretch;
+  text-align: left;
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-title-wrap {
+  margin-bottom: 1px;
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-title-seg {
+  color: #273042;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-artist,
+#music-player-mount.compact-export-history-music-mount .music-bar-time {
+  color: #5d7797;
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-artist {
+  font-size: 0.68rem;
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-time {
+  font-size: 0.64rem;
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-progress-container {
+  height: 4px;
+  margin: 4px 0 2px;
+  background: rgba(101, 136, 176, 0.16);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-progress-fill {
+  background: linear-gradient(90deg, rgba(76, 176, 255, 0.88), rgba(112, 205, 239, 0.76));
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-play,
+#music-player-mount.compact-export-history-music-mount .music-bar-volume-btn {
+  width: 28px;
+  height: 28px;
+  color: #eaf7ff;
+  background: linear-gradient(135deg, #2f8fcd, #56c5e8);
+  box-shadow: 0 5px 12px rgba(44, 122, 184, 0.2);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-volume-btn {
+  color: #2f6f9f;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(100, 184, 255, 0.16);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-close {
+  width: 22px;
+  height: 22px;
+  color: rgba(93, 119, 151, 0.76);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-close:hover {
+  color: #2f6f9f;
+  background: rgba(220, 242, 255, 0.94);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-wrapper {
+  bottom: 36px;
+  border: 1px solid rgba(100, 184, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 10px 22px rgba(22, 48, 84, 0.14);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider {
+  background: rgba(101, 136, 176, 0.18);
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-fill {
+  background: linear-gradient(to top, rgba(76, 176, 255, 0.9), rgba(112, 205, 239, 0.8));
+}
+
+#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-handle {
+  background: #f8fcff;
+  box-shadow: 0 0 0 1px rgba(72, 152, 220, 0.2), 0 3px 8px rgba(22, 48, 84, 0.16);
 }
 
 .compact-export-history-controls {
@@ -4518,10 +4665,46 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 [data-theme="dark"] .compact-export-history-controls,
+[data-theme="dark"] .compact-export-history-music-mount,
 [data-theme="dark"] .compact-export-preview-region {
   border-color: rgba(116, 187, 255, 0.22);
   background: rgba(23, 35, 50, 0.28);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.22);
+}
+
+[data-theme="dark"] .compact-export-history-music-mount {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount > .music-player-bar {
+  border-color: rgba(116, 187, 255, 0.22);
+  background: rgba(33, 45, 62, 0.88);
+  color: #e8f0fb;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-title-seg {
+  color: #e8f0fb;
+}
+
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-artist,
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-time {
+  color: rgba(210, 225, 244, 0.72);
+}
+
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-progress-container,
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-volume-slider {
+  background: rgba(202, 224, 248, 0.16);
+}
+
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-volume-btn,
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-close,
+[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-wrapper {
+  border-color: rgba(116, 187, 255, 0.18);
+  background: rgba(26, 48, 70, 0.86);
+  color: #bfe2ff;
 }
 
 [data-theme="dark"] .compact-export-history-count,
@@ -4637,6 +4820,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   .message-row-assistant,
   .compact-export-history-message,
   .compact-export-history-bubble,
+  .compact-export-history-music-mount,
   .compact-history-visibility-handle::before,
   .compact-history-visibility-handle::after,
   .text-chunk-reveal,

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2976,7 +2976,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 /* 历史面板内播放器：覆盖独立播放器的深色样式，贴合聊天记录的玻璃质感。 */
-#music-player-mount.compact-export-history-music-mount > .music-player-bar {
+.compact-export-history-music-mount > .music-player-bar {
   width: 100%;
   min-width: 0;
   margin: 0;
@@ -2992,57 +2992,57 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   -webkit-backdrop-filter: blur(10px) saturate(1.08);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-cover {
+.compact-export-history-music-mount .music-bar-cover {
   width: 32px;
   height: 32px;
   border-radius: 8px;
   box-shadow: 0 4px 10px rgba(52, 100, 148, 0.18);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-cover img {
+.compact-export-history-music-mount .music-bar-cover img {
   border-radius: 8px;
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-info {
+.compact-export-history-music-mount .music-bar-info {
   align-items: stretch;
   text-align: left;
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-title-wrap {
+.compact-export-history-music-mount .music-bar-title-wrap {
   margin-bottom: 1px;
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-title-seg {
+.compact-export-history-music-mount .music-bar-title-seg {
   color: #273042;
   font-size: 0.78rem;
   font-weight: 700;
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-artist,
-#music-player-mount.compact-export-history-music-mount .music-bar-time {
+.compact-export-history-music-mount .music-bar-artist,
+.compact-export-history-music-mount .music-bar-time {
   color: #5d7797;
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-artist {
+.compact-export-history-music-mount .music-bar-artist {
   font-size: 0.68rem;
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-time {
+.compact-export-history-music-mount .music-bar-time {
   font-size: 0.64rem;
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-progress-container {
+.compact-export-history-music-mount .music-bar-progress-container {
   height: 4px;
   margin: 4px 0 2px;
   background: rgba(101, 136, 176, 0.16);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-progress-fill {
+.compact-export-history-music-mount .music-bar-progress-fill {
   background: linear-gradient(90deg, rgba(76, 176, 255, 0.88), rgba(112, 205, 239, 0.76));
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-play,
-#music-player-mount.compact-export-history-music-mount .music-bar-volume-btn {
+.compact-export-history-music-mount .music-bar-play,
+.compact-export-history-music-mount .music-bar-volume-btn {
   width: 28px;
   height: 28px;
   color: #eaf7ff;
@@ -3050,25 +3050,25 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   box-shadow: 0 5px 12px rgba(44, 122, 184, 0.2);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-volume-btn {
+.compact-export-history-music-mount .music-bar-volume-btn {
   color: #2f6f9f;
   background: rgba(255, 255, 255, 0.72);
   box-shadow: inset 0 0 0 1px rgba(100, 184, 255, 0.16);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-close {
+.compact-export-history-music-mount .music-bar-close {
   width: 22px;
   height: 22px;
   color: rgba(93, 119, 151, 0.76);
   background: rgba(255, 255, 255, 0.58);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-close:hover {
+.compact-export-history-music-mount .music-bar-close:hover {
   color: #2f6f9f;
   background: rgba(220, 242, 255, 0.94);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-wrapper {
+.compact-export-history-music-mount .music-bar-volume-slider-wrapper {
   bottom: 36px;
   border: 1px solid rgba(100, 184, 255, 0.18);
   border-radius: 8px;
@@ -3076,15 +3076,15 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   box-shadow: 0 10px 22px rgba(22, 48, 84, 0.14);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider {
+.compact-export-history-music-mount .music-bar-volume-slider {
   background: rgba(101, 136, 176, 0.18);
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-fill {
+.compact-export-history-music-mount .music-bar-volume-slider-fill {
   background: linear-gradient(to top, rgba(76, 176, 255, 0.9), rgba(112, 205, 239, 0.8));
 }
 
-#music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-handle {
+.compact-export-history-music-mount .music-bar-volume-slider-handle {
   background: #f8fcff;
   box-shadow: 0 0 0 1px rgba(72, 152, 220, 0.2), 0 3px 8px rgba(22, 48, 84, 0.16);
 }
@@ -4678,30 +4678,30 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   box-shadow: none;
 }
 
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount > .music-player-bar {
+[data-theme="dark"] .compact-export-history-music-mount > .music-player-bar {
   border-color: rgba(116, 187, 255, 0.22);
   background: rgba(33, 45, 62, 0.88);
   color: #e8f0fb;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
 }
 
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-title-seg {
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-title-seg {
   color: #e8f0fb;
 }
 
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-artist,
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-time {
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-artist,
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-time {
   color: rgba(210, 225, 244, 0.72);
 }
 
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-progress-container,
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-volume-slider {
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-progress-container,
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-volume-slider {
   background: rgba(202, 224, 248, 0.16);
 }
 
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-volume-btn,
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-close,
-[data-theme="dark"] #music-player-mount.compact-export-history-music-mount .music-bar-volume-slider-wrapper {
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-volume-btn,
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-close,
+[data-theme="dark"] .compact-export-history-music-mount .music-bar-volume-slider-wrapper {
   border-color: rgba(116, 187, 255, 0.18);
   background: rgba(26, 48, 70, 0.86);
   color: #bfe2ff;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1181,9 +1181,8 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     pointer-events: auto;
 }
 
-/* Compact history pass-through contract: the broad surface rule above re-enables
-   hit-testing for all surface descendants, so every transparent history wrapper
-   must be reset to none. Only visible bubbles, controls, and preview are auto. */
+/* 紧凑历史面板点击穿透契约：上方通用规则会重新开启 surface 子节点命中，
+   因此透明包装层必须回到 none，只保留气泡、控制区、播放器和预览可交互。 */
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-panel,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-scroll,
@@ -1194,8 +1193,14 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-bubble,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-controls,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-music-mount,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-preview-region {
     pointer-events: auto;
+}
+
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper {
+    pointer-events: none;
 }
 
 /* compact 态不再把最小化按钮渲染成模型旁的悬浮球：呼吸灯外发光会被 Electron 窗口形状裁切，

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1183,6 +1183,11 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
 
 /* 紧凑历史面板点击穿透契约：上方通用规则会重新开启 surface 子节点命中，
    因此透明包装层必须回到 none，只保留气泡、控制区、播放器和预览可交互。 */
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount * {
+    pointer-events: auto;
+}
+
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-panel,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-scroll,

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -355,9 +355,22 @@
     let musicMountRelocationFrame = 0;
     let pendingDetachedMusicBar = null;
 
+    function isCompactHistoryMusicMountInteractive(mount) {
+        if (!(mount instanceof Element)) return false;
+        if (mount.getAttribute('data-compact-hit-region') !== 'true') return false;
+        const anchor = mount.closest ? mount.closest('.compact-export-history-anchor') : null;
+        if (anchor && anchor.getAttribute('data-compact-export-history-visibility') !== 'open') return false;
+        if (window.getComputedStyle) {
+            const style = window.getComputedStyle(mount);
+            if (style && (style.display === 'none' || style.visibility === 'hidden' || style.pointerEvents === 'none')) return false;
+            if (style && Number(style.opacity) <= 0.01) return false;
+        }
+        return true;
+    }
+
     function getPreferredMusicMountTarget() {
         const historyMount = document.querySelector('.compact-export-history-music-mount');
-        if (historyMount) return { mountTarget: historyMount, insertBeforeEl: null };
+        if (isCompactHistoryMusicMountInteractive(historyMount)) return { mountTarget: historyMount, insertBeforeEl: null };
 
         const reactMount = document.getElementById('music-player-mount');
         if (reactMount) return { mountTarget: reactMount, insertBeforeEl: null };
@@ -405,6 +418,14 @@
         return !!(node.querySelector && node.querySelector('#music-player-mount, .compact-export-history-music-mount'));
     }
 
+    function isMusicMountMutationTarget(node) {
+        if (!(node instanceof Element)) return false;
+        return node.id === 'music-player-mount'
+            || node.classList.contains('compact-export-history-anchor')
+            || node.classList.contains('compact-export-history-music-mount')
+            || !!(node.closest && node.closest('.compact-export-history-anchor'));
+    }
+
     function scheduleMusicBarRelocation(detachedMusicBar) {
         if (detachedMusicBar) pendingDetachedMusicBar = detachedMusicBar;
         if (musicMountRelocationFrame) return;
@@ -421,6 +442,10 @@
         if (musicMountObserver || typeof MutationObserver === 'undefined' || !document.body) return;
         musicMountObserver = new MutationObserver((mutations) => {
             for (const mutation of mutations) {
+                if (mutation.type === 'attributes' && isMusicMountMutationTarget(mutation.target)) {
+                    scheduleMusicBarRelocation();
+                    return;
+                }
                 for (const node of mutation.removedNodes) {
                     const removedBar = findMusicBarInNode(node);
                     if (removedBar) {
@@ -440,7 +465,17 @@
                 }
             }
         });
-        musicMountObserver.observe(document.body, { childList: true, subtree: true });
+        musicMountObserver.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: [
+                'class',
+                'data-compact-export-history-visibility',
+                'data-compact-hit-region',
+                'style'
+            ]
+        });
     }
 
     const bindMirrorBarControls = (musicBar) => {

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -564,7 +564,7 @@
                 <button type="button" class="music-bar-play" aria-label="Play/Pause" title="Play/Pause">▶</button>
                 <div class="music-bar-volume-container">
                     <button type="button" class="music-bar-volume-btn" aria-label="Volume" title="Volume">🔊</button>
-                    <div class="music-bar-volume-slider-wrapper">
+                    <div class="music-bar-volume-slider-wrapper" data-compact-hit-region="true" data-compact-hit-region-id="history:music-player:volume" data-compact-hit-region-kind="music-volume">
                         <div class="music-bar-volume-slider">
                             <div class="music-bar-volume-slider-fill"></div>
                             <div class="music-bar-volume-slider-handle"></div>
@@ -1327,7 +1327,7 @@
                 <button type="button" class="music-bar-play" aria-label="Play/Pause" title="Play/Pause">▶</button>
                 <div class="music-bar-volume-container">
                     <button type="button" class="music-bar-volume-btn" aria-label="Volume" title="Volume">🔊</button>
-                    <div class="music-bar-volume-slider-wrapper">
+                    <div class="music-bar-volume-slider-wrapper" data-compact-hit-region="true" data-compact-hit-region-id="history:music-player:volume" data-compact-hit-region-kind="music-volume">
                         <div class="music-bar-volume-slider">
                             <div class="music-bar-volume-slider-fill"></div>
                             <div class="music-bar-volume-slider-handle"></div>

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -351,6 +351,98 @@
         });
     };
 
+    let musicMountObserver = null;
+    let musicMountRelocationFrame = 0;
+    let pendingDetachedMusicBar = null;
+
+    function getPreferredMusicMountTarget() {
+        const historyMount = document.querySelector('.compact-export-history-music-mount');
+        if (historyMount) return { mountTarget: historyMount, insertBeforeEl: null };
+
+        const reactMount = document.getElementById('music-player-mount');
+        if (reactMount) return { mountTarget: reactMount, insertBeforeEl: null };
+
+        const legacyMount = document.getElementById(MUSIC_CONFIG.dom.containerId);
+        return {
+            mountTarget: legacyMount,
+            insertBeforeEl: legacyMount ? document.getElementById(MUSIC_CONFIG.dom.insertBeforeId) : null
+        };
+    }
+
+    function mountMusicBar(musicBar) {
+        if (!musicBar) return false;
+        ensureMusicMountObserver();
+        if (musicBar.dataset) delete musicBar.dataset.skipMountRelocation;
+        const target = getPreferredMusicMountTarget();
+        if (!target || !target.mountTarget) return false;
+        if (musicBar.parentNode === target.mountTarget) return true;
+        if (target.insertBeforeEl && target.insertBeforeEl.parentNode === target.mountTarget) {
+            target.mountTarget.insertBefore(musicBar, target.insertBeforeEl);
+        } else {
+            target.mountTarget.appendChild(musicBar);
+        }
+        return true;
+    }
+
+    function removeMusicBarWithoutRelocation(musicBar) {
+        if (!musicBar) return;
+        if (musicBar.dataset) musicBar.dataset.skipMountRelocation = 'true';
+        musicBar.remove();
+    }
+
+    function findMusicBarInNode(node) {
+        if (!(node instanceof Element)) return null;
+        const musicBar = node.id === MUSIC_CONFIG.dom.barId
+            ? node
+            : (node.querySelector ? node.querySelector('#' + MUSIC_CONFIG.dom.barId) : null);
+        if (musicBar && musicBar.dataset && musicBar.dataset.skipMountRelocation === 'true') return null;
+        return musicBar;
+    }
+
+    function isMusicMountMutationNode(node) {
+        if (!(node instanceof Element)) return false;
+        if (node.id === 'music-player-mount' || node.classList.contains('compact-export-history-music-mount')) return true;
+        return !!(node.querySelector && node.querySelector('#music-player-mount, .compact-export-history-music-mount'));
+    }
+
+    function scheduleMusicBarRelocation(detachedMusicBar) {
+        if (detachedMusicBar) pendingDetachedMusicBar = detachedMusicBar;
+        if (musicMountRelocationFrame) return;
+        const raf = window.requestAnimationFrame || ((callback) => window.setTimeout(callback, 16));
+        musicMountRelocationFrame = raf(() => {
+            musicMountRelocationFrame = 0;
+            const musicBar = pendingDetachedMusicBar || document.getElementById(MUSIC_CONFIG.dom.barId);
+            pendingDetachedMusicBar = null;
+            mountMusicBar(musicBar);
+        });
+    }
+
+    function ensureMusicMountObserver() {
+        if (musicMountObserver || typeof MutationObserver === 'undefined' || !document.body) return;
+        musicMountObserver = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                for (const node of mutation.removedNodes) {
+                    const removedBar = findMusicBarInNode(node);
+                    if (removedBar) {
+                        scheduleMusicBarRelocation(removedBar);
+                        return;
+                    }
+                    if (isMusicMountMutationNode(node)) {
+                        scheduleMusicBarRelocation();
+                        return;
+                    }
+                }
+                for (const node of mutation.addedNodes) {
+                    if (isMusicMountMutationNode(node)) {
+                        scheduleMusicBarRelocation();
+                        return;
+                    }
+                }
+            }
+        });
+        musicMountObserver.observe(document.body, { childList: true, subtree: true });
+    }
+
     const bindMirrorBarControls = (musicBar) => {
         const apBtn = musicBar.querySelector('.music-bar-play');
         const closeBtn = musicBar.querySelector('.music-bar-close');
@@ -521,20 +613,14 @@
 
         if (firstRender) {
             ensureMusicUiCSS();
-            let mountTarget = document.getElementById('music-player-mount');
-            let insertBeforeEl = null;
-            if (!mountTarget) {
-                mountTarget = document.getElementById(MUSIC_CONFIG.dom.containerId);
-                insertBeforeEl = document.getElementById(MUSIC_CONFIG.dom.insertBeforeId);
-            }
+            const mountTarget = getPreferredMusicMountTarget().mountTarget;
             if (!mountTarget) return;
 
             musicBar = document.createElement('div');
             musicBar.id = MUSIC_CONFIG.dom.barId;
             musicBar.className = 'music-player-bar';
             musicBar.dataset.mirror = 'true';
-            if (insertBeforeEl) mountTarget.insertBefore(musicBar, insertBeforeEl);
-            else mountTarget.appendChild(musicBar);
+            mountMusicBar(musicBar);
 
             const randomColor = MUSIC_CONFIG.themeColors[Math.floor(Math.random() * MUSIC_CONFIG.themeColors.length)];
             musicBar.style.setProperty('--dynamic-random-color', randomColor);
@@ -577,6 +663,7 @@
             bindMirrorBarControls(musicBar);
         } else {
             musicBar.classList.remove('fading-out');
+            mountMusicBar(musicBar);
         }
 
         // 切歌 / 首次：刷新标题 + 歌手 + 封面
@@ -668,7 +755,7 @@
         }
 
         const removeNow = () => {
-            if (musicBar.parentNode) musicBar.remove();
+            if (musicBar.parentNode) removeMusicBarWithoutRelocation(musicBar);
             mirrorBarTrackSig = null;
             mirrorBarLastState = null;
             mirrorBarDestroyTimer = null;
@@ -1167,11 +1254,11 @@
                 if (fullTeardown) {
                     bar.classList.add('fading-out');
                     domRemovalTimer = setTimeout(() => {
-                        bar.remove();
+                        removeMusicBarWithoutRelocation(bar);
                         domRemovalTimer = null;
                     }, 300);
                 } else {
-                    bar.remove();
+                    removeMusicBarWithoutRelocation(bar);
                 }
             }
             clearManagedListeners();
@@ -1271,7 +1358,7 @@
                 }
                 existingBar.__mirrorTeardownCleanups = null;
             }
-            existingBar.remove();
+            removeMusicBarWithoutRelocation(existingBar);
             mirrorBarTrackSig = null;
             mirrorBarLastState = null;
             // 自己升成 owner 后就不再持有"绑定到某个 leader"的状态
@@ -1284,20 +1371,14 @@
 
         // --- 1. DOM 基础架构 ---
         if (isFirstRender) {
-            // 优先挂载到 React 聊天窗口 composer-panel 内的专用挂载点，回退到旧 chat-container
-            let mountTarget = document.getElementById('music-player-mount');
-            let insertBeforeEl = null;
-            if (!mountTarget) {
-                mountTarget = document.getElementById(MUSIC_CONFIG.dom.containerId);
-                insertBeforeEl = document.getElementById(MUSIC_CONFIG.dom.insertBeforeId);
-            }
+            // 优先使用紧凑历史目标，其次 React composer 挂载点，最后回退旧 chat-container。
+            const mountTarget = getPreferredMusicMountTarget().mountTarget;
             if (!mountTarget) return;
 
             musicBar = document.createElement('div');
             musicBar.id = MUSIC_CONFIG.dom.barId;
             musicBar.className = 'music-player-bar';
-            if (insertBeforeEl) mountTarget.insertBefore(musicBar, insertBeforeEl);
-            else mountTarget.appendChild(musicBar);
+            mountMusicBar(musicBar);
 
             const randomColor = MUSIC_CONFIG.themeColors[Math.floor(Math.random() * MUSIC_CONFIG.themeColors.length)];
             musicBar.style.setProperty('--dynamic-random-color', randomColor);
@@ -1340,18 +1421,7 @@
             ensureTitleMarqueeObserver(musicBar);
         } else {
             musicBar.classList.remove('fading-out');
-
-            // Relocate musicBar if a new mount target has appeared
-            let newMountTarget = document.getElementById('music-player-mount');
-            let newInsertBeforeEl = null;
-            if (!newMountTarget) {
-                newMountTarget = document.getElementById(MUSIC_CONFIG.dom.containerId);
-                newInsertBeforeEl = document.getElementById(MUSIC_CONFIG.dom.insertBeforeId);
-            }
-            if (newMountTarget && musicBar.parentNode !== newMountTarget) {
-                if (newInsertBeforeEl) newMountTarget.insertBefore(musicBar, newInsertBeforeEl);
-                else newMountTarget.appendChild(musicBar);
-            }
+            mountMusicBar(musicBar);
         }
 
         // 切歌前，先把上一首卡片标记为"已结束"。必须在 currentPlayingTrack
@@ -1866,7 +1936,7 @@
         } catch (err) {
             if (currentToken !== latestMusicRequestToken) return;
             console.error('[Music UI] 播放器处理异常:', err);
-            if (isFirstRender && musicBar) musicBar.remove();
+            if (isFirstRender && musicBar) removeMusicBarWithoutRelocation(musicBar);
             // 回滚：前面已经发过 emitBarInitialState，但 APlayer 没建起来，
             // 后续事件不会广播，follower 会卡着占位 bar，这里补一条 destroyed
             broadcastBarDestroyed(false);

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -909,6 +909,12 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
         "    pointer-events: auto;\n"
         "}"
     )
+    fallback_music_interactive_rule = (
+        f'{compact_surface_prefix} #music-player-mount,\n'
+        f'{compact_surface_prefix} #music-player-mount * {{\n'
+        "    pointer-events: auto;\n"
+        "}"
+    )
     history_passthrough_rule = (
         f'{compact_surface_prefix} .compact-export-history-anchor,\n'
         f'{compact_surface_prefix} .compact-export-history-panel,\n'
@@ -934,10 +940,12 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
     )
 
     assert broad_surface_rule in styles
+    assert fallback_music_interactive_rule in styles
     assert history_passthrough_rule in styles
     assert history_interactive_rule in styles
     assert history_music_volume_hidden_rule in styles
-    assert styles.index(broad_surface_rule) < styles.index(history_passthrough_rule)
+    assert styles.index(broad_surface_rule) < styles.index(fallback_music_interactive_rule)
+    assert styles.index(fallback_music_interactive_rule) < styles.index(history_passthrough_rule)
     assert styles.index(history_passthrough_rule) < styles.index(history_interactive_rule)
     assert styles.index(history_interactive_rule) < styles.index(history_music_volume_hidden_rule)
     assert ".compact-export-history-scroll,\n" in history_passthrough_rule

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -874,9 +874,16 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in music_hit_block
     assert "data-compact-hit-region-kind={historyInteractive ? 'music' : undefined}" in music_hit_block
     assert "function getPreferredMusicMountTarget()" in music_ui_source
+    assert "function isCompactHistoryMusicMountInteractive(mount)" in music_ui_source
     assert "document.querySelector('.compact-export-history-music-mount')" in music_ui_source
+    assert "mount.getAttribute('data-compact-hit-region') !== 'true'" in music_ui_source
+    assert "data-compact-export-history-visibility') !== 'open'" in music_ui_source
     assert "document.getElementById('music-player-mount')" in music_ui_source
     assert "document.getElementById(MUSIC_CONFIG.dom.containerId)" in music_ui_source
+    assert "mutation.type === 'attributes' && isMusicMountMutationTarget(mutation.target)" in music_ui_source
+    assert "attributes: true" in music_ui_source
+    assert "'data-compact-export-history-visibility'" in music_ui_source
+    assert "'data-compact-hit-region'" in music_ui_source
     assert "mountMusicBar(musicBar)" in music_ui_source
     assert music_ui_source.count('data-compact-hit-region-id="history:music-player:volume"') == 2
     assert music_ui_source.count('data-compact-hit-region-kind="music-volume"') == 2

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -847,7 +847,7 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
         1,
     )[0]
     music_hit_block = panel_source.split('className="compact-export-history-music-mount"', 1)[1].split(
-        "/>",
+        'className="compact-export-history-controls"',
         1,
     )[0]
 
@@ -870,8 +870,14 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in controls_hit_block
     assert "data-compact-hit-region-kind={historyInteractive ? 'controls' : undefined}" in controls_hit_block
     assert "data-compact-hit-region-id={historyInteractive ? 'history:music-player' : undefined}" in panel_source
+    assert 'data-music-player-mount="compact-history"' in music_hit_block
     assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in music_hit_block
     assert "data-compact-hit-region-kind={historyInteractive ? 'music' : undefined}" in music_hit_block
+    assert "function getPreferredMusicMountTarget()" in music_ui_source
+    assert "document.querySelector('.compact-export-history-music-mount')" in music_ui_source
+    assert "document.getElementById('music-player-mount')" in music_ui_source
+    assert "document.getElementById(MUSIC_CONFIG.dom.containerId)" in music_ui_source
+    assert "mountMusicBar(musicBar)" in music_ui_source
     assert music_ui_source.count('data-compact-hit-region-id="history:music-player:volume"') == 2
     assert music_ui_source.count('data-compact-hit-region-kind="music-volume"') == 2
     assert ".compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper" in styles

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -4,6 +4,7 @@ from pathlib import Path
 APP_REACT_CHAT_WINDOW_PATH = Path(__file__).resolve().parents[2] / "static" / "app-react-chat-window.js"
 APP_BUTTONS_PATH = Path(__file__).resolve().parents[2] / "static" / "app-buttons.js"
 APP_CHAT_EXPORT_PATH = Path(__file__).resolve().parents[2] / "static" / "app-chat-export.js"
+MUSIC_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "music_ui.js"
 STATIC_INDEX_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "index.css"
 REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "styles.css"
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
@@ -812,6 +813,7 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
     panel_source = COMPACT_EXPORT_HISTORY_PANEL_PATH.read_text(encoding="utf-8")
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+    music_ui_source = MUSIC_UI_PATH.read_text(encoding="utf-8")
 
     anchor_block = css_block(
         styles,
@@ -829,7 +831,7 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     bubble_block = css_block(styles, ".compact-export-history-bubble {", ".compact-export-history-message.is-disabled")
     shared_hit_block = css_block(
         styles,
-        ".compact-export-history-controls,\n.compact-export-preview-region {",
+        ".compact-export-history-controls,\n.compact-export-history-music-mount,\n.compact-export-preview-region {",
         ".compact-export-history-controls {",
     )
     scroll_jsx_block = panel_source.split('className="compact-export-history-scroll"', 1)[1].split(
@@ -844,6 +846,10 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
         'compact-export-history-controls-content',
         1,
     )[0]
+    music_hit_block = panel_source.split('className="compact-export-history-music-mount"', 1)[1].split(
+        "/>",
+        1,
+    )[0]
 
     assert "pointer-events: none;" in anchor_block
     assert "pointer-events: none;" in panel_block
@@ -852,7 +858,7 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "pointer-events: none;" in content_block
     assert "pointer-events: none;" in message_block
     assert "pointer-events: auto;" in bubble_block
-    assert ".compact-export-history-controls,\n.compact-export-preview-region {" in styles
+    assert ".compact-export-history-controls,\n.compact-export-history-music-mount,\n.compact-export-preview-region {" in styles
     assert "pointer-events: auto;" in shared_hit_block
     assert "function getCompactHistoryScrollbarRect(element, parentRect)" in script
     assert "id: 'history:scrollbar'" in script
@@ -863,6 +869,13 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "data-compact-hit-region-id={historyInteractive ? 'history:controls' : undefined}" in panel_source
     assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in controls_hit_block
     assert "data-compact-hit-region-kind={historyInteractive ? 'controls' : undefined}" in controls_hit_block
+    assert "data-compact-hit-region-id={historyInteractive ? 'history:music-player' : undefined}" in panel_source
+    assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in music_hit_block
+    assert "data-compact-hit-region-kind={historyInteractive ? 'music' : undefined}" in music_hit_block
+    assert music_ui_source.count('data-compact-hit-region-id="history:music-player:volume"') == 2
+    assert music_ui_source.count('data-compact-hit-region-kind="music-volume"') == 2
+    assert ".compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper" in styles
+    assert '.compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper' in styles
     assert 'data-compact-hit-region-id="history:preview"' in panel_source
 
 
@@ -895,16 +908,25 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
     history_interactive_rule = (
         f'{compact_surface_prefix} .compact-export-history-bubble,\n'
         f'{compact_surface_prefix} .compact-export-history-controls,\n'
+        f'{compact_surface_prefix} .compact-export-history-music-mount,\n'
         f'{compact_surface_prefix} .compact-export-preview-region {{\n'
         "    pointer-events: auto;\n"
+        "}"
+    )
+    history_music_volume_hidden_rule = (
+        f'{compact_surface_prefix} .compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper,\n'
+        f'{compact_surface_prefix} .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper {{\n'
+        "    pointer-events: none;\n"
         "}"
     )
 
     assert broad_surface_rule in styles
     assert history_passthrough_rule in styles
     assert history_interactive_rule in styles
+    assert history_music_volume_hidden_rule in styles
     assert styles.index(broad_surface_rule) < styles.index(history_passthrough_rule)
     assert styles.index(history_passthrough_rule) < styles.index(history_interactive_rule)
+    assert styles.index(history_interactive_rule) < styles.index(history_music_volume_hidden_rule)
     assert ".compact-export-history-scroll,\n" in history_passthrough_rule
 
 


### PR DESCRIPTION
…导致无法调整的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 紧凑历史面板新增可交互的音乐播放器挂载点，支持命中识别与播放控件显示。

* **改进**
  * 导出历史面板打开/关闭语义调整：打开时自动滚到底，关闭时即时进入收起态并持久化状态。
  * 音乐播放器挂载/迁移与卸载逻辑优化，减少重复重定位与闪烁。

* **样式**
  * 为紧凑历史中的播放器与子控件补充视觉与深色模式样式，并在无动画偏好下禁用过渡；在特定状态下禁用音量滑块交互。

* **测试**
  * 增强对挂载点、交互命中区域与音量滑块交互规则的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->