### PR TITLE
fix(docker): 预取 embedding 权重并按 revision 缓存，根治 HF 429 死循环

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,11 +41,12 @@ config/user_preferences.json
 config/voice_storage.json
 N.E.K.O/
 
-# Embedding model weights: the image downloads the pinned revision in
-# docker/Dockerfile's pre-copy layer (step 5b), so the later `COPY . /app` must
-# not drag a developer's locally-prepared (possibly stale/partial) copy over the
-# verified download. Also trims build-context upload size.
-data/embedding_models
+# Embedding model weights are intentionally NOT ignored: CI pre-fetches the
+# pinned revision on the native runner (cached via actions/cache) and ships it in
+# the build context so the in-image step runs fully offline — see step 6b in
+# docker/Dockerfile{,.full}. That step force-re-downloads when the bundled
+# (repo, revision) doesn't match the pin, so a developer's stale/partial local
+# copy riding in via `COPY . /app` is corrected rather than shipped.
 
 # Build artifacts
 build/

--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -178,6 +178,16 @@ jobs:
       # anonymous profile folder so the bundled app can run vector memory
       # offline. The runtime (memory/embeddings.py) auto-falls back to bundled
       # assets when the user's app-data profile is incomplete.
+      # Cache the weights by revision so huggingface.co is hit at most once per
+      # pin (per OS) instead of every build — the same per-IP HTTP 429 throttle
+      # that broke the Docker build can bite here too. Cache hit -> the next step
+      # is a no-op ("keep existing"); only a cold cache actually downloads.
+      - name: Cache embedding model weights
+        uses: actions/cache@v4
+        with:
+          path: data/embedding_models
+          key: embedding-model-${{ runner.os }}-${{ env.EMBEDDING_MODEL_REVISION }}-both
+
       - name: Prepare embedding model assets
         shell: bash
         run: |

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -209,6 +209,16 @@ jobs:
       # anonymous profile folder so the bundled app can run vector memory
       # offline. The runtime (memory/embeddings.py) auto-falls back to bundled
       # assets when the user's app-data profile is incomplete.
+      # Cache the weights by revision so huggingface.co is hit at most once per
+      # pin (per OS) instead of every build — the same per-IP HTTP 429 throttle
+      # that broke the Docker build can bite here too. Cache hit -> the next step
+      # is a no-op ("keep existing"); only a cold cache actually downloads.
+      - name: Cache embedding model weights
+        uses: actions/cache@v4
+        with:
+          path: data/embedding_models
+          key: embedding-model-${{ runner.os }}-${{ env.EMBEDDING_MODEL_REVISION }}-both
+
       - name: Prepare embedding model assets
         shell: bash
         run: |

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -44,6 +44,13 @@ concurrency:
 env:
   REGISTRY_GHCR: ghcr.io
   IMAGE_NAME: project-n-e-k-o/n.e.k.o
+  # Embedding model pin (kept identical to .github/workflows/build-desktop.yml and
+  # docker/Dockerfile{,.full} ARG defaults). The weights are pre-fetched on the
+  # native runner and cached so the Docker build never hits huggingface.co — see
+  # the "Prepare embedding model" steps below and Dockerfile step 6b.
+  EMBEDDING_MODEL_REPO: jinaai/jina-embeddings-v5-text-nano-retrieval
+  EMBEDDING_MODEL_PROFILE_ID: local-text-retrieval-v1
+  EMBEDDING_MODEL_REVISION: ac5d898c8d382b17167c33e5c8af644a3519b47d
 
 jobs:
   # ============================================================================
