### PR TITLE
fix(proactive): 修复语音模式 mini-game 邀请「现在不想玩」反复出现

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -7215,9 +7215,13 @@ class LLMSessionManager:
                     # 对偶）。idle reset loop 依赖该字段判断静默时长，文本路径不补的话
                     # 纯文本会话永远满足"静默 ≥ 30 min"被误重置。
                     self.last_user_activity_time = time.time()
-                    # 文本输入天然就是真实用户消息（无 echo/噪声问题），同步刷「真
-                    # 消息」时间戳，保持跨模式语义一致。
-                    self.last_user_message_time = time.time()
+                    # 「真消息」时间戳：strip 后非空才刷，与语音路径
+                    # `if transcript_text:` 对偶——空白输入不算真实回应，否则会误
+                    # 推进 mini-game 邀请隐式 dismiss 判定（CodeRabbit）。注意
+                    # last_user_activity_time 仍无条件刷（服务 idle reset，语义是
+                    # 「有没有发请求」，与「是不是真消息」不同）。
+                    if data.strip():
+                        self.last_user_message_time = time.time()
 
                     # 更新字数限制（可能用户在对话期间修改了设置）
                     if hasattr(self.session, 'update_max_response_length'):

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -902,6 +902,14 @@ class LLMSessionManager:
         # 用户活动时间戳：用于主动搭话检测最近是否有用户输入
         self.last_user_activity_time = None  # float timestamp or None
 
+        # 用户「真实消息」时间戳：仅在非空、非 AI 回声的真用户输入时刷新（语音
+        # 真转录 / 文本输入），不含 VAD 空噪声、麦克风录回 AI 自己 TTS 的回声。
+        # 区别于 last_user_activity_time（顶部无条件刷新，含回声/空噪声）——后者拿
+        # 来判 mini-game 邀请「用户是否已回应」会被 AI 念邀请台词的回声污染，导致
+        # 隐式 dismiss 在用户还没点按钮前就把 pending 邀请清掉、按钮撤走，用户随后
+        # 点「现在不想玩」落到 expired、真正的 decline 冷却起不来、邀请反复重来。
+        self.last_user_message_time = None  # float timestamp or None
+
         # 用户静默 ≥ IDLE_SESSION_RESET_THRESHOLD_SECONDS 时主动断 session 的
         # 后台 loop。lazily 在首次 start_session 时启动，永久存活（per-manager
         # 单例），无 active session 时 sleep 后继续轮询。
@@ -2098,6 +2106,50 @@ class LLMSessionManager:
         recent_ai_text = getattr(self, "_recent_ai_voice_echo_text", "") or ""
         return _looks_like_recent_ai_echo(transcript_text, recent_ai_text)
 
