### PR TITLE
bugfix:GPT-SoViTS

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -32,6 +32,7 @@ from utils.screenshot_utils import process_screen_data, overlay_avatar_annotatio
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient
 from main_logic.tts_client import get_tts_worker, dummy_tts_worker, TTS_PROVIDER_REGISTRY
+from utils.gptsovits_config import is_gsv_disabled_voice_id
 from main_logic.tool_calling import (
     ToolCall,
     ToolDefinition,
@@ -549,7 +550,7 @@ _proactive_expected_sid: contextvars.ContextVar[str | None] = contextvars.Contex
 )
 
 # TTS 错误码：不可恢复，禁止 respawn（欠费 / API Key 无效）
-NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_KEY_REJECTED'}
+NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_KEY_REJECTED', 'TTS_CONFIG_INVALID'}
 # TTS 错误码：立即上报前端，不受"第3次才通知"门槛限制（含配额——仍允许重试）
 IMMEDIATE_REPORT_TTS_CODES = NO_RETRY_TTS_CODES | {'API_QUOTA_TIME'}
 
@@ -3317,16 +3318,13 @@ class LLMSessionManager:
         )
         if uses_provider_native_voice:
             return False
-        # 克隆音色始终走 custom 路径；
-        # ENABLE_CUSTOM_API + TTS_MODEL_URL 仅在 gptsovitsEnabled 开启时才视为 custom，
-        # 否则 caller 会用 tts_custom credentials 启动 default worker，导致鉴权失败。
+        gsv_enabled = bool(core_config.get('GPTSOVITS_ENABLED'))
+        if gsv_enabled:
+            return True
+        # 克隆音色始终走 custom 路径。
         if bool(self.voice_id) and not self._is_free_preset_voice:
             return True
