### PR TITLE
修复用户导入插件在首次扫描、手动启动和子进程启动时被内置 plugins 命名空间遮挡的问题，统一使用基于当前 plugin.toml 的…

### DIFF
--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -76,7 +76,8 @@ def _inject_extensions(
     Extension 的 entry 指向一个 PluginRouter 子类，实例化后通过 include_router 注入。
 
     如果 *extension_configs* 不为空，直接使用预构建的映射（避免全量扫描 TOML）。
-    每个元素格式: {"ext_id": str, "ext_entry": str, "prefix": str}
+    每个元素格式: {"ext_id": str, "ext_entry": str, "prefix": str, "config_path": str}
+    其中 config_path 为该扩展 plugin.toml 路径，供安全导入兜底定位用户插件目录。
     """
     # 如果主进程已预构建映射，直接使用
     if extension_configs:
@@ -88,9 +89,11 @@ def _inject_extensions(
             if not ext_entry or ":" not in ext_entry:
                 logger.warning("[Extension] Pre-built config for '{}' has invalid entry, skipping", ext_id)
                 continue
+            ext_config_path_str = ext_cfg.get("config_path", "")
+            ext_config_path = Path(ext_config_path_str) if ext_config_path_str else None
             module_path, class_name = ext_entry.split(":", 1)
             try:
-                mod = importlib.import_module(module_path)
+                mod = _import_plugin_module(module_path, ext_config_path, logger)
                 router_cls = getattr(mod, class_name)
             except Exception as e:
                 logger.warning("[Extension] Failed to import extension '{}': {}", ext_id, e)
@@ -177,7 +180,7 @@ def _inject_extensions(
                 # 导入 Extension Router 类
                 module_path, class_name = ext_entry.split(":", 1)
                 try:
-                    mod = importlib.import_module(module_path)
+                    mod = _import_plugin_module(module_path, toml_path, logger)
                     router_cls = getattr(mod, class_name)
                 except (ImportError, ModuleNotFoundError) as e:
                     logger.warning(
@@ -479,13 +482,17 @@ def _import_current_plugin_from_config(module_path: str, config_path: Path, logg
     return module
 
 
-def _import_plugin_module(module_path: str, config_path: Path, logger: Any) -> Any:
-    """导入插件模块，并在用户插件命名空间失效时使用当前插件目录兜底。"""
+def _import_plugin_module(module_path: str, config_path: Path | None, logger: Any) -> Any:
+    """导入插件模块，并在用户插件命名空间失效时使用当前插件目录兜底。
+
+    *config_path* 为空时（例如运行时启用扩展却拿不到 plugin.toml 路径），跳过兜底，
+    退化为普通 ``import_module`` 行为。
+    """
 
     try:
         return importlib.import_module(module_path)
     except ModuleNotFoundError as exc:
-        if not _is_target_module_missing(exc, module_path):
+        if config_path is None or not _is_target_module_missing(exc, module_path):
             raise
         fallback_module = _import_current_plugin_from_config(module_path, config_path, logger)
         if fallback_module is None:
@@ -1546,6 +1553,8 @@ def _plugin_process_runner(
                     ext_id = msg.get("ext_id", "")
                     ext_entry = msg.get("ext_entry", "")
                     prefix = msg.get("prefix", "")
+                    ext_config_path_str = msg.get("config_path", "")
+                    ext_config_path = Path(ext_config_path_str) if ext_config_path_str else None
                     req_id = msg.get("req_id", "unknown")
                     ret = {"req_id": req_id, "success": False, "data": None, "error": None}
                     try:
@@ -1556,7 +1565,7 @@ def _plugin_process_runner(
                             ret["error"] = f"Invalid ext_entry '{ext_entry}'"
                         else:
                             mod_path, cls_name = ext_entry.split(":", 1)
-                            mod = importlib.import_module(mod_path)
+                            mod = _import_plugin_module(mod_path, ext_config_path, logger)
                             router_cls = getattr(mod, cls_name)
                             if not (isinstance(router_cls, type) and issubclass(router_cls, PluginRouter)):
                                 ret["error"] = f"'{cls_name}' is not a PluginRouter subclass"

--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -461,6 +461,12 @@ def _import_current_plugin_from_config(module_path: str, config_path: Path, logg
         if not _is_target_module_missing(exc, module_path):
             raise
 
+    # 文件兜底只适用于插件包本身（plugins.<id> ↔ <id>/__init__.py）。更深的子模块路径
+    # （plugins.<id>.<sub>）已由上面的命名空间 import 覆盖；这里不能拿 __init__.py 顶替，
+    # 否则缺失/拼错的子模块会被包初始化静默冒充成功，应让其抛出真正的 ModuleNotFoundError。
+    if len(parts) != 2:
+        return None
+
     spec = importlib.util.spec_from_file_location(
         module_path,
         source_file,

--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import copy
 import importlib
+import importlib.machinery
+import importlib.util
 import inspect
 import multiprocessing
 import os
@@ -10,6 +12,7 @@ import sys
 import threading
 import time
 import hashlib
+import types
 import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional, Type
@@ -347,6 +350,22 @@ def _prepare_child_plugin_import_roots(logger: Any) -> None:
         sys.path.insert(0, str(repo_root))
 
 
+def _prepare_child_current_plugin_import_root(config_path: Path, logger: Any) -> None:
+    """按当前 plugin.toml 位置补充导入根，避免设置快照或路径布局差异导致用户插件不可导入。"""
+
+    try:
+        import_root = config_path.resolve().parent.parent.parent
+    except Exception as exc:
+        logger.debug("[Plugin Process] Failed to resolve current plugin import root: {}", exc)
+        return
+
+    value = str(import_root)
+    if value in sys.path:
+        return
+    sys.path.insert(0, value)
+    logger.info("[Plugin Process] Added current plugin import root to sys.path: {}", import_root)
+
+
 def _prepare_child_plugin_vendor_path(config_path: Path, logger: Any) -> None:
     """Add the current plugin's vendor/ directory before importing its entry."""
 
@@ -359,6 +378,119 @@ def _prepare_child_plugin_vendor_path(config_path: Path, logger: Any) -> None:
         return
     sys.path.insert(0, value)
     logger.info("[Plugin Process] Added plugin vendor path to sys.path: {}", vendor_dir)
+
+
+def _is_target_module_missing(exc: ModuleNotFoundError, module_path: str) -> bool:
+    """判断缺失的是目标插件模块本身，而不是插件内部依赖。"""
+
+    missing_name = getattr(exc, "name", None)
+    return bool(missing_name and (missing_name == module_path or module_path.startswith(f"{missing_name}.")))
+
+
+def _ensure_plugins_namespace(plugin_root: Path, logger: Any) -> None:
+    """确保顶层 plugins 命名空间能搜索当前用户插件根目录。"""
+
+    namespace_path = str(plugin_root)
+    existing = sys.modules.get("plugins")
+    if existing is None:
+        module = types.ModuleType("plugins")
+        module.__package__ = "plugins"
+        module.__path__ = [namespace_path]
+        module.__spec__ = importlib.machinery.ModuleSpec("plugins", loader=None, is_package=True)
+        if module.__spec__ is not None:
+            module.__spec__.submodule_search_locations = module.__path__
+        sys.modules["plugins"] = module
+        logger.info("[Plugin Process] Created plugins namespace for: {}", plugin_root)
+        return
+
+    namespace_paths = getattr(existing, "__path__", None)
+    if namespace_paths is None:
+        logger.debug("[Plugin Process] Existing 'plugins' module is not a package; path fallback may be required")
+        return
+
+    if namespace_path in list(namespace_paths):
+        return
+    try:
+        namespace_paths.append(namespace_path)
+    except AttributeError:
+        existing.__path__ = [*list(namespace_paths), namespace_path]
+    logger.info("[Plugin Process] Added current plugin root to plugins namespace: {}", plugin_root)
+
+
+def _import_current_plugin_from_config(module_path: str, config_path: Path, logger: Any) -> Any | None:
+    """在命名空间导入失败时，按当前 plugin.toml 同目录直接加载插件包。"""
+
+    parts = module_path.split(".")
+    if len(parts) < 2 or parts[0] != "plugins":
+        return None
+
+    try:
+        plugin_dir = config_path.resolve().parent
+    except Exception as exc:
+        logger.debug("[Plugin Process] Failed to resolve plugin directory for import fallback: {}", exc)
+        return None
+
+    if parts[1] != plugin_dir.name:
+        logger.debug(
+            "[Plugin Process] Import fallback skipped because module '{}' does not match plugin dir '{}'",
+            module_path,
+            plugin_dir.name,
+        )
+        return None
+
+    source_file = plugin_dir / "__init__.py"
+    if not source_file.is_file():
+        logger.debug("[Plugin Process] Import fallback skipped because missing file: {}", source_file)
+        return None
+
+    plugin_root = plugin_dir.parent
+    import_root = plugin_root.parent
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+        logger.info("[Plugin Process] Added fallback plugin import root to sys.path: {}", import_root)
+
+    _ensure_plugins_namespace(plugin_root, logger)
+    importlib.invalidate_caches()
+
+    try:
+        return importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        if not _is_target_module_missing(exc, module_path):
+            raise
+
+    spec = importlib.util.spec_from_file_location(
+        module_path,
+        source_file,
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    if spec is None or spec.loader is None:
+        logger.debug("[Plugin Process] Import fallback could not create spec for: {}", source_file)
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_path] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_path, None)
+        raise
+
+    logger.info("[Plugin Process] Loaded plugin module from current plugin directory: {}", source_file)
+    return module
+
+
+def _import_plugin_module(module_path: str, config_path: Path, logger: Any) -> Any:
+    """导入插件模块，并在用户插件命名空间失效时使用当前插件目录兜底。"""
+
+    try:
+        return importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        if not _is_target_module_missing(exc, module_path):
+            raise
+        fallback_module = _import_current_plugin_from_config(module_path, config_path, logger)
+        if fallback_module is None:
+            raise
+        return fallback_module
 
 
 def _check_extension_type_guard(config_path: Path, plugin_id: str, logger: Any) -> bool:
