### PR TITLE
fix(voice): OpenAI Realtime 上行语音改发 24kHz（其余各家维持 16kHz）

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -616,6 +616,21 @@ class OmniRealtimeClient:
         else:
             logger.info("apply_tools_to_session: api_type=%s does not support custom tools — ignoring", api)
 
+    def _clear_uplink_resampler(self) -> None:
+        """Drop the uplink resampler's pending FIR tail (soxr holds ~21ms of
+        algorithmic delay at 16k→24k HQ).
+
+        Called at every server-buffer clear/commit boundary so a finished
+        turn's residual samples are not carried into — and prepended to —
+        the next turn. Discard (not flush-and-send) is the right semantics:
+        on ``input_audio_buffer.clear`` the server is throwing that audio
+        away anyway, and on a MANUAL commit the trailing ~21ms is end-of-turn
+        tail. Mirrors AudioProcessor's downsample-resampler ``.clear()`` on
+        reset. No-op for every 16kHz-native provider (resampler is None).
+        """
+        if self._uplink_resampler is not None:
+            self._uplink_resampler.clear()
+
     def _resample_uplink(self, pcm16_bytes: bytes) -> bytes:
         """Upsample 16kHz PCM16 mic/cache audio to the provider's uplink rate.
 
@@ -750,6 +765,9 @@ class OmniRealtimeClient:
             logger.debug("Gemini mode: no WebSocket input_audio_buffer.clear event")
             return
         await self.send_event({"type": "input_audio_buffer.clear"})
+        # The server is discarding this buffer; drop the uplink resampler's
+        # held tail too so it isn't prepended to the next utterance.
+        self._clear_uplink_resampler()
         logger.debug("📤 已发送 input_audio_buffer.clear 事件")
 
     async def connect(self, instructions: str, native_audio=True) -> None:
@@ -785,8 +803,7 @@ class OmniRealtimeClient:
             self._audio_processor.reset()
         # Flush uplink resampler FIR history so a previous session's tail
         # samples don't bleed into the new connection's first frames.
-        if self._uplink_resampler is not None:
-            self._uplink_resampler.clear()
+        self._clear_uplink_resampler()
 
         # WebSocket-based APIs (GLM, Qwen, GPT, Step, Free)
         url = f"{self.base_url}?model={self.model}" if self._model_lower != "free-model" else self.base_url
@@ -897,9 +914,10 @@ class OmniRealtimeClient:
                 "audio": {
                     "input": {
                         # OpenAI Realtime PCM 输入只支持 24kHz；显式声明以匹配
-                        # 我们 _resample_uplink 上采后的实际采样率（默认也是
-                        # 24k，但写明可防 API 默认值漂移 + 自我文档化）。
-                        "format": {"type": "audio/pcm", "rate": 24000},
+                        # 我们 _resample_uplink 上采后的实际采样率。复用
+                        # _uplink_sample_rate（此分支恒为 24000）作单一数据源，
+                        # 避免声明与实际两处来源漂移。
+                        "format": {"type": "audio/pcm", "rate": self._uplink_sample_rate},
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": None if is_manual else {
                             "type": "semantic_vad",
@@ -1408,6 +1426,9 @@ class OmniRealtimeClient:
                     self._fatal_error_occurred = True
             return
         await self.send_event({"type": "input_audio_buffer.commit"})
+        # The committed buffer excludes the ~21ms tail soxr still holds in the
+        # uplink resampler; drop it so it isn't prepended to the next turn.
+        self._clear_uplink_resampler()
         await self.send_event({"type": "response.create"})
 
     async def _analyze_image_with_vision_model(self, image_b64: str) -> str:

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -8,6 +8,7 @@ import base64
 import time
 import wave
 import numpy as np
+import soxr
 from pathlib import Path
 
 from typing import Optional, Callable, Dict, Any, Awaitable, List
@@ -343,7 +344,27 @@ class OmniRealtimeClient:
             noise_reduce_enabled=True,  # RNNoise noise reduction + VAD
             on_silence_reset=self._on_silence_reset  # 静音重置时发送 input_audio_buffer.clear
         )
-        
+
+        # ── Uplink (client→provider) sample rate ──────────────────────
+        # 内部管线一律 16kHz（RNNoise 降采样到 16k、移动端原生 16k、主动
+        # 注入 WAV 也是 16k）。绝大多数 Realtime API（Gemini/Qwen/GLM/Step/
+        # Grok/free）都吃 16kHz PCM —— 唯独 OpenAI Realtime 的 PCM 输入
+        # *只* 接受 24kHz（GA 文档：audio/pcm 的 rate 固定 24000，不能声明
+        # 16000）。否则服务端会把我们的 16k 字节当 24k 解，等于喂模型 1.5×
+        # 变速变调的音频，拖累 ASR 与 server VAD。
+        # 因此只为 GPT 在「发送前的最后一刻」把 16k 上采到 24k；其余各家
+        # _uplink_sample_rate 保持 16000，_uplink_resampler 为 None → 整条
+        # 重采样彻底短路，行为与改动前完全一致。
+        self._uplink_sample_rate = 24000 if 'gpt' in self._model_lower else 16000
+        # 持续型流式重采样器：连续麦克风流必须维持 FIR 状态，否则每个 chunk
+        # 边界都会引入伪影（与 AudioProcessor 的 downsample stream 同理）。
+        # 一次性的预录 WAV（prompt_ephemeral）走整段无状态重采样，不复用它。
+        self._uplink_resampler = (
+            soxr.ResampleStream(16000, self._uplink_sample_rate, 1, dtype='float32', quality='HQ')
+            if self._uplink_sample_rate != 16000
+            else None
+        )
+
         # 静音重置事件异步队列（RNNoise 4秒静音回调用）
         self._silence_reset_pending = False
         # 按“上次语音时间”做静音清 buffer：无 RNNoise 时也生效，与 RESET_TIMEOUT 一致
@@ -595,6 +616,25 @@ class OmniRealtimeClient:
         else:
             logger.info("apply_tools_to_session: api_type=%s does not support custom tools — ignoring", api)
 
+    def _resample_uplink(self, pcm16_bytes: bytes) -> bytes:
+        """Upsample 16kHz PCM16 mic/cache audio to the provider's uplink rate.
+
+        No-op for every provider that accepts 16kHz (``_uplink_resampler``
+        is None) — returns the bytes unchanged. Only OpenAI Realtime needs
+        24kHz, in which case the persistent stream resampler converts each
+        chunk while carrying FIR state across calls (no boundary clicks).
+
+        Returns ``b''`` if the resampler is still buffering and produced no
+        output for this chunk; callers should skip sending empty frames.
+        """
+        if self._uplink_resampler is None or not pcm16_bytes:
+            return pcm16_bytes
+        samples = np.frombuffer(pcm16_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+        out = self._uplink_resampler.resample_chunk(samples)
+        if len(out) == 0:
+            return b''
+        return (out * 32768.0).clip(-32768, 32767).astype(np.int16).tobytes()
+
     async def process_audio_chunk_async(self, audio_chunk: bytes) -> bytes:
         """
         Asynchronously process audio chunk using RNNoise in a separate thread.