-        return bool(
-            core_config.get('ENABLE_CUSTOM_API')
-            and core_config.get('TTS_MODEL_URL')
-            and core_config.get('GPTSOVITS_ENABLED')
-        )
+        return False
 
     def _start_tts_thread(self):
         """创建并启动 TTS Worker 线程。
@@ -3635,9 +3633,8 @@ class LLMSessionManager:
     ) -> bool:
         """Resolve whether this session should use the external TTS pipeline."""
         has_custom_tts_config = (
-            core_config_snapshot.get('ENABLE_CUSTOM_API')
-            and core_config_snapshot.get('TTS_MODEL_URL')
-            and core_config_snapshot.get('GPTSOVITS_ENABLED')
+            bool(core_config_snapshot.get('GPTSOVITS_ENABLED'))
+            and not is_gsv_disabled_voice_id(core_config_snapshot.get('TTS_VOICE_ID', ''))
         )
 
         if input_mode == 'text':
@@ -4118,7 +4115,14 @@ class LLMSessionManager:
                 # core_config 在单次 start_session 内不会变（改它走 save_core_api → end_session），复用顶部 snapshot
                 tts_voice_id = core_config_snapshot.get('TTS_VOICE_ID', '')
                 # 过滤掉 GPT-SoVITS 禁用时的占位符（格式: __gptsovits_disabled__|...）
-                if core_config_snapshot.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
+                if (
+                    tts_voice_id
+                    and not is_gsv_disabled_voice_id(tts_voice_id)
+                    and (
+                        core_config_snapshot.get('ENABLE_CUSTOM_API')
+                        or core_config_snapshot.get('GPTSOVITS_ENABLED')
+                    )
+                ):
                     self.voice_id = tts_voice_id
                     logger.info(f"🔄 使用自定义TTS回退音色: '{self.voice_id}'")
                     self._is_free_preset_voice = False
@@ -4800,7 +4804,14 @@ class LLMSessionManager:
                 # 复用本次热切换准备顶部的 snapshot（save_core_api 会 end_session 才能改 core_config）
                 tts_voice_id = core_config_snapshot.get('TTS_VOICE_ID', '')
                 # 过滤掉 GPT-SoVITS 禁用时的占位符（格式: __gptsovits_disabled__|...）
-                if core_config_snapshot.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
+                if (
+                    tts_voice_id
+                    and not is_gsv_disabled_voice_id(tts_voice_id)
+                    and (
+                        core_config_snapshot.get('ENABLE_CUSTOM_API')
+                        or core_config_snapshot.get('GPTSOVITS_ENABLED')
+                    )
+                ):
                     self.voice_id = tts_voice_id
                     logger.info(f"🔄 热切换准备: 使用自定义TTS回退音色: '{self.voice_id}'")
                     self._is_free_preset_voice = False
@@ -7857,7 +7868,7 @@ class LLMSessionManager:
                             'API_ARREARS', 'API_QUOTA_TIME', 'API_KEY_REJECTED',
                             'API_RATE_LIMIT', 'API_POLICY_VIOLATION',
                             'API_1008_FALLBACK', 'TTS_CONNECTION_FAILED',
-                            'UPSTREAM_SERVER_BUSY',
+                            'UPSTREAM_SERVER_BUSY', 'TTS_CONFIG_INVALID',
                         }
                         _parsed_code = None
                         _keyword_target = error_msg_text  # 非 JSON 错误时回退使用

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -18,6 +18,12 @@ from urllib.parse import quote, urlparse, urlunparse
 from config import GSV_VOICE_PREFIX
 from utils.aiohttp_proxy_utils import aiohttp_session_kwargs_for_url
 from utils.config_manager import get_config_manager
+from utils.gptsovits_config import (
+    gsv_ws_url_from_http_base,
+    is_local_http_url,
+    normalize_gsv_api_url,
+    redact_url_for_log,
+)
 from utils.dashscope_region import (
     DASHSCOPE_GLOBAL_LOCK,
     configure_dashscope_sdk_urls,
@@ -2837,19 +2843,28 @@ def gptsovits_tts_worker(request_queue, response_queue, audio_api_key, voice_id)
     # 获取配置
     cm = get_config_manager()
     tts_config = cm.get_model_api_config('tts_custom')
-    base_url = (tts_config.get('base_url') or 'http://127.0.0.1:9881').rstrip('/')
+    base_url = normalize_gsv_api_url(tts_config.get('base_url'))
 
-    # 转换为 WS URL
-    if base_url.startswith('http://'):
-        ws_base = 'ws://' + base_url[7:]
-    elif base_url.startswith('https://'):
-        ws_base = 'wss://' + base_url[8:]
-    elif base_url.startswith('ws://') or base_url.startswith('wss://'):
-        ws_base = base_url
-    else:
-        ws_base = 'ws://' + base_url
+    if not is_local_http_url(base_url):
+        message = (
+            "GPT-SoVITS URL 配置无效：需要 http(s)://localhost 或 "
+            "http(s)://127.0.0.1 这类本地服务地址"
+        )
+        logger.error("[GPT-SoVITS v3] %s，当前: %s", message, redact_url_for_log(base_url))
+        _enqueue_error(response_queue, {
+            "code": "TTS_CONFIG_INVALID",
+            "provider": "gptsovits",
+            "message": message,
+        })
+        response_queue.put(("__ready__", False))
+        return
 
-    WS_URL = f'{ws_base}/api/v3/tts/stream-input'
+    WS_URL = gsv_ws_url_from_http_base(base_url)
+    logger.info(
+        "[GPT-SoVITS v3] 使用本地服务: base=%s ws=%s",
+        redact_url_for_log(base_url),
+        redact_url_for_log(WS_URL),
+    )
 
     # 剥离 gsv: 前缀（角色系统用于标识 GPT-SoVITS voice_id 的路由前缀）
     # 解析 voice_id：支持 "voice_id" 或 "voice_id|{JSON高级参数}" 格式
@@ -3934,13 +3949,9 @@ def get_tts_worker(core_api_type='qwen', has_custom_voice=False, voice_id=''):
         tts_config = cm.get_model_api_config('tts_custom')
         base_url = tts_config.get('base_url') or ''
         if tts_config.get('is_custom'):
-            # GPT-SoVITS / local CosyVoice 需要用户显式启用 gptsovitsEnabled 开关，
-            # 仅 enableCustomApi + http URL 不应自动路由到 GPT-SoVITS。
             gsv_enabled = core_cfg.get('GPTSOVITS_ENABLED', False)
-            if gsv_enabled and (base_url.startswith('http://') or base_url.startswith('https://')):
+            if gsv_enabled:
                 return gptsovits_tts_worker, None, 'gptsovits'
-            if gsv_enabled and (base_url.startswith('ws://') or base_url.startswith('wss://')):
-                return local_cosyvoice_worker, None, 'local_cosyvoice'
     except Exception as e:
         logger.warning(f'TTS调度器检查报告:{e}')
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -35,6 +35,7 @@ from utils.api_config_loader import (
 )
 from utils.custom_tts_adapter import check_custom_tts_voice_allowed
 from utils.file_utils import atomic_write_json
+from utils.gptsovits_config import normalize_gsv_api_url
 from utils.logger_config import get_module_logger
 from utils.native_voice_registry import (
     get_active_realtime_native_provider,
@@ -3445,7 +3446,7 @@ class ConfigManager:
         config['ENABLE_CUSTOM_API'] = enable_custom_api
 
         # GPT-SoVITS 配置映射
-        config['GPTSOVITS_ENABLED'] = core_cfg.get('gptsovitsEnabled', False)
+        config['GPTSOVITS_ENABLED'] = _as_bool(core_cfg.get('gptsovitsEnabled', False))
 
         config['ELEVENLABS_API_KEY'] = core_cfg.get('assistApiKeyElevenlabs', '')
         config['TTS_PROVIDER'] = core_cfg.get('ttsProvider', '')
@@ -3468,6 +3469,12 @@ class ConfigManager:
         except (TypeError, ValueError):
             config['TEXT_GUARD_MAX_LENGTH'] = 300
         
+        # GPT-SoVITS 是本地 TTS 运行时，不依赖 enableCustomApi 总开关。用户
+        # 保存的 ttsModelUrl 是 GSV server URL，不能被 follow_core/follow_assist
+        # 的 LLM URL 覆盖；空值只在运行时默认到 127.0.0.1，不写回配置文件。
+        if config['GPTSOVITS_ENABLED']:
+            config['TTS_MODEL_URL'] = normalize_gsv_api_url(core_cfg.get('ttsModelUrl'))
+
         # 只有在启用自定义API时才允许覆盖各模型相关字段
         if enable_custom_api:
             # URL / Model ID 字段：空值回退到已有配置。
@@ -3535,29 +3542,27 @@ class ConfigManager:
                 # 路径里读不到（fallback 用 CORE_MODEL，不是 REALTIME_MODEL/TTS_MODEL），
                 # 那是另一个层面的问题，下个 PR 跟进。
                 is_follow = provider in ('follow_core', 'follow_assist')
-                # GSV 启用时 ttsModelUrl 是 api_key_settings.js (save_button_down 那段)
-                # 强制覆盖进去的 GPT-SoVITS server URL，不是 follow_* 联动出来的 readonly
-                # 提示值。如果还按 skip_url_for_follow 跳过，TTS_MODEL_URL 永远是空，
-                # tts_custom 走 fallthrough → is_custom=False → 整条 GSV 链路全断
-                # （/custom_tts_voices 报 CUSTOM_API_NOT_ENABLED，TTS dispatcher 落到
-                # cosyvoice_vc_tts_worker 撞 dashscope 鉴权）。默认 ttsModelProvider 是
-                # 'follow_assist'，用户开 GSV 但不会专门去把 provider 改成 'custom'，
-                # 这条豁免必须在后端兜住。
-                gsv_enabled_for_url = bool(core_cfg.get('gptsovitsEnabled', False))
+                # GSV 启用时 ttsModelUrl 是 GPT-SoVITS server URL，不是 follow_*
+                # 联动出来的 LLM URL。即便 ttsModelProvider 仍是默认 follow_assist，
+                # 也必须优先保留 GSV URL，否则对话 TTS 会连到辅助 LLM endpoint。
+                gsv_enabled_for_url = config['GPTSOVITS_ENABLED']
+                gsv_tts_url_override = prefix == 'tts' and gsv_enabled_for_url
                 skip_url_for_follow = (
                     is_follow
                     and prefix in ('omni', 'tts')
-                    and not (prefix == 'tts' and gsv_enabled_for_url)
+                    and not gsv_tts_url_override
                 )
 
                 # URL: 空值回退到已有配置；omni/tts follow_* 时跳过
-                if not skip_url_for_follow:
+                cfg_url = core_cfg.get(f'{prefix}ModelUrl')
+                if gsv_tts_url_override:
+                    config[url_key] = normalize_gsv_api_url(cfg_url or config.get(url_key))
+                elif not skip_url_for_follow:
                     if is_follow:
                         followed_url = _resolve_follow_model_url(prefix, provider)
                         if followed_url:
                             config[url_key] = followed_url
                     else:
-                        cfg_url = core_cfg.get(f'{prefix}ModelUrl')
                         if cfg_url is not None:
                             config[url_key] = cfg_url or config.get(url_key, '')
 
@@ -3597,6 +3602,9 @@ class ConfigManager:
             # TTS Voice ID 作为角色 voice_id 的回退
             if core_cfg.get('ttsVoiceId') is not None:
                 config['TTS_VOICE_ID'] = core_cfg.get('ttsVoiceId', '')
+
+        if config['GPTSOVITS_ENABLED'] and core_cfg.get('ttsVoiceId') is not None:
+            config['TTS_VOICE_ID'] = core_cfg.get('ttsVoiceId', '')
 
         for key, value in config.items():
             if key.endswith('_URL') and isinstance(value, str):

--- a/utils/gptsovits_config.py
+++ b/utils/gptsovits_config.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""GPT-SoVITS runtime configuration helpers."""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse, urlunparse
+
+
+GSV_DISABLED_VOICE_PREFIX = "__gptsovits_disabled__|"
+DEFAULT_GSV_API_URL = "http://127.0.0.1:9881"
+
+
+def is_gsv_disabled_voice_id(voice_id: str | None) -> bool:
+    return str(voice_id or "").startswith(GSV_DISABLED_VOICE_PREFIX)
+
+
+def normalize_gsv_api_url(url: str | None, *, default: str = DEFAULT_GSV_API_URL) -> str:
+    """Return a normalized HTTP(S) GPT-SoVITS base URL.
+
+    Empty values use the local default. Non-HTTP(S) values are returned stripped
+    so callers can surface a precise configuration error instead of silently
+    rewriting an unrelated provider URL.
+    """
+    raw = str(url or "").strip()
+    if not raw:
+        raw = default
+    return raw.rstrip("/")
+
+
+def is_local_http_url(url: str | None) -> bool:
+    parsed = urlparse(str(url or "").strip())
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    host = parsed.hostname.strip().lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def gsv_ws_url_from_http_base(base_url: str) -> str:
+    parsed = urlparse(base_url)
+    if parsed.scheme == "http":
+        parsed = parsed._replace(scheme="ws")
+    elif parsed.scheme == "https":
+        parsed = parsed._replace(scheme="wss")
+    return urlunparse(parsed).rstrip("/") + "/api/v3/tts/stream-input"
+
+
+def redact_url_for_log(url: str | None) -> str:
+    parsed = urlparse(str(url or ""))
+    if not parsed.scheme or not parsed.netloc:
+        return str(url or "")
+    netloc = parsed.netloc
+    if "@" in netloc:
+        netloc = "***:***@" + netloc.split("@", 1)[1]
+    return urlunparse(parsed._replace(netloc=netloc, query="" if parsed.query else parsed.query))


