### PR TITLE
修复请她离开后猫态仍可能触发主动搭话的问题；前后端同步 goodbye 静默状态，并在回来或重新开始会话时恢复

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -830,6 +830,11 @@ class LLMSessionManager:
         # making check-and-claim atomic. (Text mode uses the SM's
         # try_start_proactive claim instead; voice deliberately bypasses the SM.)
         self._voice_proactive_inject_lock = asyncio.Lock()
+        # 请她离开/变猫期间的后端静默闸门。前端会在进入猫态时置 True，
+        # 回来或显式 start_session 时清掉；所有主动搭话入口统一读取它。
+        self.goodbye_silent: bool = False
+        self.goodbye_silent_reason: str = ""
+        self.goodbye_silent_updated_at: float = 0.0
         # ── Session takeover ──────────────────────────────────────────
         # 当某个外部 controller 接管这个 session 时，本地 chat LLM 的输出
         # （text/audio delta、output transcript、response.complete、
@@ -1019,6 +1024,35 @@ class LLMSessionManager:
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
         return task
+
+    def is_goodbye_silent(self) -> bool:
+        """请她离开后的猫态静默是否生效。"""
+        return bool(getattr(self, "goodbye_silent", False))
+
+    def set_goodbye_silent(self, active: bool, reason: str = "") -> None:
+        """同步前端猫态静默状态，并把已排队的主动回调停在持久队列里。"""
+        active = bool(active)
+        reason = str(reason or "")[:64]
+        was_active = self.is_goodbye_silent()
+        self.goodbye_silent = active
+        self.goodbye_silent_reason = reason
+        self.goodbye_silent_updated_at = time.time()
+        if active:
+            self._park_proactive_for_goodbye()
+        if was_active != active:
+            logger.info("[%s] goodbye_silent=%s reason=%s", self.lanlan_name, active, reason or "-")
+
+    def _park_proactive_for_goodbye(self) -> None:
+        """猫态静默时把 manager 内待释放回调转入持久队列，避免静默期间漏发或超时释放。"""
+        try:
+            leftover = self.proactive_manager.drain_pending()
+            for callback in leftover:
+                self.enqueue_agent_callback(callback)
+            self.proactive_manager.reset_gate()
+            if leftover:
+                logger.info("[%s] goodbye_silent parked proactive callbacks n=%d", self.lanlan_name, len(leftover))
+        except Exception:
+            logger.exception("[%s] goodbye_silent proactive park failed", self.lanlan_name)
 
     def _ensure_audio_stream_worker(self):
         if self._audio_stream_worker_task and not self._audio_stream_worker_task.done():
@@ -5215,6 +5249,9 @@ class LLMSessionManager:
         """
         if not self.is_active or not isinstance(self.session, OmniRealtimeClient):
             return False
+        if self.is_goodbye_silent():
+            logger.info("[%s] voice proactive nudge skipped: goodbye silent", self.lanlan_name)
+            return False
         if self._takeover_active:
             logger.info("[%s] voice proactive nudge skipped: session takeover active", self.lanlan_name)
             return False
@@ -5311,6 +5348,9 @@ class LLMSessionManager:
 
     async def prepare_proactive_delivery(self, min_idle_secs: float = 10.0) -> bool:
         """Phase 2 流式输出前的前置检查 + speech_id 生成。返回 True 表示可以继续。"""
+        if self.is_goodbye_silent():
+            logger.info("[%s] prepare_proactive_delivery: goodbye silent", self.lanlan_name)
+            return False
         # 早期抢占检查：在任何 await / sid 改写前快速短路，防止用户刚在入口之后
         # 抢占而后续 self.current_speech_id 写入覆盖用户的 user_sid。默认 reset()
         # 对活动 phase no-op（保护 auto-start 期间偶发并发 reset），但 end_session
@@ -5663,6 +5703,12 @@ class LLMSessionManager:
             self.lanlan_name, sess_type, self.state.phase.value, len(self.pending_agent_callbacks),
         )
         if not self.pending_agent_callbacks:
+            return
+        if self.is_goodbye_silent():
+            logger.info(
+                "[%s] trigger_agent_callbacks deferred: goodbye silent, keeping %d callback(s)",
+                self.lanlan_name, len(self.pending_agent_callbacks),
+            )
             return
         # 与 handle_text_data / handle_response_complete 等输出 handler 对偶：
         # takeover 期间普通 chat LLM 输出会被静音，所以现在派发会被吞掉、callback
@@ -6120,6 +6166,9 @@ class LLMSessionManager:
 
         流程：查询 memory_server 获取间隔 → 构建引导词 → 主动拉起 text session → 投递。
         """
