### PR TITLE
feat(chat): 复活 full 聊天界面（冻结 legacy）+ 顶层 mode dispatcher

### DIFF
--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -8,7 +8,7 @@
 
 本文覆盖当前分支已经落地的紧凑聊天框长期事实和维护边界，包括：
 
-1. `compact / minimized` 两态聊天形态。
+1. `compact / minimized` 两态聊天形态（活跃形态；被复活的 `full` 是冻结 legacy、与之严格隔离，见「已确认事实」第 2 条与 `FullChatSurface.tsx` 文件头，不在本文范围）。
 2. `default / options / input` 紧凑态内部三态。
 3. 紧凑 surface、最小化 ball、选项层、工具转轮、内联历史、历史气泡拖拽与发送链路。
 4. Web、独立 `/chat`、NEKO-PC 桌面壳三端的样式、geometry、命中、bounds 和拖拽边界。
@@ -79,7 +79,7 @@
 已确认事实：
 
 1. 当前聊天 UI 以 React chat 为准；旧 `#chat-container` 只作为兼容 DOM 存在。
-2. 宿主形态是 `chatSurfaceMode: 'compact' | 'minimized'`（localStorage 里遗留的 `'full'` 读入时迁移为 `'compact'`）。
+2. 宿主形态是 `chatSurfaceMode: 'full' | 'compact' | 'minimized'`。`full` 是被复活的**冻结 legacy** 完整聊天窗口，由 `App.tsx` 顶层无 hooks 的 dispatcher 路由到自包含的 `FullChatSurface.tsx`（删除前那版 App 的冻结快照），与本文覆盖的 `compact / minimized` **严格代码隔离**：两子树互斥挂载，hooks/state 不共享，full 不再迭代——本文只描述活跃的 compact/minimized，full 见 `FullChatSurface.tsx` 文件头。`full` 不进 `CHAT_SURFACE_MODE_SEQUENCE`（compact↔minimized 的 cycle），只由显式 `setChatSurfaceMode('full')`（如 NEKO-PC 托盘切换）进入。
 3. compact 内部状态是 `compactChatState: 'default' | 'options' | 'input'`。
 4. `effectiveCompactChatState` 会在存在 ChoicePrompt / GalGame options 时把 compact 推到 `options`，不需要业务层另造状态。
 5. compact 主体 DOM 已统一为：

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -84,6 +84,28 @@ describe('App', () => {
     expect(document.body.querySelector('.compact-input-tool-fan')).not.toBeNull();
   });
 