### PR DESCRIPTION
稳健修复 GPT-SoVITS 对话路径未送达问题
Summary
修复目标是让 N.E.K.O 的“配置页 GSV 测试路径”和“真实对话 TTS 路径”使用同一套 GPT-SoVITS 配置语义。核心问题是：保存的 ttsModelUrl 是 http://127.0.0.1:9881，但对话路径解析时被 ttsModelProvider=follow_assist 覆盖成辅助 LLM URL，导致文本没有送到 GSV。

本次不修改 GSV 连通测试的 10 秒超时，也不治理 Memory/LLM 429 重试行为；429 只作为独立日志现象归因。

Key Changes
在配置解析层修正 GSV 优先级：

当 gptsovitsEnabled=true 时，TTS_MODEL_URL 必须优先使用保存的 ttsModelUrl。
即使 ttsModelProvider=follow_core/follow_assist，也不能用核心/辅助 LLM URL 覆盖 GSV URL。
当 gptsovitsEnabled=false 时保持现有行为，不自动重新启用 GSV，保留 __gptsovits_disabled__|url|voice 哨兵语义。
统一会话侧 TTS 判断：

main_logic/core.py 中 _has_custom_tts() 和 _resolve_session_use_tts() 改为以 GPTSOVITS_ENABLED + 有效 GSV URL/默认本地 URL 为准，不再额外依赖 ENABLE_CUSTOM_API。
角色没有 voice_id 时，若 GSV 启用，则允许使用 TTS_VOICE_ID 回退；但必须跳过 __gptsovits_disabled__|... 哨兵。
加强 TTS worker 防误连：