+        if self.is_goodbye_silent():
+            logger.info("[%s] trigger_greeting: goodbye silent, skipping", self.lanlan_name)
+            return
         # ── 守卫：语音 session 正在启动 / 已活跃时，跳过 greeting ──
         if self._is_voice_session_active_or_starting():
             logger.info("[%s] trigger_greeting: voice session active/starting, skipping", self.lanlan_name)
@@ -6282,6 +6331,9 @@ class LLMSessionManager:
         测量并传入的猫咪停留时长（datetime gap 是"距上次对话"，这里是"作为猫咪待了多久"，
         两套时钟互不干扰）。流程：选行为/时长档 → 构建引导词 → 主动拉起 text session → 投递。
         """
+        if self.is_goodbye_silent():
+            logger.info("[%s] trigger_cat_greeting: goodbye silent, skipping", self.lanlan_name)
+            return
         # ── 守卫：语音 session 正在启动 / 已活跃时，跳过（与 trigger_greeting 对偶）──
         if self._is_voice_session_active_or_starting():
             logger.info("[%s] trigger_cat_greeting: voice session active/starting, skipping", self.lanlan_name)
@@ -6394,6 +6446,10 @@ class LLMSessionManager:
             logger.debug("[%s] trigger_new_character_greeting: no pending intent", self.lanlan_name)
             return
 
+        if self.is_goodbye_silent():
+            logger.info("[%s] trigger_new_character_greeting: goodbye silent, skipping", self.lanlan_name)
+            return
+
         if self._is_voice_session_active_or_starting():
             logger.info("[%s] trigger_new_character_greeting: voice session active/starting, skipping", self.lanlan_name)
             return
@@ -6504,6 +6560,10 @@ class LLMSessionManager:
         their existing direct enqueue-only path so ``delivery="passive"``'s
         "don't interrupt" promise is unchanged.
         """
+        if self.is_goodbye_silent():
+            self.enqueue_agent_callback(callback)
+            logger.info("[%s] proactive callback queued: goodbye silent", self.lanlan_name)
+            return
         self.proactive_manager.submit(callback, priority=priority, coalesce_key=coalesce_key)
 
     async def _deliver_proactive_batch(self, callbacks: list) -> None:
