### PR TITLE
fix(chat): improve compact input continuity and history scrollbar interaction

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5747,7 +5747,7 @@ describe('App', () => {
     expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test compact send' });
   });
 
-  it('keeps controlled compact input open after submitting text for continuous typing', () => {
+  it('keeps controlled compact input focused after submitting text for continuous typing', async () => {
     const onComposerSubmit = vi.fn();
 
     function CompactContinuousInputHarness() {
@@ -5766,11 +5766,17 @@ describe('App', () => {
 
     const input = screen.getByPlaceholderText('Type a message...');
     fireEvent.change(input, { target: { value: 'First compact message' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    const sendButton = screen.getByRole('button', { name: 'Send' });
+    sendButton.focus();
+    expect(document.activeElement).toBe(sendButton);
+    fireEvent.click(sendButton);
 
     expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'First compact message' });
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
     expect(screen.getByPlaceholderText('Type a message...')).toHaveValue('');
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByPlaceholderText('Type a message...'));
+    });
   });
 
   it('returns empty compact input to subtitle state when it loses focus', async () => {

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5747,6 +5747,32 @@ describe('App', () => {
     expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test compact send' });
   });
 
+  it('keeps controlled compact input open after submitting text for continuous typing', () => {
+    const onComposerSubmit = vi.fn();
+
+    function CompactContinuousInputHarness() {
+      const [compactChatState, setCompactChatState] = useState<CompactChatState>('input');
+      return (
+        <App
+          chatSurfaceMode="compact"
+          compactChatState={compactChatState}
+          onCompactChatStateChange={setCompactChatState}
+          onComposerSubmit={onComposerSubmit}
+        />
+      );
+    }
+
+    const { container } = render(<CompactContinuousInputHarness />);
+
+    const input = screen.getByPlaceholderText('Type a message...');
+    fireEvent.change(input, { target: { value: 'First compact message' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'First compact message' });
+    expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'input');
+    expect(screen.getByPlaceholderText('Type a message...')).toHaveValue('');
+  });
+
   it('returns empty compact input to subtitle state when it loses focus', async () => {
     const onCompactChatStateChange = vi.fn();
     const outsideButton = document.createElement('button');

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -1260,7 +1260,7 @@ describe('App', () => {
     expect(message).not.toHaveClass('is-selected');
   });
 
-  it('sends a compact history text bubble when dropped on the avatar range', async () => {
+  it('returns compact history text bubble drops on the avatar range without sending', async () => {
     const cleanupAvatar = setupAvatarDropBounds();
     const onCompactHistoryDrop = vi.fn();
     const textMessage = parseChatMessage({
@@ -1314,24 +1314,19 @@ describe('App', () => {
         pointerType: 'mouse',
       });
 
-      await waitFor(() => {
-        expect(onCompactHistoryDrop).toHaveBeenCalledTimes(1);
-      });
-      expect(onCompactHistoryDrop).toHaveBeenCalledWith(expect.objectContaining({
-        text: 'Send this memory again.',
-        images: [],
-        sourceMessageId: 'assistant-history-drop-text',
-        dragType: 'bubble',
-      }));
+      expect(onCompactHistoryDrop).not.toHaveBeenCalled();
       expect(message).not.toHaveClass('is-selected');
-      expect(document.body.querySelector('[data-compact-drag-layer="true"]')).toHaveAttribute('data-compact-drag-phase', 'sending');
+      await waitFor(() => {
+        expect(document.body.querySelector('[data-compact-drag-layer="true"]')).toHaveAttribute('data-compact-drag-phase', 'returning');
+      });
       await waitForCompactHistoryDragLayerToClear();
+      expect(onCompactHistoryDrop).not.toHaveBeenCalled();
     } finally {
       cleanupAvatar();
     }
   });
 
-  it('uses desktop avatar bounds for compact history drops in the Electron host', async () => {
+  it('uses desktop avatar bounds for returning compact history text bubble drops without sending', async () => {
     const cleanupAvatar = setupDesktopAvatarDropBounds();
     const onCompactHistoryDrop = vi.fn();
     const textMessage = parseChatMessage({
@@ -1383,20 +1378,18 @@ describe('App', () => {
         pointerType: 'mouse',
       });
 
+      expect(onCompactHistoryDrop).not.toHaveBeenCalled();
       await waitFor(() => {
-        expect(onCompactHistoryDrop).toHaveBeenCalledTimes(1);
+        expect(document.body.querySelector('[data-compact-drag-layer="true"]')).toHaveAttribute('data-compact-drag-phase', 'returning');
       });
-      expect(onCompactHistoryDrop).toHaveBeenCalledWith(expect.objectContaining({
-        text: 'Send this desktop memory.',
-        sourceMessageId: 'assistant-history-desktop-drop-text',
-      }));
       await waitForCompactHistoryDragLayerToClear();
+      expect(onCompactHistoryDrop).not.toHaveBeenCalled();
     } finally {
       cleanupAvatar();
     }
   });
 
-  it('accepts desktop compact history drag target feedback from NEKO-PC', async () => {
+  it('accepts desktop compact history drag target feedback from NEKO-PC while returning text bubbles', async () => {
     const onCompactHistoryDrop = vi.fn();
     const onCompactHistoryDragStateChange = vi.fn();
     const textMessage = parseChatMessage({
@@ -1485,14 +1478,12 @@ describe('App', () => {
       pointerType: 'mouse',
     });
 
+    expect(onCompactHistoryDrop).not.toHaveBeenCalled();
     await waitFor(() => {
-      expect(onCompactHistoryDrop).toHaveBeenCalledTimes(1);
+      expect(document.body.querySelector('[data-compact-drag-layer="true"]')).toHaveAttribute('data-compact-drag-phase', 'returning');
     });
-    expect(onCompactHistoryDrop).toHaveBeenCalledWith(expect.objectContaining({
-      text: 'Send through desktop feedback.',
-      sourceMessageId: 'assistant-history-desktop-feedback-drop',
-    }));
     await waitForCompactHistoryDragLayerToClear();
+    expect(onCompactHistoryDrop).not.toHaveBeenCalled();
   });
 
   it('does not send a compact history drag released outside the avatar range', async () => {
@@ -5777,6 +5768,9 @@ describe('App', () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(screen.getByPlaceholderText('Type a message...'));
     });
+    const refocusedInput = screen.getByPlaceholderText('Type a message...') as HTMLTextAreaElement;
+    expect(refocusedInput.selectionStart).toBe(refocusedInput.value.length);
+    expect(refocusedInput.selectionEnd).toBe(refocusedInput.value.length);
   });
 
   it('returns empty compact input to subtitle state when it loses focus', async () => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4503,6 +4503,9 @@ export default function App({
       return false;
     }
 
+    if (request.payload.type === 'bubble' && hasText && !hasImages) {
+      return false;
+    }
     restoreCompactExportHistoryToBottomForOutgoingMessage();
     if (onCompactHistoryDrop) {
       return normalizeCompactHistoryDropResult(onCompactHistoryDrop(payload));

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4415,6 +4415,20 @@ export default function App({
     }
   }
 
+  function focusCompactInputForContinuousTyping() {
+    const inputNode = compactInputRef.current;
+    if (!inputNode || inputNode.disabled || inputNode.readOnly) return;
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof Node
+      && compactInputShellRef.current
+      && !compactInputShellRef.current.contains(activeElement)
+    ) return;
+    inputNode.focus();
+    const selectionEnd = inputNode.value.length;
+    inputNode.setSelectionRange(selectionEnd, selectionEnd);
+  }
+
   function submitDraft() {
     if (composerDisabled) return;
     if (submittingRef.current) return;
@@ -4422,12 +4436,21 @@ export default function App({
     if (!text && composerAttachments.length === 0) return;
     closeCompactInputToolFan();
     submittingRef.current = true;
+    let shouldRefocusCompactInput = false;
     try {
       onComposerSubmit?.({ text });
       setDraft('');
       restoreCompactExportHistoryToBottomForOutgoingMessage();
+      shouldRefocusCompactInput = isCompactSurface
+        && effectiveCompactChatState === 'input'
+        && text.length > 0;
     } finally {
-      requestAnimationFrame(() => { submittingRef.current = false; });
+      requestAnimationFrame(() => {
+        submittingRef.current = false;
+        if (shouldRefocusCompactInput) {
+          focusCompactInputForContinuousTyping();
+        }
+      });
     }
   }
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4426,7 +4426,6 @@ export default function App({
       onComposerSubmit?.({ text });
       setDraft('');
       restoreCompactExportHistoryToBottomForOutgoingMessage();
-      requestCompactChatState('default');
     } finally {
       requestAnimationFrame(() => { submittingRef.current = false; });
     }

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
@@ -151,6 +151,51 @@ describe('CompactExportHistoryPanel', () => {
     }
   });
 
+  it('does not render the scrollbar hit area when the history cannot scroll', () => {
+    const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const clientHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('compact-export-history-scroll') ? 240 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('compact-export-history-scroll') ? 240 : 0;
+      },
+    });
+
+    try {
+      const { container } = renderPanel({
+        previewOpen: false,
+        visibilityState: 'open',
+      });
+
+      const scroll = container.querySelector('.compact-export-history-scroll');
+      expect(scroll).not.toBeNull();
+
+      fireEvent(window, new CustomEvent('neko:compact-history-hover-state-change', {
+        detail: { active: true },
+      }));
+      expect(scroll).toHaveAttribute('data-compact-scrollbar-visible', 'true');
+      expect(container.querySelector('.compact-export-history-scrollbar-hit')).toBeNull();
+    } finally {
+      if (scrollHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', scrollHeightDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      }
+      if (clientHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientHeightDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
+      }
+    }
+  });
+
   it('scrolls the compact history list when the visible scrollbar hit area is dragged', () => {
     const scrollTopByElement = new WeakMap<HTMLElement, number>();
     const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import CompactExportHistoryPanel from './CompactExportHistoryPanel';
 import { parseChatMessage } from './message-schema';
 
@@ -89,6 +89,138 @@ describe('CompactExportHistoryPanel', () => {
         Object.defineProperty(HTMLElement.prototype, 'scrollHeight', scrollHeightDescriptor);
       } else {
         Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      }
+      if (scrollTopDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollTop', scrollTopDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollTop');
+      }
+    }
+  });
+
+  it('shows the compact history scrollbar while the desktop cursor is over the history area', () => {
+    const { container } = renderPanel({
+      previewOpen: false,
+      visibilityState: 'open',
+    });
+
+    const scroll = container.querySelector('.compact-export-history-scroll');
+    expect(scroll).not.toBeNull();
+    expect(scroll).not.toHaveAttribute('data-compact-scrollbar-visible');
+
+    fireEvent(window, new CustomEvent('neko:compact-history-hover-state-change', {
+      detail: { active: true },
+    }));
+    expect(scroll).toHaveAttribute('data-compact-scrollbar-visible', 'true');
+
+    fireEvent(window, new CustomEvent('neko:compact-history-hover-state-change', {
+      detail: { active: false },
+    }));
+    expect(scroll).not.toHaveAttribute('data-compact-scrollbar-visible');
+  });
+
+  it('keeps the scrollbar visible while the desktop cursor remains over transparent history', () => {
+    vi.useFakeTimers();
+
+    try {
+      const { container } = renderPanel({
+        previewOpen: false,
+        visibilityState: 'open',
+      });
+
+      const scroll = container.querySelector('.compact-export-history-scroll');
+      expect(scroll).not.toBeNull();
+
+      fireEvent(window, new CustomEvent('neko:compact-history-hover-state-change', {
+        detail: { active: true },
+      }));
+      expect(scroll).toHaveAttribute('data-compact-scrollbar-visible', 'true');
+
+      fireEvent.wheel(scroll!, { deltaY: 12 });
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(scroll).toHaveAttribute('data-compact-scrollbar-visible', 'true');
+
+      fireEvent(window, new CustomEvent('neko:compact-history-hover-state-change', {
+        detail: { active: false },
+      }));
+      expect(scroll).not.toHaveAttribute('data-compact-scrollbar-visible');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('scrolls the compact history list when the visible scrollbar hit area is dragged', () => {
+    const scrollTopByElement = new WeakMap<HTMLElement, number>();
+    const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const clientHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    const scrollTopDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTop');
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('compact-export-history-scroll') ? 1000 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('compact-export-history-scroll') ? 250 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get() {
+        return scrollTopByElement.get(this) ?? 0;
+      },
+      set(value: number) {
+        scrollTopByElement.set(this, value);
+      },
+    });
+
+    try {
+      const { container } = renderPanel({
+        previewOpen: false,
+        visibilityState: 'open',
+      });
+      const scroll = container.querySelector<HTMLElement>('.compact-export-history-scroll');
+      expect(scroll).not.toBeNull();
+
+      fireEvent(window, new CustomEvent('neko:compact-history-hover-state-change', {
+        detail: { active: true },
+      }));
+      const hit = container.querySelector<HTMLElement>('.compact-export-history-scrollbar-hit');
+      expect(hit).not.toBeNull();
+
+      fireEvent.pointerDown(hit!, {
+        pointerId: 1,
+        pointerType: 'mouse',
+        button: 0,
+        clientY: 20,
+      });
+      fireEvent.pointerMove(hit!, {
+        pointerId: 1,
+        pointerType: 'mouse',
+        clientY: 70,
+      });
+      fireEvent.pointerUp(hit!, {
+        pointerId: 1,
+        pointerType: 'mouse',
+        clientY: 70,
+      });
+
+      expect(scroll!.scrollTop).toBeGreaterThan(0);
+    } finally {
+      if (scrollHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', scrollHeightDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      }
+      if (clientHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientHeightDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
       }
       if (scrollTopDescriptor) {
         Object.defineProperty(HTMLElement.prototype, 'scrollTop', scrollTopDescriptor);

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -1273,6 +1273,9 @@ export default function CompactExportHistoryPanel({
   const exportActionsDisabled = !previewHasSelection || exportBusy;
   const historyInteractive = visibilityState === 'open';
   const selectionControlsInteractive = historyInteractive && controlsOpen;
+  const scrollbarHitVisible = scrollbarVisible
+    && !!scrollRef.current
+    && !!getCompactHistoryScrollbarMetrics(scrollRef.current);
   const openingEnterDelayByMessageId = useMemo(() => (
     visibilityState === 'open' && previousVisibilityStateRef.current !== 'open'
       ? new Map(messages.map((message, index) => [
@@ -2564,7 +2567,7 @@ export default function CompactExportHistoryPanel({
                 </div>
               ) : null}
             </div>
-            {scrollbarVisible ? (
+            {scrollbarHitVisible ? (
               <div
                 className="compact-export-history-scrollbar-hit"
                 data-compact-scrollbar-hit="true"

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -24,6 +24,7 @@ const COMPACT_EXPORT_DRAG_MOVE_THRESHOLD = 8;
 const COMPACT_EXPORT_TOUCH_SCROLL_ANGLE_RATIO = 1.35;
 const COMPACT_HISTORY_SCROLL_SETTLE_FRAMES = 36;
 export const COMPACT_HISTORY_SCROLLBAR_VISIBLE_MS = 860;
+const COMPACT_HISTORY_SCROLLBAR_THUMB_MIN_HEIGHT = 24;
 const COMPACT_HISTORY_RETURN_ANIMATION_MS = 260;
 const COMPACT_HISTORY_SEND_ANIMATION_MS = 340;
 export const COMPACT_HISTORY_ENTER_DELAY_STEP_MS = 42;
@@ -220,6 +221,14 @@ type PointerIntentState = {
   originElement: HTMLElement | null;
   pointerOffset: { x: number; y: number };
   autoScrollToBottomOnStart: boolean;
+};
+
+type ScrollbarDragState = {
+  pointerId: number;
+  startY: number;
+  startScrollTop: number;
+  scrollableHeight: number;
+  draggableTrackHeight: number;
 };
 
 type CompactHistoryBubbleTone = {
@@ -569,6 +578,26 @@ function getCompactHistoryDragVisualStyle(activeDrag: ActiveCompactHistoryDrag) 
 
 function clampCompactHistoryValue(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
+}
+
+function getCompactHistoryScrollbarMetrics(scrollNode: HTMLDivElement) {
+  const scrollableHeight = scrollNode.scrollHeight - scrollNode.clientHeight;
+  const trackHeight = scrollNode.clientHeight;
+  if (scrollableHeight <= 0 || trackHeight <= 0 || scrollNode.scrollHeight <= 0) return null;
+  const proportionalThumbHeight = (scrollNode.clientHeight / scrollNode.scrollHeight) * trackHeight;
+  const thumbHeight = clampCompactHistoryValue(
+    proportionalThumbHeight,
+    Math.min(COMPACT_HISTORY_SCROLLBAR_THUMB_MIN_HEIGHT, trackHeight),
+    trackHeight,
+  );
+  const draggableTrackHeight = trackHeight - thumbHeight;
+  if (draggableTrackHeight <= 0) return null;
+  return {
+    scrollableHeight,
+    trackHeight,
+    thumbHeight,
+    draggableTrackHeight,
+  };
 }
 
 function getCompactHistoryDragCenter(activeDrag: ActiveCompactHistoryDrag) {
@@ -1198,6 +1227,8 @@ export default function CompactExportHistoryPanel({
   onDragStateChange,
 }: CompactExportHistoryPanelProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const scrollbarDragRef = useRef<ScrollbarDragState | null>(null);
+  const desktopHistoryHoverActiveRef = useRef(false);
   const pointerIntentRef = useRef<PointerIntentState | null>(null);
   const activeDragRef = useRef<ActiveCompactHistoryDrag | null>(null);
   const currentOverDropTargetRef = useRef(false);
@@ -1277,6 +1308,7 @@ export default function CompactExportHistoryPanel({
     if (!historyInteractive) return;
     clearScrollbarVisibleTimer();
     setScrollbarVisible(true);
+    if (desktopHistoryHoverActiveRef.current) return;
     scrollbarVisibleTimerRef.current = window.setTimeout(() => {
       scrollbarVisibleTimerRef.current = null;
       setScrollbarVisible(false);
@@ -1289,6 +1321,106 @@ export default function CompactExportHistoryPanel({
       revealScrollbarForWheel();
     }
   }
+
+  function handleScrollbarWheel(event: ReactWheelEvent<HTMLDivElement>) {
+    if (!historyInteractive) return;
+    const scrollNode = scrollRef.current;
+    if (!scrollNode) return;
+    const delta = event.deltaY !== 0 ? event.deltaY : event.deltaX;
+    if (delta === 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    scrollNode.scrollTop += delta;
+    handleScroll();
+    revealScrollbarForWheel();
+  }
+
+  function handleScrollbarPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+    if (!historyInteractive || !scrollbarVisible) return;
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    const scrollNode = scrollRef.current;
+    if (!scrollNode) return;
+    const metrics = getCompactHistoryScrollbarMetrics(scrollNode);
+    if (!metrics) return;
+    const rect = scrollNode.getBoundingClientRect();
+    const localY = event.clientY - rect.top;
+    const thumbTop = metrics.draggableTrackHeight * (scrollNode.scrollTop / metrics.scrollableHeight);
+    const thumbBottom = thumbTop + metrics.thumbHeight;
+    event.preventDefault();
+    event.stopPropagation();
+    clearScrollbarVisibleTimer();
+    setScrollbarVisible(true);
+    if (localY < thumbTop || localY > thumbBottom) {
+      scrollNode.scrollTop = clampCompactHistoryValue(
+        ((localY - metrics.thumbHeight / 2) / metrics.draggableTrackHeight) * metrics.scrollableHeight,
+        0,
+        metrics.scrollableHeight,
+      );
+      handleScroll();
+    }
+    scrollbarDragRef.current = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      startScrollTop: scrollNode.scrollTop,
+      scrollableHeight: metrics.scrollableHeight,
+      draggableTrackHeight: metrics.draggableTrackHeight,
+    };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  }
+
+  function handleScrollbarPointerMove(event: ReactPointerEvent<HTMLDivElement>) {
+    const drag = scrollbarDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const scrollNode = scrollRef.current;
+    if (!scrollNode) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const deltaY = event.clientY - drag.startY;
+    scrollNode.scrollTop = clampCompactHistoryValue(
+      drag.startScrollTop + (deltaY / drag.draggableTrackHeight) * drag.scrollableHeight,
+      0,
+      drag.scrollableHeight,
+    );
+    handleScroll();
+  }
+
+  function finishScrollbarPointerDrag(event: ReactPointerEvent<HTMLDivElement>) {
+    const drag = scrollbarDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    scrollbarDragRef.current = null;
+    event.stopPropagation();
+    try {
+      if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+        event.currentTarget.releasePointerCapture?.(event.pointerId);
+      }
+    } catch (_) {
+      // Some hosts release capture before dispatching the final capture event.
+    }
+    revealScrollbarForWheel();
+  }
+
+  useEffect(() => {
+    if (historyInteractive) return;
+    clearScrollbarVisibleTimer();
+    setScrollbarVisible(false);
+    scrollbarDragRef.current = null;
+    desktopHistoryHoverActiveRef.current = false;
+  }, [historyInteractive]);
+
+  useEffect(() => {
+    function handleDesktopHistoryHoverStateChange(event: Event) {
+      if (!historyInteractive) return;
+      const detail = (event as CustomEvent<{ active?: boolean }>).detail;
+      desktopHistoryHoverActiveRef.current = detail?.active === true;
+      clearScrollbarVisibleTimer();
+      setScrollbarVisible(desktopHistoryHoverActiveRef.current);
+    }
+
+    window.addEventListener('neko:compact-history-hover-state-change', handleDesktopHistoryHoverStateChange);
+    return () => {
+      window.removeEventListener('neko:compact-history-hover-state-change', handleDesktopHistoryHoverStateChange);
+    };
+  }, [historyInteractive]);
 
   function emitCompactHistoryDragState(activeDragState: ActiveCompactHistoryDrag) {
     const state = buildCompactHistoryDragState(activeDragState, dragStateSeqRef.current);
@@ -2439,6 +2571,19 @@ export default function CompactExportHistoryPanel({
                 </div>
               ) : null}
             </div>
+            {scrollbarVisible ? (
+              <div
+                className="compact-export-history-scrollbar-hit"
+                data-compact-scrollbar-hit="true"
+                aria-hidden="true"
+                onWheel={handleScrollbarWheel}
+                onPointerDown={handleScrollbarPointerDown}
+                onPointerMove={handleScrollbarPointerMove}
+                onPointerUp={finishScrollbarPointerDrag}
+                onPointerCancel={finishScrollbarPointerDrag}
+                onLostPointerCapture={finishScrollbarPointerDrag}
+              />
+            ) : null}
             <div
               className="compact-export-history-music-mount"
               data-music-player-mount="compact-history"

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -1521,13 +1521,6 @@ export default function CompactExportHistoryPanel({
     revokeCompactPreviewObjectUrl();
   }, []);
 
-  useEffect(() => {
-    if (historyInteractive) return undefined;
-    clearScrollbarVisibleTimer();
-    setScrollbarVisible(false);
-    return undefined;
-  }, [historyInteractive]);
-
   useEffect(() => () => {
     clearScrollbarVisibleTimer();
   }, []);

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2352,6 +2352,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 .compact-export-history-panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -2361,6 +2362,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-scroll,
+.compact-export-history-anchor.under-choice-prompt .compact-export-history-scrollbar-hit,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-controls,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-music-mount,
 .compact-export-history-anchor.under-choice-prompt .compact-export-preview-region {
@@ -2443,6 +2445,21 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background:
     linear-gradient(180deg, rgba(103, 202, 255, 0.82), rgba(36, 151, 217, 0.62))
     padding-box;
+}
+
+.compact-export-history-scrollbar-hit {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 20px;
+  height: calc(var(--compact-export-history-region-height) + var(--compact-export-controls-collapse-delta));
+  max-height: calc(var(--compact-export-history-region-height) + var(--compact-export-controls-collapse-delta));
+  cursor: ns-resize;
+  pointer-events: auto;
+  touch-action: none;
+  background: transparent;
+  z-index: 2;
+  -webkit-app-region: no-drag;
 }
 
 .compact-export-history-message {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1228,8 +1228,21 @@
         var scrollNode = element.querySelector('.compact-export-history-scroll');
         if (!scrollNode || typeof scrollNode.getBoundingClientRect !== 'function') return null;
         if (scrollNode.scrollHeight <= scrollNode.clientHeight + 1) return null;
+        if (scrollNode.getAttribute('data-compact-scrollbar-visible') !== 'true') return null;
         var style = window.getComputedStyle ? window.getComputedStyle(scrollNode) : null;
-        if (style && (style.display === 'none' || style.visibility === 'hidden' || style.pointerEvents === 'none')) return null;
+        if (style && (style.display === 'none' || style.visibility === 'hidden')) return null;
+        var scrollbarHit = element.querySelector('.compact-export-history-scrollbar-hit');
+        if (scrollbarHit && typeof scrollbarHit.getBoundingClientRect === 'function') {
+            var hitStyle = window.getComputedStyle ? window.getComputedStyle(scrollbarHit) : null;
+            if (!hitStyle || (
+                hitStyle.display !== 'none'
+                && hitStyle.visibility !== 'hidden'
+                && hitStyle.pointerEvents !== 'none'
+            )) {
+                var hitRect = intersectCompactRects(scrollbarHit.getBoundingClientRect(), parentRect);
+                if (hitRect) return hitRect;
+            }
+        }
         var scrollRect = intersectCompactRects(scrollNode.getBoundingClientRect(), parentRect);
         if (!scrollRect) return null;
         var gutterWidth = Math.min(Math.max(Number(scrollNode.offsetWidth - scrollNode.clientWidth) || 0, 8), 14);

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1234,6 +1234,7 @@
         var scrollbarHit = element.querySelector('.compact-export-history-scrollbar-hit');
         if (scrollbarHit && typeof scrollbarHit.getBoundingClientRect === 'function') {
             var hitStyle = window.getComputedStyle ? window.getComputedStyle(scrollbarHit) : null;
+            if (hitStyle && hitStyle.pointerEvents === 'none') return null;
             if (!hitStyle || (
                 hitStyle.display !== 'none'
                 && hitStyle.visibility !== 'hidden'

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -822,6 +822,7 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     )
     panel_block = css_block(styles, ".compact-export-history-panel {", ".compact-export-history-anchor.under-choice-prompt")
     scroll_block = css_block(styles, ".compact-export-history-scroll {", ".compact-export-history-scroll-content")
+    scrollbar_hit_block = css_block(styles, ".compact-export-history-scrollbar-hit {", ".compact-export-history-message")
     content_block = css_block(
         styles,
         ".compact-export-history-scroll-content {",
@@ -855,6 +856,9 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "pointer-events: none;" in panel_block
     assert "overflow-y: auto;" in scroll_block
     assert "pointer-events: none;" in scroll_block
+    assert "position: absolute;" in scrollbar_hit_block
+    assert "width: 20px;" in scrollbar_hit_block
+    assert "pointer-events: auto;" in scrollbar_hit_block
     assert "pointer-events: none;" in content_block
     assert "pointer-events: none;" in message_block
     assert "pointer-events: auto;" in bubble_block
@@ -862,7 +866,14 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "pointer-events: auto;" in shared_hit_block
     assert "function getCompactHistoryScrollbarRect(element, parentRect)" in script
     assert "id: 'history:scrollbar'" in script
+    assert "scrollNode.getAttribute('data-compact-scrollbar-visible') !== 'true'" in script
+    assert "element.querySelector('.compact-export-history-scrollbar-hit')" in script
+    assert "hitStyle.pointerEvents !== 'none'" in script
+    assert "style.pointerEvents === 'none'" not in script.split("function getCompactHistoryScrollbarRect(element, parentRect)", 1)[1].split("var COMPACT_TOOL_FAN_CIRCLE_SLICE_COUNT", 1)[0]
     assert "data-compact-hit-region" not in scroll_jsx_block
+    assert 'className="compact-export-history-scrollbar-hit"' in panel_source
+    assert 'data-compact-scrollbar-hit="true"' in panel_source
+    assert "hasPointerCapture?.(event.pointerId)" in panel_source
     assert 'data-compact-hit-region-id={historyInteractive ? `history:message:${message.id}` : undefined}' in panel_source
     assert "data-compact-hit-region={historyInteractive ? 'true' : undefined}" in message_hit_block
     assert "data-compact-hit-region-kind={historyInteractive ? 'message' : undefined}" in message_hit_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -868,8 +868,12 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     assert "id: 'history:scrollbar'" in script
     assert "scrollNode.getAttribute('data-compact-scrollbar-visible') !== 'true'" in script
     assert "element.querySelector('.compact-export-history-scrollbar-hit')" in script
-    assert "hitStyle.pointerEvents !== 'none'" in script
-    assert "style.pointerEvents === 'none'" not in script.split("function getCompactHistoryScrollbarRect(element, parentRect)", 1)[1].split("var COMPACT_TOOL_FAN_CIRCLE_SLICE_COUNT", 1)[0]
+    scrollbar_block = script.split("function getCompactHistoryScrollbarRect(element, parentRect)", 1)[1].split(
+        "var COMPACT_TOOL_FAN_CIRCLE_SLICE_COUNT",
+        1,
+    )[0]
+    assert "if (hitStyle && hitStyle.pointerEvents === 'none') return null;" in scrollbar_block
+    assert "style.pointerEvents === 'none'" not in scrollbar_block
     assert "data-compact-hit-region" not in scroll_jsx_block
     assert 'className="compact-export-history-scrollbar-hit"' in panel_source
     assert 'data-compact-scrollbar-hit="true"' in panel_source


### PR DESCRIPTION
## 变更内容

- 修复 compact 文本输入连续发送体验：发送一句后保持输入态，并自动把焦点恢复到输入框，用户可以直接继续输入。
- 优化 compact 历史对话滚动条交互：历史透明区域继续保持点击穿透，仅在滚动条可见时开放右侧窄条命中区。
- 复用桌面端既有 cursor poll 判断历史区域 hover，不新增独立轮询，避免无历史区域、隐藏、最小化或非 compact 状态下空转。
- 修复滚动条可见但难拖动的问题，补充右侧 scrollbar hit overlay，并扩大命中宽度降低脱手概率。
- 取消拖拽对话到模型发送。
- 收紧 under-choice、旧 layout 异步回写、pointer capture 释放等边界，避免污染其他 compact 交互链路。

## 验证

- `npm test -- App.test.tsx`
- `npm test -- CompactExportHistoryPanel.test.tsx`
- `uv run python -m pytest tests/unit/test_react_chat_window_static.py -k compact_history_hit_contract`
- `node --test test/desktop-compact-layout-contract.test.js`
- `bash build_frontend.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 紧凑输入模式在发送后会自动回焦并把光标置于末尾，支持连续输入
  * 历史面板新增可视化滚动条与可拖拽滚动热区，支持悬停、滚轮与拖拽交互

* **修复**
  * 阻止仅文本的历史气泡在回弹过程中触发提交/投放回调
  * 回弹交互不再将消息气泡置为选中状态

* **测试**
  * 增补滚动条可见性、悬停、拖拽及回焦相关测试，改进异步断言处理
<!-- end of auto-generated comment: release notes by coderabbit.ai -->