gptsovits_tts_worker 启动时记录脱敏后的有效 GSV base URL 和最终 WS URL。
如果 GSV 启用但解析出的 URL 明显不是 HTTP(S) GSV endpoint，不回退到默认/辅助 TTS，不去连 LLM provider，直接返回结构化 TTS 配置错误并标记未就绪。
不记录对话原文和 API key。
配置页连通测试保持语义：

/api/config/gptsovits/test_connectivity 继续使用 10 秒总超时。
它仍然只测试前端传入的 api_url，不受 core/assist provider follow 解析影响。
可复用同一套 voice_id 解析逻辑，但不改变超时和成功判据。
Tests
单元测试配置解析：

gptsovitsEnabled=true + ttsModelProvider=follow_assist + ttsModelUrl=http://127.0.0.1:9881 时，get_core_config()["TTS_MODEL_URL"] 和 get_model_api_config("tts_custom")["base_url"] 都必须是 http://127.0.0.1:9881。
同样场景在 enableCustomApi=false 时也成立。
gptsovitsEnabled=false 时，现有 follow 行为不变，ttsModelUrl 不污染 TTS_MODEL_URL。
已禁用哨兵 __gptsovits_disabled__|... 不会被自动重新启用。
单元测试会话路由：

GSV 启用且无角色 voice_id 时，语音会话会启用外部 TTS 并使用 TTS_VOICE_ID 回退。
GSV 禁用时不会因为禁用哨兵误判为 custom TTS。
Gemini/free 原生音色绕过外部 TTS 的既有逻辑保持不变。
Worker/调度测试：

GSV 启用时 get_tts_worker() 选择 gptsovits_tts_worker，而不是默认 qwen/free TTS。
解析到非 GSV/非本地 HTTP URL 时返回配置错误，不尝试连接 open.bigmodel.cn、DashScope 等 LLM endpoint。
当前保存配置下，最终 WS URL 应为 ws://127.0.0.1:9881/api/v3/tts/stream-input。
Assumptions
GSV 连通测试偶发 10 秒超时是健康检查结果，不在本次修复中放宽。
Memory/LLM 429 与 GSV 送达问题分开处理；本次只避免 GSV 错误路由造成的误诊和 TTS 静默。
安全自愈只影响运行时解析，不擅自改写用户配置文件；用户下一次保存时前端会自然写回规范配置。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了TTS配置验证逻辑，加强对本地服务器URL的规范化处理和校验。
  * 改进了音色ID的禁用检查机制，防止被禁用的音色被误认为自定义配置。
  * 完善了TTS错误处理，新增了对无效配置错误的识别和分流。

* **Improvements**
  * 提升了TTS路由决策的准确性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->