### PR TITLE
[codex] docs: add Linux desktop runtime triage guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,20 +9,23 @@ function guideSidebar(lang: 'en' | 'zh-CN' | 'ja') {
     en: {
       group: 'Getting Started',
       intro: 'Introduction', prereq: 'Prerequisites', dev: 'Development Setup',
-      quick: 'Quick Start', struct: 'Project Structure',
+      quick: 'Quick Start', struct: 'Project Structure', linux: 'Linux Desktop Runtime',
     },
     'zh-CN': {
       group: '快速上手',
       intro: '简介', prereq: '前置条件', dev: '开发环境搭建',
-      quick: '快速开始', struct: '项目结构',
+      quick: '快速开始', struct: '项目结构', linux: 'Linux 桌面运行时',
     },
     ja: {
       group: 'はじめに',
       intro: 'はじめに', prereq: '前提条件', dev: '開発環境の構築',
-      quick: 'クイックスタート', struct: 'プロジェクト構造',
+      quick: 'クイックスタート', struct: 'プロジェクト構造', linux: 'Linux Desktop Runtime',
     },
   }[lang]
   const p = lang === 'en' ? '' : `/${lang}`
+  const linuxDesktopItems = lang === 'ja'
+    ? []
+    : [{ text: t.linux, link: `${p}/guide/linux-desktop-runtime` }]
   return [
     {
       text: t.group,
@@ -31,6 +34,7 @@ function guideSidebar(lang: 'en' | 'zh-CN' | 'ja') {
         { text: t.prereq, link: `${p}/guide/prerequisites` },
         { text: t.dev, link: `${p}/guide/dev-setup` },
         { text: t.quick, link: `${p}/guide/quick-start` },
+        ...linuxDesktopItems,
         { text: t.struct, link: `${p}/guide/project-structure` },
       ],
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,13 +19,11 @@ function guideSidebar(lang: 'en' | 'zh-CN' | 'ja') {
     ja: {
       group: 'はじめに',
       intro: 'はじめに', prereq: '前提条件', dev: '開発環境の構築',
-      quick: 'クイックスタート', struct: 'プロジェクト構造', linux: 'Linux Desktop Runtime',
+      quick: 'クイックスタート', struct: 'プロジェクト構造', linux: 'Linux デスクトップランタイム',
     },
   }[lang]
   const p = lang === 'en' ? '' : `/${lang}`
-  const linuxDesktopItems = lang === 'ja'
-    ? []
-    : [{ text: t.linux, link: `${p}/guide/linux-desktop-runtime` }]
+  const linuxDesktopItems = [{ text: t.linux, link: `${p}/guide/linux-desktop-runtime` }]
   return [
     {
       text: t.group,

--- a/docs/guide/linux-desktop-runtime.md
+++ b/docs/guide/linux-desktop-runtime.md
@@ -31,12 +31,17 @@ echo "XMODIFIERS=$XMODIFIERS"
 echo "SteamAppId=$SteamAppId"
 ```
 
-For a running desktop shell process, inspect the real environment and arguments. Do not sample `projectneko_server` or other backend helpers for Electron window and input-method bugs:
+For a running desktop shell process, inspect the real environment and arguments. Target the **main Electron browser process**, not a `projectneko_server` backend helper nor an Electron child process. The transparent window and the GTK input-method modules live in the main browser process, while renderer/GPU/zygote children (`--type=...`) do not own them, so `pgrep -n` (newest PID) would usually land on a child and make the checks below report missing IM/input-shape state by mistake. Select the first matching process whose command line has no `--type=` flag:
 
 ```bash
-pid="$(pgrep -n -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o')"
+pid=""
+for p in $(pgrep -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o'); do
+  if ! tr '\0' '\n' < "/proc/$p/cmdline" | grep -q -- '--type='; then
+    pid="$p"; break
+  fi
+done
 if [ -z "$pid" ]; then
-  echo "N.E.K.O desktop shell process was not found" >&2
+  echo "N.E.K.O desktop shell (main Electron process) was not found" >&2
   exit 1
 fi
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'

--- a/docs/guide/linux-desktop-runtime.md
+++ b/docs/guide/linux-desktop-runtime.md
@@ -42,10 +42,11 @@ if [ "${#mains[@]}" -eq 0 ]; then
   echo "N.E.K.O desktop shell (main Electron process) was not found" >&2
   exit 1
 elif [ "${#mains[@]}" -gt 1 ]; then
-  echo "Multiple candidates found; confirm the N.E.K.O PID and set it manually:" >&2
+  echo "Multiple candidates found; pick one, set pid=<PID> manually and re-run:" >&2
   for p in "${mains[@]}"; do
     printf '  %s  %s\n' "$p" "$(tr '\0' ' ' < "/proc/$p/cmdline")" >&2
   done
+  exit 1
 fi
 pid="${mains[0]}"
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'

--- a/docs/guide/linux-desktop-runtime.md
+++ b/docs/guide/linux-desktop-runtime.md
@@ -49,6 +49,13 @@ elif [ "${#mains[@]}" -gt 1 ]; then
   exit 1
 fi
 pid="${mains[0]}"
+# AppRun/AppImage are kept so a Steam-launched build whose command line lacks
+# the literal app name is still matched, but they can also hit an unrelated
+# app. If the sole match does not look like N.E.K.O, warn and verify the
+# cmdline printed below before trusting the diagnostics.
+if ! tr '\0' '\n' < "/proc/$pid/cmdline" | grep -qiE 'n[.]?e[.]?k[.]?o'; then
+  echo "Warning: pid $pid matched only a generic AppRun/AppImage rule; confirm the cmdline below is N.E.K.O." >&2
+fi
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
 tr '\0' ' ' < "/proc/$pid/cmdline"; echo
 ```

--- a/docs/guide/linux-desktop-runtime.md
+++ b/docs/guide/linux-desktop-runtime.md
@@ -31,10 +31,14 @@ echo "XMODIFIERS=$XMODIFIERS"
 echo "SteamAppId=$SteamAppId"
 ```
 
-For a running desktop process, inspect the real environment and arguments:
+For a running desktop shell process, inspect the real environment and arguments. Do not sample `projectneko_server` or other backend helpers for Electron window and input-method bugs:
 
 ```bash
-pid="$(pgrep -n -f 'n.e.k.o|projectneko_server')"
+pid="$(pgrep -n -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o')"
+if [ -z "$pid" ]; then
+  echo "N.E.K.O desktop shell process was not found" >&2
+  exit 1
+fi
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
 tr '\0' ' ' < "/proc/$pid/cmdline"; echo
 ```

--- a/docs/guide/linux-desktop-runtime.md
+++ b/docs/guide/linux-desktop-runtime.md
@@ -1,0 +1,117 @@
+# Linux Desktop Runtime
+
+This page collects Linux desktop diagnostics for the packaged AppImage or Steam build. It is aimed at maintainers and issue triage, especially when a report involves KDE/Wayland click-through, transparent windows, or Chinese/Japanese/Korean input methods.
+
+Related reports include [#396](https://github.com/Project-N-E-K-O/N.E.K.O/issues/396), [#1276](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1276), and [#1279](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1279).
+
+## Runtime Layers
+
+The Linux desktop release is assembled from two layers:
+
+| Layer | Typical responsibility |
+|-------|------------------------|
+| Python backend bundle | API servers, storage, Steamworks, logs, runtime diagnostics |
+| Electron desktop shell | AppImage entrypoint, Chromium flags, transparent windows, desktop IME integration |
+
+When debugging a Linux-only desktop bug, first confirm which layer owns the failing behavior. Text cannot be committed into an Electron input field, a transparent window blocks clicks, or a toast ignores mouse input usually belongs to the Electron/AppImage layer. Server startup, storage, Steamworks, and Python import failures usually belong to the backend bundle.
+
+## Quick Environment Snapshot
+
+Ask reporters for the following before changing code:
+
+```bash
+echo "XDG_SESSION_TYPE=$XDG_SESSION_TYPE"
+echo "XDG_CURRENT_DESKTOP=$XDG_CURRENT_DESKTOP"
+echo "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
+echo "DISPLAY=$DISPLAY"
+echo "GTK_IM_MODULE=$GTK_IM_MODULE"
+echo "GTK_IM_MODULE_FILE=$GTK_IM_MODULE_FILE"
+echo "QT_IM_MODULE=$QT_IM_MODULE"
+echo "XMODIFIERS=$XMODIFIERS"
+echo "SteamAppId=$SteamAppId"
+```
+
+For a running desktop process, inspect the real environment and arguments:
+
+```bash
+pid="$(pgrep -n -f 'n.e.k.o|projectneko_server')"
+tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
+tr '\0' ' ' < "/proc/$pid/cmdline"; echo
+```
+
+For input-method library loading, also inspect mapped libraries:
+
+```bash
+grep -E 'im-fcitx|Fcitx5GClient|gtk|glib|ibus' "/proc/$pid/maps" | sort -u
+```
+
+## Click-Through On X11 And Wayland
+
+Linux transparent-window click-through must be treated as compositor-specific.
+
+On X11 or XWayland, the reliable path is an X11 input shape, such as a `ShapeInput` helper. This allows the visible pet or interaction rectangle to receive events while the rest of the transparent window lets clicks reach applications below it.
+
+On Wayland, Electron APIs such as `setIgnoreMouseEvents` and `setShape` can be insufficient for a full-screen transparent pet window. Some compositors, including KDE Plasma in affected reports, can still route pointer input to the transparent Electron surface even when the app continuously updates the input region. If a Wayland session reports that all windows below N.E.K.O. are unclickable, do not assume the renderer's hit-test rectangles are wrong until X11/XWayland has been compared.
+
+Suggested triage:
+
+1. Reproduce with the packaged default.
+2. Reproduce with X11/XWayland forced by the Electron shell, for example `--ozone-platform=x11`.
+3. Confirm whether the process has an X11 display and the expected X11 input-shape helper logs.
+4. If X11 works and Wayland blocks input globally, keep the issue scoped to Wayland compositor/Electron input-region behavior rather than backend startup.
+
+## Steam And CJK Input Methods
+
+CJK input in the Steam build can fail even when the same desktop environment works in a normal terminal launch. The Steam runtime can change inherited environment variables and library resolution, and Chromium may fall back to XIM.
+
+The baseline input-method environment for Fcitx should include:
+
+```bash
+export GTK_IM_MODULE=fcitx
+export QT_IM_MODULE=fcitx
+export XMODIFIERS=@im=fcitx
+export SDL_IM_MODULE=fcitx
+export INPUT_METHOD=fcitx
+```
+
+For X11/XWayland desktop builds, prefer native GTK IM modules over XIM when possible. XIM can show a candidate window but still fail to commit text into Electron text fields. A successful native Fcitx5 path normally shows `im-fcitx5.so` and `libFcitx5GClient.so.2` mapped in the Electron process.
+
+If native Fcitx fails only inside Steam, check for GLib version mismatches:
+
+```bash
+ldd -r /path/to/im-fcitx5.so | grep -E 'not found|undefined symbol|glib|gobject'
+```
+
+Known failure signatures include:
+
+```text
+undefined symbol: g_once_init_leave_pointer
+Loading IM context type 'fcitx' failed
+GLib version too old
+```
+
+These errors mean the module was found but could not initialize against the libraries visible inside the Steam runtime. A robust packaged fix should avoid depending on an arbitrary host GTK/Fcitx module that was compiled against a newer GLib than the Steam runtime provides. Practical options are:
+
+1. Bundle a compatible GTK IM module and its required libraries with the Electron shell.
+2. Generate a `GTK_IM_MODULE_FILE` cache that points at the bundled module.
+3. Keep `LD_LIBRARY_PATH` narrow so only the required compatible libraries are preferred.
+4. Log the selected IM module path and initialization failure early, before users only see "cannot type Chinese".
+
+## What To Include In A Bug Report
+
+For click-through bugs, include:
+
+- Desktop environment and session type.
+- Whether X11/XWayland and Wayland behave differently.
+- Electron command-line flags, especially `--ozone-platform`.
+- Logs around input-shape or mouse-through initialization.
+
+For input-method bugs, include:
+
+- Input method framework and version, such as Fcitx5 or IBus.
+- The process environment variables listed above.
+- Whether the candidate window appears.
+- Whether committed text reaches the chat input.
+- `ldd -r` output for the selected GTK IM module if `GTK_IM_MODULE=fcitx` or `ibus` is used.
+
+Keeping these reports separated makes fixes safer: click-through is mostly window/compositor behavior, while CJK input is mostly AppImage/Steam environment and native-library loading.

--- a/docs/guide/linux-desktop-runtime.md
+++ b/docs/guide/linux-desktop-runtime.md
@@ -31,19 +31,23 @@ echo "XMODIFIERS=$XMODIFIERS"
 echo "SteamAppId=$SteamAppId"
 ```
 
-For a running desktop shell process, inspect the real environment and arguments. Target the **main Electron browser process**, not a `projectneko_server` backend helper nor an Electron child process. The transparent window and the GTK input-method modules live in the main browser process, while renderer/GPU/zygote children (`--type=...`) do not own them, so `pgrep -n` (newest PID) would usually land on a child and make the checks below report missing IM/input-shape state by mistake. Select the first matching process whose command line has no `--type=` flag:
+For a running desktop shell process, inspect the real environment and arguments. Target the **main Electron browser process**, not a `projectneko_server` backend helper nor an Electron child process. The transparent window and the GTK input-method modules live in the main browser process, while renderer/GPU/zygote children (`--type=...`) do not own them, so `pgrep -n` (newest PID) would usually land on a child and make the checks below report missing IM/input-shape state by mistake. Match N.E.K.O's AppImage/AppRun specifically (avoid the generic `electron` term so an unrelated Electron app such as VS Code or Discord is not picked up), then keep the matching process(es) without a `--type=` flag:
 
 ```bash
-pid=""
-for p in $(pgrep -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o'); do
-  if ! tr '\0' '\n' < "/proc/$p/cmdline" | grep -q -- '--type='; then
-    pid="$p"; break
-  fi
+mains=()
+for p in $(pgrep -f 'AppRun|AppImage|N[.]E[.]K[.]O|n[.]e[.]k[.]o'); do
+  tr '\0' '\n' < "/proc/$p/cmdline" | grep -q -- '--type=' || mains+=("$p")
 done
-if [ -z "$pid" ]; then
+if [ "${#mains[@]}" -eq 0 ]; then
   echo "N.E.K.O desktop shell (main Electron process) was not found" >&2
   exit 1
+elif [ "${#mains[@]}" -gt 1 ]; then
+  echo "Multiple candidates found; confirm the N.E.K.O PID and set it manually:" >&2
+  for p in "${mains[@]}"; do
+    printf '  %s  %s\n' "$p" "$(tr '\0' ' ' < "/proc/$p/cmdline")" >&2
+  done
 fi
+pid="${mains[0]}"
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
 tr '\0' ' ' < "/proc/$pid/cmdline"; echo
 ```
@@ -85,9 +89,10 @@ export INPUT_METHOD=fcitx
 
 For X11/XWayland desktop builds, prefer native GTK IM modules over XIM when possible. XIM can show a candidate window but still fail to commit text into Electron text fields. A successful native Fcitx5 path normally shows `im-fcitx5.so` and `libFcitx5GClient.so.2` mapped in the Electron process.
 
-If native Fcitx fails only inside Steam, check for GLib version mismatches:
+If native Fcitx fails only inside Steam, check for GLib version mismatches — but run the check with the **Steam runtime's** library resolution, not your plain terminal's. `ldd -r` resolves relocations against the current environment, so a normal-terminal run can report a false clean result and hide exactly the Steam-only mismatch this section is diagnosing. Import `LD_LIBRARY_PATH` from the Steam-launched N.E.K.O process (`$pid` from the snapshot above), or run the check from a shell started by Steam:
 
 ```bash
+export LD_LIBRARY_PATH="$(tr '\0' '\n' < "/proc/$pid/environ" | sed -n 's/^LD_LIBRARY_PATH=//p')"
 ldd -r /path/to/im-fcitx5.so | grep -E 'not found|undefined symbol|glib|gobject'
 ```
 

--- a/docs/ja/guide/linux-desktop-runtime.md
+++ b/docs/ja/guide/linux-desktop-runtime.md
@@ -1,0 +1,139 @@
+# Linux デスクトップランタイム
+
+このページは、パッケージ化された AppImage または Steam ビルド向けの Linux デスクトップ診断をまとめたものです。メンテナーや issue のトリアージ、特に KDE/Wayland のクリックスルー、透明ウィンドウ、または中国語・日本語・韓国語の入力メソッドが絡む報告を対象としています。
+
+関連する報告：[#396](https://github.com/Project-N-E-K-O/N.E.K.O/issues/396)、[#1276](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1276)、[#1279](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1279)。
+
+## ランタイムの構成レイヤー
+
+Linux デスクトップ版は 2 つのレイヤーで構成されています：
+
+| レイヤー | 主な責務 |
+|------|------|
+| Python バックエンドバンドル | API サーバー、ストレージ、Steamworks、ログ、ランタイム診断 |
+| Electron デスクトップシェル | AppImage のエントリポイント、Chromium フラグ、透明ウィンドウ、デスクトップ IME 連携 |
+
+Linux 固有のデスクトップ不具合をデバッグする際は、まずどちらのレイヤーが該当の挙動を担っているかを確認します。Electron の入力欄にテキストを確定できない、透明ウィンドウがクリックを遮る、トーストがマウス入力を無視する、といった症状は通常 Electron/AppImage レイヤーに属します。サーバー起動、ストレージ、Steamworks、Python の import 失敗は通常バックエンドバンドルに属します。
+
+## 環境スナップショットの取得
+
+コードを変更する前に、報告者へ以下を依頼してください：
+
+```bash
+echo "XDG_SESSION_TYPE=$XDG_SESSION_TYPE"
+echo "XDG_CURRENT_DESKTOP=$XDG_CURRENT_DESKTOP"
+echo "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
+echo "DISPLAY=$DISPLAY"
+echo "GTK_IM_MODULE=$GTK_IM_MODULE"
+echo "GTK_IM_MODULE_FILE=$GTK_IM_MODULE_FILE"
+echo "QT_IM_MODULE=$QT_IM_MODULE"
+echo "XMODIFIERS=$XMODIFIERS"
+echo "SteamAppId=$SteamAppId"
+```
+
+実行中のデスクトップシェルプロセスについて、実際の環境変数と起動引数を調べます。**Electron のメインブラウザープロセス**を対象にしてください。`projectneko_server` などのバックエンドヘルパーでも、Electron の子プロセスでもありません。透明ウィンドウと GTK 入力メソッドモジュールはメインブラウザープロセスに常駐し、renderer/GPU/zygote の子プロセス（`--type=...` 付き）はそれらを保持しません。そのため `pgrep -n`（最新 PID）は通常子プロセスを拾ってしまい、以下のチェックが「IM/input-shape が未ロード」と誤判定します。N.E.K.O の AppImage/AppRun を特定して照合し（汎用の `electron` は使わず、VS Code や Discord など無関係な Electron アプリを拾わないように）、`--type=` フラグを持たないプロセスだけを残します：
+
+```bash
+mains=()
+for p in $(pgrep -f 'AppRun|AppImage|N[.]E[.]K[.]O|n[.]e[.]k[.]o'); do
+  tr '\0' '\n' < "/proc/$p/cmdline" | grep -q -- '--type=' || mains+=("$p")
+done
+if [ "${#mains[@]}" -eq 0 ]; then
+  echo "N.E.K.O desktop shell (main Electron process) was not found" >&2
+  exit 1
+elif [ "${#mains[@]}" -gt 1 ]; then
+  echo "複数の候補が見つかりました。1 つ選び、pid=<PID> を手動で設定して再実行してください：" >&2
+  for p in "${mains[@]}"; do
+    printf '  %s  %s\n' "$p" "$(tr '\0' ' ' < "/proc/$p/cmdline")" >&2
+  done
+  exit 1
+fi
+pid="${mains[0]}"
+# AppRun/AppImage は「Steam 起動でコマンドラインに app 名が含まれない」ケースを
+# 拾うために残していますが、無関係なアプリに当たることもあります。唯一の一致が
+# N.E.K.O らしく見えない場合は警告し、下に表示される cmdline を確認してから
+# 診断結果を信用してください。
+if ! tr '\0' '\n' < "/proc/$pid/cmdline" | grep -qiE 'n[.]?e[.]?k[.]?o'; then
+  echo "警告：pid $pid は汎用の AppRun/AppImage ルールのみで一致しました。下の cmdline が N.E.K.O であることを確認してください。" >&2
+fi
+tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
+tr '\0' ' ' < "/proc/$pid/cmdline"; echo
+```
+
+入力メソッド関連のライブラリがロードされているかも確認します：
+
+```bash
+grep -E 'im-fcitx|Fcitx5GClient|gtk|glib|ibus' "/proc/$pid/maps" | sort -u
+```
+
+## X11 と Wayland でのクリックスルー
+
+Linux の透明ウィンドウのクリックスルーは、コンポジター依存として扱う必要があります。
+
+X11 または XWayland では、信頼できる方法は `ShapeInput` ヘルパーのような X11 input shape です。これにより、表示されているペットや操作領域の矩形はイベントを受け取りつつ、透明ウィンドウの残りの部分はクリックを下のアプリへ通します。
+
+Wayland では、`setIgnoreMouseEvents` や `setShape` といった Electron API が、全画面の透明ペットウィンドウには不十分なことがあります。一部のコンポジター（報告例では KDE Plasma を含む）は、アプリが input region を継続的に更新していても、ポインター入力を透明な Electron サーフェスへルーティングし続けることがあります。Wayland セッションで N.E.K.O. の下にあるすべてのウィンドウがクリックできないと報告された場合、X11/XWayland と比較するまでは renderer の当たり判定矩形が誤っていると決めつけないでください。
+
+推奨されるトリアージ：
+
+1. パッケージ既定の状態で再現する。
+2. Electron シェルで X11/XWayland を強制して再現する（例：`--ozone-platform=x11`）。
+3. プロセスが X11 ディスプレイを持つか、期待される X11 input-shape ヘルパーのログが出ているかを確認する。
+4. X11 では動作し Wayland では入力が全面的にブロックされる場合、バックエンド起動ではなく Wayland コンポジター/Electron の input-region 挙動に問題を絞る。
+
+## Steam と CJK 入力メソッド
+
+Steam ビルドでの CJK 入力は、同じデスクトップ環境が通常のターミナル起動では動作していても失敗することがあります。Steam ランタイムは継承される環境変数やライブラリ解決を変えることがあり、Chromium が XIM にフォールバックする場合があります。
+
+Fcitx 向けの基本的な入力メソッド環境には、以下を含めるべきです：
+
+```bash
+export GTK_IM_MODULE=fcitx
+export QT_IM_MODULE=fcitx
+export XMODIFIERS=@im=fcitx
+export SDL_IM_MODULE=fcitx
+export INPUT_METHOD=fcitx
+```
+
+X11/XWayland デスクトップビルドでは、可能な限り XIM より GTK ネイティブ IM モジュールを優先してください。XIM は候補ウィンドウを表示できても、Electron のテキスト欄へのテキスト確定に失敗することがあります。ネイティブ Fcitx5 が成功している場合、通常は Electron プロセスに `im-fcitx5.so` と `libFcitx5GClient.so.2` がマップされて見えます。
+
+ネイティブ Fcitx が Steam の内側でのみ失敗する場合は、GLib のバージョン不整合を確認します。ただしチェックは通常のターミナルではなく、**Steam ランタイムの**ライブラリ解決環境で実行してください。`ldd -r` は現在の環境に対して再配置を解決するため、通常のターミナルで実行すると誤って「問題なし」と表示され、まさにこの節が診断しようとしている Steam 固有の不整合を隠してしまいます。Steam から起動された N.E.K.O プロセス（上のスナップショットの `$pid`）から `LD_LIBRARY_PATH` を取り込むか、Steam から起動したシェルでチェックを実行してください：
+
+```bash
+export LD_LIBRARY_PATH="$(tr '\0' '\n' < "/proc/$pid/environ" | sed -n 's/^LD_LIBRARY_PATH=//p')"
+ldd -r /path/to/im-fcitx5.so | grep -E 'not found|undefined symbol|glib|gobject'
+```
+
+既知の失敗シグネチャには以下が含まれます：
+
+```text
+undefined symbol: g_once_init_leave_pointer
+Loading IM context type 'fcitx' failed
+GLib version too old
+```
+
+これらのエラーは、モジュールは見つかったものの、Steam ランタイム内で見えるライブラリに対して初期化できなかったことを意味します。堅牢なパッケージ修正では、Steam ランタイムが提供するより新しい GLib に対してコンパイルされた、任意のホスト GTK/Fcitx モジュールへの依存を避けるべきです。現実的な選択肢は：
+
+1. 互換性のある GTK IM モジュールと必要なライブラリを Electron シェルに同梱する。
+2. 同梱モジュールを指す `GTK_IM_MODULE_FILE` キャッシュを生成する。
+3. `LD_LIBRARY_PATH` を狭く保ち、必要な互換ライブラリだけが優先されるようにする。
+4. 選択された IM モジュールのパスと初期化失敗を、ユーザーが「中国語が入力できない」としか見えなくなる前に、早期にログ出力する。
+
+## バグ報告に含めるべき内容
+
+クリックスルーの不具合では、以下を含めてください：
+
+- デスクトップ環境とセッションタイプ。
+- X11/XWayland と Wayland で挙動が異なるかどうか。
+- Electron のコマンドラインフラグ、特に `--ozone-platform`。
+- input-shape や mouse-through の初期化まわりのログ。
+
+入力メソッドの不具合では、以下を含めてください：
+
+- 入力メソッドフレームワークとそのバージョン（Fcitx5 や IBus など）。
+- 上記のプロセス環境変数。
+- 候補ウィンドウが表示されるかどうか。
+- 確定したテキストがチャット入力欄に届くかどうか。
+- `GTK_IM_MODULE=fcitx` または `ibus` を使う場合、選択した GTK IM モジュールの `ldd -r` 出力。
+
+これらの報告を分けて扱うことで、修正がより安全になります：クリックスルーは主にウィンドウ/コンポジターの挙動、CJK 入力は主に AppImage/Steam の環境とネイティブライブラリのロードに関わるためです。

--- a/docs/zh-CN/guide/linux-desktop-runtime.md
+++ b/docs/zh-CN/guide/linux-desktop-runtime.md
@@ -42,10 +42,11 @@ if [ "${#mains[@]}" -eq 0 ]; then
   echo "N.E.K.O desktop shell (main Electron process) was not found" >&2
   exit 1
 elif [ "${#mains[@]}" -gt 1 ]; then
-  echo "找到多个候选，请确认 N.E.K.O 的 PID 并手动指定：" >&2
+  echo "找到多个候选，请挑一个、手动设 pid=<PID> 后重跑：" >&2
   for p in "${mains[@]}"; do
     printf '  %s  %s\n' "$p" "$(tr '\0' ' ' < "/proc/$p/cmdline")" >&2
   done
+  exit 1
 fi
 pid="${mains[0]}"
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'

--- a/docs/zh-CN/guide/linux-desktop-runtime.md
+++ b/docs/zh-CN/guide/linux-desktop-runtime.md
@@ -31,19 +31,23 @@ echo "XMODIFIERS=$XMODIFIERS"
 echo "SteamAppId=$SteamAppId"
 ```
 
-对正在运行的桌面壳进程，检查真实环境变量和启动参数。要采样 **Electron 主浏览器进程**，既不要采样 `projectneko_server` 等后端 helper，也不要采样 Electron 子进程。透明窗口和 GTK 输入法模块都驻留在主浏览器进程里，renderer/GPU/zygote 子进程（带 `--type=...`）并不持有它们；而 `pgrep -n`（取最新 PID）通常会命中子进程，导致下面的检查误报「输入法/input-shape 未加载」。应选取第一个命令行不含 `--type=` 的匹配进程：
+对正在运行的桌面壳进程，检查真实环境变量和启动参数。要采样 **Electron 主浏览器进程**，既不要采样 `projectneko_server` 等后端 helper，也不要采样 Electron 子进程。透明窗口和 GTK 输入法模块都驻留在主浏览器进程里，renderer/GPU/zygote 子进程（带 `--type=...`）并不持有它们；而 `pgrep -n`（取最新 PID）通常会命中子进程，导致下面的检查误报「输入法/input-shape 未加载」。匹配时要锁定 N.E.K.O 的 AppImage/AppRun（不要用泛词 `electron`，否则会误命中 VS Code、Discord 等其他 Electron 应用），再保留命令行不含 `--type=` 的进程：
 
 ```bash
-pid=""
-for p in $(pgrep -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o'); do
-  if ! tr '\0' '\n' < "/proc/$p/cmdline" | grep -q -- '--type='; then
-    pid="$p"; break
-  fi
+mains=()
+for p in $(pgrep -f 'AppRun|AppImage|N[.]E[.]K[.]O|n[.]e[.]k[.]o'); do
+  tr '\0' '\n' < "/proc/$p/cmdline" | grep -q -- '--type=' || mains+=("$p")
 done
-if [ -z "$pid" ]; then
+if [ "${#mains[@]}" -eq 0 ]; then
   echo "N.E.K.O desktop shell (main Electron process) was not found" >&2
   exit 1
+elif [ "${#mains[@]}" -gt 1 ]; then
+  echo "找到多个候选，请确认 N.E.K.O 的 PID 并手动指定：" >&2
+  for p in "${mains[@]}"; do
+    printf '  %s  %s\n' "$p" "$(tr '\0' ' ' < "/proc/$p/cmdline")" >&2
+  done
 fi
+pid="${mains[0]}"
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
 tr '\0' ' ' < "/proc/$pid/cmdline"; echo
 ```
@@ -85,9 +89,10 @@ export INPUT_METHOD=fcitx
 
 对 X11 / XWayland 桌面包，优先使用原生 GTK IM module，而不是只依赖 XIM。XIM 可能能调出候选框，但文字 commit 仍然进不了 Electron 文本输入框。Fcitx5 原生路径成功时，Electron 进程中通常能看到 `im-fcitx5.so` 和 `libFcitx5GClient.so.2`。
 
-如果只在 Steam 内原生 Fcitx 加载失败，应检查 GLib 版本不匹配：
+如果只在 Steam 内原生 Fcitx 加载失败，应检查 GLib 版本不匹配——但要在 **Steam runtime 的**库解析环境下跑，而不是普通终端。`ldd -r` 是按当前环境解析 relocation 的，在普通终端跑可能给出假「干净」结果，恰好掩盖本节要诊断的「仅 Steam 下不匹配」。从 Steam 启动的 N.E.K.O 进程（上面快照里的 `$pid`）导入 `LD_LIBRARY_PATH`，或直接从 Steam 启动的 shell 里跑：
 
 ```bash
+export LD_LIBRARY_PATH="$(tr '\0' '\n' < "/proc/$pid/environ" | sed -n 's/^LD_LIBRARY_PATH=//p')"
 ldd -r /path/to/im-fcitx5.so | grep -E 'not found|undefined symbol|glib|gobject'
 ```
 

--- a/docs/zh-CN/guide/linux-desktop-runtime.md
+++ b/docs/zh-CN/guide/linux-desktop-runtime.md
@@ -1,0 +1,117 @@
+# Linux 桌面运行时
+
+本文整理 Linux 桌面版 AppImage / Steam 包的排障线索，主要面向维护者和 issue triage。适用场景包括 KDE / Wayland 点击穿透异常、透明窗口拦截输入、Toast 不可点击，以及中文/日文/韩文输入法无法提交文字。
+
+相关 issue：[ #396 ](https://github.com/Project-N-E-K-O/N.E.K.O/issues/396)、[ #1276 ](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1276)、[ #1279 ](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1279)。
+
+## 运行时分层
+
+Linux 桌面发行包通常由两层组成：
+
+| 层级 | 典型职责 |
+|------|----------|
+| Python 后端包 | API 服务、存储、Steamworks、日志、运行时诊断 |
+| Electron 桌面壳 | AppImage 入口、Chromium 参数、透明窗口、桌面输入法集成 |
+
+调试 Linux 桌面专属问题时，先判断问题属于哪一层。文本无法进入 Electron 输入框、透明窗口挡住下层应用、Toast 可见但点不到，通常属于 Electron / AppImage 层；服务启动、存储迁移、Steamworks、Python import 报错，则通常属于后端包。
+
+## 快速环境快照
+
+先让反馈者提供这些信息：
+
+```bash
+echo "XDG_SESSION_TYPE=$XDG_SESSION_TYPE"
+echo "XDG_CURRENT_DESKTOP=$XDG_CURRENT_DESKTOP"
+echo "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
+echo "DISPLAY=$DISPLAY"
+echo "GTK_IM_MODULE=$GTK_IM_MODULE"
+echo "GTK_IM_MODULE_FILE=$GTK_IM_MODULE_FILE"
+echo "QT_IM_MODULE=$QT_IM_MODULE"
+echo "XMODIFIERS=$XMODIFIERS"
+echo "SteamAppId=$SteamAppId"
+```
+
+对正在运行的桌面进程，检查真实环境变量和启动参数：
+
+```bash
+pid="$(pgrep -n -f 'n.e.k.o|projectneko_server')"
+tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
+tr '\0' ' ' < "/proc/$pid/cmdline"; echo
+```
+
+检查输入法相关动态库是否实际加载：
+
+```bash
+grep -E 'im-fcitx|Fcitx5GClient|gtk|glib|ibus' "/proc/$pid/maps" | sort -u
+```
+
+## X11 与 Wayland 点击穿透
+
+Linux 透明窗口点击穿透需要按合成器分别处理。
+
+在 X11 / XWayland 下，可靠路径通常是 X11 input shape，例如 `ShapeInput` helper。它可以让可见的宠物或交互矩形接收事件，而透明区域的点击继续落到下层窗口。
+
+在 Wayland 下，Electron 的 `setIgnoreMouseEvents` 和 `setShape` 对全屏透明宠物窗口可能不够可靠。受影响的 KDE Plasma 环境中，即使应用持续更新 input region，合成器仍可能把鼠标事件交给透明 Electron surface，导致 N.E.K.O. 下方窗口全部点不到。遇到 Wayland 下全局挡点击时，不要先假设 renderer 的命中矩形错误，应先和 X11 / XWayland 行为对比。
+
+建议排查顺序：
+
+1. 用发行包默认方式复现。
+2. 让 Electron 壳强制 X11 / XWayland，例如 `--ozone-platform=x11`。
+3. 确认进程是否有 X11 display，以及是否出现预期的 X11 input-shape helper 日志。
+4. 如果 X11 正常、Wayland 全局挡点击，把 issue 收敛到 Wayland 合成器 / Electron input-region 行为，不要混入后端启动问题。
+
+## Steam 与 CJK 输入法
+
+Steam 版 CJK 输入可能出现“普通终端启动正常，Steam 启动不正常”的情况。Steam runtime 会影响继承环境变量和动态库解析，Chromium 也可能回退到 XIM。
+
+Fcitx 的基础输入法环境应包含：
+
+```bash
+export GTK_IM_MODULE=fcitx
+export QT_IM_MODULE=fcitx
+export XMODIFIERS=@im=fcitx
+export SDL_IM_MODULE=fcitx
+export INPUT_METHOD=fcitx
+```
+
+对 X11 / XWayland 桌面包，优先使用原生 GTK IM module，而不是只依赖 XIM。XIM 可能能调出候选框，但文字 commit 仍然进不了 Electron 文本输入框。Fcitx5 原生路径成功时，Electron 进程中通常能看到 `im-fcitx5.so` 和 `libFcitx5GClient.so.2`。
+
+如果只在 Steam 内原生 Fcitx 加载失败，应检查 GLib 版本不匹配：
+
+```bash
+ldd -r /path/to/im-fcitx5.so | grep -E 'not found|undefined symbol|glib|gobject'
+```
+
+已见过的失败特征包括：
+
+```text
+undefined symbol: g_once_init_leave_pointer
+Loading IM context type 'fcitx' failed
+GLib version too old
+```
+
+这些报错表示模块已被找到，但无法在 Steam runtime 可见的库集合里初始化。稳妥的发行包修复不应依赖任意宿主机 GTK / Fcitx 模块，因为它可能由比 Steam runtime 更新的 GLib 编译。可行方向包括：
+
+1. 在 Electron 壳中打包兼容的 GTK IM module 及必要依赖库。
+2. 启动时生成指向该模块的 `GTK_IM_MODULE_FILE` cache。
+3. 收窄 `LD_LIBRARY_PATH`，只优先必要的兼容库。
+4. 尽早记录选中的 IM module 路径和初始化失败原因，避免用户只看到“无法输入中文”。
+
+## Bug Report 应包含的信息
+
+点击穿透问题建议包含：
+
+- 桌面环境和 session 类型。
+- X11 / XWayland 与 Wayland 行为是否不同。
+- Electron 启动参数，尤其是 `--ozone-platform`。
+- input-shape 或 mouse-through 初始化附近日志。
+
+输入法问题建议包含：
+
+- 输入法框架和版本，例如 Fcitx5 或 IBus。
+- 上文列出的进程环境变量。
+- 候选框是否能出现。
+- commit 后的文字是否进入聊天输入框。
+- 若使用 `GTK_IM_MODULE=fcitx` 或 `ibus`，提供所选 GTK IM module 的 `ldd -r` 输出。
+
+把这两类问题拆开记录会让修复更安全：点击穿透主要是窗口 / 合成器行为，CJK 输入主要是 AppImage / Steam 环境和原生库加载行为。

--- a/docs/zh-CN/guide/linux-desktop-runtime.md
+++ b/docs/zh-CN/guide/linux-desktop-runtime.md
@@ -49,6 +49,12 @@ elif [ "${#mains[@]}" -gt 1 ]; then
   exit 1
 fi
 pid="${mains[0]}"
+# 保留 AppRun/AppImage 是为了兜住「Steam 启动、命令行不含字面 app 名」的情况，
+# 但它们也可能命中无关应用。若唯一匹配看起来不像 N.E.K.O，就告警，让人先核对
+# 下面打印的 cmdline 再采信诊断结果。
+if ! tr '\0' '\n' < "/proc/$pid/cmdline" | grep -qiE 'n[.]?e[.]?k[.]?o'; then
+  echo "警告：pid $pid 仅由泛化的 AppRun/AppImage 规则命中，请确认下面的 cmdline 确属 N.E.K.O。" >&2
+fi
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
 tr '\0' ' ' < "/proc/$pid/cmdline"; echo
 ```

--- a/docs/zh-CN/guide/linux-desktop-runtime.md
+++ b/docs/zh-CN/guide/linux-desktop-runtime.md
@@ -31,12 +31,17 @@ echo "XMODIFIERS=$XMODIFIERS"
 echo "SteamAppId=$SteamAppId"
 ```
 
-对正在运行的桌面壳进程，检查真实环境变量和启动参数。排查 Electron 窗口和输入法问题时，不要采样 `projectneko_server` 或其他后端 helper：
+对正在运行的桌面壳进程，检查真实环境变量和启动参数。要采样 **Electron 主浏览器进程**，既不要采样 `projectneko_server` 等后端 helper，也不要采样 Electron 子进程。透明窗口和 GTK 输入法模块都驻留在主浏览器进程里，renderer/GPU/zygote 子进程（带 `--type=...`）并不持有它们；而 `pgrep -n`（取最新 PID）通常会命中子进程，导致下面的检查误报「输入法/input-shape 未加载」。应选取第一个命令行不含 `--type=` 的匹配进程：
 
 ```bash
-pid="$(pgrep -n -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o')"
+pid=""
+for p in $(pgrep -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o'); do
+  if ! tr '\0' '\n' < "/proc/$p/cmdline" | grep -q -- '--type='; then
+    pid="$p"; break
+  fi
+done
 if [ -z "$pid" ]; then
-  echo "N.E.K.O desktop shell process was not found" >&2
+  echo "N.E.K.O desktop shell (main Electron process) was not found" >&2
   exit 1
 fi
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'

--- a/docs/zh-CN/guide/linux-desktop-runtime.md
+++ b/docs/zh-CN/guide/linux-desktop-runtime.md
@@ -2,7 +2,7 @@
 
 本文整理 Linux 桌面版 AppImage / Steam 包的排障线索，主要面向维护者和 issue triage。适用场景包括 KDE / Wayland 点击穿透异常、透明窗口拦截输入、Toast 不可点击，以及中文/日文/韩文输入法无法提交文字。
 
-相关 issue：[ #396 ](https://github.com/Project-N-E-K-O/N.E.K.O/issues/396)、[ #1276 ](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1276)、[ #1279 ](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1279)。
+相关 issue：[#396](https://github.com/Project-N-E-K-O/N.E.K.O/issues/396)、[#1276](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1276)、[#1279](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1279)。
 
 ## 运行时分层
 
@@ -31,10 +31,14 @@ echo "XMODIFIERS=$XMODIFIERS"
 echo "SteamAppId=$SteamAppId"
 ```
 
-对正在运行的桌面进程，检查真实环境变量和启动参数：
+对正在运行的桌面壳进程，检查真实环境变量和启动参数。排查 Electron 窗口和输入法问题时，不要采样 `projectneko_server` 或其他后端 helper：
 
 ```bash
-pid="$(pgrep -n -f 'n.e.k.o|projectneko_server')"
+pid="$(pgrep -n -f 'AppRun|AppImage|electron|N[.]E[.]K[.]O|n[.]e[.]k[.]o')"
+if [ -z "$pid" ]; then
+  echo "N.E.K.O desktop shell process was not found" >&2
+  exit 1
+fi
 tr '\0' '\n' < "/proc/$pid/environ" | sort | grep -E 'DISPLAY|WAYLAND|GTK_IM|QT_IM|XMODIFIERS|Steam'
 tr '\0' ' ' < "/proc/$pid/cmdline"; echo
 ```


### PR DESCRIPTION
## Summary
- add English and Chinese Linux desktop runtime triage docs
- document X11/XWayland vs Wayland click-through diagnostics
- document Steam CJK input-method diagnostics, including Fcitx5 GTK module and GLib mismatch checks
- link the guide from the VitePress sidebar

## Related issues
Refs #396, #1276, #1279.

## Validation
- npm run build
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 新增《Linux Desktop Runtime》故障诊断指南（含英文、中文与日文页面），覆盖透明窗口点击穿透与 Steam 下 CJK 输入法问题的排查步骤、快速环境采样、动态库与进程检查命令，以及提交缺陷时应包含的信息清单。
* **新功能**
  * 指南侧边栏已在中文（zh-CN）与日文（ja）本地化中新增 “Linux Desktop Runtime” 链接项并显示于侧边栏。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->