### PR TITLE
调整紧凑历史面板布局

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2308,7 +2308,11 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     min(calc(var(--compact-export-surface-width) * 1.18), 63vh)
   );
   --compact-export-history-viewport-gutter: 24px;
+  --compact-export-history-viewport-inline-start: 0px;
   --compact-export-history-viewport-inline-size: 100vw;
+  --compact-export-history-viewport-inline-end: calc(
+    var(--compact-export-history-viewport-inline-start) + var(--compact-export-history-viewport-inline-size)
+  );
   --compact-export-history-width-ratio: 1.36;
   --compact-export-history-max-inline-size: calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter));
   --compact-export-history-inline-size: min(
@@ -2319,9 +2323,9 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   --compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);
   --compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));
   left: clamp(
-    calc(var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-inset)),
+    calc(var(--compact-export-history-viewport-inline-start) + var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-inset)),
     var(--compact-export-history-center-x),
-    calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))
+    calc(var(--compact-export-history-viewport-inline-end) - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))
   );
   bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 34px);
   /* Geometry-critical: derive collapse compensation from control metrics; do not animate layout properties here. */
@@ -2360,7 +2364,11 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     --compact-history-slot-height,
     min(calc(var(--compact-export-surface-width) * 1.18), calc(var(--compact-desktop-workarea-height, 900px) * 0.63))
   );
-  --compact-export-history-viewport-inline-size: var(--compact-desktop-workarea-width, 1440px);
+  --compact-export-history-viewport-inline-start: var(--compact-desktop-workarea-left, 0px);
+  --compact-export-history-viewport-inline-end: var(--compact-desktop-workarea-right, var(--compact-desktop-workarea-width, 1440px));
+  --compact-export-history-viewport-inline-size: calc(
+    var(--compact-export-history-viewport-inline-end) - var(--compact-export-history-viewport-inline-start)
+  );
   --compact-export-history-max-inline-size: calc(
     var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter)
   );

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2321,10 +2321,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   );
   --compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);
   --compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);
-  --compact-export-history-center-x: var(
-    --desktop-compact-history-center-x,
-    calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2) + var(--desktop-compact-history-offset-x, 0px))
-  );
+  --compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2) + var(--desktop-compact-history-offset-x, 0px));
   left: clamp(
     calc(var(--compact-export-history-viewport-inline-start) + var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-inset)),
     var(--compact-export-history-center-x),

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2303,8 +2303,31 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 .compact-export-history-anchor {
   position: fixed;
   --compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));
-  left: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));
-  bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 34px);
+  --compact-export-history-region-height: var(
+    --compact-history-slot-height,
+    min(calc(var(--compact-export-surface-width) * 1.18), 63vh)
+  );
+  --compact-export-history-viewport-gutter: 24px;
+  --compact-export-history-width-ratio: 1.36;
+  --compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));
+  --compact-export-history-inline-size: min(
+    calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio)),
+    var(--compact-export-history-max-inline-size)
+  );
+  --compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);
+  --compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);
+  --compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));
+  --compact-export-history-surface-gap: 20px;
+  left: clamp(
+    calc(var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-inset)),
+    var(--compact-export-history-center-x),
+    calc(100vw - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))
+  );
+  bottom: calc(
+    100vh
+    - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh))
+    + var(--compact-export-history-surface-gap, 20px)
+  );
   /* Geometry-critical: derive collapse compensation from control metrics; do not animate layout properties here. */
   --compact-export-controls-padding-y: clamp(4px, calc(var(--compact-export-surface-width) * 0.0116), 6px);
   --compact-export-controls-border-width: 1px;
@@ -2319,17 +2342,6 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     var(--compact-export-controls-collapsed-toggle-height) + (var(--compact-export-controls-border-width) * 2)
   );
   --compact-export-controls-collapse-delta: 0px;
