### PR TITLE
feat(compact): 历史堆砌区支持顶部 resize bar 调整高度上限

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -96,6 +96,7 @@ const COMPACT_SPEECH_FALLBACK_REVEAL_DELAY_MS = 700;
 const SPEECH_PLAYBACK_STATE_STORAGE_KEY = 'neko_speech_playback_state';
 const SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';
 const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
+const COMPACT_HISTORY_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.compactHistorySlotHeight';
 export const COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS = 560;
 const COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT = 7;
 const COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD = 22;
@@ -130,6 +131,14 @@ const COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280;
 const COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
 const COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER = 32;
 const COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER = 16;
+// compact 历史堆砌区（CompactExportHistoryPanel）顶部 resize bar 的高度上限钳位参数。
+// 下限压到 ~1-2 个气泡以便节约屏幕；上限对齐 anchor 的 max-height（width*1.46 / 78% 视口），
+// 避免拖超 anchor 二次截断产生「拖了没反应」的死区。默认（未拖动）公式仍是 width*1.18 / 63%。
+const COMPACT_HISTORY_SLOT_MIN_HEIGHT = 120;
+const COMPACT_HISTORY_SLOT_MAX_WIDTH_RATIO = 1.46;
+const COMPACT_HISTORY_SLOT_MAX_VIEWPORT_RATIO = 0.78;
+const COMPACT_HISTORY_SLOT_DEFAULT_WIDTH_RATIO = 1.18;
+const COMPACT_HISTORY_SLOT_DEFAULT_VIEWPORT_RATIO = 0.63;
 const COMPACT_CHOICE_PLACEMENT_HYSTERESIS = 24;
 const COMPOSER_OPTION_MARQUEE_MIN_DISTANCE = 6;
 const COMPOSER_OPTION_MARQUEE_MIN_DURATION_MS = 1400;
@@ -149,6 +158,14 @@ type CompactSurfaceResizeState = {
   anchorRightScreen: number;
   anchorTopScreen: number;
   surfaceHeight: number;
+  captureTarget: Element | null;
+};
+
+type CompactHistoryResizeState = {
+  pointerId: number;
+  startPointerY: number;
+  startHeight: number;
+  lastHeight: number;
   captureTarget: Element | null;
 };
 
@@ -371,6 +388,53 @@ function persistCompactExportHistoryOpen(open: boolean) {
   } catch {
     // localStorage can be unavailable in restricted hosts; keep the in-memory state.
   }