@@ -6689,6 +6749,8 @@ class LLMSessionManager:
         response.created→voice_play_start window the playback gate can't see,
         AND an active offline/text user response where try_start_proactive
         would deny the claim)."""
+        if self.is_goodbye_silent():
+            return False
         # Time-bounded read (NOT the raw _voice_playback_active flag): if the
         # frontend dropped voice_play_end, _is_voice_playing() self-heals after
         # the 30s watchdog, so a stuck flag can't make can_release return False

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4615,6 +4615,14 @@ async def proactive_chat(request: Request):
         if not mgr:
             return JSONResponse({"success": False, "error": f"角色 {lanlan_name} 不存在"}, status_code=404)
 
+        if getattr(mgr, "is_goodbye_silent", lambda: False)():
+            logger.info("[%s] 主动搭话本轮未发起：goodbye silent", lanlan_name)
+            return JSONResponse({
+                "success": True,
+                "action": "pass",
+                "message": "goodbye silent; proactive skipped",
+            })
+
         try:
             from main_routers.game_router import is_game_route_active
             if is_game_route_active(lanlan_name):

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -277,7 +277,14 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
             if action == "goodbye_state":
                 active = bool(message.get("active"))
                 reason = str(message.get("reason") or ("goodbye" if active else "return")).strip().lower()[:64]
-                session_manager[lanlan_name].set_goodbye_silent(active, reason)
+                goodbye_mgr = session_manager[lanlan_name]
+                goodbye_mgr.set_goodbye_silent(active, reason)
+                if not active and goodbye_mgr.pending_agent_callbacks:
+                    logger.info(
+                        "[%s] goodbye_state cleared: retrying %d pending callback(s)",
+                        lanlan_name, len(goodbye_mgr.pending_agent_callbacks),
+                    )
+                    _fire_task(goodbye_mgr.trigger_agent_callbacks())
                 continue
 
             if action == "start_session":

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -274,8 +274,15 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                 _handle_ws_telemetry(message, lanlan_name=lanlan_name)
                 continue
 
+            if action == "goodbye_state":
+                active = bool(message.get("active"))
+                reason = str(message.get("reason") or ("goodbye" if active else "return")).strip().lower()[:64]
+                session_manager[lanlan_name].set_goodbye_silent(active, reason)
+                continue
+
             if action == "start_session":
                 session_manager[lanlan_name].active_session_is_idle = False
+                session_manager[lanlan_name].set_goodbye_silent(False, "start_session")
                 input_type = message.get("input_type", "audio")
                 if input_type in ['audio', 'screen', 'camera', 'text']:
                     if is_game_route_active(lanlan_name):
@@ -341,6 +348,9 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
 
             elif action == "end_session":
                 session_manager[lanlan_name].active_session_is_idle = False
+                end_reason = str(message.get("reason") or "").strip().lower()[:64]
+                if bool(message.get("goodbye_active")) or end_reason == "goodbye":
+                    session_manager[lanlan_name].set_goodbye_silent(True, end_reason or "goodbye")
                 _fire_task(session_manager[lanlan_name].end_session())
 
             elif action == "pause_session":

--- a/static/app-auto-goodbye.js
+++ b/static/app-auto-goodbye.js
@@ -187,7 +187,18 @@
         return !!(socket && socket.readyState === WebSocket.OPEN);
     }
 
+    function rememberGoodbyeSilentState(active, reason, pending) {
+        window.__nekoGoodbyeSilentState = {
+            active: !!active,
+            reason: reason || (active ? 'goodbye' : 'return'),
+            pending: !!pending,
+            updatedAt: nowMs(),
+        };
+    }
+
     function syncGoodbyeSilentState(active, reason) {
+        const resolvedReason = reason || (active ? 'goodbye' : 'return');
+        rememberGoodbyeSilentState(active, resolvedReason, true);
         const socket = window.appState && window.appState.socket;
         if (!socket || typeof socket.send !== 'function') {
             return;
@@ -199,8 +210,9 @@
             socket.send(JSON.stringify({
                 action: 'goodbye_state',
                 active: !!active,
-                reason: reason || (active ? 'goodbye' : 'return'),
+                reason: resolvedReason,
             }));
+            rememberGoodbyeSilentState(active, resolvedReason, false);
         } catch (_) {}
     }
 

--- a/static/app-auto-goodbye.js
+++ b/static/app-auto-goodbye.js
@@ -187,6 +187,23 @@
         return !!(socket && socket.readyState === WebSocket.OPEN);
     }
 
+    function syncGoodbyeSilentState(active, reason) {
+        const socket = window.appState && window.appState.socket;
+        if (!socket || typeof socket.send !== 'function') {
+            return;
+        }
+        if (typeof WebSocket === 'undefined' || socket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        try {
+            socket.send(JSON.stringify({
+                action: 'goodbye_state',
+                active: !!active,
+                reason: reason || (active ? 'goodbye' : 'return'),
+            }));
+        } catch (_) {}
+    }
+
     function markIdleBaseline(source) {
         state.lastInteractionAt = nowMs();
         state.lastInteractionSource = typeof source === 'string' ? source : 'baseline-reset';
@@ -752,11 +769,13 @@
                     reason: state.lastReason,
                 });
             }
+            syncGoodbyeSilentState(true, state.lastReason);
         });
 
         const handleReturn = () => {
             // 变回猫娘前，按"作为猫咪待了多久 + 此刻所处 tier（清醒/打盹/熟睡）"
             // 请求一次专属问候。tier 必须在 setVisualTier(NONE) 清空之前读取。
+            syncGoodbyeSilentState(false, 'return-click');
             if (state.goodbyeEnteredAt > 0) {
                 const durationSeconds = Math.max(0, Math.floor((nowMs() - state.goodbyeEnteredAt) / 1000));
                 try {

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -1980,8 +1980,16 @@
             S.voiceChatActive = false;
             S.isSwitchingMode = true;
 
-            var isGoodbyeMode = window.live2dManager && window.live2dManager._goodbyeClicked;
-            console.log(window.t('console.checkingGoodbyeMode'), isGoodbyeMode, window.t('console.goodbyeClicked'), window.live2dManager ? window.live2dManager._goodbyeClicked : 'undefined');
+            var isGoodbyeMode = (typeof window.isNekoGoodbyeModeActive === 'function')
+                ? window.isNekoGoodbyeModeActive()
+                : !!((window.live2dManager && window.live2dManager._goodbyeClicked)
+                    || (window.vrmManager && window.vrmManager._goodbyeClicked)
+                    || (window.mmdManager && window.mmdManager._goodbyeClicked));
+            console.log(window.t('console.checkingGoodbyeMode'), isGoodbyeMode, window.t('console.goodbyeClicked'), {
+                live2d: window.live2dManager ? window.live2dManager._goodbyeClicked : 'undefined',
+                vrm: window.vrmManager ? window.vrmManager._goodbyeClicked : 'undefined',
+                mmd: window.mmdManager ? window.mmdManager._goodbyeClicked : 'undefined'
+            });
 
             var live2dContainer = document.getElementById('live2d-container');
             console.log(window.t('console.hideLive2dBeforeStatus'), {
@@ -2002,7 +2010,11 @@
 
             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
                 S._suppressCharacterLeft = true;
-                S.socket.send(JSON.stringify({ action: 'end_session' }));
+                S.socket.send(JSON.stringify({
+                    action: 'end_session',
+                    goodbye_active: !!isGoodbyeMode,
+                    reason: isGoodbyeMode ? 'goodbye' : 'manual'
+                }));
             }
             window.stopRecording();
             S.voiceStartPending = false;
@@ -2102,6 +2114,14 @@
                 }
                 if (window.mmdManager) {
                     window.mmdManager._goodbyeClicked = false;
+                }
+
+                if (S.socket && S.socket.readyState === WebSocket.OPEN) {
+                    S.socket.send(JSON.stringify({
+                        action: 'goodbye_state',
+                        active: false,
+                        reason: 'return-session'
+                    }));
                 }
 
                 micButton.classList.remove('recording');

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1364,24 +1364,44 @@
 
             // ── 首次连接 / 切换角色：标记 greeting 意图，若模型已就绪则立即发送 ──
             var goodbyeActiveOnOpen = false;
+            var goodbyeSyncOnOpen = null;
             try {
+                var pendingGoodbyeState = window.__nekoGoodbyeSilentState;
+                if (pendingGoodbyeState && pendingGoodbyeState.pending === true) {
+                    goodbyeSyncOnOpen = {
+                        active: !!pendingGoodbyeState.active,
+                        reason: pendingGoodbyeState.reason || (pendingGoodbyeState.active ? 'goodbye' : 'return')
+                    };
+                }
                 goodbyeActiveOnOpen = (typeof window.isNekoGoodbyeModeActive === 'function')
                     ? window.isNekoGoodbyeModeActive()
                     : !!((window.live2dManager && window.live2dManager._goodbyeClicked)
                         || (window.vrmManager && window.vrmManager._goodbyeClicked)
                         || (window.mmdManager && window.mmdManager._goodbyeClicked));
-                if (goodbyeActiveOnOpen && _thisSocket && _thisSocket.readyState === WebSocket.OPEN) {
-                    _thisSocket.send(JSON.stringify({
-                        action: 'goodbye_state',
+                if (!goodbyeSyncOnOpen && goodbyeActiveOnOpen) {
+                    goodbyeSyncOnOpen = {
                         active: true,
                         reason: 'ws-open-goodbye'
+                    };
+                }
+                if (goodbyeSyncOnOpen && _thisSocket && _thisSocket.readyState === WebSocket.OPEN) {
+                    _thisSocket.send(JSON.stringify({
+                        action: 'goodbye_state',
+                        active: !!goodbyeSyncOnOpen.active,
+                        reason: goodbyeSyncOnOpen.reason
                     }));
+                    window.__nekoGoodbyeSilentState = {
+                        active: !!goodbyeSyncOnOpen.active,
+                        reason: goodbyeSyncOnOpen.reason,
+                        pending: false,
+                        updatedAt: Date.now()
+                    };
                 }
             } catch (_) {
                 goodbyeActiveOnOpen = false;
             }
             _resetGreetingCheckRetry(true);
-            if (goodbyeActiveOnOpen) {
+            if (goodbyeActiveOnOpen || (goodbyeSyncOnOpen && goodbyeSyncOnOpen.active)) {
                 S._greetingCheckPending = false;
                 S._greetingCheckIsSwitch = false;
                 S._greetingCheckReason = '';

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1363,10 +1363,34 @@
             sendHomeTutorialState('ws-open');
 
             // ── 首次连接 / 切换角色：标记 greeting 意图，若模型已就绪则立即发送 ──
+            var goodbyeActiveOnOpen = false;
+            try {
+                goodbyeActiveOnOpen = (typeof window.isNekoGoodbyeModeActive === 'function')
+                    ? window.isNekoGoodbyeModeActive()
+                    : !!((window.live2dManager && window.live2dManager._goodbyeClicked)
+                        || (window.vrmManager && window.vrmManager._goodbyeClicked)
+                        || (window.mmdManager && window.mmdManager._goodbyeClicked));
+                if (goodbyeActiveOnOpen && _thisSocket && _thisSocket.readyState === WebSocket.OPEN) {
+                    _thisSocket.send(JSON.stringify({
+                        action: 'goodbye_state',
+                        active: true,
+                        reason: 'ws-open-goodbye'
+                    }));
+                }
+            } catch (_) {
+                goodbyeActiveOnOpen = false;
+            }
             _resetGreetingCheckRetry(true);
-            _markGreetingCheckPending(!!S._pendingGreetingSwitch, S._greetingCheckReason || 'ws-open');
-            S._pendingGreetingSwitch = false;
-            _sendGreetingCheckIfReady();
+            if (goodbyeActiveOnOpen) {
+                S._greetingCheckPending = false;
+                S._greetingCheckIsSwitch = false;
+                S._greetingCheckReason = '';
+                S._pendingGreetingSwitch = false;
+            } else {
+                _markGreetingCheckPending(!!S._pendingGreetingSwitch, S._greetingCheckReason || 'ws-open');
+                S._pendingGreetingSwitch = false;
+                _sendGreetingCheckIfReady();
+            }
 
             // ── game-window-state 重连兜底（codex P2）──
             // game_window_state_change 是 edge-triggered WS 事件——只在 activate

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1384,6 +1384,12 @@
                         reason: 'ws-open-goodbye'
                     };
                 }
+                if (!goodbyeSyncOnOpen && pendingGoodbyeState && pendingGoodbyeState.active === true) {
+                    goodbyeSyncOnOpen = {
+                        active: true,
+                        reason: 'ws-open-goodbye-from-sync'
+                    };
+                }
                 if (goodbyeSyncOnOpen && _thisSocket && _thisSocket.readyState === WebSocket.OPEN) {
                     _thisSocket.send(JSON.stringify({
                         action: 'goodbye_state',

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -58,6 +58,8 @@ def test_ws_open_resyncs_goodbye_state_and_skips_regular_greeting():
     assert "action: 'goodbye_state'" in onopen_greeting_block
     assert "active: !!goodbyeSyncOnOpen.active" in onopen_greeting_block
     assert "reason: 'ws-open-goodbye'" in onopen_greeting_block
+    assert "pendingGoodbyeState.active === true" in onopen_greeting_block
+    assert "reason: 'ws-open-goodbye-from-sync'" in onopen_greeting_block
     assert "pending: false" in onopen_greeting_block
     assert "if (goodbyeActiveOnOpen || (goodbyeSyncOnOpen && goodbyeSyncOnOpen.active))" in onopen_greeting_block
     assert "_sendGreetingCheckIfReady();" in onopen_greeting_block

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -53,8 +53,11 @@ def test_ws_open_resyncs_goodbye_state_and_skips_regular_greeting():
     )[0]
 
     assert "window.isNekoGoodbyeModeActive()" in onopen_greeting_block
+    assert "window.__nekoGoodbyeSilentState" in onopen_greeting_block
+    assert "pendingGoodbyeState.pending === true" in onopen_greeting_block
     assert "action: 'goodbye_state'" in onopen_greeting_block
-    assert "active: true" in onopen_greeting_block
+    assert "active: !!goodbyeSyncOnOpen.active" in onopen_greeting_block
     assert "reason: 'ws-open-goodbye'" in onopen_greeting_block
-    assert "if (goodbyeActiveOnOpen)" in onopen_greeting_block
+    assert "pending: false" in onopen_greeting_block
+    assert "if (goodbyeActiveOnOpen || (goodbyeSyncOnOpen && goodbyeSyncOnOpen.active))" in onopen_greeting_block
     assert "_sendGreetingCheckIfReady();" in onopen_greeting_block

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -42,3 +42,19 @@ def test_goodbye_blocks_stale_audio_session_started():
     assert "window.cancelPendingSessionStart('Voice start cancelled by goodbye');" in stale_audio_guard
     assert "S.socket.send(JSON.stringify({ action: 'end_session' }));" in stale_audio_guard
     assert "return;" in stale_audio_guard
+
+
+def test_ws_open_resyncs_goodbye_state_and_skips_regular_greeting():
+    source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+
+    onopen_greeting_block = source.split("// ── 首次连接 / 切换角色：标记 greeting 意图", 1)[1].split(
+        "// ── game-window-state 重连兜底",
+        1,
+    )[0]
+
+    assert "window.isNekoGoodbyeModeActive()" in onopen_greeting_block
+    assert "action: 'goodbye_state'" in onopen_greeting_block
+    assert "active: true" in onopen_greeting_block
+    assert "reason: 'ws-open-goodbye'" in onopen_greeting_block
+    assert "if (goodbyeActiveOnOpen)" in onopen_greeting_block
+    assert "_sendGreetingCheckIfReady();" in onopen_greeting_block

--- a/tests/unit/test_auto_goodbye_goodbye_return_contract.py
+++ b/tests/unit/test_auto_goodbye_goodbye_return_contract.py
@@ -21,6 +21,7 @@ def test_auto_goodbye_reuses_existing_goodbye_base_chain():
     buttons_source = _read(APP_BUTTONS_PATH)
 
     assert "window.dispatchEvent(new CustomEvent('live2d-goodbye-click'" in auto_source
+    assert "window.__nekoGoodbyeSilentState" in auto_source
     assert "action: 'start_session'" not in auto_source
     assert "resetSessionButton.click();" in ui_source
     assert "function playModelGoodbyeExit(container, rect)" in ui_source

--- a/tests/unit/test_auto_goodbye_goodbye_return_contract.py
+++ b/tests/unit/test_auto_goodbye_goodbye_return_contract.py
@@ -35,7 +35,10 @@ def test_auto_goodbye_reuses_existing_goodbye_base_chain():
         "resetSessionButton.addEventListener('click', function () {",
         "// ----------------------------------------------------------------\n        // Return session button click",
     )
-    assert "S.socket.send(JSON.stringify({ action: 'end_session' }));" in reset_block
+    assert "window.isNekoGoodbyeModeActive()" in reset_block
+    assert "action: 'end_session'" in reset_block
+    assert "goodbye_active: !!isGoodbyeMode" in reset_block
+    assert "reason: isGoodbyeMode ? 'goodbye' : 'manual'" in reset_block
     assert "window.cancelPendingSessionStart('Voice start cancelled by goodbye');" in reset_block
     assert "S.voiceStartPending = false;" in reset_block
     assert "window.isMicStarting = false;" in reset_block
@@ -68,3 +71,5 @@ def test_return_ball_keeps_handle_return_click_semantics():
         "function markFirstUserInputForAchievement() {",
     )
     assert "action: 'start_session'" in return_session_block
+    assert "action: 'goodbye_state'" in return_session_block
+    assert "active: false" in return_session_block

--- a/tests/unit/test_phase5_regression_boundary.py
+++ b/tests/unit/test_phase5_regression_boundary.py
@@ -6,7 +6,6 @@ Phase 5 — 回归与边界验证：静态契约测试
 """
 
 from pathlib import Path
