### PR TITLE
限制紧凑聊天历史记录和展开把手在视口内显示，避免贴近屏幕左右边缘时溢出

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2308,7 +2308,6 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 .compact-export-history-anchor {
   position: fixed;
   --compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));
-  left: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2));
   bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 2px);
   /* Geometry-critical: derive collapse compensation from control metrics; do not animate layout properties here. */
   --compact-export-controls-padding-y: clamp(4px, calc(var(--compact-export-surface-width) * 0.0116), 6px);
@@ -2335,10 +2334,26 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
     calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio)),
     var(--compact-export-history-max-inline-size)
   );
+  --compact-export-history-preferred-center: calc(
+    var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-export-surface-width) / 2)
+  );
+  --compact-export-history-safe-gutter: calc(var(--compact-export-history-viewport-gutter) / 2);
+  --compact-export-history-half-inline-size: calc(var(--compact-export-history-inline-size) / 2);
+  --compact-export-history-safe-center-min: calc(
+    var(--compact-export-history-half-inline-size) + var(--compact-export-history-safe-gutter)
+  );
+  --compact-export-history-safe-center-max: calc(
+    100vw - var(--compact-export-history-half-inline-size) - var(--compact-export-history-safe-gutter)
+  );
   --compact-export-history-bubble-max-ratio: 86%;
   --compact-export-history-system-bubble-max-ratio: 94%;
   --compact-export-preview-bubble-max-ratio: 90%;
   --compact-export-preview-system-bubble-max-ratio: 95%;
+  left: clamp(
+    var(--compact-export-history-safe-center-min),
+    var(--compact-export-history-preferred-center),
+    var(--compact-export-history-safe-center-max)
+  );
   width: var(--compact-export-history-inline-size);
   /* 与 JS getCompactHistorySlotMaxHeight 对齐：高度上限只受屏幕(78vh)约束、不再挂对话条宽度，
      否则窄宽+高屏时 JS 允许的 slot 高 > CSS anchor 高，hit region 会被裁出死区(Codex P2)。 */
@@ -2361,6 +2376,17 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   );
   --compact-export-history-max-inline-size: calc(
     var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)
+  );
+  --compact-export-history-safe-center-min: calc(
+    var(--compact-desktop-workarea-page-left, 0px) +
+      var(--compact-export-history-half-inline-size) +
+      var(--compact-export-history-safe-gutter)
+  );
+  --compact-export-history-safe-center-max: calc(
+    var(--compact-desktop-workarea-page-left, 0px) +
+      var(--compact-desktop-workarea-width, 1440px) -
+      var(--compact-export-history-half-inline-size) -
+      var(--compact-export-history-safe-gutter)
   );
   max-height: min(calc(var(--compact-export-surface-width) * 1.46), calc(var(--compact-desktop-workarea-height, 900px) * 0.78));
 }
@@ -3008,7 +3034,19 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   flex: 0 0 auto;
   --compact-history-handle-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));
   --compact-history-handle-line-width: clamp(38px, calc(var(--compact-history-handle-surface-width) * 0.102), 50px);
-  width: clamp(96px, calc(var(--compact-history-handle-surface-width) * 0.24), 132px);
+  --compact-history-handle-width: clamp(96px, calc(var(--compact-history-handle-surface-width) * 0.24), 132px);
+  --compact-history-handle-preferred-center: calc(
+    var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-history-handle-surface-width) / 2)
+  );
+  --compact-history-handle-safe-gutter: 12px;
+  --compact-history-handle-half-width: calc(var(--compact-history-handle-width) / 2);
+  --compact-history-handle-safe-center-min: calc(
+    var(--compact-history-handle-half-width) + var(--compact-history-handle-safe-gutter)
+  );
+  --compact-history-handle-safe-center-max: calc(
+    100vw - var(--compact-history-handle-half-width) - var(--compact-history-handle-safe-gutter)
+  );
+  width: var(--compact-history-handle-width);
   height: clamp(22px, calc(var(--compact-history-handle-surface-width) * 0.052), 28px);
   padding: 0;
   border: 0;
@@ -3021,7 +3059,11 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-history-visibility-handle {
   position: fixed;
-  left: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--compact-history-handle-surface-width) / 2));
+  left: clamp(
+    var(--compact-history-handle-safe-center-min),
+    var(--compact-history-handle-preferred-center),
+    var(--compact-history-handle-safe-center-max)
+  );
   top: calc(var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 8px);
   bottom: auto;
   transform: translate(-50%, -50%);
@@ -3032,7 +3074,21 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 .compact-history-visibility-handle.is-open {
   --compact-history-handle-line-width: 100%;
-  width: clamp(124px, calc(var(--compact-history-handle-surface-width) * 0.30), 168px);
+  --compact-history-handle-width: clamp(124px, calc(var(--compact-history-handle-surface-width) * 0.30), 168px);
+}
+
+body.electron-chat-window.subtitle-web-host .compact-history-visibility-handle {
+  --compact-history-handle-safe-center-min: calc(
+    var(--compact-desktop-workarea-page-left, 0px) +
+      var(--compact-history-handle-half-width) +
+      var(--compact-history-handle-safe-gutter)
+  );
+  --compact-history-handle-safe-center-max: calc(
+    var(--compact-desktop-workarea-page-left, 0px) +
+      var(--compact-desktop-workarea-width, 1440px) -
+      var(--compact-history-handle-half-width) -
+      var(--compact-history-handle-safe-gutter)
+  );
 }
 
 .compact-history-visibility-handle::before,

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1651,6 +1651,7 @@
         document.documentElement.style.removeProperty('--desktop-compact-surface-height');
         document.documentElement.style.removeProperty('--compact-desktop-workarea-width');
         document.documentElement.style.removeProperty('--compact-desktop-workarea-height');
