### PR TITLE
修复紧凑聊天输入态下，长文本显示区域被右侧操作按钮遮挡的问题，并补充静态布局契约测试

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3478,10 +3478,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-chat-surface-frame[data-compact-chat-state="input"] .composer-input {
   flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
   height: 42px;
   min-height: 42px;
   max-height: 42px;
-  padding: 10px 0;
+  padding: 10px 8px 10px 0;
   border: 0;
   background: transparent;
   color: #2f526b;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3983,7 +3983,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   }
 
   .compact-chat-surface-frame[data-compact-chat-state="input"] {
-    padding: 5px 8px 5px 18px;
+    padding: 5px 62px 5px 18px;
   }
 
   /* Only use the phone fallback when the original wheel geometry would overflow the viewport. */

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -454,6 +454,11 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
 
     fan_block = css_block(styles, ".compact-input-tool-fan {", ".compact-chat-surface-shell *")
+    compact_input_block = css_block(
+        styles,
+        '.compact-chat-surface-frame[data-compact-chat-state="input"] .composer-input {',
+        '.compact-chat-surface-frame[data-compact-chat-state="input"] .composer-input::placeholder',
+    )
     wheel_block = styles.split(".compact-input-tool-fan .compact-input-tool-item {", 1)[1].split(
         ".compact-input-tool-fan .composer-tool-btn img",
         1,
@@ -513,6 +518,9 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
         '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] '
         '.compact-input-tool-toggle:hover'
     ) in styles
+    assert "width: auto;" in compact_input_block
+    assert "min-width: 0;" in compact_input_block
+    assert "padding: 10px 8px 10px 0;" in compact_input_block
     assert 'padding: 5px 62px 5px 2px;' in styles
     assert '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"])' in styles
     assert 'padding-right: 62px;' in styles

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -459,6 +459,11 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
         '.compact-chat-surface-frame[data-compact-chat-state="input"] .composer-input {',
         '.compact-chat-surface-frame[data-compact-chat-state="input"] .composer-input::placeholder',
     )
+    compact_mobile_block = css_block(
+        styles,
+        "@media (max-width: 820px) {",
+        "/* ===================================================================",
+    )
     wheel_block = styles.split(".compact-input-tool-fan .compact-input-tool-item {", 1)[1].split(
         ".compact-input-tool-fan .composer-tool-btn img",
         1,
@@ -522,6 +527,9 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     assert "min-width: 0;" in compact_input_block
     assert "padding: 10px 8px 10px 0;" in compact_input_block
     assert 'padding: 5px 62px 5px 2px;' in styles
+    assert '.compact-chat-surface-frame[data-compact-chat-state="input"]' in compact_mobile_block
+    assert 'padding: 5px 62px 5px 18px;' in compact_mobile_block
+    assert 'padding: 5px 8px 5px 18px;' not in compact_mobile_block
     assert '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"])' in styles
     assert 'padding-right: 62px;' in styles
     assert 'right: 9px;' in styles


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **样式调整**
  * 优化紧凑聊天输入框的宽度、最小宽度与内边距，保持高度一致，改善输入区布局与可用空间。
  * 在窄屏/移动视图下增加右侧内边距以为操作区域留出空间，提升触控与视觉体验。

* **测试**
  * 新增/更新测试以验证紧凑输入框在不同视口和状态下的样式表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->