### PR TITLE
chore(plugin): improve config write diagnostics

### DIFF
--- a/plugin/plugins/mcp_adapter/__init__.py
+++ b/plugin/plugins/mcp_adapter/__init__.py
@@ -2082,6 +2082,10 @@ class MCPAdapterPlugin(NekoAdapterPlugin):
         try:
             await self._persist_servers_config(servers_config)
         except Exception as exc:
+            self.ctx.logger.exception(
+                f"Failed to persist MCP server config while adding server '{name}' "
+                f"(transport={transport}): {exc}"
+            )
             return Err(SdkError(f"Failed to save server config: {exc}"))
         
         # 缓存配置
@@ -2154,6 +2158,10 @@ class MCPAdapterPlugin(NekoAdapterPlugin):
         try:
             await self._persist_servers_config(dict(servers_config))
         except Exception as exc:
+            self.ctx.logger.exception(
+                "Failed to persist MCP server config while removing servers "
+                f"(requested={len(server_names)}, removed={len(removed)}): {exc}"
+            )
             return Err(SdkError(f"Failed to save server config: {exc}"))
         self._servers_config = servers_config
         

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from plugin.core.state import state
+from plugin._types.exceptions import PluginExecutionError
 from plugin._types.models import PluginUiSurface, PluginUiWarning
 from plugin.logging_config import get_logger
 from plugin.core.ui_manifest import (
@@ -910,7 +911,32 @@ class PluginUiQueryService:
                     details={"plugin_id": plugin_id, "kind": kind, "surface_id": surface_id, "action_id": action_id},
                 )
 
-            result = await host.trigger(resolved_action_id, dict(args or {}))
+            try:
+                result = await host.trigger(resolved_action_id, dict(args or {}))
+            except PluginExecutionError as exc:
+                message = exc.error if isinstance(exc.error, str) and exc.error else str(exc)
+                logger.warning(
+                    "Hosted UI action failed in plugin entry: plugin_id={}, surface={}:{}, action_id={}, entry_id={}, err={}",
+                    plugin_id,
+                    kind,
+                    surface_id,
+                    action_id,
+                    resolved_action_id,
+                    message,
+                )
+                raise ServerDomainError(
+                    code="PLUGIN_UI_ACTION_FAILED",
+                    message=message,
+                    status_code=500,
+                    details={
+                        "plugin_id": plugin_id,
+                        "kind": kind,
+                        "surface_id": surface_id,
+                        "action_id": action_id,
+                        "entry_id": resolved_action_id,
+                        "error_type": type(exc).__name__,
+                    },
+                ) from exc
             return {
                 "plugin_id": plugin_id,
                 "action_id": resolved_action_id,

--- a/plugin/server/infrastructure/config_paths.py
+++ b/plugin/server/infrastructure/config_paths.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from fastapi import HTTPException
 
 from plugin.core.state import state
+from plugin.logging_config import get_logger
 from plugin.settings import PLUGIN_CONFIG_ROOTS
+
+logger = get_logger("server.infrastructure.config_paths")
 
 
 def _resolve_registered_plugin_config_path(plugin_id: str) -> Path | None:
@@ -29,10 +32,30 @@ def _resolve_registered_plugin_config_path(plugin_id: str) -> Path | None:
             continue
         try:
             path = Path(candidate).resolve()
-        except (TypeError, ValueError, OSError, RuntimeError):
+        except (TypeError, ValueError, OSError, RuntimeError) as exc:
+            logger.warning(
+                "Plugin config registered path ignored: plugin_id={}, candidate_type={}, err_type={}, err={}",
+                plugin_id,
+                type(candidate).__name__,
+                type(exc).__name__,
+                str(exc),
+            )
             continue
         if path.is_file() and path.name == "plugin.toml":
+            logger.debug(
+                "Plugin config path resolved from registered metadata: plugin_id={}, config_path={}",
+                plugin_id,
+                path,
+            )
             return path
+        logger.warning(
+            "Plugin config registered path ignored: plugin_id={}, config_path={}, exists={}, is_file={}, name={}",
+            plugin_id,
+            path,
+            path.exists(),
+            path.is_file(),
+            path.name,
+        )
 
     return None
 
@@ -72,6 +95,12 @@ def get_plugin_config_path(plugin_id: str) -> Path:
                 continue
 
         if config_file.exists():
+            logger.debug(
+                "Plugin config path resolved from config root: plugin_id={}, root={}, config_path={}",
+                plugin_id,
+                root,
+                config_file,
+            )
             return config_file
 
     raise HTTPException(

--- a/plugin/server/infrastructure/config_storage.py
+++ b/plugin/server/infrastructure/config_storage.py
@@ -32,21 +32,40 @@ def atomic_write_bytes(*, target: Path, payload: bytes, prefix: str) -> None:
             dir=str(target.parent),
         )
     except OSError as exc:
+        logger.exception(
+            "Failed to create temporary config file: target={}, parent={}, prefix={}, err_type={}, err={}",
+            target,
+            target.parent,
+            prefix,
+            type(exc).__name__,
+            str(exc),
+        )
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to create temporary file for {target}",
+            detail=f"Failed to create temporary file for {target}: {type(exc).__name__}: {exc}",
         ) from exc
 
     temp_file_path = Path(temp_path)