-  --compact-export-history-region-height: var(
-    --compact-history-slot-height,
-    min(calc(var(--compact-export-surface-width) * 1.18), 63vh)
-  );
-  --compact-export-history-viewport-gutter: 24px;
-  --compact-export-history-width-ratio: 1.36;
-  --compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));
-  --compact-export-history-inline-size: min(
-    calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio)),
-    var(--compact-export-history-max-inline-size)
-  );
   --compact-export-history-bubble-max-ratio: 86%;
   --compact-export-history-system-bubble-max-ratio: 94%;
   --compact-export-preview-bubble-max-ratio: 90%;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2308,8 +2308,9 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     min(calc(var(--compact-export-surface-width) * 1.18), 63vh)
   );
   --compact-export-history-viewport-gutter: 24px;
+  --compact-export-history-viewport-inline-size: 100vw;
   --compact-export-history-width-ratio: 1.36;
-  --compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));
+  --compact-export-history-max-inline-size: calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter));
   --compact-export-history-inline-size: min(
     calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio)),
     var(--compact-export-history-max-inline-size)
@@ -2317,17 +2318,12 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   --compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);
   --compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);
   --compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));
-  --compact-export-history-surface-gap: 20px;
   left: clamp(
     calc(var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-inset)),
     var(--compact-export-history-center-x),
-    calc(100vw - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))
+    calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))
   );
-  bottom: calc(
-    100vh
-    - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh))
-    + var(--compact-export-history-surface-gap, 20px)
-  );
+  bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 34px);
   /* Geometry-critical: derive collapse compensation from control metrics; do not animate layout properties here. */
   --compact-export-controls-padding-y: clamp(4px, calc(var(--compact-export-surface-width) * 0.0116), 6px);
   --compact-export-controls-border-width: 1px;
@@ -2364,8 +2360,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     --compact-history-slot-height,
     min(calc(var(--compact-export-surface-width) * 1.18), calc(var(--compact-desktop-workarea-height, 900px) * 0.63))
   );
+  --compact-export-history-viewport-inline-size: var(--compact-desktop-workarea-width, 1440px);
   --compact-export-history-max-inline-size: calc(
-    var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)
+    var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter)
   );
   max-height: min(calc(var(--compact-export-surface-width) * 1.46), calc(var(--compact-desktop-workarea-height, 900px) * 0.78));
 }

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2365,7 +2365,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     min(calc(var(--compact-export-surface-width) * 1.18), calc(var(--compact-desktop-workarea-height, 900px) * 0.63))
   );
   --compact-export-history-viewport-inline-start: var(--compact-desktop-workarea-left, 0px);
-  --compact-export-history-viewport-inline-end: var(--compact-desktop-workarea-right, var(--compact-desktop-workarea-width, 1440px));
+  --compact-export-history-viewport-inline-end: var(
+    --compact-desktop-workarea-right,
+    calc(var(--compact-desktop-workarea-left, 0px) + var(--compact-desktop-workarea-width, 1440px))
+  );
   --compact-export-history-viewport-inline-size: calc(
     var(--compact-export-history-viewport-inline-end) - var(--compact-export-history-viewport-inline-start)
   );

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2321,7 +2321,10 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   );
   --compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);
   --compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);
-  --compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));
+  --compact-export-history-center-x: var(
+    --desktop-compact-history-center-x,
+    calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2) + var(--desktop-compact-history-offset-x, 0px))
+  );
   left: clamp(
     calc(var(--compact-export-history-viewport-inline-start) + var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-inset)),
     var(--compact-export-history-center-x),

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1589,6 +1589,8 @@
         document.documentElement.style.removeProperty('--desktop-compact-surface-top');
         document.documentElement.style.removeProperty('--desktop-compact-surface-width');
         document.documentElement.style.removeProperty('--desktop-compact-surface-height');
+        document.documentElement.style.removeProperty('--compact-desktop-workarea-left');
+        document.documentElement.style.removeProperty('--compact-desktop-workarea-right');
         document.documentElement.style.removeProperty('--compact-desktop-workarea-width');
         document.documentElement.style.removeProperty('--compact-desktop-workarea-height');
         compactSurfaceAnchorSnapshot = '';
