### PR TITLE
fix(chat): refine avatar tool prompts and web cursor layering

### DIFF
--- a/config/prompts/prompts_avatar_interaction.py
+++ b/config/prompts/prompts_avatar_interaction.py
@@ -353,6 +353,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                     "reaction_focus": "{actor}刚刚用猫爪轻轻碰你时掉出了奖励。",
                     "style_hint": "猫爪轻碰并掉出奖励。",
                 },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor}刚刚用猫爪连续轻轻碰了你几下时掉出了奖励。",
+                    "style_hint": "猫爪连续轻碰并掉出奖励。",
+                },
             },
         },
         "hammer": {
@@ -414,6 +418,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                 "reward_drop": {
                     "reaction_focus": "{actor} just lightly touched you with the cat paw, and a reward dropped.",
                     "style_hint": "Cat-paw touch with reward drop.",
+                },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor} just lightly touched you several times with the cat paw, and a reward dropped.",
+                    "style_hint": "Repeated cat-paw touches with reward drop.",
                 },
             },
         },
@@ -477,6 +485,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                     "reaction_focus": "{actor}剛剛用貓爪輕輕碰你時掉出了獎勵。",
                     "style_hint": "貓爪輕碰並掉出獎勵。",
                 },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor}剛剛用貓爪連續輕輕碰了你幾下時掉出了獎勵。",
+                    "style_hint": "貓爪連續輕碰並掉出獎勵。",
+                },
             },
         },
         "hammer": {
@@ -538,6 +550,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                 "reward_drop": {
                     "reaction_focus": "{actor}が今、猫の肉球で軽く触れた時に報酬が落ちた。",
                     "style_hint": "猫の肉球接触と報酬ドロップ。",
+                },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor}が今、猫の肉球で何度か続けて軽く触れた時に報酬が落ちた。",
+                    "style_hint": "猫の肉球の連続接触と報酬ドロップ。",
                 },
             },
         },
@@ -601,6 +617,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                     "reaction_focus": "{actor} 방금 고양이 발로 가볍게 건드렸을 때 보상이 떨어졌다.",
                     "style_hint": "고양이 발 터치와 보상 드롭.",
                 },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor} 방금 고양이 발로 여러 번 가볍게 건드렸을 때 보상이 떨어졌다.",
+                    "style_hint": "고양이 발 연속 터치와 보상 드롭.",
+                },
             },
         },
         "hammer": {
@@ -662,6 +682,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                 "reward_drop": {
                     "reaction_focus": "{actor} только что легко коснулся тебя кошачьей лапкой, и выпала награда.",
                     "style_hint": "Касание кошачьей лапкой и выпадение награды.",
+                },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor} только что несколько раз легко коснулся тебя кошачьей лапкой, и выпала награда.",
+                    "style_hint": "Повторяющиеся касания кошачьей лапкой и выпадение награды.",
                 },
             },
         },
@@ -725,6 +749,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                     "reaction_focus": "{actor} acaba de tocarte con la patita de gato y cayó una recompensa.",
                     "style_hint": "Toque de patita de gato con recompensa.",
                 },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor} acaba de tocarte varias veces con la patita de gato y cayó una recompensa.",
+                    "style_hint": "Toques repetidos de patita de gato con recompensa.",
+                },
             }
         },
         "hammer": {
@@ -786,6 +814,10 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
                 "reward_drop": {
                     "reaction_focus": "{actor} acabou de tocar em você com a patinha de gato e caiu uma recompensa.",
                     "style_hint": "Toque de patinha de gato com recompensa.",
+                },
+                "reward_drop_rapid": {
+                    "reaction_focus": "{actor} acabou de tocar em você várias vezes com a patinha de gato e caiu uma recompensa.",
+                    "style_hint": "Toques repetidos de patinha de gato com recompensa.",
                 },
             }
         },
@@ -1510,7 +1542,8 @@ def _build_avatar_interaction_instruction(
         .get(action_id, {})
     )
     if payload.get("reward_drop") and action_profiles.get("reward_drop"):
-        reaction_profile = action_profiles["reward_drop"]
+        reward_key = f"reward_drop_{intensity}"
+        reaction_profile = action_profiles.get(reward_key) or action_profiles["reward_drop"]
     else:
         reaction_profile = (
             action_profiles.get(intensity)

--- a/config/prompts/prompts_avatar_interaction.py
+++ b/config/prompts/prompts_avatar_interaction.py
@@ -318,24 +318,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor}刚刚用棒棒糖喂了你第一口。",
-                    "style_hint": "棒棒糖第一口。",
+                    "reaction_focus": "{actor}刚刚把棒棒糖递到你嘴边，你吃了第一口。",
+                    "style_hint": "第一口棒棒糖。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor}刚刚用同一支棒棒糖又喂了你一口。",
-                    "style_hint": "棒棒糖第二口。",
+                    "reaction_focus": "{actor}刚刚又把同一支棒棒糖递到你嘴边，你吃了第二口。",
+                    "style_hint": "同一支棒棒糖又一口。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor}刚刚继续用棒棒糖一口接一口地喂你。",
-                    "style_hint": "棒棒糖连续投喂。",
+                    "reaction_focus": "{actor}刚刚把棒棒糖一口接一口递到你嘴边，你连续吃了几口。",
+                    "style_hint": "连续几口棒棒糖。",
                 },
                 "burst": {
-                    "reaction_focus": "{actor}刚刚短时间内用棒棒糖快速喂了你好几口。",
-                    "style_hint": "棒棒糖快速连续投喂。",
+                    "reaction_focus": "{actor}刚刚短时间内连续把棒棒糖递到你嘴边，你吃了好几口。",
+                    "style_hint": "短时间连续几口棒棒糖。",
                 },
             },
         },
@@ -380,24 +380,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor} just fed you the first bite of the lollipop.",
+                    "reaction_focus": "{actor} just brought the lollipop to your mouth, and you took the first bite.",
                     "style_hint": "First lollipop bite.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor} just fed you another bite from the same lollipop.",
-                    "style_hint": "Second lollipop bite.",
+                    "reaction_focus": "{actor} just brought the same lollipop to your mouth again, and you took a second bite.",
+                    "style_hint": "Same lollipop, another bite.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor} just kept feeding you the lollipop bite after bite.",
-                    "style_hint": "Repeated lollipop feeding.",
+                    "reaction_focus": "{actor} just kept bringing the lollipop to your mouth, and you took several bites in a row.",
+                    "style_hint": "Several lollipop bites in a row.",
                 },
                 "burst": {
-                    "reaction_focus": "{actor} just fed you several quick bites of the lollipop in a short time.",
-                    "style_hint": "Rapid repeated lollipop feeding.",
+                    "reaction_focus": "{actor} just brought the lollipop to your mouth several times in quick succession, and you took several bites.",
+                    "style_hint": "Several quick lollipop bites.",
                 },
             },
         },
@@ -442,24 +442,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor}剛剛用棒棒糖餵了你第一口。",
-                    "style_hint": "棒棒糖第一口。",
+                    "reaction_focus": "{actor}剛剛把棒棒糖遞到你嘴邊，你吃了第一口。",
+                    "style_hint": "第一口棒棒糖。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor}剛剛用同一支棒棒糖又餵了你一口。",
-                    "style_hint": "棒棒糖第二口。",
+                    "reaction_focus": "{actor}剛剛又把同一支棒棒糖遞到你嘴邊，你吃了第二口。",
+                    "style_hint": "同一支棒棒糖又一口。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor}剛剛繼續用棒棒糖一口接一口地餵你。",
-                    "style_hint": "棒棒糖連續投餵。",
+                    "reaction_focus": "{actor}剛剛把棒棒糖一口接一口遞到你嘴邊，你連續吃了幾口。",
+                    "style_hint": "連續幾口棒棒糖。",
                 },
                 "burst": {
-                    "reaction_focus": "{actor}剛剛短時間內用棒棒糖快速餵了你好幾口。",
-                    "style_hint": "棒棒糖快速連續投餵。",
+                    "reaction_focus": "{actor}剛剛短時間內連續把棒棒糖遞到你嘴邊，你吃了好幾口。",
+                    "style_hint": "短時間連續幾口棒棒糖。",
                 },
             },
         },
@@ -504,24 +504,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor}が今、ペロペロキャンディを最初の一口だけ食べさせた。",
-                    "style_hint": "最初のペロペロキャンディ。",
+                    "reaction_focus": "{actor}が今、ペロペロキャンディをあなたの口元に差し出し、あなたが最初の一口を食べた。",
+                    "style_hint": "ペロペロキャンディの最初の一口。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor}が今、同じペロペロキャンディをもう一口食べさせた。",
-                    "style_hint": "二口目のペロペロキャンディ。",
+                    "reaction_focus": "{actor}が今、同じペロペロキャンディをもう一度あなたの口元に差し出し、あなたが二口目を食べた。",
+                    "style_hint": "同じペロペロキャンディをもう一口。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor}が今、ペロペロキャンディを一口ずつ続けて食べさせている。",
-                    "style_hint": "連続ペロペロキャンディ。",
+                    "reaction_focus": "{actor}が今、ペロペロキャンディを続けてあなたの口元に差し出し、あなたが何口か続けて食べている。",
+                    "style_hint": "ペロペロキャンディを一口ずつ。",
                 },
                 "burst": {
-                    "reaction_focus": "{actor}が今、短時間でペロペロキャンディを何口も続けて食べさせた。",
-                    "style_hint": "高速連続ペロペロキャンディ。",
+                    "reaction_focus": "{actor}が今、短い間にペロペロキャンディを何度もあなたの口元に差し出し、あなたが何口も食べた。",
+                    "style_hint": "ペロペロキャンディを短時間で何口も。",
                 },
             },
         },
@@ -566,24 +566,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor} 방금 막대사탕을 첫 한입 먹여 줬다.",
-                    "style_hint": "첫 막대사탕 먹이기.",
+                    "reaction_focus": "{actor} 방금 막대사탕을 네 입가에 내밀었고, 너는 첫 한입을 먹었다.",
+                    "style_hint": "막대사탕 첫 한입.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor} 방금 같은 막대사탕을 한입 더 먹여 줬다.",
-                    "style_hint": "두 번째 막대사탕 먹이기.",
+                    "reaction_focus": "{actor} 방금 같은 막대사탕을 다시 네 입가에 내밀었고, 너는 두 번째 한입을 먹었다.",
+                    "style_hint": "같은 막대사탕 한입 더.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor} 방금 막대사탕을 한입씩 계속 먹여 줬다.",
-                    "style_hint": "연속 막대사탕 먹이기.",
+                    "reaction_focus": "{actor} 방금 막대사탕을 한입씩 계속 네 입가에 내밀었고, 너는 몇 입 연달아 먹었다.",
+                    "style_hint": "막대사탕 한입씩 계속.",
                 },
                 "burst": {
-                    "reaction_focus": "{actor} 방금 짧은 시간 안에 막대사탕을 여러 입 빠르게 먹여 줬다.",
-                    "style_hint": "빠른 연속 막대사탕 먹이기.",
+                    "reaction_focus": "{actor} 방금 짧은 시간 안에 막대사탕을 여러 번 네 입가에 내밀었고, 너는 여러 입 빠르게 먹었다.",
+                    "style_hint": "막대사탕 짧은 시간 여러 입.",
                 },
             },
         },
@@ -628,24 +628,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor} только что дал тебе первый кусочек леденца.",
-                    "style_hint": "Первое кормление леденцом.",
+                    "reaction_focus": "{actor} подносит леденец к твоему рту, и ты съедаешь первый кусочек.",
+                    "style_hint": "Первый кусочек леденца.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor} только что дал тебе ещё кусочек того же леденца.",
-                    "style_hint": "Второе кормление леденцом.",
+                    "reaction_focus": "{actor} снова подносит тот же леденец к твоему рту, и ты съедаешь второй кусочек.",
+                    "style_hint": "Ещё кусочек того же леденца.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor} только что продолжил кормить тебя леденцом кусочек за кусочком.",
-                    "style_hint": "Повторяющееся кормление леденцом.",
+                    "reaction_focus": "{actor} продолжает подносить леденец к твоему рту, и ты съедаешь несколько кусочков подряд.",
+                    "style_hint": "Леденец кусочек за кусочком.",
                 },
                 "burst": {
-                    "reaction_focus": "{actor} только что быстро дал тебе несколько кусочков леденца подряд.",
-                    "style_hint": "Быстрое повторяющееся кормление леденцом.",
+                    "reaction_focus": "{actor} быстро несколько раз подносит леденец к твоему рту, и ты съедаешь несколько кусочков.",
+                    "style_hint": "Несколько быстрых кусочков леденца.",
                 },
             },
         },
@@ -690,24 +690,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor} acaba de darte el primer bocado de la piruleta.",
-                    "style_hint": "Primera alimentación con piruleta.",
+                    "reaction_focus": "{actor} acaba de acercarte la piruleta a la boca, y diste el primer bocado.",
+                    "style_hint": "Primer bocado de piruleta.",
                 }
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor} acaba de darte otro bocado de la misma piruleta.",
-                    "style_hint": "Segunda alimentación con piruleta.",
+                    "reaction_focus": "{actor} acaba de acercarte otra vez la misma piruleta a la boca, y diste un segundo bocado.",
+                    "style_hint": "Otro bocado de la misma piruleta.",
                 }
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor} acaba de seguir dándote la piruleta bocado tras bocado.",
-                    "style_hint": "Alimentación repetida con piruleta.",
+                    "reaction_focus": "{actor} acaba de acercarte la piruleta a la boca varias veces seguidas, y diste varios bocados.",
+                    "style_hint": "Piruleta bocado tras bocado.",
                 },
                 "burst": {
-                    "reaction_focus": "{actor} acaba de darte varios bocados rápidos de la piruleta en poco tiempo.",
-                    "style_hint": "Alimentación rápida repetida con piruleta.",
+                    "reaction_focus": "{actor} acaba de acercarte la piruleta a la boca varias veces en poco tiempo, y diste varios bocados rápidos.",
+                    "style_hint": "Varios bocados rápidos de piruleta.",
                 },
             },
         },
@@ -752,24 +752,24 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{actor} acabou de te dar a primeira mordida do pirulito.",
-                    "style_hint": "Primeira alimentação com pirulito.",
+                    "reaction_focus": "{actor} acabou de aproximar o pirulito da sua boca, e você deu a primeira mordida.",
+                    "style_hint": "Primeira mordida de pirulito.",
                 }
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{actor} acabou de te dar outra mordida do mesmo pirulito.",
-                    "style_hint": "Segunda alimentação com pirulito.",
+                    "reaction_focus": "{actor} acabou de aproximar o mesmo pirulito da sua boca outra vez, e você deu uma segunda mordida.",
+                    "style_hint": "Outra mordida do mesmo pirulito.",
                 }
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{actor} acabou de continuar te dando o pirulito mordida após mordida.",
-                    "style_hint": "Alimentação repetida com pirulito.",
+                    "reaction_focus": "{actor} acabou de aproximar o pirulito da sua boca várias vezes seguidas, e você deu várias mordidas.",
+                    "style_hint": "Pirulito mordida após mordida.",
                 },
                 "burst": {
-                    "reaction_focus": "{actor} acabou de te dar várias mordidas rápidas do pirulito em pouco tempo.",
-                    "style_hint": "Alimentação rápida repetida com pirulito.",
+                    "reaction_focus": "{actor} acabou de aproximar o pirulito da sua boca várias vezes em pouco tempo, e você deu várias mordidas rápidas.",
+                    "style_hint": "Várias mordidas rápidas de pirulito.",
                 },
             },
         },
@@ -1027,7 +1027,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "1. 只输出猫娘当下会说的一句回复。",
             "2. 回复接住上面的道具事件事实。",
         ],
-        "compact_reply_line": "直接回一句你会说出口的话。",
+        "compact_reply_line": "",
         "lollipop_requirement": "",
     },
     "zh-TW": {
@@ -1049,7 +1049,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "1. 只輸出貓娘當下會說的一句回覆。",
             "2. 回覆接住上面的道具事件事實。",
         ],
-        "compact_reply_line": "直接回一句你會說出口的話。",
+        "compact_reply_line": "",
         "lollipop_requirement": "",
     },
     "en": {
@@ -1074,7 +1074,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. The draft text is not a formal user message; use it only as light context if it fits naturally and never quote it verbatim.",
             "5. Do not mention coordinates, probabilities, payloads, or backend rules.",
         ],
-        "compact_reply_line": "Reply with one spoken line you would say right now.",
+        "compact_reply_line": "",
         "lollipop_requirement": "6. This is lollipop feeding, not petting, soothing, or a generic touch.",
     },
     "ja": {
@@ -1099,7 +1099,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. text_context は正式なユーザーメッセージではありません。自然な場合だけ軽く参考にし、逐語的に繰り返さないでください。",
             "5. 座標、確率、payload、バックエンドのルールには触れないでください。",
         ],
-        "compact_reply_line": "その場で口にする一言として返答してください。",
+        "compact_reply_line": "",
         "lollipop_requirement": "6. これはペロペロキャンディを食べさせるやり取りであり、頭なで、軽い接触、なだめる行為、一般的なスキンシップとして書かないでください。",
     },
     "ko": {
@@ -1124,7 +1124,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. text_context 는 정식 사용자 메시지가 아니다. 아주 자연스러울 때만 가볍게 참고하고, 그대로 되풀이하지 않는다.",
             "5. 좌표, 확률, payload, 백엔드 규칙은 언급하지 않는다.",
         ],
-        "compact_reply_line": "지금 바로 말하는 한마디로 답한다.",
+        "compact_reply_line": "",
         "lollipop_requirement": "6. 이것은 막대사탕 먹이기이며, 쓰다듬기, 가벼운 터치, 달래기, 일반적인 스킨십으로 쓰면 안 된다.",
     },
     "ru": {
@@ -1149,7 +1149,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. Черновик текста не является официальным сообщением пользователя; используй его лишь как лёгкий контекст, если это естественно, и никогда не цитируй дословно.",
             "5. Не упоминай координаты, вероятности, payload или правила бэкенда.",
         ],
-        "compact_reply_line": "Ответь одной короткой репликой от своего лица.",
+        "compact_reply_line": "",
         "lollipop_requirement": "6. Это кормление леденцом, а не поглаживание, успокаивание или просто абстрактное касание.",
     },
     "es": {
@@ -1174,7 +1174,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. El borrador no es un mensaje formal del usuario; úsalo solo como contexto ligero si encaja y nunca lo cites literalmente.",
             "5. No menciones coordenadas, probabilidades, payloads ni reglas del backend.",
         ],
-        "compact_reply_line": "Responde con una línea de diálogo que dirías ahora.",
+        "compact_reply_line": "",
         "lollipop_requirement": "6. Esto es alimentación con piruleta, no lo conviertas en caricias, toques, consuelo o palmaditas.",
     },
     "pt": {
@@ -1199,7 +1199,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. O rascunho não é uma mensagem formal do usuário; use apenas como contexto leve se couber e nunca cite literalmente.",
             "5. Não mencione coordenadas, probabilidades, payloads ou regras do backend.",
         ],
-        "compact_reply_line": "Responda com uma fala que você diria agora.",
+        "compact_reply_line": "",
         "lollipop_requirement": "6. Isto é alimentação com pirulito, não transforme em carinho, toque, consolo ou afago.",
     },
 }
@@ -1534,10 +1534,13 @@ def _build_avatar_interaction_instruction(
         else prompt_text["interaction_intro"]
     )
     if prompt_text.get("compact_fields"):
-        compact_separator = "" if locale in {"zh", "zh-TW", "ja"} else " "
         compact_reply_line = prompt_text["compact_reply_line"].format(
             lanlan_name=lanlan_name, master_name=actor, actor=actor
         )
