### PR TITLE
feat: add web full chat endpoint

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -281,6 +281,20 @@ async def get_chat_page(request: Request):
     templates = get_templates()
     return templates.TemplateResponse("templates/chat.html", {
         "request": request,
+        "initial_chat_surface_mode": "compact",
+        **_vrm_defaults_ctx(),
+        **_static_assets_ctx(),
+        **_react_chat_assets_ctx(),
+    })
+
+
+@router.get("/chat_full", response_class=HTMLResponse)
+async def get_chat_full_page(request: Request):
+    """Web 专用完整聊天窗口页面"""
+    templates = get_templates()
+    return templates.TemplateResponse("templates/chat.html", {
+        "request": request,
+        "initial_chat_surface_mode": "full",
         **_vrm_defaults_ctx(),
         **_static_assets_ctx(),
         **_react_chat_assets_ctx(),

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -184,6 +184,17 @@
         }
     }
 
+    function readInitialChatSurfaceMode() {
+        var body = document.body;
+        var declaredMode = body
+            ? normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))
+            : 'compact';
+        if (declaredMode === 'full') {
+            return 'full';
+        }
+        return readChatSurfaceModePreference();
+    }
+
     function persistChatSurfaceModePreference(mode) {
         // Persist only the restorable surfaces (compact/full); minimized restores
         // to lastRestorableChatSurfaceMode rather than being persisted directly.
@@ -5451,7 +5462,7 @@
         var avatarHeaderButton = $('avatarPreviewHeaderButton');
 
         ensureViewProps();
-        state.chatSurfaceMode = readChatSurfaceModePreference();
+        state.chatSurfaceMode = readInitialChatSurfaceMode();
         lastRestorableChatSurfaceMode = state.chatSurfaceMode;
         resetCompactChatState();
         state.viewProps = Object.assign({}, ensureViewProps(), {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -186,9 +186,10 @@
 
     function readInitialChatSurfaceMode() {
         var body = document.body;
-        var declaredMode = body
-            ? normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))
-            : 'compact';
+        var declaredModeAttr = body
+            ? body.getAttribute('data-initial-chat-surface-mode')
+            : '';
+        var declaredMode = declaredModeAttr ? normalizeChatSurfaceMode(declaredModeAttr) : '';
         if (declaredMode === 'compact' || declaredMode === 'full') {
             return declaredMode;
         }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -189,8 +189,8 @@
         var declaredMode = body
             ? normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))
             : 'compact';
-        if (declaredMode === 'full') {
-            return 'full';
+        if (declaredMode === 'compact' || declaredMode === 'full') {
+            return declaredMode;
         }
         return readChatSurfaceModePreference();
     }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -6,6 +6,21 @@
 let lanlan_config = {
     lanlan_name: ""
 };
+
+const RESERVED_PAGE_PATHS = new Set([
+    'api',
+    'chat',
+    'chat_full',
+    'focus',
+    'static',
+    'templates',
+    'toast',
+]);
+
+function isReservedPagePath(pathname) {
+    const pathParts = String(pathname || '').split('/').filter(Boolean);
+    return pathParts.length > 0 && RESERVED_PAGE_PATHS.has(pathParts[0]);
+}
 window.lanlan_config = lanlan_config;
 let cubism4Model = "";
 let vrmModel = "";