@@ -1651,9 +1653,14 @@
             document.documentElement.style.setProperty('--desktop-compact-surface-height', Math.round(target.height || COMPACT_SURFACE_DEFAULT_HEIGHT) + 'px');
         }
         if (layoutOverride && layoutOverride.workArea) {
+            var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);
+            document.documentElement.style.setProperty('--compact-desktop-workarea-left', Math.round(layoutOverride.workArea.left - workAreaWindowX) + 'px');
+            document.documentElement.style.setProperty('--compact-desktop-workarea-right', Math.round(layoutOverride.workArea.right - workAreaWindowX) + 'px');
             document.documentElement.style.setProperty('--compact-desktop-workarea-width', Math.round(layoutOverride.workArea.width) + 'px');
             document.documentElement.style.setProperty('--compact-desktop-workarea-height', Math.round(layoutOverride.workArea.height) + 'px');
         } else {
+            document.documentElement.style.removeProperty('--compact-desktop-workarea-left');
+            document.documentElement.style.removeProperty('--compact-desktop-workarea-right');
             document.documentElement.style.removeProperty('--compact-desktop-workarea-width');
             document.documentElement.style.removeProperty('--compact-desktop-workarea-height');
         }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1123,6 +1123,29 @@
         };
     }
 
+    function getCompactDesktopCssVarSnapshot(layoutOverride) {
+        if (!layoutOverride) return 'desktop:none';
+        var parts = [];
+        if (layoutOverride.workArea) {
+            var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);
+            parts.push(
+                'workarea',
+                Math.round(layoutOverride.workArea.left - workAreaWindowX),
+                Math.round(layoutOverride.workArea.right - workAreaWindowX),
+                Math.round(layoutOverride.workArea.width),
+                Math.round(layoutOverride.workArea.height)
+            );
+        } else {
+            parts.push('workarea:none');
+        }
+        parts.push(
+            'history',
+            Math.round(layoutOverride.historyOffsetX || 0),
+            Number.isFinite(layoutOverride.historyCenterX) ? Math.round(layoutOverride.historyCenterX) : 'none'
+        );
+        return parts.join(':');
+    }
+
     function normalizeCompactDomRect(rect) {
         if (!rect) return null;
         var left = Number(rect.left);
@@ -1633,7 +1656,8 @@
             Math.round(target.top),
             Math.round(target.width),
             Math.round(target.height || COMPACT_SURFACE_DEFAULT_HEIGHT),
-            (!!(dragState && dragState.compactSurface) || compactSurfaceDesktopDragActive) ? 'dragging' : 'idle'
+            (!!(dragState && dragState.compactSurface) || compactSurfaceDesktopDragActive) ? 'dragging' : 'idle',
+            getCompactDesktopCssVarSnapshot(layoutOverride)
         ].join(':');
         if (snapshot === compactSurfaceAnchorSnapshot) {
             return;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -375,7 +375,6 @@
         var workArea = normalizeCompactDesktopWorkArea(layout.workArea);
         var windowBounds = normalizeCompactDesktopWindowBounds(layout.windowBounds);
         var historyOffsetX = Number(layout.historyOffsetX);
-        var historyCenterX = Number(layout.historyCenterX);
         var compactChoicePlacement = layout.compactChoicePlacement === 'above' || layout.compactChoicePlacement === 'below'
             ? layout.compactChoicePlacement
             : null;
@@ -386,7 +385,6 @@
             workArea: workArea,
             windowBounds: windowBounds,
             historyOffsetX: Number.isFinite(historyOffsetX) ? historyOffsetX : 0,
-            historyCenterX: Number.isFinite(historyCenterX) ? historyCenterX : null,
             compactChoicePlacement: compactChoicePlacement
         };
     }
@@ -1140,8 +1138,7 @@
         }
         parts.push(
             'history',
-            Math.round(layoutOverride.historyOffsetX || 0),
-            Number.isFinite(layoutOverride.historyCenterX) ? Math.round(layoutOverride.historyCenterX) : 'none'
+            Math.round(layoutOverride.historyOffsetX || 0)
         );
         return parts.join(':');
     }
@@ -1621,7 +1618,6 @@
         document.documentElement.style.removeProperty('--compact-desktop-workarea-width');
         document.documentElement.style.removeProperty('--compact-desktop-workarea-height');
         document.documentElement.style.removeProperty('--desktop-compact-history-offset-x');
-        document.documentElement.style.removeProperty('--desktop-compact-history-center-x');
         compactSurfaceAnchorSnapshot = '';
         compactSurfaceAnchorLocked = false;
         dispatchCompactSurfaceLayoutChange(null);
