### PR TITLE
给插件管理器 Hosted Surface 增加 switchToMobileMode 类型和消息桥接，让插件面板能请求宿主切换手机版

### DIFF
--- a/frontend/plugin-manager/env.d.ts
+++ b/frontend/plugin-manager/env.d.ts
@@ -22,6 +22,11 @@ interface NekoWindowControlApi {
   switchToMobileMode?: () => Promise<unknown> | unknown
 }
 
+interface NekoHostApi {
+  switchToMobileMode?: () => Promise<unknown> | unknown
+}
+
 interface Window {
   nekoWindowControl?: NekoWindowControlApi
+  nekoHost?: NekoHostApi
 }

--- a/frontend/plugin-manager/env.d.ts
+++ b/frontend/plugin-manager/env.d.ts
@@ -19,6 +19,7 @@ interface NekoWindowControlApi {
   restore?: () => Promise<unknown> | unknown
   maximize?: () => Promise<NekoWindowControlResult> | NekoWindowControlResult
   isMaximized?: () => Promise<boolean> | boolean
+  switchToMobileMode?: () => Promise<unknown> | unknown
 }
 
 interface Window {

--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -331,11 +331,14 @@ function handleError() {
 
 async function switchToMobileModeForHostedSurface() {
   const api = window.nekoWindowControl
-  if (!api || typeof api.switchToMobileMode !== 'function') return
+  if (!api || typeof api.switchToMobileMode !== 'function') {
+    throw new Error('switch_to_mobile_mode_unavailable')
+  }
   try {
-    await api.switchToMobileMode()
+    return await api.switchToMobileMode()
   } catch (caught) {
     console.warn('[HostedSurfaceFrame] 切换手机版失败', caught)
+    throw caught
   }
 }
 
@@ -428,10 +431,6 @@ function handleMessage(event: MessageEvent) {
     if (url) openExternalUrl(url)
     return
   }
-  if (data && typeof data === 'object' && data.type === 'neko-hosted-surface-switch-mobile-mode') {
-    void switchToMobileModeForHostedSurface()
-    return
-  }
   if (data && typeof data === 'object' && data.type === 'neko-hosted-surface-request') {
     handleHostedRequest(data)
   }
@@ -471,6 +470,11 @@ async function handleHostedRequest(data: any) {
         locale: String(locale.value),
       })
       respond({ ok: true, result: context })
+      return
+    }
+    if (method === 'switchToMobileMode') {
+      const result = await switchToMobileModeForHostedSurface()
+      respond({ ok: true, result })
       return
     }
     respond({ ok: false, error: `Unsupported hosted surface method: ${method}` })

--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -329,6 +329,16 @@ function handleError() {
   emit('error', t('plugins.ui.loadError'))
 }
 