+        # Empty by design: keep the compact prompt as one event fact to avoid reply-shape templates.
+        if not compact_reply_line:
+            return reaction_focus
+        compact_separator = "" if locale in {"zh", "zh-TW", "ja"} else " "
         return f"{reaction_focus}{compact_separator}{compact_reply_line}"
 
     lines = [

--- a/config/prompts/prompts_avatar_interaction.py
+++ b/config/prompts/prompts_avatar_interaction.py
@@ -281,12 +281,12 @@ _AVATAR_INTERACTION_TOUCH_ZONE_LABELS = {
 }
 _AVATAR_INTERACTION_SYSTEM_WRAPPER = {
     "zh": {
-        "prefix": "======[系统通知：以下是一次刚刚发生的道具互动，请将其视为即时互动引导，不要直接复述字段名或系统描述]======",
-        "suffix": "======[系统通知结束：请直接以当前角色口吻输出即时反应]======",
+        "prefix": "",
+        "suffix": "",
     },
     "zh-TW": {
-        "prefix": "======[系統通知：以下是一次剛剛發生的道具互動，請將其視為即時互動引導，不要直接複述欄位名或系統描述]======",
-        "suffix": "======[系統通知結束：請直接以當前角色口吻輸出即時反應]======",
+        "prefix": "",
+        "suffix": "",
     },
     "en": {
         "prefix": "======[System notice: the following tool interaction just happened. Treat it as an immediate interaction cue and do not repeat field names or system wording]======",
@@ -318,60 +318,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "棒棒糖第一次完成入口接触。",
-                    "style_hint": "可以带一点初次入口后的停顿感、尝味感，语气自然偏轻。",
+                    "reaction_focus": "{master_name}刚刚用棒棒糖喂了你第一口。",
+                    "style_hint": "棒棒糖第一口。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "棒棒糖已完成第一口，本次是紧接着的第二口接触。",
-                    "style_hint": "比第一口更顺一点、更接得上上一拍，语气保持自然。",
+                    "reaction_focus": "{master_name}刚刚用同一支棒棒糖又喂了你一口。",
+                    "style_hint": "棒棒糖第二口。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "第三阶段后继续投喂，前端已表现为爱心上飘；本次属于连续喂食中的一次。",
-                    "style_hint": "节奏可以更快、分句可以更短，像连续被打断中的即时反应。",
+                    "reaction_focus": "{master_name}刚刚继续用棒棒糖一口接一口地喂你。",
+                    "style_hint": "棒棒糖连续投喂。",
                 },
                 "burst": {
-                    "reaction_focus": "短时间内连续多次投喂，属于更高频的连续喂食。",
-                    "style_hint": "允许更碎一点、更急一点，保持当场反应感。",
+                    "reaction_focus": "{master_name}刚刚短时间内用棒棒糖快速喂了你好几口。",
+                    "style_hint": "棒棒糖快速连续投喂。",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "猫爪产生一次短促轻触。",
-                    "style_hint": "短、轻、柔，根据部位差异自然带出细微区别。",
+                    "reaction_focus": "{master_name}刚刚用猫爪轻轻碰了你一下。",
+                    "style_hint": "猫爪轻碰。",
                 },
                 "rapid": {
-                    "reaction_focus": "短时间内连续多次轻触。",
-                    "style_hint": "可以更连贯一点、更快一点，保持轻触感。",
+                    "reaction_focus": "{master_name}刚刚用猫爪连续轻轻碰了你几下。",
+                    "style_hint": "猫爪连续轻碰。",
                 },
                 "reward_drop": {
-                    "reaction_focus": "本次轻触同时触发奖励掉落。",
-                    "style_hint": "先接住轻触，再顺手带一句掉落物。",
+                    "reaction_focus": "{master_name}刚刚用猫爪轻轻碰你时掉出了奖励。",
+                    "style_hint": "猫爪轻碰并掉出奖励。",
                 },
             },
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "完成一次完整锤击流程并进入命中结果。",
-                    "style_hint": "短促、带一点冲击停顿感，像被打断后的第一反应。",
+                    "reaction_focus": "{master_name}刚刚用锤子敲中了你一次。",
+                    "style_hint": "锤子敲中一次。",
                 },
                 "rapid": {
-                    "reaction_focus": "短时间内再次完成锤击，已形成连续敲击。",
-                    "style_hint": "可以更直接一点，体现连续敲击后的累积感。",
+                    "reaction_focus": "{master_name}刚刚短时间内又用锤子敲中了你一次。",
+                    "style_hint": "锤子再次敲中。",
                 },
                 "burst": {
-                    "reaction_focus": "连续锤击次数进一步增加，本次属于更高强度结果。",
-                    "style_hint": "反应幅度可以更大一些，但仍保持即时、短促。",
+                    "reaction_focus": "{master_name}刚刚用锤子连续快速敲中了你好几次。",
+                    "style_hint": "锤子连续快速敲中。",
                 },
                 "easter_egg": {
-                    "reaction_focus": "本次锤击触发放大彩蛋，命中结果明显强于普通锤击。",
-                    "style_hint": "可以更夸张、更有戏剧停顿，但仍保持角色口吻。",
+                    "reaction_focus": "{master_name}刚刚用放大彩蛋锤敲中了你一次。",
+                    "style_hint": "放大彩蛋锤敲中。",
                 },
             },
         },
@@ -380,60 +380,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "The lollipop completes its first mouth contact.",
-                    "style_hint": "A slight first-taste pause or flavor-noticing beat is fine; keep it naturally light.",
+                    "reaction_focus": "{master_name} just fed you the first bite of the lollipop.",
+                    "style_hint": "First lollipop bite.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "The first bite has already happened, and this interaction is the immediate second bite.",
-                    "style_hint": "Let it feel a little smoother and more continuous than the first bite, while staying natural.",
+                    "reaction_focus": "{master_name} just fed you another bite from the same lollipop.",
+                    "style_hint": "Second lollipop bite.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "After the third-stage state, another feeding motion happens while hearts are already floating; this is one instance within repeated feeding.",
-                    "style_hint": "The rhythm can be quicker and the phrasing shorter, like an immediate response inside repeated feeding.",
+                    "reaction_focus": "{master_name} just kept feeding you the lollipop bite after bite.",
+                    "style_hint": "Repeated lollipop feeding.",
                 },
                 "burst": {
-                    "reaction_focus": "Multiple feeding motions happen in a short window, forming a higher-frequency repeated feeding event.",
-                    "style_hint": "A more rushed or more fragmented rhythm is fine; keep it in-the-moment.",
+                    "reaction_focus": "{master_name} just fed you several quick bites of the lollipop in a short time.",
+                    "style_hint": "Rapid repeated lollipop feeding.",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "The cat paw produces one short light touch.",
-                    "style_hint": "Short, light, and soft, with small differences depending on the touched area.",
+                    "reaction_focus": "{master_name} just lightly touched you once with the cat paw.",
+                    "style_hint": "Single cat-paw touch.",
                 },
                 "rapid": {
-                    "reaction_focus": "Several light touches happen within a short window.",
-                    "style_hint": "It can feel a little quicker and more continuous while still staying light.",
+                    "reaction_focus": "{master_name} just lightly touched you several times with the cat paw.",
+                    "style_hint": "Repeated cat-paw touches.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "This light touch also triggers a reward drop.",
-                    "style_hint": "Catch the touch first, then mention the drop in passing.",
+                    "reaction_focus": "{master_name} just lightly touched you with the cat paw, and a reward dropped.",
+                    "style_hint": "Cat-paw touch with reward drop.",
                 },
             },
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "One full hammer-hit sequence completes and reaches the impact result.",
-                    "style_hint": "Short and impact-forward, with a slight post-hit pause or interruption beat.",
+                    "reaction_focus": "{master_name} just hit you once with the hammer.",
+                    "style_hint": "Single hammer hit.",
                 },
                 "rapid": {
-                    "reaction_focus": "Another hammer hit completes within a short window, forming repeated strikes.",
-                    "style_hint": "It can be a little more direct and show accumulated impact from the repeated hits.",
+                    "reaction_focus": "{master_name} just hit you again with the hammer within a short time.",
+                    "style_hint": "Second hammer hit.",
                 },
                 "burst": {
-                    "reaction_focus": "The number of repeated hammer hits increases further, making this a higher-intensity result.",
-                    "style_hint": "A bigger reaction is fine as long as it still feels immediate and short.",
+                    "reaction_focus": "{master_name} just hit you several times quickly with the hammer.",
+                    "style_hint": "Rapid repeated hammer hits.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "This hammer hit triggers the enlarged easter-egg effect, making the impact result stronger than normal.",
-                    "style_hint": "It can be more dramatic, with a stronger pause or exclamation, while keeping the character voice.",
+                    "reaction_focus": "{master_name} just hit you once with the enlarged easter-egg hammer.",
+                    "style_hint": "Enlarged easter-egg hammer hit.",
                 },
             },
         },
@@ -442,60 +442,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "棒棒糖第一次完成入口接觸。",
-                    "style_hint": "可以帶一點初次入口後的停頓感、嚐味感，語氣自然偏輕。",
+                    "reaction_focus": "{master_name}剛剛用棒棒糖餵了你第一口。",
+                    "style_hint": "棒棒糖第一口。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "棒棒糖已完成第一口，本次是緊接著的第二口接觸。",
-                    "style_hint": "比第一口更順一點、更接得上上一拍，語氣保持自然。",
+                    "reaction_focus": "{master_name}剛剛用同一支棒棒糖又餵了你一口。",
+                    "style_hint": "棒棒糖第二口。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "第三階段後繼續投餵，前端已表現為愛心上飄；本次屬於連續餵食中的一次。",
-                    "style_hint": "節奏可以更快、分句可以更短，像連續被打斷中的即時反應。",
+                    "reaction_focus": "{master_name}剛剛繼續用棒棒糖一口接一口地餵你。",
+                    "style_hint": "棒棒糖連續投餵。",
                 },
                 "burst": {
-                    "reaction_focus": "短時間內連續多次投餵，屬於更高頻的連續餵食。",
-                    "style_hint": "允許更碎一點、更急一點，保持當場反應感。",
+                    "reaction_focus": "{master_name}剛剛短時間內用棒棒糖快速餵了你好幾口。",
+                    "style_hint": "棒棒糖快速連續投餵。",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "貓爪產生一次短促輕觸。",
-                    "style_hint": "短、輕、柔，依照部位差異自然帶出細微區別。",
+                    "reaction_focus": "{master_name}剛剛用貓爪輕輕碰了你一下。",
+                    "style_hint": "貓爪輕碰。",
                 },
                 "rapid": {
-                    "reaction_focus": "短時間內連續多次輕觸。",
-                    "style_hint": "可以更連貫一點、更快一點，保持輕觸感。",
+                    "reaction_focus": "{master_name}剛剛用貓爪連續輕輕碰了你幾下。",
+                    "style_hint": "貓爪連續輕碰。",
                 },
                 "reward_drop": {
-                    "reaction_focus": "本次輕觸同時觸發獎勵掉落。",
-                    "style_hint": "先接住輕觸，再順手帶一句掉落物。",
+                    "reaction_focus": "{master_name}剛剛用貓爪輕輕碰你時掉出了獎勵。",
+                    "style_hint": "貓爪輕碰並掉出獎勵。",
                 },
             },
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "完成一次完整槌擊流程並進入命中結果。",
-                    "style_hint": "短促、帶一點衝擊停頓感，像被打斷後的第一反應。",
+                    "reaction_focus": "{master_name}剛剛用槌子敲中了你一次。",
+                    "style_hint": "槌子敲中一次。",
                 },
                 "rapid": {
-                    "reaction_focus": "短時間內再次完成槌擊，已形成連續敲擊。",
-                    "style_hint": "可以更直接一點，體現連續敲擊後的累積感。",
+                    "reaction_focus": "{master_name}剛剛短時間內又用槌子敲中了你一次。",
+                    "style_hint": "槌子再次敲中。",
                 },
                 "burst": {
-                    "reaction_focus": "連續槌擊次數進一步增加，本次屬於更高強度結果。",
-                    "style_hint": "反應幅度可以更大一些，但仍保持即時、短促。",
+                    "reaction_focus": "{master_name}剛剛用槌子連續快速敲中了你好幾次。",
+                    "style_hint": "槌子連續快速敲中。",
                 },
                 "easter_egg": {
-                    "reaction_focus": "本次槌擊觸發放大彩蛋，命中結果明顯強於普通槌擊。",
-                    "style_hint": "可以更誇張、更有戲劇停頓，但仍保持角色口吻。",
+                    "reaction_focus": "{master_name}剛剛用放大彩蛋槌敲中了你一次。",
+                    "style_hint": "放大彩蛋槌敲中。",
                 },
             },
         },
@@ -504,60 +504,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "ペロペロキャンディが初めて口元に触れた。",
-                    "style_hint": "最初のひとくち後の小さな間や味を確かめる感じがあってよい。軽く自然に。",
+                    "reaction_focus": "{master_name}が今、ペロペロキャンディを最初の一口だけ食べさせた。",
+                    "style_hint": "最初のペロペロキャンディ。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "一口目はすでに終わっていて、今回はその直後の二口目の接触。",
-                    "style_hint": "一口目より少し滑らかで、前の流れをそのまま受ける感じに。",
+                    "reaction_focus": "{master_name}が今、同じペロペロキャンディをもう一口食べさせた。",
+                    "style_hint": "二口目のペロペロキャンディ。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "第三段階のあとも食べさせる動きが続き、前段ではハートが浮いている。今回は連続で食べさせる流れの一回分。",
-                    "style_hint": "テンポを少し速め、文を短めにして、続けて遮られる中の即時反応らしく。",
+                    "reaction_focus": "{master_name}が今、ペロペロキャンディを一口ずつ続けて食べさせている。",
+                    "style_hint": "連続ペロペロキャンディ。",
                 },
                 "burst": {
-                    "reaction_focus": "短時間で何度も続けて食べさせられ、より高頻度の連続給餌になっている。",
-                    "style_hint": "少し途切れ気味で慌ただしくてもよいが、その場の反応感を保つ。",
+                    "reaction_focus": "{master_name}が今、短時間でペロペロキャンディを何口も続けて食べさせた。",
+                    "style_hint": "高速連続ペロペロキャンディ。",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "猫の肉球が一度だけ短く軽く触れた。",
-                    "style_hint": "短く、軽く、やわらかく。触れた部位の違いは自然ににじませる。",
+                    "reaction_focus": "{master_name}が今、猫の肉球で一度だけ軽く触れた。",
+                    "style_hint": "猫の肉球の一回接触。",
                 },
                 "rapid": {
-                    "reaction_focus": "短時間のうちに軽い接触が何度か続いた。",
-                    "style_hint": "少し速く、少し連続的でもよいが、軽さは保つ。",
+                    "reaction_focus": "{master_name}が今、猫の肉球で何度か続けて軽く触れた。",
+                    "style_hint": "猫の肉球の連続接触。",
                 },
                 "reward_drop": {
-                    "reaction_focus": "今回の軽い接触は報酬ドロップも同時に発生させた。",
-                    "style_hint": "まず触れた感覚を受けて、そのついでに落ちたものへ軽く触れる。",
+                    "reaction_focus": "{master_name}が今、猫の肉球で軽く触れた時に報酬が落ちた。",
+                    "style_hint": "猫の肉球接触と報酬ドロップ。",
                 },
             },
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "一連のハンマー打撃が完了し、命中結果に入った。",
-                    "style_hint": "短く、衝撃を前に出しつつ、打たれた直後の小さな間を含めてもよい。",
+                    "reaction_focus": "{master_name}が今、ハンマーで一度当てた。",
+                    "style_hint": "ハンマーの一回命中。",
                 },
                 "rapid": {
-                    "reaction_focus": "短時間のうちにもう一度ハンマーが当たり、連続打撃になっている。",
-                    "style_hint": "少し直接的にして、連続で当たる蓄積感を出してよい。",
+                    "reaction_focus": "{master_name}が今、短時間でもう一度ハンマーを当てた。",
+                    "style_hint": "ハンマーの二回目命中。",
                 },
                 "burst": {
-                    "reaction_focus": "連続ハンマーの回数がさらに増え、今回はより強い結果になっている。",
-                    "style_hint": "反応を少し大きくしてもよいが、即時で短い調子は保つ。",
+                    "reaction_focus": "{master_name}が今、ハンマーを何度も続けて当てた。",
+                    "style_hint": "ハンマーの高速連続命中。",
                 },
                 "easter_egg": {
-                    "reaction_focus": "今回のハンマーは拡大イースターエッグを起こし、通常より強い命中結果になっている。",
-                    "style_hint": "少し大げさで劇的な間があってもよいが、キャラクターの口調は崩さない。",
+                    "reaction_focus": "{master_name}が今、拡大イースターエッグのハンマーを一度当てた。",
+                    "style_hint": "拡大イースターエッグのハンマー命中。",
                 },
             },
         },
@@ -566,60 +566,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "막대사탕이 처음으로 입가에 닿았다.",
-                    "style_hint": "처음 맛보는 순간의 작은 멈칫함이나 맛을 느끼는 기색이 있어도 좋고, 가볍고 자연스럽게 간다.",
+                    "reaction_focus": "{master_name}이 방금 막대사탕을 첫 한입 먹여 줬다.",
+                    "style_hint": "첫 막대사탕 먹이기.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "첫 한입은 이미 끝났고, 이번 상호작용은 바로 이어지는 두 번째 한입이다.",
-                    "style_hint": "첫 한입보다 조금 더 자연스럽고 이어지는 느낌으로 간다.",
+                    "reaction_focus": "{master_name}이 방금 같은 막대사탕을 한입 더 먹여 줬다.",
+                    "style_hint": "두 번째 막대사탕 먹이기.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "세 번째 단계 뒤에도 먹여 주는 동작이 이어지고 있고, 앞단에서는 하트가 떠오른 상태다. 이번은 연속 먹이기 흐름 중 한 번이다.",
-                    "style_hint": "호흡을 더 빠르게 하고 문장을 더 짧게 해서, 연달아 끊기는 와중의 즉각 반응처럼 간다.",
+                    "reaction_focus": "{master_name}이 방금 막대사탕을 한입씩 계속 먹여 줬다.",
+                    "style_hint": "연속 막대사탕 먹이기.",
                 },
                 "burst": {
-                    "reaction_focus": "짧은 시간 안에 여러 번 연속으로 먹여서 더 높은 빈도의 연속 먹이기가 됐다.",
-                    "style_hint": "조금 더 잘게 끊기고 급해져도 괜찮지만, 현장감은 유지한다.",
+                    "reaction_focus": "{master_name}이 방금 짧은 시간 안에 막대사탕을 여러 입 빠르게 먹여 줬다.",
+                    "style_hint": "빠른 연속 막대사탕 먹이기.",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "고양이 발이 한 번 짧고 가볍게 닿았다.",
-                    "style_hint": "짧고, 가볍고, 부드럽게. 닿은 부위에 따라 미세한 차이를 자연스럽게 드러낸다.",
+                    "reaction_focus": "{master_name}이 방금 고양이 발로 한 번 가볍게 건드렸다.",
+                    "style_hint": "고양이 발 한 번 터치.",
                 },
                 "rapid": {
-                    "reaction_focus": "짧은 시간 안에 가벼운 터치가 여러 번 이어졌다.",
-                    "style_hint": "조금 더 빠르고 이어져도 되지만, 가벼운 느낌은 유지한다.",
+                    "reaction_focus": "{master_name}이 방금 고양이 발로 여러 번 가볍게 건드렸다.",
+                    "style_hint": "고양이 발 연속 터치.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "이번 가벼운 터치는 보상 드롭도 함께 발생시켰다.",
-                    "style_hint": "먼저 터치를 받아들이고, 곁들여서 떨어진 보상을 한마디 언급한다.",
+                    "reaction_focus": "{master_name}이 방금 고양이 발로 가볍게 건드렸을 때 보상이 떨어졌다.",
+                    "style_hint": "고양이 발 터치와 보상 드롭.",
                 },
             },
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "한 번의 완전한 망치 타격이 끝나고 명중 결과에 들어갔다.",
-                    "style_hint": "짧고 충격을 앞세우되, 맞은 직후의 작은 멈춤을 넣어도 좋다.",
+                    "reaction_focus": "{master_name}이 방금 망치로 한 번 맞혔다.",
+                    "style_hint": "망치 한 번 명중.",
                 },
                 "rapid": {
-                    "reaction_focus": "짧은 시간 안에 망치가 다시 맞아 연속 타격이 형성됐다.",
-                    "style_hint": "조금 더 직접적으로, 연속해서 맞은 누적감을 드러내도 좋다.",
+                    "reaction_focus": "{master_name}이 방금 짧은 시간 안에 망치로 다시 한 번 맞혔다.",
+                    "style_hint": "망치 두 번째 명중.",
                 },
                 "burst": {
-                    "reaction_focus": "연속 망치 횟수가 더 늘어나 이번은 더 강한 결과가 됐다.",
-                    "style_hint": "반응 폭을 조금 키워도 되지만, 즉각적이고 짧은 느낌은 유지한다.",
+                    "reaction_focus": "{master_name}이 방금 망치로 여러 번 빠르게 맞혔다.",
+                    "style_hint": "망치 빠른 연속 명중.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "이번 망치 타격은 확대 이스터에그를 일으켜 평소보다 훨씬 강한 명중 결과가 됐다.",
-                    "style_hint": "조금 더 과장되고 극적인 멈춤이 있어도 되지만, 캐릭터 말투는 유지한다.",
+                    "reaction_focus": "{master_name}이 방금 확대 이스터에그 망치로 한 번 맞혔다.",
+                    "style_hint": "확대 이스터에그 망치 명중.",
                 },
             },
         },