+  it('dispatches the frozen legacy full surface for chatSurfaceMode="full"', () => {
+    // The dispatcher routes `full` to the isolated FullChatSurface, which shows
+    // the full history list + full composer instead of the compact surface.
+    const message = parseChatMessage({
+      id: 'm-full',
+      role: 'assistant',
+      author: 'Neko',
+      time: '12:00',
+      blocks: [{ type: 'text', text: 'hello from full' }],
+    });
+    const { container } = render(<App chatSurfaceMode="full" messages={[message]} />);
+
+    // Full surface: history list + full composer with the persistent textarea.
+    expect(container.querySelector('.message-list')).not.toBeNull();
+    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument();
+    expect(container.querySelector('.composer-bottom-bar')).not.toBeNull();
+
+    // Compact surface must NOT mount — the two subtrees are mutually exclusive.
+    expect(container.querySelector('.compact-chat-surface-shell')).toBeNull();
+    expect(container.querySelector('.compact-chat-stage')).toBeNull();
+  });
+
   it('enters compact input from the subtitle capsule when used uncontrolled', () => {
     const { container } = render(<App chatSurfaceMode="compact" />);
 

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -1,18 +1,25 @@
-﻿import {
+/**
+ * FROZEN LEGACY — the `full` chat surface (full window: history list + full
+ * composer). This is a snapshot of `App.tsx` as it stood at commit 1afbc8d1d^,
+ * the last revision where the full surface still worked, lifted into its own
+ * component so the active `compact`/`minimized` App can evolve without ever
+ * touching — or being touched by — full. The host dispatcher (App.tsx) renders
+ * this ONLY for chatSurfaceMode === 'full'; the compact branches retained below
+ * are intentionally dead in that mode. Do NOT add features here — all ongoing
+ * chat work happens on the compact App. See FullChatSurface in the dispatcher.
+ */
+import {
   useState,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useCallback,
   type CSSProperties,
-  type FocusEvent as ReactFocusEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
-  type WheelEvent as ReactWheelEvent,
 } from 'react';
 import { createPortal } from 'react-dom';
-import FullChatSurface from './FullChatSurface';
+import MessageList from './MessageList';
 import CompactExportHistoryPanel, {
   COMPACT_EXPORT_SELECTION_LIMIT,
   isCompactExportMessageSelectable,
@@ -34,7 +41,7 @@ import {
   type ChoicePromptSource,
 } from './message-schema';
 
-export type ChatWindowProps = ChatWindowSchemaProps & {
+type ChatWindowProps = ChatWindowSchemaProps & {
   onMessageAction?: (message: ChatMessage, action: MessageAction) => void;
   onComposerImportImage?: () => void;
   onComposerScreenshot?: () => void;
@@ -51,7 +58,6 @@ export type ChatWindowProps = ChatWindowSchemaProps & {
   // callback path until the host fully migrates to the shared choice slot.
   onChoiceSelect?: (option: ChoiceOption, source: ChoicePromptSource) => void;
   onCompactChatStateChange?: (state: CompactChatState) => void;
-  onCompactMinimizeRequest?: () => void;
 };
 
 type CompactInlineExportBridge = {
@@ -66,11 +72,7 @@ type AvatarToolId = AvatarInteractionPayload['toolId'];
 function getEffectiveCompactChatState(
   requestedState: CompactChatState,
   hasVisibleChoices: boolean,
-  composerHidden: boolean,
 ): CompactChatState {
-  if (composerHidden) {
-    return 'default';
-  }
   if (requestedState === 'input') {
     return 'input';
   }
@@ -83,85 +85,21 @@ function getEffectiveCompactChatState(
   return requestedState;
 }
 
-function isGuideChatButtonLockActive(): boolean {
-  return document.body?.classList.contains('yui-guide-chat-buttons-disabled') === true;
-}
-
+const COMPACT_PREVIEW_MAX_LENGTH = 84;
 const COMPACT_SPEECH_REVEAL_MAX_CHARS_PER_SECOND = 8;
 const COMPACT_SPEECH_TURN_MERGE_WINDOW_MS = 12000;
 const COMPACT_SPEECH_FALLBACK_REVEAL_DELAY_MS = 700;
 const SPEECH_PLAYBACK_STATE_STORAGE_KEY = 'neko_speech_playback_state';
 const SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';
 const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
-const COMPACT_HISTORY_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.compactHistorySlotHeight';
-export const COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS = 560;
 const COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT = 7;
-const COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD = 22;
-const COMPACT_INPUT_TOOL_WHEEL_SCROLL_DEADZONE = 0.5;
-const COMPACT_INPUT_TOOL_WHEEL_DRAG_GUARD_MS = 4000;
-const COMPACT_INPUT_TOOL_WHEEL_FAST_GESTURE_MS = 140;
-const COMPACT_INPUT_TOOL_WHEEL_FAST_ANIMATION_MS = 180;
-const COMPACT_INPUT_TOOL_WHEEL_CHARGE_START_STEPS = COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT * 4;
-const COMPACT_INPUT_TOOL_WHEEL_CHARGE_LAP_STEPS = COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT * 2;
-const COMPACT_INPUT_TOOL_WHEEL_CHARGE_MAX_STEPS = COMPACT_INPUT_TOOL_WHEEL_CHARGE_LAP_STEPS * 2;
-const COMPACT_INPUT_TOOL_WHEEL_CHARGE_RELEASE_STEP_MS = 36;
-const COMPACT_INPUT_TOOL_WHEEL_CENTER_X = 116;
-const COMPACT_INPUT_TOOL_WHEEL_CENTER_Y = 116;
-// Drag-to-rotate sensitivity scalar (arc = radius * angleDelta), NOT a layout
-// value. Kept at 91.92 so the rotate-by-drag feel is unchanged even though the
-// visual orbit radius (--compact-tool-wheel-orbit-radius in styles.css) was
-// halved — the angle itself is measured from real geometry, this only scales
-// how much angular travel counts as one step.
-const COMPACT_INPUT_TOOL_WHEEL_ORBIT_RADIUS = 91.92;
-const COMPACT_INPUT_TOOL_WHEEL_HOVER_RADIUS = 116;
-const COMPACT_INPUT_TOOL_WHEEL_ANGLE_MIN_RADIUS = 16;
-const COMPACT_INPUT_TOOL_WHEEL_VIEWPORT_MARGIN = 8;
-const COMPACT_INPUT_TOOL_TOGGLE_HOVER_OUTSET = 14;
+const COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD = 28;
 const COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE = 48;
-// 在工具轮盘中心（toggle / fan 原点）按下后，指针移动超过此像素阈值即视为「拖动文本框」
-// 而非「点一下展开/关闭轮盘」。与宿主 surface 拖拽的 CLICK_THRESHOLD(5px) 量级一致。
-const COMPACT_INPUT_TOOL_ORIGIN_DRAG_THRESHOLD = 6;
 const COMPACT_INPUT_TOOL_FAN_INTERACTIVE_DELAY_MS = 220;
-const COMPACT_INPUT_TOOL_FAN_TRANSIENT_CLOSE_DELAY_MS = 360;
-const COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS = 650;
-const compactInputToolWheelDefaultVisibleSlots = [
-  { angleDeg: 107.35, scale: 0.86 },
-  { angleDeg: 75.82, scale: 0.98 },
-  { angleDeg: 45, scale: 1.04 },
-  { angleDeg: 14.18, scale: 0.98 },
-  { angleDeg: -17.35, scale: 0.86 },
-] as const;
-const compactInputToolWheelViewportFitVisibleSlots = [
-  { angleDeg: -200, scale: 0.86 },
-  { angleDeg: -170, scale: 0.98 },
-  { angleDeg: -140, scale: 1.04 },
-  { angleDeg: -110, scale: 0.98 },
-  { angleDeg: -80, scale: 0.86 },
-] as const;
-const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 280;
-// compact 对话条默认/初始宽度（无法从 rect/CSS 量到时的回退值）。与 resize 下限解耦：
-// 减小最短宽度只动 RESIZE_MIN_WIDTH，默认仍是这个值，保证「默认宽度不变」。
-const COMPACT_SURFACE_DEFAULT_WIDTH = 430;
-const COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280;
+const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 430;
 const COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
 const COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER = 32;
-const COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER = 16;
-// compact 历史堆砌区（CompactExportHistoryPanel）顶部 resize bar 的高度上限钳位参数。
-// 下限压到 ~1-2 个气泡以便节约屏幕；上限对齐 anchor 的 max-height（width*1.46 / 78% 视口），
-// 避免拖超 anchor 二次截断产生「拖了没反应」的死区。默认（未拖动）公式仍是 width*1.18 / 63%。
-const COMPACT_HISTORY_SLOT_MIN_HEIGHT = 120;
-const COMPACT_HISTORY_SLOT_MAX_VIEWPORT_RATIO = 0.78;
-const COMPACT_HISTORY_SLOT_DEFAULT_WIDTH_RATIO = 1.18;
-const COMPACT_HISTORY_SLOT_DEFAULT_VIEWPORT_RATIO = 0.63;
-// scroll 区上方的 bar(12px+margin) 与下方 controls(展开块 ≤44px) 的固定 chrome；
-// 从 anchor max-height 里扣掉，避免拖到上限时 scroll 吃满 anchor、controls 溢出被裁成非交互。
-const COMPACT_HISTORY_SLOT_CHROME_RESERVE = 72;
 const COMPACT_CHOICE_PLACEMENT_HYSTERESIS = 24;
-const COMPOSER_OPTION_MARQUEE_MIN_DISTANCE = 6;
-const COMPOSER_OPTION_MARQUEE_MIN_DURATION_MS = 1400;
-const COMPOSER_OPTION_MARQUEE_MAX_DURATION_MS = 12000;
-const COMPOSER_OPTION_MARQUEE_PIXELS_PER_SECOND = 96;
-const COMPOSER_OPTION_MARQUEE_END_PADDING = 28;
 
 type CompactSurfaceResizeSide = 'left' | 'right';
 
@@ -178,90 +116,20 @@ type CompactSurfaceResizeState = {
   captureTarget: Element | null;
 };
 
-type CompactHistoryResizeState = {
-  pointerId: number;
-  startPointerY: number;
-  startHeight: number;
-  lastHeight: number;
-  moved: boolean;
-  captureTarget: Element | null;
-};
-
 type CompactToolWheelPointerState = {
   id: number;
   x: number;
-  y: number;
-  angle: number | null;
-  angleRemainder: number;
   didRotate: boolean;
   captureTarget: Element | null;
 };
 
-type CompactToolWheelChargeState = {
-  direction: 1 | -1 | null;
-  sameDirectionSteps: number;
-  chargeSteps: number;
-};
-
-type CompactToolWheelDragPoint = {
-  x: number;
-  y: number;
-  angle: number | null;
-};
-
-type CompactToolWheelDragInput = {
-  pointerId: number;
-  clientX: number;
-  clientY: number;
-  buttons?: number;
-  pointerType?: string;
-  preventDefault?: () => void;
-};
-
-function normalizeCompactToolWheelAngleDelta(delta: number): number {
-  const fullTurn = Math.PI * 2;
-  return ((((delta + Math.PI) % fullTurn) + fullTurn) % fullTurn) - Math.PI;
-}
-
-function getCompactToolWheelTimestamp(): number {
-  return window.performance?.now?.() ?? Date.now();
-}
-
-function createCompactToolWheelChargeState(): CompactToolWheelChargeState {
-  return {
-    direction: null,
-    sameDirectionSteps: 0,
-    chargeSteps: 0,
-  };
-}
-
 type CompactMessagePreview = {
   messageId: string;
-  // Stable identity of the whole merged turn: the id of the earliest message
-  // folded into this preview. Unchanged as more bubbles stream into the same
-  // turn (messageId re-keys to the latest bubble, this does not), and changes
-  // when a genuinely new turn begins. Used to tell an appended bubble from a
-  // new turn without relying on text-prefix matching.
-  turnStartId: string;
-  turnId?: string;
   author: string;
   text: string;
   fullText: string;
   isStreaming: boolean;
   isAssistant: boolean;
-  isGuide: boolean;
-};
-
-type CompactCaptionState = {
-  turnId: string;
-  segmentId: string;
-  lastSegmentText: string;
-  segments: Array<{
-    segmentId: string;
-    text: string;
-  }>;
-  text: string;
-  isEnded?: boolean;
 };
 
 type DesktopCompactChoicePlacementLayout = {
@@ -286,17 +154,12 @@ type DesktopCompactChoicePlacementLayout = {
   } | null;
 };
 
-function clampCompactSurfaceResizeWidth(
-  width: number,
-  maxAvailableWidth: number,
-  minAvailableWidth = COMPACT_SURFACE_RESIZE_MIN_WIDTH,
-  viewportGutter = COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER,
-): number {
+function clampCompactSurfaceResizeWidth(width: number, maxAvailableWidth: number): number {
   const maxWidth = Math.max(
     0,
-    Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, maxAvailableWidth - viewportGutter),
+    Math.min(COMPACT_SURFACE_RESIZE_MAX_WIDTH, maxAvailableWidth - COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER),
   );
-  const minWidth = Math.min(minAvailableWidth, maxWidth || minAvailableWidth);
+  const minWidth = Math.min(COMPACT_SURFACE_RESIZE_MIN_WIDTH, maxWidth || COMPACT_SURFACE_RESIZE_MIN_WIDTH);
   return Math.round(Math.max(minWidth, Math.min(width, Math.max(minWidth, maxWidth))));
 }
 
@@ -316,12 +179,11 @@ function isDesktopCompactSurfaceLayoutActive(): boolean {
 }
 
 function readPersistedCompactExportHistoryOpen(): boolean {
-  if (typeof window === 'undefined') return true;
+  if (typeof window === 'undefined') return false;
   try {
-    const persisted = window.localStorage?.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
-    return persisted === null ? true : persisted === 'true';
+    return window.localStorage?.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY) === 'true';
   } catch {
-    return true;
+    return false;
   }
 }
 
@@ -334,58 +196,8 @@ function persistCompactExportHistoryOpen(open: boolean) {
   }
 }
 
-function readPersistedCompactHistorySlotHeight(): number | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const persisted = window.localStorage?.getItem(COMPACT_HISTORY_HEIGHT_STORAGE_KEY);
-    if (persisted === null || persisted === undefined) return null;
-    const value = Number(persisted);
-    return Number.isFinite(value) && value > 0 ? value : null;
-  } catch {
-    return null;
-  }
-}
-
-function persistCompactHistorySlotHeight(value: number | null) {
-  if (typeof window === 'undefined') return;
-  try {
-    if (value === null) {
-      window.localStorage?.removeItem(COMPACT_HISTORY_HEIGHT_STORAGE_KEY);
-    } else {
-      window.localStorage?.setItem(COMPACT_HISTORY_HEIGHT_STORAGE_KEY, String(Math.round(value)));
-    }
-  } catch {
-    // localStorage can be unavailable in restricted hosts; keep the in-memory state.
-  }
-}
-
-// 历史区高度上限的基数：Electron 独立窗口用工作区高度（窗口可能只覆盖部分屏，不能用 innerHeight），
-// 网页路径用视口高度。与 styles.css 里默认公式的 63vh / workarea*0.63 取同一基数。
-function getCompactHistoryViewportBase(): number {
-  if (typeof window === 'undefined') return 900;
-  const desktopLayout = (window as typeof window & {
-    __nekoDesktopCompactLayout?: { workArea?: { height?: number } | null } | null;
-  }).__nekoDesktopCompactLayout;
-  const workAreaHeight = Number(desktopLayout?.workArea?.height);
-  if (isDesktopCompactSurfaceLayoutActive() && Number.isFinite(workAreaHeight) && workAreaHeight > 0) {
-    return workAreaHeight;
-  }
-  return window.innerHeight || 900;
-}
-
-function getCompactHistoryResizePointerY(event: ReactPointerEvent<HTMLDivElement>): number {
-  const screenY = Number(event.screenY);
-  if (Number.isFinite(screenY)) {
-    return screenY;
-  }
-  return event.clientY;
-}
-
 type SpeechPlaybackState = {
   active: boolean;
-  turnId?: string | null;
-  playbackTurnId?: string | null;
-  speechId?: string | null;
   audioContextTime: number;
   playbackStartAudioTime: number;
   playbackEndAudioTime: number;
@@ -399,17 +211,11 @@ function normalizeCompactPreviewText(text: string): string {
     .trim();
 }
 
-function splitCompactPreviewGraphemes(text: string): string[] {
-  const segmenter = (Intl as typeof Intl & {
-    Segmenter?: new (
-      locale?: string,
-      options?: { granularity?: 'grapheme' },
-    ) => { segment(input: string): Iterable<{ segment: string }> };
-  }).Segmenter;
-  if (typeof segmenter === 'function') {
-    return Array.from(new segmenter(undefined, { granularity: 'grapheme' }).segment(text), part => part.segment);
+function truncateCompactPreview(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
   }
-  return Array.from(text);
+  return `${text.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
 }
 
 function getCompactSpeechRevealDuration(textLength: number, audioDuration: number): number {
@@ -423,18 +229,6 @@ function getEstimatedSpeechAudioTime(state: SpeechPlaybackState): number {
   }
   const elapsedSinceUpdate = Math.max(0, (Date.now() - state.updatedAt) / 1000);
   return state.audioContextTime + elapsedSinceUpdate;
-}
-
-function isSpeechPlaybackStateForCompactPreview(
-  state: SpeechPlaybackState | null,
-  preview: { turnId?: string } | null,
-): state is SpeechPlaybackState {
-  if (!state) return false;
-  const previewTurnId = preview?.turnId;
-  if (!previewTurnId) return true;
-  const stateTurnIds = [state.playbackTurnId, state.turnId].filter((value): value is string => !!value);
-  if (stateTurnIds.length === 0) return true;
-  return stateTurnIds.includes(previewTurnId);
 }
 
 function getMessageBlockPreviewText(message: ChatMessage): string {
@@ -457,19 +251,11 @@ function getMessageBlockPreviewText(message: ChatMessage): string {
   return normalizeCompactPreviewText(text);
 }
 
-function isGuideMessageId(id: unknown): boolean {
-  return typeof id === 'string' && id.startsWith('yui-guide-');
-}
-
 function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePreview | null {
   let latestStreamingAssistantIndex = -1;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (
-      message?.role === 'assistant'
-      && message.status === 'streaming'
-      && getMessageBlockPreviewText(message)
-    ) {
+    if (message?.role === 'assistant' && message.status === 'streaming' && getMessageBlockPreviewText(message)) {
       latestStreamingAssistantIndex = index;
       break;
     }
@@ -479,11 +265,7 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
     const turnTexts: string[] = [];
     let turnAuthor = '';
     const latestStreamingMessage = messages[latestStreamingAssistantIndex];
-    const latestStreamingTurnId = latestStreamingMessage?.turnId;
     const turnMessageId = String(latestStreamingMessage?.id || 'assistant-streaming');
-    // Walks backward to the earliest merged bubble, so the last assignment in
-    // the loop is the turn's anchor id.
-    let turnStartId = latestStreamingTurnId ? `assistant-turn:${latestStreamingTurnId}` : turnMessageId;
     let previousIncludedCreatedAt = typeof latestStreamingMessage?.createdAt === 'number'
       && Number.isFinite(latestStreamingMessage.createdAt)
       ? latestStreamingMessage.createdAt
@@ -494,29 +276,18 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
       if (message.role !== 'assistant') {
         break;
       }
-      if (index !== latestStreamingAssistantIndex && latestStreamingTurnId && message.turnId !== latestStreamingTurnId) {
-        break;
-      }
       if (index !== latestStreamingAssistantIndex && message.status !== 'streaming') {
         const createdAt = typeof message.createdAt === 'number' && Number.isFinite(message.createdAt)
           ? message.createdAt
           : null;
-        if (!latestStreamingTurnId && (
+        if (
           previousIncludedCreatedAt === null
           || createdAt === null
           || Math.abs(previousIncludedCreatedAt - createdAt) > COMPACT_SPEECH_TURN_MERGE_WINDOW_MS
-        )) {
+        ) {
           break;
         }
         previousIncludedCreatedAt = createdAt;
-      }
-      // Anchor the turn to every message folded in, before the empty-text skip.
-      // A bubble can be momentarily text-less (still streaming, image-only) then
-      // gain text; if the anchor only moved on text-bearing bubbles it would
-      // drift to a later bubble and back, re-keying the same turn as a new one
-      // and replaying the caption.
-      if (!latestStreamingTurnId) {
-        turnStartId = String(message.id || turnMessageId);
       }
       const text = getMessageBlockPreviewText(message);
       if (!text) continue;
@@ -527,19 +298,39 @@ function getCompactMessagePreview(messages: ChatMessage[]): CompactMessagePrevie
       const turnText = normalizeCompactPreviewText(turnTexts.join(' '));
       return {
         messageId: turnMessageId || 'assistant-streaming',
-        turnStartId,
-        turnId: latestStreamingTurnId,
         author: turnAuthor,
         text: turnText,
         fullText: turnText,
         isStreaming: true,
         isAssistant: true,
-        isGuide: isGuideMessageId(latestStreamingMessage?.id),
       };
     }
   }
 
-  return null;
+  let fallbackPreview: CompactMessagePreview | null = null;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message) continue;
+    const text = getMessageBlockPreviewText(message);
+    if (!text) continue;
+
+    const isStreamingAssistantMessage = message.role === 'assistant' && message.status === 'streaming';
+    const preview = {
+      messageId: message.id,
+      author: message.author,
+      text: isStreamingAssistantMessage ? text : truncateCompactPreview(text, COMPACT_PREVIEW_MAX_LENGTH),
+      fullText: text,
+      isStreaming: isStreamingAssistantMessage,
+      isAssistant: message.role === 'assistant',
+    };
+    if (message.role === 'assistant') {
+      return preview;
+    }
+    if (!fallbackPreview) {
+      fallbackPreview = preview;
+    }
+  }
+  return fallbackPreview;
 }
 
 type ToolIconItem = {
@@ -634,7 +425,6 @@ const compactCursorZoneSelector = [
   '.compact-input-tool-fan',
   '.compact-input-tool-toggle',
   '.compact-export-history-anchor',
-  '.compact-history-visibility-handle',
   '.send-button-circle',
   '.window-topbar-actions',
   '.topbar-action-btn',
@@ -671,7 +461,6 @@ type ToolCursorVariantState = Record<string, CursorVariant>;
 type InteractionIntensity = NonNullable<AvatarInteractionPayload['intensity']>;
 type AvatarInteractionToolId = AvatarToolId;
 type AvatarTouchZone = 'ear' | 'head' | 'face' | 'body';
-type CompactInputToolWheelLayout = 'default' | 'viewport-fit';
 type AvatarInteractionPayloadByTool = {
   [K in AvatarInteractionToolId]: Extract<AvatarInteractionPayload, { toolId: K }>;
 };
@@ -709,6 +498,13 @@ type AvatarToolCacheState = {
 type AvatarRangeHit = {
   bounds: HostAvatarBounds;
   touchZone: AvatarTouchZone;
+};
+
+type CompactHistoryDesktopDropTargetDetail = {
+  active?: boolean;
+  sessionId?: string;
+  desktopOverAvatar?: boolean | null;
+  timestamp?: number;
 };
 
 function normalizeHostAvatarBounds(bounds: unknown): HostAvatarBounds | null {
@@ -1113,33 +909,19 @@ function sanitizeInteractionTextContext(text: string): string | undefined {
   return trimmed.length > 80 ? trimmed.slice(0, 80).trimEnd() : trimmed;
 }
 
-/**
- * Top-level dispatcher. The host mounts this as the chat window root. It routes
- * the frozen legacy `full` surface to the self-contained {@link FullChatSurface}
- * and keeps the active `compact`/`minimized` experience on {@link CompactChatApp}.
- * The two are sibling subtrees — only one mounts at a time, so their hooks and
- * state stay fully isolated. Compact work never touches full, and vice versa.
- */
-export default function ChatWindowRoot(props: ChatWindowProps) {
-  if (props.chatSurfaceMode === 'full') {
-    return <FullChatSurface {...props} />;
-  }
-  return <CompactChatApp {...props} />;
-}
-
-function CompactChatApp({
+export default function FullChatSurface({
   title = i18n('chat.title', 'N.E.K.O Chat'),
   iconSrc = '/static/icons/chat_icon.png',
   messages = defaultMessages,
   inputPlaceholder = i18n('chat.textInputPlaceholder', 'Type a message...'),
   sendButtonLabel = i18n('chat.send', 'Send'),
   chatWindowAriaLabel = i18n('chat.reactWindowAriaLabel', 'Neko chat window'),
-  messageListAriaLabel: _messageListAriaLabel,
-  composerToolsAriaLabel: _composerToolsAriaLabel,
+  messageListAriaLabel = i18n('chat.messageListAriaLabel', 'Chat messages'),
+  composerToolsAriaLabel = i18n('chat.composerToolsAriaLabel', 'Composer tools'),
   composerHidden = false,
   composerDisabled = false,
-  chatSurfaceMode = 'compact',
-  compactChatState,
+  chatSurfaceMode = 'full',
+  compactChatState = 'default',
   composerAttachments = [],
   composerAttachmentsAriaLabel = i18n('chat.pendingImagesAriaLabel', 'Pending attachments'),
   importImageButtonLabel = i18n('chat.importImage', 'Import Image'),
@@ -1159,10 +941,7 @@ function CompactChatApp({
   galgameToggleButtonLabel = i18n('chat.galgameToggle', 'GalGame Mode'),
   galgameToggleButtonAriaLabel,
   galgameLoadingLabel = i18n('chat.galgameLoading', 'Generating options...'),
-  // Retained for host API compatibility; the compact-only surface no longer
-  // renders the per-message action menu, so this handler is currently unused
-  // (the `_` prefix opts it out of unused-var lint).
-  onMessageAction: _onMessageAction,
+  onMessageAction,
   onComposerImportImage,
   onComposerScreenshot,
   onComposerRemoveAttachment,
@@ -1170,23 +949,27 @@ function CompactChatApp({
   onAvatarInteraction,
   onAvatarToolStateChange,
   onJukeboxClick,
-  // Retained for host API compatibility; export lives outside the compact
-  // surface now, so this handler is currently unused (the `_` prefix opts it
-  // out of unused-var lint).
-  onExportConversationClick: _onExportConversationClick,
+  onExportConversationClick,
   onTranslateToggle,
   onGalgameModeToggle,
   onGalgameOptionSelect,
   choicePrompt = null,
   onChoiceSelect,
   onCompactChatStateChange,
-  onCompactMinimizeRequest,
   rollbackDraft,
   _rollbackKey,
   _toolCursorResetKey,
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
   const [toolMenuOpen, setToolMenuOpen] = useState(false);
+  // Collapse the right-side tools into an overflow menu when the composer gets
+  // narrow, while preserving the exit and re-entry animations for the tool row.
+  type ComposerLayout = 'expanded' | 'collapsing' | 'compact' | 'expanding';
+  const [composerLayout, setComposerLayout] = useState<ComposerLayout>('expanded');
+  const showRightTools = composerLayout === 'expanded' || composerLayout === 'collapsing';
+  const [collapseFromWidth, setCollapseFromWidth] = useState<number | null>(null);
+  const [overflowMenuOpen, setOverflowMenuOpen] = useState(false);
+  const [composerBottomBarNode, setComposerBottomBarNode] = useState<HTMLDivElement | null>(null);
   const [activeCursorToolId, setActiveCursorToolId] = useState<string | null>(null);
   const [avatarRangeCursorVariants, setAvatarRangeCursorVariants] = useState<ToolCursorVariantState>(() => createDefaultToolCursorVariantState());
   const [outsideRangeCursorVariants, setOutsideRangeCursorVariants] = useState<ToolCursorVariantState>(() => createDefaultToolCursorVariantState());
@@ -1197,32 +980,14 @@ function CompactChatApp({
   const [isInnerHammerEasterEggActive, setIsInnerHammerEasterEggActive] = useState(false);
   const appShellRef = useRef<HTMLElement | null>(null);
   const toolMenuRef = useRef<HTMLDivElement | null>(null);
+  const composerBottomBarRef = useRef<HTMLDivElement | null>(null);
+  const composerToolsRightRef = useRef<HTMLDivElement | null>(null);
   const compactInputShellRef = useRef<HTMLDivElement | null>(null);
   const compactInputToolToggleRef = useRef<HTMLButtonElement | null>(null);
   const compactInputToolFanRef = useRef<HTMLDivElement | null>(null);
   const compactInputToolWheelPointerRef = useRef<CompactToolWheelPointerState | null>(null);
-  const compactInputToolWheelDragActiveRef = useRef(false);
-  const compactInputToolWheelDragGuardTimerRef = useRef<number | null>(null);
-  const compactInputToolWheelFastAnimationTimerRef = useRef<number | null>(null);
-  const compactInputToolWheelChargeReleaseTimerRef = useRef<number | null>(null);
-  const compactInputToolWheelLastRotationAtRef = useRef(0);
-  const compactInputToolWheelChargeRef = useRef<CompactToolWheelChargeState>(createCompactToolWheelChargeState());
-  const compactInputToolWheelChargeReleaseActiveRef = useRef(false);
   const compactInputToolWheelSuppressClickRef = useRef(false);
-  // 工具轮盘原点（toggle / fan 中心）的「按住拖动文本框」手势追踪。与轮盘旋转
-  // (compactInputToolWheelPointerRef) 互斥：原点按下时不建立旋转 pointer，旋转路径自然 no-op。
-  const compactToolOriginDragRef = useRef<{
-    pointerId: number;
-    startClientX: number;
-    startClientY: number;
-    startScreenX: number;
-    startScreenY: number;
-    moved: boolean;
-    captureTarget: Element | null;
-  } | null>(null);
-  // 专用于「拖动文本框后吞掉补发 click」的标志。独立于 compactInputToolWheelSuppressClickRef，
-  // 因为轮盘关闭 effect 会重置后者，无法跨「关闭轮盘 + 随后 click」存活。
-  const compactToolOriginSuppressClickRef = useRef(false);
+  const compactInputToolTogglePointerHandledRef = useRef(false);
   const compactInputToolFanPositionSyncRef = useRef<(() => void) | null>(null);
   const compactInputToolFanCloseTimerRef = useRef<number | null>(null);
   const compactInputToolFanInteractiveTimerRef = useRef<number | null>(null);
@@ -1233,6 +998,8 @@ function CompactChatApp({
   const compactInputToolFanInteractiveRef = useRef(false);
   const compactInputRef = useRef<HTMLTextAreaElement | null>(null);
   const compactChoiceLayerRef = useRef<HTMLDivElement | null>(null);
+  const composerLayoutRef = useRef<ComposerLayout>('expanded');
+  const overflowMenuRef = useRef<HTMLDivElement | null>(null);
   const avatarCursorOverlayRef = useRef<HTMLDivElement | null>(null);
   const hammerCursorOverlayRef = useRef<HTMLDivElement | null>(null);
   const hammerSwingTimeoutIdsRef = useRef<number[]>([]);
@@ -1244,6 +1011,7 @@ function CompactChatApp({
   const interactionBurstHistoryRef = useRef<Record<string, number[]>>({});
   const latestPointerPositionRef = useRef({ x: 0, y: 0 });
   const latestPointerTargetRef = useRef<EventTarget | null>(null);
+  const compactHistoryDesktopDropTargetRef = useRef<{ sessionId?: string; overTarget: boolean; timestamp: number } | null>(null);
   const avatarRangeHoldUntilRef = useRef(0);
   const avatarRangeHoldTimerRef = useRef<number | null>(null);
   const draftRef = useRef(draft);
@@ -1257,13 +1025,6 @@ function CompactChatApp({
   const compactSpeechLastFrameTimeRef = useRef(0);
   const compactSpeechPreviewIdRef = useRef('');
   const compactSpeechPreviewTextRef = useRef('');
-  const compactSpeechPreviewTurnIdRef = useRef('');
-  // Identity of the turn the speech reveal is currently walking through (the
-  // preview's turnStartId). Updated when the preview re-keys (messageId change),
-  // so it holds the *previous* turn's anchor at the moment a new bubble arrives
-  // — used to tell an appended bubble (same turn → keep revealing) from a
-  // brand-new turn (rewind to the start) without text-prefix guessing.
-  const compactSpeechRevealTurnIdRef = useRef('');
   const compactSpeechFallbackRevealRef = useRef(false);
   const compactSpeechFallbackTimerRef = useRef<number | null>(null);
   const isCompactSurfaceRef = useRef(false);
@@ -1284,34 +1045,16 @@ function CompactChatApp({
   const [compactSpeechVisibleLength, setCompactSpeechVisibleLength] = useState(0);
   const [compactSpeechFallbackRevealActive, setCompactSpeechFallbackRevealActive] = useState(false);
   const [speechPlaybackState, setSpeechPlaybackState] = useState<SpeechPlaybackState | null>(null);
-  const [compactCaptionState, setCompactCaptionState] = useState<CompactCaptionState | null>(null);
-  const [compactAssistantStreamingGap, setCompactAssistantStreamingGap] = useState<{
-    turnId: string;
-    acceptStreaming: boolean;
-  } | null>(null);
   const [compactChoiceLayerPlacement, setCompactChoiceLayerPlacement] = useState<'above' | 'below'>('above');
   const [compactInputToolFanOpen, setCompactInputToolFanOpen] = useState(false);
   const [compactInputToolFanInteractive, setCompactInputToolFanInteractive] = useState(false);
-  const [compactInputToolWheelLayout, setCompactInputToolWheelLayout] = useState<CompactInputToolWheelLayout>('default');
   const [compactInputToolWheelIndex, setCompactInputToolWheelIndex] = useState(0);
-  const [compactInputToolWheelFastAnimation, setCompactInputToolWheelFastAnimation] = useState(false);
-  const [compactInputToolWheelChargeRatio, setCompactInputToolWheelChargeRatio] = useState(0);
-  const [compactInputToolWheelChargeDirection, setCompactInputToolWheelChargeDirection] = useState<1 | -1 | null>(null);
-  const [compactInputToolWheelChargeReleaseActive, setCompactInputToolWheelChargeReleaseActive] = useState(false);
   const [compactSurfaceResizeWidth, setCompactSurfaceResizeWidth] = useState<number | null>(null);
-  const [compactHistorySlotHeight, setCompactHistorySlotHeight] = useState<number | null>(readPersistedCompactHistorySlotHeight);
-  const [compactHistoryResizeActive, setCompactHistoryResizeActive] = useState(false);
   const [compactExportHistoryOpen, setCompactExportHistoryOpen] = useState(readPersistedCompactExportHistoryOpen);
-  const [compactExportHistoryMounted, setCompactExportHistoryMounted] = useState(readPersistedCompactExportHistoryOpen);
-  const [compactExportHistoryClosingMessages, setCompactExportHistoryClosingMessages] = useState<ChatMessage[] | null>(null);
-  const [compactExportControlsOpen, setCompactExportControlsOpen] = useState(false);
   const [compactExportPreviewOpen, setCompactExportPreviewOpen] = useState(false);
   const [compactExportSelectedIds, setCompactExportSelectedIds] = useState<Set<string>>(() => new Set());
   const [compactExportAutoScrollToBottom, setCompactExportAutoScrollToBottom] = useState(true);
   const compactSurfaceResizeStateRef = useRef<CompactSurfaceResizeState | null>(null);
-  const compactHistoryResizeStateRef = useRef<CompactHistoryResizeState | null>(null);
-  const compactHistoryVisibilitySuppressClickRef = useRef(false);
-  const compactExportHistoryUnmountTimerRef = useRef<number | null>(null);
   const submittingRef = useRef(false);
   const lastRollbackKeyRef = useRef('');
   const lastToolCursorResetKeyRef = useRef('');
@@ -1436,13 +1179,7 @@ function CompactChatApp({
   const resolvedScreenshotAriaLabel = screenshotButtonAriaLabel || screenshotButtonLabel;
   const resolvedTranslateAriaLabel = translateButtonAriaLabel || translateButtonLabel;
   const resolvedGalgameAriaLabel = galgameToggleButtonAriaLabel || galgameToggleButtonLabel;
-  const compactExportControlsVisible = compactExportHistoryOpen && compactExportControlsOpen;
-  const compactExportHistoryToggleLabel = compactExportHistoryOpen
-    ? i18n('chat.compactHistoryToggleClose', 'Hide history')
-    : i18n('chat.compactHistoryToggleOpen', 'Show history');
-  const compactExportControlsButtonLabel = compactExportControlsVisible
-    ? i18n('chat.compactHistoryControlsHide', 'Hide history actions')
-    : i18n('chat.compactHistoryControlsShow', 'Show history actions');
+  const compactExportHistoryButtonLabel = i18n('chat.compactExportHistory', 'History');
   // ChoicePrompt and galgame options share the same composer-anchored slot.
   // The transient invite should win when both are present so we do not stack
   // two button groups in the same compact surface.
@@ -1453,15 +1190,12 @@ function CompactChatApp({
     compactChoiceInteractionsAllowed && galgameModeEnabled && !choicePromptHasOptions
     && (galgameOptionsLoading || galgameOptions.length > 0);
   const compactSurfaceChoicesVisible = choicePromptHasOptions || galgameOptionsVisible;
-  const isCompactSurface = chatSurfaceMode !== 'minimized';
-  // compactChatState 受控时跟随外部 prop；未受控（独立挂载 / 开发预览 main.tsx）时用
-  // 内部 state 兜底，让字幕胶囊点击能真正切到输入态，而不是停在胶囊里出不来喵。
-  const isCompactChatStateControlled = compactChatState !== undefined;
-  const [uncontrolledCompactChatState, setUncontrolledCompactChatState] =
-    useState<CompactChatState>('default');
-  const requestedCompactChatState = compactChatState ?? uncontrolledCompactChatState;
+  const isCompactSurface = chatSurfaceMode === 'compact';
+  const requestedCompactChatState = isCompactSurface && composerHidden && compactChatState === 'input'
+    ? 'default'
+    : compactChatState;
   const effectiveCompactChatState = isCompactSurface
-    ? getEffectiveCompactChatState(requestedCompactChatState, compactSurfaceChoicesVisible, composerHidden)
+    ? getEffectiveCompactChatState(requestedCompactChatState, compactSurfaceChoicesVisible)
     : requestedCompactChatState;
   const getCompactSurfaceResizeMaxAvailableWidth = useCallback(() => {
     const desktopWindow = window as typeof window & {
@@ -1473,34 +1207,9 @@ function CompactChatApp({
     }
     return window.innerWidth || COMPACT_SURFACE_RESIZE_MIN_WIDTH + COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER;
   }, []);
-  const getCompactSurfaceResizeMinAvailableWidth = useCallback(() => (
-    !document.body?.classList.contains('electron-chat-window')
-      && !document.body?.classList.contains('lanlan-pet-mode')
-      && !(window as typeof window & { __LANLAN_IS_ELECTRON_PET__?: boolean }).__LANLAN_IS_ELECTRON_PET__
-      && window.innerWidth <= 768
-      ? COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH
-      : COMPACT_SURFACE_RESIZE_MIN_WIDTH
-  ), []);
-  const getCompactSurfaceResizeViewportGutter = useCallback(() => (
-    !document.body?.classList.contains('electron-chat-window')
-      && !document.body?.classList.contains('lanlan-pet-mode')
-      && !(window as typeof window & { __LANLAN_IS_ELECTRON_PET__?: boolean }).__LANLAN_IS_ELECTRON_PET__
-      && window.innerWidth <= 768
-      ? COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER
-      : COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER
-  ), []);
   const getClampedCompactSurfaceResizeWidth = useCallback((width: number) => (
-    clampCompactSurfaceResizeWidth(
-      width,
-      getCompactSurfaceResizeMaxAvailableWidth(),
-      getCompactSurfaceResizeMinAvailableWidth(),
-      getCompactSurfaceResizeViewportGutter(),
-    )
-  ), [
-    getCompactSurfaceResizeMaxAvailableWidth,
-    getCompactSurfaceResizeMinAvailableWidth,
-    getCompactSurfaceResizeViewportGutter,
-  ]);
+    clampCompactSurfaceResizeWidth(width, getCompactSurfaceResizeMaxAvailableWidth())
+  ), [getCompactSurfaceResizeMaxAvailableWidth]);
   const getClampedCompactSurfaceResizeWidthForSide = useCallback((
     side: CompactSurfaceResizeSide,
     width: number,
@@ -1526,21 +1235,11 @@ function CompactChatApp({
         ? resizeState.anchorRightScreen - areaLeft
         : areaRight - resizeState.anchorLeftScreen;
       if (Number.isFinite(maxWidth) && maxWidth > 0) {
-        const viewportGutter = getCompactSurfaceResizeViewportGutter();
-        return clampCompactSurfaceResizeWidth(
-          width,
-          maxWidth + viewportGutter,
-          getCompactSurfaceResizeMinAvailableWidth(),
-          viewportGutter,
-        );
+        return clampCompactSurfaceResizeWidth(width, maxWidth + COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER);
       }
     }
     return getClampedCompactSurfaceResizeWidth(width);
-  }, [
-    getCompactSurfaceResizeMinAvailableWidth,
-    getCompactSurfaceResizeViewportGutter,
-    getClampedCompactSurfaceResizeWidth,
-  ]);
+  }, [getClampedCompactSurfaceResizeWidth]);
   const getCurrentCompactSurfaceWidth = useCallback(() => {
     const rectWidth = compactInputShellRef.current?.getBoundingClientRect().width;
     if (Number.isFinite(rectWidth) && rectWidth && rectWidth > 0) {
@@ -1552,13 +1251,15 @@ function CompactChatApp({
     if (Number.isFinite(cssWidth) && cssWidth > 0) {
       return getClampedCompactSurfaceResizeWidth(cssWidth);
     }
-    return getClampedCompactSurfaceResizeWidth(COMPACT_SURFACE_DEFAULT_WIDTH);
+    return COMPACT_SURFACE_RESIZE_MIN_WIDTH;
   }, [getClampedCompactSurfaceResizeWidth]);
   const compactSurfaceEffectiveWidth = isCompactSurface
     && compactSurfaceResizeWidth !== null
     ? getClampedCompactSurfaceResizeWidth(compactSurfaceResizeWidth)
     : null;
-  const compactChoiceLayerOpen = isCompactSurface && compactSurfaceChoicesVisible;
+  const compactChoiceLayerOpen = !isCompactSurface
+    ? compactSurfaceChoicesVisible
+    : effectiveCompactChatState === 'options';
   const compactExportSelectedCount = compactExportSelectedIds.size;
   const compactExportSelectableMessages = useMemo(
     () => messages.filter(isCompactExportMessageSelectable),
@@ -1569,78 +1270,22 @@ function CompactChatApp({
     [compactExportSelectableMessages],
   );
   const compactExportSelectableCount = compactExportSelectableMessages.length;
-  const clearCompactExportHistoryUnmountTimer = useCallback(() => {
-    if (compactExportHistoryUnmountTimerRef.current === null) return;
-    window.clearTimeout(compactExportHistoryUnmountTimerRef.current);
-    compactExportHistoryUnmountTimerRef.current = null;
-  }, []);
-  const openCompactExportHistory = useCallback(() => {
-    clearCompactExportHistoryUnmountTimer();
-    setCompactExportHistoryClosingMessages(null);
-    setCompactExportHistoryMounted(true);
-    setCompactExportHistoryOpen(true);
-    persistCompactExportHistoryOpen(true);
-    setCompactExportAutoScrollToBottom(true);
-  }, [clearCompactExportHistoryUnmountTimer]);
-  const closeCompactExportHistory = useCallback(() => {
-    clearCompactExportHistoryUnmountTimer();
-    setCompactExportHistoryClosingMessages(messages);
-    setCompactExportHistoryOpen(false);
-    persistCompactExportHistoryOpen(false);
-    setCompactExportPreviewOpen(false);
-    compactExportHistoryUnmountTimerRef.current = window.setTimeout(() => {
-      setCompactExportHistoryMounted(false);
-      setCompactExportHistoryClosingMessages(null);
-      compactExportHistoryUnmountTimerRef.current = null;
-    }, COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS);
-  }, [clearCompactExportHistoryUnmountTimer, messages]);
-  useEffect(() => () => {
-    clearCompactExportHistoryUnmountTimer();
-  }, [clearCompactExportHistoryUnmountTimer]);
-  const handleCompactHistoryVisibilityToggle = useCallback(() => {
-    if (compactExportHistoryOpen) {
-      closeCompactExportHistory();
+  const handleCompactExportConversationClick = useCallback(() => {
+    if (!isCompactSurface) {
+      onExportConversationClick?.();
       return;
     }
-    openCompactExportHistory();
-  }, [closeCompactExportHistory, compactExportHistoryOpen, openCompactExportHistory]);
-  const handleCompactHistoryVisibilityPress = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
-    if (event.pointerType === 'mouse' && event.button !== 0) return;
-    event.preventDefault();
-    event.stopPropagation();
-    compactHistoryVisibilitySuppressClickRef.current = true;
-    handleCompactHistoryVisibilityToggle();
-  }, [handleCompactHistoryVisibilityToggle]);
-  const handleCompactHistoryVisibilityClick = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
-    if (compactHistoryVisibilitySuppressClickRef.current) {
-      compactHistoryVisibilitySuppressClickRef.current = false;
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-    handleCompactHistoryVisibilityToggle();
-  }, [handleCompactHistoryVisibilityToggle]);
-  const handleCompactHistoryVisibilityPointerCancel = useCallback(() => {
-    compactHistoryVisibilitySuppressClickRef.current = false;
-  }, []);
-  const handleCompactExportControlsToggle = useCallback(() => {
-    if (!compactExportHistoryOpen) {
-      openCompactExportHistory();
-      setCompactExportControlsOpen(true);
-      return;
-    }
-    if (compactExportPreviewOpen) {
-      setCompactExportPreviewOpen(false);
-      setCompactExportControlsOpen(true);
-      return;
-    }
-    setCompactExportControlsOpen((open) => {
-      if (open) {
-        setCompactExportSelectedIds(prev => (prev.size === 0 ? prev : new Set()));
+    setCompactExportHistoryOpen((open) => {
+      const nextOpen = !open;
+      persistCompactExportHistoryOpen(nextOpen);
+      if (nextOpen) {
+        setCompactExportAutoScrollToBottom(true);
+      } else {
+        setCompactExportPreviewOpen(false);
       }
-      return !open;
+      return nextOpen;
     });
-  }, [compactExportHistoryOpen, compactExportPreviewOpen, openCompactExportHistory]);
+  }, [isCompactSurface, onExportConversationClick]);
   const handleCompactExportToggleMessage = useCallback((messageId: string) => {
     if (!compactExportSelectableIds.has(messageId)) return;
     setCompactExportSelectedIds((prev) => {
@@ -1724,7 +1369,6 @@ function CompactChatApp({
     setCompactExportPreviewOpen(false);
     setCompactExportSelectedIds(prev => (prev.size === 0 ? prev : new Set()));
     setCompactExportAutoScrollToBottom(true);
-    setCompactExportControlsOpen(false);
   }, [isCompactSurface]);
 
   useEffect(() => {
@@ -1750,85 +1394,37 @@ function CompactChatApp({
     }
   }, [compactExportSelectedIds, compactExportSelectableIds]);
   const surfaceModeClassName = `chat-surface-mode-${chatSurfaceMode}`;
-  const compactMessagePreviewFromMessages = useMemo(() => getCompactMessagePreview(messages), [messages]);
-  const compactCaptionPreview = useMemo<CompactMessagePreview | null>(() => {
-    if (!compactCaptionState?.turnId || !compactCaptionState.text) {
-      return null;
-    }
-    const captionMessageId = `compact-caption:${compactCaptionState.turnId}`;
-    return {
-      messageId: captionMessageId,
-      turnStartId: captionMessageId,
-      turnId: compactCaptionState.turnId,
-      author: 'Neko',
-      text: compactCaptionState.text,
-      fullText: compactCaptionState.text,
-      isStreaming: !compactCaptionState.isEnded,
-      isAssistant: true,
-      isGuide: false,
-    };
-  }, [compactCaptionState]);
-  const compactMessagePreview = compactCaptionPreview || compactMessagePreviewFromMessages;
-  const compactMatchedSpeechPlaybackState = isSpeechPlaybackStateForCompactPreview(
-    speechPlaybackState,
-    compactMessagePreview,
-  ) ? speechPlaybackState : null;
-  const compactPreviewMatchesStreamingGap = !!compactAssistantStreamingGap
-    && !!compactMessagePreview?.isAssistant
-    && !!compactMessagePreview.isStreaming
-    && !!compactMessagePreview.turnId
-    && compactMessagePreview.turnId === compactAssistantStreamingGap.turnId;
-  const compactPreservedSpeechMatchesEndingGap = !!compactAssistantStreamingGap
-    && !compactAssistantStreamingGap.acceptStreaming
-    && !!compactSpeechPreviewTurnIdRef.current
-    && compactSpeechPreviewTurnIdRef.current === compactAssistantStreamingGap.turnId;
-  const compactSuppressAssistantFallback = !!compactAssistantStreamingGap
-    && !compactPreviewMatchesStreamingGap
-    && !compactPreservedSpeechMatchesEndingGap;
-  const compactPreservedSpeechActive = !compactMessagePreview
-    && !compactSuppressAssistantFallback
-    && !!compactSpeechPreviewIdRef.current
-    && !!compactSpeechPreviewTextRef.current;
-  const compactSpeechModeActive = compactPreservedSpeechActive
-    || (!compactSuppressAssistantFallback
-    && !!compactMessagePreview?.isAssistant
+  const compactMessagePreview = useMemo(() => getCompactMessagePreview(messages), [messages]);
+  const compactSpeechModeActive = !!compactMessagePreview?.isAssistant
     && !!compactMessagePreview?.messageId
-    && !compactMessagePreview.isGuide
     && (
       compactMessagePreview.isStreaming
       || compactSpeechPreviewIdRef.current === compactMessagePreview.messageId
-    ));
-  const compactSpeechPreservedText = (compactSpeechModeActive && !compactMessagePreview?.isStreaming)
+    );
+  const compactSpeechPreservedText = compactSpeechModeActive && !compactMessagePreview?.isStreaming
     ? compactSpeechPreviewTextRef.current
     : '';
-  const compactPreviewText = compactSuppressAssistantFallback
-    ? ''
-    : compactSpeechModeActive
-      ? (
-        compactMessagePreview?.isStreaming
-          ? compactMessagePreview?.fullText || ''
-          : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
-      )
-      : compactMessagePreview?.text
-      || i18n('chat.emptyState', 'Chat content will appear here.');
+  const compactPreviewText = compactSpeechModeActive
+    ? (
+      compactMessagePreview?.isStreaming
+        ? compactMessagePreview?.fullText || ''
+        : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
+    )
+    : compactMessagePreview?.text
+    || i18n('chat.emptyState', 'Chat content will appear here.');
   const compactPreviewIsStreaming = compactSpeechModeActive;
-  const compactPreviewAllowsScroll = compactPreviewIsStreaming || !!compactMessagePreview?.isGuide;
   const compactPreviewSpeechDuration = useMemo(() => {
-    if (!compactPreviewIsStreaming || !compactMatchedSpeechPlaybackState) {
+    if (!compactPreviewIsStreaming || !speechPlaybackState) {
       return null;
     }
-    const audioDuration = compactMatchedSpeechPlaybackState.playbackEndAudioTime
-      - compactMatchedSpeechPlaybackState.playbackStartAudioTime;
+    const audioDuration = speechPlaybackState.playbackEndAudioTime - speechPlaybackState.playbackStartAudioTime;
     if (!Number.isFinite(audioDuration) || audioDuration <= 0.05) {
       return null;
     }
     return getCompactSpeechRevealDuration(compactPreviewText.length, audioDuration);
-  }, [compactMatchedSpeechPlaybackState, compactPreviewIsStreaming, compactPreviewText.length]);
+  }, [compactPreviewIsStreaming, compactPreviewText.length, speechPlaybackState]);
   const compactPreviewDisplayText = useMemo(() => {
     if (!compactPreviewIsStreaming) {
-      if (!compactPreviewText) {
-        return '';
-      }
       return compactPreviewTextVisible || compactPreviewText;
     }
     const visibleLength = Math.min(compactPreviewText.length, compactSpeechVisibleLength);
@@ -1842,35 +1438,6 @@ function CompactChatApp({
     compactSpeechVisibleLength,
     compactPreviewText,
     compactPreviewTextVisible,
-  ]);
-  const compactPreviewDisplayContent = useMemo(() => {
-    if (!compactPreviewIsStreaming || !compactPreviewDisplayText) {
-      return compactPreviewDisplayText;
-    }
-    const graphemes = splitCompactPreviewGraphemes(compactPreviewDisplayText);
-    const latestIndex = graphemes.length - 1;
-    if (latestIndex < 0) {
-      return '';
-    }
-    const prefix = graphemes.slice(0, latestIndex).join('');
-    const latestGrapheme = graphemes[latestIndex];
-    const keyPrefix = compactMessagePreview?.turnStartId || compactMessagePreview?.messageId || 'compact-preview';
-    return (
-      <>
-        {prefix}
-        <span
-          key={`${keyPrefix}:${latestIndex}:${latestGrapheme}`}
-          className="compact-chat-capsule-glyph"
-        >
-          {latestGrapheme}
-        </span>
-      </>
-    );
-  }, [
-    compactMessagePreview?.messageId,
-    compactMessagePreview?.turnStartId,
-    compactPreviewDisplayText,
-    compactPreviewIsStreaming,
   ]);
   const emojiButtonAriaLabel = i18n('chat.emojiButtonAriaLabel', 'Emoji');
   const toolIconsAriaLabel = i18n('chat.toolIconsAriaLabel', 'Tool icons');
@@ -1946,142 +1513,12 @@ function CompactChatApp({
   }, [compactPreviewTextVisible]);
 
   useEffect(() => {
+    compactPreviewTextVisibleRef.current = compactPreviewTextVisible;
+  }, [compactPreviewTextVisible]);
+
+  useEffect(() => {
     speechPlaybackStateRef.current = speechPlaybackState;
   }, [speechPlaybackState]);
-
-  useEffect(() => {
-    const handleAssistantTurnStart = (event: Event) => {
-      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
-      const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-${Date.now()}`;
-      setCompactCaptionState(current => (
-        current?.turnId === turnId ? current : null
-      ));
-      setCompactAssistantStreamingGap({
-        turnId,
-        acceptStreaming: true,
-      });
-    };
-    const handleAssistantTurnBoundary = (event: Event) => {
-      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
-      const turnId = detail?.turnId ? String(detail.turnId) : `assistant-gap-ended-${Date.now()}`;
-      setCompactCaptionState(current => (
-        current?.turnId === turnId
-          ? {
-            ...current,
-            isEnded: true,
-          }
-          : current
-      ));
-      setCompactAssistantStreamingGap({
-        turnId,
-        acceptStreaming: false,
-      });
-    };
-    const handleCompactCaptionUpdate = (event: Event) => {
-      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
-      const turnId = detail?.turnId ? String(detail.turnId) : '';
-      const text = detail?.text ? normalizeCompactPreviewText(String(detail.text)) : '';
-      const rawSegmentId = detail?.segmentId ?? detail?.segmentIndex;
-      const explicitSegmentId = rawSegmentId !== undefined && rawSegmentId !== null && rawSegmentId !== ''
-        ? String(rawSegmentId)
-        : '';
-      if (!turnId || !text) {
-        return;
-      }
-      setCompactCaptionState(current => {
-        if (!current || current.turnId !== turnId) {
-          const segmentId = explicitSegmentId || 'legacy-segment-0';
-          return {
-            turnId,
-            segmentId,
-            lastSegmentText: text,
-            segments: [{
-              segmentId,
-              text,
-            }],
-            text,
-          };
-        }
-        const currentSegments = current.segments.length > 0
-          ? current.segments
-          : [{
-            segmentId: current.segmentId || 'legacy-segment-0',
-            text: current.lastSegmentText || current.text,
-          }];
-        const previousSegmentText = current.lastSegmentText || '';
-        const segmentId = explicitSegmentId
-          || (
-            !previousSegmentText
-            || text === previousSegmentText
-            || text.startsWith(previousSegmentText)
-            || previousSegmentText.startsWith(text)
-              ? current.segmentId
-              : `legacy-segment-${currentSegments.length}`
-          );
-        const existingSegmentIndex = currentSegments.findIndex(segment => segment.segmentId === segmentId);
-        const nextSegments = existingSegmentIndex >= 0
-          ? currentSegments.map((segment, index) => (
-            index === existingSegmentIndex
-              ? {
-                segmentId,
-                text,
-              }
-              : segment
-          ))
-          : currentSegments.concat({
-            segmentId,
-            text,
-          });
-        const nextText = normalizeCompactPreviewText(nextSegments.map(segment => segment.text).join(' '));
-        return {
-          turnId,
-          segmentId,
-          lastSegmentText: text,
-          segments: nextSegments,
-          text: nextText,
-          isEnded: false,
-        };
-      });
-    };
-
-    window.addEventListener('neko-assistant-turn-start', handleAssistantTurnStart);
-    window.addEventListener('neko-assistant-turn-ending', handleAssistantTurnBoundary);
-    window.addEventListener('neko-assistant-turn-end', handleAssistantTurnBoundary);
-    window.addEventListener('neko-compact-caption-update', handleCompactCaptionUpdate);
-    return () => {
-      window.removeEventListener('neko-assistant-turn-start', handleAssistantTurnStart);
-      window.removeEventListener('neko-assistant-turn-ending', handleAssistantTurnBoundary);
-      window.removeEventListener('neko-assistant-turn-end', handleAssistantTurnBoundary);
-      window.removeEventListener('neko-compact-caption-update', handleCompactCaptionUpdate);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (compactMessagePreview?.isAssistant && compactMessagePreview.isStreaming) {
-      setCompactAssistantStreamingGap(currentGap => {
-        if (!currentGap) {
-          return null;
-        }
-        if (
-          !compactMessagePreview.turnId
-          || compactMessagePreview.turnId !== currentGap.turnId
-        ) {
-          return currentGap;
-        }
-        if (!currentGap.acceptStreaming) {
-          return currentGap;
-        }
-        return null;
-      });
-    }
-  }, [
-    compactAssistantStreamingGap?.acceptStreaming,
-    compactAssistantStreamingGap?.turnId,
-    compactMessagePreview?.isAssistant,
-    compactMessagePreview?.isStreaming,
-    compactMessagePreview?.messageId,
-    compactMessagePreview?.turnId,
-  ]);
 
   useEffect(() => {
     isCompactSurfaceRef.current = isCompactSurface;
@@ -2092,77 +1529,37 @@ function CompactChatApp({
   }, [compactSpeechVisibleLength]);
 
   useEffect(() => {
-    if (compactMessagePreview?.isGuide) {
-      compactSpeechPreviewIdRef.current = '';
-      compactSpeechPreviewTextRef.current = '';
-      compactSpeechPreviewTurnIdRef.current = '';
-      return;
-    }
     if (compactMessagePreview?.isStreaming && compactMessagePreview.isAssistant) {
       compactSpeechPreviewIdRef.current = compactMessagePreview.messageId;
       compactSpeechPreviewTextRef.current = compactMessagePreview.fullText || compactMessagePreview.text || '';
-      compactSpeechPreviewTurnIdRef.current = compactMessagePreview.turnId || '';
     } else if (compactSpeechPreviewIdRef.current && (
-      compactMessagePreview?.messageId
-      && compactSpeechPreviewIdRef.current !== compactMessagePreview.messageId
+      !compactMessagePreview?.messageId
+      || compactSpeechPreviewIdRef.current !== compactMessagePreview.messageId
     )) {
       compactSpeechPreviewIdRef.current = '';
       compactSpeechPreviewTextRef.current = '';
-      compactSpeechPreviewTurnIdRef.current = '';
     }
   }, [
     compactMessagePreview?.fullText,
     compactMessagePreview?.isAssistant,
-    compactMessagePreview?.isGuide,
     compactMessagePreview?.isStreaming,
     compactMessagePreview?.messageId,
     compactMessagePreview?.text,
-    compactMessagePreview?.turnId,
   ]);
 
   useEffect(() => {
-    if (!compactMessagePreview && compactPreservedSpeechActive) {
-      return;
-    }
     if (compactSpeechFallbackTimerRef.current !== null) {
       window.clearTimeout(compactSpeechFallbackTimerRef.current);
       compactSpeechFallbackTimerRef.current = null;
     }
-    // Decouple the input-bar caption from per-bubble identity. The merged-turn
-    // preview is re-keyed to the latest streaming bubble's id, so every new
-    // bubble changes messageId even though it belongs to the same turn. While
-    // we're still inside that turn (same turnStartId), keep the revealed length
-    // so the caption continues appending instead of replaying the whole turn;
-    // only a genuinely new turn rewinds the reveal to the start. Keyed on the
-    // turn anchor rather than a text prefix, so two turns whose text happens to
-    // share a prefix can't be mistaken for a continuation.
-    const previousRevealTurnId = compactSpeechRevealTurnIdRef.current;
-    const nextRevealTurnId = compactPreviewIsStreaming ? (compactMessagePreview?.turnStartId || '') : '';
-    const continuesPreviousTurn = nextRevealTurnId.length > 0
-      && nextRevealTurnId === previousRevealTurnId;
-    const seedVisibleLength = continuesPreviousTurn
-      ? Math.min(compactSpeechVisibleLengthRef.current, compactPreviewText.length)
-      : 0;
-    // When the same turn continues, keep or immediately start the fallback
-    // reveal driver so appended text continues without a 700ms idle gap. The
-    // playback state is still reset to false so a finished bubble's audio can't
-    // snap the appended text to full.
-    const sameTurnHasAppendedText = continuesPreviousTurn
-      && seedVisibleLength < compactPreviewText.length;
-    const keepFallbackReveal = continuesPreviousTurn && (
-      compactSpeechFallbackRevealRef.current
-      || sameTurnHasAppendedText
-    );
-    compactSpeechRevealTurnIdRef.current = nextRevealTurnId;
-
-    compactSpeechVisibleLengthRef.current = seedVisibleLength;
+    compactSpeechVisibleLengthRef.current = 0;
     compactSpeechPlaybackStartedRef.current = false;
-    compactSpeechFallbackRevealRef.current = keepFallbackReveal;
+    compactSpeechFallbackRevealRef.current = false;
     compactSpeechRevealCarryRef.current = 0;
     compactSpeechLastFrameTimeRef.current = 0;
-    setCompactSpeechVisibleLength(seedVisibleLength);
-    setCompactSpeechFallbackRevealActive(keepFallbackReveal);
-  }, [compactMessagePreview, compactMessagePreview?.messageId, compactPreservedSpeechActive]);
+    setCompactSpeechVisibleLength(0);
+    setCompactSpeechFallbackRevealActive(false);
+  }, [compactMessagePreview?.messageId]);
 
   useEffect(() => {
     if (!compactPreviewIsStreaming) {
@@ -2180,11 +1577,11 @@ function CompactChatApp({
       return;
     }
 
-    if (!compactMatchedSpeechPlaybackState?.active) {
+    if (!speechPlaybackState?.active) {
       return;
     }
-    const estimatedAudioTime = getEstimatedSpeechAudioTime(compactMatchedSpeechPlaybackState);
-    if (estimatedAudioTime >= compactMatchedSpeechPlaybackState.playbackStartAudioTime) {
+    const estimatedAudioTime = getEstimatedSpeechAudioTime(speechPlaybackState);
+    if (estimatedAudioTime >= speechPlaybackState.playbackStartAudioTime) {
       compactSpeechPlaybackStartedRef.current = true;
       if (compactSpeechFallbackTimerRef.current !== null) {
         window.clearTimeout(compactSpeechFallbackTimerRef.current);
@@ -2195,7 +1592,7 @@ function CompactChatApp({
         setCompactSpeechFallbackRevealActive(false);
       }
     }
-  }, [compactMatchedSpeechPlaybackState, compactPreviewIsStreaming]);
+  }, [compactPreviewIsStreaming, speechPlaybackState]);
 
   useEffect(() => {
     if (compactSpeechFallbackTimerRef.current !== null) {
@@ -2209,37 +1606,20 @@ function CompactChatApp({
     compactSpeechFallbackTimerRef.current = window.setTimeout(() => {
       compactSpeechFallbackTimerRef.current = null;
       const playbackState = speechPlaybackStateRef.current;
-      const playbackMatchesPreview = isSpeechPlaybackStateForCompactPreview(
-        playbackState,
-        compactMessagePreview,
-      );
       const playbackHasStarted = !!playbackState?.active
-        && playbackMatchesPreview
         && getEstimatedSpeechAudioTime(playbackState) >= playbackState.playbackStartAudioTime;
       if (
         !isCompactSurfaceRef.current
         || compactSpeechPlaybackStartedRef.current
         || playbackHasStarted
-        // Bail when the reveal is already being driven or has finished — NOT
-        // merely when visibleLength > 0. A same-turn continuation seeds a
-        // nonzero prefix that may still be stalled (e.g. the previous bubble was
-        // revealed by speech, the appended bubble gets no playback/unavailable
-        // signal); the old `> 0` guard left that frozen. Let the timer engage so
-        // it reveals the appended text instead.
-        || compactSpeechFallbackRevealRef.current
-        || compactSpeechVisibleLengthRef.current >= compactPreviewText.length
+        || compactSpeechVisibleLengthRef.current > 0
       ) {
         return;
       }
       compactSpeechFallbackRevealRef.current = true;
       compactSpeechRevealCarryRef.current = 0;
       compactSpeechLastFrameTimeRef.current = 0;
-      // Resume from the already-seeded prefix (continuation) rather than rewinding
-      // to the first char; only an unseeded first bubble starts at 1.
-      compactSpeechVisibleLengthRef.current = Math.max(
-        compactSpeechVisibleLengthRef.current,
-        Math.min(1, compactPreviewText.length),
-      );
+      compactSpeechVisibleLengthRef.current = Math.min(1, compactPreviewText.length);
       setCompactSpeechVisibleLength(compactSpeechVisibleLengthRef.current);
       setCompactSpeechFallbackRevealActive(true);
     }, COMPACT_SPEECH_FALLBACK_REVEAL_DELAY_MS);
@@ -2250,16 +1630,11 @@ function CompactChatApp({
         compactSpeechFallbackTimerRef.current = null;
       }
     };
-  }, [compactMessagePreview, compactPreviewIsStreaming, compactPreviewText.length]);
+  }, [compactPreviewIsStreaming, compactPreviewText.length, compactMessagePreview?.messageId]);
 
   useEffect(() => {
-    function handleAssistantSpeechUnavailable(event: Event) {
+    function handleAssistantSpeechUnavailable() {
       if (!isCompactSurfaceRef.current || !compactPreviewIsStreaming || !compactMessagePreview?.isAssistant) {
-        return;
-      }
-      const detail = (event as CustomEvent).detail as Record<string, unknown> | undefined;
-      const eventTurnId = detail?.turnId ? String(detail.turnId) : '';
-      if (eventTurnId && compactMessagePreview.turnId && eventTurnId !== compactMessagePreview.turnId) {
         return;
       }
       compactSpeechFallbackRevealRef.current = true;
@@ -2272,7 +1647,7 @@ function CompactChatApp({
     return () => {
       window.removeEventListener('neko-assistant-speech-unavailable', handleAssistantSpeechUnavailable);
     };
-  }, [compactMessagePreview, compactPreviewIsStreaming]);
+  }, [compactMessagePreview?.isAssistant, compactPreviewIsStreaming]);
 
   useEffect(() => {
     if (compactSpeechAnimationFrameRef.current !== null) {
@@ -2287,10 +1662,7 @@ function CompactChatApp({
     }
 
     const tick = (frameTime: number) => {
-      const playbackState = isSpeechPlaybackStateForCompactPreview(
-        speechPlaybackStateRef.current,
-        compactMessagePreview,
-      ) ? speechPlaybackStateRef.current : null;
+      const playbackState = speechPlaybackStateRef.current;
       const fallbackReveal = compactSpeechFallbackRevealRef.current;
       const shouldContinueAfterSpeech = (compactSpeechPlaybackStartedRef.current || fallbackReveal)
         && compactSpeechVisibleLengthRef.current < compactPreviewText.length;
@@ -2354,13 +1726,7 @@ function CompactChatApp({
         compactSpeechAnimationFrameRef.current = null;
       }
     };
-  }, [
-    compactMessagePreview,
-    compactPreviewIsStreaming,
-    compactPreviewText.length,
-    compactPreviewSpeechDuration,
-    compactSpeechFallbackRevealActive,
-  ]);
+  }, [compactPreviewIsStreaming, compactPreviewText.length, compactPreviewSpeechDuration, compactSpeechFallbackRevealActive]);
 
   useEffect(() => {
     const readState = (value: unknown): SpeechPlaybackState | null => {
@@ -2373,9 +1739,6 @@ function CompactChatApp({
       const playbackEndAudioTime = Number(state.playbackEndAudioTime);
       return {
         active: !!state.active,
-        turnId: state.turnId ? String(state.turnId) : null,
-        playbackTurnId: state.playbackTurnId ? String(state.playbackTurnId) : null,
-        speechId: state.speechId ? String(state.speechId) : null,
         audioContextTime: Number.isFinite(audioContextTime) ? audioContextTime : 0,
         playbackStartAudioTime: Number.isFinite(playbackStartAudioTime) ? playbackStartAudioTime : 0,
         playbackEndAudioTime: Number.isFinite(playbackEndAudioTime) ? playbackEndAudioTime : 0,
@@ -2439,27 +1802,12 @@ function CompactChatApp({
   useEffect(() => {
     const textNode = compactPreviewTextRef.current;
     if (!textNode) return;
-    if (!isCompactSurface || !compactPreviewAllowsScroll) {
+    if (!isCompactSurface || !compactPreviewIsStreaming) {
       textNode.scrollLeft = 0;
       return;
     }
     textNode.scrollLeft = textNode.scrollWidth;
-  }, [compactPreviewAllowsScroll, compactPreviewDisplayText, isCompactSurface]);
-
-  const handleCompactPreviewWheel = useCallback((event: ReactWheelEvent<HTMLSpanElement>) => {
-    const textNode = event.currentTarget;
-    const maxScrollLeft = Math.max(0, textNode.scrollWidth - textNode.clientWidth);
-    if (maxScrollLeft <= 0) return;
-
-    const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY)
-      ? event.deltaX
-      : event.deltaY;
-    if (delta === 0) return;
-
-    event.preventDefault();
-    event.stopPropagation();
-    textNode.scrollLeft = Math.max(0, Math.min(maxScrollLeft, textNode.scrollLeft + delta));
-  }, []);
+  }, [compactPreviewDisplayText, compactPreviewIsStreaming, isCompactSurface]);
 
   useEffect(() => {
     if (!isCompactSurface) return;
@@ -2477,12 +1825,14 @@ function CompactChatApp({
     if (!isCompactSurface) return;
     if (!compactChoiceLayerOpen) return;
 
-    const shellNode = compactInputShellRef.current;
+    const shellNode = appShellRef.current;
     const layerNode = compactChoiceLayerRef.current;
     if (!shellNode || !layerNode) return;
 
     const gap = 16;
     let frameId: number | null = null;
+    let trackingFrameId: number | null = null;
+    let disposed = false;
 
     const getDesktopPlacementSpace = (shellRect: DOMRect) => {
       const layout = (window as typeof window & {
@@ -2502,11 +1852,8 @@ function CompactChatApp({
         return null;
       }
 
-      const surfaceTop = Number(layout?.surface?.top);
-      const surfaceHeight = Number(layout?.surface?.height);
-      const surfaceScreenTop = windowY + (Number.isFinite(surfaceTop) ? surfaceTop : shellRect.top);
-      const surfaceScreenBottom = surfaceScreenTop
-        + (Number.isFinite(surfaceHeight) && surfaceHeight > 0 ? surfaceHeight : shellRect.height);
+      const surfaceScreenTop = windowY + shellRect.top;
+      const surfaceScreenBottom = windowY + shellRect.bottom;
       const workAreaBottom = workAreaY + workAreaHeight;
       return {
         availableAbove: Math.max(0, surfaceScreenTop - workAreaY),
@@ -2515,10 +1862,15 @@ function CompactChatApp({
     };
 
     const updatePlacement = () => {
-      const nextShellNode = compactInputShellRef.current;
+      const nextShellNode = appShellRef.current;
       const nextLayerNode = compactChoiceLayerRef.current;
       if (!nextShellNode || !nextLayerNode) return;
 
+      const shellRect = nextShellNode.getBoundingClientRect();
+      const layerRect = nextLayerNode.getBoundingClientRect();
+      const layerHeight = Math.max(layerRect.height, nextLayerNode.scrollHeight);
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const desktopSpace = getDesktopPlacementSpace(shellRect);
       const desktopForcedPlacement = ((window as typeof window & {
         __nekoDesktopCompactLayout?: DesktopCompactChoicePlacementLayout | null;
       }).__nekoDesktopCompactLayout?.compactChoicePlacement);
@@ -2526,11 +1878,6 @@ function CompactChatApp({
         setCompactChoiceLayerPlacement(current => (current === desktopForcedPlacement ? current : desktopForcedPlacement));
         return;
       }
-      const shellRect = nextShellNode.getBoundingClientRect();
-      const layerRect = nextLayerNode.getBoundingClientRect();
-      const layerHeight = Math.max(layerRect.height, nextLayerNode.scrollHeight);
-      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
-      const desktopSpace = getDesktopPlacementSpace(shellRect);
       const availableBelow = desktopSpace?.availableBelow ?? Math.max(0, viewportHeight - shellRect.bottom);
       const availableAbove = desktopSpace?.availableAbove ?? Math.max(0, shellRect.top);
       const requiredSpace = layerHeight + gap;
@@ -2571,12 +1918,17 @@ function CompactChatApp({
       });
     };
 
+    const trackPlacement = () => {
+      if (disposed) return;
+      updatePlacement();
+      trackingFrameId = window.requestAnimationFrame(trackPlacement);
+    };
+
     schedulePlacementUpdate();
+    trackingFrameId = window.requestAnimationFrame(trackPlacement);
 
     const visualViewport = window.visualViewport;
     window.addEventListener('resize', schedulePlacementUpdate);
-    window.addEventListener('neko:compact-surface-layout-change', schedulePlacementUpdate);
-    window.addEventListener('neko:desktop-compact-layout-change', schedulePlacementUpdate);
     visualViewport?.addEventListener('resize', schedulePlacementUpdate);
     visualViewport?.addEventListener('scroll', schedulePlacementUpdate);
 
@@ -2590,12 +1942,14 @@ function CompactChatApp({
     }
 
     return () => {
+      disposed = true;
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
       }
+      if (trackingFrameId !== null) {
+        window.cancelAnimationFrame(trackingFrameId);
+      }
       window.removeEventListener('resize', schedulePlacementUpdate);
-      window.removeEventListener('neko:compact-surface-layout-change', schedulePlacementUpdate);
-      window.removeEventListener('neko:desktop-compact-layout-change', schedulePlacementUpdate);
       visualViewport?.removeEventListener('resize', schedulePlacementUpdate);
       visualViewport?.removeEventListener('scroll', schedulePlacementUpdate);
       observer?.disconnect();
@@ -2604,11 +1958,8 @@ function CompactChatApp({
 
   const requestCompactChatState = useCallback((nextState: CompactChatState) => {
     if (!isCompactSurface) return;
-    if (!isCompactChatStateControlled) {
-      setUncontrolledCompactChatState(nextState);
-    }
     onCompactChatStateChange?.(nextState);
-  }, [isCompactSurface, isCompactChatStateControlled, onCompactChatStateChange]);
+  }, [isCompactSurface, onCompactChatStateChange]);
 
   const applyCompactSurfaceResizeWidthVar = useCallback((width: number | null) => {
     const shell = compactInputShellRef.current;
@@ -2754,152 +2105,6 @@ function CompactChatApp({
     finishCompactSurfaceResize(event);
   }, [finishCompactSurfaceResize]);
 
-  const getCompactHistorySlotMaxHeight = useCallback(() => {
-    const base = getCompactHistoryViewportBase();
-    // 上限只受「屏幕可用高度」约束（去掉对话条宽度挂钩那条）；panel 里 scroll 上方有 bar、下方有 controls，
-    // 先扣掉这部分非滚动 chrome，scroll 区才不会吃满 anchor 把 controls / 底部气泡顶出可视/可点区。
-    const anchorMax = base * COMPACT_HISTORY_SLOT_MAX_VIEWPORT_RATIO;
-    return Math.round(Math.max(
-      COMPACT_HISTORY_SLOT_MIN_HEIGHT,
-      anchorMax - COMPACT_HISTORY_SLOT_CHROME_RESERVE,
-    ));
-  }, []);
-
-  const getClampedCompactHistorySlotHeight = useCallback((height: number) => (
-    Math.round(Math.max(
-      COMPACT_HISTORY_SLOT_MIN_HEIGHT,
-      Math.min(height, getCompactHistorySlotMaxHeight()),
-    ))
-  ), [getCompactHistorySlotMaxHeight]);
-
-  // 用户未拖动过时（slot 为 null），起拖高度取 styles.css 默认公式值（width*1.18 / 63%），
-  // 保证拖动第一帧从当前可见高度连续起步、不跳变。
-  const getCompactHistoryStartHeight = useCallback(() => {
-    // 起拖基准必须是「当前可见高度」（按当前约束 clamp 后）。存量高度可能来自更大屏 / 更宽 surface，
-    // 此时面板已被钳到 max、若用 stale 大值做基准，向下拖会出现「先拖一段没反应」的死区。
-    if (compactHistorySlotHeight !== null) {
-      return getClampedCompactHistorySlotHeight(compactHistorySlotHeight);
-    }
-    const surfaceWidth = getCurrentCompactSurfaceWidth();
-    const base = getCompactHistoryViewportBase();
-    return getClampedCompactHistorySlotHeight(Math.round(Math.min(
-      surfaceWidth * COMPACT_HISTORY_SLOT_DEFAULT_WIDTH_RATIO,
-      base * COMPACT_HISTORY_SLOT_DEFAULT_VIEWPORT_RATIO,
-    )));
-  }, [compactHistorySlotHeight, getClampedCompactHistorySlotHeight, getCurrentCompactSurfaceWidth]);
-
-  const applyCompactHistorySlotHeightVar = useCallback((height: number | null) => {
-    if (typeof document === 'undefined') return;
-    // 内容布局高度锚定在「最大高度」上（scroll-content min-height 用它），缩小 slot 只裁剪可视窗口、
-    // 不再让内容随 slot 收缩 reflow。max 只挂屏幕/工作区高度，会随视口变化，故每次 apply 一并刷新。
-    document.documentElement.style.setProperty(
-      '--compact-history-slot-max-height',
-      `${getCompactHistorySlotMaxHeight()}px`,
-    );
-    if (height === null) {
-      document.documentElement.style.removeProperty('--compact-history-slot-height');
-    } else {
-      document.documentElement.style.setProperty(
-        '--compact-history-slot-height',
-        `${getClampedCompactHistorySlotHeight(height)}px`,
-      );
-    }
-    // CSS 变量变更不会自己通知宿主；让宿主重算 history 命中 rect / Electron 窗口 bounds / 鼠标穿透区。
-    // 同时通知 panel：slot/max 已变，按 autoScrollToBottom 把可视窗口重新锚定到下端（卷帘从上往下收）。
-    if (typeof window !== 'undefined') {
-      window.dispatchEvent(new CustomEvent('neko:compact-interaction-geometry-refresh'));
-    }
-  }, [getClampedCompactHistorySlotHeight, getCompactHistorySlotMaxHeight]);
-
-  const finishCompactHistoryResize = useCallback((event?: ReactPointerEvent<HTMLDivElement>) => {
-    const resizeState = compactHistoryResizeStateRef.current;
-    if (!resizeState) return;
-    if (event && resizeState.pointerId !== event.pointerId) return;
-    // 只在真正拖动过才落库：纯点击不该把响应式默认高度锁成固定像素值（否则之后视口/宽度变化不再响应）。
-    if (resizeState.moved) {
-      persistCompactHistorySlotHeight(resizeState.lastHeight);
-      setCompactHistorySlotHeight(resizeState.lastHeight);
-    }
-    const captureTarget = resizeState.captureTarget;
-    if (captureTarget && typeof captureTarget.releasePointerCapture === 'function') {
-      try {
-        if (captureTarget.hasPointerCapture?.(resizeState.pointerId)) {
-          captureTarget.releasePointerCapture(resizeState.pointerId);
-        }
-      } catch (_) {}
-    }
-    compactHistoryResizeStateRef.current = null;
-    setCompactHistoryResizeActive(false);
-  }, []);
-
-  const handleCompactHistoryResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (!isCompactSurface) return;
-    if (event.pointerType === 'mouse' && event.button !== 0) return;
-    event.preventDefault();
-    event.stopPropagation();
-    const startHeight = getCompactHistoryStartHeight();
-    compactHistoryResizeStateRef.current = {
-      pointerId: event.pointerId,
-      startPointerY: getCompactHistoryResizePointerY(event),
-      startHeight,
-      lastHeight: getClampedCompactHistorySlotHeight(startHeight),
-      moved: false,
-      captureTarget: event.currentTarget,
-    };
-    setCompactHistoryResizeActive(true);
-    try {
-      event.currentTarget.setPointerCapture?.(event.pointerId);
-    } catch (_) {}
-  }, [getClampedCompactHistorySlotHeight, getCompactHistoryStartHeight, isCompactSurface]);
-
-  const handleCompactHistoryResizePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const resizeState = compactHistoryResizeStateRef.current;
-    if (!resizeState || resizeState.pointerId !== event.pointerId) return;
-    event.preventDefault();
-    event.stopPropagation();
-    // bar 在堆砌区顶部：上拖（deltaY < 0）增高，下拖减高。
-    const deltaY = getCompactHistoryResizePointerY(event) - resizeState.startPointerY;
-    if (deltaY !== 0) resizeState.moved = true;
-    const nextHeight = getClampedCompactHistorySlotHeight(resizeState.startHeight - deltaY);
-    resizeState.lastHeight = nextHeight;
-    setCompactHistorySlotHeight(nextHeight);
-    applyCompactHistorySlotHeightVar(nextHeight);
-  }, [applyCompactHistorySlotHeightVar, getClampedCompactHistorySlotHeight]);
-
-  const handleCompactHistoryResizePointerUp = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    finishCompactHistoryResize(event);
-  }, [finishCompactHistoryResize]);
-
-  const handleCompactHistoryResizePointerCancel = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    finishCompactHistoryResize(event);
-  }, [finishCompactHistoryResize]);
-
-  // 把已存/恢复的高度写进 CSS 变量（覆盖默认公式）；slot 为 null 时清掉、回落默认。
-  useEffect(() => {
-    if (!isCompactSurface) return;
-    applyCompactHistorySlotHeightVar(compactHistorySlotHeight);
-  }, [applyCompactHistorySlotHeightVar, compactHistorySlotHeight, isCompactSurface]);
-
-  // 视口 / 工作区 / compact surface 宽度变化后，按新约束重写 CSS 变量（用新 max clamp 显示高度）。
-  // 刻意不改 state、不覆盖 storage：存量 raw 值保留，换屏 / 改宽再放大时能恢复；起拖死区另由
-  // getCompactHistoryStartHeight 对基准 clamp 解决。
-  useEffect(() => {
-    if (!isCompactSurface) return undefined;
-    const reapplySlotHeight = () => applyCompactHistorySlotHeightVar(compactHistorySlotHeight);
-    window.addEventListener('resize', reapplySlotHeight);
-    window.addEventListener('neko:desktop-compact-layout-change', reapplySlotHeight);
-    window.addEventListener('neko:compact-surface-resize-width-change', reapplySlotHeight);
-    return () => {
-      window.removeEventListener('resize', reapplySlotHeight);
-      window.removeEventListener('neko:desktop-compact-layout-change', reapplySlotHeight);
-      window.removeEventListener('neko:compact-surface-resize-width-change', reapplySlotHeight);
-    };
-  }, [applyCompactHistorySlotHeightVar, compactHistorySlotHeight, isCompactSurface]);
-
   useEffect(() => {
     if (!isCompactSurface || compactSurfaceEffectiveWidth === null) {
       applyCompactSurfaceResizeWidthVar(null);
@@ -2970,66 +2175,6 @@ function CompactChatApp({
     compactInputToolFanInteractiveTimerRef.current = null;
   }, []);
 
-  const clearCompactInputToolWheelDragGuardTimer = useCallback(() => {
-    if (compactInputToolWheelDragGuardTimerRef.current === null) return;
-    window.clearTimeout(compactInputToolWheelDragGuardTimerRef.current);
-    compactInputToolWheelDragGuardTimerRef.current = null;
-  }, []);
-
-  const clearCompactInputToolWheelFastAnimationTimer = useCallback(() => {
-    if (compactInputToolWheelFastAnimationTimerRef.current === null) return;
-    window.clearTimeout(compactInputToolWheelFastAnimationTimerRef.current);
-    compactInputToolWheelFastAnimationTimerRef.current = null;
-  }, []);
-
-  const clearCompactInputToolWheelChargeReleaseTimer = useCallback(() => {
-    if (compactInputToolWheelChargeReleaseTimerRef.current !== null) {
-      window.clearTimeout(compactInputToolWheelChargeReleaseTimerRef.current);
-      compactInputToolWheelChargeReleaseTimerRef.current = null;
-    }
-    compactInputToolWheelChargeReleaseActiveRef.current = false;
-    setCompactInputToolWheelChargeReleaseActive(false);
-  }, []);
-
-  const resetCompactInputToolWheelCharge = useCallback(() => {
-    compactInputToolWheelChargeRef.current = createCompactToolWheelChargeState();
-    setCompactInputToolWheelChargeRatio(0);
-    setCompactInputToolWheelChargeDirection(null);
-  }, []);
-
-  const dispatchCompactToolWheelDragState = useCallback((active: boolean, pointerId?: number) => {
-    window.dispatchEvent(new CustomEvent('neko:compact-tool-wheel-drag-state-change', {
-      detail: {
-        active,
-        pointerId,
-        timestamp: Date.now(),
-      },
-    }));
-  }, []);
-
-  // Tell the desktop shell to keep the whole wheel region solid while the fan is
-  // open, so mouse-wheel scrolling responds across the entire circle (not only
-  // over the icon buttons). Released when the fan closes. See preload
-  // neko:compact-tool-fan-open-state-change.
-  const dispatchCompactToolFanOpenState = useCallback((open: boolean) => {
-    window.dispatchEvent(new CustomEvent('neko:compact-tool-fan-open-state-change', {
-      detail: {
-        open,
-        timestamp: Date.now(),
-      },
-    }));
-  }, []);
-
-  const scheduleCompactInputToolWheelDragGuardRelease = useCallback(() => {
-    clearCompactInputToolWheelDragGuardTimer();
-    compactInputToolWheelDragGuardTimerRef.current = window.setTimeout(() => {
-      compactInputToolWheelDragGuardTimerRef.current = null;
-      compactInputToolWheelDragActiveRef.current = false;
-      compactInputToolWheelPointerRef.current = null;
-      dispatchCompactToolWheelDragState(false);
-    }, COMPACT_INPUT_TOOL_WHEEL_DRAG_GUARD_MS);
-  }, [clearCompactInputToolWheelDragGuardTimer, dispatchCompactToolWheelDragState]);
-
   const setCompactInputToolFanInteractiveState = useCallback((interactive: boolean) => {
     compactInputToolFanInteractiveRef.current = interactive;
     setCompactInputToolFanInteractive(interactive);
@@ -3040,82 +2185,17 @@ function CompactChatApp({
     compactInputToolFanSuppressHoverUntilLeaveRef.current = false;
   }, []);
 
-  const resolveCompactInputToolWheelLayout = useCallback((): CompactInputToolWheelLayout => {
-    if (!window.matchMedia?.('(max-width: 820px)').matches) return 'default';
-    const fanElement = compactInputToolFanRef.current;
-    const fanRect = fanElement?.getBoundingClientRect();
-    if (!fanElement || !fanRect || fanRect.width <= 0 || fanRect.height <= 0) return 'default';
-
-    const visualViewport = window.visualViewport;
-    const viewportLeft = visualViewport?.offsetLeft ?? 0;
-    const viewportTop = visualViewport?.offsetTop ?? 0;
-    const viewportWidth = visualViewport?.width ?? window.innerWidth;
-    const viewportHeight = visualViewport?.height ?? window.innerHeight;
-    if (!Number.isFinite(viewportWidth) || viewportWidth <= 0 || !Number.isFinite(viewportHeight) || viewportHeight <= 0) {
-      return 'default';
-    }
-
-    const fanStyle = window.getComputedStyle ? window.getComputedStyle(fanElement) : null;
-    const readFanPixelVar = (name: string, fallback: number) => {
-      const rawValue = fanStyle?.getPropertyValue(name).trim() || '';
-      const parsedValue = Number.parseFloat(rawValue);
-      return Number.isFinite(parsedValue) ? parsedValue : fallback;
-    };
-
-    const centerX = fanRect.left + readFanPixelVar('--compact-tool-wheel-center-x', COMPACT_INPUT_TOOL_WHEEL_CENTER_X);
-    const centerY = fanRect.top + readFanPixelVar('--compact-tool-wheel-center-y', COMPACT_INPUT_TOOL_WHEEL_CENTER_Y);
-    const orbitRadius = readFanPixelVar('--compact-tool-wheel-orbit-radius', 80);
-    const buttonSize = readFanPixelVar('--compact-tool-button-size', 38);
-    const minX = viewportLeft + COMPACT_INPUT_TOOL_WHEEL_VIEWPORT_MARGIN;
-    const minY = viewportTop + COMPACT_INPUT_TOOL_WHEEL_VIEWPORT_MARGIN;
-    const maxX = viewportLeft + viewportWidth - COMPACT_INPUT_TOOL_WHEEL_VIEWPORT_MARGIN;
-    const maxY = viewportTop + viewportHeight - COMPACT_INPUT_TOOL_WHEEL_VIEWPORT_MARGIN;
-
-    const wheelLayoutFitsViewport = (slots: ReadonlyArray<{ angleDeg: number; scale: number }>) => slots.every(({ angleDeg, scale }) => {
-      const angle = angleDeg * (Math.PI / 180);
-      const itemCenterX = centerX + (Math.cos(angle) * orbitRadius);
-      const itemCenterY = centerY + (Math.sin(angle) * orbitRadius);
-      const halfSize = (buttonSize * scale) / 2;
-      return itemCenterX - halfSize >= minX
-        && itemCenterX + halfSize <= maxX
-        && itemCenterY - halfSize >= minY
-        && itemCenterY + halfSize <= maxY;
-    });
-
-    if (wheelLayoutFitsViewport(compactInputToolWheelDefaultVisibleSlots)) return 'default';
-    if (wheelLayoutFitsViewport(compactInputToolWheelViewportFitVisibleSlots)) return 'viewport-fit';
-    return 'default';
-  }, []);
-
-  const syncCompactInputToolWheelLayout = useCallback(() => {
-    const nextLayout = resolveCompactInputToolWheelLayout();
-    setCompactInputToolWheelLayout(currentLayout => (
-      currentLayout === nextLayout ? currentLayout : nextLayout
-    ));
-  }, [resolveCompactInputToolWheelLayout]);
-
   const closeCompactInputToolFan = useCallback((options?: {
     afterClose?: () => void;
     deferDesktopAction?: boolean;
   }) => {
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
-    clearCompactInputToolWheelDragGuardTimer();
-    clearCompactInputToolWheelFastAnimationTimer();
-    clearCompactInputToolWheelChargeReleaseTimer();
     compactInputToolFanOpenIntentRef.current = null;
-    compactInputToolWheelDragActiveRef.current = false;
-    compactInputToolWheelPointerRef.current = null;
-    dispatchCompactToolWheelDragState(false);
-    compactInputToolWheelLastRotationAtRef.current = 0;
-    resetCompactInputToolWheelCharge();
-    setCompactInputToolWheelFastAnimation(false);
-    setCompactInputToolWheelLayout('default');
     setCompactInputToolFanInteractiveState(false);
     compactInputToolFanPositionSyncRef.current?.();
     compactInputToolFanOpenRef.current = false;
     setCompactInputToolFanOpen(false);
-    dispatchCompactToolFanOpenState(false);
     if (!options?.afterClose) return;
     const desktopWindow = window as Window & {
       __nekoDesktopCompactLayout?: {
@@ -3127,99 +2207,28 @@ function CompactChatApp({
       return;
     }
     options.afterClose();
-  }, [
-    clearCompactInputToolFanCloseTimer,
-    clearCompactInputToolFanInteractiveTimer,
-    clearCompactInputToolWheelDragGuardTimer,
-    clearCompactInputToolWheelFastAnimationTimer,
-    clearCompactInputToolWheelChargeReleaseTimer,
-    dispatchCompactToolWheelDragState,
-    dispatchCompactToolFanOpenState,
-    resetCompactInputToolWheelCharge,
-    setCompactInputToolFanInteractiveState,
-  ]);
+  }, [clearCompactInputToolFanCloseTimer, clearCompactInputToolFanInteractiveTimer, setCompactInputToolFanInteractiveState]);
 
   const updateCompactInputToolFanPosition = useCallback(() => {}, []);
 
-  const scheduleCompactInputToolFanTransientClose = useCallback((options?: {
-    delayMs?: number;
-    force?: boolean;
-    keepExistingTimer?: boolean;
-  }) => {
-    if (!compactInputToolFanOpenRef.current) return;
-    if (!options?.force && compactInputToolFanOpenIntentRef.current !== 'hover') return;
-    if (
-      compactInputToolWheelDragActiveRef.current
-      || compactInputToolWheelPointerRef.current
-      || compactInputToolWheelChargeReleaseActiveRef.current
-    ) return;
-    if (options?.keepExistingTimer && compactInputToolFanCloseTimerRef.current !== null) return;
+  const scheduleCompactInputToolFanTransientClose = useCallback(() => {
+    if (compactInputToolFanOpenIntentRef.current !== 'hover') return;
     clearCompactInputToolFanCloseTimer();
     compactInputToolFanCloseTimerRef.current = window.setTimeout(() => {
       compactInputToolFanCloseTimerRef.current = null;
-      if (
-        compactInputToolWheelDragActiveRef.current
-        || compactInputToolWheelPointerRef.current
-        || compactInputToolWheelChargeReleaseActiveRef.current
-      ) return;
       closeCompactInputToolFan();
-    }, options?.delayMs ?? COMPACT_INPUT_TOOL_FAN_TRANSIENT_CLOSE_DELAY_MS);
+    }, 160);
   }, [clearCompactInputToolFanCloseTimer, closeCompactInputToolFan]);
-
-  useEffect(() => {
-    if (!isCompactSurface) return;
-    const frameId = window.requestAnimationFrame(() => {
-      window.dispatchEvent(new CustomEvent('neko:compact-interaction-geometry-change'));
-    });
-    return () => window.cancelAnimationFrame(frameId);
-  }, [
-    activeCursorToolId,
-    compactInputToolFanInteractive,
-    compactInputToolFanOpen,
-    compactInputToolWheelIndex,
-    effectiveCompactChatState,
-    isCompactSurface,
-    toolMenuOpen,
-  ]);
-
-  useLayoutEffect(() => {
-    if (!compactInputToolFanOpen) {
-      setCompactInputToolWheelLayout('default');
-      return undefined;
-    }
-
-    syncCompactInputToolWheelLayout();
-    const frameId = window.requestAnimationFrame(syncCompactInputToolWheelLayout);
-    window.addEventListener('resize', syncCompactInputToolWheelLayout);
-    window.addEventListener('neko:compact-interaction-geometry-change', syncCompactInputToolWheelLayout);
-    window.visualViewport?.addEventListener('resize', syncCompactInputToolWheelLayout);
-    window.visualViewport?.addEventListener('scroll', syncCompactInputToolWheelLayout);
-
-    return () => {
-      window.cancelAnimationFrame(frameId);
-      window.removeEventListener('resize', syncCompactInputToolWheelLayout);
-      window.removeEventListener('neko:compact-interaction-geometry-change', syncCompactInputToolWheelLayout);
-      window.visualViewport?.removeEventListener('resize', syncCompactInputToolWheelLayout);
-      window.visualViewport?.removeEventListener('scroll', syncCompactInputToolWheelLayout);
-    };
-  }, [
-    compactInputToolFanOpen,
-    compactSurfaceResizeWidth,
-    effectiveCompactChatState,
-    syncCompactInputToolWheelLayout,
-  ]);
 
   const openCompactInputToolFan = useCallback((intent: 'click' | 'hover') => {
     if (composerDisabled || compactInputHasPayload) return;
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
     compactInputToolFanOpenIntentRef.current = intent;
-    setCompactInputToolWheelLayout('default');
     setCompactInputToolFanInteractiveState(false);
     updateCompactInputToolFanPosition();
     compactInputToolFanOpenRef.current = true;
     setCompactInputToolFanOpen(true);
-    dispatchCompactToolFanOpenState(true);
     compactInputToolFanInteractiveTimerRef.current = window.setTimeout(() => {
       compactInputToolFanInteractiveTimerRef.current = null;
       if (!compactInputToolFanOpenIntentRef.current) return;
@@ -3230,41 +2239,12 @@ function CompactChatApp({
     clearCompactInputToolFanInteractiveTimer,
     compactInputHasPayload,
     composerDisabled,
-    dispatchCompactToolFanOpenState,
     setCompactInputToolFanInteractiveState,
     updateCompactInputToolFanPosition,
   ]);
 
-  const shouldOpenCompactToolFanOnHover = useCallback((pointerType: string) => {
-    return pointerType === 'mouse';
-  }, []);
-
-  const isCompactInputToolPointerInToggleHoverRegion = useCallback((clientX: number, clientY: number, relatedTarget?: EventTarget | null) => {
-    if (relatedTarget instanceof Node && compactInputToolToggleRef.current?.contains(relatedTarget)) return true;
-    if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return false;
-    const toggleRect = compactInputToolToggleRef.current?.getBoundingClientRect();
-    if (!toggleRect || toggleRect.width <= 0 || toggleRect.height <= 0) return false;
-    const centerX = toggleRect.left + (toggleRect.width / 2);
-    const centerY = toggleRect.top + (toggleRect.height / 2);
-    const radius = (Math.max(toggleRect.width, toggleRect.height) / 2) + COMPACT_INPUT_TOOL_TOGGLE_HOVER_OUTSET;
-    return Math.hypot(clientX - centerX, clientY - centerY) <= radius;
-  }, []);
-
-  const getCompactInputToolFanCircularHoverRegion = useCallback(() => {
-    const fanElement = compactInputToolFanRef.current;
-    const fanRect = fanElement?.getBoundingClientRect();
-    if (!fanRect || fanRect.width <= 0 || fanRect.height <= 0) return null;
-    const fanStyle = fanElement && window.getComputedStyle ? window.getComputedStyle(fanElement) : null;
-    const readFanPixelVar = (name: string, fallback: number) => {
-      const rawValue = fanStyle?.getPropertyValue(name).trim() || '';
-      const parsedValue = Number.parseFloat(rawValue);
-      return Number.isFinite(parsedValue) ? parsedValue : fallback;
-    };
-    const centerX = fanRect.left + readFanPixelVar('--compact-tool-wheel-center-x', COMPACT_INPUT_TOOL_WHEEL_CENTER_X);
-    const centerY = fanRect.top + readFanPixelVar('--compact-tool-wheel-center-y', COMPACT_INPUT_TOOL_WHEEL_CENTER_Y);
-    const radius = readFanPixelVar('--compact-tool-wheel-hover-radius', COMPACT_INPUT_TOOL_WHEEL_HOVER_RADIUS);
-    if (!Number.isFinite(radius) || radius <= 0) return null;
-    return { centerX, centerY, radius };
+  const shouldOpenCompactToolFanOnHover = useCallback((event: ReactPointerEvent) => {
+    return event.pointerType === 'mouse';
   }, []);
 
   const isCompactInputToolPointerInHoverRegion = useCallback((clientX: number, clientY: number, relatedTarget?: EventTarget | null) => {
@@ -3272,25 +2252,31 @@ function CompactChatApp({
       if (compactInputToolToggleRef.current?.contains(relatedTarget)) return true;
       if (compactInputToolFanRef.current?.contains(relatedTarget)) return true;
     }
-    if (isCompactInputToolPointerInToggleHoverRegion(clientX, clientY, relatedTarget)) return true;
-    const fanRegion = getCompactInputToolFanCircularHoverRegion();
-    if (!fanRegion) return false;
-    return Math.hypot(clientX - fanRegion.centerX, clientY - fanRegion.centerY) <= fanRegion.radius;
-  }, [
-    getCompactInputToolFanCircularHoverRegion,
-    isCompactInputToolPointerInToggleHoverRegion,
-  ]);
+    if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return false;
+    const rects = [
+      compactInputToolToggleRef.current?.getBoundingClientRect(),
+      compactInputToolFanRef.current?.getBoundingClientRect(),
+    ];
+    return rects.some(rect => (
+      !!rect
+      && rect.width > 0
+      && rect.height > 0
+      && clientX >= rect.left
+      && clientX <= rect.right
+      && clientY >= rect.top
+      && clientY <= rect.bottom
+    ));
+  }, []);
 
   const handleCompactInputToolHoverEnter = useCallback((event: ReactPointerEvent) => {
-    if (!shouldOpenCompactToolFanOnHover(event.pointerType)) return;
+    if (!shouldOpenCompactToolFanOnHover(event)) return;
     if (compactInputToolFanSuppressHoverUntilLeaveRef.current) return;
-    if (compactInputToolFanHoverInsideRef.current && compactInputToolFanOpenRef.current) return;
+    if (compactInputToolFanHoverInsideRef.current) return;
     compactInputToolFanHoverInsideRef.current = true;
     openCompactInputToolFan('hover');
   }, [openCompactInputToolFan, shouldOpenCompactToolFanOnHover]);
 
   const handleCompactInputToolHoverLeave = useCallback((event: ReactPointerEvent) => {
-    if (compactInputToolWheelDragActiveRef.current || compactInputToolWheelPointerRef.current) return;
     if (isCompactInputToolPointerInHoverRegion(event.clientX, event.clientY, event.relatedTarget)) return;
     resetCompactInputToolFanHoverBlock();
     scheduleCompactInputToolFanTransientClose();
@@ -3300,18 +2286,6 @@ function CompactChatApp({
     compactInputToolFanSuppressHoverUntilLeaveRef.current = true;
     closeCompactInputToolFan();
   }, [closeCompactInputToolFan]);
-
-  const closeCompactInputToolFanFromDesktopOutside = useCallback(() => {
-    resetCompactInputToolFanHoverBlock();
-    scheduleCompactInputToolFanTransientClose({
-      delayMs: COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS,
-      force: true,
-      keepExistingTimer: true,
-    });
-  }, [
-    resetCompactInputToolFanHoverBlock,
-    scheduleCompactInputToolFanTransientClose,
-  ]);
 
   const toggleCompactInputToolFanByClick = useCallback(() => {
     if (compactInputToolFanOpenRef.current) {
@@ -3326,184 +2300,6 @@ function CompactChatApp({
     setCompactInputToolWheelIndex(current => (
       (current + direction + COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT) % COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT
     ));
-  }, []);
-
-  const markCompactInputToolWheelMotion = useCallback((stepCount: number, options?: { forceFast?: boolean }) => {
-    const now = getCompactToolWheelTimestamp();
-    const elapsed = compactInputToolWheelLastRotationAtRef.current > 0
-      ? now - compactInputToolWheelLastRotationAtRef.current
-      : Number.POSITIVE_INFINITY;
-    compactInputToolWheelLastRotationAtRef.current = now;
-    if (!options?.forceFast && stepCount <= 1 && elapsed > COMPACT_INPUT_TOOL_WHEEL_FAST_GESTURE_MS) return;
-
-    clearCompactInputToolWheelFastAnimationTimer();
-    setCompactInputToolWheelFastAnimation(true);
-    compactInputToolWheelFastAnimationTimerRef.current = window.setTimeout(() => {
-      compactInputToolWheelFastAnimationTimerRef.current = null;
-      setCompactInputToolWheelFastAnimation(false);
-    }, COMPACT_INPUT_TOOL_WHEEL_FAST_ANIMATION_MS);
-  }, [clearCompactInputToolWheelFastAnimationTimer]);
-
-  const rotateCompactInputToolWheelSteps = useCallback((direction: 1 | -1, stepCount: number, options?: { forceFast?: boolean }) => {
-    if (stepCount <= 0) return;
-    markCompactInputToolWheelMotion(stepCount, options);
-    for (let step = 0; step < stepCount; step += 1) {
-      rotateCompactInputToolWheel(direction);
-    }
-  }, [markCompactInputToolWheelMotion, rotateCompactInputToolWheel]);
-
-  const recordCompactInputToolWheelCharge = useCallback((direction: 1 | -1, stepCount: number) => {
-    if (stepCount <= 0) return;
-    const previous = compactInputToolWheelChargeRef.current;
-    let nextDirection: 1 | -1 | null = direction;
-    let sameDirectionSteps = previous.direction === direction ? previous.sameDirectionSteps + stepCount : stepCount;
-    let chargeSteps = 0;
-
-    if (previous.chargeSteps > 0) {
-      if (previous.direction === direction) {
-        chargeSteps = Math.min(COMPACT_INPUT_TOOL_WHEEL_CHARGE_MAX_STEPS, previous.chargeSteps + stepCount);
-        sameDirectionSteps = COMPACT_INPUT_TOOL_WHEEL_CHARGE_START_STEPS + chargeSteps;
-      } else {
-        const remainingChargeSteps = previous.chargeSteps - stepCount;
-        if (remainingChargeSteps > 0) {
-          nextDirection = previous.direction;
-          chargeSteps = remainingChargeSteps;
-          sameDirectionSteps = COMPACT_INPUT_TOOL_WHEEL_CHARGE_START_STEPS + remainingChargeSteps;
-        } else {
-          const leftoverSteps = Math.abs(remainingChargeSteps);
-          if (leftoverSteps <= 0) {
-            nextDirection = null;
-            sameDirectionSteps = 0;
-            chargeSteps = 0;
-          } else {
-            nextDirection = direction;
-            sameDirectionSteps = leftoverSteps;
-            chargeSteps = Math.min(
-              COMPACT_INPUT_TOOL_WHEEL_CHARGE_MAX_STEPS,
-              Math.max(0, leftoverSteps - COMPACT_INPUT_TOOL_WHEEL_CHARGE_START_STEPS),
-            );
-          }
-        }
-      }
-    } else {
-      chargeSteps = Math.min(
-        COMPACT_INPUT_TOOL_WHEEL_CHARGE_MAX_STEPS,
-        Math.max(0, sameDirectionSteps - COMPACT_INPUT_TOOL_WHEEL_CHARGE_START_STEPS),
-      );
-    }
-
-    compactInputToolWheelChargeRef.current = {
-      direction: nextDirection,
-      sameDirectionSteps,
-      chargeSteps,
-    };
-    setCompactInputToolWheelChargeRatio(chargeSteps / COMPACT_INPUT_TOOL_WHEEL_CHARGE_MAX_STEPS);
-    setCompactInputToolWheelChargeDirection(chargeSteps > 0 ? nextDirection : null);
-  }, []);
-
-  const startCompactInputToolWheelChargeRelease = useCallback((direction: 1 | -1, stepCount: number) => {
-    const releaseSteps = Math.max(0, Math.round(stepCount));
-    clearCompactInputToolWheelChargeReleaseTimer();
-    if (releaseSteps <= 0) return;
-
-    let remainingSteps = releaseSteps;
-    compactInputToolWheelChargeReleaseActiveRef.current = true;
-    setCompactInputToolWheelChargeReleaseActive(true);
-
-    const runReleaseStep = () => {
-      if (!compactInputToolFanOpenRef.current || remainingSteps <= 0) {
-        compactInputToolWheelChargeReleaseTimerRef.current = null;
-        compactInputToolWheelChargeReleaseActiveRef.current = false;
-        setCompactInputToolWheelChargeReleaseActive(false);
-        return;
-      }
-
-      rotateCompactInputToolWheelSteps(direction, 1, { forceFast: true });
-      remainingSteps -= 1;
-      if (remainingSteps <= 0) {
-        compactInputToolWheelChargeReleaseTimerRef.current = null;
-        compactInputToolWheelChargeReleaseActiveRef.current = false;
-        setCompactInputToolWheelChargeReleaseActive(false);
-        return;
-      }
-      compactInputToolWheelChargeReleaseTimerRef.current = window.setTimeout(
-        runReleaseStep,
-        COMPACT_INPUT_TOOL_WHEEL_CHARGE_RELEASE_STEP_MS,
-      );
-    };
-
-    compactInputToolWheelChargeReleaseTimerRef.current = window.setTimeout(runReleaseStep, 0);
-  }, [clearCompactInputToolWheelChargeReleaseTimer, rotateCompactInputToolWheelSteps]);
-
-  const getCompactInputToolWheelNormalizedDelta = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
-    const rawDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX)
-      ? event.deltaY
-      : event.deltaX;
-    if (!Number.isFinite(rawDelta) || rawDelta === 0) return 0;
-    if (event.deltaMode === 1) {
-      return rawDelta * 16;
-    }
-    if (event.deltaMode === 2) {
-      return rawDelta * Math.max(window.innerHeight || 1, 1);
-    }
-    return rawDelta;
-  }, []);
-
-  const rotateCompactInputToolWheelByScroll = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
-    const normalizedDelta = getCompactInputToolWheelNormalizedDelta(event);
-    if (Math.abs(normalizedDelta) < COMPACT_INPUT_TOOL_WHEEL_SCROLL_DEADZONE) return;
-
-    event.preventDefault();
-    event.stopPropagation();
-
-    const direction: 1 | -1 = normalizedDelta > 0 ? 1 : -1;
-    rotateCompactInputToolWheelSteps(direction, 1, { forceFast: true });
-  }, [getCompactInputToolWheelNormalizedDelta, rotateCompactInputToolWheelSteps]);
-
-  const getCompactToolWheelBoundedDragPoint = useCallback((clientX: number, clientY: number): CompactToolWheelDragPoint => {
-    if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) {
-      return { x: clientX, y: clientY, angle: null };
-    }
-    const fanElement = compactInputToolFanRef.current;
-    const fanRect = fanElement?.getBoundingClientRect();
-    if (!fanRect || fanRect.width <= 0 || fanRect.height <= 0) {
-      return { x: clientX, y: clientY, angle: null };
-    }
-    const fanStyle = fanElement && window.getComputedStyle ? window.getComputedStyle(fanElement) : null;
-    const readFanPixelVar = (name: string, fallback: number) => {
-      const rawValue = fanStyle?.getPropertyValue(name).trim() || '';
-      const parsedValue = Number.parseFloat(rawValue);
-      return Number.isFinite(parsedValue) ? parsedValue : fallback;
-    };
-    const centerX = fanRect.left + readFanPixelVar('--compact-tool-wheel-center-x', COMPACT_INPUT_TOOL_WHEEL_CENTER_X);
-    const centerY = fanRect.top + readFanPixelVar('--compact-tool-wheel-center-y', COMPACT_INPUT_TOOL_WHEEL_CENTER_Y);
-    const radius = Math.max(
-      centerX - fanRect.left,
-      fanRect.right - centerX,
-      centerY - fanRect.top,
-      fanRect.bottom - centerY,
-    );
-    if (!Number.isFinite(radius) || radius <= 0) {
-      return { x: clientX, y: clientY, angle: null };
-    }
-    const deltaX = clientX - centerX;
-    const deltaY = clientY - centerY;
-    const distance = Math.hypot(deltaX, deltaY);
-    if (distance <= 0) {
-      return { x: clientX, y: clientY, angle: null };
-    }
-    const angle = distance >= COMPACT_INPUT_TOOL_WHEEL_ANGLE_MIN_RADIUS
-      ? Math.atan2(deltaY, deltaX)
-      : null;
-    if (distance <= radius) {
-      return { x: clientX, y: clientY, angle };
-    }
-    const scale = radius / distance;
-    return {
-      x: centerX + deltaX * scale,
-      y: centerY + deltaY * scale,
-      angle,
-    };
   }, []);
 
   const isCompactToolFanOriginPoint = useCallback((clientX: number, clientY: number) => {
@@ -3549,91 +2345,10 @@ function CompactChatApp({
     closeCompactInputToolFanFromUserClick();
   }, [closeCompactInputToolFanFromUserClick]);
 
-  // ── 工具轮盘原点「按住拖动文本框」手势 ────────────────────────────────────
-  // 在 toggle（轮盘关闭时）或 fan 中心（轮盘展开时，命中原点）按下后移动超阈值 → 把 surface
-  // 拖拽交给宿主（web: app-react-chat-window.js / Electron: preload-chat-react.js）经
-  // neko:compact-surface-drag-grab 接管。
-  // 点按（无移动）语义保持原样：toggle 由自身 onClick 展开/关闭；fan 原点由 onPointerDownCapture
-  // 的 markCompactToolFanOriginClickSuppressed 收起（这条收起+抑制路径不动，保证既有命中测试不回归）。
-  // 用独立的 compactToolOriginSuppressClickRef 抑制拖动后补发的 click——不能复用
-  // compactInputToolWheelSuppressClickRef，因为关闭轮盘的 effect 会把它清掉（见下方 fan 关闭 effect）。
-  const beginCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
-    if (event.pointerType === 'mouse' && event.button !== 0) return;
-    // 每次新的原点按下都清掉可能残留的抑制标志（上一次拖拽若没补发 click 会留下 true），
-    // 保证本次点按/拖拽自洁——抑制只靠「拖动置位 + click 消费 / 下次按下清零」，不再用定时器。
-    compactToolOriginSuppressClickRef.current = false;
-    const previous = compactToolOriginDragRef.current;
-    if (previous && previous.captureTarget && previous.captureTarget.hasPointerCapture?.(previous.pointerId)) {
-      // 兜底：上一手势没收到 pointerup（罕见）→ 释放旧捕获再重置，避免卡死。
-      try { previous.captureTarget.releasePointerCapture(previous.pointerId); } catch (_) {}
-    }
-    const captureTarget = event.currentTarget instanceof Element ? event.currentTarget : null;
-    compactToolOriginDragRef.current = {
-      pointerId: event.pointerId,
-      startClientX: event.clientX,
-      startClientY: event.clientY,
-      startScreenX: event.screenX,
-      startScreenY: event.screenY,
-      moved: false,
-      captureTarget,
-    };
-    try {
-      captureTarget?.setPointerCapture?.(event.pointerId);
-    } catch (_) {}
-  }, []);
-
-  const updateCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
-    const state = compactToolOriginDragRef.current;
-    if (!state || state.pointerId !== event.pointerId || state.moved) return;
-    const dx = event.clientX - state.startClientX;
-    const dy = event.clientY - state.startClientY;
-    if (Math.hypot(dx, dy) < COMPACT_INPUT_TOOL_ORIGIN_DRAG_THRESHOLD) return;
-    state.moved = true;
-    // 吞掉本次指针序列随后补发的 click，避免拖完误触发 toggle 展开 / 工具按钮。
-    // 一直 armed 到那次 click 被消费（或下次原点/轮盘按下清零）——不能用定时器，慢速拖拽
-    // 往往远超任何固定时长，定时器会在 release click 之前清掉、导致拖完轮盘被误开关。
-    compactToolOriginSuppressClickRef.current = true;
-    // 拖动是「移动文本框」手势而非工具手势，收起轮盘。
-    closeCompactInputToolFan();
-    // 把 surface 拖拽交给宿主，锚点用按下点（而非当前点），避免 surface 跳变。
-    window.dispatchEvent(new CustomEvent('neko:compact-surface-drag-grab', {
-      detail: {
-        clientX: state.startClientX,
-        clientY: state.startClientY,
-        screenX: state.startScreenX,
-        screenY: state.startScreenY,
-      },
-    }));
-  }, [closeCompactInputToolFan]);
-
-  const endCompactToolOriginDrag = useCallback((event: ReactPointerEvent) => {
-    const state = compactToolOriginDragRef.current;
-    if (!state || state.pointerId !== event.pointerId) return;
-    const captureTarget = state.captureTarget;
-    compactToolOriginDragRef.current = null;
-    if (captureTarget && typeof captureTarget.releasePointerCapture === 'function') {
-      try {
-        if (captureTarget.hasPointerCapture?.(event.pointerId)) {
-          captureTarget.releasePointerCapture(event.pointerId);
-        }
-      } catch (_) {}
-    }
-    // 无移动 = 点按：toggle 交给自身 onClick；fan 原点已由 onPointerDownCapture 收起。这里不再处理。
-  }, []);
-
   useEffect(() => () => {
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
-    clearCompactInputToolWheelDragGuardTimer();
-    clearCompactInputToolWheelFastAnimationTimer();
-    clearCompactInputToolWheelChargeReleaseTimer();
-  }, [
-    clearCompactInputToolFanCloseTimer,
-    clearCompactInputToolFanInteractiveTimer,
-    clearCompactInputToolWheelDragGuardTimer,
-    clearCompactInputToolWheelFastAnimationTimer,
-    clearCompactInputToolWheelChargeReleaseTimer,
-  ]);
+  }, [clearCompactInputToolFanCloseTimer, clearCompactInputToolFanInteractiveTimer]);
 
   useEffect(() => {
     if (!isCompactSurface || effectiveCompactChatState !== 'input') {
@@ -3642,39 +2357,9 @@ function CompactChatApp({
     }
 
     const handlePointerMove = (event: PointerEvent) => {
-      // 工具轮盘原点拖拽进行中时不跑悬停展开/收起逻辑，避免拖动文本框时悬停又把轮盘弹开。
-      if (compactToolOriginDragRef.current) return;
-      const pointerInHoverRegion = isCompactInputToolPointerInHoverRegion(event.clientX, event.clientY, event.target);
-      if (compactInputToolFanSuppressHoverUntilLeaveRef.current) {
-        if (!pointerInHoverRegion) {
-          resetCompactInputToolFanHoverBlock();
-        }
-        return;
-      }
-      if (pointerInHoverRegion) {
-        compactInputToolFanHoverInsideRef.current = true;
-        clearCompactInputToolFanCloseTimer();
-      }
-      if (
-        !compactInputHasPayload
-        && !composerDisabled
-        && shouldOpenCompactToolFanOnHover(event.pointerType)
-        && isCompactInputToolPointerInToggleHoverRegion(event.clientX, event.clientY, event.target)
-      ) {
-        if (!compactInputToolFanOpenRef.current) {
-          openCompactInputToolFan('hover');
-        }
-        return;
-      }
-      if (
-        compactInputToolFanOpenRef.current
-        && !pointerInHoverRegion
-        && !compactInputToolWheelDragActiveRef.current
-        && !compactInputToolWheelPointerRef.current
-      ) {
-        resetCompactInputToolFanHoverBlock();
-        scheduleCompactInputToolFanTransientClose();
-      }
+      if (!compactInputToolFanSuppressHoverUntilLeaveRef.current) return;
+      if (isCompactInputToolPointerInHoverRegion(event.clientX, event.clientY, event.target)) return;
+      resetCompactInputToolFanHoverBlock();
     };
 
     window.addEventListener('pointermove', handlePointerMove, true);
@@ -3682,20 +2367,13 @@ function CompactChatApp({
       window.removeEventListener('pointermove', handlePointerMove, true);
     };
   }, [
-    clearCompactInputToolFanCloseTimer,
-    compactInputHasPayload,
-    composerDisabled,
     effectiveCompactChatState,
     isCompactInputToolPointerInHoverRegion,
-    isCompactInputToolPointerInToggleHoverRegion,
     isCompactSurface,
-    openCompactInputToolFan,
     resetCompactInputToolFanHoverBlock,
-    scheduleCompactInputToolFanTransientClose,
-    shouldOpenCompactToolFanOnHover,
   ]);
 
-  const finishCompactToolWheelPointer = useCallback((event?: { pointerId: number }) => {
+  const finishCompactToolWheelPointer = useCallback((event?: ReactPointerEvent<HTMLDivElement>) => {
     const pointerState = compactInputToolWheelPointerRef.current;
     if (!pointerState) return;
     if (event && pointerState.id !== event.pointerId) return;
@@ -3715,139 +2393,8 @@ function CompactChatApp({
         compactInputToolWheelSuppressClickRef.current = false;
       }, 0);
     }
-    const chargeState = compactInputToolWheelChargeRef.current;
-    const releaseDirection = chargeState.direction === null
-      ? null
-      : (chargeState.direction === 1 ? -1 : 1);
-    const releaseSteps = chargeState.chargeSteps;
-    resetCompactInputToolWheelCharge();
-    clearCompactInputToolWheelDragGuardTimer();
     compactInputToolWheelPointerRef.current = null;
-    compactInputToolWheelDragActiveRef.current = false;
-    dispatchCompactToolWheelDragState(false, pointerState.id);
-    if (releaseDirection !== null && releaseSteps > 0) {
-      startCompactInputToolWheelChargeRelease(releaseDirection, releaseSteps);
-    }
-  }, [
-    clearCompactInputToolWheelDragGuardTimer,
-    dispatchCompactToolWheelDragState,
-    resetCompactInputToolWheelCharge,
-    startCompactInputToolWheelChargeRelease,
-  ]);
-
-  const updateCompactInputToolWheelDrag = useCallback((input: CompactToolWheelDragInput) => {
-    const pointerState = compactInputToolWheelPointerRef.current;
-    if (!pointerState || pointerState.id !== input.pointerId) return false;
-    dispatchCompactToolWheelDragState(true, input.pointerId);
-    scheduleCompactInputToolWheelDragGuardRelease();
-    if (input.pointerType === 'mouse' && input.buttons === 0) {
-      finishCompactToolWheelPointer({ pointerId: input.pointerId });
-      return true;
-    }
-
-    const dragPoint = getCompactToolWheelBoundedDragPoint(input.clientX, input.clientY);
-    if (pointerState.angle !== null && dragPoint.angle !== null) {
-      const angleDelta = normalizeCompactToolWheelAngleDelta(dragPoint.angle - pointerState.angle);
-      const arcDelta = angleDelta * COMPACT_INPUT_TOOL_WHEEL_ORBIT_RADIUS;
-      const totalDelta = pointerState.angleRemainder + arcDelta;
-      const stepCount = Math.floor(Math.abs(totalDelta) / COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD);
-      pointerState.x = dragPoint.x;
-      pointerState.y = dragPoint.y;
-      pointerState.angle = dragPoint.angle;
-      if (stepCount <= 0) {
-        pointerState.angleRemainder = totalDelta;
-        return true;
-      }
-
-      input.preventDefault?.();
-      const direction: 1 | -1 = totalDelta > 0 ? 1 : -1;
-      rotateCompactInputToolWheelSteps(direction, stepCount);
-      recordCompactInputToolWheelCharge(direction, stepCount);
-      pointerState.angleRemainder = totalDelta - (
-        direction * stepCount * COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD
-      );
-      pointerState.didRotate = true;
-      return true;
-    }
-
-    const deltaX = dragPoint.x - pointerState.x;
-    const deltaY = dragPoint.y - pointerState.y;
-    const useVerticalDelta = Math.abs(deltaY) >= Math.abs(deltaX);
-    const primaryDelta = useVerticalDelta ? deltaY : deltaX;
-    const stepCount = Math.floor(Math.abs(primaryDelta) / COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD);
-    if (stepCount <= 0) return true;
-
-    input.preventDefault?.();
-    const direction: 1 | -1 = useVerticalDelta
-      ? (primaryDelta > 0 ? 1 : -1)
-      : (primaryDelta < 0 ? 1 : -1);
-    rotateCompactInputToolWheelSteps(direction, stepCount);
-    recordCompactInputToolWheelCharge(direction, stepCount);
-    if (useVerticalDelta) {
-      pointerState.x = dragPoint.x;
-      pointerState.y += direction === 1
-        ? stepCount * COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD
-        : -(stepCount * COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD);
-    } else {
-      pointerState.x += direction === 1
-        ? -(stepCount * COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD)
-        : stepCount * COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD;
-      pointerState.y = dragPoint.y;
-    }
-    pointerState.angle = dragPoint.angle;
-    pointerState.angleRemainder = 0;
-    pointerState.didRotate = true;
-    return true;
-  }, [
-    dispatchCompactToolWheelDragState,
-    finishCompactToolWheelPointer,
-    getCompactToolWheelBoundedDragPoint,
-    recordCompactInputToolWheelCharge,
-    rotateCompactInputToolWheelSteps,
-    scheduleCompactInputToolWheelDragGuardRelease,
-  ]);
-
-  useEffect(() => {
-    const handleGlobalPointerMove = (event: PointerEvent) => {
-      updateCompactInputToolWheelDrag({
-        pointerId: event.pointerId,
-        clientX: event.clientX,
-        clientY: event.clientY,
-        buttons: event.buttons,
-        pointerType: event.pointerType,
-        preventDefault: () => event.preventDefault(),
-      });
-    };
-
-    const handleGlobalPointerEnd = (event: PointerEvent) => {
-      const pointerState = compactInputToolWheelPointerRef.current;
-      if (!pointerState || pointerState.id !== event.pointerId) return;
-      finishCompactToolWheelPointer({ pointerId: event.pointerId });
-    };
-
-    const handleGlobalMouseUp = () => {
-      if (!compactInputToolWheelDragActiveRef.current) return;
-      finishCompactToolWheelPointer();
-    };
-
-    const handleWindowBlur = () => {
-      if (!compactInputToolWheelDragActiveRef.current && !compactInputToolWheelPointerRef.current) return;
-      scheduleCompactInputToolWheelDragGuardRelease();
-    };
-
-    window.addEventListener('pointermove', handleGlobalPointerMove, true);
-    window.addEventListener('pointerup', handleGlobalPointerEnd, true);
-    window.addEventListener('pointercancel', handleGlobalPointerEnd, true);
-    window.addEventListener('mouseup', handleGlobalMouseUp, true);
-    window.addEventListener('blur', handleWindowBlur);
-    return () => {
-      window.removeEventListener('pointermove', handleGlobalPointerMove, true);
-      window.removeEventListener('pointerup', handleGlobalPointerEnd, true);
-      window.removeEventListener('pointercancel', handleGlobalPointerEnd, true);
-      window.removeEventListener('mouseup', handleGlobalMouseUp, true);
-      window.removeEventListener('blur', handleWindowBlur);
-    };
-  }, [finishCompactToolWheelPointer, scheduleCompactInputToolWheelDragGuardRelease, updateCompactInputToolWheelDrag]);
+  }, []);
 
   useEffect(() => {
     compactInputToolFanPositionSyncRef.current = () => updateCompactInputToolFanPosition();
@@ -3860,12 +2407,18 @@ function CompactChatApp({
     clearCompactInputToolFanCloseTimer();
   }, [clearCompactInputToolFanCloseTimer]);
 
-  const collapseCompactInputIfEmpty = useCallback((options?: { ignoreFocusedShell?: boolean; ignoreToolFan?: boolean }) => {
+  const handleComposerBottomBarRef = useCallback((node: HTMLDivElement | null) => {
+    composerBottomBarRef.current = node;
+    setComposerBottomBarNode(prev => (prev === node ? prev : node));
+  }, []);
+
+  const collapseCompactInputIfEmpty = useCallback((options?: { ignoreFocusedShell?: boolean }) => {
     if (!isCompactSurface) return;
     if (effectiveCompactChatState !== 'input') return;
-    if (!options?.ignoreToolFan && compactInputToolFanOpen) return;
+    if (compactInputToolFanOpen) return;
     if (draftRef.current.trim().length > 0) return;
     if (composerAttachments.length > 0) return;
+    if (!options?.ignoreFocusedShell && compactExportHistoryOpen) return;
     const activeElement = document.activeElement;
     if (
       !options?.ignoreFocusedShell
@@ -3874,7 +2427,7 @@ function CompactChatApp({
         !!compactInputShellRef.current?.contains(activeElement)
         || (
           activeElement instanceof Element
-          && !!activeElement.closest('.compact-export-history-anchor, .compact-history-visibility-handle')
+          && !!activeElement.closest('.compact-export-history-anchor')
         )
       )
     ) {
@@ -3883,6 +2436,7 @@ function CompactChatApp({
     requestCompactChatState('default');
   }, [
     compactInputToolFanOpen,
+    compactExportHistoryOpen,
     composerAttachments.length,
     effectiveCompactChatState,
     isCompactSurface,
@@ -3913,7 +2467,7 @@ function CompactChatApp({
         || !!compactChoiceLayerRef.current?.contains(target)
         || (
           target instanceof Element
-          && !!target.closest('.compact-export-history-anchor, .compact-history-visibility-handle')
+          && !!target.closest('.compact-export-history-anchor')
         )
       )
     );
@@ -3940,7 +2494,7 @@ function CompactChatApp({
 
   useEffect(() => {
     if (!compactInputToolFanOpen) return;
-    if (!isCompactSurface || composerHidden || composerDisabled || compactInputHasPayload) {
+    if (!isCompactSurface || effectiveCompactChatState !== 'input' || composerHidden || composerDisabled || compactInputHasPayload) {
       closeCompactInputToolFan();
     }
   }, [
@@ -3949,50 +2503,28 @@ function CompactChatApp({
     compactInputToolFanOpen,
     composerDisabled,
     composerHidden,
+    effectiveCompactChatState,
     isCompactSurface,
   ]);
 
   useEffect(() => {
     if (compactInputToolFanOpen) return;
     clearCompactInputToolFanCloseTimer();
-    clearCompactInputToolWheelDragGuardTimer();
-    clearCompactInputToolWheelFastAnimationTimer();
-    clearCompactInputToolWheelChargeReleaseTimer();
     compactInputToolFanOpenIntentRef.current = null;
     compactInputToolWheelPointerRef.current = null;
-    compactInputToolWheelDragActiveRef.current = false;
     compactInputToolWheelSuppressClickRef.current = false;
-    compactInputToolWheelLastRotationAtRef.current = 0;
-    resetCompactInputToolWheelCharge();
-    setCompactInputToolWheelFastAnimation(false);
-    dispatchCompactToolWheelDragState(false);
-  }, [
-    clearCompactInputToolFanCloseTimer,
-    clearCompactInputToolWheelDragGuardTimer,
-    clearCompactInputToolWheelFastAnimationTimer,
-    clearCompactInputToolWheelChargeReleaseTimer,
-    compactInputToolFanOpen,
-    dispatchCompactToolWheelDragState,
-    resetCompactInputToolWheelCharge,
-  ]);
+  }, [clearCompactInputToolFanCloseTimer, compactInputToolFanOpen]);
 
   useEffect(() => {
     if (!isCompactSurface) return;
 
     const handleDesktopCompactPointerOutside = () => {
-      if (
-        compactInputToolWheelDragActiveRef.current
-        || compactInputToolWheelPointerRef.current
-        || compactInputToolWheelChargeReleaseActiveRef.current
-      ) return;
-      closeCompactInputToolFanFromDesktopOutside();
-      if (compactInputToolFanOpenRef.current) {
-        window.setTimeout(() => {
-          collapseCompactInputIfEmpty({ ignoreFocusedShell: true, ignoreToolFan: true });
-        }, COMPACT_INPUT_TOOL_FAN_OUTSIDE_CLOSE_DELAY_MS);
-        return;
-      }
-      collapseCompactInputIfEmpty({ ignoreFocusedShell: true, ignoreToolFan: true });
+      resetCompactInputToolFanHoverBlock();
+      closeCompactInputToolFan();
+      if (effectiveCompactChatState !== 'input') return;
+      if (draftRef.current.trim().length > 0) return;
+      if (composerAttachments.length > 0) return;
+      requestCompactChatState('default');
     };
 
     window.addEventListener('neko:desktop-compact-pointer-outside', handleDesktopCompactPointerOutside);
@@ -4000,9 +2532,12 @@ function CompactChatApp({
       window.removeEventListener('neko:desktop-compact-pointer-outside', handleDesktopCompactPointerOutside);
     };
   }, [
-    collapseCompactInputIfEmpty,
-    closeCompactInputToolFanFromDesktopOutside,
+    closeCompactInputToolFan,
+    composerAttachments.length,
+    effectiveCompactChatState,
     isCompactSurface,
+    requestCompactChatState,
+    resetCompactInputToolFanHoverBlock,
   ]);
 
   useEffect(() => {
@@ -4035,12 +2570,6 @@ function CompactChatApp({
 
   useEffect(() => {
     if (!isCompactSurface) {
-      setCompactPreviewTextVisible(compactPreviewText);
-      previousCompactPreviewTextRef.current = compactPreviewText;
-      return;
-    }
-
-    if (compactMessagePreview?.isGuide) {
       setCompactPreviewTextVisible(compactPreviewText);
       previousCompactPreviewTextRef.current = compactPreviewText;
       return;
@@ -4084,7 +2613,7 @@ function CompactChatApp({
         window.clearTimeout(timeoutId);
       }
     };
-  }, [compactMessagePreview?.isGuide, compactPreviewText, isCompactSurface]);
+  }, [compactPreviewText, isCompactSurface]);
 
   useEffect(() => {
     if (!isCompactSurface) return;
@@ -4305,6 +2834,100 @@ function CompactChatApp({
       document.removeEventListener('keydown', closeMenuOnEscape);
     };
   }, [toolMenuOpen]);
+
+  useEffect(() => {
+    composerLayoutRef.current = composerLayout;
+  }, [composerLayout]);
+
+  useEffect(() => {
+    const target = composerBottomBarNode;
+    if (!target || typeof ResizeObserver === 'undefined') return;
+    const COMPACT_THRESHOLD = 300;
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const wantCompact = entry.contentRect.width < COMPACT_THRESHOLD;
+        // 鍦?expanded 鈫?collapsing 杩欎竴鍒绘姄涓€涓嬪彸 4 鎸夐挳缁勭殑褰撳墠鍍忕礌瀹藉害锛?        // 鍚屼竴鎵?setState 浼氬拰 layout 鍒囨崲涓€璧?commit锛宺ender 鍑烘潵鏃?        // .is-leaving 绫诲拰 --collapse-from-width 鍙橀噺鍚屾椂鐢熸晥锛?        // CSS keyframe 灏辫兘浠庤繖涓浐瀹氬搴︽彃鍊煎埌 0銆?        // 鐢?offsetWidth 鑰岄潪 getBoundingClientRect().width锛氬墠鑰呭熀浜庡竷灞€鐩掞紝
+        // 涓嶅彈鍏ュ満 scaleX 鍔ㄧ敾褰卞搷锛涘鏋?expand 鍔ㄧ敾杩樻病璺戝畬灏卞張琚帇绐勶紝
+        if (wantCompact && composerLayoutRef.current === 'expanded' && composerToolsRightRef.current) {
+          const node = composerToolsRightRef.current;
+          const w = Math.max(node.offsetWidth, node.scrollWidth);
+          if (w > 0) setCollapseFromWidth(w);
+        }
+        setComposerLayout(prev => {
+          if (wantCompact) {
+            if (prev === 'expanded') return 'collapsing';
+            if (prev === 'expanding') return 'compact';
+            return prev;
+          } else {
+            if (prev === 'compact') return 'expanding';
+            if (prev === 'collapsing') return 'expanded';
+            return prev;
+          }
+        });
+      }
+    });
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [composerBottomBarNode]);
+
+  useEffect(() => {
+    if (isCompactSurface) {
+      setOverflowMenuOpen(false);
+      return;
+    }
+    if (!composerBottomBarNode) return;
+    if (composerBottomBarNode.getBoundingClientRect().width >= 300) {
+      setComposerLayout(prev => (
+        prev === 'compact' || prev === 'collapsing' ? 'expanded' : prev
+      ));
+    }
+  }, [composerBottomBarNode, isCompactSurface]);
+
+  // 鏀惰捣/灞曞紑鍔ㄧ敾璺戝畬鍚庡垏鍒扮ǔ鎬併€傛椂闀块渶涓?styles.css 涓殑 keyframes 瀵归綈銆?  // prefers-reduced-motion 涓?styles.css 鎶婂姩鐢昏鎴?none锛岃繖鏃惰繕绛?270/220ms
+  // 浼氳宸ュ叿鍖烘粸鐣欏湪杩囨浮鎬侊紙鎺т欢瑙嗚涓婃彁鍓嶅埌浣嶄絾 layout state 娌″垏锛夛紝
+  useEffect(() => {
+    const prefersReducedMotion =
+      typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (composerLayout === 'collapsing') {
+      const timerId = window.setTimeout(() => {
+        setComposerLayout(prev => (prev === 'collapsing' ? 'compact' : prev));
+      }, prefersReducedMotion ? 0 : 270);
+      return () => window.clearTimeout(timerId);
+    }
+    if (composerLayout === 'expanding') {
+      const timerId = window.setTimeout(() => {
+        setComposerLayout(prev => (prev === 'expanding' ? 'expanded' : prev));
+      }, prefersReducedMotion ? 0 : 220);
+      return () => window.clearTimeout(timerId);
+    }
+    return undefined;
+  }, [composerLayout]);
+
+  useEffect(() => {
+    if (composerLayout !== 'compact') setOverflowMenuOpen(false);
+  }, [composerLayout]);
+
+  // 路路路 鑿滃崟鐨勫閮ㄧ偣鍑?/ Esc 鍏抽棴
+  useEffect(() => {
+    if (!overflowMenuOpen) return;
+    const closeOnOutsideClick = (event: MouseEvent) => {
+      const node = overflowMenuRef.current;
+      if (!node) return;
+      if (node.contains(event.target as Node)) return;
+      setOverflowMenuOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOverflowMenuOpen(false);
+    };
+    document.addEventListener('mousedown', closeOnOutsideClick);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('mousedown', closeOnOutsideClick);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [overflowMenuOpen]);
 
   useEffect(() => {
     if (!activeCursorToolId) return;
@@ -4666,20 +3289,6 @@ function CompactChatApp({
     }
   }
 
-  function focusCompactInputForContinuousTyping() {
-    const inputNode = compactInputRef.current;
-    if (!inputNode || inputNode.disabled || inputNode.readOnly) return;
-    const activeElement = document.activeElement;
-    if (
-      activeElement instanceof Node
-      && compactInputShellRef.current
-      && !compactInputShellRef.current.contains(activeElement)
-    ) return;
-    inputNode.focus();
-    const selectionEnd = inputNode.value.length;
-    inputNode.setSelectionRange(selectionEnd, selectionEnd);
-  }
-
   function submitDraft() {
     if (composerDisabled) return;
     if (submittingRef.current) return;
@@ -4687,33 +3296,197 @@ function CompactChatApp({
     if (!text && composerAttachments.length === 0) return;
     closeCompactInputToolFan();
     submittingRef.current = true;
-    let shouldRefocusCompactInput = false;
     try {
       onComposerSubmit?.({ text });
       setDraft('');
       restoreCompactExportHistoryToBottomForOutgoingMessage();
-      shouldRefocusCompactInput = isCompactSurface
-        && effectiveCompactChatState === 'input'
-        && text.length > 0;
+      requestCompactChatState('default');
     } finally {
-      requestAnimationFrame(() => {
-        submittingRef.current = false;
-        if (shouldRefocusCompactInput) {
-          focusCompactInputForContinuousTyping();
-        }
-      });
+      requestAnimationFrame(() => { submittingRef.current = false; });
     }
   }
 
-  const compactFanRunAction = (action: (() => void) | undefined) => (event: ReactMouseEvent) => {
+  useEffect(() => {
+    function handleDesktopDropTargetChange(event: Event) {
+      const detail = (event as CustomEvent<CompactHistoryDesktopDropTargetDetail>).detail;
+      if (detail?.active === false) {
+        compactHistoryDesktopDropTargetRef.current = null;
+        return;
+      }
+      if (!detail?.sessionId || typeof detail.desktopOverAvatar !== 'boolean') return;
+      compactHistoryDesktopDropTargetRef.current = {
+        sessionId: detail.sessionId,
+        overTarget: detail.desktopOverAvatar,
+        timestamp: Number.isFinite(Number(detail.timestamp)) ? Number(detail.timestamp) : Date.now(),
+      };
+    }
+
+    window.addEventListener('neko:compact-history-drag-desktop-target-change', handleDesktopDropTargetChange);
+    return () => {
+      window.removeEventListener('neko:compact-history-drag-desktop-target-change', handleDesktopDropTargetChange);
+    };
+  }, []);
+
+  const translateButtonNode = (
+    <button
+      className={`composer-tool-btn composer-translate-btn${translateEnabled ? ' is-active' : ''}`}
+      type="button"
+      aria-label={resolvedTranslateAriaLabel}
+      aria-pressed={translateEnabled}
+      title={translateButtonLabel}
+      disabled={composerDisabled}
+      onClick={() => onTranslateToggle?.()}
+    >
+      <img src="/static/icons/translate_icon.png" alt="" aria-hidden="true" />
+    </button>
+  );
+
+  const jukeboxButtonNode = (
+    <button
+      className="composer-tool-btn"
+      type="button"
+      aria-label={jukeboxButtonAriaLabel}
+      title={jukeboxButtonLabel}
+      disabled={composerDisabled}
+      onClick={() => onJukeboxClick?.()}
+    >
+      <img src="/static/icons/jukebox_icon.png" alt="" aria-hidden="true" />
+    </button>
+  );
+
+  const galgameToggleButtonNode = (
+    <button
+      className={`composer-tool-btn composer-galgame-btn${galgameModeEnabled ? ' is-active' : ''}`}
+      type="button"
+      aria-label={resolvedGalgameAriaLabel}
+      aria-pressed={galgameModeEnabled}
+      title={galgameToggleButtonLabel}
+      disabled={composerDisabled}
+      onClick={() => onGalgameModeToggle?.()}
+    >
+      <span className="composer-galgame-btn-glyph" aria-hidden="true">G</span>
+    </button>
+  );
+
+  const emojiToolMenuNode = (
+    <div className="composer-tool-menu" ref={toolMenuRef}>
+      <button
+        className={`composer-tool-btn composer-emoji-btn${toolMenuOpen || activeToolItem ? ' is-active' : ''}`}
+        type="button"
+        aria-label={selectedEmojiButtonAriaLabel}
+        title={selectedEmojiButtonAriaLabel}
+        aria-controls={toolMenuOpen ? 'composer-tool-popover' : undefined}
+        aria-expanded={toolMenuOpen}
+        disabled={composerDisabled}
+        onClick={() => {
+          if (activeToolItem) {
+            clearActiveCursorToolSelection();
+            return;
+          }
+          setToolMenuOpen(open => !open);
+        }}
+      >
+        <img
+          src={activeToolMenuVisual?.imagePath || '/static/icons/emoji_icon.png'}
+          style={activeToolItem ? {
+            transform: `translate(${activeToolMenuVisual?.offsetX ?? 0}px, ${activeToolMenuVisual?.offsetY ?? 0}px) scale(${activeToolItem.menuIconScale ?? 1})`,
+          } : undefined}
+          alt=""
+          aria-hidden="true"
+        />
+      </button>
+      {activeToolItem ? (
+        <button
+          className="composer-tool-clear-btn"
+          type="button"
+          aria-label={clearCursorToolAriaLabel}
+          title={clearCursorToolAriaLabel}
+          disabled={composerDisabled}
+          onClick={(event) => {
+            event.stopPropagation();
+            setIsCursorInsideHostWindow(true);
+            setActiveCursorToolId(null);
+            setToolMenuOpen(false);
+          }}
+        >
+          <span aria-hidden="true">脳</span>
+        </button>
+      ) : null}
+      {toolMenuOpen ? (
+        <div
+          id="composer-tool-popover"
+          className="composer-icon-popover"
+          role="group"
+          aria-label={toolIconsAriaLabel}
+        >
+          {toolIconItems.map(item => {
+            const itemLabel = getToolItemLabel(item);
+            const menuVariant = activeCursorToolId === item.id
+              ? effectiveCursorVariant
+              : 'primary';
+            const menuVisual = resolveMenuIconVisual(item, menuVariant);
+            return (
+            <button
+              key={item.id}
+              className={`composer-icon-button${activeCursorToolId === item.id ? ' is-active' : ''}`}
+              type="button"
+              aria-pressed={activeCursorToolId === item.id}
+              aria-label={itemLabel}
+              title={itemLabel}
+              disabled={composerDisabled}
+              onClick={(event) => {
+                latestPointerPositionRef.current = {
+                  x: event.clientX,
+                  y: event.clientY,
+                };
+                latestPointerTargetRef.current = event.currentTarget;
+                setIsCursorInsideHostWindow(true);
+                setIsCursorOverCompactCursorZone(true);
+                setCursorOverAvatarRange(
+                  isPointerWithinAvatarRange(event.clientX, event.clientY, avatarToolCacheState),
+                  { allowHold: true },
+                );
+                if (activeCursorToolId === item.id) {
+                  setActiveCursorToolId(null);
+                  setToolMenuOpen(false);
+                  return;
+                }
+                setAvatarRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
+                setOutsideRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
+                setActiveCursorToolId(item.id);
+                setToolMenuOpen(false);
+              }}
+            >
+              <img
+                className="composer-icon-button-image"
+                src={menuVisual.imagePath}
+                style={{
+                  transform: `translate(${menuVisual.offsetX}px, ${menuVisual.offsetY}px) scale(${item.menuIconScale ?? 1})`,
+                }}
+                alt=""
+                aria-hidden="true"
+              />
+            </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+
+  const compactFanCloseOnAction = (
+    action: (() => void) | undefined,
+    options?: { deferDesktopAction?: boolean },
+  ) => (event: ReactMouseEvent) => {
     if (shouldSuppressCompactToolClick(event)) {
       event.preventDefault();
       event.stopPropagation();
       return;
     }
-    compactInputToolFanOpenIntentRef.current = 'click';
-    clearCompactInputToolFanCloseTimer();
-    action?.();
+    closeCompactInputToolFan({
+      afterClose: action,
+      deferDesktopAction: options?.deferDesktopAction,
+    });
   };
 
   const compactFanToggleOnAction = (action: (() => void) | undefined) => (event: ReactMouseEvent) => {
@@ -4722,8 +3495,6 @@ function CompactChatApp({
       event.stopPropagation();
       return;
     }
-    compactInputToolFanOpenIntentRef.current = 'click';
-    clearCompactInputToolFanCloseTimer();
     action?.();
   };
 
@@ -4750,102 +3521,14 @@ function CompactChatApp({
 
   const getCompactToolWheelSlotValue = (toolIndex: number): string => {
     const slot = getCompactToolWheelSlot(toolIndex);
-    if (slot !== null) return String(slot);
-
-    const forwardDistance = (toolIndex - compactInputToolWheelIndex + COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT) % COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT;
-    if (forwardDistance === 3) return 'hidden-forward';
-    if (forwardDistance === COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT - 3) return 'hidden-backward';
-    return 'hidden';
+    return slot === null ? 'hidden' : String(slot);
   };
 
   const compactInputToolFanActionsDisabled = composerDisabled
     || !compactInputToolFanOpen
     || !compactInputToolFanInteractive;
-  const compactInputToolWheelChargeLapRatio = compactInputToolWheelChargeRatio * 2;
-  const compactInputToolWheelChargeFirstLapAngle = Math.round(
-    Math.min(1, compactInputToolWheelChargeLapRatio) * 360,
-  );
-  const compactInputToolWheelChargeSecondLapAngle = Math.round(
-    Math.min(1, Math.max(0, compactInputToolWheelChargeLapRatio - 1)) * 360,
-  );
-  const compactInputToolWheelChargeStyle = {
-    '--compact-tool-wheel-charge-first-angle': `${compactInputToolWheelChargeFirstLapAngle}deg`,
-    '--compact-tool-wheel-charge-second-angle': `${compactInputToolWheelChargeSecondLapAngle}deg`,
-  } as CSSProperties;
-  const compactToolToggleVisible = isCompactSurface && !composerHidden;
-  const compactToolToggleActsAsSubmit = effectiveCompactChatState === 'input' && compactInputHasPayload;
-  const compactInputToolToggleButton = compactToolToggleVisible ? (
-    <button
-      className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
-      ref={compactInputToolToggleRef}
-      type={compactToolToggleActsAsSubmit ? 'submit' : 'button'}
-      data-compact-no-drag="true"
-      aria-label={compactToolToggleActsAsSubmit ? sendButtonLabel : overflowMenuAriaLabel}
-      aria-haspopup={compactToolToggleActsAsSubmit ? undefined : 'true'}
-      aria-expanded={compactToolToggleActsAsSubmit ? undefined : compactInputToolFanOpen}
-      disabled={compactToolToggleActsAsSubmit ? !canSubmit : composerDisabled}
-      onPointerEnter={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverEnter}
-      onPointerLeave={compactToolToggleActsAsSubmit ? undefined : handleCompactInputToolHoverLeave}
-      onPointerDown={compactToolToggleActsAsSubmit ? undefined : beginCompactToolOriginDrag}
-      onPointerMove={compactToolToggleActsAsSubmit ? undefined : updateCompactToolOriginDrag}
-      onPointerUp={compactToolToggleActsAsSubmit ? undefined : endCompactToolOriginDrag}
-      onPointerCancel={compactToolToggleActsAsSubmit ? undefined : endCompactToolOriginDrag}
-      onFocus={compactToolToggleActsAsSubmit ? undefined : clearCompactInputToolFanCloseTimer}
-      onBlur={compactToolToggleActsAsSubmit ? scheduleCompactInputCollapse : () => {
-        scheduleCompactInputToolFanTransientClose();
-        scheduleCompactInputCollapse();
-      }}
-      onClick={compactToolToggleActsAsSubmit ? undefined : () => {
-        // 拖动文本框后补发的 click 已在 origin-drag 里置位抑制，这里消费掉，避免误展开/收起轮盘。
-        if (compactToolOriginSuppressClickRef.current) {
-          compactToolOriginSuppressClickRef.current = false;
-          return;
-        }
-        toggleCompactInputToolFanByClick();
-      }}
-    >
-      <img
-        className={compactToolToggleActsAsSubmit ? undefined : 'compact-input-tool-toggle-icon'}
-        src={compactToolToggleActsAsSubmit ? '/static/icons/send_new_icon.png' : '/static/icons/dropdown_arrow.png'}
-        alt=""
-        aria-hidden="true"
-      />
-    </button>
-  ) : null;
 
-  // compact 输入框/胶囊左侧毛绒球：点按=折叠为 minimized（毛绒球小窗口），按住拖>6px=拖动整个 surface。
-  // 复用与右侧工具轮盘原点对偶的 origin-drag 手势：data-compact-no-drag 让宿主被动 hit-test 不重复起拖，
-  // 真正拖拽经 neko:compact-surface-drag-grab 交宿主接管（web: startDrag / Electron: preload 原生窗口拖拽）。
-  const compactMinimizeButton = (
-    <button
-      type="button"
-      className="compact-chat-minimize-ball"
-      aria-label={i18n('chat.reactWindowMinimize', 'Minimize')}
-      title={i18n('chat.reactWindowMinimize', 'Minimize')}
-      data-compact-no-drag="true"
-      onPointerDown={beginCompactToolOriginDrag}
-      onPointerMove={updateCompactToolOriginDrag}
-      onPointerUp={endCompactToolOriginDrag}
-      onPointerCancel={endCompactToolOriginDrag}
-      onClick={() => {
-        // 拖动后补发的 click 已在 origin-drag 里置位抑制，这里消费掉；仅「无拖动的纯点按」折叠。
-        if (compactToolOriginSuppressClickRef.current) {
-          compactToolOriginSuppressClickRef.current = false;
-          return;
-        }
-        onCompactMinimizeRequest?.();
-      }}
-    >
-      <img
-        className="compact-chat-minimize-ball-icon"
-        src="/static/assets/neko-idle/chat-minimized-yarn-ball.png"
-        alt=""
-        aria-hidden="true"
-      />
-    </button>
-  );
-
-  const compactInputToolFanNode = compactToolToggleVisible ? (
+  const compactInputToolFanNode = isCompactSurface && effectiveCompactChatState === 'input' ? (
     <div
       ref={compactInputToolFanRef}
       className="compact-input-tool-fan"
@@ -4853,14 +3536,8 @@ function CompactChatApp({
       aria-label={overflowMenuAriaLabel}
       data-compact-geometry-item="toolFan"
       data-compact-geometry-owner="surface"
-      data-compact-no-drag="true"
       data-compact-input-tool-fan-open={compactInputToolFanOpen ? 'true' : 'false'}
       data-compact-input-tool-fan-interactive={compactInputToolFanInteractive ? 'true' : 'false'}
-      data-compact-tool-wheel-layout={compactInputToolWheelLayout}
-      data-compact-tool-wheel-fast-animation={compactInputToolWheelFastAnimation ? 'true' : 'false'}
-      data-compact-tool-wheel-charge-active={compactInputToolWheelChargeRatio > 0 ? 'true' : 'false'}
-      data-compact-tool-wheel-charge-direction={compactInputToolWheelChargeDirection === 1 ? 'forward' : compactInputToolWheelChargeDirection === -1 ? 'backward' : 'none'}
-      data-compact-tool-wheel-charge-release-active={compactInputToolWheelChargeReleaseActive ? 'true' : 'false'}
       aria-hidden={compactInputToolFanOpen ? 'false' : 'true'}
       onPointerEnter={handleCompactInputToolHoverEnter}
       onPointerLeave={handleCompactInputToolHoverLeave}
@@ -4873,7 +3550,6 @@ function CompactChatApp({
       onClickCapture={(event) => {
         if (
           compactInputToolWheelSuppressClickRef.current
-          || compactToolOriginSuppressClickRef.current
           || (compactInputToolFanOpen && !compactInputToolFanInteractiveRef.current)
         ) {
           event.preventDefault();
@@ -4900,13 +3576,9 @@ function CompactChatApp({
             && localY <= COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE
           );
         if (!isOriginClick) return;
-        // 按在轮盘中心：保持原有「即时收起 + 抑制随后 click」语义（既有命中测试依赖此路径），
-        // 同时额外开启原点拖拽追踪——setPointerCapture 让 fan 关闭后仍能收到 pointermove/up，
-        // 以便检测是否要拖动文本框。stopPropagation 阻止冒泡 onPointerDown 启动轮盘旋转。
         event.preventDefault();
         event.stopPropagation();
         markCompactToolFanOriginClickSuppressed();
-        beginCompactToolOriginDrag(event);
       }}
       onPointerDown={(event) => {
         if (event.pointerType === 'mouse' && event.button !== 0) return;
@@ -4928,29 +3600,16 @@ function CompactChatApp({
             && localY <= COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE
           );
         if (isOriginClick) {
-          // 防御：通常 onPointerDownCapture 已 stopPropagation 接管原点；这里兜底维持原收起语义。
           event.preventDefault();
           event.stopPropagation();
           markCompactToolFanOriginClickSuppressed();
           return;
         }
         const captureTarget = event.target instanceof Element ? event.target : event.currentTarget;
-        const dragPoint = getCompactToolWheelBoundedDragPoint(event.clientX, event.clientY);
-        clearCompactInputToolWheelChargeReleaseTimer();
-        resetCompactInputToolWheelCharge();
         compactInputToolWheelSuppressClickRef.current = false;
-        // 清掉可能残留的原点拖拽抑制（上次原点拖拽若无补发 click），避免误吞这次轮盘按钮 click。
-        compactToolOriginSuppressClickRef.current = false;
-        compactInputToolWheelDragActiveRef.current = true;
-        dispatchCompactToolWheelDragState(true, event.pointerId);
-        clearCompactInputToolFanCloseTimer();
-        scheduleCompactInputToolWheelDragGuardRelease();
         compactInputToolWheelPointerRef.current = {
           id: event.pointerId,
-          x: dragPoint.x,
-          y: dragPoint.y,
-          angle: dragPoint.angle,
-          angleRemainder: 0,
+          x: event.clientX,
           didRotate: false,
           captureTarget,
         };
@@ -4959,41 +3618,35 @@ function CompactChatApp({
         } catch (_) {}
       }}
       onPointerMove={(event) => {
-        if (compactToolOriginDragRef.current) {
-          updateCompactToolOriginDrag(event);
+        const pointerState = compactInputToolWheelPointerRef.current;
+        if (!pointerState || pointerState.id !== event.pointerId) return;
+        if (event.pointerType === 'mouse' && event.buttons === 0) {
+          finishCompactToolWheelPointer(event);
           return;
         }
-        updateCompactInputToolWheelDrag({
-          pointerId: event.pointerId,
-          clientX: event.clientX,
-          clientY: event.clientY,
-          buttons: event.buttons,
-          pointerType: event.pointerType,
-          preventDefault: () => event.preventDefault(),
-        });
+        const deltaX = event.clientX - pointerState.x;
+        const stepCount = Math.floor(Math.abs(deltaX) / COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD);
+        if (stepCount <= 0) return;
+        event.preventDefault();
+        const direction = deltaX < 0 ? 1 : -1;
+        for (let step = 0; step < stepCount; step += 1) {
+          rotateCompactInputToolWheel(direction);
+        }
+        pointerState.x += direction === 1
+          ? -(stepCount * COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD)
+          : stepCount * COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD;
+        pointerState.didRotate = true;
       }}
-      onWheel={rotateCompactInputToolWheelByScroll}
       onPointerUp={(event) => {
-        if (compactToolOriginDragRef.current) {
-          endCompactToolOriginDrag(event);
-          return;
-        }
         finishCompactToolWheelPointer(event);
       }}
       onPointerCancel={(event) => {
-        if (compactToolOriginDragRef.current) {
-          endCompactToolOriginDrag(event);
-          return;
-        }
+        finishCompactToolWheelPointer(event);
+      }}
+      onLostPointerCapture={(event) => {
         finishCompactToolWheelPointer(event);
       }}
     >
-      <div className="compact-input-tool-fan-hit-region" aria-hidden="true" />
-      <div
-        className="compact-input-tool-wheel-charge"
-        style={compactInputToolWheelChargeStyle}
-        aria-hidden="true"
-      />
       <button
         className="composer-tool-btn compact-input-tool-item compact-input-tool-item-import"
         type="button"
@@ -5003,7 +3656,7 @@ function CompactChatApp({
         tabIndex={getCompactToolWheelTabIndex(0)}
         aria-hidden={getCompactToolWheelAriaHidden(0)}
         data-compact-tool-wheel-slot={getCompactToolWheelSlotValue(0)}
-        onClick={compactFanRunAction(onComposerImportImage)}
+        onClick={compactFanCloseOnAction(onComposerImportImage)}
       >
         <img src="/static/icons/import_image_icon.png" alt="" aria-hidden="true" />
       </button>
@@ -5016,7 +3669,7 @@ function CompactChatApp({
         tabIndex={getCompactToolWheelTabIndex(1)}
         aria-hidden={getCompactToolWheelAriaHidden(1)}
         data-compact-tool-wheel-slot={getCompactToolWheelSlotValue(1)}
-        onClick={compactFanRunAction(onComposerScreenshot)}
+        onClick={compactFanCloseOnAction(onComposerScreenshot)}
       >
         <img src="/static/icons/screenshot_new_icon.png" alt="" aria-hidden="true" />
       </button>
@@ -5059,22 +3712,22 @@ function CompactChatApp({
         tabIndex={getCompactToolWheelTabIndex(4)}
         aria-hidden={getCompactToolWheelAriaHidden(4)}
         data-compact-tool-wheel-slot={getCompactToolWheelSlotValue(4)}
-        onClick={compactFanRunAction(onJukeboxClick)}
+        onClick={compactFanCloseOnAction(onJukeboxClick)}
       >
         <img src="/static/icons/jukebox_icon.png" alt="" aria-hidden="true" />
       </button>
       <button
-        className={`composer-tool-btn compact-input-tool-item compact-input-tool-item-export${compactExportControlsVisible ? ' is-active' : ''}`}
+        className={`composer-tool-btn compact-input-tool-item compact-input-tool-item-export${compactExportHistoryOpen ? ' is-active' : ''}`}
         type="button"
-        aria-label={compactExportControlsButtonLabel}
-        aria-pressed={compactExportControlsVisible}
-        title={compactExportControlsButtonLabel}
+        aria-label={compactExportHistoryButtonLabel}
+        aria-pressed={compactExportHistoryOpen}
+        title={compactExportHistoryButtonLabel}
         disabled={compactInputToolFanActionsDisabled}
         tabIndex={getCompactToolWheelTabIndex(5)}
         aria-hidden={getCompactToolWheelAriaHidden(5)}
         data-compact-tool-wheel-slot={getCompactToolWheelSlotValue(5)}
-        data-compact-tool-active={compactExportControlsVisible ? 'true' : 'false'}
-        onClick={compactFanRunAction(handleCompactExportControlsToggle)}
+        data-compact-tool-active={compactExportHistoryOpen ? 'true' : 'false'}
+        onClick={compactFanCloseOnAction(handleCompactExportConversationClick, { deferDesktopAction: true })}
       >
         <svg viewBox="0 0 1024 1024" width="24" height="24" fill="currentColor" aria-hidden="true">
           <path d="M855.467 501.333c-17.067 0-32 14.934-32 32v198.4c0 70.4-59.734 130.134-130.134 130.134H356.267c-83.2 0-151.467-66.134-151.467-149.334V358.4c0-64 53.333-117.333 117.333-117.333h168.534c17.066 0 32-14.934 32-32s-14.934-32-32-32H322.133c-100.266 0-181.333 81.066-181.333 181.333v352c0 117.333 96 213.333 215.467 213.333h337.066c106.667 0 194.134-87.466 194.134-194.133V533.333c0-17.066-14.934-32-32-32zM680.533 256H761.6L458.667 569.6A30.933 30.933 0 0 0 480 622.933c8.533 0 17.067-4.266 23.467-10.666l305.066-313.6v89.6c0 17.066 14.934 32 32 32s32-14.934 32-32v-147.2c0-27.734-23.466-51.2-51.2-51.2h-140.8c-17.066 0-32 14.933-32 32s14.934 34.133 32 34.133z" />
@@ -5085,7 +3738,6 @@ function CompactChatApp({
         ref={toolMenuRef}
         aria-hidden={getCompactToolWheelAriaHidden(6)}
         data-compact-tool-wheel-slot={getCompactToolWheelSlotValue(6)}
-        data-compact-tool-active={toolMenuOpen || activeToolItem ? 'true' : 'false'}
       >
         <button
           className={`composer-tool-btn composer-emoji-btn${toolMenuOpen || activeToolItem ? ' is-active' : ''}`}
@@ -5104,6 +3756,7 @@ function CompactChatApp({
             }
             if (activeToolItem) {
               clearActiveCursorToolSelection();
+              closeCompactInputToolFan();
               return;
             }
             compactInputToolFanOpenIntentRef.current = 'click';
@@ -5138,9 +3791,10 @@ function CompactChatApp({
               setIsCursorInsideHostWindow(true);
               setActiveCursorToolId(null);
               setToolMenuOpen(false);
+              closeCompactInputToolFan();
             }}
           >
-            <span className="composer-tool-clear-icon" aria-hidden="true" />
+            <span aria-hidden="true">脳</span>
           </button>
         ) : null}
       </div>
@@ -5186,12 +3840,14 @@ function CompactChatApp({
                 if (activeCursorToolId === item.id) {
                   setActiveCursorToolId(null);
                   setToolMenuOpen(false);
+                  closeCompactInputToolFan();
                   return;
                 }
                 setAvatarRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setOutsideRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setActiveCursorToolId(item.id);
                 setToolMenuOpen(false);
+                closeCompactInputToolFan();
               }}
             >
               <img
@@ -5210,81 +3866,6 @@ function CompactChatApp({
       ) : null}
     </div>
   ) : null;
-  const composerAttachmentPreviewNode = composerAttachments.length > 0 ? (
-    <div
-      className={`composer-attachment-viewport${isCompactSurface ? ' composer-attachment-viewport-compact' : ''}`}
-      aria-label={composerAttachmentsAriaLabel}
-      data-compact-geometry-item={isCompactSurface ? 'attachments' : undefined}
-      data-compact-geometry-owner={isCompactSurface ? 'surface' : undefined}
-      data-compact-no-drag={isCompactSurface ? 'true' : undefined}
-    >
-      <div className="composer-attachments" role="list">
-        {composerAttachments.map((attachment) => (
-          <figure key={attachment.id} className="composer-attachment-card" role="listitem">
-            <img
-              className="composer-attachment-image"
-              src={attachment.url}
-              alt={attachment.alt || ''}
-              loading="lazy"
-            />
-            <button
-              className="composer-attachment-remove"
-              type="button"
-              aria-label={`${removeAttachmentButtonAriaLabel}: ${attachment.alt || attachment.id}`}
-              aria-disabled={composerDisabled}
-              disabled={composerDisabled}
-              onClick={() => {
-                if (!composerDisabled) {
-                  onComposerRemoveAttachment?.(attachment.id);
-                }
-              }}
-            >
-              <span className="composer-attachment-remove-icon" aria-hidden="true" />
-            </button>
-          </figure>
-        ))}
-      </div>
-    </div>
-  ) : null;
-
-  function prepareComposerOptionMarquee(
-    event: ReactMouseEvent<HTMLButtonElement> | ReactFocusEvent<HTMLButtonElement>,
-  ) {
-    const button = event.currentTarget;
-    const text = button.querySelector<HTMLElement>('.composer-galgame-option-text');
-    const inner = button.querySelector<HTMLElement>('.composer-galgame-option-text-inner');
-
-    button.removeAttribute('data-composer-option-marquee');
-    button.style.removeProperty('--composer-option-marquee-distance');
-    button.style.removeProperty('--composer-option-marquee-duration');
-
-    if (!text || !inner) return;
-
-    const overflowDistance = Math.ceil(inner.scrollWidth - text.clientWidth);
-    if (overflowDistance <= COMPOSER_OPTION_MARQUEE_MIN_DISTANCE) return;
-
-    const distance = overflowDistance + COMPOSER_OPTION_MARQUEE_END_PADDING;
-
-    const duration = Math.min(
-      Math.max(
-        Math.ceil((distance / COMPOSER_OPTION_MARQUEE_PIXELS_PER_SECOND) * 1000),
-        COMPOSER_OPTION_MARQUEE_MIN_DURATION_MS,
-      ),
-      COMPOSER_OPTION_MARQUEE_MAX_DURATION_MS,
-    );
-
-    button.style.setProperty('--composer-option-marquee-distance', `${distance}px`);
-    button.style.setProperty('--composer-option-marquee-duration', `${duration}ms`);
-    button.setAttribute('data-composer-option-marquee', 'true');
-  }
-
-  function clearComposerOptionMarquee(
-    event: ReactMouseEvent<HTMLButtonElement> | ReactFocusEvent<HTMLButtonElement>,
-  ) {
-    event.currentTarget.removeAttribute('data-composer-option-marquee');
-    event.currentTarget.style.removeProperty('--composer-option-marquee-distance');
-    event.currentTarget.style.removeProperty('--composer-option-marquee-duration');
-  }
 
   const choiceLayerNode = (
     <div
@@ -5292,7 +3873,6 @@ function CompactChatApp({
       ref={isCompactSurface ? compactChoiceLayerRef : undefined}
       data-compact-geometry-item={isCompactSurface ? 'choice' : undefined}
       data-compact-geometry-owner={isCompactSurface ? 'surface' : undefined}
-      data-compact-no-drag={isCompactSurface ? 'true' : undefined}
       data-choice-layer-open={compactChoiceLayerOpen ? 'true' : 'false'}
       data-chat-surface-mode={chatSurfaceMode}
       data-compact-choice-placement={isCompactSurface ? compactChoiceLayerPlacement : undefined}
@@ -5313,12 +3893,9 @@ function CompactChatApp({
                     key={`${index}-${option.label}`}
                     type="button"
                     className="composer-galgame-option"
+                    title={option.text}
                     disabled={composerDisabled || galgameOptionsLoading}
                     tabIndex={compactChoiceLayerOpen && galgameOptionsVisible ? 0 : -1}
-                    onMouseEnter={prepareComposerOptionMarquee}
-                    onMouseLeave={clearComposerOptionMarquee}
-                    onFocus={prepareComposerOptionMarquee}
-                    onBlur={clearComposerOptionMarquee}
                     onClick={() => {
                       if (submittingRef.current) return;
                       submittingRef.current = true;
@@ -5332,9 +3909,7 @@ function CompactChatApp({
                     }}
                   >
                     <span className="composer-galgame-option-label" aria-hidden="true">{option.label}.</span>
-                    <span className="composer-galgame-option-text">
-                      <span className="composer-galgame-option-text-inner">{option.text}</span>
-                    </span>
+                    <span className="composer-galgame-option-text">{option.text}</span>
                   </button>
                 ))
               : galgameOptionsLoading
@@ -5347,9 +3922,7 @@ function CompactChatApp({
                       tabIndex={-1}
                     >
                       <span className="composer-galgame-option-label" aria-hidden="true">{label}.</span>
-                      <span className="composer-galgame-option-text">
-                        <span className="composer-galgame-option-text-inner">{galgameLoadingLabel}</span>
-                      </span>
+                      <span className="composer-galgame-option-text">{galgameLoadingLabel}</span>
                     </button>
                   ))
                 : null}
@@ -5374,11 +3947,8 @@ function CompactChatApp({
                 key={`${index}-${option.choice}`}
                 type="button"
                 className="composer-galgame-option composer-choice-option"
+                title={option.label}
                 disabled={composerDisabled}
-                onMouseEnter={prepareComposerOptionMarquee}
-                onMouseLeave={clearComposerOptionMarquee}
-                onFocus={prepareComposerOptionMarquee}
-                onBlur={clearComposerOptionMarquee}
                 onClick={() => {
                   if (submittingRef.current) return;
                   submittingRef.current = true;
@@ -5392,7 +3962,7 @@ function CompactChatApp({
                 }}
               >
                 <span className="composer-galgame-option-text composer-choice-option-text">
-                  <span className="composer-galgame-option-text-inner">{option.label}</span>
+                  {option.label}
                 </span>
               </button>
             ))}
@@ -5405,20 +3975,24 @@ function CompactChatApp({
     ? (typeof document !== 'undefined' ? createPortal(choiceLayerNode, document.body) : choiceLayerNode)
     : null;
 
-  const compactExportHistoryMessages = compactExportHistoryOpen
-    ? messages
-    : (compactExportHistoryClosingMessages || messages);
-  const compactExportHistoryElement = isCompactSurface && compactExportHistoryMounted ? (
+  const messageListNode = (
+    <MessageList
+      messages={messages}
+      ariaLabel={messageListAriaLabel}
+      failedStatusLabel={failedStatusLabel}
+      onAction={onMessageAction}
+    />
+  );
+  const compactExportHistoryElement = isCompactSurface && compactExportHistoryOpen ? (
     <CompactExportHistoryPanel
-      messages={compactExportHistoryMessages}
+      messages={messages}
       selectedIds={compactExportSelectedIds}
       selectedCount={compactExportSelectedCount}
       selectableCount={compactExportSelectableCount}
       autoScrollToBottom={compactExportAutoScrollToBottom}
       previewOpen={compactExportPreviewOpen}
-      controlsOpen={compactExportControlsOpen}
+      controlsOpen={false}
       choiceLayerAbove={compactChoiceLayerOpen && compactChoiceLayerPlacement === 'above'}
-      visibilityState={compactExportHistoryOpen ? 'open' : 'closing'}
       failedStatusLabel={failedStatusLabel}
       onAutoScrollToBottomChange={setCompactExportAutoScrollToBottom}
       onToggleMessage={handleCompactExportToggleMessage}
@@ -5430,49 +4004,9 @@ function CompactChatApp({
       onBuildPreview={handleCompactInlineBuildPreview}
       onCopyExport={handleCompactInlineCopyExport}
       onDownloadExport={handleCompactInlineDownloadExport}
-      historyResizeActive={compactHistoryResizeActive}
-      onHistoryResizePointerDown={handleCompactHistoryResizePointerDown}
-      onHistoryResizePointerMove={handleCompactHistoryResizePointerMove}
-      onHistoryResizePointerUp={handleCompactHistoryResizePointerUp}
-      onHistoryResizePointerCancel={handleCompactHistoryResizePointerCancel}
     />
   ) : null;
   const compactExportHistoryNode = compactExportHistoryElement;
-  const compactHistoryVisibilityHandleNode = isCompactSurface ? (
-    <button
-      className={`compact-history-visibility-handle${compactExportHistoryOpen ? ' is-open' : ''}`}
-      type="button"
-      aria-label={compactExportHistoryToggleLabel}
-      aria-expanded={compactExportHistoryOpen}
-      title={compactExportHistoryToggleLabel}
-      data-compact-geometry-owner="surface"
-      data-compact-geometry-item="historyHandle"
-      data-compact-no-drag="true"
-      data-compact-history-open={compactExportHistoryOpen ? 'true' : 'false'}
-      onPointerDown={handleCompactHistoryVisibilityPress}
-      onPointerCancel={handleCompactHistoryVisibilityPointerCancel}
-      onPointerLeave={handleCompactHistoryVisibilityPointerCancel}
-      onClick={handleCompactHistoryVisibilityClick}
-    >
-      <span className="compact-history-visibility-handle-triangle" aria-hidden="true" />
-    </button>
-  ) : null;
-  const compactMusicPlayerVisibility = compactExportHistoryOpen
-    ? 'open'
-    : (compactExportHistoryMounted ? 'closing' : 'closed');
-  const compactMusicPlayerMountNode = isCompactSurface ? (
-    <div
-      id="music-player-mount"
-      className="compact-music-player-mount"
-      data-music-player-mount="compact-surface"
-      data-compact-music-player-visibility={compactMusicPlayerVisibility}
-      data-compact-geometry-owner="surface"
-      data-compact-geometry-item="musicPlayer"
-      data-compact-geometry-hit-scope="children"
-      data-compact-no-drag="true"
-      aria-hidden={compactMusicPlayerVisibility === 'open' ? undefined : true}
-    />
-  ) : null;
   const compactSurfaceShellStyle = isCompactSurface
     && compactSurfaceEffectiveWidth !== null
     && !isDesktopCompactSurfaceLayoutActive()
@@ -5498,7 +4032,11 @@ function CompactChatApp({
         />
       </div>
     </section>
-  ) : null;
+  ) : (
+    <section className="chat-body">
+      {messageListNode}
+    </section>
+  );
 
   return (
     <main
@@ -5507,15 +4045,11 @@ function CompactChatApp({
       data-chat-surface-mode={chatSurfaceMode}
       data-compact-chat-state={effectiveCompactChatState}
       data-compact-export-history-open={isCompactSurface && compactExportHistoryOpen ? 'true' : 'false'}
-      data-compact-export-controls-open={isCompactSurface && compactExportControlsVisible ? 'true' : 'false'}
       data-compact-export-preview-open={isCompactSurface && compactExportPreviewOpen ? 'true' : 'false'}
       data-compact-export-selected-count={isCompactSurface ? compactExportSelectedCount : 0}
       data-compact-export-auto-scroll={isCompactSurface && compactExportAutoScrollToBottom ? 'true' : 'false'}
-      data-compact-tool-layer-open={isCompactSurface && compactInputToolFanOpen ? 'true' : 'false'}
     >
       {compactExportHistoryNode}
-      {compactHistoryVisibilityHandleNode}
-      {compactMusicPlayerMountNode}
       {compactChoiceLayerNode}
       {floatingFistDrops.map(drop => (
         <span
@@ -5641,7 +4175,35 @@ function CompactChatApp({
           data-chat-surface-mode={chatSurfaceMode}
           data-compact-chat-state={effectiveCompactChatState}
         >
-          {!isCompactSurface ? <div id="music-player-mount" className="composer-music-player-mount" /> : null}
+          <div id="music-player-mount" />
+          {composerAttachments.length > 0 ? (
+            <div className="composer-attachments" aria-label={composerAttachmentsAriaLabel}>
+              {composerAttachments.map((attachment) => (
+                <figure key={attachment.id} className="composer-attachment-card">
+                  <img
+                    className="composer-attachment-image"
+                    src={attachment.url}
+                    alt={attachment.alt || ''}
+                    loading="lazy"
+                  />
+                  <button
+                    className="composer-attachment-remove"
+                    type="button"
+                    aria-label={`${removeAttachmentButtonAriaLabel}: ${attachment.alt || attachment.id}`}
+                    aria-disabled={composerDisabled}
+                    disabled={composerDisabled}
+                    onClick={() => {
+                      if (!composerDisabled) {
+                        onComposerRemoveAttachment?.(attachment.id);
+                      }
+                    }}
+                  >
+                    脳
+                  </button>
+                </figure>
+              ))}
+            </div>
+          ) : null}
           <form className="composer" onSubmit={(event) => {
             event.preventDefault();
             submitDraft();
@@ -5651,16 +4213,21 @@ function CompactChatApp({
                 className="compact-chat-surface-shell"
                 ref={compactInputShellRef}
                 data-compact-chat-state={effectiveCompactChatState}
-                data-compact-tool-layer-open={compactToolToggleVisible && compactInputToolFanOpen ? 'true' : 'false'}
                 style={compactSurfaceShellStyle}
                 onBlurCapture={effectiveCompactChatState === 'input' ? scheduleCompactInputCollapse : undefined}
               >
+                <div
+                  className="compact-chat-drag-handle"
+                  data-compact-drag-handle="true"
+                  data-compact-geometry-item="dragHandle"
+                  data-compact-geometry-owner="surface"
+                  aria-hidden="true"
+                />
                 <div
                   className="compact-chat-resize-handle compact-chat-resize-handle-left"
                   data-compact-resize-side="left"
                   data-compact-geometry-item="resizeHandle"
                   data-compact-geometry-owner="surface"
-                  data-compact-no-drag="true"
                   aria-hidden="true"
                   onPointerDown={(event) => handleCompactSurfaceResizePointerDown('left', event)}
                   onPointerMove={handleCompactSurfaceResizePointerMove}
@@ -5673,7 +4240,6 @@ function CompactChatApp({
                   data-compact-resize-side="right"
                   data-compact-geometry-item="resizeHandle"
                   data-compact-geometry-owner="surface"
-                  data-compact-no-drag="true"
                   aria-hidden="true"
                   onPointerDown={(event) => handleCompactSurfaceResizePointerDown('right', event)}
                   onPointerMove={handleCompactSurfaceResizePointerMove}
@@ -5685,20 +4251,14 @@ function CompactChatApp({
                   className="compact-chat-surface-frame"
                   data-compact-geometry-item={effectiveCompactChatState === 'input' ? 'input' : 'capsule'}
                   data-compact-geometry-owner="surface"
-                  data-compact-drag-surface="true"
                   data-compact-chat-state={effectiveCompactChatState}
                   data-compact-geometry-part={effectiveCompactChatState === 'input' ? 'inputBody' : 'capsuleBody'}
-                  data-compact-tool-toggle-visible={compactToolToggleVisible ? 'true' : 'false'}
                 >
                   {effectiveCompactChatState === 'input' ? (
                     <>
-                      {/* 输入态左侧毛绒球：点按折叠为 minimized，按住拖动整个输入框（见 compactMinimizeButton 定义）。
-                          按住把手不会让 textarea 失焦收起输入态——宿主 mousedown 会 preventDefault。 */}
-                      {compactMinimizeButton}
                       <textarea
                         className="composer-input"
                         ref={compactInputRef}
-                        data-compact-no-drag="true"
                         placeholder={inputPlaceholder}
                         aria-label={inputPlaceholder}
                         rows={1}
@@ -5720,39 +4280,184 @@ function CompactChatApp({
                           }
                         }}
                       />
-                      {compactInputToolToggleButton}
-                    </>
-                  ) : (
-                    <>
-                      {compactMinimizeButton}
                       <button
-                        className="compact-chat-capsule-button"
-                        type="button"
-                        disabled={composerDisabled}
-                        onClick={() => {
-                          if (composerHidden) return;
-                          if (isGuideChatButtonLockActive()) return;
-                          requestCompactChatState('input');
+                        className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
+                        ref={compactInputToolToggleRef}
+                        type={compactInputHasPayload ? 'submit' : 'button'}
+                        aria-label={compactInputHasPayload ? sendButtonLabel : overflowMenuAriaLabel}
+                        aria-haspopup={compactInputHasPayload ? undefined : 'true'}
+                        aria-expanded={compactInputHasPayload ? undefined : compactInputToolFanOpen}
+                        disabled={compactInputHasPayload ? !canSubmit : composerDisabled}
+                        onPointerDown={compactInputHasPayload ? undefined : (event) => {
+                          event.preventDefault();
+                          compactInputToolTogglePointerHandledRef.current = true;
+                          toggleCompactInputToolFanByClick();
+                        }}
+                        onPointerEnter={compactInputHasPayload ? undefined : handleCompactInputToolHoverEnter}
+                        onPointerLeave={compactInputHasPayload ? undefined : handleCompactInputToolHoverLeave}
+                        onFocus={compactInputHasPayload ? undefined : clearCompactInputToolFanCloseTimer}
+                        onBlur={compactInputHasPayload ? scheduleCompactInputCollapse : () => {
+                          scheduleCompactInputToolFanTransientClose();
+                          scheduleCompactInputCollapse();
+                        }}
+                        onClick={compactInputHasPayload ? undefined : () => {
+                          if (compactInputToolTogglePointerHandledRef.current) {
+                            compactInputToolTogglePointerHandledRef.current = false;
+                            return;
+                          }
+                          toggleCompactInputToolFanByClick();
                         }}
                       >
-                        <span
-                          ref={compactPreviewTextRef}
-                          className="compact-chat-capsule-text"
-                          data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
-                          data-compact-preview-scrollable={compactPreviewAllowsScroll ? 'true' : 'false'}
-                          onWheel={handleCompactPreviewWheel}
-                        >
-                          {compactPreviewDisplayContent}
-                        </span>
+                        <img
+                          className={compactInputHasPayload ? undefined : 'compact-input-tool-toggle-icon'}
+                          src={compactInputHasPayload ? '/static/icons/send_new_icon.png' : '/static/icons/dropdown_arrow.png'}
+                          alt=""
+                          aria-hidden="true"
+                        />
                       </button>
-                      {compactInputToolToggleButton}
                     </>
+                  ) : (
+                    <button
+                      className="compact-chat-capsule-button"
+                      type="button"
+                      disabled={composerDisabled}
+                      onClick={() => {
+                        if (composerHidden) return;
+                        requestCompactChatState('input');
+                      }}
+                    >
+                      <span
+                        ref={compactPreviewTextRef}
+                        className="compact-chat-capsule-text"
+                        data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
+                      >
+                        {compactPreviewDisplayText}
+                      </span>
+                    </button>
+	                  )}
+		                </div>
+		                {compactInputToolFanNode}
+		              </div>
+            ) : (
+              <div
+                className="composer-input-shell"
+                data-compact-chat-state={effectiveCompactChatState}
+              >
+              <textarea
+                className="composer-input"
+                placeholder={inputPlaceholder}
+                aria-label={inputPlaceholder}
+                rows={1}
+                value={draft}
+                readOnly={composerDisabled}
+                disabled={composerDisabled}
+                onChange={(event) => { setDraft(event.target.value); }}
+                onKeyDown={(event) => {
+                  if (event.nativeEvent.isComposing) return;
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault();
+                    submitDraft();
+                  }
+                }}
+              />
+              {!isCompactSurface ? choiceLayerNode : null}
+              <div
+                className="composer-bottom-bar"
+                ref={handleComposerBottomBarRef}
+              >
+                <div className="composer-bottom-tools" aria-label={composerToolsAriaLabel}>
+                  <button
+                    className="composer-tool-btn"
+                    type="button"
+                    aria-label={resolvedImportImageAriaLabel}
+                    title={importImageButtonLabel}
+                    disabled={composerDisabled}
+                    onClick={() => onComposerImportImage?.()}
+                  >
+                    <img src="/static/icons/import_image_icon.png" alt="" aria-hidden="true" />
+                  </button>
+                  <span className="composer-tool-divider" aria-hidden="true">|</span>
+                  <button
+                    className="composer-tool-btn"
+                    type="button"
+                    aria-label={resolvedScreenshotAriaLabel}
+                    title={screenshotButtonLabel}
+                    disabled={composerDisabled}
+                    onClick={() => onComposerScreenshot?.()}
+                  >
+                    <img src="/static/icons/screenshot_new_icon.png" alt="" aria-hidden="true" />
+                  </button>
+                  {/* 杩欐潯鍒嗛殧绗﹀湪 expanded / compact 涓ゆ€佷笅閮藉父椹诲悓涓€浣嶇疆锛?                      閬垮厤鍒囨崲鏃跺垎闅旂闂儊锛岃鍔ㄧ敾杩囨浮鏇撮『婊?*/}
+                  <span className="composer-tool-divider" aria-hidden="true">|</span>
+                  {showRightTools ? (
+                    <div
+                      ref={composerToolsRightRef}
+                      className={`composer-tools-right${composerLayout === 'collapsing' ? ' is-leaving' : ''}`}
+                      key="composer-tools-expanded"
+                      style={
+                        composerLayout === 'collapsing' && collapseFromWidth != null
+                          ? ({ '--collapse-from-width': `${collapseFromWidth}px` } as CSSProperties)
+                          : undefined
+                      }
+                    >
+                      {galgameToggleButtonNode}
+                      <span className="composer-tool-divider" aria-hidden="true">|</span>
+                      {translateButtonNode}
+                      <span className="composer-tool-divider" aria-hidden="true">|</span>
+                      {jukeboxButtonNode}
+                      <span className="composer-tool-divider" aria-hidden="true">|</span>
+                      {emojiToolMenuNode}
+                    </div>
+                  ) : (
+                    <div
+                      className={`composer-overflow-menu${composerLayout === 'expanding' ? ' is-leaving' : ''}`}
+                      key="composer-tools-collapsed"
+                      ref={overflowMenuRef}
+                    >
+                      <button
+                        className={`composer-tool-btn composer-overflow-btn${overflowMenuOpen ? ' is-active' : ''}`}
+                        type="button"
+                        aria-label={overflowMenuAriaLabel}
+                        title={overflowMenuAriaLabel}
+                        aria-haspopup="true"
+                        aria-expanded={overflowMenuOpen}
+                        disabled={composerDisabled}
+                        onClick={() => setOverflowMenuOpen(open => !open)}
+                      >
+                        <svg
+                          width="20"
+                          height="20"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <circle cx="6" cy="12" r="2" />
+                          <circle cx="12" cy="12" r="2" />
+                          <circle cx="18" cy="12" r="2" />
+                        </svg>
+                      </button>
+                      {overflowMenuOpen ? (
+                        <div
+                          className="composer-overflow-popover"
+                          role="group"
+                          aria-label={overflowMenuAriaLabel}
+                        >
+                          {galgameToggleButtonNode}
+                          {translateButtonNode}
+                          {jukeboxButtonNode}
+                          {emojiToolMenuNode}
+                        </div>
+                      ) : null}
+                    </div>
                   )}
                 </div>
-                {composerAttachmentPreviewNode}
-                {compactInputToolFanNode}
+                <button className="send-button-circle" type="submit" aria-label={sendButtonLabel} disabled={!canSubmit}>
+                  <img src="/static/icons/send_new_icon.png" alt="" aria-hidden="true" />
+                </button>
               </div>
-            ) : null}
+            </div>
+            )}
           </form>
         </footer>
       </section>

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -3409,7 +3409,7 @@ export default function FullChatSurface({
             setToolMenuOpen(false);
           }}
         >
-          <span aria-hidden="true">脳</span>
+          <span aria-hidden="true">×</span>
         </button>
       ) : null}
       {toolMenuOpen ? (
@@ -3794,7 +3794,7 @@ export default function FullChatSurface({
               closeCompactInputToolFan();
             }}
           >
-            <span aria-hidden="true">脳</span>
+            <span aria-hidden="true">×</span>
           </button>
         ) : null}
       </div>
@@ -4198,7 +4198,7 @@ export default function FullChatSurface({
                       }
                     }}
                   >
-                    脳
+                    ×
                   </button>
                 </figure>
               ))}

--- a/frontend/react-neko-chat/src/message-schema.test.ts
+++ b/frontend/react-neko-chat/src/message-schema.test.ts
@@ -64,14 +64,15 @@ describe('message-schema', () => {
     expect(props.compactChatState).toBe('input');
   });
 
-  it('migrates the legacy "full" surface mode to compact instead of throwing', () => {
+  it('accepts the revived "full" surface mode', () => {
+    // `full` is the frozen legacy surface revived alongside compact/minimized.
+    // The schema accepts all three; the host dispatcher routes `full` to the
+    // isolated FullChatSurface.
     const props = parseChatWindowProps({
-      // Cast: 'full' is no longer part of the public type but mixed-version
-      // hosts can still send it; the schema must migrate rather than reject.
-      chatSurfaceMode: 'full' as unknown as 'compact',
+      chatSurfaceMode: 'full',
     });
 
-    expect(props.chatSurfaceMode).toBe('compact');
+    expect(props.chatSurfaceMode).toBe('full');
   });
 
   it('accepts an avatar interaction callback in window props', () => {

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -48,16 +48,11 @@ const composerAttachmentSchema = z.object({
   alt: z.string().optional(),
 });
 
-const chatSurfaceModeSchema = z.enum(['compact', 'minimized']);
-// Mixed-version hosts (or any direct NekoChatWindow.mount consumer) may still
-// pass the legacy three-state value 'full' from before the home chat collapsed
-// to compact/minimized. Accept it at the parse boundary and migrate to
-// 'compact' — mirroring the localStorage migration — so the chat window keeps
-// mounting instead of throwing a ZodError. The public output stays two-state.
-const chatSurfaceModeInputSchema = z.preprocess(
-  (value) => (value === 'full' ? 'compact' : value),
-  chatSurfaceModeSchema,
-);
+// `full` is the frozen legacy surface (full chat window) revived alongside the
+// active `compact` floating bar and `minimized` ball. The host dispatcher routes
+// `full` to the isolated FullChatSurface; `compact`/`minimized` stay on the
+// active App. Keep all three valid at the parse boundary.
+const chatSurfaceModeSchema = z.enum(['full', 'compact', 'minimized']);
 const compactChatStateSchema = z.enum(['default', 'options', 'input']);
 
 const galgameOptionSchema = z.object({
@@ -220,7 +215,7 @@ export const chatWindowPropsSchema = z.object({
   exportConversationButtonAriaLabel: z.string().optional(),
   composerHidden: z.boolean().optional(),
   composerDisabled: z.boolean().optional(),
-  chatSurfaceMode: chatSurfaceModeInputSchema.optional(),
+  chatSurfaceMode: chatSurfaceModeSchema.optional(),
   compactChatState: compactChatStateSchema.optional(),
   onCompactChatStateChange: z.function()
     .args(compactChatStateSchema)

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3400,6 +3400,16 @@
                 lastRestorableChatSurfaceMode = previousChatSurfaceMode;
             }
             state.chatSurfaceMode = normalizedChatSurfaceMode;
+            if (surfaceModeChanged) {
+                // setViewProps is a public entry point (exposed + the
+                // `set-view-props` event), so it can land a real surface change —
+                // e.g. an external `{chatSurfaceMode:'full'}`. Mirror
+                // setChatSurfaceMode and persist the restorable preference, else
+                // the switch is lost on reload (readChatSurfaceModePreference
+                // returns the stale value). persistChatSurfaceModePreference
+                // no-ops for minimized, which still restores via lastRestorable.
+                persistChatSurfaceModePreference(normalizedChatSurfaceMode);
+            }
         }
         if (Object.prototype.hasOwnProperty.call(nextProps, 'compactChatState')) {
             state.compactChatState = normalizeCompactChatState(nextProps.compactChatState);

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3385,10 +3385,12 @@
 
     function setViewProps(nextViewProps) {
         var nextProps = nextViewProps || {};
+        var surfaceModeChanged = false;
         if (Object.prototype.hasOwnProperty.call(nextProps, 'chatSurfaceMode')) {
             var normalizedChatSurfaceMode = normalizeChatSurfaceMode(nextProps.chatSurfaceMode);
             var previousChatSurfaceMode = getCurrentChatSurfaceMode();
-            if (normalizedChatSurfaceMode !== previousChatSurfaceMode
+            surfaceModeChanged = normalizedChatSurfaceMode !== previousChatSurfaceMode;
+            if (surfaceModeChanged
                 && !Object.prototype.hasOwnProperty.call(nextProps, 'compactChatState')) {
                 resetCompactChatState();
             }
@@ -3407,6 +3409,16 @@
             compactChatState: getCurrentCompactChatState()
         });
         renderWindow();
+        // setViewProps can now land a real surface change (e.g. compact -> the
+        // revived `full`) because normalizeChatSurfaceMode preserves all three
+        // modes. renderWindow only updates the React tree; the host shell's
+        // data-chat-surface-mode attribute — which the compact CSS rules key off —
+        // is owned by syncChatSurfaceModeUI, so sync it here too or the shell keeps
+        // the stale mode and compact chrome leaks onto the new surface. (Minimize
+        // transitions still route through setChatSurfaceMode/setMinimized.)
+        if (surfaceModeChanged) {
+            syncChatSurfaceModeUI();
+        }
         return state.viewProps;
     }
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -60,7 +60,13 @@
     var lastRestorableChatSurfaceMode = 'compact';
     var _sortKeySeq = 0; // monotonically increasing sortKey counter
     var COMPACT_CHAT_STATES = ['default', 'options', 'input'];
+    // The active compact↔minimized cycle. `full` is intentionally NOT here: it is
+    // the frozen legacy surface, entered only via an explicit setChatSurfaceMode
+    // ('full') (e.g. the NEKO-PC tray toggle), never by cycling through compact.
     var CHAT_SURFACE_MODE_SEQUENCE = ['compact', 'minimized'];
+    // Full set of valid surface modes for normalization. Keeps `full` a first-class
+    // mode the host honors when set, without letting it pollute the compact cycle.
+    var CHAT_SURFACE_MODES = ['full', 'compact', 'minimized'];
 
     var state = {
         viewProps: null,
@@ -101,8 +107,7 @@
     };
 
     function normalizeChatSurfaceMode(mode) {
-        if (mode === 'full') return 'compact';
-        return CHAT_SURFACE_MODE_SEQUENCE.indexOf(mode) >= 0 ? mode : 'compact';
+        return CHAT_SURFACE_MODES.indexOf(mode) >= 0 ? mode : 'compact';
     }
 
     function normalizeCompactChatState(mode) {
@@ -164,12 +169,13 @@
         }
         try {
             var raw = localStorage.getItem(CHAT_SURFACE_MODE_STORAGE_KEY);
-            // The storage key only ever holds the restorable surface ('compact').
-            // Migrate any legacy value persisted by the old three-state build
-            // ('full') or a stray 'minimized' back to 'compact' so stale values
-            // don't linger in storage. Any other value (or first run) just
-            // resolves to 'compact' without an extra write.
-            if (raw === 'full' || raw === 'minimized') {
+            // The storage key holds the last restorable surface: 'compact'
+            // (default) or 'full' (frozen legacy, entered via the NEKO-PC tray
+            // toggle, which has its own per-window storage). Web never persists
+            // 'full' since it exposes no toggle yet. Migrate a stray 'minimized'
+            // back to 'compact' so a minimized value never lingers in storage.
+            if (raw === 'full') return 'full';
+            if (raw === 'minimized') {
                 localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, 'compact');
             }
             return 'compact';
@@ -179,7 +185,9 @@
     }
 
     function persistChatSurfaceModePreference(mode) {
-        if (mode !== 'compact') return;
+        // Persist only the restorable surfaces (compact/full); minimized restores
+        // to lastRestorableChatSurfaceMode rather than being persisted directly.
+        if (mode !== 'compact' && mode !== 'full') return;
         if (!shouldPersistChatSurfaceModePreference()) return;
         try {
             localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode);

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -81,7 +81,9 @@ def test_chat_surface_mode_preference_is_shared_with_electron():
     assert "electron-chat-window" not in gate_block
     assert "return true;" in gate_block
     assert "localStorage.getItem(CHAT_SURFACE_MODE_STORAGE_KEY)" in read_block
-    assert "if (mode !== 'compact') return;" in persist_block
+    # Restorable surfaces (compact + the revived legacy full) persist; minimized
+    # never does — it restores via lastRestorableChatSurfaceMode.
+    assert "if (mode !== 'compact' && mode !== 'full') return;" in persist_block
     assert "localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode)" in persist_block
 
 


### PR DESCRIPTION
## 背景
`1afbc8d1d` 把 react-neko-chat 的 **full** 聊天 surface（完整窗口：历史列表 + 完整 composer）整个删掉了，只留 compact 悬浮条 + minimized。本 PR 把 full **复活**回来，作为**冻结的 legacy 历史遗产**——以后所有迭代只在 compact 上做，full 与 compact **严格代码隔离**。

> 这是 Phase B 的**第一块（主仓 React + host shim）**。Electron 侧的 full/compact 托盘切换开关 + full 原生大窗口在另一个仓（lanlan_frd）并行推进，单独 PR。

## 改了什么
- **`FullChatSurface.tsx`（新）**：删除前那版 `App.tsx`（`1afbc8d1d^`，full 还能用的最后一版）的**冻结快照**，自带独立 state。只删掉一簇引用「已删类型」的 compact-history-drag 死代码（4 处编译错误），其余原样保留。文件头有显眼注释标明「冻结、勿改、迭代走 compact」。
- **`App.tsx`**：顶部加**无 hooks 的 dispatcher**（默认导出 `ChatWindowRoot`）按 mode 分派——`full → FullChatSurface`，`compact/minimized → 现有 App`（改名内部 `CompactChatApp`，**几乎零改动**）。两子树互斥挂载，hooks/state 彻底隔离：full 模式下 compact 的 hook 一个都不跑，反之亦然。
- **`message-schema.ts`**：加回 `'full'` enum，去掉 `full→compact` 迁移。
- **`app-react-chat-window.js`（host shim）**：新增 `CHAT_SURFACE_MODES=['full','compact','minimized']` 让 normalize/persist/read 认 full；`CHAT_SURFACE_MODE_SEQUENCE` **仍是** `['compact','minimized']`——full **不掺进** compact 的 cycle（`toggleMinimized` 用它，动它会改坏现有循环）。

## 为什么用「冻结快照」而非手搓
full 的 composer 深度依赖头像光标工具系统等共享基础设施。整段快照对现有 compact **零触碰**、行为与删除前**完全一致**，调和尾巴也意外地短（只有一簇 compact 死代码 + 1 处 panel prop 漂移）。符合「full 冻结、宁可冗长也不复用 compact」的取向。

## 验证
- `vitest` **169 全过**（含新加的 full 渲染冒烟：full 模式渲染历史列表 + 完整 composer，且**不渲染** compact surface；compact 零回归）。
- `pytest` 静态 **31 全过**（更新 persist 断言）。
- `npm run build` 干净：`tsc -b` 全量类型检查过、bundle 含 FullChatSurface、CSS 同步。full 的 CSS 类一直都在 styles.css 里，会带样式渲染。
- ⚠️ 待人工验证三条路径：index.html 宽屏 / 窄宽(<768px) / chat.html Electron。

## 范围说明
- full 全平台可达（web 端入口）留作 future TODO（走新 endpoint，不用 flag），单独提 issue。
- 本 PR 默认形态仍是 **compact**，不回归现有体验；full 暂只能由 Electron 托盘（后续 PR）显式切入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 将“完整表面（Full）”作为正式可选显示模式，切换时呈现独立的完整输入区与消息列表视图。
* **修复**
  * 聊天表面模式偏好仅持久化可还原模式（compact 与 full）；切换时主界面样式会同步更新，避免紧凑视图残留。
* **文档**
  * 更新紧凑模式设计说明，明确 full 为冻结 legacy，划清与 compact/minimized 的边界。
* **测试**
  * 新增/调整测试覆盖 full 模式渲染、偏好持久化及紧凑视图未挂载断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->