### PR TITLE
fix: keep compact history open after first press

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -630,6 +630,29 @@ describe('App', () => {
     }
   });
 
+  it('keeps compact history open when the first press causes the handle to leave before click', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+
+    const { container } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" />,
+    );
+
+    const handle = container.querySelector<HTMLButtonElement>('.compact-history-visibility-handle');
+    expect(handle).not.toBeNull();
+    expect(handle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.pointerDown(handle!, { pointerType: 'mouse', button: 0, buttons: 1 });
+    expect(handle).toHaveAttribute('aria-expanded', 'true');
+    expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
+
+    fireEvent.pointerLeave(handle!, { pointerType: 'mouse', buttons: 1 });
+    fireEvent.click(handle!);
+
+    expect(handle).toHaveAttribute('aria-expanded', 'true');
+    expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'open');
+    expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBe('true');
+  });
+
   it('keeps compact export history message actions read-only', async () => {
     const onMessageAction = vi.fn();
     const message = parseChatMessage({

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5458,7 +5458,6 @@ function CompactChatApp({
       data-compact-history-open={compactExportHistoryOpen ? 'true' : 'false'}
       onPointerDown={handleCompactHistoryVisibilityPress}
       onPointerCancel={handleCompactHistoryVisibilityPointerCancel}
-      onPointerLeave={handleCompactHistoryVisibilityPointerCancel}
       onClick={handleCompactHistoryVisibilityClick}
     >
       <span className="compact-history-visibility-handle-triangle" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- 修复 PC compact 聊天记录展开时，首次点击因布局变化触发 pointerleave 后又被 click 关回去的问题
- 移除历史展开按钮上对 pointerleave 的 click 抑制清理，仅保留 pointercancel 作为真正取消路径
- 补充回归测试覆盖 pointerdown -> pointerleave -> click 的首次展开场景

## Test Plan
- npm test -- --run src/App.test.tsx -t "keeps compact history open when the first press causes the handle to leave before click"
- npm test -- --run src/App.test.tsx
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了紧凑历史面板在指针事件交错时可能出现的状态回退问题。

* **Tests**
  * 新增测试用例，覆盖历史面板按钮在指针按下、离开、点击交错场景下的状态管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->