### PR TITLE
修复 compact 模式音乐播放器回退到旧挂载点的问题，恢复独立播放器窗口

### DIFF
--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -126,7 +126,7 @@
    - 监听 `neko:compact-surface-drag-grab`（来自 React 工具轮盘原点拖拽），非 Electron 时以事件坐标为锚启动 compact surface 本体拖拽（复用既有 startDrag/全局 mousemove/mouseup 与落点 click 守卫）。Electron 由 `preload-chat-react.js` 监听同一事件改走原生窗口拖拽。
 5. `static/app-buttons.js` 是发送桥之一。compact history 文本发送必须带清晰 session / request 语义，不能让已有 composer 附件在 deferred send 中被误带上。
 6. 语音模式 / `composerHidden` 下的 history drop 只保留前端拖拽、命中和收束动效；真实发送必须在 `sendCompactHistoryDropPayload` 边界跳过，不能通过改 React 拖拽 phase 或样式来伪装。
-7. `static/music_ui.js` 的音乐播放器在 compact 模式下优先挂到常驻 `.compact-music-player-mount#music-player-mount`；历史关闭或卸载只影响消息面板，不能把播放器挪回 composer fallback，也不能被通用 `#music-player-mount` 样式撑成超过 compact surface 的横向尺寸。
+7. `static/music_ui.js` 的音乐播放器在 compact 模式下优先挂到常驻 `.compact-music-player-mount#music-player-mount`；历史关闭或卸载不能把播放器挪回 composer fallback，但播放器视觉显隐必须跟随历史打开、closing、closed 状态，也不能被通用 `#music-player-mount` 样式撑成超过 compact surface 的横向尺寸。
 
 ### NEKO-PC 桌面壳
 
@@ -373,7 +373,7 @@ Compact 历史默认在初次启动时显示。历史列表本身由常驻展开
 13. 操作栏隐藏时退出选择模式：必须清空当前选中项，并禁止继续通过点击或键盘选择；拖拽源识别和拖拽发送不受这个选择模式限制。
 14. 操作栏包含选择和导出动作，如计数、全选、取消/清空、反选、导出预览等；操作栏自身进入 history hit region。
 15. 选择状态、导出预览和操作栏显示状态由 React state 管理；操作栏状态可以跨历史显隐保留，但只在历史实际打开时算作可见。
-16. 音乐播放器有独立 `.compact-music-player-mount#music-player-mount`，它与历史消息面板分离并作为 `musicPlayer` 几何项进入 compact surface；历史关闭/卸载后播放器必须继续停留在该独立挂载点，横向尺寸必须限制在 compact surface 宽度内；历史记录底部必须为播放器高度和阴影预留间距，不能与播放器重叠。
+16. 音乐播放器有独立 `.compact-music-player-mount#music-player-mount`，它与历史消息面板分离并作为 `musicPlayer` 几何项进入 compact surface；历史关闭/卸载后播放器必须继续停留在该独立挂载点，但视觉上要随历史一起收起和展开；横向尺寸必须限制在 compact surface 宽度内；历史记录底部必须为播放器高度和阴影预留间距，不能与播放器重叠。
 17. 预览关闭时要清理 stale export error 和必要 preview lifecycle 状态，避免重新打开显示旧错误。
 18. 历史透明区域不能长期遮挡后方；可见气泡、按钮、预览控件和必要滚动区域可命中，气泡间透明区应尽量穿透。
 19. GalGame / ChoicePrompt 出现时，选项层在历史层上方。
@@ -581,7 +581,7 @@ Surface：
 7. 历史透明区不遮挡后方。
 8. 历史关闭动画结束后，历史面板卸载；关闭期间继续发生文字/语音对话时，历史区域不出现新气泡闪现。
 9. 历史重新展开后，关闭期间产生的新消息会按最新 `messages` 正常出现在历史中。
-10. 播放中的音乐栏在 compact 模式下停留在独立播放器挂载点；历史打开、关闭或卸载都不能把它挪回 composer，横向宽度不能突破 compact surface，历史记录不能贴住或覆盖播放器。
+10. 播放中的音乐栏在 compact 模式下停留在独立播放器挂载点；历史打开时显示，历史 closing / closed 时同步收起且不再命中；历史打开、关闭或卸载都不能把它挪回 composer，横向宽度不能突破 compact surface，历史记录不能贴住或覆盖播放器。
 11. 预览关闭不会保留旧 error。
 
 历史拖拽：

--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -126,7 +126,7 @@
    - 监听 `neko:compact-surface-drag-grab`（来自 React 工具轮盘原点拖拽），非 Electron 时以事件坐标为锚启动 compact surface 本体拖拽（复用既有 startDrag/全局 mousemove/mouseup 与落点 click 守卫）。Electron 由 `preload-chat-react.js` 监听同一事件改走原生窗口拖拽。
 5. `static/app-buttons.js` 是发送桥之一。compact history 文本发送必须带清晰 session / request 语义，不能让已有 composer 附件在 deferred send 中被误带上。
 6. 语音模式 / `composerHidden` 下的 history drop 只保留前端拖拽、命中和收束动效；真实发送必须在 `sendCompactHistoryDropPayload` 边界跳过，不能通过改 React 拖拽 phase 或样式来伪装。
-7. `static/music_ui.js` 的音乐播放器在 compact 模式下优先挂到常驻 `.compact-music-player-mount#music-player-mount`；历史关闭或卸载不能把播放器挪回 composer fallback，但播放器视觉显隐必须跟随历史打开、closing、closed 状态，也不能被通用 `#music-player-mount` 样式撑成超过 compact surface 的横向尺寸。
+7. `static/music_ui.js` 的音乐播放器在 compact 模式下优先挂到常驻 `.compact-music-player-mount#music-player-mount`；历史关闭或卸载不能把播放器挪回 composer fallback，但播放器视觉显隐必须跟随历史打开、closing、closed 状态，也不能被通用 `#music-player-mount` 样式撑成超过 compact surface 的横向尺寸；音量弹层展开/收起时必须刷新 compact geometry，避免浮出播放器原生矩形的滑块看得见但不可点。
 
 ### NEKO-PC 桌面壳
 
@@ -373,7 +373,7 @@ Compact 历史默认在初次启动时显示。历史列表本身由常驻展开
 13. 操作栏隐藏时退出选择模式：必须清空当前选中项，并禁止继续通过点击或键盘选择；拖拽源识别和拖拽发送不受这个选择模式限制。
 14. 操作栏包含选择和导出动作，如计数、全选、取消/清空、反选、导出预览等；操作栏自身进入 history hit region。
 15. 选择状态、导出预览和操作栏显示状态由 React state 管理；操作栏状态可以跨历史显隐保留，但只在历史实际打开时算作可见。
-16. 音乐播放器有独立 `.compact-music-player-mount#music-player-mount`，它与历史消息面板分离并作为 `musicPlayer` 几何项进入 compact surface；历史关闭/卸载后播放器必须继续停留在该独立挂载点，但视觉上要随历史一起收起和展开；横向尺寸必须限制在 compact surface 宽度内；历史记录底部必须为播放器高度和阴影预留间距，不能与播放器重叠。
+16. 音乐播放器有独立 `.compact-music-player-mount#music-player-mount`，它与历史消息面板分离并作为 `musicPlayer` 几何项进入 compact surface；历史关闭/卸载后播放器必须继续停留在该独立挂载点，但视觉上要随历史一起收起和展开；横向尺寸必须限制在 compact surface 宽度内；历史记录底部必须为播放器高度和阴影预留间距，不能与播放器重叠；音量滑块展开到播放器外侧时要触发 geometry refresh。
 17. 预览关闭时要清理 stale export error 和必要 preview lifecycle 状态，避免重新打开显示旧错误。
 18. 历史透明区域不能长期遮挡后方；可见气泡、按钮、预览控件和必要滚动区域可命中，气泡间透明区应尽量穿透。
 19. GalGame / ChoicePrompt 出现时，选项层在历史层上方。
