### PR TITLE
feat(chat): compact 折叠/展开方向性擦除 + 毛绒球挤压/入场 + 蓝条/历史收回

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -52,6 +52,9 @@ export type ChatWindowProps = ChatWindowSchemaProps & {
   onChoiceSelect?: (option: ChoiceOption, source: ChoicePromptSource) => void;
   onCompactChatStateChange?: (state: CompactChatState) => void;
   onCompactMinimizeRequest?: () => void;
+  // 折叠取消序号：host 在「进行中的折叠被取消」（如 280ms 折叠延时内 closeWindow）时递增。
+  // 组件用它在重开时立即复位 compactCollapsing（避免快速关→重开露出残留擦除态，Codex P2）。
+  compactMinimizeCancelSeq?: number;
 };
 
 type CompactInlineExportBridge = {
@@ -1166,6 +1169,7 @@ function CompactChatApp({
   composerHidden = false,
   composerDisabled = false,
   chatSurfaceMode = 'compact',
+  compactMinimizeCancelSeq = 0,
   compactChatState,
   composerAttachments = [],
   composerAttachmentsAriaLabel = i18n('chat.pendingImagesAriaLabel', 'Pending attachments'),
@@ -1345,6 +1349,8 @@ function CompactChatApp({
   // 折叠时若历史区是开的，记下「恢复后应重新打开历史区」。配合 closeCompactExportHistory
   // ({persist:false})：折叠只播收回动画、不写偏好，恢复（minimized→compact）时据此重开。
   const compactHistoryReopenAfterRestoreRef = useRef(false);
+  // host 折叠取消序号上次值，用于检测「取消」事件（见下方 useLayoutEffect）。
+  const prevCompactMinimizeCancelSeqRef = useRef(compactMinimizeCancelSeq);
   const compactSurfaceResizeStateRef = useRef<CompactSurfaceResizeState | null>(null);
   const compactHistoryResizeStateRef = useRef<CompactHistoryResizeState | null>(null);
   const compactHistoryVisibilitySuppressClickRef = useRef(false);
@@ -1688,6 +1694,20 @@ function CompactChatApp({
     }, 600);
     return () => window.clearTimeout(t);
   }, [compactCollapsing, openCompactExportHistory]);
+  // host 折叠取消序号变化 = 一次进行中的折叠被取消（如 280ms 折叠延时内 closeWindow）。host 关窗
+  // 只隐藏 overlay、React 树与 state 存活；重开时该 prop 携新值到达。用 useLayoutEffect 在重开
+  // 首帧绘制前立即复位 compactCollapsing 并恢复历史区——否则要等上面 600ms 兜底，快速「关→重开」
+  // 会让 compact 表面带着擦除 mask 的不可见 forwards 末态 + 历史区临时关闭重新出现（Codex P2）。
+  // 600ms 兜底保留作为「取消后一直没重开」场景的更晚双保险。
+  useLayoutEffect(() => {
+    if (compactMinimizeCancelSeq === prevCompactMinimizeCancelSeqRef.current) return;
+    prevCompactMinimizeCancelSeqRef.current = compactMinimizeCancelSeq;
+    setCompactCollapsing(false);
+    if (compactHistoryReopenAfterRestoreRef.current) {
+      compactHistoryReopenAfterRestoreRef.current = false;
+      openCompactExportHistory();
+    }
+  }, [compactMinimizeCancelSeq, openCompactExportHistory]);
   const handleCompactHistoryVisibilityToggle = useCallback(() => {
     if (compactExportHistoryOpen) {
       closeCompactExportHistory();

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1675,9 +1675,19 @@ function CompactChatApp({
   // 复位无可见副作用。
   useEffect(() => {
     if (!compactCollapsing) return undefined;
-    const t = window.setTimeout(() => setCompactCollapsing(false), 600);
+    const t = window.setTimeout(() => {
+      setCompactCollapsing(false);
+      // 折叠被取消（mode 没到 minimized，故正常的 minimized→compact 重开路径不会触发）→ 若折叠时
+      // 用 persist:false 关掉了历史区，这里把它恢复回开，否则历史区会被一次未完成的折叠永久收起、
+      // 而持久化偏好其实仍是开的（Codex P2）。openCompactExportHistory 在非 compact 态仅置状态、
+      // 不渲染（受 isCompactSurface 门控），无副作用。正常折叠走 minimized→compact 重开、不到这里。
+      if (compactHistoryReopenAfterRestoreRef.current) {
+        compactHistoryReopenAfterRestoreRef.current = false;
+        openCompactExportHistory();
+      }
+    }, 600);
     return () => window.clearTimeout(t);
-  }, [compactCollapsing]);
+  }, [compactCollapsing, openCompactExportHistory]);
   const handleCompactHistoryVisibilityToggle = useCallback(() => {
     if (compactExportHistoryOpen) {
       closeCompactExportHistory();

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1654,6 +1654,18 @@ function CompactChatApp({
       setCompactCollapsing(false);
     }
   }, [chatSurfaceMode, compactCollapsing]);
+  // 安全兜底：折叠流程是「compact 态置 collapsing→true，host ~280ms 后把 mode 切 minimized，
+  // 上面的 minimized 复位 effect 清掉 collapsing」。但若这 280ms 内窗口被关闭 / 折叠被取消，
+  // mode 永远到不了 minimized，collapsing 会卡在 true；而 host 的 closeWindow 是隐藏而非卸载
+  // React 树，重开时复用同一组件 → 胶囊带着 neko-compact-collapsing 的 mask 卡在不可见末态
+  // （Codex P2）。这里挂一道超过擦除时长（280ms wipe）的兜底超时确保复位：正常折叠会在
+  // mode→minimized 时先复位、cleanup 清掉本超时（永不触发）；仅在取消场景兜底，此时窗口已隐藏，
+  // 复位无可见副作用。
+  useEffect(() => {
+    if (!compactCollapsing) return undefined;
+    const t = window.setTimeout(() => setCompactCollapsing(false), 600);
+    return () => window.clearTimeout(t);
+  }, [compactCollapsing]);
   const handleCompactHistoryVisibilityToggle = useCallback(() => {
     if (compactExportHistoryOpen) {
       closeCompactExportHistory();

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -52,9 +52,8 @@ export type ChatWindowProps = ChatWindowSchemaProps & {
   onChoiceSelect?: (option: ChoiceOption, source: ChoicePromptSource) => void;
   onCompactChatStateChange?: (state: CompactChatState) => void;
   onCompactMinimizeRequest?: () => void;
-  // 折叠取消序号：host 在「进行中的折叠被取消」（如 280ms 折叠延时内 closeWindow）时递增。
-  // 组件用它在重开时立即复位 compactCollapsing（避免快速关→重开露出残留擦除态，Codex P2）。
-  compactMinimizeCancelSeq?: number;
+  // 注：compactMinimizeCancelSeq 在 message-schema.ts 的 chatWindowPropsSchema 里声明
+  // （ChatWindowSchemaProps 已含），必须在 schema 里、否则 parse 会 strip 掉（Codex P2）。
 };
 
 type CompactInlineExportBridge = {
@@ -1672,6 +1671,15 @@ function CompactChatApp({
       setCompactCollapsing(false);
     }
   }, [chatSurfaceMode, compactCollapsing]);
+  // 展开被打断时复位 compactExpanding：展开 reveal 是「minimized→compact 置 expanding→true，340ms
+  // 后复位」。若这 340ms 内 mode 又被切走（如公开 setChatSurfaceMode('full') / setViewProps），上面
+  // 展开 effect 的 cleanup 取消了那次 setCompactExpanding(false)，而该转换不是从这里发起 → expanding
+  // 残留 true 带进后续 compact 渲染，令 full→compact 重放/保留展开 mask（Codex P2）。离开 compact 即复位。
+  useEffect(() => {
+    if (chatSurfaceMode !== 'compact' && compactExpanding) {
+      setCompactExpanding(false);
+    }
+  }, [chatSurfaceMode, compactExpanding]);
   // 安全兜底：折叠流程是「compact 态置 collapsing→true，host ~280ms 后把 mode 切 minimized，
   // 上面的 minimized 复位 effect 清掉 collapsing」。但若这 280ms 内窗口被关闭 / 折叠被取消，
   // mode 永远到不了 minimized，collapsing 会卡在 true；而 host 的 closeWindow 是隐藏而非卸载

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1652,13 +1652,20 @@ function CompactChatApp({
   useLayoutEffect(() => {
     const prev = prevChatSurfaceModeRef.current;
     prevChatSurfaceModeRef.current = chatSurfaceMode;
+    // 重新进入 compact（从 minimized 或 full）时消费历史区重开请求（折叠时 persist:false 记下的）。
+    // 不限于 minimized→compact——经公开 setChatSurfaceMode 的 minimized→full→compact 间接恢复也要重开，
+    // 否则历史区该开没开、而偏好其实仍是开（Codex P2）。ref 仅在「带历史区折叠」时置位，无请求不触发。
+    // 注意用 prev!=='compact' 而非裸 mode==='compact'：折叠点击当帧 mode 仍是 compact，裸判会立即把刚
+    // 关掉的历史区又开回来。
+    if (chatSurfaceMode === 'compact' && prev !== 'compact'
+      && compactHistoryReopenAfterRestoreRef.current) {
+      compactHistoryReopenAfterRestoreRef.current = false;
+      openCompactExportHistory();
+    }
+    // 方向性 reveal 擦除只在毛线球 minimized→compact 恢复时播（full→compact 不播）。~340ms 后复位。
+    // useLayoutEffect 让首帧绘制前就挂 mask，消除 web 端首帧闪（壳侧有 opacity-0 门、Electron 看不出）。
     if (prev === 'minimized' && chatSurfaceMode === 'compact') {
       setCompactExpanding(true);
-      // 折叠前历史区是开的（minimize 用 persist:false 关掉只播了动画、未写偏好）→ 恢复时重开。
-      if (compactHistoryReopenAfterRestoreRef.current) {
-        compactHistoryReopenAfterRestoreRef.current = false;
-        openCompactExportHistory();
-      }
       const t = window.setTimeout(() => setCompactExpanding(false), 340);
       return () => window.clearTimeout(t);
     }

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1633,7 +1633,11 @@ function CompactChatApp({
   }, [clearCompactExportHistoryUnmountTimer]);
   // 展开 reveal：minimized → compact（恢复）时置 compactExpanding → 胶囊左→右展开（React state 写
    // className，不被覆盖）。~340ms 后复位。prev ref 仅在此 effect（deps 只 mode）更新，准确跟踪模式变化。
-  useEffect(() => {
+   // 用 useLayoutEffect 而非 useEffect：passive effect 在首帧绘制后才置 compactExpanding，胶囊会先
+   // 无 mask 全显一帧再重启擦除（Codex P2）。Electron 路径有壳侧 opacity-0 稳定门挡着看不出，但 web
+   // compact 路径没有那道门，layout effect 让首帧绘制前就挂上 mask，消除 web 端首帧闪。仅提前 1 帧，
+   // 340ms 擦除时长不变，prev ref 无其它时序读者 → 无竞态。
+  useLayoutEffect(() => {
     const prev = prevChatSurfaceModeRef.current;
     prevChatSurfaceModeRef.current = chatSurfaceMode;
     if (prev === 'minimized' && chatSurfaceMode === 'compact') {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1342,6 +1342,9 @@ function CompactChatApp({
   const [compactCollapsing, setCompactCollapsing] = useState(false);
   const [compactExpanding, setCompactExpanding] = useState(false);
   const prevChatSurfaceModeRef = useRef(chatSurfaceMode);
+  // 折叠时若历史区是开的，记下「恢复后应重新打开历史区」。配合 closeCompactExportHistory
+  // ({persist:false})：折叠只播收回动画、不写偏好，恢复（minimized→compact）时据此重开。
+  const compactHistoryReopenAfterRestoreRef = useRef(false);
   const compactSurfaceResizeStateRef = useRef<CompactSurfaceResizeState | null>(null);
   const compactHistoryResizeStateRef = useRef<CompactHistoryResizeState | null>(null);
   const compactHistoryVisibilitySuppressClickRef = useRef(false);
@@ -1616,11 +1619,15 @@ function CompactChatApp({
     persistCompactExportHistoryOpen(true);
     setCompactExportAutoScrollToBottom(true);
   }, [clearCompactExportHistoryUnmountTimer]);
-  const closeCompactExportHistory = useCallback(() => {
+  // persist=false：只播收回动画、不把「历史区关闭」写进持久化偏好。折叠（minimize）时用，
+  // 这样 minimize→恢复后历史区按折叠前状态重新打开，而不是把临时折叠误当成偏好变更。
+  // 显式关闭（点蓝条/handle）仍默认 persist=true，正常写偏好。
+  const closeCompactExportHistory = useCallback((opts?: { persist?: boolean }) => {
+    const persist = opts?.persist !== false;
     clearCompactExportHistoryUnmountTimer();
     setCompactExportHistoryClosingMessages(messages);
     setCompactExportHistoryOpen(false);
-    persistCompactExportHistoryOpen(false);
+    if (persist) persistCompactExportHistoryOpen(false);
     setCompactExportPreviewOpen(false);
     compactExportHistoryUnmountTimerRef.current = window.setTimeout(() => {
       setCompactExportHistoryMounted(false);
@@ -1642,11 +1649,16 @@ function CompactChatApp({
     prevChatSurfaceModeRef.current = chatSurfaceMode;
     if (prev === 'minimized' && chatSurfaceMode === 'compact') {
       setCompactExpanding(true);
+      // 折叠前历史区是开的（minimize 用 persist:false 关掉只播了动画、未写偏好）→ 恢复时重开。
+      if (compactHistoryReopenAfterRestoreRef.current) {
+        compactHistoryReopenAfterRestoreRef.current = false;
+        openCompactExportHistory();
+      }
       const t = window.setTimeout(() => setCompactExpanding(false), 340);
       return () => window.clearTimeout(t);
     }
     return undefined;
-  }, [chatSurfaceMode]);
+  }, [chatSurfaceMode, openCompactExportHistory]);
   // 折叠完成（mode→minimized）后复位 compactCollapsing：此刻蓝条/胶囊已随 isCompactSurface 卸载，
   // 复位无视觉副作用，只为下次恢复干净。
   useEffect(() => {
@@ -4916,8 +4928,11 @@ function CompactChatApp({
           return;
         }
         // #3 折叠时若历史区已开，异步触发其收回动画（与折叠并行，不阻塞）。
+        // 用 persist:false：只播收回动画、不把「关闭」写进偏好；并记下恢复后重开，
+        // 这样 minimize→恢复后历史区按折叠前状态重新打开（不把临时折叠误当偏好变更）。
         if (compactExportHistoryOpen) {
-          closeCompactExportHistory();
+          compactHistoryReopenAfterRestoreRef.current = true;
+          closeCompactExportHistory({ persist: false });
         }
         // #2 折叠时蓝条（历史区开关）淡出。compactCollapsing→true 给蓝条加 is-collapsing。
         setCompactCollapsing(true);

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1335,6 +1335,13 @@ function CompactChatApp({
   const [compactExportPreviewOpen, setCompactExportPreviewOpen] = useState(false);
   const [compactExportSelectedIds, setCompactExportSelectedIds] = useState<Set<string>>(() => new Set());
   const [compactExportAutoScrollToBottom, setCompactExportAutoScrollToBottom] = useState(true);
+  // 折叠进行中：点最小化时置 true → 蓝条（历史区开关）淡出（#2）+ 胶囊右→左擦除收走。mode 切到
+  // minimized 后由下方 useEffect 复位。展开进行中：minimized→compact 时置 true → 胶囊左→右展开 reveal。
+  // 这两个擦除/reveal 类必须由 React state 写进 className（而非 host/preload 用 classList 加）—— 否则
+  // React 重渲染会用 JSX className 覆盖、把类删掉，导致动画被打断、胶囊瞬跳（偶发"展开销毁闪一下"）。
+  const [compactCollapsing, setCompactCollapsing] = useState(false);
+  const [compactExpanding, setCompactExpanding] = useState(false);
+  const prevChatSurfaceModeRef = useRef(chatSurfaceMode);
   const compactSurfaceResizeStateRef = useRef<CompactSurfaceResizeState | null>(null);
   const compactHistoryResizeStateRef = useRef<CompactHistoryResizeState | null>(null);
   const compactHistoryVisibilitySuppressClickRef = useRef(false);
@@ -1624,6 +1631,25 @@ function CompactChatApp({
   useEffect(() => () => {
     clearCompactExportHistoryUnmountTimer();
   }, [clearCompactExportHistoryUnmountTimer]);
+  // 展开 reveal：minimized → compact（恢复）时置 compactExpanding → 胶囊左→右展开（React state 写
+   // className，不被覆盖）。~340ms 后复位。prev ref 仅在此 effect（deps 只 mode）更新，准确跟踪模式变化。
+  useEffect(() => {
+    const prev = prevChatSurfaceModeRef.current;
+    prevChatSurfaceModeRef.current = chatSurfaceMode;
+    if (prev === 'minimized' && chatSurfaceMode === 'compact') {
+      setCompactExpanding(true);
+      const t = window.setTimeout(() => setCompactExpanding(false), 340);
+      return () => window.clearTimeout(t);
+    }
+    return undefined;
+  }, [chatSurfaceMode]);
+  // 折叠完成（mode→minimized）后复位 compactCollapsing：此刻蓝条/胶囊已随 isCompactSurface 卸载，
+  // 复位无视觉副作用，只为下次恢复干净。
+  useEffect(() => {
+    if (chatSurfaceMode === 'minimized' && compactCollapsing) {
+      setCompactCollapsing(false);
+    }
+  }, [chatSurfaceMode, compactCollapsing]);
   const handleCompactHistoryVisibilityToggle = useCallback(() => {
     if (compactExportHistoryOpen) {
       closeCompactExportHistory();
@@ -4866,6 +4892,12 @@ function CompactChatApp({
           return;
         }
         clearActiveCursorToolSelection();
+        // #3 折叠时若历史区已开，异步触发其收回动画（与折叠并行，不阻塞）。
+        if (compactExportHistoryOpen) {
+          closeCompactExportHistory();
+        }
+        // #2 折叠时蓝条（历史区开关）淡出。compactCollapsing→true 给蓝条加 is-collapsing。
+        setCompactCollapsing(true);
         onCompactMinimizeRequest?.();
       }}
     >
@@ -5473,7 +5505,7 @@ function CompactChatApp({
   const compactExportHistoryNode = compactExportHistoryElement;
   const compactHistoryVisibilityHandleNode = isCompactSurface ? (
     <button
-      className={`compact-history-visibility-handle${compactExportHistoryOpen ? ' is-open' : ''}`}
+      className={`compact-history-visibility-handle${compactExportHistoryOpen ? ' is-open' : ''}${compactCollapsing ? ' is-collapsing' : ''}`}
       type="button"
       aria-label={compactExportHistoryToggleLabel}
       aria-expanded={compactExportHistoryOpen}
@@ -5681,7 +5713,7 @@ function CompactChatApp({
           }}>
             {isCompactSurface ? (
               <div
-                className="compact-chat-surface-shell"
+                className={`compact-chat-surface-shell${compactCollapsing ? ' neko-compact-collapsing' : ''}${compactExpanding ? ' neko-compact-expanding' : ''}`}
                 ref={compactInputShellRef}
                 data-compact-chat-state={effectiveCompactChatState}
                 data-compact-tool-layer-open={compactToolToggleVisible && compactInputToolFanOpen ? 'true' : 'false'}

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5789,7 +5789,13 @@ function CompactChatApp({
           }}>
             {isCompactSurface ? (
               <div
-                className={`compact-chat-surface-shell${compactCollapsing ? ' neko-compact-collapsing' : ''}${compactExpanding ? ' neko-compact-expanding' : ''}`}
+                className={`compact-chat-surface-shell${
+                  compactCollapsing
+                    ? ' neko-compact-collapsing'
+                    : compactExpanding
+                      ? ' neko-compact-expanding'
+                      : ''
+                }`}
                 ref={compactInputShellRef}
                 data-compact-chat-state={effectiveCompactChatState}
                 data-compact-tool-layer-open={compactToolToggleVisible && compactInputToolFanOpen ? 'true' : 'false'}

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4892,13 +4892,20 @@ function CompactChatApp({
           return;
         }
         clearActiveCursorToolSelection();
+        // onCompactMinimizeRequest 是可选 prop：真正把 surfaceMode 切到 'minimized'
+        // 的是宿主回调，切回 minimized 后才会复位 compactCollapsing。宿主没传回调时
+        // 若仍 setCompactCollapsing(true)，模式永不变、collapsing 永不复位，蓝条/胶囊
+        // 会一直卡在折叠样式（CodeRabbit Major）。所以缺回调时直接早退、不进折叠态。
+        if (!onCompactMinimizeRequest) {
+          return;
+        }
         // #3 折叠时若历史区已开，异步触发其收回动画（与折叠并行，不阻塞）。
         if (compactExportHistoryOpen) {
           closeCompactExportHistory();
         }
         // #2 折叠时蓝条（历史区开关）淡出。compactCollapsing→true 给蓝条加 is-collapsing。
         setCompactCollapsing(true);
-        onCompactMinimizeRequest?.();
+        onCompactMinimizeRequest();
       }}
     >
       <img

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -216,6 +216,9 @@ export const chatWindowPropsSchema = z.object({
   composerHidden: z.boolean().optional(),
   composerDisabled: z.boolean().optional(),
   chatSurfaceMode: chatSurfaceModeSchema.optional(),
+  // host 折叠取消序号：必须在 schema 里声明，否则 z.object().parse() 默认 strip 未知键、
+  // App 永远只看到默认 0，重开立即复位的 useLayoutEffect 不会触发（Codex P2）。
+  compactMinimizeCancelSeq: z.number().optional(),
   compactChatState: compactChatStateSchema.optional(),
   onCompactChatStateChange: z.function()
     .args(compactChatStateSchema)

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -218,7 +218,9 @@ export const chatWindowPropsSchema = z.object({
   chatSurfaceMode: chatSurfaceModeSchema.optional(),
   // host 折叠取消序号：必须在 schema 里声明，否则 z.object().parse() 默认 strip 未知键、
   // App 永远只看到默认 0，重开立即复位的 useLayoutEffect 不会触发（Codex P2）。
-  compactMinimizeCancelSeq: z.number().optional(),
+  // 逻辑上是单调递增的非负整数计数（host 从 0 起 += 1），加 int/nonnegative 作边界防御
+  // （CodeRabbit）；host 恒传合法值，约束不会触发拒绝。
+  compactMinimizeCancelSeq: z.number().int().nonnegative().optional(),
   compactChatState: compactChatStateSchema.optional(),
   onCompactChatStateChange: z.function()
     .args(compactChatStateSchema)

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3046,6 +3046,54 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   pointer-events: none;
 }
 
+/* 折叠/展开方向性擦除 + 毛绒球按下挤压动画。这些 class 由 React 组件（App.tsx）发出，
+   但动画规则原本只在 host 的 static/css/index.css。Vite dev / 独立 React bundle 路径下没有
+   index.css，class 会失效、擦除/挤压不跑（Codex P2）。这里在 bundle 自带的 styles.css 里镜像
+   同一套规则，保证组件自带动画 CSS。两份保持一致。 */
+@keyframes neko-compact-minimize-press {
+  0%   { transform: scale(1, 1); }
+  30%  { transform: scale(1.12, 0.74); }
+  58%  { transform: scale(0.94, 1.08); }
+  80%  { transform: scale(1.03, 0.97); }
+  100% { transform: scale(1, 1); }
+}
+.compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
+  transform-origin: center bottom;
+  animation: neko-compact-minimize-press 420ms cubic-bezier(0.3, 0.8, 0.4, 1) both;
+}
+@keyframes neko-compact-collapse-wipe {
+  from { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
+  to   { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
+}
+@keyframes neko-compact-expand-wipe {
+  from { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
+  to   { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
+}
+.compact-chat-surface-shell.neko-compact-collapsing,
+.compact-chat-surface-shell.neko-compact-expanding {
+  -webkit-mask-image: linear-gradient(to right, #000 33%, transparent 50%);
+  mask-image: linear-gradient(to right, #000 33%, transparent 50%);
+  -webkit-mask-size: 300% 100%; mask-size: 300% 100%;
+  -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
+}
+.compact-chat-surface-shell.neko-compact-collapsing {
+  animation: neko-compact-collapse-wipe 280ms ease forwards;
+}
+.compact-chat-surface-shell.neko-compact-expanding {
+  animation: neko-compact-expand-wipe 300ms ease forwards;
+}
+/* reduced-motion 禁用上面这些动画。必须放在动画规则之后：同特异性下 CSS 后定义者胜、
+   media query 不加特异性（与 index.css 同样处理，Codex P2）。 */
+@media (prefers-reduced-motion: reduce) {
+  .compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
+    animation: none;
+  }
+  .compact-chat-surface-shell.neko-compact-collapsing,
+  .compact-chat-surface-shell.neko-compact-expanding {
+    animation: none;
+  }
+}
+
 .compact-history-visibility-handle::before,
 .compact-history-visibility-handle::after {
   content: "";

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3038,6 +3038,14 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   width: clamp(124px, calc(var(--compact-history-handle-surface-width) * 0.30), 168px);
 }
 
+/* #2 折叠时蓝条（历史区开关）淡出：App.tsx 点最小化置 compactCollapsing→加 .is-collapsing，
+   ~0.22s 淡掉，与折叠擦除同步消失。 */
+.compact-history-visibility-handle.is-collapsing {
+  opacity: 0;
+  transition: opacity 0.18s ease 0.08s; /* 略延 0.08s 再淡 0.18s，~0.26s 内消失（在 host 折叠 280ms 窗口内） */
+  pointer-events: none;
+}
+
 .compact-history-visibility-handle::before,
 .compact-history-visibility-handle::after {
   content: "";

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3237,10 +3237,15 @@
         //    （onClick 里已 setCompactCollapsing(true)）—— 不再在此用 classList 加类（会被 React 重渲染覆盖）。
         compactMinimizePressTimer = window.setTimeout(function () {
             compactMinimizePressTimer = 0;
-            // 多一道保险：擦除期间窗口若已退出 Electron compact 语境（关闭/重开会经
+            // 守卫：擦除期间窗口若已退出 Electron compact 语境（关闭/重开会经
             // closeWindow→cancelActiveAnimation 清掉本 timer，但状态可能在其它路径变更），
             // 不强行折叠，避免覆盖更新后的 surface mode。
             if (!isElectronChatWindow()) return;
+            // 守卫：宿主可能在这 280ms 内经公开 API 把 surface mode 切走
+            // （setChatSurfaceMode('full') 或 setViewProps({chatSurfaceMode}) 直写 state，
+            // 后者绕过 cancelActiveAnimation 不清本 timer）。只有「仍处于 compact」才执行
+            // 这次延迟折叠，否则会用陈旧的 minimized 覆盖更新后的模式（Codex P2）。
+            if (getCurrentChatSurfaceMode() !== 'compact') return;
             setChatSurfaceMode('minimized');
         }, COMPACT_MINIMIZE_PRESS_MS);
     }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3197,8 +3197,40 @@
     // React compact 输入框/胶囊左侧毛绒球点按 → 折叠为 minimized。最小化控制权在宿主，
     // 走 setChatSurfaceMode('minimized')（既有的 setMinimized + 位置持久化 + chat-surface-mode-change
     // 派发都在其中）；不用 toggleMinimized——毛绒球只在非 minimized 态出现，语义恒为「收起」。
+    //
+    // 说明：曾尝试「在 compact 态把 root 原位慢速淡出 + 提前异步显示独立球」做收起 overlap，但
+    // (a) 淡出期间 compact 仍可交互/未冻结，提前显示的球与 relayout/hit-test/moveTop 互相打架 →
+    //     球在光标下抖、cursor 在箭头/手之间闪；
+    // (b) 给 root 设 inline opacity:0 做淡出，频繁点击时 setMinimized 因状态 desync 提前 return、
+    //     跳过 opacity 复位 → root 卡在 0 = 输入框隐身。
+    // 这套机制竞态太重，已回退。现仅保留一个安全增强：给按下的毛绒球补「按下挤压」动画（CSS），
+    // 留一个短延时让挤压动画露出来再瞬时折叠（折叠本体走原有 PRE_COLLAPSE_DIM 瞬时路径，零竞态）。
+    // 独立球出现时的「放大长出」靠球自身入场动画（neko-ball-appear），与此处解耦。
+    var COMPACT_MINIMIZE_PRESS_MS = 280; // = neko-compact-collapse-wipe 擦除时长：擦完再瞬时折叠
+    var compactMinimizePressTimer = 0;
     function handleCompactMinimizeRequest() {
-        setChatSurfaceMode('minimized');
+        // 给按下的毛绒球补「按下挤压」弹性动画（CSS index.css neko-compact-minimize-press）。
+        try {
+            var pressIcons = document.querySelectorAll('.compact-chat-minimize-ball-icon');
+            for (var pi = 0; pi < pressIcons.length; pi++) {
+                var pressIcon = pressIcons[pi];
+                pressIcon.classList.remove('neko-minimize-ball-pressing');
+                void pressIcon.offsetWidth;
+                pressIcon.classList.add('neko-minimize-ball-pressing');
+            }
+        } catch (e) {}
+        if (!isElectronChatWindow()) {
+            setChatSurfaceMode('minimized');
+            return;
+        }
+        // 防重入：擦除途中再次点最小化忽略。
+        if (compactMinimizePressTimer) return;
+        // #1 折叠方向性擦除（右→左收）由 App.tsx 的 compactCollapsing state 驱动 className 实现
+        //    （onClick 里已 setCompactCollapsing(true)）—— 不再在此用 classList 加类（会被 React 重渲染覆盖）。
+        compactMinimizePressTimer = window.setTimeout(function () {
+            compactMinimizePressTimer = 0;
+            setChatSurfaceMode('minimized');
+        }, COMPACT_MINIMIZE_PRESS_MS);
     }
 
     function handleMiniGameInviteChoice(option) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -2223,6 +2223,7 @@
             _toolCursorResetKey: state._toolCursorResetKey || undefined,
             composerHidden: state.composerHidden,
             chatSurfaceMode: getCurrentChatSurfaceMode(),
+            compactMinimizeCancelSeq: compactMinimizeCancelSeq,
             compactChatState: getCurrentCompactChatState(),
             galgameModeEnabled: !!state.galgameModeEnabled,
             galgameOptions: Array.isArray(state.galgameOptions) ? state.galgameOptions : [],
@@ -3208,6 +3209,7 @@
     // 独立球出现时的「放大长出」靠球自身入场动画（neko-ball-appear），与此处解耦。
     var COMPACT_MINIMIZE_PRESS_MS = 280; // = neko-compact-collapse-wipe 擦除时长：擦完再瞬时折叠
     var compactMinimizePressTimer = 0;
+    var compactMinimizeCancelSeq = 0; // 折叠取消序号（见 clearCompactMinimizePressTimer），传给 React
     // 清掉挂起的「按下挤压→瞬时折叠」延时。窗口关闭/动画取消时必须调用，否则这个
     // 跨 280ms 存活的回调会在窗口已关闭/重开后仍 setChatSurfaceMode('minimized')，
     // 把更新后的状态覆盖成「幽灵最小化」（CodeRabbit Minor / Codex P2）。
@@ -3215,6 +3217,11 @@
         if (!compactMinimizePressTimer) return;
         window.clearTimeout(compactMinimizePressTimer);
         compactMinimizePressTimer = 0;
+        // 真清掉一个 pending 折叠延时 = 一次进行中的折叠被取消（如 280ms 内 closeWindow）。
+        // 递增序号；buildRenderProps 把它当 prop 传给 React，让组件在重开时立即复位
+        // compactCollapsing，而不必等 600ms 兜底——否则快速「关→重开」会让 compact 表面带着擦除
+        // mask 的不可见末态 + 历史区临时关闭重新出现（Codex P2）。
+        compactMinimizeCancelSeq += 1;
     }
     function handleCompactMinimizeRequest() {
         // reduced-motion：折叠擦除/按压挤压动画已被 CSS（@media prefers-reduced-motion: reduce）

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3208,6 +3208,14 @@
     // 独立球出现时的「放大长出」靠球自身入场动画（neko-ball-appear），与此处解耦。
     var COMPACT_MINIMIZE_PRESS_MS = 280; // = neko-compact-collapse-wipe 擦除时长：擦完再瞬时折叠
     var compactMinimizePressTimer = 0;
+    // 清掉挂起的「按下挤压→瞬时折叠」延时。窗口关闭/动画取消时必须调用，否则这个
+    // 跨 280ms 存活的回调会在窗口已关闭/重开后仍 setChatSurfaceMode('minimized')，
+    // 把更新后的状态覆盖成「幽灵最小化」（CodeRabbit Minor / Codex P2）。
+    function clearCompactMinimizePressTimer() {
+        if (!compactMinimizePressTimer) return;
+        window.clearTimeout(compactMinimizePressTimer);
+        compactMinimizePressTimer = 0;
+    }
     function handleCompactMinimizeRequest() {
         // 给按下的毛绒球补「按下挤压」弹性动画（CSS index.css neko-compact-minimize-press）。
         try {
@@ -3229,6 +3237,10 @@
         //    （onClick 里已 setCompactCollapsing(true)）—— 不再在此用 classList 加类（会被 React 重渲染覆盖）。
         compactMinimizePressTimer = window.setTimeout(function () {
             compactMinimizePressTimer = 0;
+            // 多一道保险：擦除期间窗口若已退出 Electron compact 语境（关闭/重开会经
+            // closeWindow→cancelActiveAnimation 清掉本 timer，但状态可能在其它路径变更），
+            // 不强行折叠，避免覆盖更新后的 surface mode。
+            if (!isElectronChatWindow()) return;
             setChatSurfaceMode('minimized');
         }, COMPACT_MINIMIZE_PRESS_MS);
     }
@@ -4527,6 +4539,9 @@
             activeAnimationCleanup = null;
         }
         isMinimizeTransitioning = false;
+        // 取消进行中的折叠/展开时一并清掉挂起的「按下挤压→瞬时折叠」延时（closeWindow
+        // 也走这里），避免该回调在窗口关闭/重开后幽灵触发 setChatSurfaceMode('minimized')。
+        clearCompactMinimizePressTimer();
     }
 
     // The minimized ball belongs to the surface we'll restore to: the revived

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3227,24 +3227,19 @@
                 pressIcon.classList.add('neko-minimize-ball-pressing');
             }
         } catch (e) {}
-        if (!isElectronChatWindow()) {
-            setChatSurfaceMode('minimized');
-            return;
-        }
         // 防重入：擦除途中再次点最小化忽略。
         if (compactMinimizePressTimer) return;
         // #1 折叠方向性擦除（右→左收）由 App.tsx 的 compactCollapsing state 驱动 className 实现
         //    （onClick 里已 setCompactCollapsing(true)）—— 不再在此用 classList 加类（会被 React 重渲染覆盖）。
+        // web 与 Electron 统一走这条 = 擦除时长的延时再瞬时折叠：web 若同步 setChatSurfaceMode
+        // ('minimized') 会在下一帧前就让 isCompactSurface=false、卸载 .compact-chat-surface-shell，
+        // 新加的 neko-compact-collapsing 擦除遮罩与蓝条淡出根本来不及渲染（Codex P2）。
         compactMinimizePressTimer = window.setTimeout(function () {
             compactMinimizePressTimer = 0;
-            // 守卫：擦除期间窗口若已退出 Electron compact 语境（关闭/重开会经
-            // closeWindow→cancelActiveAnimation 清掉本 timer，但状态可能在其它路径变更），
-            // 不强行折叠，避免覆盖更新后的 surface mode。
-            if (!isElectronChatWindow()) return;
-            // 守卫：宿主可能在这 280ms 内经公开 API 把 surface mode 切走
-            // （setChatSurfaceMode('full') 或 setViewProps({chatSurfaceMode}) 直写 state，
-            // 后者绕过 cancelActiveAnimation 不清本 timer）。只有「仍处于 compact」才执行
-            // 这次延迟折叠，否则会用陈旧的 minimized 覆盖更新后的模式（Codex P2）。
+            // 守卫：擦除期间宿主可能把 surface mode 切走（关闭/重开经
+            // closeWindow→cancelActiveAnimation 清掉本 timer；或经公开 API setChatSurfaceMode
+            // ('full') / setViewProps 直写 state 绕过清理）。只有「仍处于 compact」才执行这次
+            // 延迟折叠，否则会用陈旧的 minimized 覆盖更新后的模式（Codex P2）。两端通用。
             if (getCurrentChatSurfaceMode() !== 'compact') return;
             setChatSurfaceMode('minimized');
         }, COMPACT_MINIMIZE_PRESS_MS);

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3217,6 +3217,17 @@
         compactMinimizePressTimer = 0;
     }
     function handleCompactMinimizeRequest() {
+        // reduced-motion：折叠擦除/按压挤压动画已被 CSS（@media prefers-reduced-motion: reduce）
+        // 禁用，此时再延时 COMPACT_MINIMIZE_PRESS_MS(280ms) 才折叠，只会让窗口「点了没反应」一段，
+        // 无任何动画反馈。无障碍模式下直接立即折叠，保持即时响应（Codex P2）。
+        var reduceMotion = false;
+        try {
+            reduceMotion = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+        } catch (e) {}
+        if (reduceMotion) {
+            setChatSurfaceMode('minimized');
+            return;
+        }
         // 给按下的毛绒球补「按下挤压」弹性动画（CSS index.css neko-compact-minimize-press）。
         try {
             var pressIcons = document.querySelectorAll('.compact-chat-minimize-ball-icon');

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3521,6 +3521,9 @@
             }
             state.chatSurfaceMode = normalizedChatSurfaceMode;
             if (surfaceModeChanged) {
+                // 同 setChatSurfaceMode：mode 经此公开入口变更时取消挂起的延时折叠，防 full→compact
+                // hop 内陈旧折叠回调误折叠刚恢复的表面（Codex P2）。timer 已=0 时为 no-op。
+                clearCompactMinimizePressTimer();
                 // setViewProps is a public entry point (exposed + the
                 // `set-view-props` event), so it can land a real surface change —
                 // e.g. an external `{chatSurfaceMode:'full'}`. Mirror
@@ -4630,6 +4633,12 @@
             syncChatSurfaceModeUI();
             return normalized;
         }
+
+        // 任何真实的 surface mode 变更都取消挂起的「按下挤压→延时折叠」：否则 full→compact 之类
+        // 快速跳变会让 280ms 内的陈旧折叠回调在 mode 又回到 compact 时误折叠刚恢复的表面（Codex P2，
+        // 仅靠回调里 getCurrentChatSurfaceMode()==='compact' 守卫挡不住这种 hop）。timer 自身的
+        // minimize 调用此时 timer 已=0，clear 为 no-op，不影响正常折叠。
+        clearCompactMinimizePressTimer();
 
         if (!nextMinimized) {
             lastRestorableChatSurfaceMode = normalized;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -516,6 +516,15 @@ body.neko-game-active [id$="-lock-icon"] {
     .neko-idle-return-button-container.is-cat1-dropping-from-compact-top-edge > .neko-idle-return-btn {
         animation: none;
     }
+    /* 减少动态效果偏好下，禁用毛绒球按压挤压与折叠/展开方向性擦除动画，给动画敏感
+       用户即时的折叠/展开（CodeRabbit 无障碍 nitpick）。仅影响开启该系统设置的用户。 */
+    .compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
+        animation: none;
+    }
+    .compact-chat-surface-shell.neko-compact-collapsing,
+    .compact-chat-surface-shell.neko-compact-expanding {
+        animation: none;
+    }
 }
 
 @media (max-width: 768px) {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -516,15 +516,6 @@ body.neko-game-active [id$="-lock-icon"] {
     .neko-idle-return-button-container.is-cat1-dropping-from-compact-top-edge > .neko-idle-return-btn {
         animation: none;
     }
-    /* 减少动态效果偏好下，禁用毛绒球按压挤压与折叠/展开方向性擦除动画，给动画敏感
-       用户即时的折叠/展开（CodeRabbit 无障碍 nitpick）。仅影响开启该系统设置的用户。 */
-    .compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
-        animation: none;
-    }
-    .compact-chat-surface-shell.neko-compact-collapsing,
-    .compact-chat-surface-shell.neko-compact-expanding {
-        animation: none;
-    }
 }
 
 @media (max-width: 768px) {
@@ -1045,6 +1036,20 @@ body.subtitle-web-host #react-chat-window-shell.is-dragging {
 }
 .compact-chat-surface-shell.neko-compact-expanding {
     animation: neko-compact-expand-wipe 300ms ease forwards;
+}
+
+/* 减少动态效果偏好下，禁用毛绒球按压挤压与折叠/展开方向性擦除动画，给动画敏感用户
+   即时的折叠/展开（CodeRabbit 无障碍 nitpick）。仅影响开启该系统设置的用户。
+   必须放在上面动画规则之后：同特异性（两类选择器）下 CSS 后定义者胜，media query 不加
+   特异性，若放在文件靠前的 @media 块里会被这些动画规则覆盖、override 不生效（Codex P2）。 */
+@media (prefers-reduced-motion: reduce) {
+    .compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
+        animation: none;
+    }
+    .compact-chat-surface-shell.neko-compact-collapsing,
+    .compact-chat-surface-shell.neko-compact-expanding {
+        animation: none;
+    }
 }
 
 /* GalGame 模式：撑高聊天框最小高度，避免移动/桌面下选项被裁切 */

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -992,6 +992,52 @@ body.subtitle-web-host #react-chat-window-shell.is-dragging {
     box-shadow: 0 36px 110px rgba(12, 20, 34, 0.36);
 }
 
+/* compact 输入框左侧毛绒球「按下挤压回弹」弹性动画：点按折叠时由 app-react-chat-window.js
+   handleCompactMinimizeRequest 给图标加 .neko-minimize-ball-pressing 触发（与展开时按独立
+   球的 squash bounce 对偶；折叠原本无动画）。运行中的动画 transform 会盖过 :active 的 scale(1.08)。
+   transform-origin 底部 + scale Y 变矮/X 变宽 = 向下挤扁（不是均匀缩小），与 neko-ball-bounce 同手感。 */
+@keyframes neko-compact-minimize-press {
+    0%   { transform: scale(1, 1); }
+    30%  { transform: scale(1.12, 0.74); }  /* 向下挤扁（squash：变宽变矮） */
+    58%  { transform: scale(0.94, 1.08); }  /* 回弹拉伸 */
+    80%  { transform: scale(1.03, 0.97); }  /* 小回压 */
+    100% { transform: scale(1, 1); }        /* 落定 */
+}
+.compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
+    transform-origin: center bottom;
+    animation: neko-compact-minimize-press 420ms cubic-bezier(0.3, 0.8, 0.4, 1) both;
+}
+
+/* compact 对话条折叠/展开的「方向性渐变擦除」：折叠＝从右往左收（右先消失），展开＝反向从左往右展。
+   作用在 .compact-chat-surface-shell（position:fixed 的胶囊本体）上 —— 不能擦 #react-chat-window-root，
+   因为 fixed 子元素可能在 root 盒子外、mask 盖不到。用 mask 渐变 + 动 mask-position（gradient 本身
+   不可 tween，但 mask-position 可以）实现软边扫过。
+   安全：展开用 forwards 让保留态 = mask-position 0%（全可见），即使清理失败也不隐身；折叠类由宿主
+   setChatSurfaceMode 顶部无条件复位兜底（频繁点击也不会卡在「擦没了」）。 */
+@keyframes neko-compact-collapse-wipe {
+    from { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
+    to   { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
+}
+@keyframes neko-compact-expand-wipe {
+    from { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
+    to   { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
+}
+.compact-chat-surface-shell.neko-compact-collapsing,
+.compact-chat-surface-shell.neko-compact-expanding {
+    /* mask 300% 宽 + 渐变软边落在中间三分之一：mask-position 0% 时胶囊只看到纯黑（全可见），
+       100% 时只看到全透明（全隐），软边在 0%↔100% 之间从右向左/左向右扫过。 */
+    -webkit-mask-image: linear-gradient(to right, #000 33%, transparent 50%);
+    mask-image: linear-gradient(to right, #000 33%, transparent 50%);
+    -webkit-mask-size: 300% 100%; mask-size: 300% 100%;
+    -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
+}
+.compact-chat-surface-shell.neko-compact-collapsing {
+    animation: neko-compact-collapse-wipe 280ms ease forwards;
+}
+.compact-chat-surface-shell.neko-compact-expanding {
+    animation: neko-compact-expand-wipe 300ms ease forwards;
+}
+
 /* GalGame 模式：撑高聊天框最小高度，避免移动/桌面下选项被裁切 */
 body.galgame-mode-enabled #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
     min-height: min(420px, calc(100vh - 22px));


### PR DESCRIPTION
毛线球折叠/展开的动效（**前端**，与壳侧 N.E.K.O.-PC#194 配套，需同时合）。

## 方向性擦除（折叠右→左收 / 展开左→右展）
- mask-position 软边扫过；由 React state `compactCollapsing`/`compactExpanding` 驱动 className —— **不用 classList 加类**（避免 React 重渲染覆盖、动画被打断导致胶囊瞬跳的偶发"展开销毁闪一下"）。

## 折叠交互动效
- 点最小化：毛绒球**按下挤压**弹性动画（`neko-compact-minimize-press`，向下挤扁）；留短延时让动画露出再瞬时折叠（不碰会触发 full reflow 的 mode 切换时序）。
- 折叠时**蓝条**（历史区开关）延后淡出；**历史区已开则异步触发收回动画**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 紧凑模式引入折叠/展开两段动效并同步类名，支持方向感知过渡与历史区恢复。
  * 最小化交互增加按压反馈与延时流程，尊重 prefers-reduced-motion 自动跳过动画。
  * 历史区关闭支持可选不写入持久化偏好，恢复后可自动重开历史区。
  * 渲染属性与消息 schema 新增 compactMinimizeCancelSeq 字段以协调折叠取消。

* **Bug Fixes**
  * 增加定时器清理、超时兜底与取消序号递增，防止折叠动画卡死或挂起回调异常。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->