+    stage = "write_temp"
     try:
         with os.fdopen(temp_fd, "wb") as temp_file:
             temp_file.write(payload)
             temp_file.flush()
             os.fsync(temp_file.fileno())
 
+        stage = "replace"
         os.replace(temp_file_path, target)
+        stage = "fsync_parent"
         _fsync_parent_dir(target)
     except (OSError, RuntimeError, ValueError, TypeError) as exc:
+        logger.exception(
+            "Failed to persist config file: target={}, temp_path={}, stage={}, err_type={}, err={}",
+            target,
+            temp_file_path,
+            stage,
+            type(exc).__name__,
+            str(exc),
+        )
         try:
             if temp_file_path.exists():
                 temp_file_path.unlink()
@@ -58,7 +77,7 @@ def atomic_write_bytes(*, target: Path, payload: bytes, prefix: str) -> None:
             )
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to persist config file {target}",
+            detail=f"Failed to persist config file {target} while {stage}: {type(exc).__name__}: {exc}",
         ) from exc
 
 

--- a/plugin/server/infrastructure/config_updates.py
+++ b/plugin/server/infrastructure/config_updates.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
+from pathlib import Path
 
 from fastapi import HTTPException
 
@@ -18,6 +20,8 @@ from plugin.server.infrastructure.config_toml import (
 )
 
 logger = get_logger("server.infrastructure.config_updates")
+
+_CONFIG_UPDATE_RUNTIME_ERRORS = (OSError, RuntimeError, ValueError, TypeError)
 
 
 def _ensure_string_key_mapping(value: object, *, field: str) -> dict[str, object]:
@@ -65,30 +69,183 @@ def _fill_plugin_protected_fields(
     return result
 
 
+def _probe_path_value(probe: object) -> object:
+    try:
+        if callable(probe):
+            return probe()
+    except (OSError, RuntimeError, ValueError, TypeError) as exc:
+        return f"unknown({type(exc).__name__}: {exc})"
+    return "unknown"
+
+
+def _describe_config_path(config_path: Path) -> str:
+    parent = config_path.parent
+    return (
+        f"exists={_probe_path_value(config_path.exists)}, "
+        f"is_file={_probe_path_value(config_path.is_file)}, "
+        f"file_writable={_probe_path_value(lambda: os.access(config_path, os.W_OK))}, "
+        f"parent={parent}, "
+        f"parent_exists={_probe_path_value(parent.exists)}, "
+        f"parent_writable={_probe_path_value(lambda: os.access(parent, os.W_OK))}"
+    )
+
+
+def _log_config_update_start(*, operation: str, plugin_id: str, config_path: Path) -> None:
+    logger.info(
+        "Plugin config {} started: plugin_id={}, config_path={}, path_state={}",
+        operation,
+        plugin_id,
+        config_path,
+        _describe_config_path(config_path),
+    )
+
+
+def _log_config_path_resolution_failure(
+    *,
+    operation: str,
+    plugin_id: str,
+    exc: BaseException,
+) -> None:
+    logger.exception(
+        "Plugin config {} failed: plugin_id={}, stage=resolve_path, err_type={}, err={}",
+        operation,
+        plugin_id,
+        type(exc).__name__,
+        str(exc),
+    )
+
+
+def _log_config_update_success(*, operation: str, plugin_id: str, config_path: Path) -> None:
+    logger.info(
+        "Plugin config {} persisted: plugin_id={}, config_path={}, path_state={}",
+        operation,
+        plugin_id,
+        config_path,
+        _describe_config_path(config_path),
+    )
+
+
+def _log_config_update_failure(
+    *,
+    operation: str,
+    plugin_id: str,
+    config_path: Path,
+    stage: str,
+    exc: BaseException,
+) -> None:
+    logger.exception(
+        "Plugin config {} failed: plugin_id={}, config_path={}, stage={}, err_type={}, err={}, path_state={}",
+        operation,
+        plugin_id,
+        config_path,
+        stage,
+        type(exc).__name__,
+        str(exc),
+        _describe_config_path(config_path),
+    )
+
+
+def _resolve_config_path_for_update(*, operation: str, plugin_id: str) -> Path:
+    try:
+        return get_plugin_config_path(plugin_id)
+    except HTTPException as exc:
+        _log_config_path_resolution_failure(operation=operation, plugin_id=plugin_id, exc=exc)
+        raise
+    except _CONFIG_UPDATE_RUNTIME_ERRORS as exc:
+        _log_config_path_resolution_failure(operation=operation, plugin_id=plugin_id, exc=exc)
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Failed to resolve plugin config path for {plugin_id} "
+                f"while {operation}: {type(exc).__name__}: {exc}"
+            ),
+        ) from exc
+
+
 def replace_plugin_config(plugin_id: str, new_config: dict[str, object]) -> dict[str, object]:
     normalized_new_config = _ensure_string_key_mapping(new_config, field="config")
     lock = get_plugin_update_lock(plugin_id)