@@ -154,6 +161,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pre-fetch the embedding weights on the native runner and cache them by
+      # revision, so the (QEMU-emulated, throttle-prone) Docker build below never
+      # touches huggingface.co. Cache hit -> the downloader is a no-op; only a
+      # cold cache (revision bump / 7-day eviction) actually downloads, natively,
+      # once. The weights ride into the build via the context (Dockerfile 6b).
+      # Standard image ships int8 only to stay lightweight.
+      - name: Cache embedding model weights (int8)
+        uses: actions/cache@v4
+        with:
+          path: data/embedding_models
+          key: embedding-model-${{ env.EMBEDDING_MODEL_REVISION }}-int8
+
+      - name: Prepare embedding model assets (int8)
+        run: |
+          python3 scripts/prepare_embedding_model.py \
+            --repo "$EMBEDDING_MODEL_REPO" \
+            --revision "$EMBEDDING_MODEL_REVISION" \
+            --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \
+            --output-root data/embedding_models \
+            --variant int8
+
       - name: Check if Dockerfile exists
         id: check-dockerfile
         run: |
@@ -247,6 +275,10 @@ jobs:
           file: ./docker/Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
+          build-args: |
+            EMBEDDING_MODEL_REPO=${{ env.EMBEDDING_MODEL_REPO }}
+            EMBEDDING_MODEL_REVISION=${{ env.EMBEDDING_MODEL_REVISION }}
+            EMBEDDING_MODEL_PROFILE_ID=${{ env.EMBEDDING_MODEL_PROFILE_ID }}
           tags: ${{ steps.meta_ghcr.outputs.tags || steps.meta_both.outputs.tags }}
           labels: ${{ steps.meta_ghcr.outputs.labels || steps.meta_both.outputs.labels }}
           cache-from: type=gha
@@ -271,6 +303,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # Pre-fetch the embedding weights on the native runner and cache them by
+      # revision, so the (QEMU-emulated, throttle-prone) Docker build below never
+      # touches huggingface.co. Cache hit -> the downloader is a no-op; only a
+      # cold cache (revision bump / 7-day eviction) actually downloads, natively,
+      # once. The weights ride into the build via the context (Dockerfile.full
+      # 6b). Full image bundles both int8 and fp32.
+      - name: Cache embedding model weights (both)
+        uses: actions/cache@v4
+        with:
+          path: data/embedding_models
+          key: embedding-model-${{ env.EMBEDDING_MODEL_REVISION }}-both
+
+      - name: Prepare embedding model assets (both)
+        run: |
+          python3 scripts/prepare_embedding_model.py \
+            --repo "$EMBEDDING_MODEL_REPO" \
+            --revision "$EMBEDDING_MODEL_REVISION" \
+            --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \
+            --output-root data/embedding_models \
+            --variant both
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -350,6 +403,10 @@ jobs:
           file: ./docker/Dockerfile.full
           platforms: ${{ matrix.platform }}
           push: true
+          build-args: |
+            EMBEDDING_MODEL_REPO=${{ env.EMBEDDING_MODEL_REPO }}
+            EMBEDDING_MODEL_REVISION=${{ env.EMBEDDING_MODEL_REVISION }}
+            EMBEDDING_MODEL_PROFILE_ID=${{ env.EMBEDDING_MODEL_PROFILE_ID }}
           tags: ${{ steps.meta_ghcr.outputs.tags || steps.meta_both.outputs.tags }}
           labels: ${{ steps.meta_ghcr.outputs.labels || steps.meta_both.outputs.labels }}
           cache-from: type=gha

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,22 +119,26 @@ RUN mkdir -p /root/.config/uv && \
       'url = "https://pypi.tuna.tsinghua.edu.cn/simple/"' \
       > /root/.config/uv/uv.toml
 