-import subprocess
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -25,15 +24,15 @@ def _read(path: Path) -> str:
 # ── 5.1 手动 goodbye 链路未被改写 ──────────────────────────
 
 
-def test_app_buttons_not_modified_by_feature():
-    """app-buttons.js 不在本功能的改动范围内。"""
-    result = subprocess.run(
-        ["git", "diff", "HEAD", "--", "static/app-buttons.js"],
-        capture_output=True, text=True, cwd=str(PROJECT_ROOT),
-    )
-    assert result.stdout.strip() == "", (
-        "app-buttons.js has unexpected changes"
-    )
+def test_app_buttons_preserve_goodbye_backend_silence_contract():
+    """请她离开链路必须把猫态静默同步给后端。"""
+    source = _read(APP_BUTTONS_PATH)
+
+    assert "window.isNekoGoodbyeModeActive()" in source
+    assert "action: 'end_session'" in source
+    assert "goodbye_active: !!isGoodbyeMode" in source
+    assert "action: 'goodbye_state'" in source
+    assert "reason: 'return-session'" in source
 
 
 def test_app_ui_changes_are_limited_to_return_ball_desktop_bridge_contract():
@@ -50,13 +49,14 @@ def test_app_ui_changes_are_limited_to_return_ball_desktop_bridge_contract():
     assert "start_session" not in source
 
 