@@ -68,7 +83,7 @@ async function loadPageConfig() {
         // 从路径中提取 lanlan_name (例如 /{lanlan_name})
         if (!lanlanNameFromUrl) {
             const pathParts = window.location.pathname.split('/').filter(Boolean);
-            if (pathParts.length > 0 && !['focus', 'api', 'static', 'templates', 'chat', 'toast'].includes(pathParts[0])) {
+            if (pathParts.length > 0 && !RESERVED_PAGE_PATHS.has(pathParts[0])) {
                 lanlanNameFromUrl = decodeURIComponent(pathParts[0]);
             }
         }
@@ -300,7 +315,7 @@ window.startPageConfigLoad = function startPageConfigLoad() {
                 await window.__nekoStorageLocationStartupBarrier;
             }
 
-            if (window.__NEKO_MULTI_WINDOW__ && window.location.pathname === '/chat') {
+            if (window.__NEKO_MULTI_WINDOW__ && isReservedPagePath(window.location.pathname)) {
                 return resolvePageConfig(await startMultiWindowPageConfigLoad());
             }
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -472,7 +472,8 @@
         }
     </style>
 </head>
-<body class="electron-chat-window subtitle-web-host">
+<body class="electron-chat-window subtitle-web-host"
+      data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default('compact', true) }}">
 
     <div id="status-toast"></div>
     <div id="yui-guide-chat-spotlight" hidden>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="/static/css/index.css?v={{ static_asset_version }}">
     <link rel="stylesheet" href="/static/css/subtitle.css?v={{ static_asset_version }}">
     <link rel="stylesheet" href="/static/css/dark-mode.css?v={{ static_asset_version }}">
-    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ static_asset_version }}">
+    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ react_chat_asset_version }}">
     <script src="/static/theme-manager.js?v={{ static_asset_version }}"></script>
     <link rel="stylesheet" href="/static/libs/APlayer.min.css?v={{ static_asset_version }}">
     <script src="/static/libs/APlayer.min.js?v={{ static_asset_version }}"></script>
@@ -676,7 +676,7 @@
          mutation 共用 window.nekoLocalMutationSecurity 拿 X-CSRF-Token；必须
          在 app-react-chat-window.js 之前加载，与 index.html 同序。 -->
     <script src="/static/app-prompt-shared.js?v={{ static_asset_version }}"></script>
-    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ static_asset_version }}"></script>
+    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ react_chat_asset_version }}"></script>
     <script src="/static/app-react-chat-window.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-chat-adapter.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-chat-export.js?v={{ static_asset_version }}"></script>

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -8,6 +8,7 @@ MUSIC_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "music_ui.js"
 MUSIC_UI_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "music_ui.css"
 STATIC_INDEX_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "index.css"
 STATIC_DARK_MODE_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "dark-mode.css"
+STATIC_INDEX_JS_PATH = Path(__file__).resolve().parents[2] / "static" / "js" / "index.js"
 REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "styles.css"
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
 CHAT_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "chat.html"
@@ -103,6 +104,16 @@ def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
     )[0]
     assert '"initial_chat_surface_mode": "compact"' in chat_route_block
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
+
+
+def test_chat_full_is_reserved_from_character_page_config_routing():
+    source = STATIC_INDEX_JS_PATH.read_text(encoding="utf-8")
+
+    assert "const RESERVED_PAGE_PATHS = new Set([" in source
+    assert "'chat'" in source
+    assert "'chat_full'" in source
+    assert "RESERVED_PAGE_PATHS.has(pathParts[0])" in source
+    assert "isReservedPagePath(window.location.pathname)" in source
 
 
 def test_chat_host_initial_surface_mode_prefers_template_override_before_storage():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -106,6 +106,13 @@ def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
 
 
+def test_chat_templates_version_react_chat_bundle_from_react_assets():
+    chat_template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert 'neko-chat-window.css?v={{ react_chat_asset_version }}' in chat_template
+    assert 'neko-chat-window.iife.js?v={{ react_chat_asset_version }}' in chat_template
+
+
 def test_chat_full_is_reserved_from_character_page_config_routing():
     source = STATIC_INDEX_JS_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -109,6 +109,13 @@ def test_chat_host_initial_surface_mode_prefers_template_override_before_storage
     source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 
     assert "function readInitialChatSurfaceMode()" in source