@@ -743,6 +783,10 @@ class OmniRealtimeClient:
         self._ai_recent_activity_time = 0.0
         if self._audio_processor is not None:
             self._audio_processor.reset()
+        # Flush uplink resampler FIR history so a previous session's tail
+        # samples don't bleed into the new connection's first frames.
+        if self._uplink_resampler is not None:
+            self._uplink_resampler.clear()
 
         # WebSocket-based APIs (GLM, Qwen, GPT, Step, Free)
         url = f"{self.base_url}?model={self.model}" if self._model_lower != "free-model" else self.base_url
@@ -852,6 +896,10 @@ class OmniRealtimeClient:
                 "output_modalities": ['audio'] if 'audio' in self._modalities else ['text'],
                 "audio": {
                     "input": {
+                        # OpenAI Realtime PCM 输入只支持 24kHz；显式声明以匹配
+                        # 我们 _resample_uplink 上采后的实际采样率（默认也是
+                        # 24k，但写明可防 API 默认值漂移 + 自我文档化）。
+                        "format": {"type": "audio/pcm", "rate": 24000},
                         "transcription": {"model": "gpt-4o-mini-transcribe"},
                         "turn_detection": None if is_manual else {
                             "type": "semantic_vad",
@@ -1285,11 +1333,18 @@ class OmniRealtimeClient:
             self._silence_reset_pending = False
             await self.clear_audio_buffer()
 
-        # Gemini uses different API
+        # Gemini uses different API (16kHz, no uplink resample needed)
         if self._is_gemini:
             await self._stream_audio_gemini(audio_chunk)
             return
-        
+
+        # By this point audio_chunk is always 16kHz (RNNoise-downsampled,
+        # mobile-native, or hot-swap-cache replay). Upsample to the provider
+        # uplink rate as the very last step (24kHz for OpenAI; no-op others).
+        audio_chunk = self._resample_uplink(audio_chunk)
+        if not audio_chunk:
+            return  # resampler still buffering — nothing to send this frame
+
         audio_b64 = base64.b64encode(audio_chunk).decode()
 
         append_event = {
@@ -2088,6 +2143,15 @@ class OmniRealtimeClient:
                 logger.warning("prompt_ephemeral: no audio file found for %s", filename)
                 return False
 
+        # Proactive WAVs are stored at 16kHz; for OpenAI's 24kHz-only uplink,
+        # upsample the whole clip once (stateless — it's a complete signal, so
+        # no chunk-boundary artifacts and no need to touch the mic-stream
+        # resampler). No-op for every 16kHz-native provider.
+        if self._uplink_sample_rate != 16000:
+            _clip = np.frombuffer(pcm_data, dtype=np.int16).astype(np.float32) / 32768.0
+            _clip = soxr.resample(_clip, 16000, self._uplink_sample_rate, quality='HQ')
+            pcm_data = (_clip * 32768.0).clip(-32768, 32767).astype(np.int16).tobytes()
+
         # ── Non-native vision: inject text description before audio ───
         # step / lanlan.tech+free can't receive raw images; send the
         # VISION_MODEL text analysis so the model has visual context.
@@ -2106,8 +2170,9 @@ class OmniRealtimeClient:
         self._proactive_injecting = True
 
         # ── Send audio chunks (same pacing as hot-swap flush) ─────────
-        # 320 bytes = 10 ms @16 kHz 16-bit mono, ×5 multiplier → 1600 bytes
-        chunk_size = 320 * 5  # 1600 bytes = 50 ms of audio
+        # 10 ms @16-bit mono = (rate/100)*2 bytes, ×5 multiplier → 50 ms/chunk.
+        # Rate-derived so pacing stays 50 ms/chunk after the 24kHz upsample.
+        chunk_size = (self._uplink_sample_rate // 100) * 2 * 5  # 50 ms of audio
         sleep_interval = 0.025  # 25 ms → 40 chunks/s, 2× real-time
 
         logger.info(

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -956,6 +956,7 @@ async def test_signal_user_activity_end_gpt_manual_clears_uplink_resampler():
         try:
             sent.append(json.loads(payload))
         except json.JSONDecodeError:
+            # Why: payload may be bytes audio frames, not JSON — ignore non-JSON in this collector.
             pass
 
     client.ws = AsyncMock()

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -804,3 +804,119 @@ async def test_connect_websocket_invalid_turn_detection_mode_raises_before_webso
             await client.connect(instructions="hi", native_audio=True)
 
         mock_ws_connect.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Uplink sample rate — OpenAI Realtime PCM input only accepts 24kHz, every
+# other provider takes the internal 16kHz unchanged. The client keeps the
+# whole pipeline at 16kHz and upsamples to 24kHz only at the send boundary
+# (and only for gpt models). See OmniRealtimeClient._resample_uplink.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _make_server_vad_client(model: str, api_type: str = "", base_url: str = "wss://example.test/realtime"):
+    return OmniRealtimeClient(
+        base_url=base_url,
+        api_key="sk-test",
+        model=model,
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type=api_type,
+    )
+
+
+@pytest.mark.unit
+def test_uplink_rate_gpt_is_24k_with_resampler():
+    """gpt models must target a 24kHz uplink and own a stream resampler."""
+    client = _make_server_vad_client(model="gpt-realtime", api_type="openai")
+    assert client._uplink_sample_rate == 24000
+    assert client._uplink_resampler is not None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "model,api_type",
+    [
+        ("qwen-omni-turbo-realtime", "qwen"),
+        ("glm-realtime", "glm"),
+        ("step-1o-audio", "step"),
+        ("grok-realtime", "grok"),
+        ("free-model", "free"),
+    ],
+)
+def test_uplink_rate_non_gpt_is_16k_no_resampler(model, api_type):
+    """Every 16kHz-native provider keeps rate=16000 and no resampler, so the
+    uplink resample path is fully short-circuited (zero behaviour change)."""
+    client = _make_server_vad_client(model=model, api_type=api_type)
+    assert client._uplink_sample_rate == 16000
+    assert client._uplink_resampler is None
+
+
+@pytest.mark.unit
+async def test_stream_audio_gpt_upsamples_16k_to_24k():
+    """A 16kHz chunk sent through a gpt client must reach the wire as ~1.5×
+    the samples (24kHz). Without this OpenAI reads our 16k bytes as 24k and
+    the model hears 1.5× speed-shifted audio."""
+    import numpy as np
+
+    client = _make_server_vad_client(model="gpt-realtime", api_type="openai")
+    sent: list[dict] = []
+
+    async def fake_send(payload):
+        sent.append(json.loads(payload))
+
+    client.ws = AsyncMock()
+    client.ws.send = AsyncMock(side_effect=fake_send)
+
+    # 1 second of 16kHz PCM16 (16000 samples → 32000 bytes). A full second
+    # dwarfs the resampler's FIR latency so the ratio lands cleanly on ~1.5.
+    in_samples = 16000
+    chunk = (np.zeros(in_samples, dtype=np.int16)).tobytes()
+    await client.stream_audio(chunk)
+
+    appends = [e for e in sent if e.get("type") == "input_audio_buffer.append"]
+    assert appends, "no input_audio_buffer.append emitted"
+    out_bytes = base64.b64decode(appends[0]["audio"])
+    out_samples = len(out_bytes) // 2
+    ratio = out_samples / in_samples
+    assert 1.4 < ratio < 1.6, f"expected ~1.5× (24k/16k) upsample, got {ratio:.3f}"
+
+
+@pytest.mark.unit
+async def test_stream_audio_non_gpt_passes_16k_through_unchanged():
+    """A 16kHz chunk through a 16k-native provider must reach the wire byte-
+    identical — the resample helper is a no-op when _uplink_resampler is None."""
+    import numpy as np
+
+    client = _make_server_vad_client(model="qwen-omni-turbo-realtime", api_type="qwen")
+    sent: list[dict] = []
+
+    async def fake_send(payload):
+        sent.append(json.loads(payload))
+
+    client.ws = AsyncMock()
+    client.ws.send = AsyncMock(side_effect=fake_send)
+
+    # 512 samples @16k = 1024 bytes — not the 480-sample RNNoise frame, so it
+    # bypasses AudioProcessor and should pass straight through.
+    chunk = np.arange(512, dtype=np.int16).tobytes()
+    await client.stream_audio(chunk)
+
+    appends = [e for e in sent if e.get("type") == "input_audio_buffer.append"]
+    assert appends, "no input_audio_buffer.append emitted"
+    assert base64.b64decode(appends[0]["audio"]) == chunk
+
+
+@pytest.mark.unit
+async def test_connect_gpt_session_declares_24k_pcm_input_format():
+    """gpt session.update must declare audio.input.format = audio/pcm @24kHz
+    so the server interprets our upsampled bytes at the correct rate."""
+    client = _make_server_vad_client(
+        model="gpt-realtime",
+        api_type="openai",
+        base_url="wss://api.openai.com/v1/realtime",
+    )
+    session = await _run_connect_and_capture_session(client)
+
+    assert session is not None
+    fmt = session.get("audio", {}).get("input", {}).get("format")
+    assert fmt == {"type": "audio/pcm", "rate": 24000}, f"got {fmt!r}"

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -920,3 +920,52 @@ async def test_connect_gpt_session_declares_24k_pcm_input_format():
     assert session is not None
     fmt = session.get("audio", {}).get("input", {}).get("format")
     assert fmt == {"type": "audio/pcm", "rate": 24000}, f"got {fmt!r}"
+
+
+@pytest.mark.unit
+async def test_clear_audio_buffer_drops_uplink_resampler_tail_for_gpt():
+    """clear_audio_buffer must also clear the uplink resampler. soxr holds
+    ~21ms of FIR tail; on a server-buffer clear (e.g. 4s-silence reset) that
+    tail must be dropped, not prepended to the next utterance."""
+    from unittest.mock import MagicMock
+
+    client = _make_server_vad_client(model="gpt-realtime", api_type="openai")
+    client.ws = AsyncMock()
+    fake_resampler = MagicMock()
+    client._uplink_resampler = fake_resampler
+
+    await client.clear_audio_buffer()
+
+    fake_resampler.clear.assert_called_once()
+
+
+@pytest.mark.unit
+async def test_signal_user_activity_end_gpt_manual_clears_uplink_resampler():
+    """MANUAL commit excludes soxr's held ~21ms tail; that tail must be
+    dropped so it isn't carried into the next turn (Codex P2 on PR #1644)."""
+    from unittest.mock import MagicMock
+
+    client = _make_manual_client(
+        model="gpt-realtime",
+        base_url="wss://api.openai.com/v1/realtime",
+        api_type="openai",
+    )
+    sent: list[dict] = []
+
+    async def fake_send(payload):
+        try:
+            sent.append(json.loads(payload))
+        except json.JSONDecodeError:
+            pass
+
+    client.ws = AsyncMock()
+    client.ws.send = AsyncMock(side_effect=fake_send)
+    fake_resampler = MagicMock()
+    client._uplink_resampler = fake_resampler
+
+    await client.signal_user_activity_end()
+
+    types_sent = [e.get("type") for e in sent]
+    assert "input_audio_buffer.commit" in types_sent
+    assert "response.create" in types_sent
+    fake_resampler.clear.assert_called_once()


### PR DESCRIPTION
## 背景

`OmniRealtimeClient` 此前对**所有** provider 统一发 16kHz PCM 上行语音。但 OpenAI Realtime 的 PCM 输入**只接受 24kHz**（GA 文档：`audio/pcm` 的 `rate` 固定 24000，不能声明 16000），且我们的 GPT session 此前压根没设 `audio.input.format`。结果服务端把我们的 16k 字节当 24k 解 —— 等于喂模型 **1.5× 变速变调**的音频，拖累 ASR 与 server VAD。其余各家（Gemini/Qwen/GLM/Step/Grok/free）确认就是 16kHz，无需改动。

## 做法

内部音频管线**保持全程 16kHz 不变**（RNNoise 降采样到 16k、移动端原生 16k、主动注入 WAV 也是 16k），仅为 GPT 在「发送前的最后一刻」把 16k 上采到 24kHz。这样 `stream_audio` 无需分辨手里 chunk 的源采样率（抵达发送点的永远是 16k），逻辑零歧义。

非 GPT 各家 `_uplink_sample_rate` 保持 16000、`_uplink_resampler` 为 `None`，**整条重采样彻底短路，行为与改动前逐字节一致**。

### 改动点（均在 `main_logic/omni_realtime_client.py`）

- **派生上行采样率 + 流式重采样器**（`__init__`）：`_uplink_sample_rate = 24000 if 'gpt' in model else 16000`，与挑选 OpenAI session 分支的判据同源。
- **麦克风/缓存流出口**（`stream_audio`）：base64 编码前插 `_resample_uplink()`，用持续型 `soxr.ResampleStream` 维持 FIR 状态，避免 chunk 边界爆音。
- **主动语音注入**（`prompt_ephemeral`）：16k 预录 WAV 整段无状态重采样（完整信号无边界问题，不复用麦克风流的 resampler）；`chunk_size` 改按采样率推导，保持 50ms/chunk 节奏。
- **GPT session 显式声明** `audio.input.format = {"type":"audio/pcm","rate":24000}`，匹配实际发出的采样率。
- **重连清状态**：`connect()` 音频重置块里 flush resampler，防上个 session 尾音渗入。

## 取舍

PC 那条现在是 **48k → 16k(RNNoise) → 24k** 两次重采样，8kHz 以上摩擦音细节恢复不回来。换来的是 `stream_audio` 完全不用穿透传源采样率（否则要在多个调用点透传 `source_rate`，极易出歧义 bug）。对 ASR 无感，且远好过现状的变速损坏。下行（API 返回音频）本次不动。

## 验证

新增 9 个单测（`tests/unit/test_voice_session.py`）：GPT=24k/有 resampler、其余 5 家=16k/无 resampler、GPT 流出口实测上采 ≈1.5×、非 GPT 字节透传、GPT session 带 24k format 声明。

- 新测 **9 passed**
- 全套 `test_voice_session.py` **34 passed / 3 skipped**（skip 为未配 API key 的）
- 相邻音频套件（audio_stream_queue / gemini_realtime_voice_routing / audio_silence_*）**87 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 按模型自动选择上行采样率（GPT 24kHz，其他 16kHz），发送前对音频重采样；在重采样器仍在缓冲时跳过该帧以避免发送异常数据
  * 会话切换、清空缓冲与提交用户活动后清理重采样器尾部，防止跨回合音频拼接
  * 预录注入保留 16kHz 存储，必要时一次性重采样并按目标速率调整注入分片节奏

* **测试**
  * 新增回归测试覆盖上行采样率、重采样行为、尾部清理与流传输路径验证
<!-- end of auto-generated comment: release notes by coderabbit.ai -->