@@ -581,7 +581,7 @@ Surface：
 7. 历史透明区不遮挡后方。
 8. 历史关闭动画结束后，历史面板卸载；关闭期间继续发生文字/语音对话时，历史区域不出现新气泡闪现。
 9. 历史重新展开后，关闭期间产生的新消息会按最新 `messages` 正常出现在历史中。
-10. 播放中的音乐栏在 compact 模式下停留在独立播放器挂载点；历史打开时显示，历史 closing / closed 时同步收起且不再命中；历史打开、关闭或卸载都不能把它挪回 composer，横向宽度不能突破 compact surface，历史记录不能贴住或覆盖播放器。
+10. 播放中的音乐栏在 compact 模式下停留在独立播放器挂载点；历史打开时显示，历史 closing / closed 时同步收起且不再命中；历史打开、关闭或卸载都不能把它挪回 composer，横向宽度不能突破 compact surface，历史记录不能贴住或覆盖播放器；音量滑块展开后可以点击和拖拽。
 11. 预览关闭不会保留旧 error。
 
 历史拖拽：

--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -126,7 +126,7 @@
    - 监听 `neko:compact-surface-drag-grab`（来自 React 工具轮盘原点拖拽），非 Electron 时以事件坐标为锚启动 compact surface 本体拖拽（复用既有 startDrag/全局 mousemove/mouseup 与落点 click 守卫）。Electron 由 `preload-chat-react.js` 监听同一事件改走原生窗口拖拽。
 5. `static/app-buttons.js` 是发送桥之一。compact history 文本发送必须带清晰 session / request 语义，不能让已有 composer 附件在 deferred send 中被误带上。
 6. 语音模式 / `composerHidden` 下的 history drop 只保留前端拖拽、命中和收束动效；真实发送必须在 `sendCompactHistoryDropPayload` 边界跳过，不能通过改 React 拖拽 phase 或样式来伪装。
-7. `static/music_ui.js` 的音乐播放器优先挂到打开且可交互的 `.compact-export-history-music-mount`；历史关闭或卸载后应回落到 composer 内唯一 `#music-player-mount`。不要为了保住音乐挂载点让整个历史消息面板长期常驻。
+7. `static/music_ui.js` 的音乐播放器在 compact 模式下优先挂到常驻 `.compact-music-player-mount#music-player-mount`；历史关闭或卸载只影响消息面板，不能把播放器挪回 composer fallback，也不能被通用 `#music-player-mount` 样式撑成超过 compact surface 的横向尺寸。
 
 ### NEKO-PC 桌面壳
 
@@ -368,12 +368,12 @@ Compact 历史默认在初次启动时显示。历史列表本身由常驻展开
 8. 常驻 `.compact-history-visibility-handle` 只控制历史列表显隐；它关闭历史时不清除操作栏打开状态。
 9. 工具转轮历史/导出按钮控制操作栏显示；如果历史关闭时点击该按钮，应先打开历史并显示操作栏。
 10. 历史关闭后可以播放 closing 动画；动画结束后历史面板必须卸载。关闭期间新增的文字/语音消息不得进入历史面板 DOM，也不得在历史区域短暂闪现；重新打开历史时再按最新 `messages` 完整渲染。
-11. closing 期间历史气泡、操作栏、音乐 mount 和预览控件都不进入 history hit region，不保留按钮语义、键盘焦点或透明命中区。
+11. closing 期间历史气泡、操作栏和预览控件都不进入 history hit region，不保留按钮语义、键盘焦点或透明命中区。
 12. 操作栏显示期间进入选择模式：气泡点击 / 键盘 Enter / Space 可以选中或取消选中历史消息。
 13. 操作栏隐藏时退出选择模式：必须清空当前选中项，并禁止继续通过点击或键盘选择；拖拽源识别和拖拽发送不受这个选择模式限制。
 14. 操作栏包含选择和导出动作，如计数、全选、取消/清空、反选、导出预览等；操作栏自身进入 history hit region。
 15. 选择状态、导出预览和操作栏显示状态由 React state 管理；操作栏状态可以跨历史显隐保留，但只在历史实际打开时算作可见。
-16. 历史面板内有专用 `.compact-export-history-music-mount`，只在历史打开且可交互时作为音乐播放器优先挂载点；关闭/卸载后播放器必须回落到 composer 的 `#music-player-mount`。
+16. 音乐播放器有独立 `.compact-music-player-mount#music-player-mount`，它与历史消息面板分离并作为 `musicPlayer` 几何项进入 compact surface；历史关闭/卸载后播放器必须继续停留在该独立挂载点，横向尺寸必须限制在 compact surface 宽度内；历史记录底部必须为播放器高度和阴影预留间距，不能与播放器重叠。
 17. 预览关闭时要清理 stale export error 和必要 preview lifecycle 状态，避免重新打开显示旧错误。
 18. 历史透明区域不能长期遮挡后方；可见气泡、按钮、预览控件和必要滚动区域可命中，气泡间透明区应尽量穿透。
 19. GalGame / ChoicePrompt 出现时，选项层在历史层上方。
@@ -581,7 +581,7 @@ Surface：
 7. 历史透明区不遮挡后方。
 8. 历史关闭动画结束后，历史面板卸载；关闭期间继续发生文字/语音对话时，历史区域不出现新气泡闪现。
 9. 历史重新展开后，关闭期间产生的新消息会按最新 `messages` 正常出现在历史中。
