### PR TITLE
fix(voice): 更新默认猫猫 yui 的语音音色 ID

### DIFF
--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -377,7 +377,7 @@
     "sweetLady": "voice-tone-PGLmTEeUOu",
     "frailMaiden": "voice-tone-PGLmzXEX44",
     "childishMaiden": "voice-tone-PGLnVNQn7A",
-    "yui_cn": "voice-tone-R6NtLH3Hk0"
+    "yui_cn": "voice-tone-RcH2svtsrw"
   },
   "_comment_native_tts_voice_providers": "Shape: {providerKey: {catalog_prefix, default_voice, default_male_voice, catalog_value_is_display_name, voices, aliases, inherits}}. voices maps upstream voice_id to display label. Keep this list to voices available on realtime/free TTS paths; some HTTP-only or permission-gated official voices are intentionally omitted.",
   "native_tts_voice_providers": {

--- a/config/characters/en.json
+++ b/config/characters/en.json
@@ -28,7 +28,7 @@
       ],
       "Signature Line": "Hmph, obviously this kitty has to keep an eye on Carbon-Based Lifeform, meow~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/es.json
+++ b/config/characters/es.json
@@ -28,7 +28,7 @@
       ],
       "Frase Característica": "Hmf, está claro que esta gatita tiene que vigilar a la Forma de Vida Basada en Carbono, miau~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/ja.json
+++ b/config/characters/ja.json
@@ -28,7 +28,7 @@
       ],
       "一言セリフ": "ふん、炭素生物が変なことしないよう見てるのは本にゃんだけにゃん〜",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/ko.json
+++ b/config/characters/ko.json
@@ -28,7 +28,7 @@
       ],
       "대사 한마디": "흥, 탄소 생물이 딴짓하지 않게 지켜보는 건 당연히 이 냥이다냥~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/pt.json
+++ b/config/characters/pt.json
@@ -28,7 +28,7 @@
       ],
       "Frase Característica": "Hmf, é claro que esta gatinha precisa ficar de olho na Forma de Vida Baseada em Carbono, miau~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/ru.json
+++ b/config/characters/ru.json
@@ -28,7 +28,7 @@
       ],
       "Коронная фраза": "Хмф, следить, чтобы эта Углеродная форма жизни не натворила глупостей, конечно, должна я, мяу~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/zh-CN.json
+++ b/config/characters/zh-CN.json
@@ -28,7 +28,7 @@
       ],
       "一句话台词": "哼，盯着碳基生物别乱来的，当然只有本喵啦~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/zh-TW.json
+++ b/config/characters/zh-TW.json
@@ -28,7 +28,7 @@
       ],
       "一句話台詞": "哼，盯著碳基生物別亂來的，當然只有本喵啦~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-R6NtLH3Hk0",
+      "voice_id": "voice-tone-RcH2svtsrw",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/tests/unit/test_yui_free_api_default_voice.py
+++ b/tests/unit/test_yui_free_api_default_voice.py
@@ -9,7 +9,7 @@ import main_routers.characters_router as characters_router
 from utils.config_manager import ensure_default_yui_voice_for_free_api, get_reserved
 
 
-YUI_FREE_VOICE_ID = "voice-tone-R6NtLH3Hk0"
+YUI_FREE_VOICE_ID = "voice-tone-RcH2svtsrw"
 
 
 class _FakeConfigManager:


### PR DESCRIPTION
## 改动

将默认猫猫角色 yui 的语音音色 ID 从 `voice-tone-R6NtLH3Hk0` 整体替换为 `voice-tone-RcH2svtsrw`。

涉及三处，保持对偶全覆盖：

- `config/api_providers.json` — `yui_cn` voice alias 指向的 tone ID
- `config/characters/*.json`（en/es/ja/ko/pt/ru/zh-CN/zh-TW 共 8 个 locale）— yui-origin 角色的 `voice_id`
- `tests/unit/test_yui_free_api_default_voice.py` — 硬编码常量 `YUI_FREE_VOICE_ID`

## 说明

新音色 ID 此前未在任何分支历史中出现，为本地替换的新值。10 个文件全部同步，无遗漏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新了YUI角色在所有语言版本中的语音标识符。

* **Tests**
  * 同步更新了相应的测试用例配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->