@@ -546,6 +678,7 @@ def _plugin_process_runner(
 
     try:
         _prepare_child_plugin_import_roots(logger)
+        _prepare_child_current_plugin_import_root(config_path, logger)
         _prepare_child_plugin_vendor_path(config_path, logger)
         try:
             from plugin.settings import BUILTIN_PLUGIN_CONFIG_ROOT
@@ -565,7 +698,7 @@ def _plugin_process_runner(
         
         module_path, class_name = entry_point.split(":", 1)
         logger.debug("[Plugin Process] Importing module: {}", module_path)
-        mod = importlib.import_module(module_path)
+        mod = _import_plugin_module(module_path, config_path, logger)
         cls = getattr(mod, class_name)
         logger.debug("[Plugin Process] Class loaded: {}", cls.__name__)
 

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
-import importlib
 import inspect
 import os
 import re
@@ -22,6 +21,15 @@ _pending_async_shutdown_tasks: set = set()
 def _wrap_logger(logger: Any) -> Any:
     """向后兼容函数，现在直接返回 logger。"""
     return logger
+
+
+def _import_plugin_entry_module(module_path: str, toml_path: Path, logger: Any) -> Any:
+    """延迟使用插件宿主导入兜底，避免用户插件命名空间被内置 plugins 包遮挡。"""
+
+    from plugin.core.host import _import_plugin_module
+
+    return _import_plugin_module(module_path, toml_path, logger)
+
 
 try:
     import tomllib  # type: ignore[attr-defined]
@@ -1652,7 +1660,7 @@ def _load_adapter_plugin(
 
     try:
         module_path, class_name = entry.split(":", 1)
-        mod = importlib.import_module(module_path)
+        mod = _import_plugin_entry_module(module_path, toml_path, logger)
         cls = getattr(mod, class_name)
         if isinstance(cls, type):
             entries_preview = _extract_entries_preview(pid, cls, conf, pdata)
@@ -2032,7 +2040,7 @@ def load_plugins_from_roots(
         module_path, class_name = entry.split(":", 1)
         logger.debug("Plugin {}: importing {}:{}", pid, module_path, class_name)
         try:
-            mod = importlib.import_module(module_path)
+            mod = _import_plugin_entry_module(module_path, toml_path, logger)
             cls: Type[Any] = getattr(mod, class_name)
         except (ImportError, ModuleNotFoundError) as e:
             logger.error("Failed to import module '{}' for plugin {}: {}", module_path, pid, e, exc_info=True)

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1299,6 +1299,7 @@ def _build_extension_map(
             "ext_id": ctx.pid,
             "ext_entry": ctx.entry,
             "prefix": host_conf.get("prefix", ""),
+            "config_path": str(ctx.toml_path),
         })
     
     return extension_map

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 import re
 import shutil
 import time as time_module
@@ -17,7 +16,7 @@ from typing import Protocol, runtime_checkable
 from fastapi import HTTPException
 
 from plugin._types.exceptions import PluginError
-from plugin.core.host import PluginProcessHost
+from plugin.core.host import PluginProcessHost, _import_plugin_module
 from plugin.core.registry import (
     _collect_plugin_python_requirements,
     _collect_plugin_python_requirement_paths,
@@ -670,7 +669,7 @@ class PluginLifecycleService:
                 current_plugin_id,
             )
             module_path, class_name = entry.split(":", 1)
-            module_obj = await asyncio.to_thread(importlib.import_module, module_path)
+            module_obj = await asyncio.to_thread(_import_plugin_module, module_path, config_path, logger)
             cls_obj = getattr(module_obj, class_name)
             if not isinstance(cls_obj, type):
                 raise _to_domain_error(

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -1108,16 +1108,15 @@ class PluginLifecycleService:
             )
 
         prefix = ""
-        config_path_obj = ext_meta.get("config_path")
-        if isinstance(config_path_obj, str) and config_path_obj:
-            config_path = Path(config_path_obj)
+        resolved_config_path = await asyncio.to_thread(_resolve_registered_config_path_sync, ext_meta)
+        if resolved_config_path is not None:
             try:
-                prefix = await asyncio.to_thread(_read_extension_prefix_sync, config_path)
+                prefix = await asyncio.to_thread(_read_extension_prefix_sync, resolved_config_path)
             except (FileNotFoundError, PermissionError, OSError, ValueError) as exc:
                 logger.warning(
                     "failed to read extension prefix: ext_id={}, config_path={}, err_type={}, err={}",
                     ext_id,
-                    str(config_path),
+                    str(resolved_config_path),
                     type(exc).__name__,
                     str(exc),
                 )
@@ -1136,7 +1135,7 @@ class PluginLifecycleService:
                         "ext_id": ext_id,
                         "ext_entry": ext_entry_obj,
                         "prefix": prefix,
-                        "config_path": config_path_obj if isinstance(config_path_obj, str) else "",
+                        "config_path": str(resolved_config_path) if resolved_config_path is not None else "",
                     },
                     timeout=10.0,
                 )

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -1136,6 +1136,7 @@ class PluginLifecycleService:
                         "ext_id": ext_id,
                         "ext_entry": ext_entry_obj,
                         "prefix": prefix,
+                        "config_path": config_path_obj if isinstance(config_path_obj, str) else "",
                     },
                     timeout=10.0,
                 )

