### PR TITLE
fix(chat): full 独立窗口补回玻璃半透明（四边渐隐 mask + 顶栏 0.35），#1695 漏的两层

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -148,6 +148,38 @@
                 animation: none;
             }
         }
+        /* 玻璃边缘渐隐 mask 复活（与 ::before/::after 完全相同的 full gate）：把不透明聊天内容
+           （.chat-body 是 rgba(255,255,255,0.91)，近乎实心白）在四边窄带淡出，露出底下 z-index:0
+           的 ::before 静态高光层与 shell 反光边框 —— 这正是「玻璃」观感的本体。#1695 只复活了浮在
+           最上层（z-index:10）的 ::after 流光，::before 高光层被不透明内容整块盖住，故当时「只有
+           流光、没有玻璃」。补回这层 mask 让内容边缘让位、高光透出，玻璃才回来。
+           与裸选择器的旧版（#1594 因无门槛、在共享 /chat 上 React 挂载前先画 → 闪帧而删）不同：
+           这里挂在 full gate 下，compact（attr=compact）与 web /chat_full（无 neko-electron-runtime）
+           都不命中，结构上不可能在共享路径复现闪帧。
+           裁切顾虑：resize 把手 #neko-resize-handle 在 #react-chat-window-root 之外、不受 mask 影响；
+           顶 50 / 侧 12 / 底 16px 均为内容空 padding，淡出带落 padding 上不碰文字。底边收到 6px 且
+           更轻（终点 alpha 0.8 而非旧版 0.6），避免最后一行/滚动条发虚。 */
+        body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) #react-chat-window-root {
+            -webkit-mask-image:
+                linear-gradient(to bottom, rgba(0,0,0,0.3) 0px, black 10px, black calc(100% - 6px), rgba(0,0,0,0.8) 100%),
+                linear-gradient(to right, rgba(0,0,0,0.4) 0px, black 8px, black calc(100% - 8px), rgba(0,0,0,0.4) 100%);
+            -webkit-mask-composite: source-in;
+            mask-image:
+                linear-gradient(to bottom, rgba(0,0,0,0.3) 0px, black 10px, black calc(100% - 6px), rgba(0,0,0,0.8) 100%),
+                linear-gradient(to right, rgba(0,0,0,0.4) 0px, black 8px, black calc(100% - 8px), rgba(0,0,0,0.4) 100%);
+            mask-composite: intersect;
+        }
+        /* 顶栏半透明玻璃（同期 1afbc8d1d 实现：rgba 0.35，比 styles.css 默认 0.75 更透；配
+           styles.css 自带的 blur(48px) 成磨砂条）。#1695 漏了这层 → 顶栏偏实、「玻璃半透明」
+           观感缺失。只覆写背景、不动 styles.css 的 54px 高度/布局（不复活旧版 45px 顶栏 chrome）。
+           注：full 窗口 transparent:true 且同期 lanlan_frd 无 vibrancy/acrylic（已核 git 全史），
+           桌面是锐透出来的、非 OS 磨砂 —— 与当年一致，纯 CSS 半透明，无需 lanlan_frd 配合。 */
+        body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) .window-topbar {
+            background: rgba(255, 255, 255, 0.35);
+        }
+        [data-theme="dark"] body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed) .window-topbar {
+            background: rgba(50, 50, 72, 0.35);
+        }
         /* ──────────────────────────────────────────────────────────────────────
            full 形态在**共享 /chat（compact）**上不注入，仅在此留档：
            旧版在这里把 #react-chat-window-shell 钉成 inset:40px 的全窗口玻璃面板
@@ -361,11 +393,11 @@
                          'Hiragino Sans', 'Malgun Gothic', sans-serif !important;
             font-weight: 400 !important;
         }
-        /* full 形态的暗色顶栏底、#react-chat-window-root 四边渐隐 mask、is-collapsing/
-           is-expanding/is-minimized 全窗口几何复位仍随旧 full 形态退环境（compact 态的
-           最小化/折叠/展开几何由 index.css 的 subtitle-web-host 规则统一负责）。注：
-           liquidFlow 玻璃流光关键帧与 shell 的 ::before/::after 玻璃层已在上方带门槛复活
-           （仅 Electron full 独立窗口），lightSweep 因从未被 animation 引用未恢复。 */
+        /* full 形态的暗色顶栏底、is-collapsing/is-expanding/is-minimized 全窗口几何复位仍随旧
+           full 形态退环境（compact 态的最小化/折叠/展开几何由 index.css 的 subtitle-web-host
+           规则统一负责）。注：liquidFlow 玻璃流光关键帧、shell 的 ::before/::after 玻璃层、以及
+           #react-chat-window-root 四边渐隐 mask 均已在上方带门槛复活（仅 Electron full 独立窗口），
+           lightSweep 因从未被 animation 引用未恢复。 */
         /* 输入区提到光晕层之上，保持原始不透明度 */
         .composer-panel {
             position: relative !important;

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -813,7 +813,18 @@ def test_electron_compact_chat_retires_full_surface_chrome():
     # test_full_chat_glass_flow_revived_and_gated），但**无门槛**的旧形态必须保持移除，
     # 共享 /chat 这条路径才永远不会画出它。
     assert "@keyframes lightSweep" not in template            # 死代码关键帧，未恢复
-    assert "-webkit-mask-image" not in template               # 全窗口 root 四边渐隐 mask
+    # 四边渐隐 mask 已带 full gate 复活（见 test_full_chat_glass_flow_revived_and_gated）。这里只守
+    # 「无门槛」旧形态：每处 -webkit-mask-image 前必须紧邻 full gate —— 裸 #react-chat-window-root
+    # 直接带 mask 才是 #1594 在共享 /chat 上挂载前先画的闪帧根因，必须保持不存在。
+    _mask_token = "-webkit-mask-image"
+    _gate_token = 'data-chat-surface-mode="full"'
+    _scan = 0
+    while True:
+        _scan = template.find(_mask_token, _scan)
+        if _scan == -1:
+            break
+        assert _gate_token in template[max(0, _scan - 400):_scan], "发现无门槛 mask（共享 /chat 闪帧根因）"
+        _scan += len(_mask_token)
     assert "#react-chat-window-shell:not(.is-minimized)::before" not in template
     assert "#react-chat-window-shell:not(.is-minimized)::after" not in template
     assert "inset: 40px 25px 25px 20px" not in template       # 全窗口 shell 几何
@@ -850,6 +861,13 @@ def test_full_chat_glass_flow_revived_and_gated():
     )
     assert glass_gate + "::before" in template      # 静态边缘/顶部高光
     assert glass_gate + "::after" in template        # 三色流光层
