### PR TITLE
feat(chat): /chat_full Electron 独立窗口适配

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -98,7 +98,7 @@
     }
 
     function supportsLocalModelRuntime() {
-        return !/^\/chat(?:\/|$)/.test(window.location.pathname || '');
+        return !/^\/chat(?:_full)?(?:\/|$)/.test(window.location.pathname || '');
     }
 
     function emitAssistantSpeechCancel(source) {

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -981,7 +981,7 @@
     async function autoOpenReactChat() {
         await waitForStartupBarrier();
         hideOldChat();
-        if (window.__NEKO_MULTI_WINDOW__ && !/^\/chat(?:\/|$)/.test(window.location.pathname || '')) {
+        if (window.__NEKO_MULTI_WINDOW__ && !/^\/chat(?:_full)?(?:\/|$)/.test(window.location.pathname || '')) {
             return;
         }
         var host = getHost();

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -4102,6 +4102,15 @@
     }
 
     async function enterElectronIdleDock(screenRect) {
+        // full 独立窗口（Electron part B）完全避开 idle-dock —— 与 web 路径 enterIdleDock 的
+        // full 守卫对偶：CAT2/CAT3 idle tier 不应把展开的 full 窗口自动折叠/贴猫。full 用旧版
+        // 独立窗口折叠机制（preload 物理缩窗），不参与 idle-dock。
+        if (getCurrentChatSurfaceMode() === 'full' || isLegacyFullMinimizedBall()) return;
+        // 隐藏的聊天窗口不 idle-dock：full 激活时 compact 窗口被 .hide()（document.hidden=true）
+        // 仍会收到 idle 事件，若不挡会在后台折叠并 spawn 出与当前可见 surface 无关的毛线球。
+        // 正常 minimized 态用 dimReactChatForMinimize(setOpacity 0) 而非 hide，document.hidden
+        // 仍为 false，故此守卫不影响 minimized 态的 idle-dock 跟随。
+        if (typeof document !== 'undefined' && document.hidden) return;
         var bridge = getElectronIdleDockBridge();
         var targetRect = normalizeElectronRect(screenRect);
         if (!bridge || !targetRect) return;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -43,6 +43,29 @@
             background: transparent !important;
         }
         #react-chat-window-backdrop { display: none !important; }
+        /* Electron 独立 full 窗口（part B）：full shell 改用「固定 30px inset 充满窗口」定位 +
+           收敛阴影，取代基础规则的 translate(-50%,-50%) 居中 + 0 30px 100px(~130px) 巨阴影。
+           两个目的：
+           (1) 阴影：基础巨阴影在「窗口≈内容」的独立窗口里会被窗口边缘大面积裁掉（"周围一圈阴影
+               被截断"）。收敛到能落在 30px inset 留白内。
+           (2) 展开飞出截断：b718b611 preload 的展开动画用 WAAPI 设 transform（替换掉 translate）、
+               结束设 shell.style.transform='none' —— 它假设 shell 不靠 transform 居中。与基础规则
+               的 translate 居中冲突 → 展开结束 translate 丢失，shell 左上角落到窗口中心、整块飞出
+               被截断。改用 inset 定位（不依赖 transform），展开全程及结束都正确贴窗、阴影留白稳定。
+           作用域：仅 Electron full 独立窗口、且非折叠球态（neko-e-collapsed）/非最小化（is-minimized）
+           —— 那两态有自己的定位/呼吸灯阴影；compact 窗口（attr=compact）走胶囊规则，均不受影响。 */
+        body.electron-chat-window #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) {
+            top: 30px;
+            left: 30px;
+            right: 30px;
+            bottom: 30px;
+            width: auto;
+            height: auto;
+            max-width: none;
+            max-height: none;
+            transform: none;
+            box-shadow: 0 8px 20px rgba(12, 20, 34, 0.28);
+        }
         /* ──────────────────────────────────────────────────────────────────────
            full 形态（覆盖全窗口的玻璃面板）已退环境，仅在此留档：
            旧版在这里把 #react-chat-window-shell 钉成 inset:40px 的全窗口玻璃面板

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -54,7 +54,7 @@
                被截断。改用 inset 定位（不依赖 transform），展开全程及结束都正确贴窗、阴影留白稳定。
            作用域：仅 Electron full 独立窗口、且非折叠球态（neko-e-collapsed）/非最小化（is-minimized）
            —— 那两态有自己的定位/呼吸灯阴影；compact 窗口（attr=compact）走胶囊规则，均不受影响。 */
-        body.electron-chat-window #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) {
+        body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) {
             top: 30px;
             left: 30px;
             right: 30px;
@@ -497,6 +497,24 @@
 </head>
 <body class="electron-chat-window subtitle-web-host"
       data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default('compact', true) }}">