@@ -1682,11 +1678,6 @@
             document.documentElement.style.setProperty('--desktop-compact-surface-width', Math.round(target.width) + 'px');
             document.documentElement.style.setProperty('--desktop-compact-surface-height', Math.round(target.height || COMPACT_SURFACE_DEFAULT_HEIGHT) + 'px');
             document.documentElement.style.setProperty('--desktop-compact-history-offset-x', Math.round(layoutOverride.historyOffsetX || 0) + 'px');
-            if (Number.isFinite(layoutOverride.historyCenterX)) {
-                document.documentElement.style.setProperty('--desktop-compact-history-center-x', Math.round(layoutOverride.historyCenterX) + 'px');
-            } else {
-                document.documentElement.style.removeProperty('--desktop-compact-history-center-x');
-            }
         }
         if (layoutOverride && layoutOverride.workArea) {
             var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -374,6 +374,8 @@
         var ball = normalizeCompactDesktopRect(layout.ball);
         var workArea = normalizeCompactDesktopWorkArea(layout.workArea);
         var windowBounds = normalizeCompactDesktopWindowBounds(layout.windowBounds);
+        var historyOffsetX = Number(layout.historyOffsetX);
+        var historyCenterX = Number(layout.historyCenterX);
         var compactChoicePlacement = layout.compactChoicePlacement === 'above' || layout.compactChoicePlacement === 'below'
             ? layout.compactChoicePlacement
             : null;
@@ -383,6 +385,8 @@
             ball: ball,
             workArea: workArea,
             windowBounds: windowBounds,
+            historyOffsetX: Number.isFinite(historyOffsetX) ? historyOffsetX : 0,
+            historyCenterX: Number.isFinite(historyCenterX) ? historyCenterX : null,
             compactChoicePlacement: compactChoicePlacement
         };
     }
@@ -1593,6 +1597,8 @@
         document.documentElement.style.removeProperty('--compact-desktop-workarea-right');
         document.documentElement.style.removeProperty('--compact-desktop-workarea-width');
         document.documentElement.style.removeProperty('--compact-desktop-workarea-height');
+        document.documentElement.style.removeProperty('--desktop-compact-history-offset-x');
+        document.documentElement.style.removeProperty('--desktop-compact-history-center-x');
         compactSurfaceAnchorSnapshot = '';
         compactSurfaceAnchorLocked = false;
         dispatchCompactSurfaceLayoutChange(null);
@@ -1651,6 +1657,12 @@
             document.documentElement.style.setProperty('--desktop-compact-surface-top', Math.round(target.top) + 'px');
             document.documentElement.style.setProperty('--desktop-compact-surface-width', Math.round(target.width) + 'px');
             document.documentElement.style.setProperty('--desktop-compact-surface-height', Math.round(target.height || COMPACT_SURFACE_DEFAULT_HEIGHT) + 'px');
+            document.documentElement.style.setProperty('--desktop-compact-history-offset-x', Math.round(layoutOverride.historyOffsetX || 0) + 'px');
+            if (Number.isFinite(layoutOverride.historyCenterX)) {
+                document.documentElement.style.setProperty('--desktop-compact-history-center-x', Math.round(layoutOverride.historyCenterX) + 'px');
+            } else {
+                document.documentElement.style.removeProperty('--desktop-compact-history-center-x');
+            }
         }
         if (layoutOverride && layoutOverride.workArea) {
             var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -258,7 +258,9 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "width: var(--compact-export-history-inline-size);" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter));" in anchor_block
     assert "--compact-export-history-viewport-inline-start: var(--compact-desktop-workarea-left, 0px);" in desktop_history_block
-    assert "--compact-export-history-viewport-inline-end: var(--compact-desktop-workarea-right, var(--compact-desktop-workarea-width, 1440px));" in desktop_history_block
+    assert "--compact-export-history-viewport-inline-end: var(" in desktop_history_block
+    assert "--compact-desktop-workarea-right," in desktop_history_block
+    assert "calc(var(--compact-desktop-workarea-left, 0px) + var(--compact-desktop-workarea-width, 1440px))" in desktop_history_block
     assert "--compact-export-history-viewport-inline-size: calc(" in desktop_history_block
     assert "var(--compact-export-history-viewport-inline-end) - var(--compact-export-history-viewport-inline-start)" in desktop_history_block
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -195,20 +195,15 @@ def test_desktop_compact_history_uses_workarea_not_browserwindow_viewport():
     assert "--compact-desktop-workarea-width" in script
     assert "--compact-desktop-workarea-height" in script
     assert "var historyOffsetX = Number(layout.historyOffsetX);" in script
