### PR TITLE
修复刷新/重启 renderer 后后端 goodbye_silent 残留致角色静默（#1698 follow-up）

### DIFF
--- a/static/app-auto-goodbye.js
+++ b/static/app-auto-goodbye.js
@@ -216,6 +216,24 @@
         } catch (_) {}
     }
 
+    // 刷新 / 重启 renderer 后，前端 goodbye 视觉态（_goodbyeClicked）随页面重置为「她已回来」，
+    // 但后端 LLMSessionManager.goodbye_silent 跨 WS 重连存活，可能仍残留上一会话「请她离开」的
+    // 静默——使 greeting / proactive 被压住，角色看着在场却不主动搭话，直到用户显式开会话才解除。
+    // 本控制器只在 pet / 具名角色页（isEligiblePage）启动，是唯一对 goodbye 状态有权威判断的窗口；
+    // chat 等不挂 model manager 的窗口不跑本控制器，天然不会误清别的窗口里真实的 goodbye。
+    // 仅在「全新页面（无 __nekoGoodbyeSilentState 记忆）且当前不在 goodbye」时对账一次，发
+    // goodbye_state:false 清掉后端陈旧静默。同会话内的 WS 重连已有记忆 → 跳过不重复发；真处于
+    // goodbye → isGoodbyeActive 拦住，仍由现有 onopen / goodbye-click 链路重新断言 active=true。
+    function reconcileStaleGoodbyeSilentOnPrime() {
+        if (isGoodbyeActive()) {
+            return;
+        }
+        if (window.__nekoGoodbyeSilentState) {
+            return;
+        }
+        syncGoodbyeSilentState(false, 'fresh-connect-reconcile');
+    }
+
     function markIdleBaseline(source) {
         state.lastInteractionAt = nowMs();
         state.lastInteractionSource = typeof source === 'string' ? source : 'baseline-reset';
@@ -486,6 +504,7 @@
         emitStateChange('infrastructure-primed', {
             reason: 'websocket-open',
         });
+        reconcileStaleGoodbyeSilentOnPrime();
         return true;
     }
 

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -155,7 +155,17 @@ def test_app_auto_goodbye_phase1_harness():
           win.document = doc;
           win.location = {{ pathname }};
           win.appConst = {{}};
-          win.appState = {{ socket: {{ readyState: 0 }} }};
+          const sentMessages = [];
+          win.appState = {{ socket: {{
+            readyState: 0,
+            send(payload) {{
+              try {{
+                sentMessages.push(JSON.parse(payload));
+              }} catch (_) {{
+                sentMessages.push(payload);
+              }}
+            }},
+          }} }};
           win.live2dManager = {{ _goodbyeClicked: false }};
           win.vrmManager = {{ _goodbyeClicked: false }};
           win.mmdManager = {{ _goodbyeClicked: false }};
@@ -227,6 +237,7 @@ def test_app_auto_goodbye_phase1_harness():
             win,
             doc,
             goodbyeEvents,
+            sentMessages,
             advance(ms) {{
               now += ms;
             }},
@@ -583,6 +594,37 @@ def test_app_auto_goodbye_phase1_harness():
           assert(manualState.visualTier === 'cat1', 'manual goodbye should still resolve to cat1');
           assert(manualState.autoGoodbyeTriggered === false, 'manual goodbye should not set auto flag');
           assert(manualState.lastReason === 'manual-goodbye', 'manual goodbye should preserve manual reason');
