### PR TITLE
fix(memory): 杀软真凶是注释里的 shellcode token 链，从 embeddings.py 清除

### DIFF
--- a/memory/embedding_worker.py
+++ b/memory/embedding_worker.py
@@ -47,7 +47,7 @@ try:
     )
 except ImportError:
     # ``memory/embeddings.py`` is missing (typically because an antivirus
-    # quarantined it — historically as ``Trojan/Python.ShellLoader.i``).
+    # quarantined it — see memory.embeddings for the false-positive history).
     # Fall back to disabled stubs so the warmup/backfill loop still
     # imports; the loop's own ``is_available()`` short-circuit then
     # turns the whole worker into a one-shot no-op.

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -315,8 +315,8 @@ def detect_total_ram_gb() -> float | None:
 # Known-good thresholds for CPU microarchitectures that ship AVX-VNNI.
 # Family/model is a stable hardware identifier readable from
 # ``HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0\Identifier`` on
-# Windows and ``/proc/cpuinfo`` on Linux — no executable-page allocation,
-# no inline machine code, no AV heuristic match.
+# Windows and ``/proc/cpuinfo`` on Linux — a plain registry / text read,
+# nothing an AV heuristic can mistake for a low-level CPU-probing trick.
 #
 # Conservative: a "yes" from the table is authoritative (confirmed=True);
 # an "I don't know" falls through to numpy CPU features / /proc/cpuinfo so
@@ -358,7 +358,7 @@ _AMD_ZEN3_MODEL_RANGES_FAMILY_19 = (
 
 
 def _read_cpu_family_model() -> tuple[str, int, int] | None:
-    """Return ``(vendor, family, model)`` from a non-shellcode source,
+    """Return ``(vendor, family, model)`` from a plain registry/text read,
     or None when neither the Windows registry nor ``/proc/cpuinfo``
     answered.
 
@@ -423,7 +423,7 @@ def _vnni_via_family_model() -> tuple[bool, bool]:
     answer is final. ``(False, False)`` means the table doesn't know —
     let the caller fall through to numpy CPU features / ``/proc/cpuinfo``.
 
-    Replaces the deleted CPUID shellcode probe. Strictly less precise
+    Replaces the deleted low-level CPUID probe. Strictly less precise
     in one direction (brand-new microarchitectures that ship before the
     table is updated stay inconclusive instead of authoritative), but
     the consumer's ``auto`` quantization path treats inconclusive as
@@ -474,17 +474,17 @@ def _numpy_cpu_features() -> dict | None:
     numpy probes CPU features in its compiled C core at import (for kernel
     dispatch) and exposes the result as ``__cpu_features__`` — a plain
     ``{feature_name: bool}`` dict. We read it instead of calling py-cpuinfo
-    because py-cpuinfo detects features by allocating an *executable* memory
-    page and running inline CPUID machine code inside a ``multiprocessing``
-    child (its ``ASM`` class: VirtualAlloc → VirtualProtect(PAGE_EXECUTE) →
-    CFUNCTYPE → call). That is the exact VirtualAlloc+shellcode pattern
-    PR #1437 stripped out of *this* module — Huorong's heuristic scanner
-    flags it as ``Trojan/Python.ShellLoader`` and quarantines this file (it's
-    the module on the import stack when py-cpuinfo's cpuid subprocess fires,
-    which is why the AV report blames ``embeddings.py`` running under
-    ``multiprocessing.spawn``). numpy's detection is pure compiled C — no
-    user-space RWX page, no subprocess — so the heuristic has nothing to
-    bite, and numpy is already a hard dependency we import for inference.
+    because py-cpuinfo probes the CPU by generating a tiny native routine at
+    runtime and calling into it from a child process — a low-level trick that
+    antivirus heuristics (notably Huorong) match and act on, quarantining
+    whichever Python file happens to be on the import stack at the time. The
+    launcher starts the memory server as a spawn child that re-imports this
+    module, so on Windows that file is ``embeddings.py`` — which is why the AV
+    report blamed it (the report's ``--multiprocessing-fork`` line is that
+    spawn child, not the probe). numpy's detection is pure compiled C with
+    none of that, so the heuristic has nothing to bite, and numpy is already a
+    hard dependency we import for inference. See PR #1437 / #1525 and this
+    module's git history for the full write-up.
 
     Returns None on exotic builds where the private attribute is gone, so
     callers fall through to ``/proc/cpuinfo`` (Linux) or stay inconclusive.
@@ -532,7 +532,7 @@ def _np_feature(feats: dict, *needles: str) -> bool:
 def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
     """x86 INT8 fast path = AVX-VNNI (client) or AVX512-VNNI (server).
 
-    Detection order (no shellcode, no subprocess):
+    Detection order (plain reads only, no child process):
       1. CPU family/model lookup (:func:`_vnni_via_family_model`) — the
          only path that authoritatively answers for Alder-Lake+ Intel
          *client* CPUs, whose AVX-VNNI flag numpy's feature map does not
@@ -571,7 +571,7 @@ def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
 def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
     """ARM64 INT8 fast path = ARMv8.2-A NEON sdot/udot (``asimddp`` feature).
 
-    Strategy (no shellcode, no subprocess):
+    Strategy (plain reads only, no child process):
 
       * macOS — Apple Silicon (M1+) universally has dotprod; Apple has
         never shipped an ARM Mac without it, so we short-circuit to
@@ -588,7 +588,7 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
         is unavailable. The ARM SBC ecosystem still has plenty of
         Cortex-A53 / A57 / A72 cores that predate dotprod (Pi-3 class).
       * Windows — ``IsProcessorFeaturePresent`` kernel32 API (a documented
-        call, not executable-memory injection). Its 0 return is ambiguous
+        feature-query call, nothing low-level). Its 0 return is ambiguous
         (lacks dotprod OR old Win build that returns 0 for unknown feature
         ids), reported as inconclusive so ``auto`` stays optimistic.
 
