### PR TITLE
fix(voice): 修复带工具调用的语音轮「有声无字」

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -2633,6 +2633,24 @@ class OmniRealtimeClient:
                     else:
                         self._last_response_transcript = ""
                         print(f"OmniRealtimeClient: response.done - 没有转录文本 | audio_deltas={self._audio_delta_count}")
+                    # [有声无字兜底] 部分 provider（如 lanlan.app Gemini 语音代理）只发
+                    # response.audio_transcript.delta、从不发 response.audio_transcript.done，
+                    # 输出转录全靠下面 streaming 分支（_print_input_transcript=True）实时送出。
+                    # 但带工具调用的一轮里，工具调用那一轮的 response.done 会把
+                    # _print_input_transcript 置 False（见下方），紧随其后的真回复转录便走
+                    # buffer 分支累积进 _output_transcript_buffer，没有 transcript.done 来 flush，
+                    # 就在这里被直接清空 → 前端有声无字。这里在清空前补一次 flush：只要本轮真
+                    # 出过声（audio_delta_count>0）且 buffer 仍有残留就补发。streaming 分支每次都
+                    # 会清空 buffer，故正常轮此处为 no-op，不会重复发送。
+                    if (
+                        self._output_transcript_buffer
+                        and self.on_output_transcript
+                        and self._audio_delta_count > 0
+                    ):
+                        await self.on_output_transcript(
+                            self._output_transcript_buffer, self._is_first_transcript_chunk
+                        )
+                        self._is_first_transcript_chunk = False
                     self._audio_delta_count = 0
                     # 确保 buffer 被清空
                     self._output_transcript_buffer = ""

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -2647,6 +2647,15 @@ class OmniRealtimeClient:
                         and self.on_output_transcript
                         and self._audio_delta_count > 0
                     ):
+                        # 「有声无字」是反复出现的问题（见上方 ISSUE4b），留一条 debug
+                        # 日志方便下次诊断时确认是这条兜底生效、还是 streaming/transcript.done
+                        # 路径生效。audio_delta_count 此处尚未清零，记录的是本轮真实值。
+                        logger.debug(
+                            "response.done 兜底 flush 输出转录: buffer_len=%d audio_deltas=%d is_first=%s",
+                            len(self._output_transcript_buffer),
+                            self._audio_delta_count,
+                            self._is_first_transcript_chunk,
+                        )
                         await self.on_output_transcript(
                             self._output_transcript_buffer, self._is_first_transcript_chunk
                         )


### PR DESCRIPTION
## 现象

语音模式下能听到猫猫说话，但**前端不显示文字**。每轮都复现，尤其是带 `recall_memory` 工具调用的问答（如让猫猫回忆昨天聊了啥）。后端日志能看到 `response.done - 当前转录: 'Yeah...'`（转录已收齐），但前端 `analyzeEmotion` 永远拿到上一轮旧文本。

## 根因

部分语音 provider（lanlan.app Gemini 语音代理）**只发 `response.audio_transcript.delta`、从不发 `response.audio_transcript.done`**。输出转录在 `omni_realtime_client.py` 里分两条路（由 `_print_input_transcript` 决定）：

- `_print_input_transcript == True` → 每个 delta 实时 `on_output_transcript` 送出（**正常轮文字能显示靠的就是这条**）；
- `_print_input_transcript == False` → 攒进 `_output_transcript_buffer`，只在 `response.audio_transcript.done` 才 flush —— 而这家 provider 不发该事件。

正常一轮：用户语音转录完成事件把 `_print_input_transcript` 置 True，紧接着的回复 delta 走 streaming → 有字。

**带工具调用的一轮**时序变成：

1. 用户语音转录完成 → `_print_input_transcript = True`
2. 工具调用那一轮的空 `response.done`（`没有转录文本 | audio_deltas=0`）→ `_print_input_transcript = False`（该行由 #547 后的 OpenAI realtime 修复 commit `99e48af7f` 引入）
3. 工具（recall_memory）执行
4. 真回复 transcript delta 到达，此时 `_print_input_transcript == False` → 全攒进 buffer
5. 真回复 `response.done` → 直接 `_output_transcript_buffer = ""` 清空，**从没 flush** → 有声无字

本局每轮都触发 `recall_memory`（系统 prompt 强制时间相关问题先查记忆），所以每条回复的文字都丢了。

**证据闭环：** 后端日志中**没有 `send_lanlan_response first=...`**（`core.py:2414`，`handle_output_transcript` 被调过必打）→ 转录在后端就丢了、没发前端；而 `当前转录: 'Yeah...'` 证明 delta 到齐、攒进了 buffer。

## 修复

在 `response.done` 清空 buffer 前补一次 flush——仅当本轮真出过声（`audio_delta_count > 0`）且 buffer 仍有残留时补发。这是**不依赖 `transcript.done` 是否触发、不依赖 `_print_input_transcript` 状态**的兜底。

### 为什么安全、不重复发

- 正常轮（streaming 分支）：每个 delta 发完都清空 buffer，`response.done` 时 buffer 已空 → no-op；
- 工具调用轮（buffer 分支，provider 不发 `transcript.done`）：buffer 攒着整段 → 补发一次，`is_first_chunk` 仍为 True，前端建新气泡；
- 没真出声的轮（纯工具调用 / 出声前被打断）：`audio_delta_count == 0` → 跳过；
- flush 在 `on_response_done`(turn_end) **之前**触发，`gemini_response` 先到、`turn end` 后到，时序正确。

## 测试

- `py_compile` 通过；逻辑已静态走查。
- ⚠️ 尚未跑活的语音会话端到端验证（需连真 provider）。建议合并前实测一轮带 recall 的语音问答，确认文字正常显示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 解决了在工具调用与音频回复并发场景下可能导致转录丢失的问题：若已接收到音频增量且仍有未发送的转录内容，系统会先将该缓冲转录发送到前端再清理状态，避免在回复完成时丢失转录片段，提升转录可靠性与前端展示一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->