-# 5b. Bundle the local embedding model BEFORE copying the source tree.
-# Keying this layer on the model ARGs + the downloader script alone — instead of
-# on every source change via the `COPY . /app` below — keeps it cached across
-# commits, so it only re-downloads when the pin changes. Previously this sat
-# AFTER `COPY . /app`, re-ran on every commit, and kept tripping huggingface.co's
-# per-IP rate limit (HTTP 429), failing the build. The build context excludes
-# data/embedding_models, so the later `COPY . /app` does not clobber these
-# weights. Pure-stdlib downloader run on the system python3 (the uv venv is not
-# built yet); honors the proxy ARGs. repo+revision are pinned identically to
-# .github/workflows/build-desktop.yml so every build path resolves the same
-# on-disk profile. Standard image ships only the int8 variant (the runtime
-# `auto` default) to stay lightweight; the full image bundles fp32 too.
+# 6. Copy N.E.K.O. project from local build context (with correct ownership)
+COPY --chown=neko:neko . /app
+
+# 6b. Verify (and, only for non-CI builds, download) the pinned local embedding
+# model. CI pre-fetches these weights on the native runner and caches them with
+# actions/cache, then ships them in the build context (.dockerignore no longer
+# excludes data/embedding_models), so this step finds them already present via
+# `COPY . /app` above and runs FULLY OFFLINE — no huggingface.co call. That
+# anonymous per-IP HTTP 429 throttle on shared runner egress is exactly what kept
+# failing the build at this point with no recovery. A plain `docker build` with
+# no pre-fetched weights falls back to downloading here (honoring the proxy ARGs).
+# The script force-re-downloads when the bundled (repo, revision) doesn't match
+# the pin, so a developer's stale local copy can't ship. repo+revision are pinned
+# identically to .github/workflows/{build-desktop,docker-multi-arch}.yml so every
+# build path resolves the same on-disk profile. Standard image ships only the
+# int8 variant (the runtime `auto` default) to stay lightweight; the full image
+# bundles fp32 too.
 ARG EMBEDDING_MODEL_REPO=jinaai/jina-embeddings-v5-text-nano-retrieval
 ARG EMBEDDING_MODEL_REVISION=ac5d898c8d382b17167c33e5c8af644a3519b47d
 ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
-COPY scripts/prepare_embedding_model.py /app/scripts/prepare_embedding_model.py
 RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
@@ -146,9 +150,6 @@ RUN cd /app && \
         --variant int8 && \
     unset http_proxy && \
     unset https_proxy
-
-# 6. Copy N.E.K.O. project from local build context (with correct ownership)
-COPY --chown=neko:neko . /app
 
 # 7. Copy frontend build artifacts
 # Note: react-neko-chat's vite.config.ts writes to outDir `../../static/react/neko-chat`

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -190,22 +190,25 @@ RUN mkdir -p /root/.config/uv && \
       'url = "https://pypi.tuna.tsinghua.edu.cn/simple/"' \
       > /root/.config/uv/uv.toml
 
-# 5b. Bundle the local embedding model BEFORE copying the source tree.
-# Keying this layer on the model ARGs + the downloader script alone — instead of
-# on every source change via the `COPY . /app` below — keeps it cached across
-# commits, so it only re-downloads when the pin changes. Previously this sat
-# AFTER `COPY . /app`, re-ran on every commit, and kept tripping huggingface.co's
-# per-IP rate limit (HTTP 429), failing the build. The build context excludes
-# data/embedding_models, so the later `COPY . /app` does not clobber these
-# weights. Pure-stdlib downloader run on the system python3 (the uv venv is not
-# built yet); honors the proxy ARGs. repo+revision are pinned identically to
-# .github/workflows/build-desktop.yml so every build path resolves the same
-# on-disk profile. `--variant both` ships int8 (the runtime `auto` default) AND
-# fp32 weights so a VECTORS_QUANTIZATION=fp32 override also works.
+# 6. Copy N.E.K.O. project from local build context (with correct ownership)
+COPY --chown=neko:neko . /app
+
+# 6b. Verify (and, only for non-CI builds, download) the pinned local embedding
+# model. CI pre-fetches these weights on the native runner and caches them with
+# actions/cache, then ships them in the build context (.dockerignore no longer
+# excludes data/embedding_models), so this step finds them already present via
+# `COPY . /app` above and runs FULLY OFFLINE — no huggingface.co call. That
+# anonymous per-IP HTTP 429 throttle on shared runner egress is exactly what kept
+# failing the build at this point with no recovery. A plain `docker build` with
+# no pre-fetched weights falls back to downloading here (honoring the proxy ARGs).
+# The script force-re-downloads when the bundled (repo, revision) doesn't match
+# the pin, so a developer's stale local copy can't ship. repo+revision are pinned
+# identically to .github/workflows/{build-desktop,docker-multi-arch}.yml so every
+# build path resolves the same on-disk profile. `--variant both` ships int8 (the
+# runtime `auto` default) AND fp32 so a VECTORS_QUANTIZATION=fp32 override works.
 ARG EMBEDDING_MODEL_REPO=jinaai/jina-embeddings-v5-text-nano-retrieval
 ARG EMBEDDING_MODEL_REVISION=ac5d898c8d382b17167c33e5c8af644a3519b47d
 ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