+async function switchToMobileModeForHostedSurface() {
+  const api = window.nekoWindowControl
+  if (!api || typeof api.switchToMobileMode !== 'function') return
+  try {
+    await api.switchToMobileMode()
+  } catch (caught) {
+    console.warn('[HostedSurfaceFrame] 切换手机版失败', caught)
+  }
+}
+
 async function loadHostedTsx() {
   if (!['hosted-tsx', 'markdown'].includes(props.surface.mode) || props.surface.available === false) {
     hostedDocument.value = ''
@@ -416,6 +426,10 @@ function handleMessage(event: MessageEvent) {
   if (data && typeof data === 'object' && data.type === 'neko-hosted-surface-open-external') {
     const url = typeof data.payload?.url === 'string' ? data.payload.url : ''
     if (url) openExternalUrl(url)
+    return
+  }
+  if (data && typeof data === 'object' && data.type === 'neko-hosted-surface-switch-mobile-mode') {
+    void switchToMobileModeForHostedSurface()
     return
   }
   if (data && typeof data === 'object' && data.type === 'neko-hosted-surface-request') {

--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -330,12 +330,17 @@ function handleError() {
 }
 
 async function switchToMobileModeForHostedSurface() {
-  const api = window.nekoWindowControl
-  if (!api || typeof api.switchToMobileMode !== 'function') {
+  const api = window.nekoWindowControl?.switchToMobileMode || window.nekoHost?.switchToMobileMode
+  if (typeof api !== 'function') {
     throw new Error('switch_to_mobile_mode_unavailable')
   }
   try {
-    return await api.switchToMobileMode()
+    const result = await api()
+    if (result && typeof result === 'object' && 'ok' in result && (result as { ok?: boolean }).ok === false) {
+      const error = (result as { error?: unknown }).error
+      throw new Error(error ? String(error) : 'switch_to_mobile_mode_failed')
+    }
+    return result
   } catch (caught) {
     console.warn('[HostedSurfaceFrame] 切换手机版失败', caught)
     throw caught

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
@@ -215,7 +215,7 @@ describe('hosted TSX document runtime', () => {
     expect(root.textContent).toContain('ok')
   })
 
-  it('bridges api.call and api.refresh through parent postMessage', async () => {
+  it('bridges hosted api methods through parent postMessage', async () => {
     const { root, messages } = executeHostedDocument(`
       export default function Panel(props) {
         const [done, setDone] = props.useLocalState("done", "idle")
@@ -223,6 +223,7 @@ describe('hosted TSX document runtime', () => {
           <button id="run" onClick={async () => {
             await props.api.call("do_it", { value: 1 })
             await props.api.refresh()
+            await props.api.switchToMobileMode()
             setDone("done")
           }}>{done}</button>
         )
@@ -235,6 +236,7 @@ describe('hosted TSX document runtime', () => {
 
     expect(messages.some((message) => message.method === 'call' && message.payload?.actionId === 'do_it')).toBe(true)
     expect(messages.some((message) => message.method === 'refresh')).toBe(true)
+    expect(messages.some((message) => message.method === 'switchToMobileMode')).toBe(true)
     expect(root.querySelector('#run')?.textContent).toBe('done')
   })
 

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
@@ -99,7 +99,7 @@ ${escapeScriptContent(uiKit.runtime)}
     if (!window.NekoUiKit || __requiredUiKitApis.some((name) => typeof window.NekoUiKit[name] !== 'function')) {
       throw new Error('N.E.K.O UI Kit failed to initialize with the required hosted TSX APIs.');
     }
-    if (!window.NekoUiKit.api || typeof window.NekoUiKit.api.call !== 'function' || typeof window.NekoUiKit.api.refresh !== 'function') {
+    if (!window.NekoUiKit.api || typeof window.NekoUiKit.api.call !== 'function' || typeof window.NekoUiKit.api.refresh !== 'function' || typeof window.NekoUiKit.api.switchToMobileMode !== 'function') {
       throw new Error('N.E.K.O UI Kit failed to initialize the hosted API bridge.');
     }
     function __normalizeHostedPayload(context) {

--- a/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
+++ b/frontend/plugin-manager/src/components/plugin/hosted/ui-kit/runtime.js
@@ -1017,6 +1017,7 @@ const api = {
     const context = await requestHost('refresh', {});
     return refreshHostedPayload(context);
   },
+  switchToMobileMode() { return requestHost('switchToMobileMode', {}); },
 };
 function ActionButton(props) {
   const action = props.action || {};

--- a/plugin/sdk/hosted-ui/index.d.ts
+++ b/plugin/sdk/hosted-ui/index.d.ts
@@ -28,6 +28,7 @@ export type HostedAction = {
 export type HostedApi = {
   call: (actionId: string, args?: Record<string, any>) => Promise<any>
   refresh: () => Promise<any>
+  switchToMobileMode: () => Promise<any>
 }
 
 export type HostedI18n = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 插件宿主与嵌入内容增加“切换到移动模式”对外接口，嵌入内容可触发以获得移动端视图体验。  
* **Bug Fixes / Reliability**
  * 嵌入运行时初始化校验更严格，确保新接口存在以减少运行时错误与异常。  
* **Tests**
  * 集成/端到端测试扩展，覆盖新接口的消息传递与调用行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->