+    initial_reader_block = source.split("function readInitialChatSurfaceMode()", 1)[1].split(
+        "function persistChatSurfaceModePreference",
+        1,
+    )[0]
+    assert "if (declaredMode === 'compact' || declaredMode === 'full')" in initial_reader_block
+    assert "return declaredMode;" in initial_reader_block
+
     init_block = source.split("function init()", 1)[1].split(
         "function initAfterStorageBarrier()",
         1,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -12,6 +12,7 @@ REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "rea
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
 CHAT_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "chat.html"
 SUBTITLE_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "subtitle.html"
+PAGES_ROUTER_PATH = Path(__file__).resolve().parents[2] / "main_routers" / "pages_router.py"
 COMPACT_EXPORT_HISTORY_PANEL_PATH = (
     Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "CompactExportHistoryPanel.tsx"
 )
@@ -85,6 +86,39 @@ def test_chat_surface_mode_preference_is_shared_with_electron():
     # never does — it restores via lastRestorableChatSurfaceMode.
     assert "if (mode !== 'compact' && mode !== 'full') return;" in persist_block
     assert "localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode)" in persist_block
+
+
+def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
+    router_source = PAGES_ROUTER_PATH.read_text(encoding="utf-8")
+    template_source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert '@router.get("/chat_full", response_class=HTMLResponse)' in router_source
+    assert '"initial_chat_surface_mode": "full"' in router_source
+    assert '"initial_chat_surface_mode": "compact"' in router_source
+    assert 'data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default(\'compact\', true) }}"' in template_source
+
+    chat_route_block = router_source.split('async def get_chat_page', 1)[1].split(
+        '@router.get("/chat_full"',
+        1,
+    )[0]
+    assert '"initial_chat_surface_mode": "compact"' in chat_route_block
+    assert '"initial_chat_surface_mode": "full"' not in chat_route_block
+
+
+def test_chat_host_initial_surface_mode_prefers_template_override_before_storage():
+    source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    assert "function readInitialChatSurfaceMode()" in source
+    init_block = source.split("function init()", 1)[1].split(
+        "function initAfterStorageBarrier()",
+        1,
+    )[0]
+    initial_assignment = "state.chatSurfaceMode = readInitialChatSurfaceMode();"
+    storage_read = "readChatSurfaceModePreference()"
+
+    assert initial_assignment in init_block
+    assert init_block.index(initial_assignment) < init_block.index("lastRestorableChatSurfaceMode = state.chatSurfaceMode;")
+    assert storage_read not in init_block.split(initial_assignment, 1)[0]
 
 
 def test_close_from_minimized_preserves_compact_surface_mode():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -113,8 +113,13 @@ def test_chat_host_initial_surface_mode_prefers_template_override_before_storage
         "function persistChatSurfaceModePreference",
         1,
     )[0]
+    assert "var declaredModeAttr = body" in initial_reader_block
+    assert "body.getAttribute('data-initial-chat-surface-mode')" in initial_reader_block
+    assert "declaredModeAttr ? normalizeChatSurfaceMode(declaredModeAttr) : ''" in initial_reader_block
+    assert "normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))" not in initial_reader_block
     assert "if (declaredMode === 'compact' || declaredMode === 'full')" in initial_reader_block
     assert "return declaredMode;" in initial_reader_block
+    assert initial_reader_block.index("return declaredMode;") < initial_reader_block.index("return readChatSurfaceModePreference();")
 
     init_block = source.split("function init()", 1)[1].split(
         "function initAfterStorageBarrier()",


### PR DESCRIPTION
## Summary
- 新增 web-only 的 `/chat_full` 路由，复用现有 `templates/chat.html` 并以 full surface 初始化。
- 保持原 `/chat` 默认 compact，不影响 Electron 托盘切换和 PC 端入口。
- React Chat host 优先读取模板注入的初始 surface mode，再回退到本地存储偏好。

## Test Plan
- [x] `uv run pytest tests/unit/test_react_chat_window_static.py -q`
- [x] `node --check static/app-react-chat-window.js`
- [x] `uv run python -m py_compile main_routers/pages_router.py`
- [x] `git diff --check`
- [x] live check: `/chat` 注入 compact，`/chat_full` 注入 full

Closes #1682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增可直接以“全屏”模式打开的聊天页面路由。

* **改进**
  * 前端初始化现在优先采用页面声明的初始聊天显示模式（紧凑或全屏），通过页面属性传递该模式，优先于本地存储偏好。
  * 路由识别逻辑引入保留路径判定，以支持多窗口/页面加载分支并统一保留页处理。

* **测试**
  * 增加静态测试，覆盖保留路径、模板注入的初始模式及前端优先级行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->