+
+    <!-- Electron 运行时标记：/chat_full 与 /chat 共用本模板，body.electron-chat-window 是静态写入，
+         浏览器访问 web /chat_full 时也会带它 —— 故「仅 Electron 独立窗口」的样式（如 full 30px inset
+         布局）不能用它做门禁，必须用运行时信号：preload 注入的 window.nekoChatWindow（compact/full
+         两个 chat preload 都暴露）/ Electron UA / process.versions.electron。preload 在页面脚本之前
+         注入，这里同步可读；内容 overlay 默认 hidden 到 React 挂载，class 早已就位，无闪。dev 浏览器
+         无这些信号 → 不打标记，full 退回 base 居中。对偶 index.html 头部的 __LANLAN_IS_ELECTRON_PET__。 -->
+    <script>(function () {
+        try {
+            var w = window;
+            var isElectronRuntime = !!w.nekoChatWindow
+                || /Electron/i.test(navigator.userAgent || '')
+                || !!(w.process && w.process.versions && w.process.versions.electron);
+            if (isElectronRuntime) {
+                document.body.classList.add('neko-electron-runtime');
+            }
+        } catch (e) { /* 检测失败按非 Electron 处理，full 退回浏览器 base 居中 */ }
+    })();</script>
 
     <div id="status-toast"></div>
     <div id="yui-guide-chat-spotlight" hidden>

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -106,6 +106,29 @@ def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
 
 
+def test_full_inset_layout_gated_by_electron_runtime_marker():
+    """full 30px inset 布局是「仅 Electron 独立窗口」样式。chat.html 同时服务 Electron 独立窗口
+    和 web /chat_full（两者共用本模板，body.electron-chat-window 是静态写入，浏览器访问 web
+    /chat_full 时也会带它），故 inset 门禁必须用 preload 注入的运行时标记 neko-electron-runtime，
+    否则 web /chat_full 会被误改成 30px inset。"""
+    source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    # inset 规则用运行时标记门禁，不再用静态 electron-chat-window（web /chat_full 也会命中它）。
+    assert (
+        'body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]'
+        in source
+    )
+    assert (
+        'body.electron-chat-window #react-chat-window-shell[data-chat-surface-mode="full"]'
+        not in source
+    )
+
+    # 运行时标记由 body 内联脚本基于 preload 信号（window.nekoChatWindow）/ Electron UA 注入；
+    # web 浏览器无这些信号 → 不打标记 → full 退回 base 居中。
+    assert "document.body.classList.add('neko-electron-runtime')" in source
+    assert "w.nekoChatWindow" in source
+
+
 def test_chat_templates_version_react_chat_bundle_from_react_assets():
     chat_template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 概要
配合 Electron 壳（lanlan_frd）把 full 完整聊天复活为**独立窗口**（载 `/chat_full`、与 compact 绝对隔离）。本 PR 是后端侧三处适配，缺它 full 独立窗口会空白 / 折叠错乱 / idle-dock 误触发。

> 配套 Electron 壳 PR：Project-N-E-K-O/N.E.K.O.-PC#183

## 改动
### 1. 路径正则放宽 /chat_full（app-chat-adapter.js / app-character.js）
`autoOpenReactChat` 与 `supportsLocalModelRuntime` 的 `/^\/chat(?:\/|$)/` → `/^\/chat(?:_full)?(?:\/|$)/`，让 `/chat_full` 与 `/chat` 同待遇：adapter 让多窗口下 mount React（#1684 web full mount 必需，Electron 下 preload 亦自驱属双保险）；character 让聊天窗口不加载 VRM 本地模型（否则 full 窗口切角色误触发模型加载）。

### 2. Electron idle-dock 守卫（app-react-chat-window.js）
`enterElectronIdleDock` 入口加两道守卫，补齐 Electron 路径缺失、web 路径 `enterIdleDock` 早有的 full 守卫：
- **full surface 完全避开 idle-dock**（`mode==='full' || isLegacyFullMinimizedBall()`）：CAT2/CAT3 idle tier 不应把展开的 full 窗口自动折叠贴猫。
- **隐藏的聊天窗口不 idle-dock**（`document.hidden`）：full 激活时 compact 窗口被 `.hide()` 仍收到 idle 事件，若不挡会在后台折叠 spawn 出与可见 surface 无关的毛线球。正常 minimized 用 dim(opacity) 非 hide，document.hidden 仍 false，不受影响。

### 3. Electron full shell 布局（chat.html）
Electron full 独立窗口的 shell 改用**固定 30px inset 充满窗口** + 收敛 box-shadow，取代基础规则的 `translate(-50%,-50%)` 居中：对话框 preload 的展开动画用 WAAPI 覆盖 transform、结束设 `transform:none`，与 translate 居中冲突 → 展开后 shell 飞出窗口被截断。inset 定位不依赖 transform、且作阴影留白。

⚠️ **副作用**：选择器命中点是 `body.electron-chat-window … [data-chat-surface-mode="full"]`，而 `electron-chat-window` body class 是 chat.html 模板写死、无 electron-only CSS 钩子，故会**同时命中 web `/chat_full`**（web full 也从「居中浮动玻璃面板」变为「inset 充满」）。若需保留 web full 原貌，可加 electron-only body 标记类再收窄选择器——按需。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug修复**
  * 防止在 full 页面模式下触发本地模型运行时热切换
  * 优化 chat 自动打开的路径识别，支持 full 路径变体
  * 避免 Electron 独立窗口在隐藏/full 状态下错误折叠或生成最小化球导致的错位

* **新功能**
  * 在 Electron 运行时下启用专用 full 窗口定位样式，运行时检测决定生效

* **测试**
  * 新增单元测试以验证 Electron 运行时门控的 full 布局逻辑
<!-- end of auto-generated comment: release notes by coderabbit.ai -->