+
+          // Fresh-page priming reconciles stale backend goodbye_silent: a model/pet window that is
+          // not in goodbye sends goodbye_state:false once on first prime, clearing leftover silence
+          // from a previous "请她离开" so greeting / proactive are not永久 suppressed after a reload.
+          const reconcile = createHarness('/', {{ barrierResolved: true }});
+          await reconcile.flush();
+          assert(reconcile.sentMessages.length === 0, 'reconcile should not fire before websocket open');
+          reconcile.setSocketOpen(true);
+          reconcile.tickAll();
+          const reconcileSends = reconcile.sentMessages.filter((m) => m && m.action === 'goodbye_state');
+          assert(reconcileSends.length === 1, 'fresh prime should send exactly one goodbye_state reconcile');
+          assert(reconcileSends[0].active === false, 'reconcile should clear stale goodbye silence');
+          assert(reconcileSends[0].reason === 'fresh-connect-reconcile', 'reconcile should be tagged');
+          // A subsequent same-session reconnect already has the in-memory state → no duplicate send.
+          reconcile.setSocketOpen(false);
+          reconcile.tickAll();
+          reconcile.setSocketOpen(true);
+          reconcile.tickAll();
+          const reconcileSendsAfter = reconcile.sentMessages.filter((m) => m && m.action === 'goodbye_state');
+          assert(reconcileSendsAfter.length === 1, 'reconnect with cached state should not re-send reconcile');
+
+          // A window already in goodbye must NOT have its silence cleared by the prime reconcile.
+          const stillGoodbye = createHarness('/', {{ barrierResolved: true }});
+          await stillGoodbye.flush();
+          stillGoodbye.win.dispatchEvent(new CustomEventLike('live2d-goodbye-click'));
+          stillGoodbye.setSocketOpen(true);
+          stillGoodbye.tickAll();
+          const clearedWhileGoodbye = stillGoodbye.sentMessages.filter(
+            (m) => m && m.action === 'goodbye_state' && m.active === false
+          );
+          assert(clearedWhileGoodbye.length === 0, 'prime must not clear silence while still in goodbye');
 
           console.log('app-auto-goodbye phase1 harness passed');
         }})().catch((error) => {{


### PR DESCRIPTION
@
## 背景

[#1698](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1698) 让后端 `LLMSessionManager.goodbye_silent` 跨 WS 重连存活，避免「请她离开」后 proactive / greeting 复活。合并后 Codex 在末条 review comment 指出一个残留边界（P2 *Clear stale goodbye silence on fresh reconnect*）。本 PR 修这个边界。

## 问题

只在一个窄场景出现：**renderer 刷新 / 重启，但后端进程没重启，且上一会话处于 goodbye**。

- 前端 goodbye 是纯内存视觉态（`_goodbyeClicked`），刷新后重置 → 角色视觉上「已回来」；
- `window.__nekoGoodbyeSilentState` 记忆也随页面清空；
- `app-websocket.js` 的 onopen 走 else 分支只发 `greeting_check`，**不发** `goodbye_state:false`；
- 后端 `goodbye_silent` 仍卡在上一会话的 `True` → greeting / proactive 被压住。

结果：角色看着在场却不主动搭话，直到用户显式开会话（`start_session` 清 flag）才恢复。

## 为什么不在 onopen 里改

Codex 建议「UI 非 goodbye 就在 onopen 发 `goodbye_state:false`」，但这撞上同 PR 里 CodeRabbit 提的多窗口问题：

- onopen（`app-websocket.js`）是 window-agnostic 的，且 model manager 在 onopen 时未必就绪 → 无法可靠判断「本窗口是否真不在 goodbye」；
- 不挂 model manager 的 chat / chat_full 窗口 `isNekoGoodbyeModeActive()` 永远 false，盲发 `goodbye_state:false` 会**误清别的窗口里真实的 goodbye**，反而复活 proactive，违背 #1698 目的。

## 方案

把对账放进 `app-auto-goodbye.js`——它**只在 pet / 具名角色页（`isEligiblePage`）启动**（chat 等天然不跑），是唯一对 goodbye 有权威判断的窗口，且 tick 驱动可在模型加载后再判。

在 `infrastructure-primed`（WS open）转换时，**仅当「全新页面无 `__nekoGoodbyeSilentState` 记忆 + 当前不在 goodbye」对账一次**，发 `goodbye_state:false` 清陈旧静默：

- 同会话内的 WS 重连已有记忆 → 跳过，不重复发；
- 真处于 goodbye → `isGoodbyeActive()` 拦住，仍由现有 onopen / goodbye-click 链路重新断言 `active=true`；
- 非 model 窗口不跑本控制器 → 不会误清；
- 后端 `set_goodbye_silent(False)` 在 `False→False` 是 no-op（不 log、不 park），冗余对账无副作用。

> 注：刷新后那一刻的「greeting」仍会被在途的旧静默压掉（清除信号晚于 greeting_check），但这与「刷新 ≠ 显式 return」的语义一致；核心修复是 **proactive / 后续行为不再被永久压住**。

## 测试

扩展 `tests/unit/test_app_auto_goodbye_phase1.py` 的 node VM harness（给 mock socket 加 `send` 捕获），新增断言：

- 全新页面首次 prime → 恰好发一条 `goodbye_state{active:false, reason:"fresh-connect-reconcile"}`；
- 同会话重连（已有记忆）→ 不重复发；
- 已处于 goodbye 的窗口 prime → **不**清静默。

`uv run pytest` 跑相关 4 个 goodbye 测试文件 14 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本更新说明

* **Bug 修复**
  * 修复了 WebSocket 重连时可能残留的过期会话状态问题，确保系统功能不被意外阻碍。

* **测试**
  * 增强测试框架的消息收集和验证能力，新增重连场景的一致性检验，提升状态同步的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->