-    assert "var historyCenterX = Number(layout.historyCenterX);" in script
     assert "historyOffsetX: Number.isFinite(historyOffsetX) ? historyOffsetX : 0" in script
-    assert "historyCenterX: Number.isFinite(historyCenterX) ? historyCenterX : null" in script
     assert "document.documentElement.style.setProperty('--desktop-compact-history-offset-x', Math.round(layoutOverride.historyOffsetX || 0) + 'px');" in script
-    assert "document.documentElement.style.setProperty('--desktop-compact-history-center-x', Math.round(layoutOverride.historyCenterX) + 'px');" in script
     assert "document.documentElement.style.removeProperty('--desktop-compact-history-offset-x');" in script
-    assert "document.documentElement.style.removeProperty('--desktop-compact-history-center-x');" in script
     assert "var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);" in script
     assert "Math.round(layoutOverride.workArea.left - workAreaWindowX) + 'px'" in script
     assert "Math.round(layoutOverride.workArea.right - workAreaWindowX) + 'px'" in script
     assert "function getCompactDesktopCssVarSnapshot(layoutOverride)" in script
     assert "Math.round(layoutOverride.workArea.left - workAreaWindowX)" in script
     assert "Math.round(layoutOverride.workArea.right - workAreaWindowX)" in script
-    assert "Number.isFinite(layoutOverride.historyCenterX) ? Math.round(layoutOverride.historyCenterX) : 'none'" in script
 
     sync_anchor_block = script.split("function syncCompactSurfaceAnchor()", 1)[1].split(
         "function stopCompactMinimizeBallTracking()",
@@ -268,9 +263,8 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio))" in anchor_block
     assert "--compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);" in anchor_block
     assert "--compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);" in anchor_block
-    assert "--compact-export-history-center-x: var(" in anchor_block
-    assert "--desktop-compact-history-center-x," in anchor_block
-    assert "calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2) + var(--desktop-compact-history-offset-x, 0px))" in anchor_block
+    assert "--compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2) + var(--desktop-compact-history-offset-x, 0px));" in anchor_block
+    assert "--desktop-compact-history-center-x" not in anchor_block
     assert "--compact-export-history-viewport-inline-start: 0px;" in anchor_block
     assert "--compact-export-history-viewport-inline-size: 100vw;" in anchor_block
     assert "--compact-export-history-viewport-inline-end: calc(" in anchor_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -190,14 +190,21 @@ def test_desktop_compact_history_uses_workarea_not_browserwindow_viewport():
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
 
     assert "normalizeCompactDesktopWorkArea" in script
+    assert "--compact-desktop-workarea-left" in script
+    assert "--compact-desktop-workarea-right" in script
     assert "--compact-desktop-workarea-width" in script
     assert "--compact-desktop-workarea-height" in script
+    assert "var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);" in script
+    assert "Math.round(layoutOverride.workArea.left - workAreaWindowX) + 'px'" in script
+    assert "Math.round(layoutOverride.workArea.right - workAreaWindowX) + 'px'" in script
 
     desktop_history_block = styles.split(
         "body.electron-chat-window.subtitle-web-host .compact-export-history-anchor",
         1,
     )[1].split(".compact-export-history-panel", 1)[0]
 
+    assert "--compact-desktop-workarea-left" in desktop_history_block
+    assert "--compact-desktop-workarea-right" in desktop_history_block
     assert "--compact-desktop-workarea-width" in desktop_history_block
     assert "--compact-desktop-workarea-height" in desktop_history_block
     assert "vh" not in desktop_history_block
@@ -240,14 +247,20 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "--compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);" in anchor_block
     assert "--compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);" in anchor_block
     assert "--compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));" in anchor_block
+    assert "--compact-export-history-viewport-inline-start: 0px;" in anchor_block
     assert "--compact-export-history-viewport-inline-size: 100vw;" in anchor_block