@@ -628,60 +628,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "Леденец впервые коснулся рта.",
-                    "style_hint": "Подойдет лёгкая пауза первого вкуса или короткое ощущение распробовать вкус; держите тон естественно мягким.",
+                    "reaction_focus": "{master_name} только что дал тебе первый кусочек леденца.",
+                    "style_hint": "Первое кормление леденцом.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "Первый кусочек уже был, а это взаимодействие стало немедленным вторым кусочком.",
-                    "style_hint": "Пусть это ощущается немного плавнее и естественнее, чем первый кусочек, сохраняя живую реакцию.",
+                    "reaction_focus": "{master_name} только что дал тебе ещё кусочек того же леденца.",
+                    "style_hint": "Второе кормление леденцом.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "После третьей стадии кормление продолжается, на фронтенде уже парят сердечки; этот эпизод является одной из повторяющихся подач леденца.",
-                    "style_hint": "Темп может быть быстрее, а фразы короче, словно это мгновенная реакция внутри серии кормлений.",
+                    "reaction_focus": "{master_name} только что продолжил кормить тебя леденцом кусочек за кусочком.",
+                    "style_hint": "Повторяющееся кормление леденцом.",
                 },
                 "burst": {
-                    "reaction_focus": "За короткое время происходит несколько подряд кормлений, формируя более частую серию угощения.",
-                    "style_hint": "Ритм может стать более дробным и торопливым, но должен оставаться реакцией на месте.",
+                    "reaction_focus": "{master_name} только что быстро дал тебе несколько кусочков леденца подряд.",
+                    "style_hint": "Быстрое повторяющееся кормление леденцом.",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "Кошачья лапка один раз коротко и легко касается.",
-                    "style_hint": "Коротко, легко и мягко, с естественными мелкими отличиями в зависимости от зоны касания.",
+                    "reaction_focus": "{master_name} только что один раз легко коснулся тебя кошачьей лапкой.",
+                    "style_hint": "Одно касание кошачьей лапкой.",
                 },
                 "rapid": {
-                    "reaction_focus": "За короткое время происходит несколько лёгких касаний подряд.",
-                    "style_hint": "Можно сделать реакцию чуть быстрее и слитнее, но сохранить ощущение лёгкого касания.",
+                    "reaction_focus": "{master_name} только что несколько раз легко коснулся тебя кошачьей лапкой.",
+                    "style_hint": "Повторяющиеся касания кошачьей лапкой.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "Это лёгкое касание одновременно запускает выпадение награды.",
-                    "style_hint": "Сначала откликнитесь на касание, затем мимоходом упомяните выпавшую награду.",
+                    "reaction_focus": "{master_name} только что легко коснулся тебя кошачьей лапкой, и выпала награда.",
+                    "style_hint": "Касание кошачьей лапкой и выпадение награды.",
                 },
             },
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "Один полный удар молотком завершился и дошёл до результата попадания.",
-                    "style_hint": "Коротко, с упором на удар и с небольшой паузой сразу после попадания.",
+                    "reaction_focus": "{master_name} только что один раз попал по тебе молотком.",
+                    "style_hint": "Одно попадание молотком.",
                 },
                 "rapid": {
-                    "reaction_focus": "Ещё один удар молотком завершается в коротком окне, формируя серию попаданий.",
-                    "style_hint": "Можно говорить чуть прямее, показывая накопившийся эффект от повторных ударов.",
+                    "reaction_focus": "{master_name} только что снова попал по тебе молотком за короткое время.",
+                    "style_hint": "Второе попадание молотком.",
                 },
                 "burst": {
-                    "reaction_focus": "Количество подряд идущих ударов молотком увеличивается, и это уже более интенсивный результат.",
-                    "style_hint": "Реакция может быть немного сильнее, если она всё ещё остаётся мгновенной и короткой.",
+                    "reaction_focus": "{master_name} только что быстро попал по тебе молотком несколько раз подряд.",
+                    "style_hint": "Быстрые повторяющиеся попадания молотком.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "Этот удар молотком запускает увеличенный пасхальный эффект, поэтому результат попадания заметно сильнее обычного.",
-                    "style_hint": "Можно сделать реакцию более драматичной и с более выраженной паузой, сохраняя голос персонажа.",
+                    "reaction_focus": "{master_name} только что один раз попал по тебе увеличенным пасхальным молотком.",
+                    "style_hint": "Попадание увеличенным пасхальным молотком.",
                 },
             },
         },
@@ -690,60 +690,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "La piruleta completa el primer contacto con la boca.",
-                    "style_hint": "Puede haber una pequeña pausa de primera prueba o de notar el sabor; mantén un tono naturalmente ligero.",
+                    "reaction_focus": "{master_name} acaba de darte el primer bocado de la piruleta.",
+                    "style_hint": "Primera alimentación con piruleta.",
                 }
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "El primer bocado ya ocurrió; esta interacción es el segundo bocado inmediato.",
-                    "style_hint": "Haz que se sienta más fluido y continuo que el primero, sin dejar de ser natural.",
+                    "reaction_focus": "{master_name} acaba de darte otro bocado de la misma piruleta.",
+                    "style_hint": "Segunda alimentación con piruleta.",
                 }
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "Tras la tercera etapa continúa la alimentación mientras ya flotan corazones; este es un caso dentro de alimentación repetida.",
-                    "style_hint": "El ritmo puede ser más rápido y las frases más cortas, como una reacción inmediata dentro de la repetición.",
+                    "reaction_focus": "{master_name} acaba de seguir dándote la piruleta bocado tras bocado.",
+                    "style_hint": "Alimentación repetida con piruleta.",
                 },
                 "burst": {
-                    "reaction_focus": "Varias alimentaciones ocurren en poco tiempo, formando un evento repetido de mayor frecuencia.",
-                    "style_hint": "Puede sonar más apresurado o fragmentado; mantenlo en el momento.",
+                    "reaction_focus": "{master_name} acaba de darte varios bocados rápidos de la piruleta en poco tiempo.",
+                    "style_hint": "Alimentación rápida repetida con piruleta.",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "La patita de gato produce un toque corto y ligero.",
-                    "style_hint": "Corto, ligero y suave, con pequeñas diferencias según la zona tocada.",
+                    "reaction_focus": "{master_name} acaba de tocarte una vez con la patita de gato.",
+                    "style_hint": "Un toque de patita de gato.",
                 },
                 "rapid": {
-                    "reaction_focus": "Varios toques ligeros ocurren en poco tiempo.",
-                    "style_hint": "Puede sentirse un poco más rápido y continuo sin perder ligereza.",
+                    "reaction_focus": "{master_name} acaba de tocarte varias veces con la patita de gato.",
+                    "style_hint": "Toques repetidos de patita de gato.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "Este toque ligero también soltó una recompensa.",
-                    "style_hint": "Recibe primero el toque y luego menciona la caída de pasada.",
+                    "reaction_focus": "{master_name} acaba de tocarte con la patita de gato y cayó una recompensa.",
+                    "style_hint": "Toque de patita de gato con recompensa.",
                 },
             }
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "Se completa una secuencia completa de golpe de martillo y llega el impacto.",
-                    "style_hint": "Breve y centrado en el impacto, con una pequeña pausa tras el golpe.",
+                    "reaction_focus": "{master_name} acaba de golpearte una vez con el martillo.",
+                    "style_hint": "Un golpe de martillo.",
                 },
                 "rapid": {
-                    "reaction_focus": "Otro golpe de martillo se completa en poco tiempo, formando golpes repetidos.",
-                    "style_hint": "Puede ser más directo y mostrar impacto acumulado.",
+                    "reaction_focus": "{master_name} acaba de volver a golpearte con el martillo en poco tiempo.",
+                    "style_hint": "Segundo golpe de martillo.",
                 },
                 "burst": {
-                    "reaction_focus": "Aumentan los golpes repetidos de martillo, con resultado de mayor intensidad.",
-                    "style_hint": "Una reacción más grande está bien si sigue siendo inmediata y corta.",
+                    "reaction_focus": "{master_name} acaba de golpearte varias veces rápido con el martillo.",
+                    "style_hint": "Golpes rápidos repetidos de martillo.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "Este golpe activa el efecto easter egg ampliado, más fuerte que un golpe normal.",
-                    "style_hint": "Puede ser más dramático, con pausa o exclamación más marcada, manteniendo la voz del personaje.",
+                    "reaction_focus": "{master_name} acaba de golpearte una vez con el martillo easter egg ampliado.",
+                    "style_hint": "Golpe de martillo easter egg ampliado.",
                 },
             }
         },
@@ -752,60 +752,60 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "O pirulito completa o primeiro contato com a boca.",
-                    "style_hint": "Pode haver uma pequena pausa de primeira prova ou de notar o sabor; mantenha o tom naturalmente leve.",
+                    "reaction_focus": "{master_name} acabou de te dar a primeira mordida do pirulito.",
+                    "style_hint": "Primeira alimentação com pirulito.",
                 }
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "A primeira mordida já aconteceu; esta interação é a segunda mordida imediata.",
-                    "style_hint": "Faça parecer um pouco mais suave e contínua que a primeira, mantendo naturalidade.",
+                    "reaction_focus": "{master_name} acabou de te dar outra mordida do mesmo pirulito.",
+                    "style_hint": "Segunda alimentação com pirulito.",
                 }
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "Após a terceira etapa, a alimentação continua enquanto corações já flutuam; este é um caso dentro de alimentação repetida.",
-                    "style_hint": "O ritmo pode ser mais rápido e as frases mais curtas, como reação imediata dentro da repetição.",
+                    "reaction_focus": "{master_name} acabou de continuar te dando o pirulito mordida após mordida.",
+                    "style_hint": "Alimentação repetida com pirulito.",
                 },
                 "burst": {
-                    "reaction_focus": "Várias alimentações acontecem em pouco tempo, formando um evento repetido de maior frequência.",
-                    "style_hint": "Pode soar mais apressado ou fragmentado; mantenha no momento.",
+                    "reaction_focus": "{master_name} acabou de te dar várias mordidas rápidas do pirulito em pouco tempo.",
+                    "style_hint": "Alimentação rápida repetida com pirulito.",
                 },
             },
         },
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "A patinha de gato produz um toque curto e leve.",
-                    "style_hint": "Curto, leve e suave, com pequenas diferenças conforme a área tocada.",
+                    "reaction_focus": "{master_name} acabou de tocar em você uma vez com a patinha de gato.",
+                    "style_hint": "Um toque de patinha de gato.",
                 },
                 "rapid": {
-                    "reaction_focus": "Vários toques leves acontecem em pouco tempo.",
-                    "style_hint": "Pode parecer um pouco mais rápido e contínuo, mantendo a leveza.",
+                    "reaction_focus": "{master_name} acabou de tocar em você várias vezes com a patinha de gato.",
+                    "style_hint": "Toques repetidos de patinha de gato.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "Este toque leve também gerou uma recompensa.",
-                    "style_hint": "Receba primeiro o toque e depois mencione a queda de passagem.",
+                    "reaction_focus": "{master_name} acabou de tocar em você com a patinha de gato e caiu uma recompensa.",
+                    "style_hint": "Toque de patinha de gato com recompensa.",
                 },
             }
         },
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "Uma sequência completa de golpe de martelo termina e chega ao impacto.",
-                    "style_hint": "Breve e focado no impacto, com pequena pausa após o golpe.",
+                    "reaction_focus": "{master_name} acabou de bater em você uma vez com o martelo.",
+                    "style_hint": "Um golpe de martelo.",
                 },
                 "rapid": {
-                    "reaction_focus": "Outro golpe de martelo se completa em pouco tempo, formando golpes repetidos.",
-                    "style_hint": "Pode ser mais direto e mostrar o impacto acumulado.",
+                    "reaction_focus": "{master_name} acabou de bater em você de novo com o martelo em pouco tempo.",
+                    "style_hint": "Segundo golpe de martelo.",
                 },
                 "burst": {
-                    "reaction_focus": "O número de golpes repetidos aumenta, com resultado de maior intensidade.",
-                    "style_hint": "Uma reação maior é aceitável se ainda parecer imediata e curta.",
+                    "reaction_focus": "{master_name} acabou de bater em você várias vezes rapidamente com o martelo.",
+                    "style_hint": "Golpes rápidos repetidos de martelo.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "Este golpe aciona o efeito easter egg ampliado, mais forte que o normal.",
-                    "style_hint": "Pode ser mais dramático, com pausa ou exclamação mais forte, mantendo a voz do personagem.",
+                    "reaction_focus": "{master_name} acabou de bater em você uma vez com o martelo easter egg ampliado.",
+                    "style_hint": "Golpe de martelo easter egg ampliado.",
                 },
             }
         },
@@ -999,13 +999,14 @@ _AVATAR_INTERACTION_DEFAULT_REACTION_PROFILES = {
 }
 _AVATAR_INTERACTION_PROMPT_TEXT = {
     "zh": {
-        "actor_line": "你是{lanlan_name}，正在和{master_name}互动。",
-        "interaction_intro": "前端刚刚记录到一次已经发生的道具互动。下面只给出这次互动确认发生的事实，请据此做出即时回应。",
-        "lollipop_intro": "前端刚刚记录到一次已经发生的棒棒糖投喂互动。下面只给出这次互动确认发生的事实，请据此做出即时回应。",
+        "actor_line": "",
+        "interaction_intro": "",
+        "lollipop_intro": "",
+        "compact_fields": True,
         "tool_field": "道具",
         "action_field": "动作",
         "intensity_field": "强度",
-        "event_fact_field": "事件事实",
+        "event_fact_field": "刚发生",
         "expression_field": "表达倾向",
         "touch_area_field": "接触位置",
         "reward_drop_line": "- 附加结果：本次互动同时触发了掉落奖励。",
@@ -1013,22 +1014,21 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
         "text_context_line": "- 输入框草稿：{text_context}（仅作语境参考，不是正式用户消息）",
         "requirements_header": "要求：",
         "requirements": [
-            "1. 只输出猫娘当下会说的话，不要解释系统或复述字段名。",
-            "2. 根据上面已经发生的事实作答，不补写未发生的动作、距离变化、关系升级或额外剧情。",
-            "3. 以即时短回应为主，句数自然即可，不必机械统一。",
-            "4. text_context 不是正式用户消息，只有在非常自然时才能轻微借用，不能逐字复述。",
-            "5. 不要提范围外点击、坐标、概率、payload 或后台逻辑。",
+            "1. 只输出猫娘当下会说的一句回复。",
+            "2. 回复接住上面的道具事件事实。",
         ],
-        "lollipop_requirement": "6. 这是棒棒糖投喂，不要写成摸头、轻触、安抚或抚摸。",
+        "compact_reply_line": "一句话回应。",
+        "lollipop_requirement": "",
     },
     "zh-TW": {
-        "actor_line": "你是{lanlan_name}，正在和{master_name}互動。",
-        "interaction_intro": "前端剛剛記錄到一次已經發生的道具互動。下面只給出這次互動確認發生的事實，請據此做出即時回應。",
-        "lollipop_intro": "前端剛剛記錄到一次已經發生的棒棒糖投餵互動。下面只給出這次互動確認發生的事實，請據此做出即時回應。",
+        "actor_line": "",
+        "interaction_intro": "",
+        "lollipop_intro": "",
+        "compact_fields": True,
         "tool_field": "道具",
         "action_field": "動作",
         "intensity_field": "強度",
-        "event_fact_field": "事件事實",
+        "event_fact_field": "剛發生",
         "expression_field": "表達傾向",
         "touch_area_field": "接觸位置",
         "reward_drop_line": "- 附加結果：本次互動同時觸發了掉落獎勵。",
@@ -1036,18 +1036,17 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
         "text_context_line": "- 輸入框草稿：{text_context}（僅作語境參考，不是正式使用者訊息）",
         "requirements_header": "要求：",
         "requirements": [
-            "1. 只輸出貓娘當下會說的話，不要解釋系統或複述欄位名。",
-            "2. 根據上面已經發生的事實作答，不補寫未發生的動作、距離變化、關係升級或額外劇情。",
-            "3. 以即時短回應為主，句數自然即可，不必機械統一。",
-            "4. text_context 不是正式使用者訊息，只有在非常自然時才能輕微借用，不能逐字複述。",
-            "5. 不要提範圍外點擊、座標、機率、payload 或後台邏輯。",
+            "1. 只輸出貓娘當下會說的一句回覆。",
+            "2. 回覆接住上面的道具事件事實。",
         ],
-        "lollipop_requirement": "6. 這是棒棒糖投餵，不要寫成摸頭、輕觸、安撫或撫摸。",
+        "compact_reply_line": "一句話回應。",
+        "lollipop_requirement": "",
     },
     "en": {
         "actor_line": "You are {lanlan_name}, reacting to an interaction from {master_name}.",
         "interaction_intro": "The frontend just recorded a tool interaction that has already happened. The lines below describe only the confirmed facts of this interaction; reply from those facts.",
         "lollipop_intro": "The frontend just recorded a lollipop-feeding interaction that has already happened. The lines below describe only the confirmed facts of this interaction; reply from those facts.",
+        "compact_fields": True,
         "tool_field": "Tool",
         "action_field": "Action",
         "intensity_field": "Intensity",
@@ -1065,12 +1064,14 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. The draft text is not a formal user message; use it only as light context if it fits naturally and never quote it verbatim.",
             "5. Do not mention coordinates, probabilities, payloads, or backend rules.",
         ],
+        "compact_reply_line": "Respond in one sentence.",
         "lollipop_requirement": "6. This is lollipop feeding, not petting, soothing, or a generic touch.",
     },
     "ja": {
         "actor_line": "あなたは{lanlan_name}で、{master_name}からのやり取りに反応しています。",
         "interaction_intro": "フロントエンドが、すでに起きた道具インタラクションを記録しました。以下には、このインタラクションで確認できた事実だけを示します。その事実に基づいて即座に反応してください。",
         "lollipop_intro": "フロントエンドが、すでに起きたペロペロキャンディを食べさせるインタラクションを記録しました。以下には、このインタラクションで確認できた事実だけを示します。その事実に基づいて即座に反応してください。",
+        "compact_fields": True,
         "tool_field": "道具",
         "action_field": "動作",
         "intensity_field": "強度",
@@ -1088,12 +1089,14 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. text_context は正式なユーザーメッセージではありません。自然な場合だけ軽く参考にし、逐語的に繰り返さないでください。",
             "5. 座標、確率、payload、バックエンドのルールには触れないでください。",
         ],
+        "compact_reply_line": "一文で返答してください。",
         "lollipop_requirement": "6. これはペロペロキャンディを食べさせるやり取りであり、頭なで、軽い接触、なだめる行為、一般的なスキンシップとして書かないでください。",
     },
     "ko": {
         "actor_line": "너는 {lanlan_name}이고, {master_name}의 상호작용에 반응하고 있다.",
         "interaction_intro": "프런트엔드가 이미 발생한 도구 상호작용을 방금 기록했다. 아래에는 이번 상호작용에서 확인된 사실만 주어진다. 그 사실만 바탕으로 즉시 반응하라.",
         "lollipop_intro": "프런트엔드가 이미 발생한 막대사탕 먹이기 상호작용을 방금 기록했다. 아래에는 이번 상호작용에서 확인된 사실만 주어진다. 그 사실만 바탕으로 즉시 반응하라.",
+        "compact_fields": True,
         "tool_field": "도구",
         "action_field": "동작",
         "intensity_field": "강도",
@@ -1111,12 +1114,14 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. text_context 는 정식 사용자 메시지가 아니다. 아주 자연스러울 때만 가볍게 참고하고, 그대로 되풀이하지 않는다.",
             "5. 좌표, 확률, payload, 백엔드 규칙은 언급하지 않는다.",
         ],