-10. 播放中的音乐栏在历史打开时可挂到历史面板，历史关闭/卸载后能回落到 composer 挂载点。
+10. 播放中的音乐栏在 compact 模式下停留在独立播放器挂载点；历史打开、关闭或卸载都不能把它挪回 composer，横向宽度不能突破 compact surface，历史记录不能贴住或覆盖播放器。
 11. 预览关闭不会保留旧 error。
 
 历史拖拽：

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -405,11 +405,13 @@ describe('App', () => {
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-id', 'history:message:assistant-history-1');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-kind', 'message');
     expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
-    expect(container.querySelector('.composer-panel #music-player-mount')).not.toBeNull();
+    expect(container.querySelector('.compact-music-player-mount#music-player-mount')).not.toBeNull();
+    expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-music-player-mount', 'compact-surface');
+    expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-geometry-item', 'musicPlayer');
+    expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-geometry-hit-scope', 'children');
+    expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
     expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
-    expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-music-player-mount', 'compact-history');
-    expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-id', 'history:music-player');
-    expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-kind', 'music');
+    expect(container.querySelector('.compact-export-history-music-mount')).toBeNull();
     expect(container.querySelector('.compact-export-history-controls')).toBeNull();
     expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('data-compact-geometry-item', 'historyHandle');
     expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('aria-expanded', 'true');
@@ -451,7 +453,7 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('aria-disabled', 'true');
       expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('tabindex', '-1');
       expect(container.querySelector('.compact-export-history-bubble')).not.toHaveAttribute('data-compact-hit-region');
-      expect(container.querySelector('.compact-export-history-music-mount')).not.toHaveAttribute('data-compact-hit-region');
+      expect(container.querySelector('.compact-export-history-music-mount')).toBeNull();
       expect(container.querySelector('.compact-export-history-controls')).toHaveAttribute('aria-disabled', 'true');
       expect(container.querySelector('.compact-export-history-controls')).not.toHaveAttribute('data-compact-hit-region');
       container.querySelectorAll<HTMLButtonElement>('.compact-export-history-control').forEach((button) => {
@@ -465,7 +467,8 @@ describe('App', () => {
 
       expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
       expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
-      expect(container.querySelector('.composer-panel #music-player-mount')).not.toBeNull();
+      expect(container.querySelector('.compact-music-player-mount#music-player-mount')).not.toBeNull();
+      expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
       expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
       expect(container.querySelector('[data-compact-hit-region-id^="history:"]')).toBeNull();
 
@@ -473,7 +476,7 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'open');
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-open', 'true');
-      expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-compact-hit-region-id', 'history:music-player');
+      expect(container.querySelector('.compact-export-history-music-mount')).toBeNull();
       expect(container.querySelector('.compact-export-history-controls')).toHaveAttribute('data-compact-hit-region-id', 'history:controls');
       expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('aria-expanded', 'true');
       expect(exportButton).toHaveAttribute('aria-pressed', 'true');
@@ -588,14 +591,16 @@ describe('App', () => {
       expect(handle).toHaveAttribute('aria-expanded', 'false');
       expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
       expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
-      expect(container.querySelector('.composer-panel #music-player-mount')).not.toBeNull();
+      expect(container.querySelector('.compact-music-player-mount#music-player-mount')).not.toBeNull();
+      expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
 
       fireEvent.pointerDown(handle!, { pointerType: 'mouse', button: 0 });
       expect(handle).toHaveAttribute('aria-expanded', 'true');
       expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
       expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
       expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
-      expect(container.querySelector('.compact-export-history-music-mount')).toHaveAttribute('data-music-player-mount', 'compact-history');
+      expect(container.querySelector('.compact-export-history-music-mount')).toBeNull();
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-music-player-mount', 'compact-surface');
       expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBe('true');
       expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
 

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -407,6 +407,8 @@ describe('App', () => {
     expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
     expect(container.querySelector('.compact-music-player-mount#music-player-mount')).not.toBeNull();
     expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-music-player-mount', 'compact-surface');
+    expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-music-player-visibility', 'open');
+    expect(container.querySelector('.compact-music-player-mount')).not.toHaveAttribute('aria-hidden');
     expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-geometry-item', 'musicPlayer');
     expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-geometry-hit-scope', 'children');
     expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
@@ -446,6 +448,8 @@ describe('App', () => {
 
       fireEvent.click(container.querySelector<HTMLButtonElement>('.compact-history-visibility-handle')!);
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'closing');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-music-player-visibility', 'closing');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('aria-hidden', 'true');
       expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('aria-expanded', 'false');
       expect(exportButton).toHaveAttribute('aria-pressed', 'false');
       expect(container.querySelector('.compact-export-history-bubble')).not.toHaveAttribute('role');
@@ -468,6 +472,8 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
       expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
       expect(container.querySelector('.compact-music-player-mount#music-player-mount')).not.toBeNull();
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-music-player-visibility', 'closed');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('aria-hidden', 'true');
       expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
       expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
       expect(container.querySelector('[data-compact-hit-region-id^="history:"]')).toBeNull();
@@ -476,6 +482,8 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'open');
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-open', 'true');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-music-player-visibility', 'open');
+      expect(container.querySelector('.compact-music-player-mount')).not.toHaveAttribute('aria-hidden');
       expect(container.querySelector('.compact-export-history-music-mount')).toBeNull();
       expect(container.querySelector('.compact-export-history-controls')).toHaveAttribute('data-compact-hit-region-id', 'history:controls');
       expect(container.querySelector('.compact-history-visibility-handle')).toHaveAttribute('aria-expanded', 'true');
@@ -592,6 +600,8 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-anchor')).toBeNull();
       expect(container.querySelectorAll('#music-player-mount')).toHaveLength(1);
       expect(container.querySelector('.compact-music-player-mount#music-player-mount')).not.toBeNull();
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-music-player-visibility', 'closed');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('aria-hidden', 'true');
       expect(container.querySelector('.composer-panel #music-player-mount')).toBeNull();
 
       fireEvent.pointerDown(handle!, { pointerType: 'mouse', button: 0 });
@@ -601,6 +611,8 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-panel #music-player-mount')).toBeNull();
       expect(container.querySelector('.compact-export-history-music-mount')).toBeNull();
       expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-music-player-mount', 'compact-surface');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-music-player-visibility', 'open');
+      expect(container.querySelector('.compact-music-player-mount')).not.toHaveAttribute('aria-hidden');
       expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBe('true');
       expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
 
@@ -610,6 +622,8 @@ describe('App', () => {
       fireEvent.pointerDown(handle!, { pointerType: 'mouse', button: 0 });
       expect(handle).toHaveAttribute('aria-expanded', 'false');
       expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'closing');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('data-compact-music-player-visibility', 'closing');
+      expect(container.querySelector('.compact-music-player-mount')).toHaveAttribute('aria-hidden', 'true');
       expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBe('false');
 
       fireEvent.click(handle!);

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5209,6 +5209,17 @@ export default function App({
       <span className="compact-history-visibility-handle-triangle" aria-hidden="true" />
     </button>
   ) : null;
+  const compactMusicPlayerMountNode = isCompactSurface ? (
+    <div
+      id="music-player-mount"
+      className="compact-music-player-mount"
+      data-music-player-mount="compact-surface"
+      data-compact-geometry-owner="surface"
+      data-compact-geometry-item="musicPlayer"
+      data-compact-geometry-hit-scope="children"
+      data-compact-no-drag="true"
+    />
+  ) : null;
   const compactSurfaceShellStyle = isCompactSurface
     && compactSurfaceEffectiveWidth !== null
     && !isDesktopCompactSurfaceLayoutActive()
@@ -5250,6 +5261,7 @@ export default function App({
     >
       {compactExportHistoryNode}
       {compactHistoryVisibilityHandleNode}
+      {compactMusicPlayerMountNode}
       {compactChoiceLayerNode}
       {floatingFistDrops.map(drop => (
         <span
@@ -5375,7 +5387,7 @@ export default function App({
           data-chat-surface-mode={chatSurfaceMode}
           data-compact-chat-state={effectiveCompactChatState}
         >
-          <div id="music-player-mount" className="composer-music-player-mount" />
+          {!isCompactSurface ? <div id="music-player-mount" className="composer-music-player-mount" /> : null}
           <form className="composer" onSubmit={(event) => {
             event.preventDefault();
             submitDraft();

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5209,15 +5209,20 @@ export default function App({
       <span className="compact-history-visibility-handle-triangle" aria-hidden="true" />
     </button>
   ) : null;
+  const compactMusicPlayerVisibility = compactExportHistoryOpen
+    ? 'open'
+    : (compactExportHistoryMounted ? 'closing' : 'closed');
   const compactMusicPlayerMountNode = isCompactSurface ? (
     <div
       id="music-player-mount"
       className="compact-music-player-mount"
       data-music-player-mount="compact-surface"
+      data-compact-music-player-visibility={compactMusicPlayerVisibility}
       data-compact-geometry-owner="surface"
       data-compact-geometry-item="musicPlayer"
       data-compact-geometry-hit-scope="children"
       data-compact-no-drag="true"
+      aria-hidden={compactMusicPlayerVisibility === 'open' ? undefined : true}
     />
   ) : null;
   const compactSurfaceShellStyle = isCompactSurface

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -2439,13 +2439,6 @@ export default function CompactExportHistoryPanel({
                 </div>
               ) : null}
             </div>
-            <div
-              className="compact-export-history-music-mount"
-              data-music-player-mount="compact-history"
-              data-compact-hit-region={historyInteractive ? 'true' : undefined}
-              data-compact-hit-region-id={historyInteractive ? 'history:music-player' : undefined}
-              data-compact-hit-region-kind={historyInteractive ? 'music' : undefined}
-            />
             {controlsOpen ? (
               <div
                 className="compact-export-history-controls"

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2975,6 +2975,14 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   -webkit-app-region: no-drag;
 }
 
+/* 音量弹层展开时滑块会向上伸进 history 区域：播放器常驻 z-index:8 低于
+   history-anchor(100001)，重叠处 history 会盖住滑块上半部并抢走点击。展开态
+   把播放器整体提到 history 之上，但仍低于工具轮盘展开态的 surface-shell(100003)，
+   不影响工具轮盘对表情按钮的让位。 */
+#music-player-mount.compact-music-player-mount:has(.music-bar-volume-container.expanded) {
+  z-index: 100002;
+}
+
 #music-player-mount.compact-music-player-mount:empty {
   display: none;
 }

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1934,6 +1934,9 @@ svg {
 }
 
 .app-shell.chat-surface-mode-compact {
+  --compact-music-player-offset-y: 12px;
+  --compact-music-player-reserved-block-size: 88px;
+  --compact-music-player-history-gap: 14px;
   height: auto;
   position: relative;
   overflow: visible;
@@ -2362,7 +2365,6 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-scroll,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-controls,
-.compact-export-history-anchor.under-choice-prompt .compact-export-history-music-mount,
 .compact-export-history-anchor.under-choice-prompt .compact-export-preview-region {
   opacity: 0.32;
   filter: blur(1.5px);
@@ -2372,12 +2374,6 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-bubble,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-empty {
-  pointer-events: none;
-}
-
-.compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper {
-  opacity: 0;
-  visibility: hidden;
   pointer-events: none;
 }
 
@@ -2467,17 +2463,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .compact-export-history-controls,
-.compact-export-history-anchor[data-compact-export-history-visibility="closing"] .compact-export-history-music-mount,
 .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .compact-export-preview-region {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
-}
-
-.compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper {
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
 }
 
 @keyframes compact-history-message-enter {
@@ -2938,7 +2927,6 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 .compact-export-history-controls,
-.compact-export-history-music-mount,
 .compact-export-preview-region {
   display: flex;
   align-items: center;
@@ -2957,10 +2945,15 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   -webkit-app-region: no-drag;
 }
 
-.compact-export-history-music-mount {
+#music-player-mount.compact-music-player-mount {
+  --compact-music-player-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));
+  position: fixed;
+  left: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-music-player-surface-width) / 2));
+  bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + var(--compact-music-player-offset-y, 12px));
   box-sizing: border-box;
   display: block;
-  width: 100%;
+  width: min(calc(var(--compact-music-player-surface-width) - 16px), 360px, calc(100vw - 24px));
+  max-width: min(calc(var(--compact-music-player-surface-width) - 16px), calc(100vw - 24px));
   min-width: 0;
   margin: 0;
   padding: 0 6px;
@@ -2969,16 +2962,33 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background: transparent;
   box-shadow: none;
   overflow: visible;
+  pointer-events: auto;
+  transform: translateX(-50%);
+  z-index: 8;
+  -webkit-app-region: no-drag;
 }
 
-.compact-export-history-music-mount:empty {
+#music-player-mount.compact-music-player-mount:empty {
   display: none;
 }
 
-/* 历史面板内播放器：覆盖独立播放器的深色样式，贴合聊天记录的玻璃质感。 */
-.compact-export-history-music-mount > .music-player-bar {
+.app-shell:has(> .compact-music-player-mount:not(:empty)) .compact-export-history-anchor {
+  bottom: calc(
+    100vh
+    - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh))
+    + var(--compact-music-player-offset-y, 12px)
+    + var(--compact-music-player-reserved-block-size, 88px)
+    + var(--compact-music-player-history-gap, 14px)
+  );
+}
+
+/* 紧凑独立播放器：覆盖独立播放器的深色样式，贴合聊天记录的玻璃质感。 */
+#music-player-mount.compact-music-player-mount > .music-player-bar {
+  flex: 0 1 auto;
   width: 100%;
+  max-width: 100%;
   min-width: 0;
+  max-inline-size: 100%;
   margin: 0;
   padding: 7px 8px;
   gap: 8px;
@@ -2992,83 +3002,104 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   -webkit-backdrop-filter: blur(10px) saturate(1.08);
 }
 
-.compact-export-history-music-mount .music-bar-cover {
+#music-player-mount.compact-music-player-mount .music-bar-cover {
+  flex: 0 0 32px;
   width: 32px;
   height: 32px;
+  min-width: 32px;
   border-radius: 8px;
   box-shadow: 0 4px 10px rgba(52, 100, 148, 0.18);
 }
 
-.compact-export-history-music-mount .music-bar-cover img {
+#music-player-mount.compact-music-player-mount .music-bar-cover img {
   border-radius: 8px;
 }
 
-.compact-export-history-music-mount .music-bar-info {
+#music-player-mount.compact-music-player-mount .music-bar-info {
+  flex: 1 1 0;
   align-items: stretch;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   text-align: left;
 }
 
-.compact-export-history-music-mount .music-bar-title-wrap {
+#music-player-mount.compact-music-player-mount .music-bar-title-wrap {
+  min-width: 0;
+  max-width: 100%;
   margin-bottom: 1px;
 }
 
-.compact-export-history-music-mount .music-bar-title-seg {
+#music-player-mount.compact-music-player-mount .music-bar-title-seg {
   color: #273042;
   font-size: 0.78rem;
   font-weight: 700;
 }
 
-.compact-export-history-music-mount .music-bar-artist,
-.compact-export-history-music-mount .music-bar-time {
+#music-player-mount.compact-music-player-mount .music-bar-artist,
+#music-player-mount.compact-music-player-mount .music-bar-time {
+  min-width: 0;
+  max-width: 100%;
   color: #5d7797;
 }
 
-.compact-export-history-music-mount .music-bar-artist {
+#music-player-mount.compact-music-player-mount .music-bar-artist {
   font-size: 0.68rem;
 }
 
-.compact-export-history-music-mount .music-bar-time {
+#music-player-mount.compact-music-player-mount .music-bar-time {
   font-size: 0.64rem;
 }
 
-.compact-export-history-music-mount .music-bar-progress-container {
+#music-player-mount.compact-music-player-mount .music-bar-progress-container {
+  min-width: 0;
+  max-width: 100%;
   height: 4px;
   margin: 4px 0 2px;
   background: rgba(101, 136, 176, 0.16);
 }
 
-.compact-export-history-music-mount .music-bar-progress-fill {
+#music-player-mount.compact-music-player-mount .music-bar-progress-fill {
   background: linear-gradient(90deg, rgba(76, 176, 255, 0.88), rgba(112, 205, 239, 0.76));
 }
 
-.compact-export-history-music-mount .music-bar-play,
-.compact-export-history-music-mount .music-bar-volume-btn {
+#music-player-mount.compact-music-player-mount .music-bar-play,
+#music-player-mount.compact-music-player-mount .music-bar-volume-btn {
+  flex: 0 0 28px;
   width: 28px;
   height: 28px;
+  min-width: 28px;
   color: #eaf7ff;
   background: linear-gradient(135deg, #2f8fcd, #56c5e8);
   box-shadow: 0 5px 12px rgba(44, 122, 184, 0.2);
 }
 
-.compact-export-history-music-mount .music-bar-volume-btn {
+#music-player-mount.compact-music-player-mount .music-bar-volume-container {
+  flex: 0 0 28px;
+  min-width: 28px;
+}
+
+#music-player-mount.compact-music-player-mount .music-bar-volume-btn {
   color: #2f6f9f;
   background: rgba(255, 255, 255, 0.72);
   box-shadow: inset 0 0 0 1px rgba(100, 184, 255, 0.16);
 }
 
-.compact-export-history-music-mount .music-bar-close {
+#music-player-mount.compact-music-player-mount .music-bar-close {
+  flex: 0 0 22px;
   width: 22px;
   height: 22px;
+  min-width: 22px;
   color: rgba(93, 119, 151, 0.76);
   background: rgba(255, 255, 255, 0.58);
 }
 
-.compact-export-history-music-mount .music-bar-close:hover {
+#music-player-mount.compact-music-player-mount .music-bar-close:hover {
   color: #2f6f9f;
   background: rgba(220, 242, 255, 0.94);
 }
 
-.compact-export-history-music-mount .music-bar-volume-slider-wrapper {
+#music-player-mount.compact-music-player-mount .music-bar-volume-slider-wrapper {
   bottom: 36px;
   border: 1px solid rgba(100, 184, 255, 0.18);
   border-radius: 8px;
@@ -3076,15 +3107,15 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   box-shadow: 0 10px 22px rgba(22, 48, 84, 0.14);
 }
 
-.compact-export-history-music-mount .music-bar-volume-slider {
+#music-player-mount.compact-music-player-mount .music-bar-volume-slider {
   background: rgba(101, 136, 176, 0.18);
 }
 
-.compact-export-history-music-mount .music-bar-volume-slider-fill {
+#music-player-mount.compact-music-player-mount .music-bar-volume-slider-fill {
   background: linear-gradient(to top, rgba(76, 176, 255, 0.9), rgba(112, 205, 239, 0.8));
 }
 
-.compact-export-history-music-mount .music-bar-volume-slider-handle {
+#music-player-mount.compact-music-player-mount .music-bar-volume-slider-handle {
   background: #f8fcff;
   box-shadow: 0 0 0 1px rgba(72, 152, 220, 0.2), 0 3px 8px rgba(22, 48, 84, 0.16);
 }
@@ -4665,43 +4696,42 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 [data-theme="dark"] .compact-export-history-controls,
-[data-theme="dark"] .compact-export-history-music-mount,
 [data-theme="dark"] .compact-export-preview-region {
   border-color: rgba(116, 187, 255, 0.22);
   background: rgba(23, 35, 50, 0.28);
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.22);
 }
 
-[data-theme="dark"] .compact-export-history-music-mount {
+[data-theme="dark"] #music-player-mount.compact-music-player-mount {
   border: 0;
   background: transparent;
   box-shadow: none;
 }
 
-[data-theme="dark"] .compact-export-history-music-mount > .music-player-bar {
+[data-theme="dark"] #music-player-mount.compact-music-player-mount > .music-player-bar {
   border-color: rgba(116, 187, 255, 0.22);
   background: rgba(33, 45, 62, 0.88);
   color: #e8f0fb;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
 }
 
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-title-seg {
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-title-seg {
   color: #e8f0fb;
 }
 
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-artist,
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-time {
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-artist,
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-time {
   color: rgba(210, 225, 244, 0.72);
 }
 
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-progress-container,
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-volume-slider {
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-progress-container,
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-volume-slider {
   background: rgba(202, 224, 248, 0.16);
 }
 
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-volume-btn,
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-close,
-[data-theme="dark"] .compact-export-history-music-mount .music-bar-volume-slider-wrapper {
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-volume-btn,
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-close,
+[data-theme="dark"] #music-player-mount.compact-music-player-mount .music-bar-volume-slider-wrapper {
   border-color: rgba(116, 187, 255, 0.18);
   background: rgba(26, 48, 70, 0.86);
   color: #bfe2ff;
@@ -4820,7 +4850,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   .message-row-assistant,
   .compact-export-history-message,
   .compact-export-history-bubble,
-  .compact-export-history-music-mount,
+  .compact-music-player-mount,
   .compact-history-visibility-handle::before,
   .compact-history-visibility-handle::after,
   .text-chunk-reveal,

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2962,14 +2962,34 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background: transparent;
   box-shadow: none;
   overflow: visible;
+  opacity: 1;
+  visibility: visible;
   pointer-events: auto;
   transform: translateX(-50%);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0s linear 0s;
   z-index: 8;
   -webkit-app-region: no-drag;
 }
 
 #music-player-mount.compact-music-player-mount:empty {
   display: none;
+}
+
+#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"],
+#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"] {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(8px);
+}
+
+#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"] {
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0s linear 0.2s;
+}
+
+#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"] *,
+#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"] * {
+  pointer-events: none;
 }
 
 .app-shell:has(> .compact-music-player-mount:not(:empty)) .compact-export-history-anchor {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1404,7 +1404,9 @@
                 if (style && Number(style.opacity) <= 0.01) return null;
                 var rect = normalizeCompactDomRect(child.getBoundingClientRect());
                 if (!rect) return null;
-                var clippedRect = parentRect ? intersectCompactRects(rect, parentRect) : rect;
+                var clippedRect = kind === 'musicPlayer'
+                    ? rect
+                    : (parentRect ? intersectCompactRects(rect, parentRect) : rect);
                 if (!clippedRect) return null;
                 var interactive = style ? style.pointerEvents !== 'none' : true;
                 if (!interactive) return null;
@@ -5622,6 +5624,9 @@
             applyCompactSurfaceResizeRequest(event.detail || {});
         }, true);
         window.addEventListener('neko:compact-surface-resize-width-change', function () {
+            syncCompactInteractionGeometry();
+        });
+        window.addEventListener('neko:compact-interaction-geometry-refresh', function () {
             syncCompactInteractionGeometry();
         });
     }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1194,7 +1194,7 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
 }
 
 /* 紧凑历史面板点击穿透契约：上方通用规则会重新开启 surface 子节点命中，
-   因此透明包装层必须回到 none，只保留气泡、控制区、播放器和预览可交互。 */
+   因此透明包装层必须回到 none，只保留气泡、控制区和预览可交互。 */
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount * {
     pointer-events: auto;
@@ -1210,14 +1210,8 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-bubble,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-controls,
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-music-mount,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-preview-region {
     pointer-events: auto;
-}
-
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper,
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper {
-    pointer-events: none;
 }
 
 /* compact 态不再把最小化按钮渲染成模型旁的悬浮球：呼吸灯外发光会被 Electron 窗口形状裁切，

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1200,6 +1200,13 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     pointer-events: auto;
 }
 
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"],
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"] *,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"],
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"] * {
+    pointer-events: none;
+}
+
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-anchor,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-panel,
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-scroll,

--- a/static/css/music_ui.css
+++ b/static/css/music_ui.css
@@ -57,6 +57,58 @@
     border-radius: 12px 12px 0 0;
 }
 
+/* 紧凑聊天独立挂载点必须压过上方 ID 通用宽度，避免播放器撑成整屏。 */
+#music-player-mount.compact-music-player-mount {
+    --compact-music-player-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));
+    width: min(calc(var(--compact-music-player-surface-width) - 16px), 360px, calc(100vw - 24px));
+    max-width: min(calc(var(--compact-music-player-surface-width) - 16px), calc(100vw - 24px));
+    min-width: 0;
+    box-sizing: border-box;
+}
+
+#music-player-mount.compact-music-player-mount > .music-player-bar {
+    flex: 0 1 auto;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    max-inline-size: 100%;
+    box-sizing: border-box;
+}
+
+#music-player-mount.compact-music-player-mount .music-bar-info,
+#music-player-mount.compact-music-player-mount .music-bar-title-wrap,
+#music-player-mount.compact-music-player-mount .music-bar-artist,
+#music-player-mount.compact-music-player-mount .music-bar-time,
+#music-player-mount.compact-music-player-mount .music-bar-progress-container {
+    min-width: 0;
+    max-width: 100%;
+}
+
+#music-player-mount.compact-music-player-mount .music-bar-info {
+    flex: 1 1 0;
+}
+
+#music-player-mount.compact-music-player-mount .music-bar-cover {
+    flex: 0 0 32px;
+    min-width: 32px;
+}
+
+#music-player-mount.compact-music-player-mount .music-bar-play,
+#music-player-mount.compact-music-player-mount .music-bar-volume-btn {
+    flex: 0 0 28px;
+    min-width: 28px;
+}
+
+#music-player-mount.compact-music-player-mount .music-bar-volume-container {
+    flex: 0 0 28px;
+    min-width: 28px;
+}
+
+#music-player-mount.compact-music-player-mount .music-bar-close {
+    flex: 0 0 22px;
+    min-width: 22px;
+}
+
 .music-player-bar.fading-out {
     animation: musicBarFadeOut 0.2s ease forwards;
 }

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -439,6 +439,14 @@
             || node.getAttribute('data-music-player-mount') === 'compact-surface';
     }
 