-COPY scripts/prepare_embedding_model.py /app/scripts/prepare_embedding_model.py
 RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
@@ -217,9 +220,6 @@ RUN cd /app && \
         --variant both && \
     unset http_proxy && \
     unset https_proxy
-
-# 6. Copy N.E.K.O. project from local build context (with correct ownership)
-COPY --chown=neko:neko . /app
 
 # 7. Copy frontend build artifacts
 # Note: react-neko-chat's vite.config.ts writes to outDir `../../static/react/neko-chat`

--- a/scripts/prepare_embedding_model.py
+++ b/scripts/prepare_embedding_model.py
@@ -307,6 +307,25 @@ def main(argv: list[str] | None = None) -> int:
             f"forcing re-download for {args.repo}@{args.revision}",
         )
 
+    # Existing non-empty weights with no .prepared.json marker can't be trusted
+    # to match the pin: they may be a developer's runtime-downloaded copy that
+    # rode into the Docker build context (.dockerignore no longer excludes
+    # data/embedding_models). Otherwise _download would keep them and the marker
+    # written below would bless them as the pinned revision, silently packaging
+    # the wrong model. Re-fetch instead. CI's prepare step always writes the
+    # marker, so the cache-hit path stays fully offline.
+    unmarked_existing = existing is None and any(
+        (profile_dir / rel).exists() and (profile_dir / rel).stat().st_size > 0
+        for rel in files
+    )
+    if unmarked_existing:
+        print(
+            "[embedding-model] existing weights present without a .prepared.json "
+            f"marker; re-downloading pinned {args.repo}@{args.revision} rather "
+            "than trusting unverified files",
+        )
+
+    force = args.force or revision_changed or unmarked_existing
     endpoints = _endpoints()
     for rel in files:
         _download(
@@ -315,7 +334,7 @@ def main(argv: list[str] | None = None) -> int:
             repo=args.repo,
             revision=args.revision,
             endpoints=endpoints,
-            force=args.force or revision_changed,
+            force=force,
         )
     _verify(profile_dir, files)
     _write_marker(profile_dir, args.repo, args.revision)

--- a/tests/unit/test_prepare_embedding_model.py
+++ b/tests/unit/test_prepare_embedding_model.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -164,3 +165,56 @@ def test_sends_stable_user_agent(prep, monkeypatch, tmp_path):
     monkeypatch.setattr(prep.urllib.request, "urlopen", fake_urlopen)
     prep._download_one("https://huggingface.co/r/m/resolve/abc/x", tmp_path / "x")
     assert captured["ua"] == prep._USER_AGENT