+
+    # 玻璃边缘渐隐 mask 复活，且必须挂在与 ::before/::after 完全相同的 full gate 下：把不透明聊天
+    # 内容（.chat-body rgba 0.91）四边淡出、露出 ::before 高光层 —— 这才是「玻璃」本体。#1695 只复活
+    # 了浮在最上层的 ::after 流光，高光层被不透明内容盖住，故当时只有流光没有玻璃。裸 mask 会在共享
+    # /chat 挂载前画→闪帧（#1594 删它的根因），所以这里断言 mask 只出现在 gated root 选择器上。
+    assert glass_gate + " #react-chat-window-root {" in template
+    assert "-webkit-mask-image" in template
 
     # 尊重系统「减少动态」：流光在 prefers-reduced-motion 下停掉。按花括号配平取整段 media
     # 块（而非定长切片），块体增长也不会让断言失真。


### PR DESCRIPTION
## 背景

#1695 复活「玻璃流光」时，实际只复活了**流光**没复活**玻璃**：它还了浮在最上层（`z-index:10`）的 `::after` 三色流光，但「玻璃半透明」的本体是 `z-index:0` 的 `::before` 高光层 + 反光边框，被近乎实心白的 `.chat-body`（`rgba(255,255,255,0.91)`）整块盖住 → 只剩流光透出。

按同期实现（`1afbc8d1d`）对照，被 #1594 删、#1695 没还的半透明层正好两处。本 PR 原值补回。

## 改动（templates/chat.html，均 gated 到 full）

1. **`#react-chat-window-root` 四边渐隐 mask**：把 `.chat-body` 在四边窄带淡出，露出底下 `::before` 高光层与 shell 反光边框 —— 这是「玻璃」观感本体。#1695 以「mask 会裁内容」为由弃用；实测 resize 把手 `#neko-resize-handle` 在 root 之外、顶 50/侧 12/底 16px 均为空 padding，淡出落 padding 上不碰文字。底边从 10px 收到 6px、终点 alpha `0.6→0.8` 防最后一行/滚动条发虚。
2. **`.window-topbar` 半透明覆写 `rgba(255,255,255,0.35)`**（暗色 `rgba(50,50,72,0.35)`）：被 #1594 删、#1695 回落 styles.css 默认 0.75 偏实。配 styles.css 自带 `blur(48px)` 成半透明磨砂条。只覆写背景，不复活旧版 45px 顶栏 chrome。

## 隔离

两条都挂在与 `::before`/`::after` **完全相同的 full gate**（`body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="full"]:not(.is-minimized):not(.neko-e-collapsed)`）下。compact（`attr=compact`）与 web `/chat_full`（无 `neko-electron-runtime`）都不命中，**结构上不可能复现 #1594 的共享 `/chat` 闪帧**（那次根因正是裸选择器无门槛）。未碰共享 `styles.css`。

## 核实「需不需要 lanlan_frd 配合」

读了同期 lanlan_frd（`95a6a10`，2026-05-31）：`REACT_CHAT_DEFAULTS` 与现在一字不差 —— `transparent:true` + `backgroundColor:#00000000`，**无 `backgroundMaterial`/`vibrancy`**（git 全史亦无）。即当年玻璃半透明**纯靠 CSS**，桌面是锐透出来的、非 OS 磨砂，无需 lanlan_frd 配合。

## 测试

- `test_electron_compact_chat_retires_full_surface_chrome`：「裸 `-webkit-mask-image` 必须不存在」改为「每处 mask 前 400 字必须带 full gate」——允许 gated mask 复活，继续守死「无门槛 mask → 共享 /chat 闪帧」根因。
- `test_full_chat_glass_flow_revived_and_gated`：增断言 gated root mask 存在。
- `pytest tests/unit/test_react_chat_window_static.py` → **37 passed**。

## 待人工验证

纯模板 CSS。需在 Electron full 独立窗口目视：玻璃半透明回来、且 compact 切换无残留/闪帧。注：`.chat-body` 同期也是 0.91（为可读性），半透明主要在顶栏+四边，正文区本就不是深度透视 —— 严格照同期复刻，未加码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 优化了聊天窗口的视觉效果，在边缘处添加了渐隐蒙版以实现更平滑的过渡
  * 改进了窗口顶栏的背景样式，增加了半透明效果，在深色主题下提供更佳的视觉体验

<!-- end of auto-generated comment: release notes by coderabbit.ai -->