### PR TITLE
兼容模式下禁用返回球 native 缩窗拖拽接管，回退到普通 DOM 拖拽，并补充返回球恢复显示兜底，避免猫咪/模型消失

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -1472,6 +1472,7 @@
     const MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_SIZE = 160;
     const MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_FALLBACK_MS = 220;
     const MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS = 600;
+    const MULTI_WINDOW_RETURN_BALL_REVEAL_FALLBACK_MS = 600;
     let multiWindowReturnBallDragState = null;
     let idleReturnBallDesktopDragStateFrame = 0;
     let idleReturnBallDesktopDragStatePending = null;
@@ -2347,14 +2348,47 @@
             restoreSavedReturnBallStyle(container, state);
         }
 
-        async function revealReturnBallDragWindow() {
+        function dispatchReturnBallRevealFailed(reason, error) {
+            scheduleIdleReturnBallDesktopBridge('return-ball-reveal-failed', container);
+            window.dispatchEvent(new CustomEvent('neko:return-ball-reveal-failed', {
+                detail: {
+                    reason: reason || 'unknown',
+                    container: container,
+                    errorMessage: error && (error.message || String(error))
+                }
+            }));
+        }
+
+        function revealReturnBallDragWindow() {
             if (!window.nekoPetDrag || typeof window.nekoPetDrag.reveal !== 'function') {
+                dispatchReturnBallRevealFailed('bridge-unavailable');
                 return false;
             }
+            let settled = false;
+            const fallbackTimer = setTimeout(() => {
+                if (settled) return;
+                dispatchReturnBallRevealFailed('reveal-timeout');
+            }, MULTI_WINDOW_RETURN_BALL_REVEAL_FALLBACK_MS);
             try {
-                return await window.nekoPetDrag.reveal();
+                const revealResult = window.nekoPetDrag.reveal();
+                Promise.resolve(revealResult).then((ok) => {
+                    settled = true;
+                    clearTimeout(fallbackTimer);
+                    if (ok === false) {
+                        dispatchReturnBallRevealFailed('reveal-failed');
+                    }
+                }).catch((error) => {
+                    settled = true;
+                    clearTimeout(fallbackTimer);
+                    console.warn('[App] 返回球拖拽渲染完成后恢复窗口显示失败:', error);
+                    dispatchReturnBallRevealFailed('reveal-rejected', error);
+                });
+                return true;
             } catch (error) {
+                settled = true;
+                clearTimeout(fallbackTimer);
                 console.warn('[App] 返回球拖拽渲染完成后恢复窗口显示失败:', error);
+                dispatchReturnBallRevealFailed('reveal-threw', error);
                 return false;
             }
         }
@@ -2694,12 +2728,12 @@
                 if (!isActiveDragToken(dragToken)) return;
                 const expectedWidth = restoreBounds ? restoreBounds.width : state.savedWindowW;
                 const expectedHeight = restoreBounds ? restoreBounds.height : state.savedWindowH;
-                waitForViewportSize(dragToken, expectedWidth, expectedHeight, async () => {
+                waitForViewportSize(dragToken, expectedWidth, expectedHeight, () => {
                     restoreSavedBallStyle();
                     delete document.body.dataset.nekoBallDrag;
                     container.setAttribute('data-dragging', 'false');
                     scheduleIdleReturnBallDesktopBridge('return-ball-drag-click', container);
-                    await revealReturnBallDragWindow();
+                    revealReturnBallDragWindow();
                     dispatchReturnBallClick();
                 }, {
                     fallbackMs: MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS,
@@ -2734,7 +2768,7 @@
 
             const expectedWidth = finalBounds ? finalBounds.width : state.savedWindowW;
             const expectedHeight = finalBounds ? finalBounds.height : state.savedWindowH;
-            waitForViewportSize(dragToken, expectedWidth, expectedHeight, async () => {
+            waitForViewportSize(dragToken, expectedWidth, expectedHeight, () => {
                 if (shouldRestoreSavedBallStyle) {
                     restoreSavedBallStyle();
                     container.setAttribute('data-dragging', 'false');
@@ -2747,7 +2781,7 @@
                             movedDistancePx: movedDistancePx
                         }
                     }));
-                    await revealReturnBallDragWindow();
+                    revealReturnBallDragWindow();
                     return;
                 }
                 // 先同步恢复球 opacity，再删除 nekoBallDrag 显示页面内容，
@@ -2765,7 +2799,7 @@
                         movedDistancePx: movedDistancePx
                     }
                 }));
-                await revealReturnBallDragWindow();
+                revealReturnBallDragWindow();
                 // 延迟恢复 transition，避免恢复瞬间触发动画
                 state.transitionCleanupTimer = setTimeout(() => {
                     state.transitionCleanupTimer = null;

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -1470,6 +1470,8 @@
     // ================================================================
 
     const MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_SIZE = 160;
+    const MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_FALLBACK_MS = 220;
+    const MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS = 600;
     let multiWindowReturnBallDragState = null;
     let idleReturnBallDesktopDragStateFrame = 0;
     let idleReturnBallDesktopDragStatePending = null;
@@ -2260,6 +2262,14 @@
         }
     }
 
+    function isNativeReturnBallDragDisabled() {
+        const runtime = window.__NEKO_DESKTOP_RUNTIME__ || {};
+        return !!(
+            window.__NEKO_DISABLE_NATIVE_RETURN_BALL_DRAG__ ||
+            runtime.disableNativeReturnBallDrag
+        );
+    }
+
     function cleanupMultiWindowReturnBallDrag() {
         const state = multiWindowReturnBallDragState;
         if (!state) return;
@@ -2286,7 +2296,7 @@
     }
 
     function ensureMultiWindowReturnBallDrag(container) {
-        if (!window.__NEKO_MULTI_WINDOW__ || !window.nekoPetDrag || !container) {
+        if (!window.__NEKO_MULTI_WINDOW__ || isNativeReturnBallDragDisabled() || !window.nekoPetDrag || !container) {
             cleanupMultiWindowReturnBallDrag();
             return;
         }
@@ -2337,14 +2347,15 @@
             restoreSavedReturnBallStyle(container, state);
         }
 
-        function revealReturnBallDragWindow() {
+        async function revealReturnBallDragWindow() {
             if (!window.nekoPetDrag || typeof window.nekoPetDrag.reveal !== 'function') {
-                return;
+                return false;
             }
             try {
-                void window.nekoPetDrag.reveal();
+                return await window.nekoPetDrag.reveal();
             } catch (error) {
                 console.warn('[App] 返回球拖拽渲染完成后恢复窗口显示失败:', error);
+                return false;
             }
         }
 
@@ -2425,12 +2436,13 @@
                 : 600;
             const fallbackDeadline = Date.now() + Math.max(0, fallbackMs);
             const hardFallbackDeadline = fallbackDeadline + Math.max(1000, Math.max(0, fallbackMs) * 2);
+            const continueOnFallback = !!(options && options.continueOnFallback);
 
-            const runWhenStable = () => {
+            const runWhenStable = (meta) => {
                 requestAnimationFrame(() => {
                     requestAnimationFrame(() => {
                         if (!isActiveDragToken(dragToken)) return;
-                        onReady();
+                        onReady(meta || {});
                     });
                 });
             };
@@ -2458,6 +2470,17 @@
 
                 const remainingMs = fallbackDeadline - Date.now();
                 if (remainingMs <= 0) {
+                    if (continueOnFallback) {
+                        console.warn(
+                            '[pollViewportRestore] waitForViewportSize timed out; continuing best-effort cleanup.',
+                            'dragToken:', state.dragSessionToken,
+                            'fallbackMs:', fallbackMs,
+                            'fallbackDeadline:', fallbackDeadline
+                        );
+                        clearMultiWindowReturnBallDeferredWork(state);
+                        runWhenStable({ timedOut: true });
+                        return;
+                    }
                     if (Date.now() >= hardFallbackDeadline) {
                         console.warn(
                             '[pollViewportRestore] waitForViewportSize hard timeout; continuing best-effort cleanup.',
@@ -2602,7 +2625,10 @@
                     container.style.visibility = getSavedBallStyleValue('visibility');
                     container.style.willChange = 'opacity';
                 },
-                { fallbackMs: 600 }
+                {
+                    fallbackMs: MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_FALLBACK_MS,
+                    continueOnFallback: true
+                }
             );
 
             if (event) {
@@ -2668,13 +2694,16 @@
                 if (!isActiveDragToken(dragToken)) return;
                 const expectedWidth = restoreBounds ? restoreBounds.width : state.savedWindowW;
                 const expectedHeight = restoreBounds ? restoreBounds.height : state.savedWindowH;
-                waitForViewportSize(dragToken, expectedWidth, expectedHeight, () => {
+                waitForViewportSize(dragToken, expectedWidth, expectedHeight, async () => {
                     restoreSavedBallStyle();
                     delete document.body.dataset.nekoBallDrag;
                     container.setAttribute('data-dragging', 'false');
                     scheduleIdleReturnBallDesktopBridge('return-ball-drag-click', container);
-                    revealReturnBallDragWindow();
+                    await revealReturnBallDragWindow();
                     dispatchReturnBallClick();
+                }, {
+                    fallbackMs: MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS,
+                    continueOnFallback: true
                 });
                 return;
             }
@@ -2705,7 +2734,7 @@
 
             const expectedWidth = finalBounds ? finalBounds.width : state.savedWindowW;
             const expectedHeight = finalBounds ? finalBounds.height : state.savedWindowH;
-            waitForViewportSize(dragToken, expectedWidth, expectedHeight, () => {
+            waitForViewportSize(dragToken, expectedWidth, expectedHeight, async () => {
                 if (shouldRestoreSavedBallStyle) {
                     restoreSavedBallStyle();
                     container.setAttribute('data-dragging', 'false');
@@ -2718,7 +2747,7 @@
                             movedDistancePx: movedDistancePx
                         }
                     }));
-                    revealReturnBallDragWindow();
+                    await revealReturnBallDragWindow();
                     return;
                 }
                 // 先同步恢复球 opacity，再删除 nekoBallDrag 显示页面内容，
@@ -2736,7 +2765,7 @@
                         movedDistancePx: movedDistancePx
                     }
                 }));
-                revealReturnBallDragWindow();
+                await revealReturnBallDragWindow();
                 // 延迟恢复 transition，避免恢复瞬间触发动画
                 state.transitionCleanupTimer = setTimeout(() => {
                     state.transitionCleanupTimer = null;
@@ -2744,6 +2773,9 @@
                     container.style.transition = getSavedBallStyleValue('transition');
                     state.savedBallStyle = null;
                 }, 180);
+            }, {
+                fallbackMs: MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS,
+                continueOnFallback: true
             });
         }
 

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -330,6 +330,14 @@ function _normalizeNekoIdleReturnTier(tier) {
     return _NEKO_IDLE_TIER_CAT1;
 }
 