+    function isCompactMusicGeometryMutationTarget(node) {
+        if (!(node instanceof Element)) return false;
+        const compactMusicMount = node.closest && node.closest('[data-music-player-mount="compact-surface"]');
+        if (!compactMusicMount) return false;
+        return node.classList.contains('music-bar-volume-container')
+            || node.classList.contains('music-bar-volume-slider-wrapper');
+    }
+
     function scheduleMusicBarRelocation(detachedMusicBar) {
         if (detachedMusicBar) pendingDetachedMusicBar = detachedMusicBar;
         if (musicMountRelocationFrame) return;
@@ -457,6 +465,10 @@
             for (const mutation of mutations) {
                 if (mutation.type === 'attributes' && isMusicMountMutationTarget(mutation.target)) {
                     scheduleMusicBarRelocation();
+                    return;
+                }
+                if (mutation.type === 'attributes' && isCompactMusicGeometryMutationTarget(mutation.target)) {
+                    requestCompactMusicGeometrySync();
                     return;
                 }
                 for (const node of mutation.removedNodes) {
@@ -514,7 +526,10 @@
 
         if (volumeBtn) volumeBtn.onclick = (e) => {
             e.preventDefault(); e.stopPropagation();
-            if (volumeContainer) volumeContainer.classList.toggle('expanded');
+            if (volumeContainer) {
+                volumeContainer.classList.toggle('expanded');
+                requestCompactMusicGeometrySync();
+            }
         };
 
         if (volumeSliderWrapper && volumeSlider) {
@@ -634,6 +649,7 @@
             const closeOnOutside = (e) => {
                 if (volumeContainer.classList.contains('expanded') && !volumeContainer.contains(e.target)) {
                     volumeContainer.classList.remove('expanded');
+                    requestCompactMusicGeometrySync();
                 }
             };
             document.addEventListener('mousedown', closeOnOutside);
@@ -1747,6 +1763,7 @@
                     e.preventDefault();
                     e.stopPropagation();
                     volumeContainer.classList.toggle('expanded');
+                    requestCompactMusicGeometrySync();
                 };
 
                 let isDraggingVolume = false;
@@ -1811,6 +1828,7 @@
                 const closeVolumeOnOutsideClick = (e) => {
                     if (volumeContainer.classList.contains('expanded') && !volumeContainer.contains(e.target)) {
                         volumeContainer.classList.remove('expanded');
+                        requestCompactMusicGeometrySync();
                     }
                 };
                 addManagedListener('mousedown', closeVolumeOnOutsideClick);

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -353,24 +353,17 @@
 
     let musicMountObserver = null;
     let musicMountRelocationFrame = 0;
+    let musicMountGeometryFrame = 0;
     let pendingDetachedMusicBar = null;
 
-    function isCompactHistoryMusicMountInteractive(mount) {
-        if (!(mount instanceof Element)) return false;
-        if (mount.getAttribute('data-compact-hit-region') !== 'true') return false;
-        const anchor = mount.closest ? mount.closest('.compact-export-history-anchor') : null;
-        if (anchor && anchor.getAttribute('data-compact-export-history-visibility') !== 'open') return false;
-        if (window.getComputedStyle) {
-            const style = window.getComputedStyle(mount);
-            if (style && (style.display === 'none' || style.visibility === 'hidden' || style.pointerEvents === 'none')) return false;
-            if (style && Number(style.opacity) <= 0.01) return false;
-        }
-        return true;
+    function getCompactMusicMountTarget() {
+        const compactMount = document.querySelector('[data-music-player-mount="compact-surface"]');
+        return compactMount instanceof Element ? compactMount : null;
     }
 
     function getPreferredMusicMountTarget() {
-        const historyMount = document.querySelector('.compact-export-history-music-mount');
-        if (isCompactHistoryMusicMountInteractive(historyMount)) return { mountTarget: historyMount, insertBeforeEl: null };
+        const compactMount = getCompactMusicMountTarget();
+        if (compactMount) return { mountTarget: compactMount, insertBeforeEl: null };
 
         const reactMount = document.getElementById('music-player-mount');
         if (reactMount) return { mountTarget: reactMount, insertBeforeEl: null };
@@ -382,18 +375,39 @@
         };
     }
 
+    function requestCompactMusicGeometrySync() {
+        if (musicMountGeometryFrame) return;
+        const raf = window.requestAnimationFrame || ((callback) => window.setTimeout(callback, 16));
+        musicMountGeometryFrame = raf(() => {
+            musicMountGeometryFrame = 0;
+            window.dispatchEvent(new CustomEvent('neko:compact-interaction-geometry-refresh'));
+        });
+    }
+
+    function prepareMusicBarHitRegion(musicBar) {
+        if (!musicBar) return;
+        musicBar.setAttribute('data-compact-hit-region', 'true');
+        musicBar.setAttribute('data-compact-hit-region-id', 'music-player');
+        musicBar.setAttribute('data-compact-hit-region-kind', 'music');
+    }
+
     function mountMusicBar(musicBar) {
         if (!musicBar) return false;
         ensureMusicMountObserver();
         if (musicBar.dataset) delete musicBar.dataset.skipMountRelocation;
+        prepareMusicBarHitRegion(musicBar);
         const target = getPreferredMusicMountTarget();
         if (!target || !target.mountTarget) return false;
-        if (musicBar.parentNode === target.mountTarget) return true;
+        if (musicBar.parentNode === target.mountTarget) {
+            requestCompactMusicGeometrySync();
+            return true;
+        }
         if (target.insertBeforeEl && target.insertBeforeEl.parentNode === target.mountTarget) {
             target.mountTarget.insertBefore(musicBar, target.insertBeforeEl);
         } else {
             target.mountTarget.appendChild(musicBar);
         }
+        requestCompactMusicGeometrySync();
         return true;
     }
 
@@ -401,6 +415,7 @@
         if (!musicBar) return;
         if (musicBar.dataset) musicBar.dataset.skipMountRelocation = 'true';
         musicBar.remove();
+        requestCompactMusicGeometrySync();
     }
 
     function findMusicBarInNode(node) {
@@ -414,16 +429,14 @@
 
     function isMusicMountMutationNode(node) {
         if (!(node instanceof Element)) return false;
-        if (node.id === 'music-player-mount' || node.classList.contains('compact-export-history-music-mount')) return true;
-        return !!(node.querySelector && node.querySelector('#music-player-mount, .compact-export-history-music-mount'));
+        if (node.id === 'music-player-mount' || node.getAttribute('data-music-player-mount') === 'compact-surface') return true;
+        return !!(node.querySelector && node.querySelector('#music-player-mount, [data-music-player-mount="compact-surface"]'));
     }
 
     function isMusicMountMutationTarget(node) {
         if (!(node instanceof Element)) return false;
         return node.id === 'music-player-mount'
-            || node.classList.contains('compact-export-history-anchor')
-            || node.classList.contains('compact-export-history-music-mount')
-            || !!(node.closest && node.closest('.compact-export-history-anchor'));
+            || node.getAttribute('data-music-player-mount') === 'compact-surface';
     }
 
     function scheduleMusicBarRelocation(detachedMusicBar) {
@@ -471,8 +484,7 @@
             attributes: true,
             attributeFilter: [
                 'class',
-                'data-compact-export-history-visibility',
-                'data-compact-hit-region',
+                'data-music-player-mount',
                 'style'
             ]
         });
@@ -685,7 +697,7 @@
                 <button type="button" class="music-bar-play" aria-label="Play/Pause" title="Play/Pause">▶</button>
                 <div class="music-bar-volume-container">
                     <button type="button" class="music-bar-volume-btn" aria-label="Volume" title="Volume">🔊</button>
-                    <div class="music-bar-volume-slider-wrapper" data-compact-hit-region="true" data-compact-hit-region-id="history:music-player:volume" data-compact-hit-region-kind="music-volume">
+                    <div class="music-bar-volume-slider-wrapper" data-compact-hit-region="true" data-compact-hit-region-id="music-player:volume" data-compact-hit-region-kind="music-volume">
                         <div class="music-bar-volume-slider">
                             <div class="music-bar-volume-slider-fill"></div>
                             <div class="music-bar-volume-slider-handle"></div>
@@ -1443,7 +1455,7 @@
                 <button type="button" class="music-bar-play" aria-label="Play/Pause" title="Play/Pause">▶</button>
                 <div class="music-bar-volume-container">
                     <button type="button" class="music-bar-volume-btn" aria-label="Volume" title="Volume">🔊</button>
-                    <div class="music-bar-volume-slider-wrapper" data-compact-hit-region="true" data-compact-hit-region-id="history:music-player:volume" data-compact-hit-region-kind="music-volume">
+                    <div class="music-bar-volume-slider-wrapper" data-compact-hit-region="true" data-compact-hit-region-id="music-player:volume" data-compact-hit-region-kind="music-volume">
                         <div class="music-bar-volume-slider">
                             <div class="music-bar-volume-slider-fill"></div>
                             <div class="music-bar-volume-slider-handle"></div>

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -872,6 +872,8 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "compact-export-history-music-mount" not in panel_source
     assert 'className="compact-music-player-mount"' in app_source
     assert 'data-music-player-mount="compact-surface"' in app_source
+    assert 'data-compact-music-player-visibility={compactMusicPlayerVisibility}' in app_source
+    assert "aria-hidden={compactMusicPlayerVisibility === 'open' ? undefined : true}" in app_source
     assert 'data-compact-geometry-item="musicPlayer"' in app_source
     assert 'data-compact-geometry-hit-scope="children"' in app_source
     assert "function getPreferredMusicMountTarget()" in music_ui_source
@@ -891,6 +893,13 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert music_ui_source.count('data-compact-hit-region-kind="music-volume"') == 2
     assert "#music-player-mount.compact-music-player-mount {" in styles
     assert "#music-player-mount.compact-music-player-mount {" in music_ui_styles
+    assert '#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"]' in styles
+    assert '#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"]' in styles
+    assert "visibility: hidden;" in css_block(
+        styles,
+        '#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"] {',
+        '#music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"] *',
+    )
     assert "width: min(calc(var(--compact-music-player-surface-width) - 16px), 360px, calc(100vw - 24px));" in styles
     assert "width: min(calc(var(--compact-music-player-surface-width) - 16px), 360px, calc(100vw - 24px));" in music_ui_styles
     assert "#music-player-mount.compact-music-player-mount > .music-player-bar" in styles
@@ -930,6 +939,14 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
         "    pointer-events: auto;\n"
         "}"
     )
+    compact_music_hidden_rule = (
+        f'{compact_surface_prefix} #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"],\n'
+        f'{compact_surface_prefix} #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"] *,\n'
+        f'{compact_surface_prefix} #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"],\n'
+        f'{compact_surface_prefix} #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closed"] * {{\n'
+        "    pointer-events: none;\n"
+        "}"
+    )
     history_passthrough_rule = (
         f'{compact_surface_prefix} .compact-export-history-anchor,\n'
         f'{compact_surface_prefix} .compact-export-history-panel,\n'
@@ -949,10 +966,12 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
 
     assert broad_surface_rule in styles
     assert compact_music_interactive_rule in styles
+    assert compact_music_hidden_rule in styles
     assert history_passthrough_rule in styles
     assert history_interactive_rule in styles
     assert styles.index(broad_surface_rule) < styles.index(compact_music_interactive_rule)
-    assert styles.index(compact_music_interactive_rule) < styles.index(history_passthrough_rule)
+    assert styles.index(compact_music_interactive_rule) < styles.index(compact_music_hidden_rule)
+    assert styles.index(compact_music_hidden_rule) < styles.index(history_passthrough_rule)
     assert styles.index(history_passthrough_rule) < styles.index(history_interactive_rule)
     assert ".compact-export-history-scroll,\n" in history_passthrough_rule
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -926,6 +926,13 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "+ var(--compact-music-player-reserved-block-size, 88px)" in styles
     assert "+ var(--compact-music-player-history-gap, 14px)" in styles
     assert ".app-shell:has(> .compact-music-player-mount:not(:empty)) .compact-export-history-anchor" in styles
+    # 音量弹层展开时滑块向上伸进 history 区域，播放器整体提到 history(100001) 之上，
+    # 但仍低于工具轮盘态 surface-shell(100003)，避免抢点击又不破坏工具轮盘对表情按钮的让位。
+    assert "z-index: 100002;" in css_block(
+        styles,
+        "#music-player-mount.compact-music-player-mount:has(.music-bar-volume-container.expanded) {",
+        "#music-player-mount.compact-music-player-mount:empty",
+    )
     assert 'data-compact-hit-region-id="history:preview"' in panel_source
 
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -5,6 +5,7 @@ APP_REACT_CHAT_WINDOW_PATH = Path(__file__).resolve().parents[2] / "static" / "a
 APP_BUTTONS_PATH = Path(__file__).resolve().parents[2] / "static" / "app-buttons.js"
 APP_CHAT_EXPORT_PATH = Path(__file__).resolve().parents[2] / "static" / "app-chat-export.js"
 MUSIC_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "music_ui.js"
+MUSIC_UI_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "music_ui.css"
 STATIC_INDEX_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "index.css"
 REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "styles.css"
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
@@ -505,7 +506,9 @@ def test_desktop_compact_history_hit_regions_are_clipped_to_visible_parent():
         1,
     )[0]
 
-    assert "var clippedRect = parentRect ? intersectCompactRects(rect, parentRect) : rect;" in composite_block
+    assert "var clippedRect = kind === 'musicPlayer'" in composite_block
+    assert "? rect" in composite_block
+    assert ": (parentRect ? intersectCompactRects(rect, parentRect) : rect);" in composite_block
     assert "if (!clippedRect) return null;" in composite_block
     assert "visualRect: clippedRect" in composite_block
     assert "hitRect: clippedRect" in composite_block
@@ -811,7 +814,9 @@ def test_compact_history_enter_animation_excludes_drag_sources():
 
 def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regions():
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
+    music_ui_styles = MUSIC_UI_CSS_PATH.read_text(encoding="utf-8")
     panel_source = COMPACT_EXPORT_HISTORY_PANEL_PATH.read_text(encoding="utf-8")
+    app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
     music_ui_source = MUSIC_UI_PATH.read_text(encoding="utf-8")
 
@@ -831,7 +836,7 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     bubble_block = css_block(styles, ".compact-export-history-bubble {", ".compact-export-history-message.is-disabled")
     shared_hit_block = css_block(
         styles,
-        ".compact-export-history-controls,\n.compact-export-history-music-mount,\n.compact-export-preview-region {",
+        ".compact-export-history-controls,\n.compact-export-preview-region {",
         ".compact-export-history-controls {",
     )
     scroll_jsx_block = panel_source.split('className="compact-export-history-scroll"', 1)[1].split(
@@ -846,11 +851,6 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
         'compact-export-history-controls-content',
         1,
     )[0]
-    music_hit_block = panel_source.split('className="compact-export-history-music-mount"', 1)[1].split(
-        'className="compact-export-history-controls"',
-        1,
-    )[0]
-
     assert "pointer-events: none;" in anchor_block
     assert "pointer-events: none;" in panel_block
     assert "overflow-y: auto;" in scroll_block
@@ -858,7 +858,7 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "pointer-events: none;" in content_block
     assert "pointer-events: none;" in message_block
     assert "pointer-events: auto;" in bubble_block
-    assert ".compact-export-history-controls,\n.compact-export-history-music-mount,\n.compact-export-preview-region {" in styles
+    assert ".compact-export-history-controls,\n.compact-export-preview-region {" in styles
     assert "pointer-events: auto;" in shared_hit_block
     assert "function getCompactHistoryScrollbarRect(element, parentRect)" in script
     assert "id: 'history:scrollbar'" in script
@@ -869,26 +869,41 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "data-compact-hit-region-id={historyInteractive ? 'history:controls' : undefined}" in panel_source
     assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in controls_hit_block
     assert "data-compact-hit-region-kind={historyInteractive ? 'controls' : undefined}" in controls_hit_block
-    assert "data-compact-hit-region-id={historyInteractive ? 'history:music-player' : undefined}" in panel_source
-    assert 'data-music-player-mount="compact-history"' in music_hit_block
-    assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in music_hit_block
-    assert "data-compact-hit-region-kind={historyInteractive ? 'music' : undefined}" in music_hit_block
+    assert "compact-export-history-music-mount" not in panel_source
+    assert 'className="compact-music-player-mount"' in app_source
+    assert 'data-music-player-mount="compact-surface"' in app_source
+    assert 'data-compact-geometry-item="musicPlayer"' in app_source
+    assert 'data-compact-geometry-hit-scope="children"' in app_source
     assert "function getPreferredMusicMountTarget()" in music_ui_source
-    assert "function isCompactHistoryMusicMountInteractive(mount)" in music_ui_source
-    assert "document.querySelector('.compact-export-history-music-mount')" in music_ui_source
-    assert "mount.getAttribute('data-compact-hit-region') !== 'true'" in music_ui_source
-    assert "data-compact-export-history-visibility') !== 'open'" in music_ui_source
+    assert "function getCompactMusicMountTarget()" in music_ui_source
+    assert "document.querySelector('[data-music-player-mount=\"compact-surface\"]')" in music_ui_source
     assert "document.getElementById('music-player-mount')" in music_ui_source
     assert "document.getElementById(MUSIC_CONFIG.dom.containerId)" in music_ui_source
     assert "mutation.type === 'attributes' && isMusicMountMutationTarget(mutation.target)" in music_ui_source
     assert "attributes: true" in music_ui_source
-    assert "'data-compact-export-history-visibility'" in music_ui_source
-    assert "'data-compact-hit-region'" in music_ui_source
+    assert "'data-music-player-mount'" in music_ui_source
     assert "mountMusicBar(musicBar)" in music_ui_source
-    assert music_ui_source.count('data-compact-hit-region-id="history:music-player:volume"') == 2
+    assert "musicBar.setAttribute('data-compact-hit-region-id', 'music-player')" in music_ui_source
+    assert "neko:compact-interaction-geometry-refresh" in music_ui_source
+    assert "window.addEventListener('neko:compact-interaction-geometry-refresh'" in script
+    assert "kind === 'musicPlayer'" in script
+    assert music_ui_source.count('data-compact-hit-region-id="music-player:volume"') == 2
     assert music_ui_source.count('data-compact-hit-region-kind="music-volume"') == 2
-    assert ".compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper" in styles
-    assert '.compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper' in styles
+    assert "#music-player-mount.compact-music-player-mount {" in styles
+    assert "#music-player-mount.compact-music-player-mount {" in music_ui_styles
+    assert "width: min(calc(var(--compact-music-player-surface-width) - 16px), 360px, calc(100vw - 24px));" in styles
+    assert "width: min(calc(var(--compact-music-player-surface-width) - 16px), 360px, calc(100vw - 24px));" in music_ui_styles
+    assert "#music-player-mount.compact-music-player-mount > .music-player-bar" in styles
+    assert "#music-player-mount.compact-music-player-mount > .music-player-bar" in music_ui_styles
+    assert "max-inline-size: 100%;" in styles
+    assert "max-inline-size: 100%;" in music_ui_styles
+    assert "#music-player-mount.compact-music-player-mount .music-bar-info" in styles
+    assert "#music-player-mount.compact-music-player-mount .music-bar-info" in music_ui_styles
+    assert "--compact-music-player-reserved-block-size: 88px;" in styles
+    assert "--compact-music-player-history-gap: 14px;" in styles
+    assert "+ var(--compact-music-player-reserved-block-size, 88px)" in styles
+    assert "+ var(--compact-music-player-history-gap, 14px)" in styles
+    assert ".app-shell:has(> .compact-music-player-mount:not(:empty)) .compact-export-history-anchor" in styles
     assert 'data-compact-hit-region-id="history:preview"' in panel_source
 
 
@@ -909,7 +924,7 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
         "    pointer-events: auto;\n"
         "}"
     )