@@ -734,9 +734,9 @@ def detect_avx2_details() -> tuple[bool, bool]:
     (SSE-only) int8 would be too slow to auto-enable.
 
     Source is numpy ``__cpu_features__['AVX2']`` (compiled C probe) rather
-    than py-cpuinfo, whose CPUID probe allocates an executable page and runs
-    machine code in a multiprocessing child — the VirtualAlloc+shellcode
-    pattern Huorong quarantines as ShellLoader (see :func:`_numpy_cpu_features`).
+    than py-cpuinfo, whose CPU probe runs a generated native routine in a
+    child process — the low-level pattern Huorong's heuristic quarantines
+    this file over (see :func:`_numpy_cpu_features`).
     ``absence_confirmed=False`` means no source could read CPU features —
     caller stays optimistic (picks int8), matching the VNNI-inconclusive policy.
     """

--- a/memory/embeddings_fallback.py
+++ b/memory/embeddings_fallback.py
@@ -2,9 +2,9 @@
 """Import-time fallback stubs for :mod:`memory.embeddings`.
 
 This module exists so that if ``memory/embeddings.py`` is quarantined or
-deleted by an external actor (over-eager antivirus has done both: the
-historical CPUID probe was flagged ``Trojan/Python.ShellLoader.i`` and
-the file was removed on disk while N.E.K.O was running), the memory
+deleted by an external actor (over-eager antivirus has done both: a
+historical low-level CPU probe was flagged as a trojan and the file was
+removed on disk while N.E.K.O was running), the memory
 subsystem still imports successfully and degrades to the pre-vector code
 path instead of crashing with ``ImportError`` at module load.
 
@@ -16,8 +16,8 @@ would answer when its :class:`EmbeddingService` is in the sticky
 pipeline, so consumers don't need any extra ``hasattr`` guards.
 
 Kept intentionally pure-Python with no imports beyond ``logging`` and no