+
+
+# --- main(): trusting pre-existing weights ---------------------------------
+# Since .dockerignore no longer excludes data/embedding_models, weights can ride
+# into the build context. main() must only treat them as authoritative when a
+# .prepared.json marker proves they match the pin — otherwise a stale local copy
+# would be kept and blessed as the pinned revision (silently wrong model).
+
+_INT8_FILES = ("tokenizer.json", "onnx/model_quantized.onnx", "onnx/model_quantized.onnx_data")
+_REV = "a" * 40  # main() requires a 40-char lowercase hex revision
+
+
+def _seed_profile(tmp_path, body, *, marker):
+    profile = tmp_path / "p"
+    (profile / "onnx").mkdir(parents=True)
+    for rel in _INT8_FILES:
+        (profile / rel).write_bytes(body)
+    if marker is not None:
+        (profile / ".prepared.json").write_text(json.dumps(marker), encoding="utf-8")
+    return profile
+
+
+def _run_main(prep, tmp_path):
+    return prep.main([
+        "--repo", "jinaai/x", "--revision", _REV,
+        "--profile-id", "p", "--output-root", str(tmp_path), "--variant", "int8",
+    ])
+
+
+def test_main_redownloads_unmarked_existing_weights(prep, monkeypatch, tmp_path):
+    profile = _seed_profile(tmp_path, b"STALE", marker=None)
+    seen: list[str] = []
+    _install_urlopen(monkeypatch, prep, lambda url: b"FRESH", record=seen)
+
+    assert _run_main(prep, tmp_path) == 0
+    assert seen, "expected a re-download when no marker vouches for the files"
+    assert (profile / "tokenizer.json").read_bytes() == b"FRESH"
+    assert json.loads((profile / ".prepared.json").read_text()) == {
+        "repo": "jinaai/x",
+        "revision": _REV,
+    }
+
+
+def test_main_keeps_offline_when_marker_matches(prep, monkeypatch, tmp_path):
+    profile = _seed_profile(tmp_path, b"GOOD", marker={"repo": "jinaai/x", "revision": _REV})
+
+    def explode(url):
+        raise AssertionError("must not download when a matching marker is present")
+
+    _install_urlopen(monkeypatch, prep, explode)
+
+    assert _run_main(prep, tmp_path) == 0
+    assert (profile / "tokenizer.json").read_bytes() == b"GOOD"


### PR DESCRIPTION
## 背景

[#1640](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1640) 想用镜像 fallback 治 HF 429，但没救活构建（[失败 run](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/27000388295/job/79679322797)）：

- `huggingface.co` → 5 次全 **429**（匿名请求按出口 IP 小时级限流，CI 共享 runner IP 长期被掐）
- fallback 的 `hf-mirror.com` → 4 次 429 后第 5 次 **HTTP 308 无限重定向**，这个镜像对 `/resolve/` 路径本身就坏的

更要命的是**死循环**：下模型这步在 Docker 构建层里失败 → buildx 不导出 gha 缓存 → 下次构建全冷重跑 → 又下 → 又 429 → 又失败。所以"永远卡在同一处"。

## 修法：把 HF 从构建热路径里彻底拿掉

| 文件 | 改动 |
|---|---|
| `docker-multi-arch.yml` | `build-standard`/`build-full` 各加 `actions/cache`（按 revision 缓存）+ 在**原生 runner** 上预取权重；模型 pin 提到 workflow `env`，经 `build-args` 下传 |
| `docker/Dockerfile{,.full}` | 删掉 `COPY . /app` **之前**的下载层；改成之后一个 `RUN prepare`——文件已在（CI 预取经 context 带入）就**纯离线校验**，不在（本地无预取）才回落下载。脚本对 `revision` 不符会强制重下，旧副本不会被打包 |
| `.dockerignore` | 不再排除 `data/embedding_models`，让预取权重随 context 进镜像 |
| `build-desktop{,-linux}.yml` | 同款无缓存下载也加 `actions/cache`（按 OS+revision），保持对偶 |

`actions/cache` **独立于构建成败**：命中就跳过下载（纯离线），只有 revision 变更/缓存 7 天过期才冷下一次，而且在原生 runner 上、不在 QEMU 里。死循环就此断开。

## 诚实交代

冷路径（revision 变更那次原生下载）**仍可能 429**。要彻底关掉得叠加 `HF_TOKEN` secret（脚本改带 token 鉴权）——本 PR 未做，按需后续。

## 验证

该 workflow PR 不触发，已手动 `workflow_dispatch` 在本分支跑真构建验证 `build-full` arm64（之前炸的那条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 优化构建与镜像流程：新增嵌入模型权重缓存与预处理步骤、固定模型版本并调整复制顺序，以加速构建并改进离线支持。
* **Documentation**
  * 在构建忽略配置中补充说明，明确嵌入模型权重在构建上下文中的处理与重下载策略，避免发布误用。
* **Tests**
  * 增加针对嵌入模型准备流程的单元测试，验证缓存标记与重下载行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->