### PR TITLE
fix(proactive): 修 Phase 2 截图 413 + 截图编辑亮度 + 国际服搜索改用 DuckDuckGo

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5157,7 +5157,11 @@ class LLMSessionManager:
     # ------------------------------------------------------------------
 
     async def request_fresh_screenshot(self, timeout: float = 3.0) -> str:
-        """通过 WebSocket 向前端请求最新截图，失败时用后端 pyautogui 兜底。返回 base64（不含前缀）。"""
+        """通过 WebSocket 向前端请求最新截图，失败时用后端 pyautogui 兜底。
+
+        两条路径都会把截图统一压到 720p/JPEG-80，返回归一化后的 base64（不含前缀），
+        避免前端原生分辨率大图直发 vision LLM 触发代理 413。
+        """
         # 策略1: 前端 WebSocket 截图
         if self.websocket:
             try:
@@ -5166,6 +5170,25 @@ class LLMSessionManager:
                 await self.websocket.send_json({"type": "request_screenshot"})
                 b64 = await asyncio.wait_for(self._screenshot_future, timeout=timeout)
                 if b64:
+                    # 前端有的截图路径（如 Electron 主进程直捕 captureSourceAsDataUrl）
+                    # 返回原生分辨率，未走 720p 缩放，base64 可达 ~1.4MB，直接发给
+                    # vision LLM 会被代理 nginx 以 413 Request Entity Too Large 拒掉。
+                    # 这里和下方 pyautogui 兜底分支对称，统一压到 720p/JPEG-80 再返回
+                    # （avatar 注解会在其上二次编码，不影响）。压缩失败则退回原图。
+                    try:
+                        from utils.screenshot_utils import (
+                            decode_and_compress_screenshot_b64,
+                            COMPRESS_TARGET_HEIGHT, COMPRESS_JPEG_QUALITY,
+                        )
+                        b64 = await asyncio.to_thread(
+                            decode_and_compress_screenshot_b64,
+                            b64, COMPRESS_TARGET_HEIGHT, COMPRESS_JPEG_QUALITY,
+                        )
+                    except Exception as comp_err:
+                        logger.warning(
+                            "[%s] request_fresh_screenshot WS compress failed, using raw: %s",
+                            self.lanlan_name, comp_err,
+                        )
                     return b64
             except (asyncio.TimeoutError, Exception) as e:
                 logger.warning("[%s] request_fresh_screenshot WS failed: %s", self.lanlan_name, e)

--- a/static/app-crop.js
+++ b/static/app-crop.js
@@ -1346,10 +1346,11 @@
         ctx.fillRect(0, 0, w, h);
 
         if (!sel) {
-            // No selection — show image area more clearly
+            // 未选区时按原图亮度预览：只把图片区域上的暗罩清掉，不再额外压暗。
+            // 之前这里又盖了一层 rgba(0,0,0,0.15)，让刚进编辑界面的整图就暗了 15%、
+            // 对比度也被拉低显得发糊——用户要的是临时预览＝原图画质，故移除。
+            // 图片外的 letterbox 仍保留上面的 0.5 遮罩。
             ctx.clearRect(imgDisplayLeft, imgDisplayTop, imgDisplayWidth, imgDisplayHeight);
-            ctx.fillStyle = 'rgba(0, 0, 0, 0.15)';
-            ctx.fillRect(imgDisplayLeft, imgDisplayTop, imgDisplayWidth, imgDisplayHeight);
             return;
         }
 