+    operation = "replace"
     with lock:
-        config_path = get_plugin_config_path(plugin_id)
-        with config_path.open("r+b") as file_obj:
-            with file_lock(file_obj):
-                current_config = load_toml_from_stream(file_obj, context=f"{plugin_id}.plugin.toml")
-                validate_protected_fields_unchanged(
-                    current_config=current_config,
-                    new_config=normalized_new_config,
-                )
-                completed_config = _fill_plugin_protected_fields(
-                    current_config=current_config,
-                    incoming_config=normalized_new_config,
-                )
-                payload = dump_toml_bytes(completed_config)
-                atomic_write_bytes(
-                    target=config_path,
-                    payload=payload,
-                    prefix=".plugin_config_",
-                )
+        config_path = _resolve_config_path_for_update(operation=operation, plugin_id=plugin_id)
+        stage = "open"
+        _log_config_update_start(operation=operation, plugin_id=plugin_id, config_path=config_path)
+        try:
+            with config_path.open("r+b") as file_obj:
+                stage = "lock"
+                with file_lock(file_obj):
+                    stage = "read"
+                    current_config = load_toml_from_stream(file_obj, context=f"{plugin_id}.plugin.toml")
+                    stage = "validate"
+                    validate_protected_fields_unchanged(
+                        current_config=current_config,
+                        new_config=normalized_new_config,
+                    )
+                    stage = "fill_protected_fields"
+                    completed_config = _fill_plugin_protected_fields(
+                        current_config=current_config,
+                        incoming_config=normalized_new_config,
+                    )
+                    stage = "serialize"
+                    payload = dump_toml_bytes(completed_config)
+                    stage = "atomic_write"
+                    atomic_write_bytes(
+                        target=config_path,
+                        payload=payload,
+                        prefix=".plugin_config_",
+                    )
+            _log_config_update_success(operation=operation, plugin_id=plugin_id, config_path=config_path)
+        except HTTPException as exc:
+            _log_config_update_failure(
+                operation=operation,
+                plugin_id=plugin_id,
+                config_path=config_path,
+                stage=stage,
+                exc=exc,
+            )
+            raise
+        except _CONFIG_UPDATE_RUNTIME_ERRORS as exc:
+            _log_config_update_failure(
+                operation=operation,
+                plugin_id=plugin_id,
+                config_path=config_path,
+                stage=stage,
+                exc=exc,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"Failed to replace plugin config at {config_path} "
+                    f"while {stage}: {type(exc).__name__}: {exc}"
+                ),
+            ) from exc
 
