### PR TITLE
feat(proactive): 主动搭话未发起时在 info 记录原因

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4618,6 +4618,7 @@ async def proactive_chat(request: Request):
         try:
             from main_routers.game_router import is_game_route_active
             if is_game_route_active(lanlan_name):
+                logger.info("[%s] 主动搭话本轮未发起：游戏路由 active", lanlan_name)
                 return JSONResponse({
                     "success": True,
                     "action": "pass",
@@ -4665,6 +4666,7 @@ async def proactive_chat(request: Request):
                     action=_voice_advance_outcome.get('action', 'suppress'),
                 )
             if not mgr.state.can_start_proactive(session=probe_session):
+                logger.info("[%s] 主动搭话本轮未发起：语音模式 AI 正在响应中（409）", lanlan_name)
                 return JSONResponse({
                     "success": False,
                     "error": "AI正在响应中，无法主动搭话",
@@ -4678,6 +4680,8 @@ async def proactive_chat(request: Request):
                 _mini_game_invite_count_post_response_chat(lanlan_name)
                 # 持久化"累计成功投递的主动搭话总数"，给 force-first 用。
                 await _increment_proactive_chat_total(lanlan_name)
+            else:
+                logger.info("[%s] 主动搭话本轮未发起：语音 nudge 被 guard 跳过", lanlan_name)
             return JSONResponse({
                 "success": True,
                 "action": "chat" if delivered else "pass",
@@ -4690,6 +4694,7 @@ async def proactive_chat(request: Request):
         # 各自 fire(PROACTIVE_START) 导致两路 proactive 同时进入 PHASE1。
         from main_logic.session_state import SessionEvent as _SE
         if not await mgr.state.try_start_proactive(session=probe_session):
+            logger.info("[%s] 主动搭话本轮未发起：AI 正在响应或已有一轮在跑（409）", lanlan_name)
             return JSONResponse({
                 "success": False,
                 "error": "AI正在响应中，无法主动搭话",
@@ -4725,13 +4730,28 @@ async def proactive_chat(request: Request):
                 return resp
             if not isinstance(body, dict):
                 return resp
+            # text-mode 占坑后的所有出口都经过这里。本轮最终没把话说出来
+            # （action != "chat"：各种 guard/skip/内容为空/被用户接管）就在
+            # info 留一条带原因的日志，原因取响应体 message（无则 error）。
+            # 散落各分支无需各自记；排查"她这轮为什么没主动说话"看这条即可。
+            # 占坑前的早退（游戏路由 / voice 与 text 的 409 并发拒绝）不经过
+            # 本出口，各自就地补了同前缀（"主动搭话本轮未发起："）的 info。
+            if body.get("action") != "chat":
+                logger.info(
+                    "[%s] 主动搭话本轮未发起：%s",
+                    lanlan_name,
+                    body.get("message") or body.get("error") or "(无原因说明)",
+                )
             if 'next_schedule_fixed_mode' in body:
                 return resp
             body['next_schedule_fixed_mode'] = _next_schedule_fixed_mode
             return JSONResponse(body, status_code=resp.status_code)
 
         def _proactive_preempted_json(where: str) -> dict:
-            logger.info(
+            # 细粒度的 state 快照留 debug；面向排查的"本轮未发起 + 原因"由统一
+            # 出口 _end_proactive 按 message 打 info（这些 dict 全部经它返回），
+            # 避免同一轮 skip 打出两条重复 info。
+            logger.debug(
                 "[%s] proactive %s preempted by user takeover (state=%s)",
                 lanlan_name, where, mgr.state.snapshot(),
             )


### PR DESCRIPTION
## 背景

`proactive_chat`（主动搭话后端入口）有 20 多个「不说话」的出口散落在 2000+ 行里：有的 `print`、有的 `logger.warning`、有的**完全没日志**（并发 409 / 所有信息源失败 / anti-slack 与水分提醒投递失败等）。结果是「她这轮为什么没主动说话」在 info 日志里基本看不出来。

## 改法

复用了一个现成的统一收口，而不是去 20 多个散点各加一行：

- **统一收口 `_end_proactive`**：text-mode 占坑后的全部出口都经过它（成功 `action:"chat"`、各种 `action:"pass"`、被用户接管）。在这一处按 `action != "chat"` 打一条 info，原因直接复用各分支早就写好的 `message` 字段，一处覆盖十几种 skip 原因。
- **4 个占坑前的早退**绕开了收口，就地补同前缀（`主动搭话本轮未发起：`）的 info：游戏路由 active、语音模式 409、语音 nudge 被 guard 跳过、text 模式 409。
- **preempted 专用 info 降为 debug**：原本它自己打 info，现在统一收口会按 message 接管，降级是为了同一轮 skip 不打出两条重复 info；state 快照细节仍留 debug 可深挖。

实际日志：

```
INFO [小八] 主动搭话本轮未发起：all configured modes failed; nothing to say
INFO [小八] 主动搭话本轮未发起：AI 正在响应或已有一轮在跑（409）
```

## 影响范围

纯加日志，不改任何控制流 / 返回值 / 状态机行为。

## 验证

- `python -m py_compile main_routers/system_router.py` 通过
- `tests/unit/test_proactive_sm_integration.py`、`test_proactive_sid_guard.py` 共 46 项单测全过
- 确认无测试依赖被降级的 preempted 日志级别（测试断言的是状态机 `_preempted` 标志，与日志无关）

## 备注

按产品设计主动搭话大多数轮次本就是 skip，所以这条 info 会比较频繁（normal ~15s/轮、frequent ~5s/轮，409 在 AI 忙时前端快速重试可能短时连发几条）。如果偏吵，后续可把高频的两类 409 降到 debug、info 只留「真正做了决策才跳过」的那些。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 改进了系统诊断日志的精准性，为各类场景提供更详细的调试信息
  * 优化了日志级别配置，增强问题排查体验和系统可观测性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->