--- a/tests/unit/test_duckduckgo_search.py
+++ b/tests/unit/test_duckduckgo_search.py
@@ -1,0 +1,86 @@
+"""Tests for DuckDuckGo search parsing (取代主动搭话窗口上下文里的 Google 搜索)。
+
+无法对 html.duckduckgo.com 做端到端实跑时（如被网络屏蔽），这些测试用真实的
+DDG HTML 结构校验解析器：跳转链接解码、广告跳过、字段提取、上限裁剪。
+"""
+import pytest
+
+from utils.web_scraper import parse_duckduckgo_results
+
+
+# 取自 html.duckduckgo.com/html/ 的真实结构（精简）：
+# - 第 1 条：正常结果，href 是 //duckduckgo.com/l/?uddg=<urlencoded>&rut=...
+# - 第 2 条：广告（class 含 result--ad），必须被跳过
+# - 第 3 条：真实 URL 自带查询参数（含 %3D），验证 parse_qs 只解一次码、不破坏
+_DDG_HTML = """
+<html><body>
+  <div class="result results_links results_links_deep web-result">
+    <div class="links_main links_deep result__body">
+      <h2 class="result__title">
+        <a rel="nofollow" class="result__a"
+           href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.com%2Fneko&amp;rut=abc123">Project NEKO Official</a>
+      </h2>
+      <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fwww.example.com%2Fneko">
+        Project NEKO is a virtual desktop companion.
+      </a>
+    </div>
+  </div>
+
+  <div class="result result--ad result--ad--small">
+    <div class="links_main result__body">
+      <h2 class="result__title">
+        <a class="result__a" href="//duckduckgo.com/y.js?ad_provider=x">Buy NEKO Merch Now</a>
+      </h2>
+      <a class="result__snippet">Sponsored listing.</a>
+    </div>
+  </div>
+
+  <div class="result results_links results_links_deep web-result">
+    <div class="links_main links_deep result__body">
+      <h2 class="result__title">
+        <a rel="nofollow" class="result__a"
+           href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fshop.example.com%2Fp%3Fid%3D42&amp;rut=def">NEKO Store Page</a>
+      </h2>
+      <a class="result__snippet">Buy the figure here.</a>
+    </div>
+  </div>
+</body></html>
+"""
+
+
+@pytest.mark.unit
+def test_parse_decodes_uddg_redirect_and_skips_ads():
+    results = parse_duckduckgo_results(_DDG_HTML, limit=10)
+
+    # 广告被跳过，只剩两条真实结果
+    assert len(results) == 2
+
+    first = results[0]
+    assert first['title'] == 'Project NEKO Official'
+    # uddg 跳转链接被解码成真实地址
+    assert first['url'] == 'https://www.example.com/neko'
+    assert 'virtual desktop companion' in first['abstract']
+
+    # 任何结果都不应残留 DDG 跳转域名
+    assert all('duckduckgo.com/l/' not in r['url'] for r in results)
+    # 广告标题不应出现
+    assert all('Merch' not in r['title'] for r in results)
+
+
+@pytest.mark.unit
+def test_parse_preserves_target_url_query_params():
+    """真实 URL 自带的查询参数（id=42，原文 %3D）只被解一次码，不被二次破坏。"""
+    results = parse_duckduckgo_results(_DDG_HTML, limit=10)
+    store = next(r for r in results if r['title'] == 'NEKO Store Page')
+    assert store['url'] == 'https://shop.example.com/p?id=42'
+
+
+@pytest.mark.unit
+def test_parse_respects_limit():
+    results = parse_duckduckgo_results(_DDG_HTML, limit=1)
+    assert len(results) == 1
+
+
+@pytest.mark.unit
+def test_parse_empty_html_returns_empty_list():
+    assert parse_duckduckgo_results('<html><body>no results</body></html>', limit=5) == []