-    updated = load_plugin_config(plugin_id)
+    try:
+        updated = load_plugin_config(plugin_id)
+    except HTTPException as exc:
+        _log_config_update_failure(
+            operation="replace",
+            plugin_id=plugin_id,
+            config_path=config_path,
+            stage="reload",
+            exc=exc,
+        )
+        raise
+    except _CONFIG_UPDATE_RUNTIME_ERRORS as exc:
+        _log_config_update_failure(
+            operation="replace",
+            plugin_id=plugin_id,
+            config_path=config_path,
+            stage="reload",
+            exc=exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Failed to reload plugin config after replace at {config_path}: "
+                f"{type(exc).__name__}: {exc}"
+            ),
+        ) from exc
     logger.info("Replaced config for plugin {}", plugin_id)
     return {
         "success": True,
@@ -102,24 +259,84 @@ def replace_plugin_config(plugin_id: str, new_config: dict[str, object]) -> dict
 def update_plugin_config(plugin_id: str, updates: dict[str, object]) -> dict[str, object]:
     normalized_updates = _ensure_string_key_mapping(updates, field="updates")
     lock = get_plugin_update_lock(plugin_id)
+    operation = "update"
     with lock:
-        config_path = get_plugin_config_path(plugin_id)
-        with config_path.open("r+b") as file_obj:
-            with file_lock(file_obj):
-                current_config = load_toml_from_stream(file_obj, context=f"{plugin_id}.plugin.toml")
-                merged = deep_merge(current_config, normalized_updates)
-                validate_protected_fields_unchanged(
-                    current_config=current_config,
-                    new_config=merged,
-                )
-                payload = dump_toml_bytes(merged)
-                atomic_write_bytes(
-                    target=config_path,
-                    payload=payload,
-                    prefix=".plugin_config_",
-                )
+        config_path = _resolve_config_path_for_update(operation=operation, plugin_id=plugin_id)
+        stage = "open"
+        _log_config_update_start(operation=operation, plugin_id=plugin_id, config_path=config_path)
+        try:
+            with config_path.open("r+b") as file_obj:
+                stage = "lock"
+                with file_lock(file_obj):
+                    stage = "read"
+                    current_config = load_toml_from_stream(file_obj, context=f"{plugin_id}.plugin.toml")
+                    stage = "merge"
+                    merged = deep_merge(current_config, normalized_updates)
+                    stage = "validate"
+                    validate_protected_fields_unchanged(
+                        current_config=current_config,
+                        new_config=merged,
+                    )
+                    stage = "serialize"
+                    payload = dump_toml_bytes(merged)
+                    stage = "atomic_write"
+                    atomic_write_bytes(
+                        target=config_path,
+                        payload=payload,
+                        prefix=".plugin_config_",
+                    )
+            _log_config_update_success(operation=operation, plugin_id=plugin_id, config_path=config_path)
+        except HTTPException as exc:
+            _log_config_update_failure(
+                operation=operation,
+                plugin_id=plugin_id,
+                config_path=config_path,
+                stage=stage,
+                exc=exc,
+            )
+            raise
+        except _CONFIG_UPDATE_RUNTIME_ERRORS as exc:
+            _log_config_update_failure(
+                operation=operation,
+                plugin_id=plugin_id,
+                config_path=config_path,
+                stage=stage,
+                exc=exc,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"Failed to update plugin config at {config_path} "
+                    f"while {stage}: {type(exc).__name__}: {exc}"
+                ),
+            ) from exc
 