-# ── 5.2 auto-goodbye 只派发 live2d-goodbye-click ──────────
+# ── 5.2 auto-goodbye 不直接执行离开副作用 ──────────
 
 
-def test_auto_goodbye_does_not_call_any_goodbye_side_effects_directly():
+def test_auto_goodbye_only_syncs_silence_without_running_goodbye_side_effects():
     source = _read(APP_AUTO_GOODBYE_PATH)
 
     assert "window.dispatchEvent(new CustomEvent('live2d-goodbye-click'" in source
+    assert "action: 'goodbye_state'" in source
     assert "end_session" not in source
     assert "stopProactiveChatSchedule" not in source
     assert "syncVoiceChatComposerHidden" not in source

--- a/tests/unit/test_phase5_regression_boundary.py
+++ b/tests/unit/test_phase5_regression_boundary.py
@@ -57,6 +57,8 @@ def test_auto_goodbye_only_syncs_silence_without_running_goodbye_side_effects():
 
     assert "window.dispatchEvent(new CustomEvent('live2d-goodbye-click'" in source
     assert "action: 'goodbye_state'" in source
+    assert "window.__nekoGoodbyeSilentState" in source
+    assert "pending: !!pending" in source
     assert "end_session" not in source
     assert "stopProactiveChatSchedule" not in source
     assert "syncVoiceChatComposerHidden" not in source

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -96,6 +96,9 @@ def _make_mgr(session=None) -> LLMSessionManager:
     mgr._voice_playback_active = False
     mgr._takeover_active = False
     mgr._takeover_input_dispatcher = None