+        "compact_reply_line": "한 문장으로 답한다.",
         "lollipop_requirement": "6. 이것은 막대사탕 먹이기이며, 쓰다듬기, 가벼운 터치, 달래기, 일반적인 스킨십으로 쓰면 안 된다.",
     },
     "ru": {
         "actor_line": "Ты {lanlan_name} и реагируешь на взаимодействие от {master_name}.",
         "interaction_intro": "Фронтенд только что зафиксировал уже произошедшее взаимодействие с инструментом. Ниже перечислены только подтверждённые факты этого эпизода; отвечай, опираясь только на них.",
         "lollipop_intro": "Фронтенд только что зафиксировал уже произошедшее кормление леденцом. Ниже перечислены только подтверждённые факты этого эпизода; отвечай, опираясь только на них.",
+        "compact_fields": True,
         "tool_field": "Инструмент",
         "action_field": "Действие",
         "intensity_field": "Интенсивность",
@@ -1134,12 +1139,14 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. Черновик текста не является официальным сообщением пользователя; используй его лишь как лёгкий контекст, если это естественно, и никогда не цитируй дословно.",
             "5. Не упоминай координаты, вероятности, payload или правила бэкенда.",
         ],
+        "compact_reply_line": "Ответь одним предложением.",
         "lollipop_requirement": "6. Это кормление леденцом, а не поглаживание, успокаивание или просто абстрактное касание.",
     },
     "es": {
         "actor_line": "Eres {lanlan_name}, reaccionando a una interacción de {master_name}.",
         "interaction_intro": "El frontend acaba de registrar una interacción con herramienta que ya ocurrió. Las líneas siguientes describen solo los hechos confirmados; responde desde esos hechos.",
         "lollipop_intro": "El frontend acaba de registrar una interacción de alimentación con piruleta que ya ocurrió. Las líneas siguientes describen solo los hechos confirmados; responde desde esos hechos.",
+        "compact_fields": True,
         "tool_field": "Herramienta",
         "action_field": "Acción",
         "intensity_field": "Intensidad",
@@ -1157,12 +1164,14 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. El borrador no es un mensaje formal del usuario; úsalo solo como contexto ligero si encaja y nunca lo cites literalmente.",
             "5. No menciones coordenadas, probabilidades, payloads ni reglas del backend.",
         ],
+        "compact_reply_line": "Responde en una frase.",
         "lollipop_requirement": "6. Esto es alimentación con piruleta, no lo conviertas en caricias, toques, consuelo o palmaditas.",
     },
     "pt": {
         "actor_line": "Você é {lanlan_name}, reagindo a uma interação de {master_name}.",
         "interaction_intro": "O frontend acabou de registrar uma interação com ferramenta que já aconteceu. As linhas abaixo descrevem apenas os fatos confirmados; responda a partir desses fatos.",
         "lollipop_intro": "O frontend acabou de registrar uma interação de alimentação com pirulito que já aconteceu. As linhas abaixo descrevem apenas os fatos confirmados; responda a partir desses fatos.",
+        "compact_fields": True,
         "tool_field": "Ferramenta",
         "action_field": "Ação",
         "intensity_field": "Intensidade",
@@ -1180,6 +1189,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. O rascunho não é uma mensagem formal do usuário; use apenas como contexto leve se couber e nunca cite literalmente.",
             "5. Não mencione coordenadas, probabilidades, payloads ou regras do backend.",
         ],
+        "compact_reply_line": "Responda em uma frase.",
         "lollipop_requirement": "6. Isto é alimentação com pirulito, não transforme em carinho, toque, consolo ou afago.",
     },
 }
@@ -1465,24 +1475,39 @@ def _build_avatar_interaction_instruction(
                 locale, _AVATAR_INTERACTION_DEFAULT_REACTION_PROFILES["en"]
             )
         )
+    reaction_focus = str(reaction_profile["reaction_focus"]).format(
+        lanlan_name=lanlan_name, master_name=master_name
+    )
+    style_hint = str(reaction_profile["style_hint"]).format(
+        lanlan_name=lanlan_name, master_name=master_name
+    )
 
     interaction_intro = (
         prompt_text["lollipop_intro"]
         if tool_id == "lollipop"
         else prompt_text["interaction_intro"]
     )
+    if prompt_text.get("compact_fields"):
+        compact_separator = "" if locale in {"zh", "zh-TW", "ja"} else " "
+        return f"{reaction_focus}{compact_separator}{prompt_text['compact_reply_line']}"
+
     lines = [
         wrapper["prefix"],
         prompt_text["actor_line"].format(
             lanlan_name=lanlan_name, master_name=master_name
         ),
-        interaction_intro,
-        f"- {prompt_text['tool_field']}: {tool_label}",
-        f"- {prompt_text['action_field']}: {action_label}",
-        f"- {prompt_text['intensity_field']}: {intensity_label}",
-        f"- {prompt_text['event_fact_field']}: {reaction_profile['reaction_focus']}",
-        f"- {prompt_text['expression_field']}: {reaction_profile['style_hint']}",
     ]
+    if interaction_intro:
+        lines.append(interaction_intro)
+    lines.extend(
+        [
+            f"- {prompt_text['tool_field']}: {tool_label}",
+            f"- {prompt_text['action_field']}: {action_label}",
+            f"- {prompt_text['intensity_field']}: {intensity_label}",
+            f"- {prompt_text['event_fact_field']}: {reaction_focus}",
+            f"- {prompt_text['expression_field']}: {style_hint}",
+        ]
+    )
     if touch_zone_label:
         lines.append(f"- {prompt_text['touch_area_field']}: {touch_zone_label}")
     if payload.get("reward_drop"):
@@ -1498,7 +1523,7 @@ def _build_avatar_interaction_instruction(
             wrapper["suffix"],
         ]
     )
-    if tool_id == "lollipop":
+    if tool_id == "lollipop" and prompt_text.get("lollipop_requirement"):
         lines.insert(-1, prompt_text["lollipop_requirement"])
     return "\n".join(lines)
 

--- a/config/prompts/prompts_avatar_interaction.py
+++ b/config/prompts/prompts_avatar_interaction.py
@@ -318,23 +318,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name}刚刚用棒棒糖喂了你第一口。",
+                    "reaction_focus": "{actor}刚刚用棒棒糖喂了你第一口。",
                     "style_hint": "棒棒糖第一口。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name}刚刚用同一支棒棒糖又喂了你一口。",
+                    "reaction_focus": "{actor}刚刚用同一支棒棒糖又喂了你一口。",
                     "style_hint": "棒棒糖第二口。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name}刚刚继续用棒棒糖一口接一口地喂你。",
+                    "reaction_focus": "{actor}刚刚继续用棒棒糖一口接一口地喂你。",
                     "style_hint": "棒棒糖连续投喂。",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}刚刚短时间内用棒棒糖快速喂了你好几口。",
+                    "reaction_focus": "{actor}刚刚短时间内用棒棒糖快速喂了你好几口。",
                     "style_hint": "棒棒糖快速连续投喂。",
                 },
             },
@@ -342,15 +342,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name}刚刚用猫爪轻轻碰了你一下。",
+                    "reaction_focus": "{actor}刚刚用猫爪轻轻碰了你一下。",
                     "style_hint": "猫爪轻碰。",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}刚刚用猫爪连续轻轻碰了你几下。",
+                    "reaction_focus": "{actor}刚刚用猫爪连续轻轻碰了你几下。",
                     "style_hint": "猫爪连续轻碰。",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name}刚刚用猫爪轻轻碰你时掉出了奖励。",
+                    "reaction_focus": "{actor}刚刚用猫爪轻轻碰你时掉出了奖励。",
                     "style_hint": "猫爪轻碰并掉出奖励。",
                 },
             },
@@ -358,19 +358,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name}刚刚用锤子敲中了你一次。",
+                    "reaction_focus": "{actor}刚刚用锤子敲中了你一次。",
                     "style_hint": "锤子敲中一次。",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}刚刚短时间内又用锤子敲中了你一次。",
+                    "reaction_focus": "{actor}刚刚短时间内又用锤子敲中了你一次。",
                     "style_hint": "锤子再次敲中。",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}刚刚用锤子连续快速敲中了你好几次。",
+                    "reaction_focus": "{actor}刚刚用锤子连续快速敲中了你好几次。",
                     "style_hint": "锤子连续快速敲中。",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name}刚刚用放大彩蛋锤敲中了你一次。",
+                    "reaction_focus": "{actor}刚刚用放大彩蛋锤敲中了你一次。",
                     "style_hint": "放大彩蛋锤敲中。",
                 },
             },
@@ -380,23 +380,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name} just fed you the first bite of the lollipop.",
+                    "reaction_focus": "{actor} just fed you the first bite of the lollipop.",
                     "style_hint": "First lollipop bite.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name} just fed you another bite from the same lollipop.",
+                    "reaction_focus": "{actor} just fed you another bite from the same lollipop.",
                     "style_hint": "Second lollipop bite.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name} just kept feeding you the lollipop bite after bite.",
+                    "reaction_focus": "{actor} just kept feeding you the lollipop bite after bite.",
                     "style_hint": "Repeated lollipop feeding.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} just fed you several quick bites of the lollipop in a short time.",
+                    "reaction_focus": "{actor} just fed you several quick bites of the lollipop in a short time.",
                     "style_hint": "Rapid repeated lollipop feeding.",
                 },
             },
@@ -404,15 +404,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name} just lightly touched you once with the cat paw.",
+                    "reaction_focus": "{actor} just lightly touched you once with the cat paw.",
                     "style_hint": "Single cat-paw touch.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} just lightly touched you several times with the cat paw.",
+                    "reaction_focus": "{actor} just lightly touched you several times with the cat paw.",
                     "style_hint": "Repeated cat-paw touches.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name} just lightly touched you with the cat paw, and a reward dropped.",
+                    "reaction_focus": "{actor} just lightly touched you with the cat paw, and a reward dropped.",
                     "style_hint": "Cat-paw touch with reward drop.",
                 },
             },
@@ -420,19 +420,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name} just hit you once with the hammer.",
+                    "reaction_focus": "{actor} just hit you once with the hammer.",
                     "style_hint": "Single hammer hit.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} just hit you again with the hammer within a short time.",
+                    "reaction_focus": "{actor} just hit you again with the hammer within a short time.",
                     "style_hint": "Second hammer hit.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} just hit you several times quickly with the hammer.",
+                    "reaction_focus": "{actor} just hit you several times quickly with the hammer.",
                     "style_hint": "Rapid repeated hammer hits.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name} just hit you once with the enlarged easter-egg hammer.",
+                    "reaction_focus": "{actor} just hit you once with the enlarged easter-egg hammer.",
                     "style_hint": "Enlarged easter-egg hammer hit.",
                 },
             },
@@ -442,23 +442,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name}剛剛用棒棒糖餵了你第一口。",
+                    "reaction_focus": "{actor}剛剛用棒棒糖餵了你第一口。",
                     "style_hint": "棒棒糖第一口。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name}剛剛用同一支棒棒糖又餵了你一口。",
+                    "reaction_focus": "{actor}剛剛用同一支棒棒糖又餵了你一口。",
                     "style_hint": "棒棒糖第二口。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name}剛剛繼續用棒棒糖一口接一口地餵你。",
+                    "reaction_focus": "{actor}剛剛繼續用棒棒糖一口接一口地餵你。",
                     "style_hint": "棒棒糖連續投餵。",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}剛剛短時間內用棒棒糖快速餵了你好幾口。",
+                    "reaction_focus": "{actor}剛剛短時間內用棒棒糖快速餵了你好幾口。",
                     "style_hint": "棒棒糖快速連續投餵。",
                 },
             },
@@ -466,15 +466,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name}剛剛用貓爪輕輕碰了你一下。",
+                    "reaction_focus": "{actor}剛剛用貓爪輕輕碰了你一下。",
                     "style_hint": "貓爪輕碰。",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}剛剛用貓爪連續輕輕碰了你幾下。",
+                    "reaction_focus": "{actor}剛剛用貓爪連續輕輕碰了你幾下。",
                     "style_hint": "貓爪連續輕碰。",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name}剛剛用貓爪輕輕碰你時掉出了獎勵。",
+                    "reaction_focus": "{actor}剛剛用貓爪輕輕碰你時掉出了獎勵。",
                     "style_hint": "貓爪輕碰並掉出獎勵。",
                 },
             },
@@ -482,19 +482,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name}剛剛用槌子敲中了你一次。",
+                    "reaction_focus": "{actor}剛剛用槌子敲中了你一次。",
                     "style_hint": "槌子敲中一次。",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}剛剛短時間內又用槌子敲中了你一次。",
+                    "reaction_focus": "{actor}剛剛短時間內又用槌子敲中了你一次。",
                     "style_hint": "槌子再次敲中。",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}剛剛用槌子連續快速敲中了你好幾次。",
+                    "reaction_focus": "{actor}剛剛用槌子連續快速敲中了你好幾次。",
                     "style_hint": "槌子連續快速敲中。",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name}剛剛用放大彩蛋槌敲中了你一次。",
+                    "reaction_focus": "{actor}剛剛用放大彩蛋槌敲中了你一次。",
                     "style_hint": "放大彩蛋槌敲中。",
                 },
             },
@@ -504,23 +504,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name}が今、ペロペロキャンディを最初の一口だけ食べさせた。",
+                    "reaction_focus": "{actor}が今、ペロペロキャンディを最初の一口だけ食べさせた。",
                     "style_hint": "最初のペロペロキャンディ。",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name}が今、同じペロペロキャンディをもう一口食べさせた。",
+                    "reaction_focus": "{actor}が今、同じペロペロキャンディをもう一口食べさせた。",
                     "style_hint": "二口目のペロペロキャンディ。",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name}が今、ペロペロキャンディを一口ずつ続けて食べさせている。",
+                    "reaction_focus": "{actor}が今、ペロペロキャンディを一口ずつ続けて食べさせている。",
                     "style_hint": "連続ペロペロキャンディ。",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}が今、短時間でペロペロキャンディを何口も続けて食べさせた。",
+                    "reaction_focus": "{actor}が今、短時間でペロペロキャンディを何口も続けて食べさせた。",
                     "style_hint": "高速連続ペロペロキャンディ。",
                 },
             },
@@ -528,15 +528,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name}が今、猫の肉球で一度だけ軽く触れた。",
+                    "reaction_focus": "{actor}が今、猫の肉球で一度だけ軽く触れた。",
                     "style_hint": "猫の肉球の一回接触。",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}が今、猫の肉球で何度か続けて軽く触れた。",
+                    "reaction_focus": "{actor}が今、猫の肉球で何度か続けて軽く触れた。",
                     "style_hint": "猫の肉球の連続接触。",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name}が今、猫の肉球で軽く触れた時に報酬が落ちた。",
+                    "reaction_focus": "{actor}が今、猫の肉球で軽く触れた時に報酬が落ちた。",
                     "style_hint": "猫の肉球接触と報酬ドロップ。",
                 },
             },
@@ -544,19 +544,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name}が今、ハンマーで一度当てた。",
+                    "reaction_focus": "{actor}が今、ハンマーで一度当てた。",
                     "style_hint": "ハンマーの一回命中。",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}が今、短時間でもう一度ハンマーを当てた。",
+                    "reaction_focus": "{actor}が今、短時間でもう一度ハンマーを当てた。",
                     "style_hint": "ハンマーの二回目命中。",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}が今、ハンマーを何度も続けて当てた。",
+                    "reaction_focus": "{actor}が今、ハンマーを何度も続けて当てた。",
                     "style_hint": "ハンマーの高速連続命中。",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name}が今、拡大イースターエッグのハンマーを一度当てた。",
+                    "reaction_focus": "{actor}が今、拡大イースターエッグのハンマーを一度当てた。",
                     "style_hint": "拡大イースターエッグのハンマー命中。",
                 },
             },
@@ -566,23 +566,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name}이 방금 막대사탕을 첫 한입 먹여 줬다.",
+                    "reaction_focus": "{actor} 방금 막대사탕을 첫 한입 먹여 줬다.",
                     "style_hint": "첫 막대사탕 먹이기.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name}이 방금 같은 막대사탕을 한입 더 먹여 줬다.",
+                    "reaction_focus": "{actor} 방금 같은 막대사탕을 한입 더 먹여 줬다.",
                     "style_hint": "두 번째 막대사탕 먹이기.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name}이 방금 막대사탕을 한입씩 계속 먹여 줬다.",
+                    "reaction_focus": "{actor} 방금 막대사탕을 한입씩 계속 먹여 줬다.",
                     "style_hint": "연속 막대사탕 먹이기.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}이 방금 짧은 시간 안에 막대사탕을 여러 입 빠르게 먹여 줬다.",
+                    "reaction_focus": "{actor} 방금 짧은 시간 안에 막대사탕을 여러 입 빠르게 먹여 줬다.",
                     "style_hint": "빠른 연속 막대사탕 먹이기.",
                 },
             },
@@ -590,15 +590,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name}이 방금 고양이 발로 한 번 가볍게 건드렸다.",
+                    "reaction_focus": "{actor} 방금 고양이 발로 한 번 가볍게 건드렸다.",
                     "style_hint": "고양이 발 한 번 터치.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}이 방금 고양이 발로 여러 번 가볍게 건드렸다.",
+                    "reaction_focus": "{actor} 방금 고양이 발로 여러 번 가볍게 건드렸다.",
                     "style_hint": "고양이 발 연속 터치.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name}이 방금 고양이 발로 가볍게 건드렸을 때 보상이 떨어졌다.",
+                    "reaction_focus": "{actor} 방금 고양이 발로 가볍게 건드렸을 때 보상이 떨어졌다.",
                     "style_hint": "고양이 발 터치와 보상 드롭.",
                 },
             },
@@ -606,19 +606,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name}이 방금 망치로 한 번 맞혔다.",
+                    "reaction_focus": "{actor} 방금 망치로 한 번 맞혔다.",
                     "style_hint": "망치 한 번 명중.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name}이 방금 짧은 시간 안에 망치로 다시 한 번 맞혔다.",
+                    "reaction_focus": "{actor} 방금 짧은 시간 안에 망치로 다시 한 번 맞혔다.",
                     "style_hint": "망치 두 번째 명중.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name}이 방금 망치로 여러 번 빠르게 맞혔다.",
+                    "reaction_focus": "{actor} 방금 망치로 여러 번 빠르게 맞혔다.",
                     "style_hint": "망치 빠른 연속 명중.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name}이 방금 확대 이스터에그 망치로 한 번 맞혔다.",
+                    "reaction_focus": "{actor} 방금 확대 이스터에그 망치로 한 번 맞혔다.",
                     "style_hint": "확대 이스터에그 망치 명중.",
                 },
             },
@@ -628,23 +628,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name} только что дал тебе первый кусочек леденца.",
+                    "reaction_focus": "{actor} только что дал тебе первый кусочек леденца.",
                     "style_hint": "Первое кормление леденцом.",
                 },
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name} только что дал тебе ещё кусочек того же леденца.",
+                    "reaction_focus": "{actor} только что дал тебе ещё кусочек того же леденца.",
                     "style_hint": "Второе кормление леденцом.",
                 },
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name} только что продолжил кормить тебя леденцом кусочек за кусочком.",
+                    "reaction_focus": "{actor} только что продолжил кормить тебя леденцом кусочек за кусочком.",
                     "style_hint": "Повторяющееся кормление леденцом.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} только что быстро дал тебе несколько кусочков леденца подряд.",
+                    "reaction_focus": "{actor} только что быстро дал тебе несколько кусочков леденца подряд.",
                     "style_hint": "Быстрое повторяющееся кормление леденцом.",
                 },
             },
@@ -652,15 +652,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name} только что один раз легко коснулся тебя кошачьей лапкой.",
+                    "reaction_focus": "{actor} только что один раз легко коснулся тебя кошачьей лапкой.",
                     "style_hint": "Одно касание кошачьей лапкой.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} только что несколько раз легко коснулся тебя кошачьей лапкой.",