-    updated = load_plugin_config(plugin_id)
+    try:
+        updated = load_plugin_config(plugin_id)
+    except HTTPException as exc:
+        _log_config_update_failure(
+            operation="update",
+            plugin_id=plugin_id,
+            config_path=config_path,
+            stage="reload",
+            exc=exc,
+        )
+        raise
+    except _CONFIG_UPDATE_RUNTIME_ERRORS as exc:
+        _log_config_update_failure(
+            operation="update",
+            plugin_id=plugin_id,
+            config_path=config_path,
+            stage="reload",
+            exc=exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Failed to reload plugin config after update at {config_path}: "
+                f"{type(exc).__name__}: {exc}"
+            ),
+        ) from exc
     logger.info("Updated config for plugin {}", plugin_id)
     return {
         "success": True,
@@ -136,22 +353,80 @@ def update_plugin_config_toml(plugin_id: str, toml_text: str) -> dict[str, objec
 
     parsed_new = parse_toml_text(toml_text, context=f"{plugin_id}.plugin.toml")
     lock = get_plugin_update_lock(plugin_id)
+    operation = "toml_update"
     with lock:
-        config_path = get_plugin_config_path(plugin_id)
-        with config_path.open("r+b") as file_obj:
-            with file_lock(file_obj):
-                current_config = load_toml_from_stream(file_obj, context=f"{plugin_id}.plugin.toml")
-                validate_protected_fields_unchanged(
-                    current_config=current_config,
-                    new_config=parsed_new,
-                )
-                atomic_write_text(
-                    target=config_path,
-                    text=toml_text,
-                    prefix=".plugin_config_",
-                )
+        config_path = _resolve_config_path_for_update(operation=operation, plugin_id=plugin_id)
+        stage = "open"
+        _log_config_update_start(operation=operation, plugin_id=plugin_id, config_path=config_path)
+        try:
+            with config_path.open("r+b") as file_obj:
+                stage = "lock"
+                with file_lock(file_obj):
+                    stage = "read"
+                    current_config = load_toml_from_stream(file_obj, context=f"{plugin_id}.plugin.toml")
+                    stage = "validate"
+                    validate_protected_fields_unchanged(
+                        current_config=current_config,
+                        new_config=parsed_new,
+                    )
+                    stage = "atomic_write"
+                    atomic_write_text(
+                        target=config_path,
+                        text=toml_text,
+                        prefix=".plugin_config_",
+                    )
+            _log_config_update_success(operation=operation, plugin_id=plugin_id, config_path=config_path)
+        except HTTPException as exc:
+            _log_config_update_failure(
+                operation=operation,
+                plugin_id=plugin_id,
+                config_path=config_path,
+                stage=stage,
+                exc=exc,
+            )
+            raise
+        except _CONFIG_UPDATE_RUNTIME_ERRORS as exc:
+            _log_config_update_failure(
+                operation=operation,
+                plugin_id=plugin_id,
+                config_path=config_path,
+                stage=stage,
+                exc=exc,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"Failed to update plugin TOML config at {config_path} "
+                    f"while {stage}: {type(exc).__name__}: {exc}"
+                ),
+            ) from exc
 
-    updated = load_plugin_config(plugin_id)
+    try:
+        updated = load_plugin_config(plugin_id)
+    except HTTPException as exc:
+        _log_config_update_failure(
+            operation="toml_update",
+            plugin_id=plugin_id,
+            config_path=config_path,
+            stage="reload",
+            exc=exc,
+        )
+        raise
+    except _CONFIG_UPDATE_RUNTIME_ERRORS as exc:
+        _log_config_update_failure(
+            operation="toml_update",
+            plugin_id=plugin_id,
+            config_path=config_path,
+            stage="reload",
+            exc=exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Failed to reload plugin config after TOML update at {config_path}: "
+                f"{type(exc).__name__}: {exc}"
+            ),
+        ) from exc
     logger.info("Updated TOML config for plugin {}", plugin_id)
     return {
         "success": True,

--- a/plugin/tests/unit/server/test_config_updates.py
+++ b/plugin/tests/unit/server/test_config_updates.py
@@ -57,3 +57,23 @@ def test_update_plugin_config_toml_rejects_none() -> None:
         module.update_plugin_config_toml("demo", None)  # type: ignore[arg-type]
 
     assert exc_info.value.status_code == 400
+
+
+@pytest.mark.plugin_unit
+def test_update_plugin_config_open_failure_reports_path_and_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "missing" / "plugin.toml"
+
+    monkeypatch.setattr(module, "get_plugin_update_lock", lambda plugin_id: threading.Lock())
+    monkeypatch.setattr(module, "get_plugin_config_path", lambda plugin_id: config_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        module.update_plugin_config("demo", {"runtime": {"enabled": False}})
+
+    detail = str(exc_info.value.detail)
+    assert exc_info.value.status_code == 500
+    assert str(config_path) in detail
+    assert "while open" in detail
+    assert "FileNotFoundError" in detail

--- a/plugin/tests/unit/server/test_plugin_ui_query_service.py
+++ b/plugin/tests/unit/server/test_plugin_ui_query_service.py
@@ -6,7 +6,9 @@ import pytest
 
 from plugin.core.state import state
 from plugin.core.ui_manifest import normalize_plugin_ui_manifest
+from plugin._types.exceptions import PluginExecutionError
 from plugin.server.application import config as config_application
+from plugin.server.domain.errors import ServerDomainError
 from plugin.server.application.plugins.ui_query_service import (
     _build_plugin_list_actions_from_meta,
     _get_static_ui_config_from_meta,
@@ -126,3 +128,76 @@ def test_surface_context_includes_config_snapshot_only_with_permission(monkeypat
     assert context["config"]["value"]["feature"] == {"enabled": True}
     assert context["config"]["readonly"] is True
     assert context["actions"] == []
+
+
+def test_call_surface_action_preserves_plugin_entry_error(monkeypatch, tmp_path) -> None:
+    plugin_dir = tmp_path / "demo_plugin"
+    plugin_dir.mkdir()
+    config_path = plugin_dir / "plugin.toml"
+    config_path.write_text("[plugin]\nid='demo'\n", encoding="utf-8")
+    plugin_ui = normalize_plugin_ui_manifest(
+        {
+            "plugin": {
+                "ui": {
+                    "panel": [{
+                        "id": "main",
+                        "entry": "ui/panel.tsx",
+                        "permissions": ["action:call"],
+                    }],
+                },
+            },
+        },
+        plugin_id="demo",
+    )
+
+    class _Host:
+        def is_alive(self) -> bool:
+            return True
+
+        async def get_ui_context(self, context_id: str) -> dict[str, object]:
+            assert context_id == "main"
+            return {
+                "actions": [
+                    {"id": "add_server", "entry_id": "add_server"},
+                ],
+            }
+
+        async def trigger(self, entry_id: str, args: dict[str, object]) -> object:
+            assert entry_id == "add_server"
+            raise PluginExecutionError("demo", entry_id, "Failed to save server config: access denied")
+
+    plugins_backup = dict(state.plugins)
+    hosts_backup = dict(state.plugin_hosts)
+    try:
+        with state.acquire_plugins_write_lock():
+            state.plugins.clear()
+            state.plugins["demo"] = {
+                "id": "demo",
+                "config_path": str(config_path),
+                "plugin_ui": plugin_ui,
+                "entries": [{"id": "add_server", "name": "Add Server"}],
+            }
+        with state.acquire_plugin_hosts_write_lock():
+            state.plugin_hosts.clear()
+            state.plugin_hosts["demo"] = _Host()
+
+        with pytest.raises(ServerDomainError) as exc_info:
+            asyncio.run(
+                PluginUiQueryService().call_surface_action(
+                    "demo",
+                    action_id="add_server",
+                    args={},
+                    kind="panel",
+                    surface_id="main",
+                )
+            )
+    finally:
+        with state.acquire_plugins_write_lock():
+            state.plugins.clear()
+            state.plugins.update(plugins_backup)
+        with state.acquire_plugin_hosts_write_lock():
+            state.plugin_hosts.clear()
+            state.plugin_hosts.update(hosts_backup)
+
+    assert exc_info.value.code == "PLUGIN_UI_ACTION_FAILED"
+    assert exc_info.value.message == "Failed to save server config: access denied"


### PR DESCRIPTION
## Summary
- add staged diagnostics for plugin config path resolution, file open, validation, atomic write, and reload failures
- preserve hosted UI action plugin execution errors so UI imports surface the underlying save failure
- add MCP adapter persistence failure logs without dumping server config contents

## Verification
- `uv run pytest plugin/tests/unit/server/test_config_updates.py plugin/tests/unit/server/test_config_resolver.py plugin/tests/unit/server/test_config_profiles_apply.py plugin/tests/unit/server/test_config_command_service.py plugin/tests/unit/server/test_config_query_effective.py plugin/tests/unit/server/test_plugin_ui_query_service.py plugin/tests/unit/plugins/test_mcp_adapter_tasks.py`
- `uv run python -m compileall -q plugin/server/infrastructure/config_updates.py plugin/server/infrastructure/config_storage.py plugin/server/infrastructure/config_paths.py plugin/server/application/plugins/ui_query_service.py plugin/plugins/mcp_adapter/__init__.py`
- `git diff --check`

## Notes
This PR intentionally improves observability first. It does not change the persistence target away from the resolved `plugin.toml`; the goal is to capture the exact Windows/Steam path and OS-level write failure before choosing the smallest follow-up fix.

Related to #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了配置持久化失败时的错误日志记录，包含更详细的上下文信息
  * 增强了插件执行异常的处理和错误转换机制
  * 提升了配置路径解析的可观测性和故障报告能力

* **Tests**
  * 新增单元测试，验证配置更新和插件执行错误处理的完整性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->