### PR TITLE
Fix CAT1 minimized yarn ball targeting

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -780,15 +780,67 @@ const _NEKO_IDLE_RETURN_SUBACTION_PROFILES = Object.freeze({
 let _nekoIdleDesktopChatMinimizedState = {
     minimized: false,
     screenRect: null,
-    updatedAt: 0
+    updatedAt: 0,
+    sourceUpdatedAt: 0,
+    expandedRecent: false
 };
 let _nekoIdleDesktopCompactSurfaceState = {
     visible: false,
     screenRect: null,
-    updatedAt: 0
+    updatedAt: 0,
+    sourceUpdatedAt: 0
 };
 let _nekoIdleCompactSurfaceDragging = false;
 let _nekoIdleCompactSurfaceSettleTimer = 0;
+
+function _getNekoIdleDesktopStateSourceUpdatedAt(detail, fallbackUpdatedAt) {
+    const timestamp = Number(detail && detail.timestamp);
+    if (Number.isFinite(timestamp) && timestamp > 0) return timestamp;
+    const fallback = Number(fallbackUpdatedAt);
+    if (Number.isFinite(fallback) && fallback > 0) return fallback;
+    return Date.now();
+}
+
+function _isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, state) {
+    const incomingSourceUpdatedAt = Number(sourceUpdatedAt);
+    const currentSourceUpdatedAt = Number(state && state.sourceUpdatedAt);
+    return Number.isFinite(incomingSourceUpdatedAt) &&
+        incomingSourceUpdatedAt > 0 &&
+        Number.isFinite(currentSourceUpdatedAt) &&
+        currentSourceUpdatedAt > 0 &&
+        incomingSourceUpdatedAt < currentSourceUpdatedAt;
+}
+
+function _isNekoIdleDesktopStateNewerThan(sourceUpdatedAt, state) {
+    const incomingSourceUpdatedAt = Number(sourceUpdatedAt);
+    const currentSourceUpdatedAt = Number(state && state.sourceUpdatedAt);
+    return Number.isFinite(incomingSourceUpdatedAt) &&
+        incomingSourceUpdatedAt > 0 &&
+        (!Number.isFinite(currentSourceUpdatedAt) ||
+            currentSourceUpdatedAt <= 0 ||
+            incomingSourceUpdatedAt > currentSourceUpdatedAt);
+}
+
+function _makeNekoIdleDesktopChatMinimizedState(minimized, screenRect, updatedAt, sourceUpdatedAt, expandedRecent) {
+    const active = !!(minimized && screenRect);
+    return {
+        minimized: active,
+        screenRect: active ? screenRect : null,
+        updatedAt: updatedAt,
+        sourceUpdatedAt: sourceUpdatedAt,
+        expandedRecent: !active && !!expandedRecent
+    };
+}
+
+function _makeNekoIdleDesktopCompactSurfaceState(visible, screenRect, updatedAt, sourceUpdatedAt) {
+    const active = !!(visible && screenRect);
+    return {
+        visible: active,
+        screenRect: active ? screenRect : null,
+        updatedAt: updatedAt,
+        sourceUpdatedAt: sourceUpdatedAt
+    };
+}
 
 function _shouldReduceNekoIdleMotion() {
     try {
@@ -2174,6 +2226,11 @@ function _getNekoIdleReactChatCompactSurfaceRect() {
 function _getNekoIdleDesktopCompactSurfaceRect() {
     const state = _nekoIdleDesktopCompactSurfaceState;
     if (!state || !state.visible || !state.screenRect) return null;
+    if (_nekoIdleDesktopChatMinimizedState &&
+        _nekoIdleDesktopChatMinimizedState.minimized &&
+        _isNekoIdleDesktopStateNewerThan(_nekoIdleDesktopChatMinimizedState.sourceUpdatedAt, state)) {
+        return null;
+    }
     if (Date.now() - (state.updatedAt || 0) > _NEKO_IDLE_DESKTOP_COMPACT_SURFACE_RECT_STALE_MS) return null;
     const screenRect = _normalizeNekoIdleScreenRect(state.screenRect);
     if (!screenRect) return null;
@@ -2201,6 +2258,11 @@ function _getNekoIdleChatCompactSurfaceRect() {
 function _getNekoIdleDesktopChatMinimizedRect() {
     const state = _nekoIdleDesktopChatMinimizedState;
     if (!state || !state.minimized || !state.screenRect) return null;
+    if (_nekoIdleDesktopCompactSurfaceState &&
+        _nekoIdleDesktopCompactSurfaceState.visible &&
+        _isNekoIdleDesktopStateNewerThan(_nekoIdleDesktopCompactSurfaceState.sourceUpdatedAt, state)) {
+        return null;
+    }
     if (Date.now() - (state.updatedAt || 0) > _NEKO_IDLE_DESKTOP_CHAT_RECT_STALE_MS) return null;
     const screenRect = _normalizeNekoIdleScreenRect(state.screenRect);
     if (!screenRect) return null;
@@ -2223,6 +2285,7 @@ function _getNekoIdleDesktopChatMinimizedRect() {
 function _isNekoIdleDesktopChatExpandedRecent() {
     const state = _nekoIdleDesktopChatMinimizedState;
     if (!state || state.minimized) return false;
+    if (state.expandedRecent === false) return false;
     return Date.now() - (state.updatedAt || 0) <= _NEKO_IDLE_DESKTOP_CHAT_RECT_STALE_MS;
 }
 
@@ -2383,11 +2446,20 @@ function _setNekoIdleCat1PairMoveChatPosition(shell, left, top) {
 function _rememberNekoIdleDesktopChatPairMoveRect(screenRect) {
     const normalized = _normalizeNekoIdleScreenRect(screenRect);
     if (!normalized) return null;
-    _nekoIdleDesktopChatMinimizedState = {
-        minimized: true,
-        screenRect: normalized,
-        updatedAt: Date.now()
-    };
+    const updatedAt = Date.now();
+    _nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(
+        true,
+        normalized,
+        updatedAt,
+        updatedAt,
+        false
+    );
+    _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
+        false,
+        null,
+        updatedAt,
+        updatedAt
+    );
     return normalized;
 }
 
@@ -3507,9 +3579,20 @@ function _ensureNekoIdleReturnPresentationBridge() {
 
     window.addEventListener('neko:idle-chat-minimized-state', (event) => {
         const detail = event && event.detail && typeof event.detail === 'object' ? event.detail : null;
+        const receivedAt = Date.now();
+        const sourceUpdatedAt = _getNekoIdleDesktopStateSourceUpdatedAt(detail, receivedAt);
+        if (_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)) return;
         const screenRect = detail && detail.minimized
             ? _normalizeNekoIdleScreenRect(detail.screenRect)
             : null;
+        const nextMinimized = !!(detail && detail.minimized && screenRect);
+        const compactSurfaceCurrentlyVisible = !!_getNekoIdleDesktopCompactSurfaceRect();
+        if (nextMinimized &&
+            _nekoIdleDesktopCompactSurfaceState &&
+            _nekoIdleDesktopCompactSurfaceState.visible &&
+            _isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopCompactSurfaceState)) {
+            return;
+        }
         const previousState = _nekoIdleDesktopChatMinimizedState;
         const previousScreenRect = previousState && previousState.minimized
             ? previousState.screenRect
@@ -3517,11 +3600,21 @@ function _ensureNekoIdleReturnPresentationBridge() {
         const desktopChatMoveDistance = _getNekoIdleRectCenterMoveDistance(previousScreenRect, screenRect);
         const isSmallDesktopChatMove = !!(previousScreenRect && screenRect) &&
             desktopChatMoveDistance < _NEKO_IDLE_CAT1_RECHECK_MOVE_DISTANCE_PX;
-        _nekoIdleDesktopChatMinimizedState = {
-            minimized: !!(detail && detail.minimized && screenRect),
-            screenRect: screenRect,
-            updatedAt: Date.now()
-        };
+        _nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(
+            nextMinimized,
+            screenRect,
+            receivedAt,
+            sourceUpdatedAt,
+            !!(detail && !detail.minimized && !compactSurfaceCurrentlyVisible)
+        );
+        if (nextMinimized) {
+            _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
+                false,
+                null,
+                receivedAt,
+                sourceUpdatedAt
+            );
+        }
         document.querySelectorAll(_NEKO_IDLE_RETURN_BUTTON_SELECTOR).forEach((button) => {
             const currentState = button.__nekoIdleReturnSubactionState || button.__nekoIdleCat1Journey;
             if (currentState && (currentState.pairMovePlan || currentState.pairMoveFrame)) return;
@@ -3532,14 +3625,34 @@ function _ensureNekoIdleReturnPresentationBridge() {
 
     window.addEventListener('neko:idle-chat-compact-surface-state', (event) => {
         const detail = event && event.detail && typeof event.detail === 'object' ? event.detail : null;
+        const receivedAt = Date.now();
+        const sourceUpdatedAt = _getNekoIdleDesktopStateSourceUpdatedAt(detail, receivedAt);
+        if (_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopCompactSurfaceState)) return;
         const screenRect = detail && detail.visible
             ? _normalizeNekoIdleScreenRect(detail.screenRect)
             : null;
-        _nekoIdleDesktopCompactSurfaceState = {
-            visible: !!(detail && detail.visible && screenRect),
-            screenRect: screenRect,
-            updatedAt: Date.now()
-        };
+        const nextVisible = !!(detail && detail.visible && screenRect);
+        if (nextVisible &&
+            _nekoIdleDesktopChatMinimizedState &&
+            _nekoIdleDesktopChatMinimizedState.minimized &&
+            _isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)) {
+            return;
+        }
+        _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
+            nextVisible,
+            screenRect,
+            receivedAt,
+            sourceUpdatedAt
+        );
+        if (nextVisible) {
+            _nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(
+                false,
+                null,
+                receivedAt,
+                sourceUpdatedAt,
+                false
+            );
+        }
         _handleNekoIdleCompactSurfaceMoveState(detail);
     });
 

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -3639,9 +3639,14 @@ function _ensureNekoIdleReturnPresentationBridge() {
             _isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)) {
             return;
         }
-        // heartbeat 只用于维持 compact-top-edge 贴附位置同步，不得改变可见性状态缓存。
-        // 聊天框最小化后 compact-surface 心跳仍会继续广播 {visible:true,…}，如果让它
-        // 覆写 minimized state，CAT1 会在最小化后 1s 内失去毛线球步行目标。
+        // heartbeat 只用于维持 compact-top-edge 贴附位置同步，不得改变可见性状态：
+        // - 禁止通过 heartbeat 覆写 minimized state（聊天框最小化后心跳仍广播可见态，
+        //   清掉 minimized 会导致 CAT1 在最小化后 1s 内失去毛线球步行目标）。
+        // - 但 compact surface 可见时，心跳必须刷新缓存时间戳，防止 _NEKO_IDLE_DESKTOP_
+        //   COMPACT_SURFACE_RECT_STALE_MS (10s) 过期后 _getNekoIdleDesktopCompactSurfaceRect
+        //   返回 null，导致 CAT1 失去 compact-top-edge 目标。
+        // - 心跳用 receivedAt 刷新 updatedAt 防过期，但保留原 sourceUpdatedAt 避免扰乱
+        //   跨状态时间戳排序（心跳自身的新鲜时间戳会让 isStaleAgainst 永远判不出旧）。
         if (!heartbeat) {
             _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
                 nextVisible,
@@ -3658,6 +3663,18 @@ function _ensureNekoIdleReturnPresentationBridge() {
                     false
                 );
             }
+        } else if (nextVisible &&
+            _nekoIdleDesktopCompactSurfaceState &&
+            _nekoIdleDesktopCompactSurfaceState.visible) {
+            // 最小化时 compact state 已被 minimized listener 清为 visible:false，
+            // 此处不会进入——心跳不会把 minimized 态的「不可见 compact」刷回可见。
+            var prevCompactSourceUpdatedAt = _nekoIdleDesktopCompactSurfaceState.sourceUpdatedAt;
+            _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
+                true,
+                screenRect || _nekoIdleDesktopCompactSurfaceState.screenRect,
+                receivedAt,
+                prevCompactSourceUpdatedAt
+            );
         }
         _handleNekoIdleCompactSurfaceMoveState(detail);
     });

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -818,7 +818,7 @@ function _isNekoIdleDesktopStateNewerThan(sourceUpdatedAt, state) {
         incomingSourceUpdatedAt > 0 &&
         (!Number.isFinite(currentSourceUpdatedAt) ||
             currentSourceUpdatedAt <= 0 ||
-            incomingSourceUpdatedAt > currentSourceUpdatedAt);
+            incomingSourceUpdatedAt >= currentSourceUpdatedAt);
 }
 
 function _makeNekoIdleDesktopChatMinimizedState(minimized, screenRect, updatedAt, sourceUpdatedAt, expandedRecent) {
@@ -3631,6 +3631,7 @@ function _ensureNekoIdleReturnPresentationBridge() {
         const screenRect = detail && detail.visible
             ? _normalizeNekoIdleScreenRect(detail.screenRect)
             : null;
+        const heartbeat = !!(detail && detail.heartbeat);
         const nextVisible = !!(detail && detail.visible && screenRect);
         if (nextVisible &&
             _nekoIdleDesktopChatMinimizedState &&
@@ -3638,20 +3639,25 @@ function _ensureNekoIdleReturnPresentationBridge() {
             _isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)) {
             return;
         }
-        _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
-            nextVisible,
-            screenRect,
-            receivedAt,
-            sourceUpdatedAt
-        );
-        if (nextVisible) {
-            _nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(
-                false,
-                null,
+        // heartbeat 只用于维持 compact-top-edge 贴附位置同步，不得改变可见性状态缓存。
+        // 聊天框最小化后 compact-surface 心跳仍会继续广播 {visible:true,…}，如果让它
+        // 覆写 minimized state，CAT1 会在最小化后 1s 内失去毛线球步行目标。
+        if (!heartbeat) {
+            _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
+                nextVisible,
+                screenRect,
                 receivedAt,
-                sourceUpdatedAt,
-                false
+                sourceUpdatedAt
             );
+            if (nextVisible) {
+                _nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(
+                    false,
+                    null,
+                    receivedAt,
+                    sourceUpdatedAt,
+                    false
+                );
+            }
         }
         _handleNekoIdleCompactSurfaceMoveState(detail);
     });

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -3675,6 +3675,22 @@ function _ensureNekoIdleReturnPresentationBridge() {
                 receivedAt,
                 prevCompactSourceUpdatedAt
             );
+        } else if (nextVisible &&
+            _nekoIdleDesktopChatMinimizedState &&
+            !_nekoIdleDesktopChatMinimizedState.minimized) {
+            // 还原后来的心跳 catch-up：Electron setMinimized(false) 早退不发布
+            // compact-surface-state，compact 缓存仍为 minimize 时写下的
+            // visible:false。心跳说 visible + minimized 已 false → 信任心跳
+            // 恢复 compact 可用性，保留原 sourceUpdatedAt 不乱排序。
+            var prevCompactSourceUpdatedAt = _nekoIdleDesktopCompactSurfaceState
+                ? _nekoIdleDesktopCompactSurfaceState.sourceUpdatedAt
+                : sourceUpdatedAt;
+            _nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(
+                true,
+                screenRect,
+                receivedAt,
+                prevCompactSourceUpdatedAt
+            );
         }
         _handleNekoIdleCompactSurfaceMoveState(detail);
     });

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2344,6 +2344,11 @@ function _getNekoIdleCat1CompactTopEdgeTarget(container, surfaceRect, options = 
 }
 
 function _getNekoIdleCat1Target(container, chatRect, options = {}) {
+    const minimizedSideTarget = _getNekoIdleCat1SideTarget(container, chatRect);
+    if (minimizedSideTarget) {
+        return minimizedSideTarget;
+    }
+
     const compactSurfaceRect = _getNekoIdleChatCompactSurfaceRect();
     const compactTarget = _getNekoIdleCat1CompactTopEdgeTarget(container, compactSurfaceRect, {
         anchorRatio: options.anchorRatio
@@ -2354,7 +2359,7 @@ function _getNekoIdleCat1Target(container, chatRect, options = {}) {
         compactTarget.distance <= _NEKO_IDLE_CAT1_COMPACT_TOP_EDGE_FOLLOW_DISTANCE_PX) {
         return compactTarget;
     }
-    return _getNekoIdleCat1SideTarget(container, chatRect);
+    return null;
 }
 
 function _setNekoIdleCat1ContainerPosition(container, left, top) {

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -154,6 +154,21 @@ def test_react_chat_broadcasts_minimized_screen_rect_for_cat1_follow():
     assert "_NEKO_IDLE_DESKTOP_CHAT_RECT_STALE_MS = 2500" in avatar_source
 
 
+def test_cat1_minimized_ball_target_wins_over_stale_compact_surface():
+    source = _read(AVATAR_UI_BUTTONS_PATH)
+    target_block = _between(
+        source,
+        "function _getNekoIdleCat1Target(container, chatRect, options = {}) {",
+        "function _setNekoIdleCat1ContainerPosition",
+    )
+
+    side_index = target_block.index("const minimizedSideTarget = _getNekoIdleCat1SideTarget(container, chatRect);")
+    return_side_index = target_block.index("return minimizedSideTarget;")
+    compact_index = target_block.index("const compactSurfaceRect = _getNekoIdleChatCompactSurfaceRect();")
+    assert side_index < return_side_index < compact_index
+    assert "return null;" in target_block
+
+
 def test_electron_chat_loads_interpage_before_react_chat_for_desktop_cat1_sync():
     source = _read(CHAT_TEMPLATE_PATH)
 

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -169,6 +169,68 @@ def test_cat1_minimized_ball_target_wins_over_stale_compact_surface():
     assert "return null;" in target_block
 
 
+def test_desktop_cat1_minimized_and_compact_surface_state_are_timestamp_ordered():
+    source = _read(AVATAR_UI_BUTTONS_PATH)
+
+    assert "sourceUpdatedAt: 0" in source
+    assert "expandedRecent: false" in source
+    assert "function _getNekoIdleDesktopStateSourceUpdatedAt(detail, fallbackUpdatedAt)" in source
+    assert "function _isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, state)" in source
+    assert "function _isNekoIdleDesktopStateNewerThan(sourceUpdatedAt, state)" in source
+    assert "function _makeNekoIdleDesktopChatMinimizedState(minimized, screenRect, updatedAt, sourceUpdatedAt, expandedRecent)" in source
+    assert "function _makeNekoIdleDesktopCompactSurfaceState(visible, screenRect, updatedAt, sourceUpdatedAt)" in source
+    assert "if (state.expandedRecent === false) return false;" in source
+
+    pair_move_block = _between(
+        source,
+        "function _rememberNekoIdleDesktopChatPairMoveRect(screenRect) {",
+        "function _dispatchNekoIdleDesktopChatPairMoveBounds(screenRect) {",
+    )
+    assert "_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(" in pair_move_block
+    assert "_nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(" in pair_move_block
+
+    desktop_compact_rect = _between(
+        source,
+        "function _getNekoIdleDesktopCompactSurfaceRect() {",
+        "function _getNekoIdleChatCompactSurfaceRect() {",
+    )
+    assert "_nekoIdleDesktopChatMinimizedState.minimized" in desktop_compact_rect
+    assert "_isNekoIdleDesktopStateNewerThan(_nekoIdleDesktopChatMinimizedState.sourceUpdatedAt, state)" in desktop_compact_rect
+
+    desktop_minimized_rect = _between(
+        source,
+        "function _getNekoIdleDesktopChatMinimizedRect() {",
+        "function _isNekoIdleDesktopChatExpandedRecent() {",
+    )
+    assert "_nekoIdleDesktopCompactSurfaceState.visible" in desktop_minimized_rect
+    assert "_isNekoIdleDesktopStateNewerThan(_nekoIdleDesktopCompactSurfaceState.sourceUpdatedAt, state)" in desktop_minimized_rect
+
+    minimized_listener = _between(
+        source,
+        "window.addEventListener('neko:idle-chat-minimized-state', (event) => {",
+        "window.addEventListener('neko:idle-chat-compact-surface-state', (event) => {",
+    )
+    assert "const sourceUpdatedAt = _getNekoIdleDesktopStateSourceUpdatedAt(detail, receivedAt);" in minimized_listener
+    assert "if (_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)) return;" in minimized_listener
+    assert "const compactSurfaceCurrentlyVisible = !!_getNekoIdleDesktopCompactSurfaceRect();" in minimized_listener
+    assert "_nekoIdleDesktopCompactSurfaceState.visible" in minimized_listener
+    assert "_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopCompactSurfaceState)" in minimized_listener
+    assert "_nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(" in minimized_listener
+    assert "!!(detail && !detail.minimized && !compactSurfaceCurrentlyVisible)" in minimized_listener
+
+    compact_listener = _between(
+        source,
+        "window.addEventListener('neko:idle-chat-compact-surface-state', (event) => {",
+        "const currentTier = _readNekoAutoGoodbyeVisualTier();",
+    )
+    assert "const sourceUpdatedAt = _getNekoIdleDesktopStateSourceUpdatedAt(detail, receivedAt);" in compact_listener
+    assert "if (_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopCompactSurfaceState)) return;" in compact_listener
+    assert "_nekoIdleDesktopChatMinimizedState.minimized" in compact_listener
+    assert "_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)" in compact_listener
+    assert "_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(" in compact_listener
+    assert "false,\n                null,\n                receivedAt,\n                sourceUpdatedAt,\n                false" in compact_listener
+
+
 def test_electron_chat_loads_interpage_before_react_chat_for_desktop_cat1_sync():
     source = _read(CHAT_TEMPLATE_PATH)
 

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -172,8 +172,13 @@ def test_cat1_minimized_ball_target_wins_over_stale_compact_surface():
 def test_desktop_cat1_minimized_and_compact_surface_state_are_timestamp_ordered():
     source = _read(AVATAR_UI_BUTTONS_PATH)
 
-    assert "sourceUpdatedAt: 0" in source
-    assert "expandedRecent: false" in source
+    state_init_block = _between(
+        source,
+        "let _nekoIdleDesktopChatMinimizedState = {",
+        "function _getNekoIdleDesktopStateSourceUpdatedAt(detail, fallbackUpdatedAt) {",
+    )
+    assert "sourceUpdatedAt: 0" in state_init_block
+    assert "expandedRecent: false" in state_init_block
     assert "function _getNekoIdleDesktopStateSourceUpdatedAt(detail, fallbackUpdatedAt)" in source
     assert "function _isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, state)" in source
     assert "function _isNekoIdleDesktopStateNewerThan(sourceUpdatedAt, state)" in source
@@ -228,7 +233,10 @@ def test_desktop_cat1_minimized_and_compact_surface_state_are_timestamp_ordered(
     assert "_nekoIdleDesktopChatMinimizedState.minimized" in compact_listener
     assert "_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)" in compact_listener
     assert "_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(" in compact_listener
-    assert "false,\n                null,\n                receivedAt,\n                sourceUpdatedAt,\n                false" in compact_listener
+    reassign_line = compact_listener[compact_listener.index("_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState("):]
+    assert reassign_line.index("false") < reassign_line.index("null")
+    assert reassign_line.index("null") < reassign_line.index("receivedAt")
+    assert reassign_line.index("receivedAt") < reassign_line.index("sourceUpdatedAt")
 
 
 def test_electron_chat_loads_interpage_before_react_chat_for_desktop_cat1_sync():

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -237,6 +237,9 @@ def test_desktop_cat1_minimized_and_compact_surface_state_are_timestamp_ordered(
     assert "_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(" in compact_listener
     # heartbeat 分支必须保留原 sourceUpdatedAt，避免心跳新鲜时间戳扰乱跨状态排序
     assert "prevCompactSourceUpdatedAt" in compact_listener
+    # 还原后来心跳 catch-up：minimized 确认 false 但 compact 缓存尚未恢复时，
+    # heartbeat 应能恢复 compact 可见性（Electron setMinimized 早退不发布 compact 事件）
+    assert "!_nekoIdleDesktopChatMinimizedState.minimized" in compact_listener
     # minimized state 重赋值仅在 !heartbeat 分支内
     minimized_reassign_line = compact_listener[compact_listener.index("_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState("):]
     assert minimized_reassign_line.index("false") < minimized_reassign_line.index("null")

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -232,11 +232,16 @@ def test_desktop_cat1_minimized_and_compact_surface_state_are_timestamp_ordered(
     assert "if (_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopCompactSurfaceState)) return;" in compact_listener
     assert "_nekoIdleDesktopChatMinimizedState.minimized" in compact_listener
     assert "_isNekoIdleDesktopStateStaleAgainst(sourceUpdatedAt, _nekoIdleDesktopChatMinimizedState)" in compact_listener
+    assert "const heartbeat = !!(detail && detail.heartbeat);" in compact_listener
+    assert "if (!heartbeat) {" in compact_listener
     assert "_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(" in compact_listener
-    reassign_line = compact_listener[compact_listener.index("_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState("):]
-    assert reassign_line.index("false") < reassign_line.index("null")
-    assert reassign_line.index("null") < reassign_line.index("receivedAt")
-    assert reassign_line.index("receivedAt") < reassign_line.index("sourceUpdatedAt")
+    # heartbeat 分支必须保留原 sourceUpdatedAt，避免心跳新鲜时间戳扰乱跨状态排序
+    assert "prevCompactSourceUpdatedAt" in compact_listener
+    # minimized state 重赋值仅在 !heartbeat 分支内
+    minimized_reassign_line = compact_listener[compact_listener.index("_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState("):]
+    assert minimized_reassign_line.index("false") < minimized_reassign_line.index("null")
+    assert minimized_reassign_line.index("null") < minimized_reassign_line.index("receivedAt")
+    assert minimized_reassign_line.index("receivedAt") < minimized_reassign_line.index("sourceUpdatedAt")
 
 
 def test_electron_chat_loads_interpage_before_react_chat_for_desktop_cat1_sync():


### PR DESCRIPTION
## 修复内容

本 PR 修复 CAT1 在紧凑聊天最小化为毛线球后的两个定位问题：

1. CAT1 本应朝毛线球移动，但实际会向相反方向移动相同距离。
2. CAT1 本应根据毛线球在自身左侧或右侧切换朝向，但近距离左侧场景会判断反向，远距离场景正常。

## 根因

最小化聊天框后，CAT1 的目标点选择仍可能优先使用残留的 compact surface 几何信息，而不是当前独立毛线球的 side target。

这会导致：

- 移动目标点和真实毛线球位置不一致。
- 左右方向判断基于错误目标，出现近距离方向反转异常。

## 解决方案

调整 CAT1 idle target 的选择顺序：

- 优先使用最小化毛线球的 side target。
- 仅在毛线球目标不存在时，回退到 compact surface 顶边目标。
- 增加静态回归测试，锁定该优先级，避免后续再次被改回。

## 验证

已通过以下测试：

```bash
.\.venv\Scripts\python.exe -m pytest tests\unit\test_react_chat_idle_dock_static.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 引入跨源时间戳与陈旧判定，避免在其他来源更新后展示过期布局；优先选择侧边最小化目标、切换最小化时重置紧凑面板为不可见；心跳不再不当覆盖紧凑面板可见性。

* **Tests**
  * 新增单元测试，验证最小化与紧凑面板间的优先级与时间戳先后顺序行为符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->