### PR TITLE
fix(galgame): 语音对话下不空耗 token —— 后端 takeover 守卫 + 不变量测试

### DIFF
--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -36,7 +36,7 @@ from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
 
-from .shared_state import get_config_manager
+from .shared_state import get_config_manager, get_session_manager
 
 router = APIRouter(prefix="/api", tags=["galgame"])
 
@@ -256,6 +256,24 @@ async def generate_galgame_options(request: Request):
         or _loc(GALGAME_DEFAULT_LANLAN_PLACEHOLDER, lang)
     master_name = (data.get('master_name') or master_name_current or '').strip() \
         or _loc(GALGAME_DEFAULT_MASTER_PLACEHOLDER, lang)
+
+    # 纵深防御：game route 接管会话期间（语音输入被改路由进游戏逻辑），
+    # React composer 的 galgame 面板并非当前活动界面，此时生成选项只会白白
+    # 烧掉 summary 档 token。前端已在聊天窗口隐藏（voice-only / proactive
+    # 路径）时跳过该请求；这里与 core.py 里 voice-proactive 的 _takeover_active
+    # 守卫对称，确保异常 / 老版本客户端也无法绕过空耗 token。
+    try:
+        mgr = get_session_manager().get(lanlan_name)
+    except Exception:
+        mgr = None
+    if mgr is not None and getattr(mgr, "_takeover_active", False):
+        logger.info("GalGame options skipped: session takeover active")
+        return JSONResponse({
+            "success": True,
+            "options": _fallback_options(lang),
+            "fallback": True,
+            "reason": "session_takeover",
+        })
 
     summary_config = config_manager.get_model_api_config('summary') or {}
     api_key = (summary_config.get('api_key') or '').strip()