-    fallback_music_interactive_rule = (
+    compact_music_interactive_rule = (
         f'{compact_surface_prefix} #music-player-mount,\n'
         f'{compact_surface_prefix} #music-player-mount * {{\n'
         "    pointer-events: auto;\n"
@@ -927,27 +942,18 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
     history_interactive_rule = (
         f'{compact_surface_prefix} .compact-export-history-bubble,\n'
         f'{compact_surface_prefix} .compact-export-history-controls,\n'
-        f'{compact_surface_prefix} .compact-export-history-music-mount,\n'
         f'{compact_surface_prefix} .compact-export-preview-region {{\n'
         "    pointer-events: auto;\n"
         "}"
     )
-    history_music_volume_hidden_rule = (
-        f'{compact_surface_prefix} .compact-export-history-anchor.under-choice-prompt .music-bar-volume-slider-wrapper,\n'
-        f'{compact_surface_prefix} .compact-export-history-anchor[data-compact-export-history-visibility="closing"] .music-bar-volume-slider-wrapper {{\n'
-        "    pointer-events: none;\n"
-        "}"
-    )
 
     assert broad_surface_rule in styles
-    assert fallback_music_interactive_rule in styles
+    assert compact_music_interactive_rule in styles
     assert history_passthrough_rule in styles
     assert history_interactive_rule in styles
-    assert history_music_volume_hidden_rule in styles
-    assert styles.index(broad_surface_rule) < styles.index(fallback_music_interactive_rule)
-    assert styles.index(fallback_music_interactive_rule) < styles.index(history_passthrough_rule)
+    assert styles.index(broad_surface_rule) < styles.index(compact_music_interactive_rule)
+    assert styles.index(compact_music_interactive_rule) < styles.index(history_passthrough_rule)
     assert styles.index(history_passthrough_rule) < styles.index(history_interactive_rule)
-    assert styles.index(history_interactive_rule) < styles.index(history_music_volume_hidden_rule)
     assert ".compact-export-history-scroll,\n" in history_passthrough_rule
 
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -882,11 +882,24 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "document.getElementById('music-player-mount')" in music_ui_source
     assert "document.getElementById(MUSIC_CONFIG.dom.containerId)" in music_ui_source
     assert "mutation.type === 'attributes' && isMusicMountMutationTarget(mutation.target)" in music_ui_source
+    assert "function isCompactMusicGeometryMutationTarget(node)" in music_ui_source
+    assert "node.closest('[data-music-player-mount=\"compact-surface\"]')" in music_ui_source
+    assert "node.classList.contains('music-bar-volume-container')" in music_ui_source
+    assert "node.classList.contains('music-bar-volume-slider-wrapper')" in music_ui_source
+    assert "mutation.type === 'attributes' && isCompactMusicGeometryMutationTarget(mutation.target)" in music_ui_source
     assert "attributes: true" in music_ui_source
     assert "'data-music-player-mount'" in music_ui_source
     assert "mountMusicBar(musicBar)" in music_ui_source
     assert "musicBar.setAttribute('data-compact-hit-region-id', 'music-player')" in music_ui_source
     assert "neko:compact-interaction-geometry-refresh" in music_ui_source
+    volume_toggle_segments = music_ui_source.split("volumeContainer.classList.toggle('expanded');")
+    assert len(volume_toggle_segments) == 3
+    for segment in volume_toggle_segments[1:]:
+        assert "requestCompactMusicGeometrySync();" in segment[:96]
+    volume_close_segments = music_ui_source.split("volumeContainer.classList.remove('expanded');")
+    assert len(volume_close_segments) == 3
+    for segment in volume_close_segments[1:]:
+        assert "requestCompactMusicGeometrySync();" in segment[:96]
     assert "window.addEventListener('neko:compact-interaction-geometry-refresh'" in script
     assert "kind === 'musicPlayer'" in script
     assert music_ui_source.count('data-compact-hit-region-id="music-player:volume"') == 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能/改进**
  * 紧凑模式下音乐播放器作为独立挂载点，播放时留在独立位置，历史面板打开/关闭/卸载期间不再迁回 composer；音量面板展开/收起会触发几何刷新以保持可交互性。

* **样式**
  * 重构紧凑播放器布局、尺寸、颜色与无动画适配，限制横向宽度并为历史底部预留间距，避免遮挡。

* **修复**
  * closing/closed 状态下播放器及其子元素禁用指针事件，命中区域契约更精确。

* **测试**
  * 更新并新增断言，验证挂载位置、可见性阶段、命中区域、样式变量与几何刷新触发。

* **文档**
  * 更新紧凑模式设计文档并补充验收条款与行为约定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->