+    assert "--compact-export-history-viewport-inline-end: calc(" in anchor_block
     assert "left: clamp(" in anchor_block
     assert "var(--compact-export-history-center-x)" in anchor_block
-    assert "calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))" in anchor_block
+    assert "calc(var(--compact-export-history-viewport-inline-start) + var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-inset))" in anchor_block
+    assert "calc(var(--compact-export-history-viewport-inline-end) - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))" in anchor_block
     assert "bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 34px);" in anchor_block
     assert "width: var(--compact-export-history-inline-size);" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter));" in anchor_block
-    assert "--compact-export-history-viewport-inline-size: var(--compact-desktop-workarea-width, 1440px);" in desktop_history_block
+    assert "--compact-export-history-viewport-inline-start: var(--compact-desktop-workarea-left, 0px);" in desktop_history_block
+    assert "--compact-export-history-viewport-inline-end: var(--compact-desktop-workarea-right, var(--compact-desktop-workarea-width, 1440px));" in desktop_history_block
+    assert "--compact-export-history-viewport-inline-size: calc(" in desktop_history_block
+    assert "var(--compact-export-history-viewport-inline-end) - var(--compact-export-history-viewport-inline-start)" in desktop_history_block
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block
     assert "var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter)" in desktop_history_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-bubble-max-ratio));" in bubble_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -237,6 +237,14 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "--compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));" in anchor_block
     assert "--compact-export-history-inline-size: min(" in anchor_block
     assert "calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio))" in anchor_block
+    assert "--compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);" in anchor_block
+    assert "--compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);" in anchor_block
+    assert "--compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));" in anchor_block
+    assert "--compact-export-history-surface-gap: 20px;" in anchor_block
+    assert "left: clamp(" in anchor_block
+    assert "var(--compact-export-history-center-x)" in anchor_block
+    assert "calc(100vw - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))" in anchor_block
+    assert "+ var(--compact-export-history-surface-gap, 20px)" in anchor_block
     assert "width: var(--compact-export-history-inline-size);" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -194,6 +194,14 @@ def test_desktop_compact_history_uses_workarea_not_browserwindow_viewport():
     assert "--compact-desktop-workarea-right" in script
     assert "--compact-desktop-workarea-width" in script
     assert "--compact-desktop-workarea-height" in script
+    assert "var historyOffsetX = Number(layout.historyOffsetX);" in script
+    assert "var historyCenterX = Number(layout.historyCenterX);" in script
+    assert "historyOffsetX: Number.isFinite(historyOffsetX) ? historyOffsetX : 0" in script
+    assert "historyCenterX: Number.isFinite(historyCenterX) ? historyCenterX : null" in script
+    assert "document.documentElement.style.setProperty('--desktop-compact-history-offset-x', Math.round(layoutOverride.historyOffsetX || 0) + 'px');" in script
+    assert "document.documentElement.style.setProperty('--desktop-compact-history-center-x', Math.round(layoutOverride.historyCenterX) + 'px');" in script
+    assert "document.documentElement.style.removeProperty('--desktop-compact-history-offset-x');" in script
+    assert "document.documentElement.style.removeProperty('--desktop-compact-history-center-x');" in script
     assert "var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);" in script
     assert "Math.round(layoutOverride.workArea.left - workAreaWindowX) + 'px'" in script
     assert "Math.round(layoutOverride.workArea.right - workAreaWindowX) + 'px'" in script
@@ -207,6 +215,7 @@ def test_desktop_compact_history_uses_workarea_not_browserwindow_viewport():
     assert "--compact-desktop-workarea-right" in desktop_history_block
     assert "--compact-desktop-workarea-width" in desktop_history_block
     assert "--compact-desktop-workarea-height" in desktop_history_block
+    assert "--desktop-compact-history-offset-x" in styles
     assert "vh" not in desktop_history_block
     assert "vw" not in desktop_history_block
 
@@ -246,7 +255,9 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio))" in anchor_block
     assert "--compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);" in anchor_block
     assert "--compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);" in anchor_block
