### PR TITLE
feat(chat): full web 几何/默认 + 呼吸灯折叠球 + compact 原地折叠 + 文档

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -466,6 +466,16 @@ uv run python app/agent_server.py
 # 5. 访问 http://localhost:48911 配置 API Key 并开始使用
 ```
 
+**调试聊天界面形态（full / compact）**：Web 端默认 `full`（完整聊天窗口），Electron 端默认 `compact`（悬浮对话条）。在浏览器控制台用 localStorage 切换测试（硬刷新生效）：
+
+```js
+localStorage.setItem('neko.reactChatWindow.chatSurfaceMode','full');    location.reload(); // 进 full
+localStorage.setItem('neko.reactChatWindow.chatSurfaceMode','compact'); location.reload(); // 进 compact
+localStorage.removeItem('neko.reactChatWindow.chatSurfaceMode');        location.reload(); // 回默认
+```
+
+形态说明、各形态自测点与三端验证详见 [`docs/design/compact-chat-mode-design.md`](docs/design/compact-chat-mode-design.md) 的「形态切换与本地测试」。
+
 开发者建议加入企鹅群 995414391 交流。
 
 </details>

--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -178,6 +178,46 @@
 4. compact surface 的用户拖动位置只影响 surface，不影响 ball。
 5. 从 compact 切到 minimized 时，桌面端必须同步 native ball 窗口；从 minimized 恢复 compact 时，必须走 compact carrier bounds 而非旧 full 面板尺寸。
 
+> 复活的 `full`（冻结 legacy 完整聊天窗口）不在上述活跃形态链内，由顶层 dispatcher 路由到自包含的 `FullChatSurface.tsx`，与 compact/minimized 严格隔离；它的最小化走独立的「左下角呼吸灯球」支路（见下方「形态切换与本地测试」）。
+
+## 形态切换与本地测试（full / compact / minimized）
+
+`chatSurfaceMode` 有三态：`full`（完整聊天窗口）/ `compact`（悬浮对话条，默认活跃形态）/ `minimized`（折叠球）。
+
+### 默认形态来源
+
+宿主 `static/app-react-chat-window.js` 的 `getDefaultChatSurfaceMode()`（用户无持久化偏好时）：
+
+- **Web / 浏览器** → `full`。
+- **Electron 桌面壳** → `compact`：chat.html（electron chat body class）与 index.html 宠物窗（`window.__LANLAN_IS_ELECTRON_PET__`）都识别为 compact。
+- **显式覆盖**：`window.__NEKO_CHAT_DEFAULT_COMPACT__ = true/false` 优先于上面的运行时识别，强制 compact / full。
+
+用户的显式选择持久化在 `localStorage['neko.reactChatWindow.chatSurfaceMode']`（值只会是 `'full'` 或 `'compact'`；`minimized` 不持久化，恢复时回到 `lastRestorableChatSurfaceMode`）。
+
+### 本地切换 / 测试配方（浏览器控制台，硬刷新生效）
+
+```js
+// 进 full
+localStorage.setItem('neko.reactChatWindow.chatSurfaceMode','full'); location.reload();
+// 进 compact
+localStorage.setItem('neko.reactChatWindow.chatSurfaceMode','compact'); location.reload();
+// 看「默认」形态（清掉显式偏好）
+localStorage.removeItem('neko.reactChatWindow.chatSurfaceMode'); location.reload();
+// 在浏览器里模拟 Electron 的 compact 默认
+window.__NEKO_CHAT_DEFAULT_COMPACT__ = true;
+localStorage.removeItem('neko.reactChatWindow.chatSurfaceMode'); location.reload();
+```
+
+### 各形态自测点
+
+- **full**：渲染完整历史列表 + 完整 composer（底部工具条：导入图片 / 截图 / GalGame / 翻译 / 点歌 / 表情工具 + 发送圆钮；窗口变窄时工具折叠进溢出菜单 `⋯`）。点最小化 → 折向**左下角的蓝色呼吸灯球**（不贴角色、不折出屏幕）；点球展开 → 窗口**居中复位**。full 是冻结快照，行为对齐删除前的 full。
+- **compact**：悬浮对话条 / 字幕胶囊 / 输入态 / 工具轮盘 / 内联历史。点最小化 → **毛线球**并贴到角色/猫（idle dock，这是 compact 刻意的特性）。
+- **minimized**：折叠球；点球恢复回 `lastRestorableChatSurfaceMode`（full 回 full、compact 回 compact）。
+
+### 三端必测（react-neko-chat 改动通用）
+
+`index.html` 宽屏 / `index.html` 窄宽（<768px 纯 CSS 手机版）/ `chat.html`（Electron，Chromium fork，部分 Web API 行为与浏览器不同）。
+
 ## Compact 内部三态
 
 `chatSurfaceMode === 'compact'` 时，内部三态如下。

--- a/docs/design/compact-chat-mode-design.md
+++ b/docs/design/compact-chat-mode-design.md
@@ -210,8 +210,8 @@ localStorage.removeItem('neko.reactChatWindow.chatSurfaceMode'); location.reload
 
 ### 各形态自测点
 
-- **full**：渲染完整历史列表 + 完整 composer（底部工具条：导入图片 / 截图 / GalGame / 翻译 / 点歌 / 表情工具 + 发送圆钮；窗口变窄时工具折叠进溢出菜单 `⋯`）。点最小化 → 折向**左下角的蓝色呼吸灯球**（不贴角色、不折出屏幕）；点球展开 → 窗口**居中复位**。full 是冻结快照，行为对齐删除前的 full。
-- **compact**：悬浮对话条 / 字幕胶囊 / 输入态 / 工具轮盘 / 内联历史。点最小化 → **毛线球**并贴到角色/猫（idle dock，这是 compact 刻意的特性）。
+- **full**：渲染完整历史列表 + 完整 composer（底部工具条：导入图片 / 截图 / GalGame / 翻译 / 点歌 / 表情工具 + 发送圆钮；窗口变窄时工具折叠进溢出菜单 `⋯`）。点最小化 → 折向**左下角的蓝色呼吸灯球**（不贴角色、不折出屏幕、不走 idle dock）；点球展开 → **优先恢复上次拖拽/缩放后的记忆位置，仅在无记忆时居中**（不再回左中）。full 是冻结快照，行为对齐删除前的 full。
+- **compact**：悬浮对话条 / 字幕胶囊 / 输入态 / 工具轮盘 / 内联历史。点最小化 → **毛线球就地折叠**到自身底左锚点附近（不再强制贴角色/猫）。注：CAT2/CAT3 视觉层级（idle tier）下 compact 仍会自动贴猫的 idle dock，那是层级自动触发的特性，不是手动点最小化的行为。
 - **minimized**：折叠球；点球恢复回 `lastRestorableChatSurfaceMode`（full 回 full、compact 回 compact）。
 
 ### 三端必测（react-neko-chat 改动通用）

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -4297,6 +4297,11 @@
     // Enters through chatSurfaceMode so compact/full/minimized state stays in sync.
     function enterIdleDock() {
         if (isElectronChatWindow()) return;
+        // full 完全避开 idle-dock：CAT2/CAT3 视觉层级不应把展开的 full 窗口自动
+        // 最小化成球。这个检查必须在触发最小化之前，而不只在算 dock 位置时
+        // （getIdleDockTarget 的 isLegacyFullMinimizedBall 守卫只能阻止 dock 定位，
+        // 阻止不了 setChatSurfaceMode('minimized') 本身）。
+        if (getCurrentChatSurfaceMode() === 'full' || isLegacyFullMinimizedBall()) return;
 
         if (minimized) {
             // Already minimized — save current position and dock immediately.
@@ -4812,6 +4817,21 @@
                     if (surfaceModeAfterExpand === 'minimized') {
                         return;
                     }
+                    if (surfaceModeAfterExpand === 'full') {
+                        // full 从球展开后 expandedTop = ballBottom - height，球被拖到
+                        // 视口顶部时这会是负值，full 大半跑出屏幕、标题栏够不着。
+                        // syncCompactSurfaceAnchor 只管 compact，对 full 是 no-op，
+                        // 所以这里显式 clamp 进视口（clampPosition 保留标题栏可达）。
+                        var fullShell = getShell();
+                        if (fullShell) {
+                            var fullRect = fullShell.getBoundingClientRect();
+                            var clampedFull = clampPosition(fullRect.left, fullRect.top);
+                            if (clampedFull.left !== fullRect.left || clampedFull.top !== fullRect.top) {
+                                applyPosition(clampedFull.left, clampedFull.top);
+                            }
+                        }
+                        return;
+                    }
                     syncCompactSurfaceAnchor();
                 });
             };
@@ -4861,16 +4881,14 @@
         var btnIcon = getMinimizeIcon();
         var ballIcon = ensureMinimizedBallIcon();
         var surfaceMode = getCurrentChatSurfaceMode();
-        var ariaLabel = surfaceMode === 'compact'
-            ? getI18nText('chat.reactWindowMinimize', '最小化聊天框')
-            : surfaceMode === 'minimized'
-                ? getI18nText('chat.reactWindowRestore', '恢复聊天框')
-                : getI18nText('chat.reactWindowCompact', '切换到紧凑聊天框');
-        var shortLabel = surfaceMode === 'compact'
-            ? getI18nText('chat.reactWindowMinimizeShort', '最小化')
-            : surfaceMode === 'minimized'
-                ? getI18nText('chat.reactWindowRestoreShort', '恢复')
-                : getI18nText('chat.reactWindowCompactShort', '紧凑');
+        // full 与 compact 点头部按钮的真实动作都是「最小化」（getNextChatSurfaceMode
+        // 对二者都返回 'minimized'），所以 full 态也用最小化文案，别再写「切换到紧凑」。
+        var ariaLabel = surfaceMode === 'minimized'
+            ? getI18nText('chat.reactWindowRestore', '恢复聊天框')
+            : getI18nText('chat.reactWindowMinimize', '最小化聊天框');
+        var shortLabel = surfaceMode === 'minimized'
+            ? getI18nText('chat.reactWindowRestoreShort', '恢复')
+            : getI18nText('chat.reactWindowMinimizeShort', '最小化');
         if (button) {
             button.setAttribute('aria-label', ariaLabel);
             button.title = shortLabel;
@@ -5681,7 +5699,13 @@
                         }
                     }
                 } else {
-                    restorePosition();
+                    // full 走 restoreFullPosition()：有记忆位置才还原、无记忆保持居中，
+                    // 不能像 compact/minimized 那样走 restorePosition() → 被甩回左中。
+                    if (getCurrentChatSurfaceMode() === 'full') {
+                        restoreFullPosition();
+                    } else {
+                        restorePosition();
+                    }
                     syncCompactSurfaceAnchor();
                     scheduleMobileContentLayout();
                 }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -19,6 +19,11 @@
     var GALGAME_HISTORY_LIMIT = 6;
     var EVENT_PREFIX = 'react-chat-window:';
     var CHAT_MINIMIZED_BALL_ICON_SRC = '/static/assets/neko-idle/chat-minimized-yarn-ball.png';
+    // Frozen legacy `full` keeps its era's minimized orb — the glowing "breathing
+    // light" ball (old icon + box-shadow pulse from full-chat-minimize.css) —
+    // instead of the active compact yarn ball. Strictly gated on the restorable
+    // surface being full so the compact minimize path is untouched.
+    var CHAT_MINIMIZED_BALL_LEGACY_FULL_ICON_SRC = '/static/icons/expand_icon_off_ball.png';
 
     var loadedPromise = null;
     var mounted = false;
@@ -146,15 +151,36 @@
         if (normalized === 'minimized') {
             return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
         }
-        var currentIndex = CHAT_SURFACE_MODE_SEQUENCE.indexOf(normalized);
-        var nextIndex = currentIndex >= 0
-            ? (currentIndex + 1) % CHAT_SURFACE_MODE_SEQUENCE.length
-            : 0;
-        return CHAT_SURFACE_MODE_SEQUENCE[nextIndex];
+        // Any real surface — compact or the revived legacy full — minimizes to the
+        // ball; restoring returns to the last real surface via the branch above.
+        // full is deliberately kept out of CHAT_SURFACE_MODE_SEQUENCE so it never
+        // pollutes the compact cycle, but that made the old index-based fallback
+        // resolve full -> sequence[0] -> compact, which surfaced as "full minimize
+        // jumps to compact". Minimizing is the same intent from either surface.
+        return 'minimized';
     }
 
     function resetCompactChatState() {
         state.compactChatState = 'default';
+    }
+
+    // Default surface when the user has no persisted preference yet.
+    //   - Web / browser → `full` (the complete chat window).
+    //   - Electron desktop shell → `compact` (the floating bar): the chat window
+    //     (chat.html, electron chat body class) and the pet window (index.html,
+    //     __LANLAN_IS_ELECTRON_PET__) both opt into compact.
+    // An explicit `window.__NEKO_CHAT_DEFAULT_COMPACT__` boolean overrides either
+    // way, so a host can force the default without relying on the markers above.
+    function getDefaultChatSurfaceMode() {
+        try {
+            if (window.__NEKO_CHAT_DEFAULT_COMPACT__ === true) return 'compact';
+            if (window.__NEKO_CHAT_DEFAULT_COMPACT__ === false) return 'full';
+        } catch (_) {}
+        if (isElectronChatWindow()) return 'compact';
+        try {
+            if (window.__LANLAN_IS_ELECTRON_PET__) return 'compact';
+        } catch (_) {}
+        return 'full';
     }
 
     function shouldPersistChatSurfaceModePreference() {
@@ -164,23 +190,24 @@
     }
 
     function readChatSurfaceModePreference() {
+        var fallback = getDefaultChatSurfaceMode();
         if (!shouldPersistChatSurfaceModePreference()) {
-            return 'compact';
+            return fallback;
         }
         try {
             var raw = localStorage.getItem(CHAT_SURFACE_MODE_STORAGE_KEY);
-            // The storage key holds the last restorable surface: 'compact'
-            // (default) or 'full' (frozen legacy, entered via the NEKO-PC tray
-            // toggle, which has its own per-window storage). Web never persists
-            // 'full' since it exposes no toggle yet. Migrate a stray 'minimized'
-            // back to 'compact' so a minimized value never lingers in storage.
+            // The storage key holds the last restorable surface: 'compact' or the
+            // revived legacy 'full'. An explicit stored choice wins; otherwise we
+            // fall back to the per-runtime default (web=full / Electron=compact).
+            // A stray 'minimized' never lingers — rewrite it to the fallback.
             if (raw === 'full') return 'full';
+            if (raw === 'compact') return 'compact';
             if (raw === 'minimized') {
-                localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, 'compact');
+                localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, fallback);
             }
-            return 'compact';
+            return fallback;
         } catch (_) {
-            return 'compact';
+            return fallback;
         }
     }
 
@@ -2429,6 +2456,20 @@
         }
     }
 
+    // full 专属位置恢复（桌面）：有用户拖/缩后记住的位置就还原过去，否则保持 base
+    // CSS 的居中（top/left:50% + translate）。绝不退回 restorePosition() 的
+    // positionWindowAtLeftMiddle() —— 那会把完整窗口甩到屏幕左中。
+    function restoreFullPosition() {
+        if (isMobileWidth()) return;
+        var shell = getShell();
+        if (!shell) return;
+        var stored = getStoredPosition();
+        if (!stored) return; // 无记忆位置 → 维持 CSS 居中
+        restoreSize();
+        applyPosition(stored.left, stored.top);
+        rememberExpandedShellPosition(stored.left, stored.top);
+    }
+
     function mountWindow() {
         var root = getRoot();
         if (!root) return false;
@@ -3629,6 +3670,10 @@
     }
 
     function getIdleDockTarget() {
+        // The revived legacy full never docks its minimized orb to the idle cat —
+        // it collapses in place and stays put (pre-deletion behavior). Compact's
+        // CAT2/CAT3 return-cat dock is untouched.
+        if (isLegacyFullMinimizedBall()) return null;
         if (!idleDockActive || !isIdleDockTierActive()) return null;
         var container = getVisibleReturnButtonContainer();
         if (!container || typeof container.getBoundingClientRect !== 'function') return null;
@@ -4344,17 +4389,20 @@
     // target.left 应等于 rect.left 同列，target 底边应与 rect 底边对齐
     // （即 target.top = rect.bottom - target.height），这样动画过程中底边不漂移。
     function getMinimizedTarget(rect) {
-        var compactBallTarget = getCompactMinimizeBallTarget();
-        if (compactBallTarget) {
-            return compactBallTarget;
-        }
-
-        // 桌面端和移动端统一使用圆形毛线球
+        // Both full and compact collapse to the surface's OWN bottom-left corner:
+        // the dialog folds toward its bottom-left pivot (transform-origin 0% 100%)
+        // and the orb appears right there — NOT compact's avatar/cat dock
+        // (getCompactMinimizeBallTarget) and without the cat-leaning
+        // MINIMIZED_DOWN_OFFSET. This is the pre-#1506 in-place behaviour.
+        // Best-effort for compact: the orb stays where the bar was; carrying a
+        // dragged-orb position into the next expand is the deferred follow-up
+        // (needs the compact surface to become a free-positioned window).
+        // Web-only — Electron short-circuits in setMinimized before this runs.
         return {
             width: MINIMIZED_SIZE,
             height: MINIMIZED_SIZE,
             left: Math.max(0, Math.min(rect.left, window.innerWidth - MINIMIZED_SIZE)),
-            top: Math.max(0, Math.min(rect.bottom - MINIMIZED_SIZE + MINIMIZED_DOWN_OFFSET, window.innerHeight - MINIMIZED_SIZE))
+            top: Math.max(0, Math.min(rect.bottom - MINIMIZED_SIZE, window.innerHeight - MINIMIZED_SIZE))
         };
     }
 
@@ -4383,6 +4431,16 @@
             }
         }
 
+        if (isLegacyFullMinimizedBall()) {
+            // Legacy full expands FROM the ball: the orb may have been dragged
+            // while minimized, so the inline expand logic recomputes the dialog
+            // from ballLeft/ballBottom (球的左下角 = 对话框的左下角). Opt out of any
+            // saved-window-position pin here by returning null. (#1506 三态重构前的
+            // 老 full 行为。) Window-position memory across refresh is handled
+            // separately by restoreFullPosition() on open.
+            return null;
+        }
+
         var expandedTargetPosition = savedExpandedShellPosition
             || getStoredPosition()
             || (savedShellPosition
@@ -4408,6 +4466,29 @@
         isMinimizeTransitioning = false;
     }
 
+    // The minimized ball belongs to the surface we'll restore to: the revived
+    // legacy full uses its breathing-light orb, every other surface (compact)
+    // keeps the yarn ball. Gated purely on lastRestorableChatSurfaceMode so the
+    // compact path never sees a behavior change.
+    function isLegacyFullMinimizedBall() {
+        return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode) === 'full';
+    }
+
+    function applyMinimizedBallSkin(ballIcon) {
+        var legacyFull = isLegacyFullMinimizedBall();
+        if (ballIcon) {
+            ballIcon.src = legacyFull
+                ? CHAT_MINIMIZED_BALL_LEGACY_FULL_ICON_SRC
+                : CHAT_MINIMIZED_BALL_ICON_SRC;
+        }
+        var shell = getShell();
+        if (shell) {
+            // Glow only renders together with .is-minimized (see
+            // full-chat-minimize.css); harmless while full is expanded.
+            shell.classList.toggle('is-legacy-full-ball', legacyFull);
+        }
+    }
+
     function ensureMinimizedBallIcon() {
         var shell = getShell();
         if (!shell) return null;
@@ -4415,7 +4496,9 @@
         if (!icon) {
             icon = document.createElement('img');
             icon.className = 'react-chat-minimized-icon';
-            icon.src = CHAT_MINIMIZED_BALL_ICON_SRC;
+            icon.src = isLegacyFullMinimizedBall()
+                ? CHAT_MINIMIZED_BALL_LEGACY_FULL_ICON_SRC
+                : CHAT_MINIMIZED_BALL_ICON_SRC;
             icon.alt = '';
             icon.draggable = false;
             var handle = getHeader();
@@ -4540,10 +4623,17 @@
             void shell.offsetHeight; // 强制 reflow
 
             // 5. 设置目标 transform，触发动画
+            //    full + compact 都：动画期间 left/top **不动**，只缩放（origin 左下角），
+            //    让对话框以自己的左下角为支点原地收缩成球；finishCollapse 再把（已缩成
+            //    球大小的）shell snap 到左下角球位置，视觉无缝。这是 #1506 三态重构前的
+            //    原地折叠行为（best effort：compact 折叠原地、不再滑去贴模型/猫）。
+            var collapseHoldsPosition = true;
             requestAnimationFrame(function () {
                 requestAnimationFrame(function () {
-                    shell.style.left = targetLeft + 'px';
-                    shell.style.top = targetTop + 'px';
+                    if (!collapseHoldsPosition) {
+                        shell.style.left = targetLeft + 'px';
+                        shell.style.top = targetTop + 'px';
+                    }
                     shell.style.transform = 'scale(' + sx + ', ' + sy + ')';
                 });
             });
@@ -4569,6 +4659,11 @@
                 shell.style.left = targetLeft + 'px';
                 shell.style.top = targetTop + 'px';
                 shell.classList.add('is-minimized');
+                // The ball icon is created once at init (when the restorable
+                // surface is usually compact); re-apply the skin now so a
+                // minimize from the revived legacy full shows its breathing-light
+                // orb instead of the stale compact yarn ball.
+                applyMinimizedBallSkin(ensureMinimizedBallIcon());
                 isMinimizeTransitioning = false;
             };
             var onEnd = function (e) {
@@ -4755,10 +4850,9 @@
             btnIcon.src = minimized ? '/static/icons/expand_icon_on.png' : '/static/icons/expand_icon_off.png';
             btnIcon.alt = minimized ? getI18nText('chat.reactWindowRestore', '恢复聊天框') : getI18nText('chat.reactWindowMinimize', '最小化聊天框');
         }
-        // 重置悬浮球图标到默认态（清除可能残留的 hover 图标）
-        if (ballIcon) {
-            ballIcon.src = CHAT_MINIMIZED_BALL_ICON_SRC;
-        }
+        // 重置悬浮球图标到默认态（清除可能残留的 hover 图标），并按 restorable 形态
+        // 选皮肤：compact=毛线球 / full=呼吸灯旧球。
+        applyMinimizedBallSkin(ballIcon);
     }
 
     function syncChatSurfaceModeUI() {
@@ -4785,9 +4879,7 @@
             btnIcon.src = minimized ? '/static/icons/expand_icon_on.png' : '/static/icons/expand_icon_off.png';
             btnIcon.alt = ariaLabel;
         }
-        if (ballIcon) {
-            ballIcon.src = CHAT_MINIMIZED_BALL_ICON_SRC;
-        }
+        applyMinimizedBallSkin(ballIcon);
         if (shell) {
             shell.setAttribute('data-chat-surface-mode', surfaceMode);
             shell.setAttribute('data-compact-chat-state', getCurrentCompactChatState());
@@ -4880,6 +4972,9 @@
                     if (getCurrentChatSurfaceMode() === 'compact') {
                         syncCompactSurfaceAnchor();
                         scheduleCompactMinimizeBallTracking();
+                    } else if (getCurrentChatSurfaceMode() === 'full') {
+                        // 刷新/打开时还原 full 记住的位置（无记忆则保持居中）。
+                        restoreFullPosition();
                     }
                     scheduleMobileContentLayout();
                 }
@@ -5046,6 +5141,11 @@
             // 最小化态下不持久化悬浮球坐标到展开态存储，
             // 否则 restorePosition 会把完整窗口放到悬浮球位置
             // 移动端坐标也不持久化，避免污染桌面端保存的位置
+            // full 是可拖动的完整窗口：拖完记住位置，刷新/展开后回到这里（不再每次居中）。
+            if (!minimized && !isMobileWidth() && getCurrentChatSurfaceMode() === 'full') {
+                rememberExpandedShellPosition(rect.left, rect.top);
+                persistPosition(rect.left, rect.top);
+            }
         }
 
         dragState = null;
@@ -5297,6 +5397,11 @@
                 try {
                     localStorage.setItem(MOBILE_HEIGHT_STORAGE_KEY, String(mobileUserHeight));
                 } catch (_) {}
+            } else if (getCurrentChatSurfaceMode() === 'full') {
+                // full 是可调整大小的完整窗口：记住尺寸与位置，刷新/展开后还原。
+                persistPosition(rect.left, rect.top);
+                persistSize(rect.width, rect.height);
+                rememberExpandedShellPosition(rect.left, rect.top);
             }
         }
 
@@ -5530,13 +5635,13 @@
                 if (!minimized) return;
                 var shell = getShell();
                 var ico = shell && shell.querySelector('.react-chat-minimized-icon');
-                if (ico) ico.src = CHAT_MINIMIZED_BALL_ICON_SRC;
+                applyMinimizedBallSkin(ico);
             });
             header.addEventListener('mouseleave', function () {
                 if (!minimized) return;
                 var shell = getShell();
                 var ico = shell && shell.querySelector('.react-chat-minimized-icon');
-                if (ico) ico.src = CHAT_MINIMIZED_BALL_ICON_SRC;
+                applyMinimizedBallSkin(ico);
             });
         }
 

--- a/static/css/full-chat-minimize.css
+++ b/static/css/full-chat-minimize.css
@@ -1,0 +1,36 @@
+/*
+ * Frozen legacy `full` surface — minimized "breathing light" orb.
+ *
+ * The active compact surface minimizes to the yarn ball (#1625). The revived
+ * legacy `full` surface keeps its own era's minimized ball: the glowing blue
+ * "breathing light" orb that #1625 removed (old icon expand_icon_off_ball.png +
+ * pulsing box-shadow). This file revives ONLY that glow, strictly scoped to the
+ * `is-legacy-full-ball` marker the host shim sets when the restorable surface is
+ * `full`, so the compact minimize path (yarn ball, no glow) is never touched.
+ *
+ * Pure additive layer over the base `.is-minimized` ball geometry in index.css —
+ * loaded via index.css @import. Do not generalize; full is frozen.
+ */
+
+body.subtitle-web-host #react-chat-window-shell.is-minimized.is-legacy-full-ball {
+  box-shadow: 0 0 8px rgba(68, 183, 254, 0.6);
+  animation: neko-full-legacy-ball-breathing 2s ease-in-out infinite;
+  will-change: box-shadow;
+}
+
+@keyframes neko-full-legacy-ball-breathing {
+  0%,
+  100% {
+    box-shadow: 0 0 8px rgba(68, 183, 254, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 16px rgba(68, 183, 254, 1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.subtitle-web-host #react-chat-window-shell.is-minimized.is-legacy-full-ball {
+    animation: none;
+    box-shadow: 0 0 10px rgba(68, 183, 254, 0.8);
+  }
+}

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,4 +1,7 @@
 @import url('base.css');
+/* Frozen legacy `full` minimized breathing-light orb — isolated, gated on
+   .is-legacy-full-ball; never affects the compact yarn ball. */
+@import url('full-chat-minimize.css');
 
 :root {
     --neko-model-opacity-transition: opacity 280ms ease-in;


### PR DESCRIPTION
#1681 之后的后续（host shim + CSS + 文档；React 部分已随 #1681 合并）。全部落在 web 折叠分支里（Electron 在 `setMinimized` 第一行短路），不影响 Electron。

- **默认 reframe**：web 默认 full、Electron 默认 compact（识别 `electron-chat-window` body class / `__LANLAN_IS_ELECTRON_PET__`，另留 `__NEKO_CHAT_DEFAULT_COMPACT__` 显式覆盖）。
- **full 几何**：复活 #1506（三态重构）前的原地折叠（动画不挪 left/top、以左下角为支点缩）+ 按球位置重算展开 + 拖动/resize 位置记忆 + 打开还原（`restoreFullPosition`，无记忆保持居中、绝不退回 left-middle）。
- **full 折叠成「呼吸灯悬浮球」**（旧 `expand_icon_off_ball.png` + 蓝色呼吸 glow），隔离进新文件 `static/css/full-chat-minimize.css`、严格 gate 在 `.is-legacy-full-ball`；compact 仍毛线球；full 折叠不贴 avatar、不走 idle-dock。
- **compact best-effort**：`getMinimizedTarget` 通用原地（去 avatar 目标 + DOWN_OFFSET）+ 折叠动画恒原地 → compact 也原地折到自己左下角，不再飞角色。拖球 + 按球展开 + 自由定位是 follow-up（#1683）。
- **文档**：设计文档加「形态切换与本地测试」章节 + README 调试说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 优化最小化/展开动画与目标计算，改善不同形态间恢复与定位行为，避免展开时标题栏不可达。
  * 为“legacy full”最小化球新增专属视觉皮肤与无动画降级支持，UI 文案与无障碍提示统一处理。

* **文档**
  * 补充聊天界面形态（full/compact/minimized）调试指南与本地测试步骤与自测点链接。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->