--- a/tests/unit/test_request_fresh_screenshot.py
+++ b/tests/unit/test_request_fresh_screenshot.py
@@ -1,0 +1,80 @@
+"""Regression tests for LLMSessionManager.request_fresh_screenshot.
+
+回归保护：前端有的截图路径（Electron 主进程直捕 captureSourceAsDataUrl）返回
+原生分辨率大图，base64 可达 ~1.4MB。若 WebSocket 分支原样返回，Phase 2 直接把
+它发给 vision LLM 会被代理 nginx 以 413 Request Entity Too Large 拒掉。
+request_fresh_screenshot 的两条返回路径都必须统一压到 720p/JPEG-80。
+"""
+import asyncio
+import base64
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from main_logic.core import LLMSessionManager
+
+
+def _png_b64(width: int, height: int) -> str:
+    """生成一张指定尺寸的 PNG 并返回纯 base64（不含 data: 前缀）。"""
+    img = Image.new("RGB", (width, height))
+    # 画一点渐变，让它像真实截图而不是纯色（纯色 JPEG 会压到几乎为 0）
+    px = img.load()
+    for y in range(0, height, 4):
+        for x in range(0, width, 4):
+            px[x, y] = ((x * 255) // width, (y * 255) // height, 128)
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+@pytest.mark.unit
+def test_ws_screenshot_is_downscaled_to_720p():
+    """WebSocket 分支返回的原生分辨率大图必须被压到 720p JPEG。"""
+    big_b64 = _png_b64(2560, 1440)  # 模拟 Electron 主进程直捕的原生 1440p 大图
+
+    async def _run() -> str:
+        fake = SimpleNamespace(_screenshot_future=None, lanlan_name="桃奈")
+
+        async def _send_json(payload):
+            # send_json 在 create_future 之后、wait_for 之前被 await，
+            # 此处直接 resolve future，模拟前端回传截图。
+            assert payload == {"type": "request_screenshot"}
+            fake._screenshot_future.set_result(big_b64)
+
+        fake.websocket = SimpleNamespace(send_json=_send_json)
+        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+
+    out_b64 = asyncio.run(_run())
+
+    assert out_b64, "应返回非空 base64"
+    out_img = Image.open(BytesIO(base64.b64decode(out_b64)))
+    # 必须已被归一化为 720p JPEG，而不是原样 1440p PNG
+    assert out_img.format == "JPEG"
+    assert out_img.height == 720
+    # 字节数应远小于 nginx 默认 1MB body 限制（这正是 413 的触发线）
+    assert len(base64.b64decode(out_b64)) < 1024 * 1024
+
+
+@pytest.mark.unit
+def test_ws_screenshot_already_small_stays_under_limit():
+    """已经是小图（720p 以内）时也应正常返回，且不会被放大。"""
+    small_b64 = _png_b64(1280, 720)
+
+    async def _run() -> str:
+        fake = SimpleNamespace(_screenshot_future=None, lanlan_name="桃奈")
+
+        async def _send_json(payload):
+            fake._screenshot_future.set_result(small_b64)
+
+        fake.websocket = SimpleNamespace(send_json=_send_json)
+        return await LLMSessionManager.request_fresh_screenshot(fake, timeout=3.0)
+
+    out_b64 = asyncio.run(_run())
+
+    assert out_b64
+    out_img = Image.open(BytesIO(base64.b64decode(out_b64)))
+    assert out_img.format == "JPEG"
+    assert out_img.height <= 720
+    assert len(base64.b64decode(out_b64)) < 1024 * 1024

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1533,6 +1533,153 @@ def parse_google_results(html_content: str, limit: int = 5) -> List[Dict[str, st
         return []
 
 
+async def search_duckduckgo(query: str, limit: int = 10) -> Dict[str, Any]:
+    """
+    使用 DuckDuckGo 搜索关键词并获取搜索结果（用于非中文区域）。
+
+    取代 Google：Google 对无头/脚本请求的反爬几乎必现（302 → /sorry/index → 429），
+    主动搭话的窗口上下文搜索基本拿不到结果。DuckDuckGo 的 HTML 端点
+    （html.duckduckgo.com）对脚本访问宽容得多，结果直接内嵌在 HTML 里便于解析。
+
+    Args:
+        query: 搜索关键词
+        limit: 返回结果数量限制
+
+    Returns:
+        包含搜索结果的字典
+    """
+    try:
+        if not query or len(query.strip()) < 2:
+            return {
+                'success': False,
+                'error': '搜索关键词太短'
+            }
+
+        # 清理查询词
+        query = query.strip()
+        encoded_query = quote(query)
+
+        # DuckDuckGo 无 JS 的 HTML 端点（kl=us-en 对齐非中文区域口径）
+        url = f"https://html.duckduckgo.com/html/?q={encoded_query}&kl=us-en"
+
+        headers = {
+            'User-Agent': get_random_user_agent(),
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Referer': 'https://duckduckgo.com/',
+            'Connection': 'keep-alive',
+            'DNT': '1',
+            'Cache-Control': 'no-cache',
+        }
+
+        # 添加随机延迟
+        await asyncio.sleep(random.uniform(0.2, 0.5))
+
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, timeout=5.0)
+        response.raise_for_status()
+        html_content = response.text
+
+        # 解析搜索结果（BS4 大 HTML 同步解析放线程池，避免阻塞 event loop）
+        results = await asyncio.to_thread(parse_duckduckgo_results, html_content, limit)
+
+        if results:
+            return {
+                'success': True,
+                'query': query,
+                'results': results
+            }
+        else:
+            return {
+                'success': False,
+                'error': '未能解析到搜索结果',
+                'query': query
+            }
+
+    except httpx.TimeoutException:
+        logger.exception("DuckDuckGo搜索超时")
+        return {
+            'success': False,
+            'error': '搜索超时'
+        }
+    except Exception as e:
+        logger.exception(f"DuckDuckGo搜索失败: {e}")
+        return {
+            'success': False,
+            'error': str(e)
+        }
+
+
+def parse_duckduckgo_results(html_content: str, limit: int = 5) -> List[Dict[str, str]]:
+    """
+    解析 DuckDuckGo HTML 端点的搜索结果页面
+
+    Args:
+        html_content: HTML页面内容
+        limit: 结果数量限制
+
+    Returns:
+        搜索结果列表，每个结果包含 title, abstract, url
+    """
+    results = []
+
+    try:
+        from urllib.parse import urlparse, parse_qs
+        soup = BeautifulSoup(html_content, 'lxml')
+
+        # html.duckduckgo.com 每条结果是 div.result（正常结果还带 web-result）
+        result_divs = soup.find_all('div', class_='result')
+
+        for div in result_divs[:limit * 2]:
+            # 跳过广告（class 含 result--ad / results_links_deep 之外的 ad 变体）
+            cls = div.get('class') or []
+            if any('ad' in c for c in cls):
+                continue
+
+            link = div.find('a', class_='result__a')
+            if not link:
+                continue
+
+            title = link.get_text(strip=True)
+            if not title or not (3 < len(title) < 200):
+                continue
+
+            # DDG 用跳转链接包裹真实地址：//duckduckgo.com/l/?uddg=<urlencoded>&rut=...
+            href = link.get('href', '')
+            url = ''
+            if href:
+                if 'uddg=' in href:
+                    # //duckduckgo.com/l/?uddg=<urlencoded>&rut=... ——
+                    # parse_qs 已对 uddg 值做一次百分号解码，得到的就是真实地址，
+                    # 不要再 unquote（否则真实 URL 里的字面 % 会被二次解码损坏）。
+                    parsed = urlparse(href if href.startswith('http') else 'https:' + href)
+                    qs = parse_qs(parsed.query)
+                    url = qs.get('uddg', [''])[0]
+                elif href.startswith('http'):
+                    url = href
+
+            # 摘要片段
+            abstract = ''
+            snippet = div.find(class_='result__snippet')
+            if snippet:
+                abstract = snippet.get_text(strip=True)[:200]
+
+            results.append({
+                'title': title,
+                'abstract': abstract,
+                'url': url
+            })
+            if len(results) >= limit:
+                break
+
+        logger.info(f"解析到 {len(results)} 条DuckDuckGo搜索结果")
+        return results[:limit]
+
+    except Exception as e:
+        logger.exception(f"解析DuckDuckGo搜索结果失败: {e}")
+        return []
+
+
 async def search_baidu(query: str, limit: int = 5) -> Dict[str, Any]:
     """
     使用百度搜索关键词并获取搜索结果
@@ -1782,7 +1929,7 @@ async def fetch_window_context_content(limit: int = 5) -> Dict[str, Any]:
     
     使用区域检测来决定搜索引擎：
     - 中文区域：百度搜索
-    - 非中文区域：Google搜索
+    - 非中文区域：DuckDuckGo搜索（取代 Google，规避其反爬 429）
     
     Args:
         limit: 搜索结果数量限制
@@ -1845,7 +1992,8 @@ async def fetch_window_context_content(limit: int = 5) -> Dict[str, Any]:
         if china_region:
             search_func = search_baidu
         else:
-            search_func = search_google
+            # 非中文区域改用 DuckDuckGo：Google 对脚本请求几乎必触发 429/sorry 反爬
+            search_func = search_duckduckgo
         
         for query in search_queries:
             if not query or len(query) < 2:


### PR DESCRIPTION
## 概述
三个独立的主动搭话 / 截图相关修复，拆成 3 个 commit 便于分别 review。

### 1. Phase 2 截图走 WS 分支时压到 720p，修代理 413
`request_fresh_screenshot` 的 WebSocket 分支直接返回前端原图，而前端有的截图路径（Electron 主进程直捕 `captureSourceAsDataUrl`）返回**原生分辨率**，base64 可达 ~1.4MB，发给 vision LLM 时被代理 nginx 以 `413 Request Entity Too Large` 拒掉（Phase 1 同一张屏只有 138KB，因为后端强制压过）。

- 现在 WS 分支和 pyautogui 兜底分支**对称**，统一压到 720p/JPEG-80 再返回，压缩失败则退回原图。
- 视觉质量无回归——压到的就是 Phase 1 一直在用的档位。

### 2. 截图编辑界面未选区时按原图亮度预览
`app-crop.js` 的 `drawOverlay` 在**未框选时给整图盖了一层 `rgba(0,0,0,0.15)` 暗罩**，导致刚进编辑界面的预览亮度掉 15%、对比度被拉低显得发糊。

- 移除该暗罩，未选区时预览即原图画质；图片外的 letterbox 仍保留 0.5 遮罩。
- 排查确认：截图源（Electron 4K 屏幕 / 1080p 窗口、无损 PNG）与裁剪输出（全分辨率 PNG）本就清晰，问题只在预览暗罩，非截图本身。

### 3. 非中文区域窗口搜索改用 DuckDuckGo 替代 Google
Google 对脚本请求几乎必触发反爬（302 → `/sorry/index` → 429），主动搭话的窗口上下文搜索基本拿不到结果。

- 新增 `search_duckduckgo` / `parse_duckduckgo_results`，走 `html.duckduckgo.com` 无 JS 端点（对脚本宽容），解码 `uddg` 跳转链接得到真实地址、跳过广告。
- `fetch_window_context_content` 非中文区域分支从 `search_google` 切到 `search_duckduckgo`。
- `parse_qs` 已对 `uddg` 解一次码，故不再二次 `unquote`，避免损坏含字面 `%` 的真实 URL。
- `search_google` / `parse_google_results` 暂留为死代码未删（怕外部引用，也留对照）。

## 测试
- 新增 6 个单测全过：`test_request_fresh_screenshot.py`（2，WS 分支压到 720p 且 < 1MB）、`test_duckduckgo_search.py`（4，跳转解码 / 广告跳过 / 上限 / 双重解码守护）。
- `app-crop.js` 通过 `node --check`。

## ⚠️ 待境外验证
DuckDuckGo 端到端**只在境外的国际服上能验证**——开发机被网络屏蔽连不上 `html.duckduckgo.com`（而 Google 能连但 429）。本 PR 用真实 DDG HTML 结构做了解析单测代替。若上线后 GET 端点不返结果，一行即可切到 POST / `lite.duckduckgo.com`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 非中文地区现已支持 DuckDuckGo 搜索功能。

* **Bug 修复**
  * 优化截图处理，自动压缩至 720p/JPEG 以避免服务异常。
  * 改进图片预览显示，移除多余暗化层，提升清晰度。

* **测试**
  * 新增搜索结果解析和截图压缩功能的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->