+}
+
+function readPersistedCompactHistorySlotHeight(): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const persisted = window.localStorage?.getItem(COMPACT_HISTORY_HEIGHT_STORAGE_KEY);
+    if (persisted === null || persisted === undefined) return null;
+    const value = Number(persisted);
+    return Number.isFinite(value) && value > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistCompactHistorySlotHeight(value: number | null) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value === null) {
+      window.localStorage?.removeItem(COMPACT_HISTORY_HEIGHT_STORAGE_KEY);
+    } else {
+      window.localStorage?.setItem(COMPACT_HISTORY_HEIGHT_STORAGE_KEY, String(Math.round(value)));
+    }
+  } catch {
+    // localStorage can be unavailable in restricted hosts; keep the in-memory state.
+  }
+}
+
+// 历史区高度上限的基数：Electron 独立窗口用工作区高度（窗口可能只覆盖部分屏，不能用 innerHeight），
+// 网页路径用视口高度。与 styles.css 里默认公式的 63vh / workarea*0.63 取同一基数。
+function getCompactHistoryViewportBase(): number {
+  if (typeof window === 'undefined') return 900;
+  const desktopLayout = (window as typeof window & {
+    __nekoDesktopCompactLayout?: { workArea?: { height?: number } | null } | null;
+  }).__nekoDesktopCompactLayout;
+  const workAreaHeight = Number(desktopLayout?.workArea?.height);
+  if (isDesktopCompactSurfaceLayoutActive() && Number.isFinite(workAreaHeight) && workAreaHeight > 0) {
+    return workAreaHeight;
+  }
+  return window.innerHeight || 900;
+}
+
+function getCompactHistoryResizePointerY(event: ReactPointerEvent<HTMLDivElement>): number {
+  const screenY = Number(event.screenY);
+  if (Number.isFinite(screenY)) {
+    return screenY;
+  }
+  return event.clientY;
 }
 
 type SpeechPlaybackState = {
@@ -1284,6 +1348,8 @@ export default function App({
   const [compactInputToolWheelChargeDirection, setCompactInputToolWheelChargeDirection] = useState<1 | -1 | null>(null);
   const [compactInputToolWheelChargeReleaseActive, setCompactInputToolWheelChargeReleaseActive] = useState(false);
   const [compactSurfaceResizeWidth, setCompactSurfaceResizeWidth] = useState<number | null>(null);
+  const [compactHistorySlotHeight, setCompactHistorySlotHeight] = useState<number | null>(readPersistedCompactHistorySlotHeight);
+  const [compactHistoryResizeActive, setCompactHistoryResizeActive] = useState(false);
   const [compactExportHistoryOpen, setCompactExportHistoryOpen] = useState(readPersistedCompactExportHistoryOpen);
   const [compactExportHistoryMounted, setCompactExportHistoryMounted] = useState(readPersistedCompactExportHistoryOpen);
   const [compactExportControlsOpen, setCompactExportControlsOpen] = useState(false);
@@ -1291,6 +1357,7 @@ export default function App({
   const [compactExportSelectedIds, setCompactExportSelectedIds] = useState<Set<string>>(() => new Set());
   const [compactExportAutoScrollToBottom, setCompactExportAutoScrollToBottom] = useState(true);
   const compactSurfaceResizeStateRef = useRef<CompactSurfaceResizeState | null>(null);
+  const compactHistoryResizeStateRef = useRef<CompactHistoryResizeState | null>(null);
   const compactHistoryVisibilitySuppressClickRef = useRef(false);
   const compactExportHistoryUnmountTimerRef = useRef<number | null>(null);
   const submittingRef = useRef(false);
@@ -2731,6 +2798,137 @@ export default function App({
     event.stopPropagation();
     finishCompactSurfaceResize(event);
   }, [finishCompactSurfaceResize]);
+
+  const getCompactHistorySlotMaxHeight = useCallback(() => {
+    const surfaceWidth = getCurrentCompactSurfaceWidth();
+    const base = getCompactHistoryViewportBase();
+    return Math.round(Math.max(
+      COMPACT_HISTORY_SLOT_MIN_HEIGHT,
+      Math.min(
+        surfaceWidth * COMPACT_HISTORY_SLOT_MAX_WIDTH_RATIO,
+        base * COMPACT_HISTORY_SLOT_MAX_VIEWPORT_RATIO,
+      ),
+    ));
+  }, [getCurrentCompactSurfaceWidth]);
+
+  const getClampedCompactHistorySlotHeight = useCallback((height: number) => (
+    Math.round(Math.max(
+      COMPACT_HISTORY_SLOT_MIN_HEIGHT,
+      Math.min(height, getCompactHistorySlotMaxHeight()),
+    ))
+  ), [getCompactHistorySlotMaxHeight]);
+
+  // 用户未拖动过时（slot 为 null），起拖高度取 styles.css 默认公式值（width*1.18 / 63%），
+  // 保证拖动第一帧从当前可见高度连续起步、不跳变。
+  const getCompactHistoryStartHeight = useCallback(() => {
+    if (compactHistorySlotHeight !== null) return compactHistorySlotHeight;
+    const surfaceWidth = getCurrentCompactSurfaceWidth();
+    const base = getCompactHistoryViewportBase();
+    return Math.round(Math.min(
+      surfaceWidth * COMPACT_HISTORY_SLOT_DEFAULT_WIDTH_RATIO,
+      base * COMPACT_HISTORY_SLOT_DEFAULT_VIEWPORT_RATIO,
+    ));
+  }, [compactHistorySlotHeight, getCurrentCompactSurfaceWidth]);
+
+  const applyCompactHistorySlotHeightVar = useCallback((height: number | null) => {
+    if (typeof document === 'undefined') return;
+    if (height === null) {
+      document.documentElement.style.removeProperty('--compact-history-slot-height');
+    } else {
+      document.documentElement.style.setProperty(
+        '--compact-history-slot-height',
+        `${getClampedCompactHistorySlotHeight(height)}px`,
+      );
+    }
+    // CSS 变量变更不会自己通知宿主；让宿主重算 history 命中 rect / Electron 窗口 bounds / 鼠标穿透区。
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('neko:compact-interaction-geometry-refresh'));
+    }
+  }, [getClampedCompactHistorySlotHeight]);
+
+  const finishCompactHistoryResize = useCallback((event?: ReactPointerEvent<HTMLDivElement>) => {
+    const resizeState = compactHistoryResizeStateRef.current;
+    if (!resizeState) return;
+    if (event && resizeState.pointerId !== event.pointerId) return;
+    persistCompactHistorySlotHeight(resizeState.lastHeight);
+    setCompactHistorySlotHeight(resizeState.lastHeight);
+    const captureTarget = resizeState.captureTarget;
+    if (captureTarget && typeof captureTarget.releasePointerCapture === 'function') {
+      try {
+        if (captureTarget.hasPointerCapture?.(resizeState.pointerId)) {
+          captureTarget.releasePointerCapture(resizeState.pointerId);
+        }
+      } catch (_) {}
+    }
+    compactHistoryResizeStateRef.current = null;
+    setCompactHistoryResizeActive(false);
+  }, []);
+
+  const handleCompactHistoryResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!isCompactSurface) return;
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const startHeight = getCompactHistoryStartHeight();
+    compactHistoryResizeStateRef.current = {
+      pointerId: event.pointerId,
+      startPointerY: getCompactHistoryResizePointerY(event),
+      startHeight,
+      lastHeight: getClampedCompactHistorySlotHeight(startHeight),
+      captureTarget: event.currentTarget,
+    };
+    setCompactHistoryResizeActive(true);
+    try {
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    } catch (_) {}
+  }, [getClampedCompactHistorySlotHeight, getCompactHistoryStartHeight, isCompactSurface]);
+
+  const handleCompactHistoryResizePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const resizeState = compactHistoryResizeStateRef.current;
+    if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    // bar 在堆砌区顶部：上拖（deltaY < 0）增高，下拖减高。
+    const deltaY = getCompactHistoryResizePointerY(event) - resizeState.startPointerY;
+    const nextHeight = getClampedCompactHistorySlotHeight(resizeState.startHeight - deltaY);
+    resizeState.lastHeight = nextHeight;
+    setCompactHistorySlotHeight(nextHeight);
+    applyCompactHistorySlotHeightVar(nextHeight);
+  }, [applyCompactHistorySlotHeightVar, getClampedCompactHistorySlotHeight]);
+
+  const handleCompactHistoryResizePointerUp = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    finishCompactHistoryResize(event);
+  }, [finishCompactHistoryResize]);
+
+  const handleCompactHistoryResizePointerCancel = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    finishCompactHistoryResize(event);
+  }, [finishCompactHistoryResize]);
+
+  // 把已存/恢复的高度写进 CSS 变量（覆盖默认公式）；slot 为 null 时清掉、回落默认。
+  useEffect(() => {
+    if (!isCompactSurface) return;
+    applyCompactHistorySlotHeightVar(compactHistorySlotHeight);
+  }, [applyCompactHistorySlotHeightVar, compactHistorySlotHeight, isCompactSurface]);
+
+  // 视口 / 桌面工作区变化后，对已存高度重新 clamp，避免上限失配后被 anchor 二次截断。
+  useEffect(() => {
+    if (!isCompactSurface) return undefined;
+    const clampExistingHeight = () => {
+      setCompactHistorySlotHeight(current => (
+        current === null ? current : getClampedCompactHistorySlotHeight(current)
+      ));
+    };
+    window.addEventListener('resize', clampExistingHeight);
+    window.addEventListener('neko:desktop-compact-layout-change', clampExistingHeight);
+    return () => {
+      window.removeEventListener('resize', clampExistingHeight);
+      window.removeEventListener('neko:desktop-compact-layout-change', clampExistingHeight);
+    };
+  }, [getClampedCompactHistorySlotHeight, isCompactSurface]);
 
   useEffect(() => {
     if (!isCompactSurface || compactSurfaceEffectiveWidth === null) {
@@ -5212,6 +5410,11 @@ export default function App({
       isDropTargetAt={isCompactHistoryDropTargetAt}
       onDropToTarget={handleCompactHistoryDropToAvatar}
       onDragStateChange={onCompactHistoryDragStateChange}
+      historyResizeActive={compactHistoryResizeActive}
+      onHistoryResizePointerDown={handleCompactHistoryResizePointerDown}
+      onHistoryResizePointerMove={handleCompactHistoryResizePointerMove}
+      onHistoryResizePointerUp={handleCompactHistoryResizePointerUp}
+      onHistoryResizePointerCancel={handleCompactHistoryResizePointerCancel}
     />
   ) : null;
   const compactExportHistoryNode = compactExportHistoryElement;

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -169,6 +169,7 @@ type CompactHistoryResizeState = {
   startPointerY: number;
   startHeight: number;
   lastHeight: number;
+  moved: boolean;
   captureTarget: Element | null;
 };
 
@@ -2860,8 +2861,11 @@ export default function App({
     const resizeState = compactHistoryResizeStateRef.current;
     if (!resizeState) return;
     if (event && resizeState.pointerId !== event.pointerId) return;
-    persistCompactHistorySlotHeight(resizeState.lastHeight);
-    setCompactHistorySlotHeight(resizeState.lastHeight);
+    // 只在真正拖动过才落库：纯点击不该把响应式默认高度锁成固定像素值（否则之后视口/宽度变化不再响应）。
+    if (resizeState.moved) {
+      persistCompactHistorySlotHeight(resizeState.lastHeight);
+      setCompactHistorySlotHeight(resizeState.lastHeight);
+    }
     const captureTarget = resizeState.captureTarget;
     if (captureTarget && typeof captureTarget.releasePointerCapture === 'function') {
       try {
@@ -2885,6 +2889,7 @@ export default function App({
       startPointerY: getCompactHistoryResizePointerY(event),
       startHeight,
       lastHeight: getClampedCompactHistorySlotHeight(startHeight),
+      moved: false,
       captureTarget: event.currentTarget,
     };
     setCompactHistoryResizeActive(true);
@@ -2900,6 +2905,7 @@ export default function App({
     event.stopPropagation();
     // bar 在堆砌区顶部：上拖（deltaY < 0）增高，下拖减高。
     const deltaY = getCompactHistoryResizePointerY(event) - resizeState.startPointerY;
+    if (deltaY !== 0) resizeState.moved = true;
     const nextHeight = getClampedCompactHistorySlotHeight(resizeState.startHeight - deltaY);
     resizeState.lastHeight = nextHeight;
     setCompactHistorySlotHeight(nextHeight);

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -139,6 +139,9 @@ const COMPACT_HISTORY_SLOT_MAX_WIDTH_RATIO = 1.46;
 const COMPACT_HISTORY_SLOT_MAX_VIEWPORT_RATIO = 0.78;
 const COMPACT_HISTORY_SLOT_DEFAULT_WIDTH_RATIO = 1.18;
 const COMPACT_HISTORY_SLOT_DEFAULT_VIEWPORT_RATIO = 0.63;
+// scroll 区上方的 bar(12px+margin) 与下方 controls(展开块 ≤44px) 的固定 chrome；
+// 从 anchor max-height 里扣掉，避免拖到上限时 scroll 吃满 anchor、controls 溢出被裁成非交互。
+const COMPACT_HISTORY_SLOT_CHROME_RESERVE = 72;
 const COMPACT_CHOICE_PLACEMENT_HYSTERESIS = 24;
 const COMPOSER_OPTION_MARQUEE_MIN_DISTANCE = 6;
 const COMPOSER_OPTION_MARQUEE_MIN_DURATION_MS = 1400;
@@ -2802,12 +2805,15 @@ export default function App({
   const getCompactHistorySlotMaxHeight = useCallback(() => {
     const surfaceWidth = getCurrentCompactSurfaceWidth();
     const base = getCompactHistoryViewportBase();
+    // anchor 的 max-height = min(width*1.46, 78%)，但 panel 里 scroll 上方有 bar、下方有 controls；
+    // 先扣掉这部分非滚动 chrome，scroll 区才不会吃满 anchor 把 controls / 底部气泡顶出可视/可点区。
+    const anchorMax = Math.min(
+      surfaceWidth * COMPACT_HISTORY_SLOT_MAX_WIDTH_RATIO,
+      base * COMPACT_HISTORY_SLOT_MAX_VIEWPORT_RATIO,
+    );
     return Math.round(Math.max(
       COMPACT_HISTORY_SLOT_MIN_HEIGHT,
-      Math.min(
-        surfaceWidth * COMPACT_HISTORY_SLOT_MAX_WIDTH_RATIO,
-        base * COMPACT_HISTORY_SLOT_MAX_VIEWPORT_RATIO,
-      ),
+      anchorMax - COMPACT_HISTORY_SLOT_CHROME_RESERVE,
     ));
   }, [getCurrentCompactSurfaceWidth]);
 
@@ -2821,14 +2827,18 @@ export default function App({
   // 用户未拖动过时（slot 为 null），起拖高度取 styles.css 默认公式值（width*1.18 / 63%），
   // 保证拖动第一帧从当前可见高度连续起步、不跳变。
   const getCompactHistoryStartHeight = useCallback(() => {
-    if (compactHistorySlotHeight !== null) return compactHistorySlotHeight;
+    // 起拖基准必须是「当前可见高度」（按当前约束 clamp 后）。存量高度可能来自更大屏 / 更宽 surface，
+    // 此时面板已被钳到 max、若用 stale 大值做基准，向下拖会出现「先拖一段没反应」的死区。
+    if (compactHistorySlotHeight !== null) {
+      return getClampedCompactHistorySlotHeight(compactHistorySlotHeight);
+    }
     const surfaceWidth = getCurrentCompactSurfaceWidth();
     const base = getCompactHistoryViewportBase();
-    return Math.round(Math.min(
+    return getClampedCompactHistorySlotHeight(Math.round(Math.min(
       surfaceWidth * COMPACT_HISTORY_SLOT_DEFAULT_WIDTH_RATIO,
       base * COMPACT_HISTORY_SLOT_DEFAULT_VIEWPORT_RATIO,
-    ));
-  }, [compactHistorySlotHeight, getCurrentCompactSurfaceWidth]);
+    )));
+  }, [compactHistorySlotHeight, getClampedCompactHistorySlotHeight, getCurrentCompactSurfaceWidth]);
 
   const applyCompactHistorySlotHeightVar = useCallback((height: number | null) => {
     if (typeof document === 'undefined') return;
@@ -2914,21 +2924,21 @@ export default function App({
     applyCompactHistorySlotHeightVar(compactHistorySlotHeight);
   }, [applyCompactHistorySlotHeightVar, compactHistorySlotHeight, isCompactSurface]);
 
-  // 视口 / 桌面工作区变化后，对已存高度重新 clamp，避免上限失配后被 anchor 二次截断。
+  // 视口 / 工作区 / compact surface 宽度变化后，按新约束重写 CSS 变量（用新 max clamp 显示高度）。
+  // 刻意不改 state、不覆盖 storage：存量 raw 值保留，换屏 / 改宽再放大时能恢复；起拖死区另由
+  // getCompactHistoryStartHeight 对基准 clamp 解决。
   useEffect(() => {
     if (!isCompactSurface) return undefined;
-    const clampExistingHeight = () => {
-      setCompactHistorySlotHeight(current => (
-        current === null ? current : getClampedCompactHistorySlotHeight(current)
-      ));
-    };
-    window.addEventListener('resize', clampExistingHeight);
-    window.addEventListener('neko:desktop-compact-layout-change', clampExistingHeight);
+    const reapplySlotHeight = () => applyCompactHistorySlotHeightVar(compactHistorySlotHeight);
+    window.addEventListener('resize', reapplySlotHeight);
+    window.addEventListener('neko:desktop-compact-layout-change', reapplySlotHeight);
+    window.addEventListener('neko:compact-surface-resize-width-change', reapplySlotHeight);
     return () => {
-      window.removeEventListener('resize', clampExistingHeight);
-      window.removeEventListener('neko:desktop-compact-layout-change', clampExistingHeight);
+      window.removeEventListener('resize', reapplySlotHeight);
+      window.removeEventListener('neko:desktop-compact-layout-change', reapplySlotHeight);
+      window.removeEventListener('neko:compact-surface-resize-width-change', reapplySlotHeight);
     };
-  }, [getClampedCompactHistorySlotHeight, isCompactSurface]);
+  }, [applyCompactHistorySlotHeightVar, compactHistorySlotHeight, isCompactSurface]);
 
   useEffect(() => {
     if (!isCompactSurface || compactSurfaceEffectiveWidth === null) {

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
@@ -45,6 +45,23 @@ function renderPanel(overrides: Partial<Parameters<typeof CompactExportHistoryPa
 }
 
 describe('CompactExportHistoryPanel', () => {
+  it('shows the history height resize bar only outside preview and wires its hit-region', () => {
+    const { container, rerender } = renderPanel({ previewOpen: false, visibilityState: 'open' });
+    const bar = container.querySelector('.compact-export-history-resize-bar');
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute('data-compact-hit-region-id')).toBe('history:resize');
+    expect(bar?.getAttribute('data-compact-hit-region-kind')).toBe('resize');
+    expect(bar?.getAttribute('data-compact-no-drag')).toBe('true');
+
+    rerender(<CompactExportHistoryPanel {...createPanelProps({ previewOpen: true, visibilityState: 'open' })} />);
+    expect(container.querySelector('.compact-export-history-resize-bar')).toBeNull();
+  });
+
+  it('marks the history resize bar active while dragging', () => {
+    const { container } = renderPanel({ previewOpen: false, visibilityState: 'open', historyResizeActive: true });
+    expect(container.querySelector('.compact-export-history-resize-bar.is-active')).not.toBeNull();
+  });
+
   it('pins the history list to bottom when returning from preview', () => {
     const scrollTopValues: number[] = [];
     const scrollTopByElement = new WeakMap<HTMLElement, number>();

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
@@ -62,6 +62,14 @@ describe('CompactExportHistoryPanel', () => {
     expect(container.querySelector('.compact-export-history-resize-bar.is-active')).not.toBeNull();
   });
 
+  it('drops the history resize bar hit-region when a choice prompt sits above', () => {
+    const { container } = renderPanel({ previewOpen: false, visibilityState: 'open', choiceLayerAbove: true });
+    const bar = container.querySelector('.compact-export-history-resize-bar');
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute('data-compact-hit-region-id')).toBeNull();
+    expect(bar?.getAttribute('data-compact-hit-region')).toBeNull();
+  });
+
   it('pins the history list to bottom when returning from preview', () => {
     const scrollTopValues: number[] = [];
     const scrollTopByElement = new WeakMap<HTMLElement, number>();

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
@@ -68,6 +68,7 @@ describe('CompactExportHistoryPanel', () => {
     expect(bar).not.toBeNull();
     expect(bar?.getAttribute('data-compact-hit-region-id')).toBeNull();
     expect(bar?.getAttribute('data-compact-hit-region')).toBeNull();
+    expect(bar?.getAttribute('data-compact-hit-region-kind')).toBeNull();
   });
 
   it('pins the history list to bottom when returning from preview', () => {

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -2512,9 +2512,9 @@ export default function CompactExportHistoryPanel({
                 放在 scroll 之前，命中区随 anchor 的 children hit-scope 上报给宿主、Electron 下可点不穿透。 */}
             <div
               className={clsx('compact-export-history-resize-bar', { 'is-active': historyResizeActive })}
-              data-compact-hit-region={historyInteractive ? 'true' : undefined}
-              data-compact-hit-region-id={historyInteractive ? 'history:resize' : undefined}
-              data-compact-hit-region-kind={historyInteractive ? 'resize' : undefined}
+              data-compact-hit-region={historyInteractive && !choiceLayerAbove ? 'true' : undefined}
+              data-compact-hit-region-id={historyInteractive && !choiceLayerAbove ? 'history:resize' : undefined}
+              data-compact-hit-region-kind={historyInteractive && !choiceLayerAbove ? 'resize' : undefined}
               data-compact-no-drag="true"
               aria-hidden="true"
               onPointerDown={onHistoryResizePointerDown}

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -90,6 +90,11 @@ type CompactExportHistoryPanelProps = {
   isDropTargetAt?: (point: CompactHistoryDropPoint) => boolean;
   onDropToTarget?: (request: CompactHistoryDropRequest) => Promise<boolean | void> | boolean | void;
   onDragStateChange?: (state: CompactHistoryDragStatePayload) => void;
+  historyResizeActive?: boolean;
+  onHistoryResizePointerDown?: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onHistoryResizePointerMove?: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onHistoryResizePointerUp?: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onHistoryResizePointerCancel?: (event: ReactPointerEvent<HTMLDivElement>) => void;
 };
 
 export type CompactHistoryDragType = 'image' | 'bubble';
@@ -1225,6 +1230,11 @@ export default function CompactExportHistoryPanel({
   isDropTargetAt,
   onDropToTarget,
   onDragStateChange,
+  historyResizeActive,
+  onHistoryResizePointerDown,
+  onHistoryResizePointerMove,
+  onHistoryResizePointerUp,
+  onHistoryResizePointerCancel,
 }: CompactExportHistoryPanelProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const scrollbarDragRef = useRef<ScrollbarDragState | null>(null);
@@ -2498,6 +2508,21 @@ export default function CompactExportHistoryPanel({
         <div className="compact-export-history-panel">
         {previewOpen ? previewNode : (
           <>
+            {/* 堆砌区顶部的高度 resize bar：平时透明，hover / 拖动中半透明显现（is-active）。
+                放在 scroll 之前，命中区随 anchor 的 children hit-scope 上报给宿主、Electron 下可点不穿透。 */}
+            <div
+              className={clsx('compact-export-history-resize-bar', { 'is-active': historyResizeActive })}
+              data-compact-hit-region={historyInteractive ? 'true' : undefined}
+              data-compact-hit-region-id={historyInteractive ? 'history:resize' : undefined}
+              data-compact-hit-region-kind={historyInteractive ? 'resize' : undefined}
+              data-compact-no-drag="true"
+              aria-hidden="true"
+              onPointerDown={onHistoryResizePointerDown}
+              onPointerMove={onHistoryResizePointerMove}
+              onPointerUp={onHistoryResizePointerUp}
+              onPointerCancel={onHistoryResizePointerCancel}
+              onLostPointerCapture={onHistoryResizePointerCancel}
+            />
             <div
               ref={scrollRef}
               className="compact-export-history-scroll"

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2656,7 +2656,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   opacity: 0;
 }
 
-.compact-export-history-anchor:hover .compact-export-history-resize-bar::after,
+/* 顶部高度 bar 的浮现热区：鼠标进入「可调尺寸」区域时连带显现，而不是 hover 整个历史区就亮——
+   即左右宽度 handle（.compact-chat-resize-handle，与 anchor 同在 .app-shell 下，跨子树用 :has）
+   或历史滚动条命中区（.compact-export-history-scrollbar-hit，anchor 后代）；
+   外加直接 hover bar 本体 / 拖动中（is-active）。这样在「调宽 / 滚动」语境里统一提示也能调高度。 */
+.app-shell:has(.compact-chat-resize-handle:hover) .compact-export-history-resize-bar::after,
+.compact-export-history-anchor:has(.compact-export-history-scrollbar-hit:hover) .compact-export-history-resize-bar::after,
 .compact-export-history-resize-bar:hover::after,
 .compact-export-history-resize-bar.is-active::after {
   opacity: 0.55;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2370,6 +2370,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-scroll,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-scrollbar-hit,
+.compact-export-history-anchor.under-choice-prompt .compact-export-history-resize-bar,
 .compact-export-history-anchor.under-choice-prompt .compact-export-history-controls,
 .compact-export-history-anchor.under-choice-prompt .compact-export-preview-region {
   opacity: 0.32;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2629,6 +2629,35 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     0 8px 20px rgba(36, 151, 217, 0.12);
 }
 
+/* 堆砌区顶部的高度 resize bar：平时透明，hover 整个历史区 / 拖动中（is-active）半透明显现。
+   与左右宽度 handle 一致采用「平时低调、靠近才显形」手感（opacity 切换，无过渡）。 */
+.compact-export-history-resize-bar {
+  flex: 0 0 auto;
+  height: 12px;
+  margin: 0 8px 2px;
+  cursor: ns-resize;
+  pointer-events: auto;
+  touch-action: none;
+  opacity: 0;
+  -webkit-app-region: no-drag;
+}
+
+.compact-export-history-resize-bar::after {
+  content: "";
+  display: block;
+  width: 40px;
+  height: 4px;
+  margin: 4px auto 0;
+  border-radius: 999px;
+  background: rgba(120, 142, 170, 0.75);
+}
+
+.compact-export-history-anchor:hover .compact-export-history-resize-bar,
+.compact-export-history-resize-bar:hover,
+.compact-export-history-resize-bar.is-active {
+  opacity: 0.55;
+}
+
 .compact-history-drag-layer {
   position: fixed;
   left: var(--compact-history-drag-left, 0px);

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2629,8 +2629,11 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     0 8px 20px rgba(36, 151, 217, 0.12);
 }
 
-/* 堆砌区顶部的高度 resize bar：平时透明，hover 整个历史区 / 拖动中（is-active）半透明显现。
-   与左右宽度 handle 一致采用「平时低调、靠近才显形」手感（opacity 切换，无过渡）。 */
+/* 堆砌区顶部的高度 resize bar：视觉抓手平时透明，hover 整个历史区 / 拖动中（is-active）半透明显现。
+   与左右宽度 handle 一致采用「平时低调、靠近才显形」手感（opacity 切换，无过渡）。
+   注意：透明只施加在 ::after 伪元素上，bar 本体保持不透明——宿主几何收集器
+   （app-react-chat-window.js）会按 computed opacity <= 0.01 丢弃 hit-region，
+   若 bar 本体透明则 Electron 下整条会鼠标穿透、永远 hover/点不到、无法发起拖拽。 */
 .compact-export-history-resize-bar {
   flex: 0 0 auto;
   height: 12px;
@@ -2638,7 +2641,6 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   cursor: ns-resize;
   pointer-events: auto;
   touch-action: none;
-  opacity: 0;
   -webkit-app-region: no-drag;
 }
 
@@ -2650,11 +2652,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   margin: 4px auto 0;
   border-radius: 999px;
   background: rgba(120, 142, 170, 0.75);
+  opacity: 0;
 }
 
-.compact-export-history-anchor:hover .compact-export-history-resize-bar,
-.compact-export-history-resize-bar:hover,
-.compact-export-history-resize-bar.is-active {
+.compact-export-history-anchor:hover .compact-export-history-resize-bar::after,
+.compact-export-history-resize-bar:hover::after,
+.compact-export-history-resize-bar.is-active::after {
   opacity: 0.55;
 }
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -696,6 +696,36 @@ def test_electron_compact_chat_retires_full_surface_chrome():
     assert 'id="react-chat-window-overlay" hidden' in template
 
 
+def test_compact_history_resize_bar_is_draggable_and_persisted():
+    styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
+    panel_source = COMPACT_EXPORT_HISTORY_PANEL_PATH.read_text(encoding="utf-8")
+    app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
+
+    # 顶部 resize bar 的样式：可纵向拖、可接收 pointer、平时透明、不触发原生窗口拖动。
+    bar_block = css_block(
+        styles,
+        ".compact-export-history-resize-bar {",
+        ".compact-export-history-resize-bar::after",
+    )
+    assert "cursor: ns-resize;" in bar_block
+    assert "pointer-events: auto;" in bar_block
+    assert "opacity: 0;" in bar_block
+    assert "-webkit-app-region: no-drag;" in bar_block
+    assert ".compact-export-history-resize-bar.is-active {" in styles
+
+    # bar 的 DOM：带可命中且不穿透的 hit-region，拖拽不触发面板 / 整窗拖动。
+    assert "className={clsx('compact-export-history-resize-bar'" in panel_source
+    assert "data-compact-hit-region-id={historyInteractive ? 'history:resize' : undefined}" in panel_source
+    assert "data-compact-hit-region-kind={historyInteractive ? 'resize' : undefined}" in panel_source
+    resize_bar_jsx = panel_source.split("compact-export-history-resize-bar", 1)[1].split("/>", 1)[0]
+    assert 'data-compact-no-drag="true"' in resize_bar_jsx
+
+    # 高度上限写预留覆盖变量 + 独立 localStorage key；变更后触发宿主几何重算（Electron 窗口联动）。
+    assert "COMPACT_HISTORY_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.compactHistorySlotHeight'" in app_source
+    assert "'--compact-history-slot-height'" in app_source
+    assert "new CustomEvent('neko:compact-interaction-geometry-refresh')" in app_source
+
+
 def test_compact_history_controls_collapse_gives_height_back_to_history_scroll():
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -716,6 +716,14 @@ def test_compact_history_resize_bar_is_draggable_and_persisted():
     after_block = css_block(styles, ".compact-export-history-resize-bar::after {", ".compact-history-drag-layer")
     assert "opacity: 0;" in after_block
     assert ".compact-export-history-resize-bar.is-active::after {" in styles
+    # 浮现热区：hover 左右宽度 handle（跨子树 :has）或历史滚动条命中区时连带显现，
+    # 不再用「hover 整个历史区就亮」的旧触发。
+    assert ".app-shell:has(.compact-chat-resize-handle:hover) .compact-export-history-resize-bar::after" in styles
+    assert (
+        ".compact-export-history-anchor:has(.compact-export-history-scrollbar-hit:hover) "
+        ".compact-export-history-resize-bar::after"
+    ) in styles
+    assert ".compact-export-history-anchor:hover .compact-export-history-resize-bar" not in styles
 
     # bar 的 DOM：带可命中且不穿透的 hit-region，拖拽不触发面板 / 整窗拖动。
     assert "className={clsx('compact-export-history-resize-bar'" in panel_source

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -719,10 +719,16 @@ def test_compact_history_resize_bar_is_draggable_and_persisted():
 
     # bar 的 DOM：带可命中且不穿透的 hit-region，拖拽不触发面板 / 整窗拖动。
     assert "className={clsx('compact-export-history-resize-bar'" in panel_source
-    assert "data-compact-hit-region-id={historyInteractive ? 'history:resize' : undefined}" in panel_source
-    assert "data-compact-hit-region-kind={historyInteractive ? 'resize' : undefined}" in panel_source
+    # hit-region 受 historyInteractive && !choiceLayerAbove 双重 gate：choice prompt 压在历史上方时，
+    # bar 不再上报命中区（与 scroll/controls 一起惰性，Electron 下不留可拖 / 不穿透的活条）。
+    assert "data-compact-hit-region-id={historyInteractive && !choiceLayerAbove ? 'history:resize' : undefined}" in panel_source
+    assert "data-compact-hit-region-kind={historyInteractive && !choiceLayerAbove ? 'resize' : undefined}" in panel_source
     resize_bar_jsx = panel_source.split("compact-export-history-resize-bar", 1)[1].split("/>", 1)[0]
     assert 'data-compact-no-drag="true"' in resize_bar_jsx
+    # under-choice 态把 bar 一并纳入 pointer-events:none / 淡化规则。
+    assert ".compact-export-history-anchor.under-choice-prompt .compact-export-history-resize-bar," in styles
+    # 纯点击不落库：finish 仅在 moved 时 persist。
+    assert "if (resizeState.moved) {" in app_source
 
     # 高度上限写预留覆盖变量 + 独立 localStorage key；变更后触发宿主几何重算（Electron 窗口联动）。
     assert "COMPACT_HISTORY_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.compactHistorySlotHeight'" in app_source

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -709,9 +709,13 @@ def test_compact_history_resize_bar_is_draggable_and_persisted():
     )
     assert "cursor: ns-resize;" in bar_block
     assert "pointer-events: auto;" in bar_block
-    assert "opacity: 0;" in bar_block
     assert "-webkit-app-region: no-drag;" in bar_block
-    assert ".compact-export-history-resize-bar.is-active {" in styles
+    # bar 本体不能透明：宿主几何收集器按 opacity<=0.01 丢弃 hit-region，透明会让 Electron 下鼠标穿透、点不到。
+    assert "opacity: 0;" not in bar_block
+    # 只让视觉抓手（伪元素）平时透明、hover/拖动显现。
+    after_block = css_block(styles, ".compact-export-history-resize-bar::after {", ".compact-history-drag-layer")
+    assert "opacity: 0;" in after_block
+    assert ".compact-export-history-resize-bar.is-active::after {" in styles
 
     # bar 的 DOM：带可命中且不穿透的 hit-region，拖拽不触发面板 / 整窗拖动。
     assert "className={clsx('compact-export-history-resize-bar'" in panel_source


### PR DESCRIPTION
## 背景
compact 紧凑态下，历史对话气泡堆叠在 `CompactExportHistoryPanel`，高度上限原本写死在 `--compact-export-history-region-height`（网页 `width*1.18 / 63vh`、Electron `width*1.18 / workarea*0.63`）。compact 态只有左右两个宽度 handle（`CompactSurfaceResizeSide = ''left'' | ''right''`），**用户只能调宽、无法调高**，想把历史区压矮节约屏幕没有任何入口。

## 改动
在堆砌区顶部新增一条横向 resize bar：
- 平时透明，hover 整个历史区 / 拖动中（`is-active`）半透明显现；拖动中靠独立 state 保持可见
- 上下拖拽覆盖预留变量 `--compact-history-slot-height`（此前无人赋值），上拖增高、下拖压矮
- 范围 `120px ~ min(width*1.46, 78% 视口/工作区)`，初始未拖动保持默认高度
- React `localStorage` 持久化（`neko.reactChatWindow.compactHistorySlotHeight`）
- 复用既有宽度 resize 的指针状态机模式，但只写 CSS 变量、不走 resize-request 往返
- 变更后 dispatch 既有的 `neko:compact-interaction-geometry-refresh`，让宿主重算 history 命中 rect / Electron 窗口 bounds / 鼠标穿透
- bar 带 `data-compact-hit-region` + `data-compact-no-drag`，Electron 下可点不穿透、不触发拖窗
- compact 单行小胶囊本身不动

## 验证
- ✅ `tsc --noEmit` typecheck
- ✅ vitest 173 passed（含新增 bar 渲染 / hit-region / is-active 用例）
- ✅ pytest `test_react_chat_window_static.py` 30 passed（新增样式/DOM/storage key/几何事件断言 + 既有切片未破坏）
- ✅ `npm run build` 完整打包

## 待真机验证（Electron）
Electron compact 是独立窗口、主进程在 `lanlan_frd`（本仓库不可见）。本 PR 靠触发几何刷新让主进程扩窗，论据是「展开历史」本身已能撑窗、属同类几何变化。需真机确认：上限拖到 78% 时是否超过主进程对 compact 窗口的高度上限而被裁；若被裁需在 `lanlan_frd` 侧放宽或读取该上限。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 紧凑模式下历史记录面板顶部可拖拽调整高度，调整结果会持久化并在后续会话与布局变化中自动应用约束与恢复。

* **样式**
  * 新增顶部调整把手的视觉与交互：默认隐藏，悬停或激活时显示；在特定层级/布局下被置灰并禁用以防误触；活动状态有明显视觉反馈。

* **测试**
  * 新增覆盖把手可拖拽、样式呈现与持久化/刷新行为的自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->