### PR TITLE
feat(chat-export): 聊天历史导出默认格式改为图片

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -823,7 +823,7 @@ describe('App', () => {
       });
       expect(exportWindow.appChatExport?.buildCompactInlinePreview).toHaveBeenCalledWith({
         messageIds: ['user-history-select'],
-        format: 'markdown',
+        format: 'image',
         imageStyle: 'neko',
         imageFormat: 'png',
       });
@@ -1848,7 +1848,7 @@ describe('App', () => {
       await waitFor(() => {
         expect(buildCompactInlinePreview).toHaveBeenCalledWith({
           messageIds: ['assistant-history-export-action'],
-          format: 'markdown',
+          format: 'image',
           imageStyle: 'neko',
           imageFormat: 'png',
         });
@@ -1858,7 +1858,7 @@ describe('App', () => {
       await waitFor(() => {
         expect(copyCompactInlineSelection).toHaveBeenCalledWith({
           messageIds: ['assistant-history-export-action'],
-          format: 'markdown',
+          format: 'image',
           imageStyle: 'neko',
           imageFormat: 'png',
         });

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
@@ -129,7 +129,7 @@ describe('CompactExportHistoryPanel', () => {
       });
       expect(onCopyExport).toHaveBeenCalledWith({
         messageIds: [message.id],
-        format: 'markdown',
+        format: 'image',
         imageStyle: 'neko',
         imageFormat: 'png',
       });

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -1219,7 +1219,7 @@ export default function CompactExportHistoryPanel({
   const previewObjectUrlRef = useRef<string | null>(null);
   const enterDelayByMessageIdRef = useRef<Map<string, string>>(new Map());
   const previousVisibilityStateRef = useRef<'open' | 'closing' | null>(null);
-  const [exportFormat, setExportFormat] = useState<CompactExportFormat>('markdown');
+  const [exportFormat, setExportFormat] = useState<CompactExportFormat>('image');
   const [imageStyle, setImageStyle] = useState<CompactExportImageStyle>('neko');
   const [imageFormat, setImageFormat] = useState<CompactExportImageFormat>('png');
   const [pendingAction, setPendingAction] = useState<'copy' | 'download' | null>(null);


### PR DESCRIPTION
## 改动

聊天历史导出有两个入口，默认格式之前不一致：

- compact 聊天记录面板（React）：默认 **Markdown（文字）**
- 顶栏导出按钮（`app-chat-export.js`）：默认 **图片**

用户日常用的是 compact 面板那个，所以体感「默认导出文字」。本 PR 把 compact 面板的默认导出格式从 `markdown` 改为 `image`，与顶栏入口对齐。图片子选项默认沿用原值（`neko` 样式 + `png` 格式）。

核心改动一行：`CompactExportHistoryPanel.tsx` 里 `exportFormat` 的默认 `useState('markdown')` → `useState('image')`。

## 测试

同步更新 3 处「走默认值」的断言（panel 测试 1 处、App 集成测试 2 处）。preview iframe 内容类断言用固定 mock 文档、与格式无关，不受影响。

受影响的两个测试文件本地全过：**147 passed**（`App.test.tsx` 143 + `CompactExportHistoryPanel.test.tsx` 4）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 调整紧凑导出功能的默认格式设置，确保预览和导出操作使用正确的格式配置。

* **Tests**
  * 更新相关测试用例，使其与最新的导出格式设置保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->