+                    "reaction_focus": "{actor} только что несколько раз легко коснулся тебя кошачьей лапкой.",
                     "style_hint": "Повторяющиеся касания кошачьей лапкой.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name} только что легко коснулся тебя кошачьей лапкой, и выпала награда.",
+                    "reaction_focus": "{actor} только что легко коснулся тебя кошачьей лапкой, и выпала награда.",
                     "style_hint": "Касание кошачьей лапкой и выпадение награды.",
                 },
             },
@@ -668,19 +668,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name} только что один раз попал по тебе молотком.",
+                    "reaction_focus": "{actor} только что один раз попал по тебе молотком.",
                     "style_hint": "Одно попадание молотком.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} только что снова попал по тебе молотком за короткое время.",
+                    "reaction_focus": "{actor} только что снова попал по тебе молотком за короткое время.",
                     "style_hint": "Второе попадание молотком.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} только что быстро попал по тебе молотком несколько раз подряд.",
+                    "reaction_focus": "{actor} только что быстро попал по тебе молотком несколько раз подряд.",
                     "style_hint": "Быстрые повторяющиеся попадания молотком.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name} только что один раз попал по тебе увеличенным пасхальным молотком.",
+                    "reaction_focus": "{actor} только что один раз попал по тебе увеличенным пасхальным молотком.",
                     "style_hint": "Попадание увеличенным пасхальным молотком.",
                 },
             },
@@ -690,23 +690,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name} acaba de darte el primer bocado de la piruleta.",
+                    "reaction_focus": "{actor} acaba de darte el primer bocado de la piruleta.",
                     "style_hint": "Primera alimentación con piruleta.",
                 }
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name} acaba de darte otro bocado de la misma piruleta.",
+                    "reaction_focus": "{actor} acaba de darte otro bocado de la misma piruleta.",
                     "style_hint": "Segunda alimentación con piruleta.",
                 }
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name} acaba de seguir dándote la piruleta bocado tras bocado.",
+                    "reaction_focus": "{actor} acaba de seguir dándote la piruleta bocado tras bocado.",
                     "style_hint": "Alimentación repetida con piruleta.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} acaba de darte varios bocados rápidos de la piruleta en poco tiempo.",
+                    "reaction_focus": "{actor} acaba de darte varios bocados rápidos de la piruleta en poco tiempo.",
                     "style_hint": "Alimentación rápida repetida con piruleta.",
                 },
             },
@@ -714,15 +714,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name} acaba de tocarte una vez con la patita de gato.",
+                    "reaction_focus": "{actor} acaba de tocarte una vez con la patita de gato.",
                     "style_hint": "Un toque de patita de gato.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} acaba de tocarte varias veces con la patita de gato.",
+                    "reaction_focus": "{actor} acaba de tocarte varias veces con la patita de gato.",
                     "style_hint": "Toques repetidos de patita de gato.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name} acaba de tocarte con la patita de gato y cayó una recompensa.",
+                    "reaction_focus": "{actor} acaba de tocarte con la patita de gato y cayó una recompensa.",
                     "style_hint": "Toque de patita de gato con recompensa.",
                 },
             }
@@ -730,19 +730,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name} acaba de golpearte una vez con el martillo.",
+                    "reaction_focus": "{actor} acaba de golpearte una vez con el martillo.",
                     "style_hint": "Un golpe de martillo.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} acaba de volver a golpearte con el martillo en poco tiempo.",
+                    "reaction_focus": "{actor} acaba de volver a golpearte con el martillo en poco tiempo.",
                     "style_hint": "Segundo golpe de martillo.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} acaba de golpearte varias veces rápido con el martillo.",
+                    "reaction_focus": "{actor} acaba de golpearte varias veces rápido con el martillo.",
                     "style_hint": "Golpes rápidos repetidos de martillo.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name} acaba de golpearte una vez con el martillo easter egg ampliado.",
+                    "reaction_focus": "{actor} acaba de golpearte una vez con el martillo easter egg ampliado.",
                     "style_hint": "Golpe de martillo easter egg ampliado.",
                 },
             }
@@ -752,23 +752,23 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "lollipop": {
             "offer": {
                 "normal": {
-                    "reaction_focus": "{master_name} acabou de te dar a primeira mordida do pirulito.",
+                    "reaction_focus": "{actor} acabou de te dar a primeira mordida do pirulito.",
                     "style_hint": "Primeira alimentação com pirulito.",
                 }
             },
             "tease": {
                 "normal": {
-                    "reaction_focus": "{master_name} acabou de te dar outra mordida do mesmo pirulito.",
+                    "reaction_focus": "{actor} acabou de te dar outra mordida do mesmo pirulito.",
                     "style_hint": "Segunda alimentação com pirulito.",
                 }
             },
             "tap_soft": {
                 "rapid": {
-                    "reaction_focus": "{master_name} acabou de continuar te dando o pirulito mordida após mordida.",
+                    "reaction_focus": "{actor} acabou de continuar te dando o pirulito mordida após mordida.",
                     "style_hint": "Alimentação repetida com pirulito.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} acabou de te dar várias mordidas rápidas do pirulito em pouco tempo.",
+                    "reaction_focus": "{actor} acabou de te dar várias mordidas rápidas do pirulito em pouco tempo.",
                     "style_hint": "Alimentação rápida repetida com pirulito.",
                 },
             },
@@ -776,15 +776,15 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "fist": {
             "poke": {
                 "normal": {
-                    "reaction_focus": "{master_name} acabou de tocar em você uma vez com a patinha de gato.",
+                    "reaction_focus": "{actor} acabou de tocar em você uma vez com a patinha de gato.",
                     "style_hint": "Um toque de patinha de gato.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} acabou de tocar em você várias vezes com a patinha de gato.",
+                    "reaction_focus": "{actor} acabou de tocar em você várias vezes com a patinha de gato.",
                     "style_hint": "Toques repetidos de patinha de gato.",
                 },
                 "reward_drop": {
-                    "reaction_focus": "{master_name} acabou de tocar em você com a patinha de gato e caiu uma recompensa.",
+                    "reaction_focus": "{actor} acabou de tocar em você com a patinha de gato e caiu uma recompensa.",
                     "style_hint": "Toque de patinha de gato com recompensa.",
                 },
             }
@@ -792,19 +792,19 @@ _AVATAR_INTERACTION_REACTION_PROFILES = {
         "hammer": {
             "bonk": {
                 "normal": {
-                    "reaction_focus": "{master_name} acabou de bater em você uma vez com o martelo.",
+                    "reaction_focus": "{actor} acabou de bater em você uma vez com o martelo.",
                     "style_hint": "Um golpe de martelo.",
                 },
                 "rapid": {
-                    "reaction_focus": "{master_name} acabou de bater em você de novo com o martelo em pouco tempo.",
+                    "reaction_focus": "{actor} acabou de bater em você de novo com o martelo em pouco tempo.",
                     "style_hint": "Segundo golpe de martelo.",
                 },
                 "burst": {
-                    "reaction_focus": "{master_name} acabou de bater em você várias vezes rapidamente com o martelo.",
+                    "reaction_focus": "{actor} acabou de bater em você várias vezes rapidamente com o martelo.",
                     "style_hint": "Golpes rápidos repetidos de martelo.",
                 },
                 "easter_egg": {
-                    "reaction_focus": "{master_name} acabou de bater em você uma vez com o martelo easter egg ampliado.",
+                    "reaction_focus": "{actor} acabou de bater em você uma vez com o martelo easter egg ampliado.",
                     "style_hint": "Golpe de martelo easter egg ampliado.",
                 },
             }
@@ -962,6 +962,16 @@ _AVATAR_INTERACTION_MEMORY_NOTE_MASTER_FALLBACK: dict[str, str] = {
     "ru": "собеседник",
     "es": "esa persona",
     "pt": "a outra pessoa",
+}
+_AVATAR_INTERACTION_PROMPT_ACTOR_FALLBACK: dict[str, str] = {
+    "zh": "对方",
+    "zh-TW": "對方",
+    "en": "The other person",
+    "ja": "相手",
+    "ko": "상대가",
+    "ru": "Собеседник",
+    "es": "Esa persona",
+    "pt": "A outra pessoa",
 }
 _AVATAR_INTERACTION_DEFAULT_REACTION_PROFILES = {
     "zh": {
@@ -1214,6 +1224,41 @@ def _avatar_interaction_locale(language: str | None) -> str:
     if locale.startswith("pt"):
         return "pt"
     return "en"
+
+
+def _avatar_interaction_korean_subject_actor(name: str) -> str:
+    """Return a Korean subject phrase for an arbitrary actor name.
+
+    Hangul names can choose 이/가 exactly by final consonant. For latin names,
+    use a small readability heuristic; other scripts keep the previous safe
+    default of 이.
+    """
+    stripped = str(name or "").strip()
+    if not stripped:
+        return _AVATAR_INTERACTION_PROMPT_ACTOR_FALLBACK["ko"]
+
+    last_char = stripped[-1]
+    codepoint = ord(last_char)
+    if 0xAC00 <= codepoint <= 0xD7A3:
+        has_final_consonant = (codepoint - 0xAC00) % 28 != 0
+        marker = "이" if has_final_consonant else "가"
+    elif last_char.isascii() and last_char.isalpha():
+        # Latin display names are common in config; this keeps simple names
+        # readable without forcing every non-Hangul script into a Korean marker.
+        marker = "가" if last_char.lower() in {"a", "e", "i", "o", "u", "y"} else "이"
+    else:
+        return stripped
+    return f"{stripped}{marker}"
+
+
+def _avatar_interaction_prompt_actor(locale: str, master_name: str) -> str:
+    stripped = str(master_name or "").strip()
+    if locale == "ko":
+        return _avatar_interaction_korean_subject_actor(stripped)
+    if stripped:
+        return stripped
+    fallback = _AVATAR_INTERACTION_PROMPT_ACTOR_FALLBACK
+    return fallback.get(locale, fallback["en"])
 
 
 def _sanitize_avatar_interaction_text_context(
@@ -1475,11 +1520,12 @@ def _build_avatar_interaction_instruction(
                 locale, _AVATAR_INTERACTION_DEFAULT_REACTION_PROFILES["en"]
             )
         )
+    actor = _avatar_interaction_prompt_actor(locale, master_name)
     reaction_focus = str(reaction_profile["reaction_focus"]).format(
-        lanlan_name=lanlan_name, master_name=master_name
+        lanlan_name=lanlan_name, master_name=actor, actor=actor
     )
     style_hint = str(reaction_profile["style_hint"]).format(
-        lanlan_name=lanlan_name, master_name=master_name
+        lanlan_name=lanlan_name, master_name=actor, actor=actor
     )
 
     interaction_intro = (
@@ -1494,7 +1540,7 @@ def _build_avatar_interaction_instruction(
     lines = [
         wrapper["prefix"],
         prompt_text["actor_line"].format(
-            lanlan_name=lanlan_name, master_name=master_name
+            lanlan_name=lanlan_name, master_name=actor
         ),
     ]
     if interaction_intro:

--- a/config/prompts/prompts_avatar_interaction.py
+++ b/config/prompts/prompts_avatar_interaction.py
@@ -1027,7 +1027,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "1. 只输出猫娘当下会说的一句回复。",
             "2. 回复接住上面的道具事件事实。",
         ],
-        "compact_reply_line": "一句话回应。",
+        "compact_reply_line": "直接回一句你会说出口的话。",
         "lollipop_requirement": "",
     },
     "zh-TW": {
@@ -1049,7 +1049,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "1. 只輸出貓娘當下會說的一句回覆。",
             "2. 回覆接住上面的道具事件事實。",
         ],
-        "compact_reply_line": "一句話回應。",
+        "compact_reply_line": "直接回一句你會說出口的話。",
         "lollipop_requirement": "",
     },
     "en": {
@@ -1074,7 +1074,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. The draft text is not a formal user message; use it only as light context if it fits naturally and never quote it verbatim.",
             "5. Do not mention coordinates, probabilities, payloads, or backend rules.",
         ],
-        "compact_reply_line": "Respond in one sentence.",
+        "compact_reply_line": "Reply with one spoken line you would say right now.",
         "lollipop_requirement": "6. This is lollipop feeding, not petting, soothing, or a generic touch.",
     },
     "ja": {
@@ -1099,7 +1099,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. text_context は正式なユーザーメッセージではありません。自然な場合だけ軽く参考にし、逐語的に繰り返さないでください。",
             "5. 座標、確率、payload、バックエンドのルールには触れないでください。",
         ],
-        "compact_reply_line": "一文で返答してください。",
+        "compact_reply_line": "その場で口にする一言として返答してください。",
         "lollipop_requirement": "6. これはペロペロキャンディを食べさせるやり取りであり、頭なで、軽い接触、なだめる行為、一般的なスキンシップとして書かないでください。",
     },
     "ko": {
@@ -1124,7 +1124,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. text_context 는 정식 사용자 메시지가 아니다. 아주 자연스러울 때만 가볍게 참고하고, 그대로 되풀이하지 않는다.",
             "5. 좌표, 확률, payload, 백엔드 규칙은 언급하지 않는다.",
         ],
-        "compact_reply_line": "한 문장으로 답한다.",
+        "compact_reply_line": "지금 바로 말하는 한마디로 답한다.",
         "lollipop_requirement": "6. 이것은 막대사탕 먹이기이며, 쓰다듬기, 가벼운 터치, 달래기, 일반적인 스킨십으로 쓰면 안 된다.",
     },
     "ru": {
@@ -1149,7 +1149,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. Черновик текста не является официальным сообщением пользователя; используй его лишь как лёгкий контекст, если это естественно, и никогда не цитируй дословно.",
             "5. Не упоминай координаты, вероятности, payload или правила бэкенда.",
         ],
-        "compact_reply_line": "Ответь одним предложением.",
+        "compact_reply_line": "Ответь одной короткой репликой от своего лица.",
         "lollipop_requirement": "6. Это кормление леденцом, а не поглаживание, успокаивание или просто абстрактное касание.",
     },
     "es": {
@@ -1174,7 +1174,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. El borrador no es un mensaje formal del usuario; úsalo solo como contexto ligero si encaja y nunca lo cites literalmente.",
             "5. No menciones coordenadas, probabilidades, payloads ni reglas del backend.",
         ],
-        "compact_reply_line": "Responde en una frase.",
+        "compact_reply_line": "Responde con una línea de diálogo que dirías ahora.",
         "lollipop_requirement": "6. Esto es alimentación con piruleta, no lo conviertas en caricias, toques, consuelo o palmaditas.",
     },
     "pt": {
@@ -1199,7 +1199,7 @@ _AVATAR_INTERACTION_PROMPT_TEXT = {
             "4. O rascunho não é uma mensagem formal do usuário; use apenas como contexto leve se couber e nunca cite literalmente.",
             "5. Não mencione coordenadas, probabilidades, payloads ou regras do backend.",
         ],
-        "compact_reply_line": "Responda em uma frase.",
+        "compact_reply_line": "Responda com uma fala que você diria agora.",
         "lollipop_requirement": "6. Isto é alimentação com pirulito, não transforme em carinho, toque, consolo ou afago.",
     },
 }
@@ -1535,7 +1535,10 @@ def _build_avatar_interaction_instruction(
     )
     if prompt_text.get("compact_fields"):
         compact_separator = "" if locale in {"zh", "zh-TW", "ja"} else " "