+function _isNekoNativeReturnBallDragDisabled() {
+    const runtime = window.__NEKO_DESKTOP_RUNTIME__ || {};
+    return !!(
+        window.__NEKO_DISABLE_NATIVE_RETURN_BALL_DRAG__ ||
+        runtime.disableNativeReturnBallDrag
+    );
+}
+
 function _getNekoIdleReturnAssetUrl(tier) {
     const normalizedTier = _normalizeNekoIdleReturnTier(tier);
     const versionSuffix = _getNekoIdleReturnAssetVersionSuffix();
@@ -3898,7 +3906,7 @@ const AvatarButtonMixin = {
             document.body.appendChild(returnButtonContainer);
             this._returnButtonContainer = returnButtonContainer;
             _applyNekoIdleReturnPresentation(returnBtn, currentTier);
-            if (!window.__NEKO_MULTI_WINDOW__) {
+            if (!window.__NEKO_MULTI_WINDOW__ || _isNekoNativeReturnBallDragDisabled()) {
                 this._setupReturnButtonDrag(returnButtonContainer);
             }
 

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -232,6 +232,7 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
 
     assert "MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_FALLBACK_MS = 220" in source
     assert "MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS = 600" in source
+    assert "MULTI_WINDOW_RETURN_BALL_REVEAL_FALLBACK_MS = 600" in source
     assert "continueOnFallback" in source
     assert "waitForViewportSize timed out; continuing best-effort cleanup" in source
     assert "keeping return-ball hidden until viewport is restored" in source
@@ -239,8 +240,14 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
     assert "clearMultiWindowReturnBallDeferredWork(state)" in source
     assert "state.viewportWaitFallbackTimer = setTimeout(pollViewportRestore, 50)" in source
     assert "runWhenStable({ timedOut: true })" in source
-    assert "async function revealReturnBallDragWindow()" in source
+    assert "function revealReturnBallDragWindow()" in source
     assert "window.nekoPetDrag.reveal" in source
+    assert "function dispatchReturnBallRevealFailed(reason, error)" in source
+    assert "'return-ball-reveal-failed'" in source
+    assert "'neko:return-ball-reveal-failed'" in source
+    assert "Promise.resolve(revealResult)" in source
+    assert "dispatchReturnBallRevealFailed('reveal-timeout')" in source
+    assert "await revealReturnBallDragWindow()" not in source
     assert "function isNativeReturnBallDragDisabled()" in source
     assert "isNativeReturnBallDragDisabled() || !window.nekoPetDrag" in source
     assert "const dragStarted = window.nekoPetDrag.start(screenX, screenY)" in source
@@ -258,7 +265,7 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
     no_move_end = source.index("const finalBounds = await resolveFinalWindowBounds", no_move_start)
     no_move_block = source[no_move_start:no_move_end]
 
-    assert no_move_block.index("await revealReturnBallDragWindow();") < no_move_block.index("dispatchReturnBallClick();")
+    assert no_move_block.index("revealReturnBallDragWindow();") < no_move_block.index("dispatchReturnBallClick();")
 
 
 def test_return_button_drag_has_single_owner_per_runtime_path():

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -230,14 +230,19 @@ def test_desktop_return_ball_drag_stops_native_drag_without_waiting_for_frame():
 def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_reveal():
     source = APP_UI_PATH.read_text(encoding="utf-8")
 
-    assert ": 600" in source
+    assert "MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_FALLBACK_MS = 220" in source
+    assert "MULTI_WINDOW_RETURN_BALL_DRAG_RESTORE_FALLBACK_MS = 600" in source
+    assert "continueOnFallback" in source
+    assert "waitForViewportSize timed out; continuing best-effort cleanup" in source
     assert "keeping return-ball hidden until viewport is restored" in source
     assert "waitForViewportSize hard timeout; continuing best-effort cleanup" in source
     assert "clearMultiWindowReturnBallDeferredWork(state)" in source
     assert "state.viewportWaitFallbackTimer = setTimeout(pollViewportRestore, 50)" in source
-    assert "runWhenStable({ timedOut: true })" not in source
-    assert "function revealReturnBallDragWindow()" in source
+    assert "runWhenStable({ timedOut: true })" in source
+    assert "async function revealReturnBallDragWindow()" in source
     assert "window.nekoPetDrag.reveal" in source
+    assert "function isNativeReturnBallDragDisabled()" in source
+    assert "isNativeReturnBallDragDisabled() || !window.nekoPetDrag" in source
     assert "const dragStarted = window.nekoPetDrag.start(screenX, screenY)" in source
     assert "if (dragStarted === false)" in source
 
@@ -248,6 +253,13 @@ def test_desktop_return_ball_drag_lifecycle_waits_for_restored_viewport_before_r
 
     assert begin_index < native_start_index < dispatch_start_index < drag_style_index
 
+    finish_index = source.index("async function finishDrag(screenX, screenY)")
+    no_move_start = source.index("if (!state.hasMoved) {", finish_index)
+    no_move_end = source.index("const finalBounds = await resolveFinalWindowBounds", no_move_start)
+    no_move_block = source[no_move_start:no_move_end]
+
+    assert no_move_block.index("await revealReturnBallDragWindow();") < no_move_block.index("dispatchReturnBallClick();")
+
 
 def test_return_button_drag_has_single_owner_per_runtime_path():
     avatar_source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
@@ -255,7 +267,8 @@ def test_return_button_drag_has_single_owner_per_runtime_path():
     vrm_source = VRM_UI_BUTTONS_PATH.read_text(encoding="utf-8")
     mmd_source = MMD_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
-    assert "if (!window.__NEKO_MULTI_WINDOW__)" in avatar_source
+    assert "function _isNekoNativeReturnBallDragDisabled()" in avatar_source
+    assert "if (!window.__NEKO_MULTI_WINDOW__ || _isNekoNativeReturnBallDragDisabled())" in avatar_source
     assert "this._setupReturnButtonDrag(returnButtonContainer)" in avatar_source
     assert "Live2DManager.prototype.setupReturnButtonContainerDrag = function(container)" in live2d_source
     assert "this.setupReturnButtonContainerDrag(returnButtonContainer)" not in live2d_source
@@ -494,7 +507,7 @@ def test_cat1_walk_to_minimized_chat_contract_is_present():
     assert "'return-ball-drag-end'" in app_ui_source
     assert "movedDistancePx: movedDistancePx" in app_ui_source
     assert "this._setupReturnButtonDrag(returnButtonContainer)" in source
-    assert "if (!window.__NEKO_MULTI_WINDOW__)" in source
+    assert "if (!window.__NEKO_MULTI_WINDOW__ || _isNekoNativeReturnBallDragDisabled())" in source
 
 
 def test_return_button_idle_tier_assets_are_version_tracked():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新说明

* **功能改进**
  * 优化多窗口返回球拖拽的阶段性超时与恢复流程，拆分为收缩/恢复/揭示阶段的等待策略。
  * 在运行时增加对“原生返回球拖拽”禁用的判定，影响拖拽逻辑启用条件。
  * 揭示流程现在会返回成功/失败并在失败时触发失败事件，改进超时与回退处理，支持超时后继续执行最佳清理。

* **测试**
  * 更新并强化了返回球拖拽相关的测试断言，覆盖新超时、回退与揭示失败场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->