--- a/plugin/server/application/plugins/registry_service.py
+++ b/plugin/server/application/plugins/registry_service.py
@@ -840,6 +840,7 @@ class PluginRegistryService:
                     "ext_id": plugin_id,
                     "ext_entry": entry_point_obj,
                     "prefix": prefix,
+                    "config_path": str(config_path) if config_path is not None else "",
                 }
             )
 

--- a/plugin/server/application/plugins/registry_service.py
+++ b/plugin/server/application/plugins/registry_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 import re
 try:
     import tomllib
@@ -12,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from plugin.core.dependency import _topological_sort_plugins
+from plugin.core.host import _import_plugin_module
 from plugin.core.registry import (
     PluginContext,
     _build_plugin_meta,
@@ -431,7 +431,7 @@ def _build_discovery_payload(
                 )
                 try:
                     module_path, class_name = ctx.entry.split(":", 1)
-                    module_obj = importlib.import_module(module_path)
+                    module_obj = _import_plugin_module(module_path, ctx.toml_path, logger)
                     cls_obj = getattr(module_obj, class_name)
                     entries_preview = _extract_entries_preview(plugin_id, cls_obj, ctx.conf, ctx.pdata)
                 except (ImportError, ModuleNotFoundError) as exc:

--- a/plugin/tests/unit/core/test_host_plugin_import_fallback.py
+++ b/plugin/tests/unit/core/test_host_plugin_import_fallback.py
@@ -1,0 +1,81 @@
+"""覆盖 host 的用户插件安全导入兜底（_import_current_plugin_from_config / _import_plugin_module）。
+
+重点：缺失/拼错的子模块不能被插件包的 __init__.py 静默顶替成功。
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from plugin.core import host as host_module
+
+
+class _StubLogger:
+    def debug(self, *_args, **_kwargs) -> None:
+        return
+
+    def info(self, *_args, **_kwargs) -> None:
+        return
+
+    def warning(self, *_args, **_kwargs) -> None:
+        return
+
+
+@pytest.fixture
+def _isolate_plugins_namespace():
+    """隔离全局 sys.path / sys.modules['plugins*']，兜底会改这些全局状态。"""
+    saved_path = sys.path[:]
+    saved_modules = {
+        key: value
+        for key, value in sys.modules.items()
+        if key == "plugins" or key.startswith("plugins.")
+    }
+    for key in list(saved_modules):
+        sys.modules.pop(key, None)
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_path
+        for key in [k for k in sys.modules if k == "plugins" or k.startswith("plugins.")]:
+            sys.modules.pop(key, None)
+        sys.modules.update(saved_modules)
+
+
+def _make_user_plugin(tmp_path: Path) -> Path:
+    plugin_dir = tmp_path / "user_root" / "plugins" / "myplug"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "__init__.py").write_text("class MyPlugin:\n    pass\n", encoding="utf-8")
+    config_path = plugin_dir / "plugin.toml"
+    config_path.write_text("[plugin]\nid='myplug'\n", encoding="utf-8")
+    return config_path
+
+
+@pytest.mark.plugin_unit
+def test_import_current_plugin_loads_package_from_config(_isolate_plugins_namespace, tmp_path: Path) -> None:
+    config_path = _make_user_plugin(tmp_path)
+    mod = host_module._import_current_plugin_from_config("plugins.myplug", config_path, _StubLogger())
+    assert mod is not None
+    assert getattr(mod, "MyPlugin", None) is not None
+
+
+@pytest.mark.plugin_unit
+def test_import_current_plugin_does_not_mask_missing_submodule(
+    _isolate_plugins_namespace, tmp_path: Path
+) -> None:
+    config_path = _make_user_plugin(tmp_path)
+    # plugins.myplug.missing 不存在：兜底必须返回 None，而不是拿 __init__.py 顶替成功。
+    mod = host_module._import_current_plugin_from_config("plugins.myplug.missing", config_path, _StubLogger())
+    assert mod is None
+    assert "plugins.myplug.missing" not in sys.modules
+
+
+@pytest.mark.plugin_unit
+def test_import_plugin_module_raises_for_missing_submodule(
+    _isolate_plugins_namespace, tmp_path: Path
+) -> None:
+    config_path = _make_user_plugin(tmp_path)
+    with pytest.raises(ModuleNotFoundError):
+        host_module._import_plugin_module("plugins.myplug.missing", config_path, _StubLogger())

--- a/plugin/tests/unit/core/test_registry_build_extension_map.py
+++ b/plugin/tests/unit/core/test_registry_build_extension_map.py
@@ -77,4 +77,13 @@ def test_build_extension_map_includes_when_ctx_enabled_and_conf_missing():
         auto_start=False,
     )
     extension_map = module._build_extension_map([ctx])
-    assert extension_map == {"host": [{"ext_id": "ext", "ext_entry": "tests.fake_ext:Plugin", "prefix": ""}]}
+    assert extension_map == {
+        "host": [
+            {
+                "ext_id": "ext",
+                "ext_entry": "tests.fake_ext:Plugin",
+                "prefix": "",
+                "config_path": str(Path("/tmp/ext/plugin.toml")),
+            }
+        ]
+    }

--- a/plugin/tests/unit/core/test_registry_duplicate_cleanup.py
+++ b/plugin/tests/unit/core/test_registry_duplicate_cleanup.py
@@ -61,7 +61,7 @@ def test_load_plugins_from_roots_rolls_back_scanned_metadata_when_register_plugi
             auto_start=True,
         )
 
-        original_import_module = module.importlib.import_module
+        original_import_module = module._import_plugin_entry_module
         original_collect = module._collect_plugin_contexts_from_roots
         original_sort = module._topological_sort_plugins
         original_prepare = module._prepare_plugin_import_roots
@@ -73,7 +73,7 @@ def test_load_plugins_from_roots_rolls_back_scanned_metadata_when_register_plugi
         shutdown_calls: list[str] = []
 
         try:
-            module.importlib.import_module = lambda _: SimpleNamespace(DuplicateCleanupPlugin=_DuplicateCleanupPlugin)
+            module._import_plugin_entry_module = lambda *args, **kwargs: SimpleNamespace(DuplicateCleanupPlugin=_DuplicateCleanupPlugin)
             module._collect_plugin_contexts_from_roots = lambda roots, logger: ([ctx], {ctx.pid: ctx})
             module._topological_sort_plugins = lambda contexts, pid_to_context, logger: [ctx.pid]
             module._prepare_plugin_import_roots = lambda roots, logger: None
@@ -95,7 +95,7 @@ def test_load_plugins_from_roots_rolls_back_scanned_metadata_when_register_plugi
                 process_host_factory=lambda *args, **kwargs: _DuplicateCleanupHost(),
             )
         finally:
-            module.importlib.import_module = original_import_module
+            module._import_plugin_entry_module = original_import_module
             module._collect_plugin_contexts_from_roots = original_collect
             module._topological_sort_plugins = original_sort
             module._prepare_plugin_import_roots = original_prepare

--- a/plugin/tests/unit/core/test_registry_load_adapter_plugin_entries.py
+++ b/plugin/tests/unit/core/test_registry_load_adapter_plugin_entries.py
@@ -59,10 +59,10 @@ def test_load_adapter_plugin_registers_entries_preview_and_handlers() -> None:
             auto_start=True,
         )
 
-        original_import_module = module.importlib.import_module
+        original_import_module = module._import_plugin_entry_module
         original_register_plugin = module.register_plugin
         try:
-            module.importlib.import_module = lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin)
+            module._import_plugin_entry_module = lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin)
 
             def _register_plugin(plugin_meta, logger=None, config_path=None, entry_point=None):
                 plugin_dump = plugin_meta.model_dump()
@@ -83,7 +83,7 @@ def test_load_adapter_plugin_registers_entries_preview_and_handlers() -> None:
                 process_host_factory=lambda *args, **kwargs: _FakeHost(),
             )
         finally:
-            module.importlib.import_module = original_import_module
+            module._import_plugin_entry_module = original_import_module
             module.register_plugin = original_register_plugin
 
         assert host is not None
@@ -150,10 +150,10 @@ def test_load_adapter_plugin_rolls_back_scanned_handlers_when_register_fails() -
             auto_start=True,
         )
 
-        original_import_module = module.importlib.import_module
+        original_import_module = module._import_plugin_entry_module
         original_register_plugin = module.register_plugin
         try:
-            module.importlib.import_module = lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin)
+            module._import_plugin_entry_module = lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin)
             module.register_plugin = lambda *args, **kwargs: None
 
             host = module._load_adapter_plugin(
@@ -162,7 +162,7 @@ def test_load_adapter_plugin_rolls_back_scanned_handlers_when_register_fails() -
                 process_host_factory=lambda *args, **kwargs: _FakeHost(),
             )
         finally:
-            module.importlib.import_module = original_import_module
+            module._import_plugin_entry_module = original_import_module
             module.register_plugin = original_register_plugin
 
         assert host is None
@@ -223,9 +223,9 @@ def test_load_adapter_plugin_rolls_back_scanned_handlers_when_process_start_fail
             auto_start=True,
         )
 
-        original_import_module = module.importlib.import_module
+        original_import_module = module._import_plugin_entry_module
         try:
-            module.importlib.import_module = lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin)
+            module._import_plugin_entry_module = lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin)
 
             def failing_process_host_factory(*args, **kwargs):
                 raise RuntimeError("boom")
@@ -236,7 +236,7 @@ def test_load_adapter_plugin_rolls_back_scanned_handlers_when_process_start_fail
                 process_host_factory=failing_process_host_factory,
             )
         finally:
-            module.importlib.import_module = original_import_module
+            module._import_plugin_entry_module = original_import_module
 
         assert host is None
         with module.state.acquire_event_handlers_read_lock():

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -268,7 +268,7 @@ async def test_start_plugin_refreshes_registry_before_loading(
         )
         monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
         monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
-        monkeypatch.setattr(module.importlib, "import_module", lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
+        monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
 
         service = module.PluginLifecycleService()
@@ -340,7 +340,7 @@ async def test_start_plugin_checks_python_requirements_against_vendor_paths(
     monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
     monkeypatch.setattr(module, "_find_missing_python_requirements", _fake_find_missing)
     monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
-    monkeypatch.setattr(module.importlib, "import_module", lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
+    monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
     monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
 
     plugins_backup = copy.deepcopy(module.state.plugins)
@@ -437,7 +437,7 @@ async def test_start_plugin_persists_entries_preview_and_invalidates_stale_cache
         )
         monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
         monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
-        monkeypatch.setattr(module.importlib, "import_module", lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
+        monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
 
         service = module.PluginLifecycleService()
@@ -527,7 +527,7 @@ async def test_start_plugin_logs_structured_config_warnings_from_resolver(
         )
         monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
         monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
-        monkeypatch.setattr(module.importlib, "import_module", lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
+        monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
         monkeypatch.setattr(module, "logger", capture_logger)
 
@@ -639,7 +639,7 @@ async def test_start_plugin_allows_retry_for_load_failed_plugin(
         )
         monkeypatch.setattr(module, "_resolve_plugin_id_conflict", lambda *args, **kwargs: args[0])
         monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
-        monkeypatch.setattr(module.importlib, "import_module", lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
+        monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
 
         service = module.PluginLifecycleService()
@@ -749,7 +749,7 @@ async def test_start_plugin_passes_prebuilt_extension_configs_to_host(
             module.state.event_handlers.clear()
 
         monkeypatch.setattr(module, "PluginProcessHost", _FakeProcessHost)
-        monkeypatch.setattr(module.importlib, "import_module", lambda _: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
+        monkeypatch.setattr(module, "_import_plugin_module", lambda *args, **kwargs: SimpleNamespace(FakeAdapterPlugin=_FakeAdapterPlugin))
         monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
 
         service = module.PluginLifecycleService()
@@ -764,6 +764,7 @@ async def test_start_plugin_passes_prebuilt_extension_configs_to_host(
                 "ext_id": "demo_ext",
                 "ext_entry": "tests.fake_ext:DemoExtRouter",
                 "prefix": "/demo",
+                "config_path": str(ext_config_path.resolve()),
             }
         ]
 


### PR DESCRIPTION
…安全导入兜底，避免插件管理器刚打开显示失败但重载后恢复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进插件导入与回退加载策略，提升对不同目录布局的兼容性并避免子模块被误遮蔽，减少“模块未找到”类错误。
  * 在扩展启用与插件启动流程中显式携带并使用配置路径，提升扩展加载与运行时稳定性与可追溯性。
* **Tests**
  * 更新并新增单元测试覆盖导入回退、配置路径解析与边界情况，确保加载逻辑更稳健。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->