-    assert "--compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));" in anchor_block
+    assert "--compact-export-history-center-x: var(" in anchor_block
+    assert "--desktop-compact-history-center-x," in anchor_block
+    assert "calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2) + var(--desktop-compact-history-offset-x, 0px))" in anchor_block
     assert "--compact-export-history-viewport-inline-start: 0px;" in anchor_block
     assert "--compact-export-history-viewport-inline-size: 100vw;" in anchor_block
     assert "--compact-export-history-viewport-inline-end: calc(" in anchor_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -205,6 +205,19 @@ def test_desktop_compact_history_uses_workarea_not_browserwindow_viewport():
     assert "var workAreaWindowX = layoutOverride.windowBounds ? Math.round(layoutOverride.windowBounds.x) : Math.round(layoutOverride.workArea.left);" in script
     assert "Math.round(layoutOverride.workArea.left - workAreaWindowX) + 'px'" in script
     assert "Math.round(layoutOverride.workArea.right - workAreaWindowX) + 'px'" in script
+    assert "function getCompactDesktopCssVarSnapshot(layoutOverride)" in script
+    assert "Math.round(layoutOverride.workArea.left - workAreaWindowX)" in script
+    assert "Math.round(layoutOverride.workArea.right - workAreaWindowX)" in script
+    assert "Number.isFinite(layoutOverride.historyCenterX) ? Math.round(layoutOverride.historyCenterX) : 'none'" in script
+
+    sync_anchor_block = script.split("function syncCompactSurfaceAnchor()", 1)[1].split(
+        "function stopCompactMinimizeBallTracking()",
+        1,
+    )[0]
+    assert "getCompactDesktopCssVarSnapshot(layoutOverride)" in sync_anchor_block
+    assert sync_anchor_block.index("getCompactDesktopCssVarSnapshot(layoutOverride)") < sync_anchor_block.index(
+        "if (snapshot === compactSurfaceAnchorSnapshot)"
+    )
 
     desktop_history_block = styles.split(
         "body.electron-chat-window.subtitle-web-host .compact-export-history-anchor",

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -240,15 +240,16 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "--compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);" in anchor_block
     assert "--compact-export-history-safe-inset: calc(var(--compact-export-history-viewport-gutter) / 2);" in anchor_block
     assert "--compact-export-history-center-x: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));" in anchor_block
-    assert "--compact-export-history-surface-gap: 20px;" in anchor_block
+    assert "--compact-export-history-viewport-inline-size: 100vw;" in anchor_block
     assert "left: clamp(" in anchor_block
     assert "var(--compact-export-history-center-x)" in anchor_block
-    assert "calc(100vw - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))" in anchor_block
-    assert "+ var(--compact-export-history-surface-gap, 20px)" in anchor_block
+    assert "calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-inset))" in anchor_block
+    assert "bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 34px);" in anchor_block
     assert "width: var(--compact-export-history-inline-size);" in anchor_block
-    assert "--compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));" in anchor_block
+    assert "--compact-export-history-max-inline-size: calc(var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter));" in anchor_block
+    assert "--compact-export-history-viewport-inline-size: var(--compact-desktop-workarea-width, 1440px);" in desktop_history_block
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block
-    assert "var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)" in desktop_history_block
+    assert "var(--compact-export-history-viewport-inline-size) - var(--compact-export-history-viewport-gutter)" in desktop_history_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-bubble-max-ratio));" in bubble_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-system-bubble-max-ratio));" in system_bubble_block
     assert "max-width: var(--compact-export-preview-bubble-max-ratio);" in preview_bubble_block


### PR DESCRIPTION
约束紧凑历史面板横向位置保持在视口内，并缩短历史面板与下方聊天框之间的间距。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式优化**
  * 改进导出历史浮层的横向定位与尺寸计算：采用视口/工作区度量与护栏、半宽、安全内距与中心点计算，并用 clamp/calc 将横向位置约束在可用区间，保留底部定位，桌面模式以工作区边界推导起止与最大尺寸上限。

* **测试**
  * 增补静态断言，覆盖工作区左右/宽高、历史偏移归一化、半宽/安全内距/中心点、viewport 起止及 left: clamp(...) / bottom: calc(...) 表达式。

* **维护**
  * 优化运行时对桌面工作区相关 CSS 变量的写入与清理，加入数值容错与快照化以减少不必要的同步更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->