### PR TITLE
fix: route full chat endpoint through index

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -290,9 +290,9 @@ async def get_chat_page(request: Request):
 
 @router.get("/chat_full", response_class=HTMLResponse)
 async def get_chat_full_page(request: Request):
-    """Web 专用完整聊天窗口页面"""
+    """Web 首页入口：打开主页并让 React Chat 以 full 模式启动。"""
     templates = get_templates()
-    return templates.TemplateResponse("templates/chat.html", {
+    return templates.TemplateResponse("templates/index.html", {
         "request": request,
         "initial_chat_surface_mode": "full",
         **_vrm_defaults_ctx(),

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
     <link rel="stylesheet" href="/static/css/subtitle.css?v={{ static_asset_version }}">
     <style>/* React chat adapter: hide old chat */
     #chat-container { display: none !important; visibility: hidden !important; }</style>
-    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ static_asset_version }}">
+    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ react_chat_asset_version }}">
     <link rel="stylesheet" href="/static/css/avatar-reaction-bubble.css?v={{ static_asset_version }}">
     <!-- 暗色模式样式 -->
     <link rel="stylesheet" href="/static/css/dark-mode.css?v={{ static_asset_version }}">
@@ -61,7 +61,8 @@
     <script src="/static/libs/APlayer.min.js?v={{ static_asset_version }}"></script>
 </head>
 
-<body class="subtitle-web-host">
+<body class="subtitle-web-host"{% if initial_chat_surface_mode is defined and initial_chat_surface_mode %}
+      data-initial-chat-surface-mode="{{ initial_chat_surface_mode }}"{% endif %}>
     <!-- 同步把 Electron Pet 标记补到 body（head 脚本执行时 body 尚不存在）；
          在 chat-container 等内容解析之前执行，避免窄窗口下手机布局闪一帧。 -->
     <script>(function () {
@@ -395,7 +396,7 @@
     <script src="/static/app-autostart-prompt.js?v={{ static_asset_version }}"></script>
     <script src="/static/js/character_personality_onboarding.js?v={{ static_asset_version }}"></script>
     <script src="/static/app.js?v={{ static_asset_version }}"></script>
-    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ static_asset_version }}"></script>
+    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ react_chat_asset_version }}"></script>
     <script src="/static/app-react-chat-window.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-chat-export.js?v={{ static_asset_version }}"></script>
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -12,6 +12,7 @@ STATIC_INDEX_JS_PATH = Path(__file__).resolve().parents[2] / "static" / "js" / "
 REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "styles.css"
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
 CHAT_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "chat.html"
+INDEX_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "index.html"
 SUBTITLE_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "subtitle.html"
 PAGES_ROUTER_PATH = Path(__file__).resolve().parents[2] / "main_routers" / "pages_router.py"
 COMPACT_EXPORT_HISTORY_PANEL_PATH = (
@@ -89,28 +90,46 @@ def test_chat_surface_mode_preference_is_shared_with_electron():
     assert "localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode)" in persist_block
 
 
-def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
+def test_chat_full_endpoint_uses_index_template_with_initial_full_surface():
     router_source = PAGES_ROUTER_PATH.read_text(encoding="utf-8")
-    template_source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    index_template = INDEX_TEMPLATE_PATH.read_text(encoding="utf-8")
 
     assert '@router.get("/chat_full", response_class=HTMLResponse)' in router_source
-    assert '"initial_chat_surface_mode": "full"' in router_source
-    assert '"initial_chat_surface_mode": "compact"' in router_source
-    assert 'data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default(\'compact\', true) }}"' in template_source
+    assert "{% if initial_chat_surface_mode is defined and initial_chat_surface_mode %}" in index_template
+    assert 'data-initial-chat-surface-mode="{{ initial_chat_surface_mode }}"' in index_template
 
     chat_route_block = router_source.split('async def get_chat_page', 1)[1].split(
         '@router.get("/chat_full"',
         1,
     )[0]
+    assert 'TemplateResponse("templates/chat.html"' in chat_route_block
     assert '"initial_chat_surface_mode": "compact"' in chat_route_block
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
+
+    chat_full_route_block = router_source.split('async def get_chat_full_page', 1)[1].split(
+        '@router.get("/subtitle"',
+        1,
+    )[0]
+    assert 'TemplateResponse("templates/index.html"' in chat_full_route_block
+    assert 'TemplateResponse("templates/chat.html"' not in chat_full_route_block
+    assert '"initial_chat_surface_mode": "full"' in chat_full_route_block
+    assert '"initial_chat_surface_mode": "compact"' not in chat_full_route_block
+
+    root_route_block = router_source.split('async def get_default_index', 1)[1].split(
+        'def _render_model_manager',
+        1,
+    )[0]
+    assert '"initial_chat_surface_mode"' not in root_route_block
 
 
 def test_chat_templates_version_react_chat_bundle_from_react_assets():
     chat_template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    index_template = INDEX_TEMPLATE_PATH.read_text(encoding="utf-8")
 
     assert 'neko-chat-window.css?v={{ react_chat_asset_version }}' in chat_template
     assert 'neko-chat-window.iife.js?v={{ react_chat_asset_version }}' in chat_template
+    assert 'neko-chat-window.css?v={{ react_chat_asset_version }}' in index_template
+    assert 'neko-chat-window.iife.js?v={{ react_chat_asset_version }}' in index_template
 
 
 def test_chat_full_is_reserved_from_character_page_config_routing():


### PR DESCRIPTION
## Summary
- 将 `/chat_full` 改为渲染 `index.html`，让 Web 首页内的 React Chat 以 full 模式启动，而不是打开独立 `chat.html` 窗口。
- 在 `index.html` 支持按需注入 `data-initial-chat-surface-mode`，普通首页不注入该值，避免改动现有 Web 默认 full 行为。
- 让 index 页的 React Chat bundle 使用 `react_chat_asset_version`，减少 React bundle 更新后被通用静态版本缓存住的情况。

## Tests
- `uv run pytest tests/unit/test_react_chat_window_static.py -q`
- `node --check static/app-react-chat-window.js && node --check static/js/index.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了聊天全屏模式下的资源加载机制，确保样式表与脚本版本同步
  * 改进了页面初始化时聊天界面模式的参数传递方式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->