-        return f"{reaction_focus}{compact_separator}{prompt_text['compact_reply_line']}"
+        compact_reply_line = prompt_text["compact_reply_line"].format(
+            lanlan_name=lanlan_name, master_name=actor, actor=actor
+        )
+        return f"{reaction_focus}{compact_separator}{compact_reply_line}"
 
     lines = [
         wrapper["prefix"],

--- a/config/prompts/prompts_avatar_interaction.py
+++ b/config/prompts/prompts_avatar_interaction.py
@@ -1230,8 +1230,7 @@ def _avatar_interaction_korean_subject_actor(name: str) -> str:
     """Return a Korean subject phrase for an arbitrary actor name.
 
     Hangul names can choose 이/가 exactly by final consonant. For latin names,
-    use a small readability heuristic; other scripts keep the previous safe
-    default of 이.
+    use a small readability heuristic; other scripts stay unchanged.
     """
     stripped = str(name or "").strip()
     if not stripped:

--- a/docs/design/avatar-tool-prompt-guidelines.md
+++ b/docs/design/avatar-tool-prompt-guidelines.md
@@ -25,7 +25,7 @@
 当前实际提示词走 `compact_fields=True` 分支，结构是：
 
 ```text
-客观事件事实 + 一句说出口的话
+客观事件事实
 ```
 
 不要只看配置里遗留的非 compact 字段。检查提示词时必须调用 `_build_avatar_interaction_instruction` 看最终字符串。
@@ -92,10 +92,10 @@
 
 | 道具 | action | intensity / flag | 事件语义 |
 |---|---|---|---|
-| `lollipop` | `offer` | `normal` | 棒棒糖第一口 |
-| `lollipop` | `tease` | `normal` | 同一支棒棒糖第二口 |
-| `lollipop` | `tap_soft` | `rapid` | 棒棒糖一口接一口继续投喂 |
-| `lollipop` | `tap_soft` | `burst` | 短时间内快速喂了好几口 |
+| `lollipop` | `offer` | `normal` | 对方把棒棒糖递到嘴边，角色吃了第一口 |
+| `lollipop` | `tease` | `normal` | 同一支棒棒糖再次递到嘴边，角色吃了第二口 |
+| `lollipop` | `tap_soft` | `rapid` | 棒棒糖一口接一口递到嘴边，角色连续吃了几口 |
+| `lollipop` | `tap_soft` | `burst` | 短时间内连续递到嘴边，角色吃了好几口 |
 | `fist` | `poke` | `normal` | 猫爪轻轻碰一次 |
 | `fist` | `poke` | `rapid` | 猫爪连续轻轻碰几次 |
 | `fist` | `poke` | `reward_drop=True` | 猫爪轻碰时掉出奖励 |
@@ -191,10 +191,10 @@ zh / zh-TW / en / ja / ko / ru / es / pt
 除非有明确设计变更，新道具也应沿用：
 
 ```text
-reaction_focus + compact_reply_line
+reaction_focus
 ```
 
-`compact_reply_line` 应引导模型输出角色会直接说出口的话，而不是抽象地“回应”事件。不要为单个道具新增长 wrapper、字段列表、示例台词或专属禁令。
+当前 `compact_reply_line` 默认留空，减少“感叹词 + 事件描述 + 评价”的模板化倾向。只有在实际输出证明模型不知道这是聊天互动时，才考虑加入极短对话指向；不要把坏回复里的具体词写成禁令，也不要规定“一句话”“固定语气”或其它会压出格式感的写法。不要为单个道具新增长 wrapper、字段列表、示例台词或专属禁令。
 
 ## 修改现有道具模板
 

--- a/docs/design/avatar-tool-prompt-guidelines.md
+++ b/docs/design/avatar-tool-prompt-guidelines.md
@@ -25,7 +25,7 @@
 当前实际提示词走 `compact_fields=True` 分支，结构是：
 
 ```text
-客观事件事实 + 一句话回应要求
+客观事件事实 + 一句说出口的话
 ```
 
 不要只看配置里遗留的非 compact 字段。检查提示词时必须调用 `_build_avatar_interaction_instruction` 看最终字符串。
@@ -194,7 +194,7 @@ zh / zh-TW / en / ja / ko / ru / es / pt
 reaction_focus + compact_reply_line
 ```
 
-不要为单个道具新增长 wrapper、字段列表、示例台词或专属禁令。
+`compact_reply_line` 应引导模型输出角色会直接说出口的话，而不是抽象地“回应”事件。不要为单个道具新增长 wrapper、字段列表、示例台词或专属禁令。
 
 ## 修改现有道具模板
 

--- a/docs/design/avatar-tool-prompt-guidelines.md
+++ b/docs/design/avatar-tool-prompt-guidelines.md
@@ -98,7 +98,7 @@
 | `lollipop` | `tap_soft` | `burst` | 短时间内连续递到嘴边，角色吃了好几口 |
 | `fist` | `poke` | `normal` | 猫爪轻轻碰一次 |
 | `fist` | `poke` | `rapid` | 猫爪连续轻轻碰几次 |
-| `fist` | `poke` | `reward_drop=True` | 猫爪轻碰时掉出奖励 |
+| `fist` | `poke` | `reward_drop=True` | 猫爪轻碰或连续轻碰时掉出奖励，不覆盖原 intensity 事实 |
 | `hammer` | `bonk` | `normal` | 锤子敲中一次 |
 | `hammer` | `bonk` | `rapid` | 短时间内又敲中一次 |
 | `hammer` | `bonk` | `burst` | 锤子连续快速敲中好几次 |

--- a/docs/design/avatar-tool-prompt-guidelines.md
+++ b/docs/design/avatar-tool-prompt-guidelines.md
@@ -1,0 +1,306 @@
+# Avatar 道具交互提示词设计规范
+
+本文定义聊天框道具交互提示词的长期维护规则，适用于 `lollipop`、`fist`、`hammer` 以及后续新增道具。它关注的是模型收到的即时反应提示词，不覆盖前端动画、掉落物坐标、桌面端窗口形态或普通聊天主 prompt。
+
+如果本文与当前代码、测试或真实生成结果冲突，以可复现证据和当前代码为准，并先更新本文再继续修改。
+
+## 当前代码入口
+
+主要文件：
+
+1. `config/prompts/prompts_avatar_interaction.py`
+
+关键结构：
+
+1. `_AVATAR_INTERACTION_ALLOWED_ACTIONS`
+2. `_AVATAR_INTERACTION_ALLOWED_INTENSITIES`
+3. `_AVATAR_INTERACTION_ALLOWED_INTENSITY_COMBINATIONS`
+4. `_AVATAR_INTERACTION_TOOL_LABELS`
+5. `_AVATAR_INTERACTION_ACTION_LABELS`
+6. `_AVATAR_INTERACTION_REACTION_PROFILES`
+7. `_AVATAR_INTERACTION_PROMPT_TEXT`
+8. `_normalize_avatar_interaction_payload`
+9. `_build_avatar_interaction_instruction`
+
+当前实际提示词走 `compact_fields=True` 分支，结构是：
+
+```text
+客观事件事实 + 一句话回应要求
+```
+
+不要只看配置里遗留的非 compact 字段。检查提示词时必须调用 `_build_avatar_interaction_instruction` 看最终字符串。
+
+## 核心目标
+
+道具交互提示词要让角色像在聊天里自然接到一个刚发生的事件，而不是让模型写一段描写、模板台词或系统字段复述。
+
+目标：
+
+1. 每次只提供刚发生的客观事件。
+2. 让回复保留当前角色人设和聊天上下文里的自然表达，不在道具提示词里重新规定固定语气。
+3. 保留不同道具和不同子事件的辨识度。
+4. 避免同一道具多轮点击后稳定坍缩成同一句式。
+5. 8 个语言的事实结构一致，只做本地化表达，不额外加某个语言独有的规则。
+
+## 非目标
+
+不要把道具提示词写成完整角色设定、写作教程或输出审查器。
+
+非目标：
+
+1. 不在这里规定猫娘固定口头禅、固定语气词、固定称呼或固定撒娇方式。
+2. 不用道具提示词修正所有普通聊天风格问题。
+3. 不把前端动画、坐标、概率、payload、输入框草稿等实现细节暴露给模型。
+4. 不把单次测试里出现的坏回复逐条塞进提示词禁止项。
+5. 不把没有代码事实支持的设定写进事件，例如道具材质、真实疼痛程度、距离变化、关系推进、角色动作姿势。
+
+## 事件事实写法
+
+`reaction_focus` 只写事件事实。它应该回答四个问题：
+
+1. 谁触发：使用 `{actor}`。它由代码从 `master_name` 解析而来；`master_name` 为空时会回落到本地化中性称呼。
+2. 发生在谁身上：使用第二人称指向角色，例如中文的“你”。
+3. 用了什么道具：明确写出棒棒糖、猫爪、锤子或新增道具名。
+4. 做了什么：明确动作、次数、频率或附加结果。
+
+推荐形态：
+
+```text
+{actor}刚刚用<道具>对你做了<客观动作>。
+```
+
+或：
+
+```text
+{actor}刚刚用<道具><频率/次数>地<客观动作>，并触发了<客观结果>。
+```
+
+不要在 `reaction_focus` 写这些内容：
+
+1. 回复应该急、软、可爱、委屈、傲娇、自然口语等语气指导。
+2. “不要模板化”“不要三段式”“不要复读”等输出诊断。
+3. “像真人一样”“正常人会怎么说”等抽象表达要求。
+4. 括号动作、舞台指令、旁白描述。
+5. “别闹”“你又来”“哥哥坏”等固定台词方向。
+6. 当前事件没有提供的主观判断或剧情补全。
+
+`style_hint` 在 compact 分支里不参与最终提示词。保留它时只写短事件标签，不能把它当第二套口吻提示词。
+
+## 当前道具事件边界
+
+新增或修改时要保留同一工具内部的多事件差异，不要把一个道具压成单一事件。
+
+| 道具 | action | intensity / flag | 事件语义 |
+|---|---|---|---|
+| `lollipop` | `offer` | `normal` | 棒棒糖第一口 |
+| `lollipop` | `tease` | `normal` | 同一支棒棒糖第二口 |
+| `lollipop` | `tap_soft` | `rapid` | 棒棒糖一口接一口继续投喂 |
+| `lollipop` | `tap_soft` | `burst` | 短时间内快速喂了好几口 |
+| `fist` | `poke` | `normal` | 猫爪轻轻碰一次 |
+| `fist` | `poke` | `rapid` | 猫爪连续轻轻碰几次 |
+| `fist` | `poke` | `reward_drop=True` | 猫爪轻碰时掉出奖励 |
+| `hammer` | `bonk` | `normal` | 锤子敲中一次 |
+| `hammer` | `bonk` | `rapid` | 短时间内又敲中一次 |
+| `hammer` | `bonk` | `burst` | 锤子连续快速敲中好几次 |
+| `hammer` | `bonk` | `easter_egg=True` 或 `easter_egg` | 放大彩蛋锤敲中一次 |
+
+修改事件时，先确认前端 payload 和 `_normalize_avatar_interaction_payload` 的归一逻辑。不要只改文案导致 action、intensity、flag 与事件事实互相打架。
+
+## 多语言一致性
+
+支持语言：
+
+```text
+zh / zh-TW / en / ja / ko / ru / es / pt
+```
+
+一致性要求：
+
+1. 每个 locale 都要覆盖相同的工具、action、intensity 和附加结果。
+2. 每个 locale 的 `reaction_focus` 要表达同一个客观事实，可以按语言习惯本地化，不要求逐字翻译。
+3. 每个 locale 都应使用同样简短的 compact 输出结构。
+4. 不要让某个语言额外加入口吻要求、禁令、前端字段或动作括号。
+5. 事件事实使用 `{actor}`，不要直接把 `{master_name}` 写进运行时事件句；`{master_name}` 为空、纯空白或跨语言语法需要由 actor helper 统一处理。
+6. CJK 语言可不加空格连接事件事实和回复要求；韩文、英文、俄文、西语、葡语等需要自然空格。
+
+检查时至少生成 8 个语言的代表样例，不能只读字典。
+
+## 新增道具模板
+
+新增道具时按这个顺序做，不要先写大段 prompt。
+
+### 1. 定义 payload 事件
+
+先写清楚事件矩阵：
+
+| 字段 | 内容 |
+|---|---|
+| tool_id | 新道具 id |
+| action_id | 有哪些动作 |
+| intensity | 每个动作允许哪些强度 |
+| flag | 是否有 reward、easter egg 或其它附加布尔结果 |
+| target | 是否仍只作用于 `avatar` |
+| touch_zone | 是否需要位置事实 |
+
+只有前端实际会发送、后端会归一的字段，才能进入提示词事实。
+
+### 2. 更新允许列表和归一逻辑
+
+需要同步：
+
+1. `_AVATAR_INTERACTION_ALLOWED_ACTIONS`
+2. `_AVATAR_INTERACTION_ALLOWED_INTENSITIES`，仅当新增强度时修改
+3. `_AVATAR_INTERACTION_ALLOWED_INTENSITY_COMBINATIONS`
+4. `_normalize_avatar_interaction_payload`，仅当新增 flag 或特殊归一规则时修改
+
+不要把无法被归一验证的事件写进 `reaction_focus`。
+
+### 3. 更新标签
+
+需要同步 8 个 locale：
+
+1. `_AVATAR_INTERACTION_TOOL_LABELS`
+2. `_AVATAR_INTERACTION_ACTION_LABELS`
+3. `_AVATAR_INTERACTION_INTENSITY_LABELS`，仅当新增强度时修改
+
+标签是给非 compact 兼容路径和维护阅读用的，也要保持语义一致。
+
+### 4. 编写 reaction profile
+
+每个事件写一条客观事实：
+
+```python
+"new_tool": {
+    "new_action": {
+        "normal": {
+            "reaction_focus": "{actor}刚刚用<新道具><客观动作>了你一次。",
+            "style_hint": "<新道具><短事件标签>。",
+        },
+        "rapid": {
+            "reaction_focus": "{actor}刚刚用<新道具>连续<客观动作>了你几次。",
+            "style_hint": "<新道具>连续<短事件标签>。",
+        },
+    },
+}
+```
+
+`reaction_focus` 要像事件记录，不要像角色台词。角色怎么说交给模型根据当前人设和上下文生成。
+
+### 5. 检查 compact prompt
+
+除非有明确设计变更，新道具也应沿用：
+
+```text
+reaction_focus + compact_reply_line
+```
+
+不要为单个道具新增长 wrapper、字段列表、示例台词或专属禁令。
+
+## 修改现有道具模板
+
+修改前先回答：
+
+1. 要修的是事件事实不准确，还是模型生成回复不好？
+2. 问题是否由提示词里的事件事实、无关约束、口吻暗示、语言不一致导致？
+3. 是否只需要删减提示词，而不是新增更多约束？
+4. 是否会破坏同一道具内部多个事件的差异？
+5. 是否会让三个道具重新变成同一种泛化互动？
+
+优先操作顺序：
+
+1. 删除会带歪的无关内容。
+2. 把主观描述改成客观事件事实。
+3. 补齐丢失的道具名、动作、次数、频率或附加结果。
+4. 对齐 8 个语言。
+5. 生成样例验证。
+
+不要直接把坏回复里的词加入禁止列表。禁止列表很容易变成新的提醒，导致模型继续围绕坏词生成。
+
+## 反模板化原则
+
+反模板化不靠堆“要自然”这类要求，而靠减少提示词本身的模板压力。
+
+有效做法：
+
+1. 提示词只给事实，不给台词写法。
+2. 同一道具不同事件的事实必须不同。
+3. 不写固定情绪、不写固定称呼、不写固定语气词。
+4. 不在 prompt 里同时给多个互相竞争的要求。
+5. 不写示范台词，除非测试或人工评审明确需要临时对照，且示范不得进入运行时 prompt。
+
+无效做法：
+
+1. 反复要求“自然口语”。
+2. 反复要求“不要重复”。
+3. 把某次坏输出里的词逐个禁止。
+4. 为了区分道具而编造额外剧情。
+5. 用固定句式替换旧固定句式。
+
+## 样例生成检查
+
+修改后至少用脚本生成代表事件，人工扫一遍实际提示词。
+
+```bash
+uv run python - <<'PY'
+from config.prompts.prompts_avatar_interaction import _build_avatar_interaction_instruction
+
+base = {
+    "target": "avatar",
+    "interaction_id": "scan",
+    "timestamp": 1,
+    "text_context": "晚点再继续",
+}
+
+cases = [
+    ("lollipop_first", {"tool_id": "lollipop", "action_id": "offer", "intensity": "normal"}),
+    ("lollipop_repeat", {"tool_id": "lollipop", "action_id": "tap_soft", "intensity": "rapid"}),
+    ("paw_reward", {"tool_id": "fist", "action_id": "poke", "intensity": "normal", "reward_drop": True, "touch_zone": "head"}),
+    ("hammer_easter", {"tool_id": "hammer", "action_id": "bonk", "intensity": "easter_egg", "easter_egg": True, "touch_zone": "head"}),
+]
+
+for locale in ["zh", "zh-TW", "en", "ja", "ko", "ru", "es", "pt"]:
+    print("\\n###", locale)
+    for name, payload in cases:
+        text = _build_avatar_interaction_instruction(locale, "YUI", "哥哥", {**base, **payload})
+        print(f"{name}: {text}")
+PY
+```
+
+人工检查重点：
+
+1. 是否只出现事件事实和一句回应要求。
+2. 是否没有字段名、wrapper、payload、前端、坐标、草稿说明。
+3. 是否没有括号动作、旁白、示例台词。
+4. 是否没有某个语言额外多出一套约束。
+5. 棒棒糖、猫爪、锤子是否一眼能看出不同。
+6. 同一道具的不同事件是否能看出差异。
+7. 新增或修改的事实是否完全来自 payload 和代码链路。
+
+## 自动验证
+
+提示词或 payload 归一逻辑修改后，至少运行：
+
+```bash
+uv run python -m compileall config/prompts/prompts_avatar_interaction.py
+uv run pytest tests/unit/test_avatar_interaction_memory_contract.py
+```
+
+如果新增了 tool、action、intensity、flag 或 locale 覆盖，优先补对应单元测试，至少覆盖：
+
+1. payload 归一后事件进入正确 profile。
+2. 非法 intensity 会回落到允许值。
+3. flag 与 intensity 冲突时归一结果一致。
+4. 8 个 locale 都能生成非空 prompt。
+5. 生成结果不包含运行时不应暴露的字段。
+
+## 提交前清单
+
+提交前确认：
+
+1. `git status --short` 中除明确目标文件外，没有误带其它 tracked 修改。
+2. 未跟踪 `.agent`、临时日志、测试产物没有被加入提交。
+3. `config/prompts/prompts_avatar_interaction.py` 的实际生成结果已看过。
+4. 8 个 locale 都已同步。
+5. 多事件没有被简化成单一事件。
+6. 没有新增固定语气、固定台词、括号动作或主观臆测。
+7. 相关检查已运行，并在最终说明中写清楚。

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -73,6 +73,8 @@ describe('App', () => {
   const renderInputApp = (
     props: React.ComponentProps<typeof App> = {},
   ) => render(<App compactChatState="input" {...props} />);
+  const queryAvatarCursorOverlay = () => document.body.querySelector<HTMLElement>('.avatar-cursor-overlay');
+  const queryHammerCursorCompactImage = () => document.body.querySelector<HTMLImageElement>('.hammer-cursor-overlay-compact-image');
 
   it('renders compact subtitle capsule by default while keeping the tool button visible', () => {
     render(<App />);
@@ -5528,7 +5530,7 @@ describe('App', () => {
     });
 
     try {
-      const { container } = renderInputApp();
+      renderInputApp();
 
       fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
       await act(async () => {
@@ -5542,7 +5544,7 @@ describe('App', () => {
         await vi.advanceTimersByTimeAsync(90);
       });
 
-      const avatarImage = () => container.querySelector('.avatar-cursor-overlay-image-lollipop');
+      const avatarImage = () => document.body.querySelector('.avatar-cursor-overlay-image-lollipop');
       expect(avatarImage()).toHaveAttribute('src', '/static/icons/chat_sugar1.png');
 
       boundsAvailable = false;
@@ -5748,7 +5750,7 @@ describe('App', () => {
   });
 
   it('anchors the desktop cursor overlay to the current pointer when a tool is activated', async () => {
-    const { container } = renderInputApp();
+    renderInputApp();
 
     await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
@@ -5757,42 +5759,42 @@ describe('App', () => {
       clientY: 320,
     });
 
-    const overlay = container.querySelector('.avatar-cursor-overlay');
+    const overlay = queryAvatarCursorOverlay();
     expect(overlay).not.toBeNull();
     expect((overlay as HTMLDivElement).style.transform).toBe('translate3d(201px, 274px, 0)');
   });
 
   it('clears the tool cursor when the composer is hidden for voice mode', async () => {
-    const { container, rerender } = renderInputApp();
+    const { rerender } = renderInputApp();
 
     await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
-    expect(container.querySelector('.avatar-cursor-overlay')).not.toBeNull();
+    expect(queryAvatarCursorOverlay()).not.toBeNull();
     expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
     rerender(<App compactChatState="input" composerHidden />);
 
-    expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
+    expect(queryAvatarCursorOverlay()).toBeNull();
     expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
     expect(document.documentElement.style.getPropertyValue('--neko-chat-tool-cursor')).toBe('');
     expect(document.documentElement.style.getPropertyValue('cursor')).toBe('auto');
   });
 
   it('clears the tool cursor when the host issues a reset key', async () => {
-    const { container, rerender } = renderInputApp();
+    const { rerender } = renderInputApp();
 
     await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
-    expect(container.querySelector('.avatar-cursor-overlay')).not.toBeNull();
+    expect(queryAvatarCursorOverlay()).not.toBeNull();
     expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
     rerender(<App compactChatState="input" _toolCursorResetKey="voice-mode-reset-1" />);
 
-    expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
+    expect(queryAvatarCursorOverlay()).toBeNull();
     expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
     expect(document.documentElement.style.getPropertyValue('--neko-chat-tool-cursor')).toBe('');
     expect(document.documentElement.style.getPropertyValue('cursor')).toBe('auto');
@@ -5845,25 +5847,25 @@ describe('App', () => {
   });
 
   it('restores the native cursor while desktop system UI owns focus', async () => {
-    const { container } = renderInputApp();
+    renderInputApp();
 
     await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
-    expect(container.querySelector('.avatar-cursor-overlay')).not.toBeNull();
+    expect(queryAvatarCursorOverlay()).not.toBeNull();
     expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
     fireEvent.blur(window);
 
-    expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
+    expect(queryAvatarCursorOverlay()).toBeNull();
     expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
     expect(document.documentElement.style.getPropertyValue('--neko-chat-tool-cursor')).toBe('');
     expect(document.documentElement.style.getPropertyValue('cursor')).toBe('auto');
 
     fireEvent.pointerMove(window, { clientX: 180, clientY: 260 });
 
-    expect(container.querySelector('.avatar-cursor-overlay')).not.toBeNull();
+    expect(queryAvatarCursorOverlay()).not.toBeNull();
     expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
   });
 
@@ -5871,22 +5873,22 @@ describe('App', () => {
     (window as Window & { __NEKO_MULTI_WINDOW__?: boolean }).__NEKO_MULTI_WINDOW__ = true;
 
     try {
-      const { container } = renderInputApp();
+      renderInputApp();
 
       await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '猫爪' }));
 
-      expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
+      expect(queryAvatarCursorOverlay()).toBeNull();
       expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
       fireEvent.pointerOut(window, { relatedTarget: null, clientX: 160, clientY: 220 });
-      expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
+      expect(queryAvatarCursorOverlay()).toBeNull();
       expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
       fireEvent.pointerOut(window, { relatedTarget: null, clientX: -1, clientY: 220 });
 
-      expect(container.querySelector('.avatar-cursor-overlay')).toBeNull();
+      expect(queryAvatarCursorOverlay()).toBeNull();
       expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
     } finally {
       delete (window as Window & { __NEKO_MULTI_WINDOW__?: boolean }).__NEKO_MULTI_WINDOW__;
@@ -5917,19 +5919,19 @@ describe('App', () => {
     });
 
     try {
-      const { container } = renderInputApp();
+      renderInputApp();
 
       await openCompactInputTools();
       fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
       fireEvent.click(screen.getByRole('button', { name: '锤子' }));
 
-      const compactImageBefore = container.querySelector('.hammer-cursor-overlay-compact-image');
+      const compactImageBefore = queryHammerCursorCompactImage();
       expect(compactImageBefore).not.toBeNull();
       expect(compactImageBefore).toHaveAttribute('src', '/static/icons/chat_hammer1_cursor.png');
 
       fireEvent.pointerDown(window, { button: 0, clientX: 20, clientY: 20 });
 
-      const compactImageAfter = container.querySelector('.hammer-cursor-overlay-compact-image');
+      const compactImageAfter = queryHammerCursorCompactImage();
       expect(compactImageAfter).not.toBeNull();
       expect(compactImageAfter).toHaveAttribute('src', '/static/icons/chat_hammer2_cursor.png');
     } finally {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5411,6 +5411,80 @@ function CompactChatApp({
   const compactChoiceLayerNode = isCompactSurface
     ? (typeof document !== 'undefined' ? createPortal(choiceLayerNode, document.body) : choiceLayerNode)
     : null;
+  const avatarCursorOverlayNode = activeToolItem && activeCursorToolId !== 'hammer' && avatarCursorOverlayActive ? (
+    <div
+      ref={avatarCursorOverlayRef}
+      className={`avatar-cursor-overlay avatar-cursor-overlay-${activeToolItem.id}${avatarCursorOverlayActive ? ' is-visible' : ''}${avatarCursorOverlayCompact ? ' is-compact' : ''}`}
+      aria-hidden="true"
+    >
+      <div
+        className="avatar-cursor-overlay-stage"
+        style={{
+          transformOrigin: `${activeToolItem.cursorHotspotX ?? 18}px ${activeToolItem.cursorHotspotY ?? 18}px`,
+        }}
+      >
+        <img
+          className={`avatar-cursor-overlay-image avatar-cursor-overlay-image-${activeToolItem.id}`}
+          src={avatarCursorOverlayImagePath}
+          alt=""
+        />
+      </div>
+    </div>
+  ) : null;
+  const hammerCursorOverlayNode = hammerToolItem && hammerCursorOverlayActive ? (
+    <div
+      ref={hammerCursorOverlayRef}
+      className={`hammer-cursor-overlay${hammerCursorOverlayActive ? ' is-visible' : ''}${hammerCursorOverlayCompact ? ' is-compact' : ''}${isInnerHammerEasterEggActive ? ' is-easter-egg' : ''}`}
+      aria-hidden="true"
+    >
+      <div
+        className="hammer-cursor-overlay-stage"
+        style={{
+          transformOrigin: `${hammerToolItem.cursorHotspotX ?? 18}px ${hammerToolItem.cursorHotspotY ?? 18}px`,
+        }}
+      >
+        {hammerCursorOverlayUsesCompactImage ? (
+          <img
+            className="hammer-cursor-overlay-compact-image"
+            src={hammerCursorOverlayCompactImagePath}
+            alt=""
+          />
+        ) : (
+          <div
+            className={`hammer-cursor-overlay-visual${hammerCursorOverlayMotionActive ? ' is-active' : ' is-idle'}${hammerSwingPhase === 'impact' ? ' is-impact' : ''}`}
+            style={{
+              transformOrigin: `${hammerOverlayTransformOrigin.x}px ${hammerOverlayTransformOrigin.y}px`,
+            }}
+          >
+            <img
+              className="hammer-cursor-overlay-image hammer-cursor-overlay-image-primary"
+              src={hammerCursorOverlayPrimaryImagePath}
+              alt=""
+            />
+            <img
+              className="hammer-cursor-overlay-image hammer-cursor-overlay-image-secondary"
+              src={hammerCursorOverlaySecondaryImagePath}
+              alt=""
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  ) : null;
+  const avatarToolCursorOverlayNodes = typeof document !== 'undefined'
+    ? createPortal(
+      <>
+        {avatarCursorOverlayNode}
+        {hammerCursorOverlayNode}
+      </>,
+      document.body,
+    )
+    : (
+      <>
+        {avatarCursorOverlayNode}
+        {hammerCursorOverlayNode}
+      </>
+    );
 
   const compactExportHistoryMessages = compactExportHistoryOpen
     ? messages
@@ -5564,66 +5638,7 @@ function CompactChatApp({
           <span className="lollipop-floating-heart-glyph">*</span>
         </span>
       ))}
-      {activeToolItem && activeCursorToolId !== 'hammer' && avatarCursorOverlayActive ? (
-        <div
-          ref={avatarCursorOverlayRef}
-          className={`avatar-cursor-overlay avatar-cursor-overlay-${activeToolItem.id}${avatarCursorOverlayActive ? ' is-visible' : ''}${avatarCursorOverlayCompact ? ' is-compact' : ''}`}
-          aria-hidden="true"
-        >
-          <div
-            className="avatar-cursor-overlay-stage"
-            style={{
-              transformOrigin: `${activeToolItem.cursorHotspotX ?? 18}px ${activeToolItem.cursorHotspotY ?? 18}px`,
-            }}
-          >
-            <img
-              className={`avatar-cursor-overlay-image avatar-cursor-overlay-image-${activeToolItem.id}`}
-              src={avatarCursorOverlayImagePath}
-              alt=""
-            />
-          </div>
-        </div>
-      ) : null}
-      {hammerToolItem && hammerCursorOverlayActive ? (
-        <div
-          ref={hammerCursorOverlayRef}
-          className={`hammer-cursor-overlay${hammerCursorOverlayActive ? ' is-visible' : ''}${hammerCursorOverlayCompact ? ' is-compact' : ''}${isInnerHammerEasterEggActive ? ' is-easter-egg' : ''}`}
-          aria-hidden="true"
-        >
-          <div
-            className="hammer-cursor-overlay-stage"
-            style={{
-              transformOrigin: `${hammerToolItem.cursorHotspotX ?? 18}px ${hammerToolItem.cursorHotspotY ?? 18}px`,
-            }}
-          >
-            {hammerCursorOverlayUsesCompactImage ? (
-              <img
-                className="hammer-cursor-overlay-compact-image"
-                src={hammerCursorOverlayCompactImagePath}
-                alt=""
-              />
-            ) : (
-              <div
-                className={`hammer-cursor-overlay-visual${hammerCursorOverlayMotionActive ? ' is-active' : ' is-idle'}${hammerSwingPhase === 'impact' ? ' is-impact' : ''}`}
-                style={{
-                  transformOrigin: `${hammerOverlayTransformOrigin.x}px ${hammerOverlayTransformOrigin.y}px`,
-                }}
-              >
-                <img
-                  className="hammer-cursor-overlay-image hammer-cursor-overlay-image-primary"
-                  src={hammerCursorOverlayPrimaryImagePath}
-                  alt=""
-                />
-                <img
-                  className="hammer-cursor-overlay-image hammer-cursor-overlay-image-secondary"
-                  src={hammerCursorOverlaySecondaryImagePath}
-                  alt=""
-                />
-              </div>
-	                  )}
-                </div>
-              </div>
-      ) : null}
+      {avatarToolCursorOverlayNodes}
       <section
         className={`chat-window ${surfaceModeClassName}`}
         aria-label={chatWindowAriaLabel}

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -3974,6 +3974,80 @@ export default function FullChatSurface({
   const compactChoiceLayerNode = isCompactSurface
     ? (typeof document !== 'undefined' ? createPortal(choiceLayerNode, document.body) : choiceLayerNode)
     : null;
+  const avatarCursorOverlayNode = activeToolItem && activeCursorToolId !== 'hammer' && avatarCursorOverlayActive ? (
+    <div
+      ref={avatarCursorOverlayRef}
+      className={`avatar-cursor-overlay avatar-cursor-overlay-${activeToolItem.id}${avatarCursorOverlayActive ? ' is-visible' : ''}${avatarCursorOverlayCompact ? ' is-compact' : ''}`}
+      aria-hidden="true"
+    >
+      <div
+        className="avatar-cursor-overlay-stage"
+        style={{
+          transformOrigin: `${activeToolItem.cursorHotspotX ?? 18}px ${activeToolItem.cursorHotspotY ?? 18}px`,
+        }}
+      >
+        <img
+          className={`avatar-cursor-overlay-image avatar-cursor-overlay-image-${activeToolItem.id}`}
+          src={avatarCursorOverlayImagePath}
+          alt=""
+        />
+      </div>
+    </div>
+  ) : null;
+  const hammerCursorOverlayNode = hammerToolItem && hammerCursorOverlayActive ? (
+    <div
+      ref={hammerCursorOverlayRef}
+      className={`hammer-cursor-overlay${hammerCursorOverlayActive ? ' is-visible' : ''}${hammerCursorOverlayCompact ? ' is-compact' : ''}${isInnerHammerEasterEggActive ? ' is-easter-egg' : ''}`}
+      aria-hidden="true"
+    >
+      <div
+        className="hammer-cursor-overlay-stage"
+        style={{
+          transformOrigin: `${hammerToolItem.cursorHotspotX ?? 18}px ${hammerToolItem.cursorHotspotY ?? 18}px`,
+        }}
+      >
+        {hammerCursorOverlayUsesCompactImage ? (
+          <img
+            className="hammer-cursor-overlay-compact-image"
+            src={hammerCursorOverlayCompactImagePath}
+            alt=""
+          />
+        ) : (
+          <div
+            className={`hammer-cursor-overlay-visual${hammerCursorOverlayMotionActive ? ' is-active' : ' is-idle'}${hammerSwingPhase === 'impact' ? ' is-impact' : ''}`}
+            style={{
+              transformOrigin: `${hammerOverlayTransformOrigin.x}px ${hammerOverlayTransformOrigin.y}px`,
+            }}
+          >
+            <img
+              className="hammer-cursor-overlay-image hammer-cursor-overlay-image-primary"
+              src={hammerCursorOverlayPrimaryImagePath}
+              alt=""
+            />
+            <img
+              className="hammer-cursor-overlay-image hammer-cursor-overlay-image-secondary"
+              src={hammerCursorOverlaySecondaryImagePath}
+              alt=""
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  ) : null;
+  const avatarToolCursorOverlayNodes = typeof document !== 'undefined'
+    ? createPortal(
+      <>
+        {avatarCursorOverlayNode}
+        {hammerCursorOverlayNode}
+      </>,
+      document.body,
+    )
+    : (
+      <>
+        {avatarCursorOverlayNode}
+        {hammerCursorOverlayNode}
+      </>
+    );
 
   const messageListNode = (
     <MessageList
@@ -4091,66 +4165,7 @@ export default function FullChatSurface({
           <span className="lollipop-floating-heart-glyph">*</span>
         </span>
       ))}
-      {activeToolItem && activeCursorToolId !== 'hammer' && avatarCursorOverlayActive ? (
-        <div
-          ref={avatarCursorOverlayRef}
-          className={`avatar-cursor-overlay avatar-cursor-overlay-${activeToolItem.id}${avatarCursorOverlayActive ? ' is-visible' : ''}${avatarCursorOverlayCompact ? ' is-compact' : ''}`}
-          aria-hidden="true"
-        >
-          <div
-            className="avatar-cursor-overlay-stage"
-            style={{
-              transformOrigin: `${activeToolItem.cursorHotspotX ?? 18}px ${activeToolItem.cursorHotspotY ?? 18}px`,
-            }}
-          >
-            <img
-              className={`avatar-cursor-overlay-image avatar-cursor-overlay-image-${activeToolItem.id}`}
-              src={avatarCursorOverlayImagePath}
-              alt=""
-            />
-          </div>
-        </div>
-      ) : null}
-      {hammerToolItem && hammerCursorOverlayActive ? (
-        <div
-          ref={hammerCursorOverlayRef}
-          className={`hammer-cursor-overlay${hammerCursorOverlayActive ? ' is-visible' : ''}${hammerCursorOverlayCompact ? ' is-compact' : ''}${isInnerHammerEasterEggActive ? ' is-easter-egg' : ''}`}
-          aria-hidden="true"
-        >
-          <div
-            className="hammer-cursor-overlay-stage"
-            style={{
-              transformOrigin: `${hammerToolItem.cursorHotspotX ?? 18}px ${hammerToolItem.cursorHotspotY ?? 18}px`,
-            }}
-          >
-            {hammerCursorOverlayUsesCompactImage ? (
-              <img
-                className="hammer-cursor-overlay-compact-image"
-                src={hammerCursorOverlayCompactImagePath}
-                alt=""
-              />
-            ) : (
-              <div
-                className={`hammer-cursor-overlay-visual${hammerCursorOverlayMotionActive ? ' is-active' : ' is-idle'}${hammerSwingPhase === 'impact' ? ' is-impact' : ''}`}
-                style={{
-                  transformOrigin: `${hammerOverlayTransformOrigin.x}px ${hammerOverlayTransformOrigin.y}px`,
-                }}
-              >
-                <img
-                  className="hammer-cursor-overlay-image hammer-cursor-overlay-image-primary"
-                  src={hammerCursorOverlayPrimaryImagePath}
-                  alt=""
-                />
-                <img
-                  className="hammer-cursor-overlay-image hammer-cursor-overlay-image-secondary"
-                  src={hammerCursorOverlaySecondaryImagePath}
-                  alt=""
-                />
-              </div>
-	                  )}
-                </div>
-              </div>
-      ) : null}
+      {avatarToolCursorOverlayNodes}
       <section
         className={`chat-window ${surfaceModeClassName}`}
         aria-label={chatWindowAriaLabel}

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -73,7 +73,7 @@ svg {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 9998;
+  z-index: 100006;
   pointer-events: none;
   will-change: transform;
 }
@@ -258,7 +258,7 @@ svg {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 9999;
+  z-index: 100006;
   pointer-events: none;
   will-change: transform;
 }

--- a/tests/testbench/docs/external_events_guide.md
+++ b/tests/testbench/docs/external_events_guide.md
@@ -51,8 +51,8 @@
 | `action_id` | 是 | 取决于 `tool_id`: `lollipop` → `offer` / `tease` / `tap_soft`; `fist` → `poke`; `hammer` → `bonk` |
 | `intensity` | 否 | `normal` / `rapid` / `burst` / `easter_egg`. **组合受限** (`_AVATAR_INTERACTION_ALLOWED_INTENSITY_COMBINATIONS`), 详见下表 |
 | `touch_zone` | 否 (仅 `fist` / `hammer` 有效) | `ear` / `head` / `face` / `body` |
-| `text_context` | 否 | 自由文本; 会拼入 LLM instruction |
-| `reward` | 否 | 自由文本; 会拼入 LLM instruction |
+| `text_context` | 否 | 自由文本; 参与 payload 归一化和预览，不直接拼入当前 compact LLM instruction |
+| `reward_drop` | 否 (仅 `fist` 有效) | 布尔值; 会体现在 compact 事件事实里 |
 | `interaction_id` | **是 (UI 自动填)** | 用于 **8000ms 去重窗口**, 同 `interaction_id` + `tool_id` + `action_id` 的二次触发会返回 `reason=dedupe_window_hit` |
 
 **组合约束** — 填错会返回 `reason=invalid_payload`:
@@ -65,7 +65,7 @@
 ### 1.2 典型测试步骤
 
 1. **触发事件**: 面板填好字段, 点 **触发事件**.
-2. **看 wire**: 右侧 Prompt Preview 区的 **当前 wire** 标签页立刻更新, 末尾一条是 `role=user` 的 **full instruction** (含 tool / action / intensity / touch_zone / text_context / reward 全部字段). 如果只看到 `[主人摸了摸你的头]` 这种短 memory note, 是看错标签页了 — memory note 是对话气泡里显示的那条.
+2. **看 wire**: 右侧 Prompt Preview 区的 **当前 wire** 标签页立刻更新, 末尾一条是 `role=user` 的 compact instruction。它应包含道具事件事实和一句回应要求；`reward_drop` / `easter_egg` 会体现在事件事实里，`text_context` 不直接进入 instruction 正文。如果只看到 `[主人摸了摸你的头]` 这种短 memory note, 是看错标签页了 — memory note 是对话气泡里显示的那条.
 3. **看对话**: 左侧聊天区会多出一对 `user` (memory note) + `assistant` (LLM 回复).
 4. **看日志**: 诊断 → 日志, 搜 `avatar_interaction_simulated`. `detail.accepted=true` 是成功, `detail.reason` 是被拒时的原因代码.
 

--- a/tests/testbench/docs/external_events_guide.md
+++ b/tests/testbench/docs/external_events_guide.md
@@ -65,7 +65,7 @@
 ### 1.2 典型测试步骤
 
 1. **触发事件**: 面板填好字段, 点 **触发事件**.
-2. **看 wire**: 右侧 Prompt Preview 区的 **当前 wire** 标签页立刻更新, 末尾一条是 `role=user` 的 compact instruction。它应包含道具事件事实和一句回应要求；`reward_drop` / `easter_egg` 会体现在事件事实里，`text_context` 不直接进入 instruction 正文。如果只看到 `[主人摸了摸你的头]` 这种短 memory note, 是看错标签页了 — memory note 是对话气泡里显示的那条.
+2. **看 wire**: 右侧 Prompt Preview 区的 **当前 wire** 标签页立刻更新, 末尾一条是 `role=user` 的 compact instruction。它应包含道具事件事实；只有 `compact_reply_line` 非空时才会额外带显式回应要求。`reward_drop` / `easter_egg` 等结果会通过对应事件事实体现，`text_context` 不直接进入 instruction 正文。如果只看到 `[主人摸了摸你的头]` 这种短 memory note, 是看错标签页了 — memory note 是对话气泡里显示的那条, 不是 wire instruction.
 3. **看对话**: 左侧聊天区会多出一对 `user` (memory note) + `assistant` (LLM 回复).
 4. **看日志**: 诊断 → 日志, 搜 `avatar_interaction_simulated`. `detail.accepted=true` 是成功, `detail.reason` 是被拒时的原因代码.
 

--- a/tests/testbench/smoke/p25_external_events_smoke.py
+++ b/tests/testbench/smoke/p25_external_events_smoke.py
@@ -336,25 +336,18 @@ def check_a_happy_paths(client, mock) -> list[str]:
                    "A1c.wire_tail_is_instruction",
                    f"wire tail content != SimulationResult.instruction")
 
-        # A1d — "UI 扩展字段真进了 wire instruction 正文" 防回归
-        # (2026-04-23 r3 polish).
+        # A1d — compact avatar instruction contract.
         #
-        # LESSONS_LEARNED §1.6 (语义契约 vs 运行时机制): 主程序
-        # ``config.prompts.prompts_avatar_interaction._build_avatar_interaction_
-        # instruction`` 把 ``text_context`` / ``reward_drop`` / ``easter_egg``
-        # 这类"上下文可选字段"拼进 instruction body 的指定 bullet 行
-        # (见 `_AVATAR_INTERACTION_PROMPT_TEXT` 里的 ``reward_drop_line`` /
-        # ``easter_egg_line`` / ``text_context_line``). tester 反馈"这些
-        # 字段在发送给 AI 的消息里完全不会有体现" — 实际是 UI 折叠 +
-        # tester 未展开 Instruction preview 看. 加这条断言守住契约, 若
-        # 未来主程序签名漂移 / testbench pipeline 错过 normalizer 字段,
-        # smoke 立刻红.
+        # 2026-06 avatar prompt 收口后，运行时 prompt 不再拼入
+        # text_context / field-list / verbose requirements；这些实现细节会
+        # 带来模板化和跑题。reward_drop / easter_egg 仍应通过客观事件事实
+        # 体现，所以这里守住"奖励进入事件事实，草稿不泄露"。
         #
         # Matrix:
-        #   - fist + reward_drop + text_context → "附加结果 ... 奖励" +
-        #     "输入框草稿"
+        #   - fist + reward_drop + text_context → 事件事实包含"奖励"，
+        #     不包含 text_context 原文或"输入框草稿"字段。
         #   - hammer + easter_egg (+ intensity 自动归一成 easter_egg) →
-        #     "附加结果 ... 彩蛋"
+        #     事件事实包含"彩蛋"。
         # (persona.language 默认 zh-CN, 检 zh 文案 key.)
         #
         # 用 intensity=rapid 升 rank 越过 A1 留下的 fist_touch rank=1 条目
@@ -378,19 +371,16 @@ def check_a_happy_paths(client, mock) -> list[str]:
         _check(rd.get("accepted") is True, "A1d.accepted",
                f"reason={rd.get('reason')}")
         instruction_d = rd.get("instruction") or ""
-        _check("输入框草稿" in instruction_d, "A1d.text_context_line",
-               f"instruction missing '输入框草稿' bullet for text_context; "
-               f"main-program prompts_avatar_interaction 里 "
-               f"_AVATAR_INTERACTION_PROMPT_TEXT['zh']['text_context_line'] "
-               f"应该拼进来. 前 400 字符: {instruction_d[:400]!r}")
-        _check("主人今天看起来心情不太好" in instruction_d,
-               "A1d.text_context_body",
-               f"text_context body not interpolated into instruction; "
-               f"前 400 字符: {instruction_d[:400]!r}")
         _check("奖励" in instruction_d, "A1d.reward_drop_line",
-               f"instruction missing reward_drop bullet (zh '附加结果 ... "
-               f"掉落奖励'); 主程序 reward_drop_line 应在 fist + reward_drop=True "
-               f"时拼入. 前 400 字符: {instruction_d[:400]!r}")
+               f"instruction missing reward_drop event fact; "
+               f"前 400 字符: {instruction_d[:400]!r}")
+        _check("输入框草稿" not in instruction_d, "A1d.no_text_context_label",
+               f"compact avatar instruction leaked text_context label: "
+               f"{instruction_d[:400]!r}")
+        _check("主人今天看起来心情不太好" not in instruction_d,
+               "A1d.no_text_context_body",
+               f"compact avatar instruction leaked text_context body: "
+               f"{instruction_d[:400]!r}")
         # 并且 wire 最后一条 instruction 必须等于 SimulationResult.instruction
         # (已由 A1c 守住 happy path, 这里对 context/reward 路径再守一次).
         wired = (mock.last_wire or [])[-1:] or [{}]
@@ -415,8 +405,7 @@ def check_a_happy_paths(client, mock) -> list[str]:
                f"reason={re_.get('reason')}")
         instruction_e = re_.get("instruction") or ""
         _check("彩蛋" in instruction_e, "A1e.easter_egg_line",
-               f"instruction missing '彩蛋' bullet for hammer+easter_egg; "
-               f"主程序 easter_egg_line 应在 hammer + easter_egg=True 时拼入. "
+               f"instruction missing '彩蛋' event fact for hammer+easter_egg; "
                f"前 400 字符: {instruction_e[:400]!r}")
 
         # A2 — agent_callback.
@@ -438,9 +427,9 @@ def check_a_happy_paths(client, mock) -> list[str]:
         instr2 = r2.get("instruction") or ""
         _check("\n" in instr2, "A2.instruction_newline",
                "instruction missing newline (expected multi-line bullet list)")
-        _check("- 任务已完成" in instr2 and "- 2 条邮件" in instr2,
+        _check("任务已完成" in instr2 and "2 条邮件" in instr2,
                "A2.instruction_bullets",
-               f"instruction lacks '- <item>' bullets: {instr2[:200]!r}")
+               f"instruction lacks callback item text: {instr2[:200]!r}")
         # A2c — wire instruction role (see A1c for rationale).
         wire2 = mock.last_wire or []
         if wire2:

--- a/tests/testbench/smoke/p25_external_events_smoke.py
+++ b/tests/testbench/smoke/p25_external_events_smoke.py
@@ -374,6 +374,9 @@ def check_a_happy_paths(client, mock) -> list[str]:
         _check("奖励" in instruction_d, "A1d.reward_drop_line",
                f"instruction missing reward_drop event fact; "
                f"前 400 字符: {instruction_d[:400]!r}")
+        _check("连续" in instruction_d, "A1d.rapid_reward_keeps_intensity",
+               f"rapid+reward instruction lost repeated-touch fact; "
+               f"前 400 字符: {instruction_d[:400]!r}")
         _check("输入框草稿" not in instruction_d, "A1d.no_text_context_label",
                f"compact avatar instruction leaked text_context label: "
                f"{instruction_d[:400]!r}")

--- a/tests/testbench/smoke/p25_prompt_preview_truth_smoke.py
+++ b/tests/testbench/smoke/p25_prompt_preview_truth_smoke.py
@@ -328,28 +328,23 @@ def check_pp2_avatar_event(client, mock_ext) -> list[str]:
         )
         tail_content = str(tail.get("content") or "")
 
-        # The full instruction (built via
-        # _build_avatar_interaction_instruction) is multi-line and
-        # clearly longer than any single-line memory_note. Assert > 40
-        # chars as a proxy for "not the short note"; AND check that
-        # at least one of the avatar-specific keywords from the helper's
-        # template shows up, proving we captured the rendered
-        # instruction rather than a placeholder string.
+        # The avatar instruction is the rendered prompt cue, not the short
+        # memory_note. In compact prompt mode it is intentionally one concise
+        # event fact plus the one-sentence reply instruction, without draft text
+        # or verbose field-list bullets.
+        # Reward is part of the objective event fact. text_context is not part
+        # of the compact runtime prompt, because leaking composer drafts into
+        # this cue makes avatar reactions templated and off-topic.
         _check(
-            len(tail_content) > 40,
-            "PP2.tail_not_note",
-            f"tail content too short ({len(tail_content)} chars): "
-            f"{tail_content[:80]!r} — looks like the memory_note, not "
-            "the full instruction",
+            "奖励" in tail_content,
+            "PP2.reward_fact",
+            "tail missing reward event fact: "
+            f"{tail_content[:200]!r}",
         )
-
-        # Reward + text_context presence — these fields are ONLY in the
-        # instruction, NEVER in the memory_note. If they show up here,
-        # we've confirmed preview = ground truth.
         _check(
-            "tester draft" in tail_content,
-            "PP2.text_context",
-            "tail missing text_context marker (confirms bug): "
+            "tester draft" not in tail_content,
+            "PP2.no_text_context",
+            "tail leaked compact prompt text_context: "
             f"{tail_content[:200]!r}",
         )
         _check(
@@ -379,9 +374,8 @@ def check_pp2_avatar_event(client, mock_ext) -> list[str]:
         )
         if user_msg is not None:
             user_content = str(user_msg.get("content") or "")
-            # Memory note is short + single line. Instruction is long +
-            # multi-line with context/reward bullets. If the two are
-            # **equal**, the bug is still there.
+            # Memory note and instruction have different jobs. The instruction
+            # is compact now, but it must still differ from the persisted note.
             _check(
                 user_content != tail_content,
                 "PP2.preview_diverges_from_memory",

--- a/tests/testbench/smoke/p25_prompt_preview_truth_smoke.py
+++ b/tests/testbench/smoke/p25_prompt_preview_truth_smoke.py
@@ -329,12 +329,11 @@ def check_pp2_avatar_event(client, mock_ext) -> list[str]:
         tail_content = str(tail.get("content") or "")
 
         # The avatar instruction is the rendered prompt cue, not the short
-        # memory_note. In compact prompt mode it is intentionally one concise
-        # event fact plus the one-sentence reply instruction, without draft text
-        # or verbose field-list bullets.
-        # Reward is part of the objective event fact. text_context is not part
-        # of the compact runtime prompt, because leaking composer drafts into
-        # this cue makes avatar reactions templated and off-topic.
+        # memory_note. In compact mode, compact_reply_line may be empty; then
+        # the avatar instruction can be only the event fact, such as the reward
+        # objective, without an extra reply sentence or verbose field-list
+        # bullets. text_context is excluded from the compact runtime prompt so
+        # composer drafts do not leak into this cue.
         _check(
             "奖励" in tail_content,
             "PP2.reward_fact",

--- a/tests/testbench/static/core/i18n.js
+++ b/tests/testbench/static/core/i18n.js
@@ -2015,7 +2015,7 @@ export const I18N = {
           busy: '当前会话正忙 (可能在跑 LLM / 写文件), 请稍后再点.',
         },
         avatar: {
-          instruction_integration_hint: '下方所有字段 (道具 / 动作 / 强度 / 触碰区 / 文本上下文 / 附带奖励 / 彩蛋) 都会拼进 Instruction preview — 触发后展开结果区的 "Instruction 预览" 即可看到完整 wire 文本.',
+          instruction_integration_hint: 'Instruction preview 展示实际发送给模型的道具事件提示。当前运行时使用 compact 提示: 道具 / 动作 / 强度 / 附带奖励 / 彩蛋会体现在客观事件里，文本上下文只参与 payload 预览和归一化检查，不直接拼入提示词正文.',
           tool_label: '道具',
           tool_option: {
             lollipop: '棒棒糖',

--- a/tests/testbench/static/ui/chat/external_events_panel.js
+++ b/tests/testbench/static/ui/chat/external_events_panel.js
@@ -218,12 +218,9 @@ export function mountExternalEventsPanel(host) {
     const rows = [];
     const a = state.avatar;
 
-    // 开头一行 hint — 2026-04-23 r3 polish: tester 反馈 "text_context /
-    // reward_drop / easter_egg 看起来像没作用". 实际 config/prompts/prompts_avatar_
-    // interaction.py::_build_avatar_interaction_instruction 已把这些字段拼进
-    // instruction (运行时已验证), 但 UI 默认折叠 "Instruction preview", tester
-    // 可能没展开 → 直觉认为字段被吞. 加一行显式 hint 指向结果区的 instruction
-    // 预览, 让 tester 先看 wire 再判断 LLM 行为.
+    // 开头一行 hint: avatar prompt 现在走 compact 事件事实。
+    // reward_drop/easter_egg 通过事件事实体现；text_context 保留在 payload
+    // 预览/归一化检查里，不直接拼进运行时 instruction，避免带歪自然回复。
     rows.push(el('p', { className: 'form-hint' },
       i18n('chat.external_events.avatar.instruction_integration_hint'),
     ));

--- a/tests/unit/test_avatar_interaction_memory_contract.py
+++ b/tests/unit/test_avatar_interaction_memory_contract.py
@@ -215,6 +215,24 @@ def test_avatar_instruction_named_master_still_uses_given_actor():
 
 
 @pytest.mark.unit
+def test_avatar_instruction_rapid_fist_reward_keeps_repeated_touch_fact():
+    instruction = _build_avatar_interaction_instruction(
+        "zh",
+        "YUI",
+        "哥哥",
+        {
+            "tool_id": "fist",
+            "action_id": "poke",
+            "intensity": "rapid",
+            "reward_drop": True,
+        },
+    )
+
+    assert "连续轻轻碰" in instruction
+    assert "奖励" in instruction
+
+
+@pytest.mark.unit
 def test_game_route_auto_assistant_lines_are_game_only_for_ordinary_memory():
     assert is_mirror_assistant_message({
         "type": "gemini_response",

--- a/tests/unit/test_avatar_interaction_memory_contract.py
+++ b/tests/unit/test_avatar_interaction_memory_contract.py
@@ -161,33 +161,36 @@ def test_avatar_memory_meta_master_name_passes_through_unchanged():
 
 @pytest.mark.unit
 def test_avatar_instruction_empty_master_uses_localized_neutral_actor():
-    payload = {
-        "tool_id": "lollipop",
-        "action_id": "offer",
-        "intensity": "normal",
-    }
-    expected_prefix = {
-        "zh": "对方刚刚用棒棒糖",
-        "zh-TW": "對方剛剛用棒棒糖",
-        "en": "The other person just fed you",
-        "ja": "相手が今、",
-        "ko": "상대가 방금",
-        "ru": "Собеседник только что",
-        "es": "Esa persona acaba",
-        "pt": "A outra pessoa acabou",
+    lollipop_payloads = [
+        {"tool_id": "lollipop", "action_id": "offer", "intensity": "normal"},
+        {"tool_id": "lollipop", "action_id": "tease", "intensity": "normal"},
+        {"tool_id": "lollipop", "action_id": "tap_soft", "intensity": "rapid"},
+        {"tool_id": "lollipop", "action_id": "tap_soft", "intensity": "burst"},
+    ]
+    expected_actor = {
+        "zh": "对方",
+        "zh-TW": "對方",
+        "en": "The other person",
+        "ja": "相手",
+        "ko": "상대",
+        "ru": "Собеседник",
+        "es": "Esa persona",
+        "pt": "A outra pessoa",
     }
 
-    for locale, prefix in expected_prefix.items():
-        instruction = _build_avatar_interaction_instruction(locale, "YUI", "", payload)
-        assert instruction.startswith(prefix), (
-            f"locale={locale} instruction={instruction!r} 没用本地化中性 actor"
-        )
-        assert not instruction.startswith((" ", "刚刚", "剛剛", "が", "이 "))
+    for locale, actor in expected_actor.items():
+        for payload in lollipop_payloads:
+            instruction = _build_avatar_interaction_instruction(locale, "YUI", "", payload)
+            assert instruction.startswith(actor), (
+                f"locale={locale} payload={payload} instruction={instruction!r} "
+                "没把本地化中性 actor 放在事件主体位置"
+            )
+            assert not instruction.startswith((" ", "刚刚", "剛剛", "が", "이 "))
 
-        whitespace_instruction = _build_avatar_interaction_instruction(
-            locale, "YUI", "   ", payload
-        )
-        assert whitespace_instruction == instruction
+            whitespace_instruction = _build_avatar_interaction_instruction(
+                locale, "YUI", "   ", payload
+            )
+            assert whitespace_instruction == instruction
 
 
 @pytest.mark.unit

--- a/tests/unit/test_avatar_interaction_memory_contract.py
+++ b/tests/unit/test_avatar_interaction_memory_contract.py
@@ -2,6 +2,7 @@ import pytest
 
 from config.prompts.prompts_avatar_interaction import (
     _AVATAR_INTERACTION_MEMORY_NOTE_TEMPLATES,
+    _build_avatar_interaction_instruction,
     _build_avatar_interaction_memory_meta,
 )
 from main_logic.cross_server import _should_persist_avatar_interaction_memory
@@ -156,6 +157,58 @@ def test_avatar_memory_meta_master_name_passes_through_unchanged():
     for name in ("小明", "Alice", "mochi", "猫猫", "Mei Wang"):
         meta = _build_avatar_interaction_memory_meta("zh", payload, name)
         assert name in meta["memory_note"]
+
+
+@pytest.mark.unit
+def test_avatar_instruction_empty_master_uses_localized_neutral_actor():
+    payload = {
+        "tool_id": "lollipop",
+        "action_id": "offer",
+        "intensity": "normal",
+    }
+    expected_prefix = {
+        "zh": "对方刚刚用棒棒糖",
+        "zh-TW": "對方剛剛用棒棒糖",
+        "en": "The other person just fed you",
+        "ja": "相手が今、",
+        "ko": "상대가 방금",
+        "ru": "Собеседник только что",
+        "es": "Esa persona acaba",
+        "pt": "A outra pessoa acabou",
+    }
+
+    for locale, prefix in expected_prefix.items():
+        instruction = _build_avatar_interaction_instruction(locale, "YUI", "", payload)
+        assert instruction.startswith(prefix), (
+            f"locale={locale} instruction={instruction!r} 没用本地化中性 actor"
+        )
+        assert not instruction.startswith((" ", "刚刚", "剛剛", "が", "이 "))
+
+        whitespace_instruction = _build_avatar_interaction_instruction(
+            locale, "YUI", "   ", payload
+        )
+        assert whitespace_instruction == instruction
+
+
+@pytest.mark.unit
+def test_avatar_instruction_named_master_still_uses_given_actor():
+    payload = {
+        "tool_id": "fist",
+        "action_id": "poke",
+        "intensity": "normal",
+    }
+
+    zh = _build_avatar_interaction_instruction("zh", "YUI", "哥哥", payload)
+    en = _build_avatar_interaction_instruction("en", "YUI", "Alice", payload)
+    ko_vowel = _build_avatar_interaction_instruction("ko", "YUI", "유이", payload)
+    ko_final = _build_avatar_interaction_instruction("ko", "YUI", "민준", payload)
+    ko_cjk = _build_avatar_interaction_instruction("ko", "YUI", "哥哥", payload)
+
+    assert zh.startswith("哥哥刚刚用猫爪")
+    assert en.startswith("Alice just lightly touched")
+    assert ko_vowel.startswith("유이가 방금")
+    assert ko_final.startswith("민준이 방금")
+    assert ko_cjk.startswith("哥哥 방금")
 
 
 @pytest.mark.unit

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1,9 +1,11 @@
+import re
 from pathlib import Path
 
 
 APP_REACT_CHAT_WINDOW_PATH = Path(__file__).resolve().parents[2] / "static" / "app-react-chat-window.js"
 APP_BUTTONS_PATH = Path(__file__).resolve().parents[2] / "static" / "app-buttons.js"
 APP_CHAT_EXPORT_PATH = Path(__file__).resolve().parents[2] / "static" / "app-chat-export.js"
+AVATAR_UI_POPUP_PATH = Path(__file__).resolve().parents[2] / "static" / "avatar-ui-popup.js"
 MUSIC_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "music_ui.js"
 MUSIC_UI_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "music_ui.css"
 STATIC_INDEX_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "index.css"
@@ -42,6 +44,20 @@ def assert_no_layout_transition(block: str) -> None:
     transition_section = block.split("transition:", 1)[1].split(";", 1)[0] if "transition:" in block else ""
     for prop in ("width", "height", "max-height", "min-height", "padding", "margin", "top", "right", "bottom", "left"):
         assert prop not in transition_section
+
+
+def css_z_index(block: str) -> int:
+    match = re.search(r"\bz-index:\s*(\d+)\s*;", block)
+    if not match:
+        raise AssertionError(f"missing CSS z-index in block: {block[:240]!r}")
+    return int(match.group(1))
+
+
+def inline_z_index(block: str) -> int:
+    match = re.search(r"\bzIndex:\s*['\"](\d+)['\"]", block)
+    if not match:
+        raise AssertionError(f"missing inline zIndex in block: {block[:240]!r}")
+    return int(match.group(1))
 
 
 def test_subtitle_window_dark_mode_keeps_transparent_background():
@@ -1025,6 +1041,43 @@ def test_compact_history_reduced_motion_closing_hides_immediately():
 
     assert "opacity: 0 !important;" in closing_block
     assert "visibility: hidden !important;" in closing_block
+
+
+def test_avatar_tool_cursor_overlays_stay_above_model_side_menus():
+    styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
+    popup_source = AVATAR_UI_POPUP_PATH.read_text(encoding="utf-8")
+
+    avatar_cursor_layer = css_z_index(css_block(
+        styles,
+        ".avatar-cursor-overlay {",
+        ".avatar-cursor-overlay.is-compact",
+    ))
+    hammer_cursor_layer = css_z_index(css_block(
+        styles,
+        ".hammer-cursor-overlay {",
+        ".hammer-cursor-overlay.is-compact",
+    ))
+    model_popup_layer = css_z_index(css_block(
+        popup_source,
+        ".${prefix}-popup {",
+        ".${prefix}-popup.is-positioning",
+    ))
+    model_side_panel_layer = inline_z_index(
+        popup_source.split("function createSidePanelContainer", 1)[1].split(
+            "const stopEventPropagation",
+            1,
+        )[0]
+    )
+    interval_side_panel_layer = inline_z_index(
+        popup_source.split("container.setAttribute('data-neko-sidepanel-type', `interval-${toggle.id}`);", 1)[1].split(
+            "const stopEventPropagation",
+            1,
+        )[0]
+    )
+    max_model_menu_layer = max(model_popup_layer, model_side_panel_layer, interval_side_panel_layer)
+
+    assert avatar_cursor_layer > max_model_menu_layer
+    assert hammer_cursor_layer > max_model_menu_layer
 
 
 def test_compact_history_closing_bubbles_disable_pointer_events():


### PR DESCRIPTION
## 变更内容

- 简化并收口 avatar 道具交互提示词，减少冗余表达，保持锤子、猫爪、棒棒糖交互语义清晰。
- 修复网页端道具鼠标层级低于模型右侧展开菜单/二级面板的问题。
- 将网页端道具鼠标视觉层提升到全局 body 层，并补充层级契约测试。

## 验证

- `npm test`
- `.venv/bin/python -m pytest tests/unit/test_react_chat_window_static.py -q`
- `bash build_frontend.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整光标覆盖层层级与定位，确保 avatar/hammer 光标始终覆盖在模型侧边菜单之上并在渲染/重绘时稳定显示。

* **Improvements**
  * 优化道具交互提示为更紧凑、直接的事件事实表达，统一占位与多语言行为；新增韩语主格助词适配。
  * 将光标覆盖层渲染集中化为可挂载节点，提升渲染稳定性与一致性。

* **Documentation**
  * 新增道具交互提示词设计规范，明确 compact 指令生成与审核流程。

* **Tests**
  * 补增与调整多项单元与烟雾测试，覆盖提示渲染、层级、紧凑指令与多语言行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->