### PR TITLE
手机版 web 默认聊天界面走 compact 而非 full

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -165,7 +165,11 @@
     }
 
     // Default surface when the user has no persisted preference yet.
-    //   - Web / browser → `full` (the complete chat window).
+    //   - Web / browser (wide) → `full` (the complete chat window).
+    //   - Web / browser (mobile width, non-Electron) → `compact` (the floating
+    //     bar): the full window is built for desktop and overflows a phone, so a
+    //     fresh narrow visitor opens compact. `isMobileWidth()` already excludes
+    //     both Electron runtimes, so this only ever fires for narrow web.
     //   - Electron desktop shell → `compact` (the floating bar): the chat window
     //     (chat.html, electron chat body class) and the pet window (index.html,
     //     __LANLAN_IS_ELECTRON_PET__) both opt into compact.
@@ -180,6 +184,7 @@
         try {
             if (window.__LANLAN_IS_ELECTRON_PET__) return 'compact';
         } catch (_) {}
+        if (isMobileWidth()) return 'compact';
         return 'full';
     }
 


### PR DESCRIPTION
## 背景

`chatSurfaceMode`(compact / full)的默认值由 `getDefaultChatSurfaceMode()` 决定:Electron chat.html / Pet 默认 compact,其余一律 full。窄屏 web 手机访客目前落在 full —— 而 full 聊天窗口是为桌面设计的,在手机宽度下会溢出。

## 改动

在 `getDefaultChatSurfaceMode()` 末尾 `return 'full'` 之前加一句:

```js
if (isMobileWidth()) return 'compact';
```

`isMobileWidth()` 已经把"宽度 ≤768 且非 Electron"判定好,且对 chat.html / Pet 两个 Electron 运行时、对宽屏 web 都返回 `false`,所以这一句**只命中窄屏 web 这一条路径**,index.html 宽屏、chat.html Electron 两条上下文完全不受影响。

## 边界

- **只改默认值**:localStorage 已有的用户偏好(`neko.reactChatWindow.chatSurfaceMode`)仍然优先。只有全新的窄屏访客才默认进 compact。
- **只初始判定**:不监听运行时 resize,桌面浏览器把窗口拖窄到 768 以下不会实时切换。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化了移动设备上的聊天界面默认显示模式。在窄屏幕设备上，聊天界面现在默认采用紧凑视图，提供更适配小屏幕的用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->