-ctypes / VirtualAlloc / inline machine code, so AV heuristic scanners
-have nothing to latch onto here.
+low-level CPU-probing tricks, so AV heuristic scanners have nothing to
+latch onto here.
 """
 from __future__ import annotations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,8 @@ dependencies = [
   "cachetools>=5.3",
   # Local memory embeddings (memory/embeddings.py): ONNX + tokenizer. CPU
   # SIMD detection reads numpy's __cpu_features__ (compiled-C probe) — we do
-  # NOT use py-cpuinfo, whose CPUID probe runs VirtualAlloc+shellcode in a
-  # multiprocessing child that Huorong quarantines as Trojan.ShellLoader.
+  # NOT use py-cpuinfo, whose low-level CPU probe runs a generated native
+  # routine in a child process that Huorong's heuristic flags as a trojan.
   "onnxruntime",
   "tokenizers",
   # Cross-platform screen capture used by galgame_plugin and potentially other


### PR DESCRIPTION
## 背景

#1437 删掉了手写 CPUID shellcode，#1525 又删掉了 py-cpuinfo（其 ASM 类在子进程里跑 CPUID）。但火绒**仍然**把 `memory/embeddings.py` 删成 `Trojan/Python.ShellLoader.i`，最近一名测试同学的多个 checkout 上反复触发（同一病毒 ID `28AA9B20BBC23D61`）。

## 真因：静态特征码，不是运行时行为

火绒 `ShellLoader.i` 是**字节扫描签名**，匹配单个 `.py` 里 `VirtualAlloc` + `VirtualProtect(PAGE_EXECUTE)` + `CFUNCTYPE` 这条完整 shellcode-loader 调用链的同时出现。删掉真 shellcode 后，这条链现在躺在 **#1525 自己加进去、用来解释「为啥弃用 py-cpuinfo」的 docstring** 里。字节扫描器不区分注释和代码——那段说明本身就成了签名。

**反证（关键）：** 全仓扫了一遍这些 token：
- `ctypes.windll.kernel32` 在 `launcher.py`、`utils/port_utils.py`、`plugin/.../_window_manager.py` 等**十几个文件**都有 → 全部存活，没被删
- `CFUNCTYPE` 在 `steamworks/interfaces/*` 一堆 → 也没被删
- **唯一**把 `VirtualAlloc`+`PAGE_EXECUTE`+`CFUNCTYPE` 凑齐在一个文件里的就是 `embeddings.py`，**唯一**被删的也是它

## 为什么 #1525 没治好

火绒报告里的 `python.exe -c "...spawn_main..." --multiprocessing-fork` 子进程，不是 py-cpuinfo 的 ASM 子进程——是 `launcher.py` 用 `multiprocessing.Process`(spawn) 起 `memory_server` 等服务进程。Windows spawn 子进程启动时重新 import 整棵模块树，import 到 `embeddings.py` 时火绒实时监控触发扫描、命中签名、删文件。**子进程只是触发扫描的时机，不是命中的原因。** #1525 误把它读成 py-cpuinfo 的子进程行为，所以删 py-cpuinfo 治标不治本。

## 改动

把 `VirtualAlloc` / `VirtualProtect` / `PAGE_EXECUTE` / `CFUNCTYPE` / `shellcode` / `ShellLoader` / `RWX` / `machine code` 等字面 token 从以下文件的注释/docstring 清掉，保留解释含义、指向 PR #1437/#1525 看全文：

- `memory/embeddings.py` — `_numpy_cpu_features` / `detect_avx2_details` 等 7 处 docstring（主犯）
- `memory/embeddings_fallback.py` — 这本该是"干净到 AV 抓不住"的兜底模块，自己却带 token，自相矛盾
- `memory/embedding_worker.py` — `ImportError` 兜底注释里的签名字面量
- `pyproject.toml` — 依赖说明注释

**保留不动：** `embeddings.py:632` 的 `ctypes.windll.kernel32.IsProcessorFeaturePresent(43)`。上面反证已证明 `windll.kernel32` 单独出现到处都是、从不被删，它不是触发点；按"别基于静态推理过度清理"原则不动它。

## 验证

- 纯注释/文档改动，**零逻辑变化**
- `python -m py_compile` 三个 `.py` 全过
- 全仓复扫确认四个改动文件再无 `VirtualAlloc`/`PAGE_EXECUTE`/`CFUNCTYPE`/`shellcode` 触发链残留

仍需测试同学在装火绒的机器上拉本分支实测确认 `embeddings.py` 不再被删。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了内部 CPU 检测和量化策略相关的文档和注释说明
  * 改进了模块级别文档中关于系统兼容性的描述

**说明：** 本次更新仅涉及文档和注释的改进，不含任何功能性代码变更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->