+    mgr.goodbye_silent = False
+    mgr.goodbye_silent_reason = ""
+    mgr.goodbye_silent_updated_at = 0.0
     mgr._get_text_guard_max_length = MagicMock(return_value=200)
     # Patch OmniRealtimeClient / OmniOfflineClient isinstance 判定：
     # 在测试里我们只关心 OmniOfflineClient 分支，其他分支显式构造。
@@ -651,6 +654,41 @@ async def test_text_mode_sm_denied_when_session_responding():
     # callbacks 保留以便下轮重试
     assert mgr.pending_agent_callbacks == [{"status": "completed", "summary": "queued"}]
     assert mgr.state.phase is ProactivePhase.IDLE
+
+
+async def test_goodbye_silent_defers_agent_callbacks_and_keeps_queue():
+    """猫态静默时，主动回调不能绕过前端定时器直接投递。"""
+    sess = _FakeOmniOffline(delivered=True)
+    mgr = _make_mgr(session=sess)
+    mgr.goodbye_silent = True
+    cb = {"status": "completed", "summary": "queued"}
+    mgr.pending_agent_callbacks = [cb]
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+
+    assert sess.called_with == []
+    assert mgr.pending_agent_callbacks == [cb]
+    assert mgr.state.phase is ProactivePhase.IDLE
+
+
+def test_goodbye_silent_blocks_manager_release():
+    """猫态静默时，manager 中的 proactive cue 必须继续等待。"""
+    mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
+    mgr.goodbye_silent = True
+
+    assert LLMSessionManager._can_release_proactive(mgr) is False
+
+
+def test_submit_proactive_callback_parks_when_goodbye_silent():
+    """猫态静默期间新来的 proactive callback 进入持久队列，不触发释放泵。"""
+    mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
+    mgr.goodbye_silent = True
+    cb = {"status": "completed", "summary": "queued"}
+
+    LLMSessionManager.submit_proactive_callback(mgr, cb)
+
+    assert mgr.pending_agent_callbacks == [cb]
+    assert mgr.pending_extra_replies
 
 
 async def test_text_mode_successful_delivery_fires_full_event_sequence():

--- a/tests/unit/test_websocket_goodbye_state_static.py
+++ b/tests/unit/test_websocket_goodbye_state_static.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+WEBSOCKET_ROUTER_PATH = Path(__file__).resolve().parents[2] / "main_routers" / "websocket_router.py"
+
+
+def test_goodbye_state_clear_retries_pending_callbacks():
+    source = WEBSOCKET_ROUTER_PATH.read_text(encoding="utf-8")
+
+    goodbye_state_block = source.split('if action == "goodbye_state":', 1)[1].split(
+        'if action == "start_session":',
+        1,
+    )[0]
+
+    assert "set_goodbye_silent(active, reason)" in goodbye_state_block
+    assert "if not active and goodbye_mgr.pending_agent_callbacks:" in goodbye_state_block
+    assert "_fire_task(goodbye_mgr.trigger_agent_callbacks())" in goodbye_state_block


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“再见静默”模式：激活时阻止新的主动问候/回调被触发或释放，并将待发回调持久入列；前端按钮与连接可同步该状态。
  * WebSocket 在连接/重连时同步静默状态，开始会话时清除静默，结束时可设置静默。

* **测试**
  * 增加静默状态同步、回调入队与问候跳过等单元与集成测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->