--- a/tests/frontend/test_galgame_voice_idle.py
+++ b/tests/frontend/test_galgame_voice_idle.py
@@ -1,0 +1,104 @@
+"""GalGame 模式在语音对话下不空耗 token 的前端不变量。
+
+galgame 模式默认开启（readGalgameModePreference 在无 localStorage 时返回
+true）。「语音对话 / voice-only」= 用户没有打开 React 聊天窗口，此时
+overlay.hidden 为真。每轮 assistant 回复结束会派发 `neko-assistant-turn-end`，
+其 handler 必须因 overlay.hidden **同步早退**，不得 POST /api/galgame/options
+—— 否则就是在没人能看到、点击选项的情况下白烧 summary 档 token。
+
+参考 tests/frontend/test_avatar_reaction_bubble.py 的 turn-end 派发写法。
+"""
+
+import pytest
+from playwright.sync_api import Page, Route
+
+
+@pytest.mark.frontend
+def test_galgame_options_gated_by_chat_window_visibility(
+    mock_page: Page, running_server: str
+):
+    galgame_requests = []
+
+    def _handle(route: Route):
+        galgame_requests.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=(
+                '{"success": true, "options": ['
+                '{"label": "A", "text": "x"},'
+                '{"label": "B", "text": "y"},'
+                '{"label": "C", "text": "z"}]}'
+            ),
+        )
+
+    mock_page.route("**/api/galgame/options", _handle)
+
+    mock_page.goto(f"{running_server}/", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => !!(window.appState && window.reactChatWindowHost)",
+        timeout=10000,
+    )
+
+    pre = mock_page.evaluate(
+        """
+        () => {
+            // 解除可能的首启教程锁，让 galgame 能真正启用 —— 否则测的是
+            // 「galgame off 不发」而非「overlay hidden 不发」，失去意义。
+            ['neko:tutorial-completed', 'neko:tutorial-skipped'].forEach((name) => {
+                window.dispatchEvent(new CustomEvent(name, { detail: { page: 'home' } }));
+            });
+            const host = window.reactChatWindowHost;
+            host.setGalgameModeEnabled(true, { persist: false });
+            // 注入一段以 assistant 结尾的历史 —— 这样「没发请求」不会被归因到
+            // history 为空，而唯一归因到 overlay.hidden 这道关。
+            host.setMessages([
+                { id: 'u1', role: 'user', blocks: [{ type: 'text', text: 'hi' }] },
+                { id: 'a1', role: 'assistant', blocks: [{ type: 'text', text: '在的呀' }] },
+            ]);
+            const overlay = document.getElementById('react-chat-window-overlay');
+            return {
+                galgameEnabled: host.isGalgameModeEnabled(),
+                overlayHidden: !overlay || overlay.hidden,
+            };
+        }
+        """
+    )
+    assert pre["galgameEnabled"] is True, "前置失败：galgame 未启用，测试无意义"
+    assert pre["overlayHidden"] is True, "前置失败：overlay 应处于隐藏（voice-only）态"
+
+    # —— 主张：voice-only（overlay hidden）下 turn-end 不拉取选项 ——
+    mock_page.evaluate(
+        """
+        () => window.dispatchEvent(new CustomEvent('neko-assistant-turn-end', {
+            detail: { turnId: 'voice-turn-1', source: 'test', timestamp: Date.now() }
+        }))
+        """
+    )
+    # overlay.hidden 检查是同步的，但 fetch 走 microtask；给足时间确认请求确实没发。
+    mock_page.wait_for_timeout(800)
+    assert galgame_requests == [], (
+        f"voice-only 路径不应触发 galgame 选项生成，实际发出: {galgame_requests}"
+    )
+
+    # —— 对照：揭开 overlay 后，同一个 turn-end 会拉取选项 ——
+    # 证明上面那道关的开关确实是 overlay 可见性，而非别的原因导致没请求。
+    mock_page.evaluate(
+        """
+        () => {
+            // 直接揭开 overlay（不走完整 openWindow，避免 React bundle 异步 mount
+            // 的时序）—— turn-end handler 只读 overlay.hidden。
+            document.getElementById('react-chat-window-overlay').hidden = false;
+            // 清空 realistic 字幕队列，让 waitForAssistantBubblesFlushed 立即放行。
+            window._realisticGeminiQueue = [];
+            window._isProcessingRealisticQueue = false;
+            window.dispatchEvent(new CustomEvent('neko-assistant-turn-end', {
+                detail: { turnId: 'visible-turn-1', source: 'test', timestamp: Date.now() }
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_timeout(1500)
+    assert any("/api/galgame/options" in url for url in galgame_requests), (
+        f"对照失败：overlay 可见时 turn-end 应触发选项生成，实际: {galgame_requests}"
+    )

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -472,3 +472,106 @@ async def test_galgame_missing_model_base_url_returns_fallback(monkeypatch):
     assert data["fallback"] is True
     assert "error" not in data
     assert [item["text"] for item in data["options"]] == list(get_galgame_fallback_options("zh"))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_galgame_options_skipped_when_session_takeover_active(monkeypatch):
+    """game route 接管会话期间（语音输入被改路由进游戏逻辑），React composer
+    的 galgame 面板不是当前活动界面。此时生成选项只会白烧 summary 档 token，
+    所以端点必须短路到 fallback 且**不调用 LLM** —— 与 core.py 里 voice-proactive
+    的 `_takeover_active` 守卫对称。"""
+    config_manager = FakeConfigManager(
+        {
+            "model": "local-summary",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "",
+        }
+    )
+    monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr(
+        galgame_router,
+        "create_chat_llm",
+        lambda *args, **kwargs: pytest.fail(
+            "LLM must not be called while the session is taken over"
+        ),
+    )
+    monkeypatch.setattr(
+        galgame_router,
+        "get_session_manager",
+        lambda: {"猫娘": SimpleNamespace(_takeover_active=True)},
+    )
+
+    response = await galgame_router.generate_galgame_options(
+        FakeRequest(
+            {
+                "messages": [{"role": "assistant", "text": "刚才那件事你怎么看？"}],
+                "language": "zh-CN",
+                "lanlan_name": "猫娘",
+            }
+        )
+    )
+
+    data = _decode_response(response)
+    assert data["success"] is True
+    assert data["fallback"] is True
+    assert data["reason"] == "session_takeover"
+    assert _option_texts(data) == list(get_galgame_fallback_options("zh"))
+    # 守卫必须在解析 summary 模型配置之前短路，summary 档配置不应被读取。
+    assert "summary" not in config_manager.calls
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_galgame_options_generated_when_session_not_taken_over(monkeypatch):
+    """守卫只在接管期间短路 —— mgr 存在但未接管时必须照常生成选项。不能因为
+    「有活跃（语音）会话」就一刀切拦掉：用户开着聊天窗口用文字选项插话是合法
+    用法。"""
+    config_manager = FakeConfigManager(
+        {
+            "model": "local-summary",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "",
+        }
+    )
+    called = {"llm": False}
+
+    class FakeLLM:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def ainvoke(self, messages):
+            called["llm"] = True
+            return SimpleNamespace(
+                content=json.dumps(
+                    {"A": "认真听。", "B": "陪着你。", "C": "幻想一下。"},
+                    ensure_ascii=False,
+                )
+            )
+
+    monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **k: FakeLLM())
+    monkeypatch.setattr(
+        galgame_router,
+        "get_session_manager",
+        lambda: {"猫娘": SimpleNamespace(_takeover_active=False)},
+    )
+
+    response = await galgame_router.generate_galgame_options(
+        FakeRequest(
+            {
+                "messages": [{"role": "assistant", "text": "刚才那件事你怎么看？"}],
+                "language": "zh-CN",
+                "lanlan_name": "猫娘",
+            }
+        )
+    )
+
+    data = _decode_response(response)
+    assert called["llm"] is True
+    assert data["success"] is True
+    assert "fallback" not in data
+    assert _option_texts(data) == ["认真听。", "陪着你。", "幻想一下。"]


### PR DESCRIPTION
## 背景
galgame 选项生成走 summary 档 LLM（每次 ≤600 token），且 galgame 模式默认开启（localStorage 无值时 `readGalgameModePreference()` 返回 `true`）。

「语音对话 / voice-only」= 用户没打开 React 聊天窗口，`overlay.hidden` 为真。每轮 assistant 回复结束派发 `neko-assistant-turn-end`，其 handler 已经靠 `overlay.hidden` **同步早退**、不发 `/api/galgame/options` —— 所以纯语音路径本来就不空耗 token。本 PR 把这条不变量用测试钉死，并给后端补一道对称守卫作纵深防御。

## 改动
**后端守卫** — `main_routers/galgame_router.py`
- `generate_galgame_options` 调 LLM 前检查会话 `_takeover_active`。game route 接管期间（语音输入被改路由进游戏逻辑），galgame 面板不是当前活动界面，生成选项纯属白烧 token → 短路返回 fallback（`reason=session_takeover`），不调 LLM。
- 与 `core.py` 里 voice-proactive 的 `_takeover_active` 守卫对称，防异常 / 老版本客户端绕过前端的 overlay 检查。
- **单纯 voice 模式不拦**：用户开着聊天窗口用文字选项插话是合法用法，后端看不到窗口状态、不该误伤。

**后端单测** — `tests/unit/test_galgame_router.py`
- takeover 期间：不调 LLM、返回 fallback + `reason=session_takeover`，且不读取 summary 配置（验证短路位置正确）。
- mgr 存在但未接管：照常生成选项（守卫不误伤）。

**前端 e2e** — `tests/frontend/test_galgame_voice_idle.py`
- voice-only（`overlay.hidden`）+ galgame 默认开 + 注入 assistant 历史 + `turn-end` → 断言**不发** `/api/galgame/options`（注入历史让「没发请求」唯一归因到 overlay 这道关）。
- 对照段：揭开 overlay 后同一个 `turn-end` 会发请求，证明这道关的开关确实是聊天窗口可见性，排除假阴性。

## 验证
`uv run pytest tests/unit/test_galgame_router.py tests/frontend/test_galgame_voice_idle.py` → **13 passed**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了会话管理中的选项获取稳定性，增强防御机制。

* **Tests**
  * 新增单元测试和端到端测试，确保会话管理和选项获取功能的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->