+        document.documentElement.style.removeProperty('--compact-desktop-workarea-page-left');
         compactSurfaceAnchorSnapshot = '';
         compactSurfaceAnchorLocked = false;
         dispatchCompactSurfaceLayoutChange(null);
@@ -1713,9 +1714,14 @@
         if (layoutOverride && layoutOverride.workArea) {
             document.documentElement.style.setProperty('--compact-desktop-workarea-width', Math.round(layoutOverride.workArea.width) + 'px');
             document.documentElement.style.setProperty('--compact-desktop-workarea-height', Math.round(layoutOverride.workArea.height) + 'px');
+            var workAreaPageLeft = layoutOverride.windowBounds
+                ? layoutOverride.workArea.left - layoutOverride.windowBounds.left
+                : 0;
+            document.documentElement.style.setProperty('--compact-desktop-workarea-page-left', Math.round(workAreaPageLeft) + 'px');
         } else {
             document.documentElement.style.removeProperty('--compact-desktop-workarea-width');
             document.documentElement.style.removeProperty('--compact-desktop-workarea-height');
+            document.documentElement.style.removeProperty('--compact-desktop-workarea-page-left');
         }
         dispatchCompactSurfaceLayoutChange({
             left: Math.round(target.left),

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -258,6 +258,8 @@ def test_desktop_compact_history_uses_workarea_not_browserwindow_viewport():
     assert "normalizeCompactDesktopWorkArea" in script
     assert "--compact-desktop-workarea-width" in script
     assert "--compact-desktop-workarea-height" in script
+    assert "--compact-desktop-workarea-page-left" in script
+    assert "layoutOverride.workArea.left - layoutOverride.windowBounds.left" in script
 
     desktop_history_block = styles.split(
         "body.electron-chat-window.subtitle-web-host .compact-export-history-anchor",
@@ -266,6 +268,7 @@ def test_desktop_compact_history_uses_workarea_not_browserwindow_viewport():
 
     assert "--compact-desktop-workarea-width" in desktop_history_block
     assert "--compact-desktop-workarea-height" in desktop_history_block
+    assert "--compact-desktop-workarea-page-left" in desktop_history_block
     assert "vh" not in desktop_history_block
     assert "vw" not in desktop_history_block
 
@@ -303,10 +306,15 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "--compact-export-surface-width: var(--compact-surface-resize-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)));" in anchor_block
     assert "--compact-export-history-inline-size: min(" in anchor_block
     assert "calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio))" in anchor_block
+    assert "--compact-export-history-preferred-center:" in anchor_block
+    assert "--compact-export-history-safe-center-min:" in anchor_block
+    assert "--compact-export-history-safe-center-max:" in anchor_block
+    assert "left: clamp(" in anchor_block
     assert "width: var(--compact-export-history-inline-size);" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block
     assert "var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)" in desktop_history_block
+    assert "var(--compact-desktop-workarea-page-left, 0px) +" in desktop_history_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-bubble-max-ratio));" in bubble_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-system-bubble-max-ratio));" in system_bubble_block
     assert "max-width: var(--compact-export-preview-bubble-max-ratio);" in preview_bubble_block
@@ -882,8 +890,14 @@ def test_compact_history_controls_collapse_gives_height_back_to_history_scroll()
     assert ".compact-export-history-controls-toggle" not in styles
     assert "position: fixed;" in history_handle_block
     assert "--compact-history-handle-line-width: clamp(38px, calc(var(--compact-history-handle-surface-width) * 0.102), 50px);" in history_handle_block
+    assert "--compact-history-handle-width: clamp(96px, calc(var(--compact-history-handle-surface-width) * 0.24), 132px);" in history_handle_block
+    assert "width: var(--compact-history-handle-width);" in history_handle_block
+    assert "left: clamp(" in history_handle_block
     assert ".compact-history-visibility-handle.is-open {" in history_handle_block
     assert "--compact-history-handle-line-width: 100%;" in history_handle_block
+    assert "--compact-history-handle-width: clamp(124px, calc(var(--compact-history-handle-surface-width) * 0.30), 168px);" in history_handle_block
+    assert "body.electron-chat-window.subtitle-web-host .compact-history-visibility-handle {" in history_handle_block
+    assert "var(--compact-desktop-workarea-page-left, 0px) +" in history_handle_block
     assert "top: calc(var(--desktop-compact-surface-top, var(--compact-surface-top, 68vh)) + 8px);" in history_handle_block
     assert "bottom: auto;" in history_handle_block
     assert "bottom: calc(100vh - var(--desktop-compact-surface-top" not in history_handle_block


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发行说明

* **样式优化**
  * 改进了紧凑模式下历史面板的定位逻辑，使其能够自动适应屏幕可见范围，避免超出边界。
  * 优化了历史面板展开/收起手柄的位置计算，提升 Electron 桌面应用中的布局准确度。

* **测试**
  * 增强了紧凑模式布局变量和工作区边界计算的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->