+    async def _dispatch_mini_game_invite_keyword(self, user_text: str) -> None:
+        """扫一遍用户原话里的 mini-game 邀请 accept/decline/later 关键词，命中即
+        触发对应 state 转换 + 推 ``mini_game_invite_resolved`` 让前端 dismiss
+        ChoicePrompt（accept 时兼当 launch 信号带 game_url）。
+
+        文本输入路径（``_process_stream_data_internal``）与语音转写路径
+        （``handle_input_transcript``）共用——语音用户没法点 ChoicePrompt 三按钮，
+        只能说话；口头"现在不想玩"必须和打字 / 点按钮一样触发真正的 decline 冷却。
+        否则语音口头拒绝既不算 decline，又会被下一个 proactive tick 的
+        ``_mini_game_invite_advance_response`` 当成隐式 dismiss = 'later'（只抑制
+        5min），邀请反复重来。**不吃掉消息**：普通 chat 流水线仍然回应这条话。
+
+        main_routers' keyword matcher is registered as a hook on the bus
+        (see app/runtime_bindings.py). Dispatcher swallows per-hook errors;
+        if no hook is bound (e.g. entrypoint without main_routers), result
+        is None.
+        """
+        outcome = dispatch_text_user_message(self.lanlan_name, user_text or '')
+        # 推一条 mini_game_invite_resolved 给前端：accept 时兼当 launch 信号
+        # （带 game_url），decline/later 时让 ChoicePrompt UI 清掉不让按钮挂着——
+        # codex P2 指出，原版只对 accept 推，decline/later 命中后前端 prompt 不
+        # 消失，用户后续点按钮会被 endpoint 当 expired，state 早变了。
+        if not (outcome and outcome.get('action')):
+            return
+        try:
+            if self.websocket and hasattr(self.websocket, 'send_json'):
+                ws_state = getattr(self.websocket, 'client_state', None)
+                if ws_state is None or ws_state == ws_state.CONNECTED:
+                    payload = {
+                        'type': 'mini_game_invite_resolved',
+                        'session_id': outcome.get('session_id') or '',
+                        'action': outcome['action'],
+                    }
+                    if outcome.get('game_url'):
+                        payload['game_url'] = outcome['game_url']
+                    if outcome.get('game_type'):
+                        payload['game_type'] = outcome['game_type']
+                    await self.websocket.send_json(payload)
+        except Exception as _push_err:
+            logger.warning(
+                f"[{self.lanlan_name}] mini_game_invite_resolved "
+                f"WS push failed: {_push_err}",
+            )
+
     async def handle_input_transcript(self, transcript: str, *, is_voice_source: bool = True):
         """输入转录回调：同步转录文本到消息队列和缓存，并发送到前端显示
 
@@ -2169,6 +2221,9 @@ class LLMSessionManager:
             # emotion-tier LLM 用——空 transcript 这些副作用都不该触发。
             if transcript_text:
                 self._activity_tracker.on_user_message(text=transcript)
+                # 真实用户语音消息（已过 echo 抑制 + 非空）才刷「真消息」时间戳，
+                # 给 mini-game 邀请隐式 dismiss 用，避免回声/空噪声误判用户已回应。
+                self.last_user_message_time = time.time()
                 self._session_turn_count += 1
                 # Telemetry：D1 漏斗——本进程首条用户消息（语音路径）。
                 try:
@@ -2187,6 +2242,13 @@ class LLMSessionManager:
                 # 这里只覆盖语音路径，避免 openclaw handoff（is_voice_source=False）
                 # 重复发布。
                 self._publish_user_utterance_to_plugin_bus(transcript, is_voice_source=True)
+
+                # Mini-game 邀请关键词兜底：与文本路径
+                # （_process_stream_data_internal）对偶。语音用户没法点
+                # ChoicePrompt 三按钮，只能说话——口头"现在不想玩"必须和打字 /
+                # 点按钮一样触发真正的 decline 冷却，否则邀请会按 5min 隐式
+                # dismiss 反复重来。详见 _dispatch_mini_game_invite_keyword。
+                await self._dispatch_mini_game_invite_keyword(transcript)
         else:
             # Non-voice reuse of this method (e.g. openclaw text handoff).
             # Skip activity-tracker hooks entirely — the text-mode entry
@@ -7146,6 +7208,9 @@ class LLMSessionManager:
                     # 对偶）。idle reset loop 依赖该字段判断静默时长，文本路径不补的话
                     # 纯文本会话永远满足"静默 ≥ 30 min"被误重置。
                     self.last_user_activity_time = time.time()
+                    # 文本输入天然就是真实用户消息（无 echo/噪声问题），同步刷「真
+                    # 消息」时间戳，保持跨模式语义一致。
+                    self.last_user_message_time = time.time()
 
                     # 更新字数限制（可能用户在对话期间修改了设置）
                     if hasattr(self.session, 'update_max_response_length'):
@@ -7199,46 +7264,13 @@ class LLMSessionManager:
                     )
 
                     # Mini-game 邀请的关键词文本兜底（PR #1141 follow-up E2）。
-                    # 用户在 pending 邀请期间自己打字（没点 ChoicePrompt 三按
-                    # 钮）→ 扫关键词命中就触发对应 state 转换。**不吃掉消息**：
-                    # 继续走普通 chat 流水线，AI 仍然会回应这条话——AI 收到的
-                    # 上下文里也含这条用户输入，所以模型会自然把"好啊"、"不
-                    # 玩了"之类的回复处理掉。仅做 state side effect + accept 时
-                    # 推一条 mini_game_launch WS 让前端 window.open 游戏。
-                    # main_routers' keyword matcher is registered as a hook
-                    # on the bus (see app/runtime_bindings.py). Dispatcher
-                    # swallows per-hook errors; if no hook is bound (e.g.
-                    # entrypoint without main_routers), result is None.
-                    _kw_outcome = dispatch_text_user_message(
-                        self.lanlan_name,
+                    # 用户在 pending 邀请期间自己打字（没点 ChoicePrompt 三按钮）
+                    # → 扫关键词命中就触发对应 state 转换。与语音转写路径
+                    # （handle_input_transcript）共用同一方法，逻辑见
+                    # _dispatch_mini_game_invite_keyword。
+                    await self._dispatch_mini_game_invite_keyword(
                         data if isinstance(data, str) else '',
                     )
-                    # 推一条 mini_game_invite_resolved 给前端：accept 时兼当 launch
-                    # 信号（带 game_url），decline/later 时让 ChoicePrompt UI 清掉
-                    # 不让按钮挂着——codex P2 指出，原版只对 accept 推，
-                    # decline/later keyword 命中后前端 prompt 不消失，用户后续点
-                    # 按钮会被 endpoint 当 expired，state 早变了。
-                    if _kw_outcome and _kw_outcome.get('action'):
-                        try:
-                            if (self.websocket
-                                    and hasattr(self.websocket, 'send_json')):
-                                ws_state = getattr(self.websocket, 'client_state', None)
-                                if ws_state is None or ws_state == ws_state.CONNECTED:
-                                    payload = {
-                                        'type': 'mini_game_invite_resolved',
-                                        'session_id': _kw_outcome.get('session_id') or '',
-                                        'action': _kw_outcome['action'],
-                                    }
-                                    if _kw_outcome.get('game_url'):
-                                        payload['game_url'] = _kw_outcome['game_url']
-                                    if _kw_outcome.get('game_type'):
-                                        payload['game_type'] = _kw_outcome['game_type']
-                                    await self.websocket.send_json(payload)
-                        except Exception as _push_err:
-                            logger.warning(
-                                f"[{self.lanlan_name}] mini_game_invite_resolved "
-                                f"WS push failed: {_push_err}",
-                            )
 
                     should_handoff, openclaw_messages = await self._should_handoff_text_to_openclaw(data)
                     if should_handoff:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2166,8 +2166,13 @@ class LLMSessionManager:
         transcript_text = transcript.strip()
         voice_rms_recorded = False
 
-        # 更新用户活动时间戳（用于主动搭话检测）
-        self.last_user_activity_time = time.time()
+        # 更新用户活动时间戳（用于主动搭话检测）。先捕获「转写到达时刻」局部变量，
+        # 下面 last_user_message_time 复用同一时刻——若 takeover dispatcher 注册，
+        # 这条转写会先 await 它再走到下面的真消息块；用 await 之后的 time.time() 会
+        # 把时间戳推迟，万一 await 期间投递了 invite，invite 之前说的话会被记成 >
+        # delivered_at、被下个 tick 误判成 invite 之后的回应（codex P2）。
+        _transcript_arrival_ts = time.time()
+        self.last_user_activity_time = _transcript_arrival_ts
         if (
             is_voice_source
             and transcript_text
@@ -2223,7 +2228,9 @@ class LLMSessionManager:
                 self._activity_tracker.on_user_message(text=transcript)
                 # 真实用户语音消息（已过 echo 抑制 + 非空）才刷「真消息」时间戳，
                 # 给 mini-game 邀请隐式 dismiss 用，避免回声/空噪声误判用户已回应。
-                self.last_user_message_time = time.time()
+                # 用顶部捕获的到达时刻而非此处 time.time()：takeover dispatcher 的
+                # await 不会把它推迟到 await 之后（codex P2）。
+                self.last_user_message_time = _transcript_arrival_ts
                 self._session_turn_count += 1
                 # Telemetry：D1 漏斗——本进程首条用户消息（语音路径）。
                 try:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4641,12 +4641,20 @@ async def proactive_chat(request: Request):
         # can_start_proactive 做 409 判定即可。
         if data.get('voice_mode') and mgr.is_active and isinstance(mgr.session, OmniRealtimeClient):
             # Mini-game invite 状态机推进：voice fast path 不走 activity tracker，
-            # 直接用 mgr.last_user_activity_time（session 自己跟踪 RMS / 文本输入
-            # 活动）作为「用户最后一次活动时间」喂给 advance_response。否则纯
-            # voice 用户收到 mini-game 邀请回应后，pending 永远翻不掉，邀请会被
-            # 永久抑制；CodeRabbit Major review 指出。
+            # 直接用 session 自己跟踪的「用户最后一次真实消息时间」喂给
+            # advance_response。否则纯 voice 用户收到 mini-game 邀请回应后，
+            # pending 永远翻不掉，邀请会被永久抑制；CodeRabbit Major review 指出。
+            #
+            # ⚠️ 用 last_user_message_time（仅真实非空非 echo 用户输入）而非
+            # last_user_activity_time（顶部无条件刷新，含 VAD 空噪声 + 麦克风录回
+            # AI 自己 TTS 的回声）。后者会被 AI 念邀请台词的回声污染：邀请投递后
+            # 回声立刻把 activity 刷到 > delivered_at，下一个 tick 的隐式 dismiss
+            # 误判「用户已回应」→ 把 pending 邀请清成 'later'（5min）+ 撤掉按钮，
+            # 用户随后点「现在不想玩」落到 expired、真正的 5h decline 起不来、邀请
+            # 5min 后反复重来。改用真消息时间戳后，纯点按钮（不说话）的用户活动
+            # 时间不会越过 delivered_at，pending 一直留到用户显式点按钮 / 说话。
             _voice_advance_outcome = _mini_game_invite_advance_response(
-                lanlan_name, getattr(mgr, 'last_user_activity_time', None),
+                lanlan_name, getattr(mgr, 'last_user_message_time', None),
             )
             # advance 触发了隐式 dismiss → 推 WS 让前端清掉 prompt UI（cross-window
             # 一致性）。codex P2 指出非按钮路径漏推 WS 让 UI 挂着。

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -473,6 +473,38 @@ async def test_empty_voice_transcript_does_not_stamp_last_user_message_time(monk
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_last_user_message_time_uses_transcript_arrival_not_post_await(monkeypatch):
+    """takeover dispatcher 注册但未消费该转写时，last_user_message_time 必须用转写
+    到达时刻（await 之前），不能用 await 之后的 time.time()——否则 await 期间投递的
+    invite 会把 invite 之前的发言误记成之后的回应、提前清掉 pending invite（codex
+    P2）。time.time() 每次递增，断言两个时间戳都锁在首次（到达）取值 101。"""
+    mgr = _make_transcript_manager()
+    calls = {"n": 0}
+
+    def _ticking_time():
+        calls["n"] += 1
+        return 100.0 + calls["n"]
+
+    monkeypatch.setattr(core_module.time, "time", _ticking_time)
+    monkeypatch.setattr(core_module, "dispatch_text_user_message", lambda name, text: None)
+
+    async def _dispatcher(name, text, request_id=None):
+        core_module.time.time()  # 模拟 await 期间时钟流逝
+        return False             # 未处理 → 继续普通流程走到真消息块
+
+    mgr._takeover_input_dispatcher = _dispatcher
+    mgr.session = object()
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr, "你好呀", is_voice_source=True,
+    )
+
+    assert mgr.last_user_activity_time == 101.0
+    assert mgr.last_user_message_time == 101.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_likely_ai_echo_voice_transcript_is_suppressed(monkeypatch):
     mgr = _make_transcript_manager()
     monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections import deque
 import queue
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -112,6 +112,8 @@ def _make_manager():
     mgr._takeover_input_dispatcher = None
     mgr.sent_responses = []
     mgr.user_activity = []
+    mgr.last_user_activity_time = None
+    mgr.last_user_message_time = None
 
     async def send_user_activity(interrupted_speech_id):
         mgr.user_activity.append(interrupted_speech_id)
@@ -336,6 +338,137 @@ async def test_no_takeover_voice_transcript_uses_ordinary_flow():
         "type": "user",
         "data": {"input_type": "transcript", "data": "普通语音"},
     }]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_voice_transcript_runs_mini_game_invite_keyword(monkeypatch):
+    """语音口头回应 mini-game 邀请必须和打字 / 点按钮一样过关键词匹配器——否则
+    语音用户说"现在不想玩"永远触发不了 decline 冷却，会被下一个 proactive tick
+    当成隐式 dismiss（只抑制 5min），邀请反复重来。回归：handle_input_transcript
+    必须把原话喂给 dispatch_text_user_message（与文本路径对偶）。"""
+    mgr = _make_transcript_manager()
+    seen = []
+    monkeypatch.setattr(
+        core_module, "dispatch_text_user_message",
+        lambda name, text: seen.append((name, text)),
+    )
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr, "  现在不想玩  ", is_voice_source=True,
+    )
+
+    # 传原话（未 strip），matcher 内部自己 lower+strip；与文本路径一致
+    assert seen == [("Lan", "  现在不想玩  ")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_voice_transcript_keyword_outcome_pushes_invite_resolved(monkeypatch):
+    """关键词命中时，语音路径推 mini_game_invite_resolved 让前端 dismiss
+    ChoicePrompt（accept 兼带 game_url 当 launch 信号）。"""
+    mgr = _make_transcript_manager()
+    mgr.websocket = MagicMock()
+    mgr.websocket.send_json = AsyncMock()
+    fake_state = MagicMock()
+    fake_state.CONNECTED = fake_state
+    mgr.websocket.client_state = fake_state
+    monkeypatch.setattr(
+        core_module, "dispatch_text_user_message",
+        lambda name, text: {
+            "action": "open_game",
+            "session_id": "sid-1",
+            "game_url": "/soccer_demo?x=1",
+            "game_type": "soccer",
+        },
+    )
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr, "好啊一起玩", is_voice_source=True,
+    )
+
+    mgr.websocket.send_json.assert_awaited_once()
+    payload = mgr.websocket.send_json.await_args.args[0]
+    assert payload == {
+        "type": "mini_game_invite_resolved",
+        "session_id": "sid-1",
+        "action": "open_game",
+        "game_url": "/soccer_demo?x=1",
+        "game_type": "soccer",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_non_voice_transcript_skips_mini_game_invite_keyword(monkeypatch):
+    """非语音复用（openclaw 文本 handoff，is_voice_source=False）不重复跑关键词——
+    文本入口 _process_stream_data_internal 已经跑过一次，避免双触发。"""
+    mgr = _make_transcript_manager()
+    seen = []
+    monkeypatch.setattr(
+        core_module, "dispatch_text_user_message",
+        lambda name, text: seen.append((name, text)),
+    )
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr, "现在不想玩", is_voice_source=False,
+    )
+
+    assert seen == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_genuine_voice_transcript_stamps_last_user_message_time(monkeypatch):
+    """真实非空语音消息既刷 last_user_activity_time 也刷 last_user_message_time。
+    后者喂给 mini-game 邀请隐式 dismiss，必须只反映真用户输入。"""
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr, "今天天气不错", is_voice_source=True,
+    )
+
+    assert mgr.last_user_activity_time == FIXED_TS
+    assert mgr.last_user_message_time == FIXED_TS
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ai_echo_transcript_does_not_stamp_last_user_message_time(monkeypatch):
+    """关键回归：AI 念邀请台词被麦克风录回的回声会刷 last_user_activity_time
+    （顶部无条件），但**不能**刷 last_user_message_time——否则语音模式下用户还
+    没点「现在不想玩」按钮，隐式 dismiss 就因回声误判用户已回应、把 pending 邀请
+    清掉撤按钮，用户随后点击落到 expired、邀请 5min 后反复重来。"""
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr._recent_ai_voice_echo_text = "要不要现在跟我一起踢一会儿足球小游戏？"
+    mgr._recent_ai_voice_echo_at = FIXED_TS
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr, "要不要现在跟我一起踢一会儿足球小游戏", is_voice_source=True,
+    )
+
+    # 回声照样污染 last_user_activity_time（说明旧字段为何不能用于邀请判定）
+    assert mgr.last_user_activity_time == FIXED_TS
+    # 但真消息时间戳保持干净
+    assert mgr.last_user_message_time is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_voice_transcript_does_not_stamp_last_user_message_time(monkeypatch):
+    """空转录（VAD 误触发 / 转录失败）刷 activity 但不刷真消息时间戳。"""
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr, "   ", is_voice_source=True,
+    )
+
+    assert mgr.last_user_activity_time == FIXED_TS
+    assert mgr.last_user_message_time is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 问题

选择 mini-game 邀请的「现在不想玩」（decline）后，邀请仍反复出现——尤其语音模式下用户点按钮拒绝时。

## 根因

语音模式下 `handle_input_transcript` 在函数顶部**无条件**刷新 `last_user_activity_time`（含 AI TTS 被麦克风录回的回声、空 VAD 噪声；回声抑制的 `return` 在它之后）。而语音 proactive tick 的隐式 dismiss（`_mini_game_invite_advance_response`）拿这个字段判定「用户是否已回应邀请」。

链路：
1. 邀请投递（AI 念台词）→ 回声录回 → `last_user_activity_time` 被刷到 > `delivered_at`，用户其实没动；
2. 下个 tick → 误判「用户已回应」→ 把 pending 邀请清成 `later`（5min）+ 推 WS 撤掉按钮；
3. 用户点「现在不想玩」→ 后端没 pending → `expired`，真正的 5h decline 起不来；
4. 5min 后重来 → 反复出现。

文本模式无此问题（无麦克风，advance 用 activity tracker 的真实消息时间）。

## 修复

**主修复 ── 真消息时间戳。** 新增 `last_user_message_time`，仅在真实、非空、非回声的用户输入时刷新（语音真转录 + 文本输入），语音 advance 改用它而非被污染的 `last_user_activity_time`。
- 纯点按钮（不说话）→ 真消息时间不越过 `delivered_at` → 隐式 dismiss 不触发 → pending 保留 → 点击落到真 decline（5h）
- 回声/噪声 → 不影响邀请
- 原设计目的（用户真回应后翻掉 pending、不永久抑制）仍保留——真说话才翻

**互补修复 ── 语音关键词兜底。** 语音转写路径补上 mini-game 邀请关键词匹配（与文本路径对偶，抽成共享 `_dispatch_mini_game_invite_keyword`），口头「现在不想玩」也能触发真 decline（5h）而非退化成 5min。

## 测试

新增 6 个回归测试；`tests/unit` 中 proactive/activity/voice/core 相关 `658 passed, 3 skipped`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 改进语音输入中真实用户消息识别，避免 AI 回声/空噪声造成迷你游戏邀请回应误判。

* **新功能**
  * 新增“真实消息到达时刻”时间语义，统一语音与文本的迷你游戏关键词处理；邀请结果会通过前端推送同步（推送异常不影响主聊天流程）。

* **测试**
  * 扩展单元测试，覆盖语音/文本路径一致性、时间戳写入规则及边界行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->