### PR TITLE
fix: ensure fallback to free API provider when coreApi is empty or missing

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -678,8 +678,10 @@ def get_localized_default_characters(language: str | None = None) -> dict:
 
 DEFAULT_CORE_CONFIG = {
     "coreApiKey": "",
-    "coreApi": "qwen",
-    "assistApi": "qwen",
+    # 兜底默认走免费版而非付费的阿里 qwen：配置为空/缺失/损坏时，宁可落到不要 key、
+    # 不花钱的免费版，也绝不能静默切到付费服务商悄悄消耗用户额度。
+    "coreApi": "free",
+    "assistApi": "free",
     "assistApiKeyQwen": "",
     "assistApiKeyOpenai": "",
     "assistApiKeyGlm": "",

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -52,8 +52,6 @@ export type ChatWindowProps = ChatWindowSchemaProps & {
   onChoiceSelect?: (option: ChoiceOption, source: ChoicePromptSource) => void;
   onCompactChatStateChange?: (state: CompactChatState) => void;
   onCompactMinimizeRequest?: () => void;
-  // 注：compactMinimizeCancelSeq 在 message-schema.ts 的 chatWindowPropsSchema 里声明
-  // （ChatWindowSchemaProps 已含），必须在 schema 里、否则 parse 会 strip 掉（Codex P2）。
 };
 
 type CompactInlineExportBridge = {
@@ -1168,7 +1166,6 @@ function CompactChatApp({
   composerHidden = false,
   composerDisabled = false,
   chatSurfaceMode = 'compact',
-  compactMinimizeCancelSeq = 0,
   compactChatState,
   composerAttachments = [],
   composerAttachmentsAriaLabel = i18n('chat.pendingImagesAriaLabel', 'Pending attachments'),
@@ -1338,18 +1335,6 @@ function CompactChatApp({
   const [compactExportPreviewOpen, setCompactExportPreviewOpen] = useState(false);
   const [compactExportSelectedIds, setCompactExportSelectedIds] = useState<Set<string>>(() => new Set());
   const [compactExportAutoScrollToBottom, setCompactExportAutoScrollToBottom] = useState(true);
-  // 折叠进行中：点最小化时置 true → 蓝条（历史区开关）淡出（#2）+ 胶囊右→左擦除收走。mode 切到
-  // minimized 后由下方 useEffect 复位。展开进行中：minimized→compact 时置 true → 胶囊左→右展开 reveal。
-  // 这两个擦除/reveal 类必须由 React state 写进 className（而非 host/preload 用 classList 加）—— 否则
-  // React 重渲染会用 JSX className 覆盖、把类删掉，导致动画被打断、胶囊瞬跳（偶发"展开销毁闪一下"）。
-  const [compactCollapsing, setCompactCollapsing] = useState(false);
-  const [compactExpanding, setCompactExpanding] = useState(false);
-  const prevChatSurfaceModeRef = useRef(chatSurfaceMode);
-  // 折叠时若历史区是开的，记下「恢复后应重新打开历史区」。配合 closeCompactExportHistory
-  // ({persist:false})：折叠只播收回动画、不写偏好，恢复（minimized→compact）时据此重开。
-  const compactHistoryReopenAfterRestoreRef = useRef(false);
-  // host 折叠取消序号上次值，用于检测「取消」事件（见下方 useLayoutEffect）。
-  const prevCompactMinimizeCancelSeqRef = useRef(compactMinimizeCancelSeq);
   const compactSurfaceResizeStateRef = useRef<CompactSurfaceResizeState | null>(null);
   const compactHistoryResizeStateRef = useRef<CompactHistoryResizeState | null>(null);
   const compactHistoryVisibilitySuppressClickRef = useRef(false);
@@ -1624,15 +1609,11 @@ function CompactChatApp({
     persistCompactExportHistoryOpen(true);
     setCompactExportAutoScrollToBottom(true);
   }, [clearCompactExportHistoryUnmountTimer]);
-  // persist=false：只播收回动画、不把「历史区关闭」写进持久化偏好。折叠（minimize）时用，
-  // 这样 minimize→恢复后历史区按折叠前状态重新打开，而不是把临时折叠误当成偏好变更。
-  // 显式关闭（点蓝条/handle）仍默认 persist=true，正常写偏好。
-  const closeCompactExportHistory = useCallback((opts?: { persist?: boolean }) => {
-    const persist = opts?.persist !== false;
+  const closeCompactExportHistory = useCallback(() => {
     clearCompactExportHistoryUnmountTimer();
     setCompactExportHistoryClosingMessages(messages);
     setCompactExportHistoryOpen(false);
-    if (persist) persistCompactExportHistoryOpen(false);
+    persistCompactExportHistoryOpen(false);
     setCompactExportPreviewOpen(false);
     compactExportHistoryUnmountTimerRef.current = window.setTimeout(() => {
       setCompactExportHistoryMounted(false);
@@ -1643,86 +1624,6 @@ function CompactChatApp({
   useEffect(() => () => {
     clearCompactExportHistoryUnmountTimer();
   }, [clearCompactExportHistoryUnmountTimer]);
-  // 展开 reveal：minimized → compact（恢复）时置 compactExpanding → 胶囊左→右展开（React state 写
-   // className，不被覆盖）。~340ms 后复位。prev ref 仅在此 effect（deps 只 mode）更新，准确跟踪模式变化。
-   // 用 useLayoutEffect 而非 useEffect：passive effect 在首帧绘制后才置 compactExpanding，胶囊会先
-   // 无 mask 全显一帧再重启擦除（Codex P2）。Electron 路径有壳侧 opacity-0 稳定门挡着看不出，但 web
-   // compact 路径没有那道门，layout effect 让首帧绘制前就挂上 mask，消除 web 端首帧闪。仅提前 1 帧，
-   // 340ms 擦除时长不变，prev ref 无其它时序读者 → 无竞态。
-  useLayoutEffect(() => {
-    const prev = prevChatSurfaceModeRef.current;
-    prevChatSurfaceModeRef.current = chatSurfaceMode;
-    // 重新进入 compact（从 minimized 或 full）时消费历史区重开请求（折叠时 persist:false 记下的）。
-    // 不限于 minimized→compact——经公开 setChatSurfaceMode 的 minimized→full→compact 间接恢复也要重开，
-    // 否则历史区该开没开、而偏好其实仍是开（Codex P2）。ref 仅在「带历史区折叠」时置位，无请求不触发。
-    // 注意用 prev!=='compact' 而非裸 mode==='compact'：折叠点击当帧 mode 仍是 compact，裸判会立即把刚
-    // 关掉的历史区又开回来。
-    if (chatSurfaceMode === 'compact' && prev !== 'compact'
-      && compactHistoryReopenAfterRestoreRef.current) {
-      compactHistoryReopenAfterRestoreRef.current = false;
-      openCompactExportHistory();
-    }
-    // 方向性 reveal 擦除只在毛线球 minimized→compact 恢复时播（full→compact 不播）。~340ms 后复位。
-    // useLayoutEffect 让首帧绘制前就挂 mask，消除 web 端首帧闪（壳侧有 opacity-0 门、Electron 看不出）。
-    if (prev === 'minimized' && chatSurfaceMode === 'compact') {
-      setCompactExpanding(true);
-      const t = window.setTimeout(() => setCompactExpanding(false), 340);
-      return () => window.clearTimeout(t);
-    }
-    return undefined;
-  }, [chatSurfaceMode, openCompactExportHistory]);
-  // 折叠完成（mode→minimized）后复位 compactCollapsing：此刻蓝条/胶囊已随 isCompactSurface 卸载，
-  // 复位无视觉副作用，只为下次恢复干净。
-  useEffect(() => {
-    if (chatSurfaceMode === 'minimized' && compactCollapsing) {
-      setCompactCollapsing(false);
-    }
-  }, [chatSurfaceMode, compactCollapsing]);
-  // 展开被打断时复位 compactExpanding：展开 reveal 是「minimized→compact 置 expanding→true，340ms
-  // 后复位」。若这 340ms 内 mode 又被切走（如公开 setChatSurfaceMode('full') / setViewProps），上面
-  // 展开 effect 的 cleanup 取消了那次 setCompactExpanding(false)，而该转换不是从这里发起 → expanding
-  // 残留 true 带进后续 compact 渲染，令 full→compact 重放/保留展开 mask（Codex P2）。离开 compact 即复位。
-  useEffect(() => {
-    if (chatSurfaceMode !== 'compact' && compactExpanding) {
-      setCompactExpanding(false);
-    }
-  }, [chatSurfaceMode, compactExpanding]);
-  // 安全兜底：折叠流程是「compact 态置 collapsing→true，host ~280ms 后把 mode 切 minimized，
-  // 上面的 minimized 复位 effect 清掉 collapsing」。但若这 280ms 内窗口被关闭 / 折叠被取消，
-  // mode 永远到不了 minimized，collapsing 会卡在 true；而 host 的 closeWindow 是隐藏而非卸载
-  // React 树，重开时复用同一组件 → 胶囊带着 neko-compact-collapsing 的 mask 卡在不可见末态
-  // （Codex P2）。这里挂一道超过擦除时长（280ms wipe）的兜底超时确保复位：正常折叠会在
-  // mode→minimized 时先复位、cleanup 清掉本超时（永不触发）；仅在取消场景兜底，此时窗口已隐藏，
-  // 复位无可见副作用。
-  useEffect(() => {
-    if (!compactCollapsing) return undefined;
-    const t = window.setTimeout(() => {
-      setCompactCollapsing(false);
-      // 折叠被取消（mode 没到 minimized，故正常的 minimized→compact 重开路径不会触发）→ 若折叠时
-      // 用 persist:false 关掉了历史区，这里把它恢复回开，否则历史区会被一次未完成的折叠永久收起、
-      // 而持久化偏好其实仍是开的（Codex P2）。openCompactExportHistory 在非 compact 态仅置状态、
-      // 不渲染（受 isCompactSurface 门控），无副作用。正常折叠走 minimized→compact 重开、不到这里。
-      if (compactHistoryReopenAfterRestoreRef.current) {
-        compactHistoryReopenAfterRestoreRef.current = false;
-        openCompactExportHistory();
-      }
-    }, 600);
-    return () => window.clearTimeout(t);
-  }, [compactCollapsing, openCompactExportHistory]);
-  // host 折叠取消序号变化 = 一次进行中的折叠被取消（如 280ms 折叠延时内 closeWindow）。host 关窗
-  // 只隐藏 overlay、React 树与 state 存活；重开时该 prop 携新值到达。用 useLayoutEffect 在重开
-  // 首帧绘制前立即复位 compactCollapsing 并恢复历史区——否则要等上面 600ms 兜底，快速「关→重开」
-  // 会让 compact 表面带着擦除 mask 的不可见 forwards 末态 + 历史区临时关闭重新出现（Codex P2）。
-  // 600ms 兜底保留作为「取消后一直没重开」场景的更晚双保险。
-  useLayoutEffect(() => {
-    if (compactMinimizeCancelSeq === prevCompactMinimizeCancelSeqRef.current) return;
-    prevCompactMinimizeCancelSeqRef.current = compactMinimizeCancelSeq;
-    setCompactCollapsing(false);
-    if (compactHistoryReopenAfterRestoreRef.current) {
-      compactHistoryReopenAfterRestoreRef.current = false;
-      openCompactExportHistory();
-    }
-  }, [compactMinimizeCancelSeq, openCompactExportHistory]);
   const handleCompactHistoryVisibilityToggle = useCallback(() => {
     if (compactExportHistoryOpen) {
       closeCompactExportHistory();
@@ -4965,23 +4866,7 @@ function CompactChatApp({
           return;
         }
         clearActiveCursorToolSelection();
-        // onCompactMinimizeRequest 是可选 prop：真正把 surfaceMode 切到 'minimized'
-        // 的是宿主回调，切回 minimized 后才会复位 compactCollapsing。宿主没传回调时
-        // 若仍 setCompactCollapsing(true)，模式永不变、collapsing 永不复位，蓝条/胶囊
-        // 会一直卡在折叠样式（CodeRabbit Major）。所以缺回调时直接早退、不进折叠态。
-        if (!onCompactMinimizeRequest) {
-          return;
-        }
-        // #3 折叠时若历史区已开，异步触发其收回动画（与折叠并行，不阻塞）。
-        // 用 persist:false：只播收回动画、不把「关闭」写进偏好；并记下恢复后重开，
-        // 这样 minimize→恢复后历史区按折叠前状态重新打开（不把临时折叠误当偏好变更）。
-        if (compactExportHistoryOpen) {
-          compactHistoryReopenAfterRestoreRef.current = true;
-          closeCompactExportHistory({ persist: false });
-        }
-        // #2 折叠时蓝条（历史区开关）淡出。compactCollapsing→true 给蓝条加 is-collapsing。
-        setCompactCollapsing(true);
-        onCompactMinimizeRequest();
+        onCompactMinimizeRequest?.();
       }}
     >
       <img
@@ -5662,7 +5547,7 @@ function CompactChatApp({
   const compactExportHistoryNode = compactExportHistoryElement;
   const compactHistoryVisibilityHandleNode = isCompactSurface ? (
     <button
-      className={`compact-history-visibility-handle${compactExportHistoryOpen ? ' is-open' : ''}${compactCollapsing ? ' is-collapsing' : ''}`}
+      className={`compact-history-visibility-handle${compactExportHistoryOpen ? ' is-open' : ''}`}
       type="button"
       aria-label={compactExportHistoryToggleLabel}
       aria-expanded={compactExportHistoryOpen}
@@ -5811,13 +5696,7 @@ function CompactChatApp({
           }}>
             {isCompactSurface ? (
               <div
-                className={`compact-chat-surface-shell${
-                  compactCollapsing
-                    ? ' neko-compact-collapsing'
-                    : compactExpanding
-                      ? ' neko-compact-expanding'
-                      : ''
-                }`}
+                className="compact-chat-surface-shell"
                 ref={compactInputShellRef}
                 data-compact-chat-state={effectiveCompactChatState}
                 data-compact-tool-layer-open={compactToolToggleVisible && compactInputToolFanOpen ? 'true' : 'false'}

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -216,11 +216,6 @@ export const chatWindowPropsSchema = z.object({
   composerHidden: z.boolean().optional(),
   composerDisabled: z.boolean().optional(),
   chatSurfaceMode: chatSurfaceModeSchema.optional(),
-  // host 折叠取消序号：必须在 schema 里声明，否则 z.object().parse() 默认 strip 未知键、
-  // App 永远只看到默认 0，重开立即复位的 useLayoutEffect 不会触发（Codex P2）。
-  // 逻辑上是单调递增的非负整数计数（host 从 0 起 += 1），加 int/nonnegative 作边界防御
-  // （CodeRabbit）；host 恒传合法值，约束不会触发拒绝。
-  compactMinimizeCancelSeq: z.number().int().nonnegative().optional(),
   compactChatState: compactChatStateSchema.optional(),
   onCompactChatStateChange: z.function()
     .args(compactChatStateSchema)

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3038,62 +3038,6 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   width: clamp(124px, calc(var(--compact-history-handle-surface-width) * 0.30), 168px);
 }
 
-/* #2 折叠时蓝条（历史区开关）淡出：App.tsx 点最小化置 compactCollapsing→加 .is-collapsing，
-   ~0.22s 淡掉，与折叠擦除同步消失。 */
-.compact-history-visibility-handle.is-collapsing {
-  opacity: 0;
-  transition: opacity 0.18s ease 0.08s; /* 略延 0.08s 再淡 0.18s，~0.26s 内消失（在 host 折叠 280ms 窗口内） */
-  pointer-events: none;
-}
-
-/* 折叠/展开方向性擦除 + 毛绒球按下挤压动画。这些 class 由 React 组件（App.tsx）发出，
-   但动画规则原本只在 host 的 static/css/index.css。Vite dev / 独立 React bundle 路径下没有
-   index.css，class 会失效、擦除/挤压不跑（Codex P2）。这里在 bundle 自带的 styles.css 里镜像
-   同一套规则，保证组件自带动画 CSS。两份保持一致。 */
-@keyframes neko-compact-minimize-press {
-  0%   { transform: scale(1, 1); }
-  30%  { transform: scale(1.12, 0.74); }
-  58%  { transform: scale(0.94, 1.08); }
-  80%  { transform: scale(1.03, 0.97); }
-  100% { transform: scale(1, 1); }
-}
-.compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
-  transform-origin: center bottom;
-  animation: neko-compact-minimize-press 420ms cubic-bezier(0.3, 0.8, 0.4, 1) both;
-}
-@keyframes neko-compact-collapse-wipe {
-  from { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
-  to   { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
-}
-@keyframes neko-compact-expand-wipe {
-  from { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
-  to   { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
-}
-.compact-chat-surface-shell.neko-compact-collapsing,
-.compact-chat-surface-shell.neko-compact-expanding {
-  -webkit-mask-image: linear-gradient(to right, #000 33%, transparent 50%);
-  mask-image: linear-gradient(to right, #000 33%, transparent 50%);
-  -webkit-mask-size: 300% 100%; mask-size: 300% 100%;
-  -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
-}
-.compact-chat-surface-shell.neko-compact-collapsing {
-  animation: neko-compact-collapse-wipe 280ms ease forwards;
-}
-.compact-chat-surface-shell.neko-compact-expanding {
-  animation: neko-compact-expand-wipe 300ms ease forwards;
-}
-/* reduced-motion 禁用上面这些动画。必须放在动画规则之后：同特异性下 CSS 后定义者胜、
-   media query 不加特异性（与 index.css 同样处理，Codex P2）。 */
-@media (prefers-reduced-motion: reduce) {
-  .compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
-    animation: none;
-  }
-  .compact-chat-surface-shell.neko-compact-collapsing,
-  .compact-chat-surface-shell.neko-compact-expanding {
-    animation: none;
-  }
-}
-
 .compact-history-visibility-handle::before,
 .compact-history-visibility-handle::after {
   content: "";

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -619,7 +619,8 @@ async def get_core_config_api():
         # 但只能回退到与 coreApi / assistApi 匹配的服务商，
         # 以免将不兼容的 API Key 填充到其他服务商。
         fallback_key = api_key if api_key != 'free-access' else ''
-        _core_api_provider = core_cfg.get('coreApi') or runtime_core_api_provider or 'qwen'
+        # 兜底服务商用免费版而非付费阿里 qwen：coreApi 为空/缺失时不静默切到付费服务商。
+        _core_api_provider = core_cfg.get('coreApi') or runtime_core_api_provider or 'free'
         _assist_api_provider = core_cfg.get('assistApi') or runtime_assist_api_provider
         if not _assist_api_provider:
             _assist_api_provider = 'free' if _core_api_provider == 'free' else 'qwen'
@@ -758,9 +759,12 @@ async def update_core_config(request: Request):
                 return {"success": False, "error": str(exc)}
             if api_key is not None:
                 core_cfg['coreApiKey'] = api_key
-        if 'coreApi' in data:
+        # coreApi / assistApi 为空串 = 前端在配置尚未加载完成（下拉被清空）时提交。
+        # 绝不能用空值覆盖已存的有效 provider——否则重新加载时空值会被兜底成别的服务商，
+        # 把免费版用户悄悄切走。仅在非空时写入；空值保留 existing_core_cfg 里的旧值。
+        if data.get('coreApi'):
             core_cfg['coreApi'] = data['coreApi']
-        if 'assistApi' in data:
+        if data.get('assistApi'):
             core_cfg['assistApi'] = data['assistApi']
         if 'resolvedProviderUrls' in data:
             resolved_urls = data.get('resolvedProviderUrls')

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -2223,7 +2223,6 @@
             _toolCursorResetKey: state._toolCursorResetKey || undefined,
             composerHidden: state.composerHidden,
             chatSurfaceMode: getCurrentChatSurfaceMode(),
-            compactMinimizeCancelSeq: compactMinimizeCancelSeq,
             compactChatState: getCurrentCompactChatState(),
             galgameModeEnabled: !!state.galgameModeEnabled,
             galgameOptions: Array.isArray(state.galgameOptions) ? state.galgameOptions : [],
@@ -3198,69 +3197,8 @@
     // React compact 输入框/胶囊左侧毛绒球点按 → 折叠为 minimized。最小化控制权在宿主，
     // 走 setChatSurfaceMode('minimized')（既有的 setMinimized + 位置持久化 + chat-surface-mode-change
     // 派发都在其中）；不用 toggleMinimized——毛绒球只在非 minimized 态出现，语义恒为「收起」。
-    //
-    // 说明：曾尝试「在 compact 态把 root 原位慢速淡出 + 提前异步显示独立球」做收起 overlap，但
-    // (a) 淡出期间 compact 仍可交互/未冻结，提前显示的球与 relayout/hit-test/moveTop 互相打架 →
-    //     球在光标下抖、cursor 在箭头/手之间闪；
-    // (b) 给 root 设 inline opacity:0 做淡出，频繁点击时 setMinimized 因状态 desync 提前 return、
-    //     跳过 opacity 复位 → root 卡在 0 = 输入框隐身。
-    // 这套机制竞态太重，已回退。现仅保留一个安全增强：给按下的毛绒球补「按下挤压」动画（CSS），
-    // 留一个短延时让挤压动画露出来再瞬时折叠（折叠本体走原有 PRE_COLLAPSE_DIM 瞬时路径，零竞态）。
-    // 独立球出现时的「放大长出」靠球自身入场动画（neko-ball-appear），与此处解耦。
-    var COMPACT_MINIMIZE_PRESS_MS = 280; // = neko-compact-collapse-wipe 擦除时长：擦完再瞬时折叠
-    var compactMinimizePressTimer = 0;
-    var compactMinimizeCancelSeq = 0; // 折叠取消序号（见 clearCompactMinimizePressTimer），传给 React
-    // 清掉挂起的「按下挤压→瞬时折叠」延时。窗口关闭/动画取消时必须调用，否则这个
-    // 跨 280ms 存活的回调会在窗口已关闭/重开后仍 setChatSurfaceMode('minimized')，
-    // 把更新后的状态覆盖成「幽灵最小化」（CodeRabbit Minor / Codex P2）。
-    function clearCompactMinimizePressTimer() {
-        if (!compactMinimizePressTimer) return;
-        window.clearTimeout(compactMinimizePressTimer);
-        compactMinimizePressTimer = 0;
-        // 真清掉一个 pending 折叠延时 = 一次进行中的折叠被取消（如 280ms 内 closeWindow）。
-        // 递增序号；buildRenderProps 把它当 prop 传给 React，让组件在重开时立即复位
-        // compactCollapsing，而不必等 600ms 兜底——否则快速「关→重开」会让 compact 表面带着擦除
-        // mask 的不可见末态 + 历史区临时关闭重新出现（Codex P2）。
-        compactMinimizeCancelSeq += 1;
-    }
     function handleCompactMinimizeRequest() {
-        // reduced-motion：折叠擦除/按压挤压动画已被 CSS（@media prefers-reduced-motion: reduce）
-        // 禁用，此时再延时 COMPACT_MINIMIZE_PRESS_MS(280ms) 才折叠，只会让窗口「点了没反应」一段，
-        // 无任何动画反馈。无障碍模式下直接立即折叠，保持即时响应（Codex P2）。
-        var reduceMotion = false;
-        try {
-            reduceMotion = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
-        } catch (e) {}
-        if (reduceMotion) {
-            setChatSurfaceMode('minimized');
-            return;
-        }
-        // 给按下的毛绒球补「按下挤压」弹性动画（CSS index.css neko-compact-minimize-press）。
-        try {
-            var pressIcons = document.querySelectorAll('.compact-chat-minimize-ball-icon');
-            for (var pi = 0; pi < pressIcons.length; pi++) {
-                var pressIcon = pressIcons[pi];
-                pressIcon.classList.remove('neko-minimize-ball-pressing');
-                void pressIcon.offsetWidth;
-                pressIcon.classList.add('neko-minimize-ball-pressing');
-            }
-        } catch (e) {}
-        // 防重入：擦除途中再次点最小化忽略。
-        if (compactMinimizePressTimer) return;
-        // #1 折叠方向性擦除（右→左收）由 App.tsx 的 compactCollapsing state 驱动 className 实现
-        //    （onClick 里已 setCompactCollapsing(true)）—— 不再在此用 classList 加类（会被 React 重渲染覆盖）。
-        // web 与 Electron 统一走这条 = 擦除时长的延时再瞬时折叠：web 若同步 setChatSurfaceMode
-        // ('minimized') 会在下一帧前就让 isCompactSurface=false、卸载 .compact-chat-surface-shell，
-        // 新加的 neko-compact-collapsing 擦除遮罩与蓝条淡出根本来不及渲染（Codex P2）。
-        compactMinimizePressTimer = window.setTimeout(function () {
-            compactMinimizePressTimer = 0;
-            // 守卫：擦除期间宿主可能把 surface mode 切走（关闭/重开经
-            // closeWindow→cancelActiveAnimation 清掉本 timer；或经公开 API setChatSurfaceMode
-            // ('full') / setViewProps 直写 state 绕过清理）。只有「仍处于 compact」才执行这次
-            // 延迟折叠，否则会用陈旧的 minimized 覆盖更新后的模式（Codex P2）。两端通用。
-            if (getCurrentChatSurfaceMode() !== 'compact') return;
-            setChatSurfaceMode('minimized');
-        }, COMPACT_MINIMIZE_PRESS_MS);
+        setChatSurfaceMode('minimized');
     }
 
     function handleMiniGameInviteChoice(option) {
@@ -3521,9 +3459,6 @@
             }
             state.chatSurfaceMode = normalizedChatSurfaceMode;
             if (surfaceModeChanged) {
-                // 同 setChatSurfaceMode：mode 经此公开入口变更时取消挂起的延时折叠，防 full→compact
-                // hop 内陈旧折叠回调误折叠刚恢复的表面（Codex P2）。timer 已=0 时为 no-op。
-                clearCompactMinimizePressTimer();
                 // setViewProps is a public entry point (exposed + the
                 // `set-view-props` event), so it can land a real surface change —
                 // e.g. an external `{chatSurfaceMode:'full'}`. Mirror
@@ -4560,9 +4495,6 @@
             activeAnimationCleanup = null;
         }
         isMinimizeTransitioning = false;
-        // 取消进行中的折叠/展开时一并清掉挂起的「按下挤压→瞬时折叠」延时（closeWindow
-        // 也走这里），避免该回调在窗口关闭/重开后幽灵触发 setChatSurfaceMode('minimized')。
-        clearCompactMinimizePressTimer();
     }
 
     // The minimized ball belongs to the surface we'll restore to: the revived
@@ -4633,12 +4565,6 @@
             syncChatSurfaceModeUI();
             return normalized;
         }
-
-        // 任何真实的 surface mode 变更都取消挂起的「按下挤压→延时折叠」：否则 full→compact 之类
-        // 快速跳变会让 280ms 内的陈旧折叠回调在 mode 又回到 compact 时误折叠刚恢复的表面（Codex P2，
-        // 仅靠回调里 getCurrentChatSurfaceMode()==='compact' 守卫挡不住这种 hop）。timer 自身的
-        // minimize 调用此时 timer 已=0，clear 为 no-op，不影响正常折叠。
-        clearCompactMinimizePressTimer();
 
         if (!nextMinimized) {
             lastRestorableChatSurfaceMode = normalized;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -992,66 +992,6 @@ body.subtitle-web-host #react-chat-window-shell.is-dragging {
     box-shadow: 0 36px 110px rgba(12, 20, 34, 0.36);
 }
 
-/* compact 输入框左侧毛绒球「按下挤压回弹」弹性动画：点按折叠时由 app-react-chat-window.js
-   handleCompactMinimizeRequest 给图标加 .neko-minimize-ball-pressing 触发（与展开时按独立
-   球的 squash bounce 对偶；折叠原本无动画）。运行中的动画 transform 会盖过 :active 的 scale(1.08)。
-   transform-origin 底部 + scale Y 变矮/X 变宽 = 向下挤扁（不是均匀缩小），与 neko-ball-bounce 同手感。 */
-@keyframes neko-compact-minimize-press {
-    0%   { transform: scale(1, 1); }
-    30%  { transform: scale(1.12, 0.74); }  /* 向下挤扁（squash：变宽变矮） */
-    58%  { transform: scale(0.94, 1.08); }  /* 回弹拉伸 */
-    80%  { transform: scale(1.03, 0.97); }  /* 小回压 */
-    100% { transform: scale(1, 1); }        /* 落定 */
-}
-.compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
-    transform-origin: center bottom;
-    animation: neko-compact-minimize-press 420ms cubic-bezier(0.3, 0.8, 0.4, 1) both;
-}
-
-/* compact 对话条折叠/展开的「方向性渐变擦除」：折叠＝从右往左收（右先消失），展开＝反向从左往右展。
-   作用在 .compact-chat-surface-shell（position:fixed 的胶囊本体）上 —— 不能擦 #react-chat-window-root，
-   因为 fixed 子元素可能在 root 盒子外、mask 盖不到。用 mask 渐变 + 动 mask-position（gradient 本身
-   不可 tween，但 mask-position 可以）实现软边扫过。
-   安全：展开用 forwards 让保留态 = mask-position 0%（全可见），即使清理失败也不隐身；折叠类由宿主
-   setChatSurfaceMode 顶部无条件复位兜底（频繁点击也不会卡在「擦没了」）。 */
-@keyframes neko-compact-collapse-wipe {
-    from { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
-    to   { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
-}
-@keyframes neko-compact-expand-wipe {
-    from { -webkit-mask-position: 100% 0; mask-position: 100% 0; }
-    to   { -webkit-mask-position: 0% 0;   mask-position: 0% 0; }
-}
-.compact-chat-surface-shell.neko-compact-collapsing,
-.compact-chat-surface-shell.neko-compact-expanding {
-    /* mask 300% 宽 + 渐变软边落在中间三分之一：mask-position 0% 时胶囊只看到纯黑（全可见），
-       100% 时只看到全透明（全隐），软边在 0%↔100% 之间从右向左/左向右扫过。 */
-    -webkit-mask-image: linear-gradient(to right, #000 33%, transparent 50%);
-    mask-image: linear-gradient(to right, #000 33%, transparent 50%);
-    -webkit-mask-size: 300% 100%; mask-size: 300% 100%;
-    -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
-}
-.compact-chat-surface-shell.neko-compact-collapsing {
-    animation: neko-compact-collapse-wipe 280ms ease forwards;
-}
-.compact-chat-surface-shell.neko-compact-expanding {
-    animation: neko-compact-expand-wipe 300ms ease forwards;
-}
-
-/* 减少动态效果偏好下，禁用毛绒球按压挤压与折叠/展开方向性擦除动画，给动画敏感用户
-   即时的折叠/展开（CodeRabbit 无障碍 nitpick）。仅影响开启该系统设置的用户。
-   必须放在上面动画规则之后：同特异性（两类选择器）下 CSS 后定义者胜，media query 不加
-   特异性，若放在文件靠前的 @media 块里会被这些动画规则覆盖、override 不生效（Codex P2）。 */
-@media (prefers-reduced-motion: reduce) {
-    .compact-chat-minimize-ball-icon.neko-minimize-ball-pressing {
-        animation: none;
-    }
-    .compact-chat-surface-shell.neko-compact-collapsing,
-    .compact-chat-surface-shell.neko-compact-expanding {
-        animation: none;
-    }
-}
-
 /* GalGame 模式：撑高聊天框最小高度，避免移动/桌面下选项被裁切 */
 body.galgame-mode-enabled #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
     min-height: min(420px, calc(100vh - 22px));

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1903,6 +1903,15 @@ async function save_button_down(e) {
         }
     }
 
+    // 防御：coreApi 为空 = 服务商下拉尚未加载完成（loadCurrentApiKey 起手会先把下拉
+    // 清空成 ''，再 await 后端数据异步回填）。在这个窗口内点保存（尤其是开着自定义API
+    // 绕过了下方的空 Key 校验时）会把空 coreApi 写盘，后端解析时会把空值兜底成别的
+    // 服务商，导致免费版被悄悄切走、key 失效。一律中止保存并提示稍候重试，绝不写空 provider。
+    if (!coreApi) {
+        showStatus(window.t ? window.t('api.configNotReady') : '配置尚未加载完成，请稍候重试', 'error');
+        return;
+    }
+
     // 处理API Key（优先读取真实 key）
     let apiKey = getRealKey(apiKeyInput);
     if (isFreeVersionText(apiKey)) {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "Save failed: {{error}}",
         "apiKeyInvalid": "API Key is invalid",
         "apiKeyInvalidRetry": "API Key is invalid, please re-enter",
+        "configNotReady": "Configuration is still loading, please try again in a moment",
         "saveNetworkError": "Save failed, please check network connection",
         "saveError": "Error while saving: {{error}}",
         "saveSuccess": "API Key saved successfully!",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "Error al guardar: {{error}}",
         "apiKeyInvalid": "La clave API no es válida",
         "apiKeyInvalidRetry": "La clave API no es válida; vuelva a ingresarla",
+        "configNotReady": "La configuración aún se está cargando, inténtalo de nuevo en un momento",
         "saveNetworkError": "Error al guardar, verifique la conexión de red",
         "saveError": "Error al guardar: {{error}}",
         "saveSuccess": "¡La clave API se guardó correctamente!",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "保存失敗: {{error}}",
         "apiKeyInvalid": "APIキーが無効です",
         "apiKeyInvalidRetry": "APIキーが無効です。再入力してください",
+        "configNotReady": "設定の読み込みが完了していません。少し待ってから再試行してください",
         "saveNetworkError": "保存失敗。ネットワーク接続を確認してください",
         "saveError": "保存エラー: {{error}}",
         "saveSuccess": "APIキーを保存しました！",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "저장 실패: {{error}}",
         "apiKeyInvalid": "API 키가 잘못되었습니다.",
         "apiKeyInvalidRetry": "API 키가 잘못되었습니다. 다시 입력하세요.",
+        "configNotReady": "설정이 아직 로드되지 않았습니다. 잠시 후 다시 시도해 주세요",
         "saveNetworkError": "저장에 실패했습니다. 네트워크 연결을 확인하세요.",
         "saveError": "저장 중 오류 발생: {{error}}",
         "saveSuccess": "API 키가 성공적으로 저장되었습니다!",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "Falha ao salvar: {{error}}",
         "apiKeyInvalid": "A chave de API é inválida",
         "apiKeyInvalidRetry": "A chave de API é inválida. Digite novamente",
+        "configNotReady": "A configuração ainda está carregando, tente novamente em instantes",
         "saveNetworkError": "Falha ao salvar, verifique a conexão de rede",
         "saveError": "Erro ao salvar: {{error}}",
         "saveSuccess": "Chave de API salva com sucesso!",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "Ошибка сохранения: {{error}}",
         "apiKeyInvalid": "API Key недействителен",
         "apiKeyInvalidRetry": "API Key недействителен, введите заново",
+        "configNotReady": "Конфигурация ещё загружается, повторите попытку через мгновение",
         "saveNetworkError": "Ошибка сохранения, проверьте сеть",
         "saveError": "Ошибка при сохранении: {{error}}",
         "saveSuccess": "API Key сохранён успешно!",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "保存失败: {{error}}",
         "apiKeyInvalid": "API Key无效",
         "apiKeyInvalidRetry": "API Key无效，请重新输入",
+        "configNotReady": "配置尚未加载完成，请稍候重试",
         "saveNetworkError": "保存失败，请检查网络连接",
         "saveError": "保存时出错: {{error}}",
         "saveSuccess": "API Key保存成功！",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1146,6 +1146,7 @@
         "saveFailed": "保存失敗: {{error}}",
         "apiKeyInvalid": "API Key無效",
         "apiKeyInvalidRetry": "API Key無效，請重新輸入",
+        "configNotReady": "設定尚未載入完成，請稍候重試",
         "saveNetworkError": "保存失敗，請檢查網絡連接",
         "saveError": "保存時出錯: {{error}}",
         "saveSuccess": "API Key保存成功！",

--- a/tests/frontend/test_repro_custom_toggle.py
+++ b/tests/frontend/test_repro_custom_toggle.py
@@ -1,0 +1,121 @@
+"""回归：自定义 API 开关 / 加载竞态不能把免费版悄悄切成付费阿里。
+
+历史 bug：loadCurrentApiKey 起手把服务商下拉清成 ''，再异步回填。在这个窗口内
+开着自定义 API 点保存时，空 coreApi 绕过了空 Key 校验被写盘，后端把空值兜底成
+付费的 qwen(阿里 dashscope)，残留的 free-access 被发给阿里 → 「API key 无效」。
+
+修复三层：
+  A1 前端 save_button_down：coreApi 为空时中止保存（提示稍候重试）。
+  A2 后端 update_core_config：空 coreApi/assistApi 不覆盖已存的有效值。
+  B  解析兜底：空/缺失/损坏 → free（不花钱），而非 qwen。
+"""
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+def _establish_free_config(page: Page):
+    """直接 POST 一个干净的免费版配置作为基线。"""
+    result = page.evaluate(
+        """async () => {
+            const r = await fetch('/api/config/core_api', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    coreApiKey: 'free-access', coreApi: 'free',
+                    assistApi: 'free', enableCustomApi: false,
+                }),
+            });
+            return await r.json();
+        }"""
+    )
+    assert result.get("success"), f"建立免费版基线失败: {result}"
+
+
+def _open_free_settings(page: Page, server: str):
+    page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    page.goto(f"{server}/api_key")
+    expect(page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    _establish_free_config(page)
+    page.reload()
+    expect(page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    page.wait_for_selector("#coreApiSelect option[value='free']", state="attached", timeout=10000)
+    expect(page.locator("#coreApiSelect")).to_have_value("free", timeout=5000)
+
+
+@pytest.mark.frontend
+def test_pure_free_toggle_preserves_free(mock_page: Page, running_server: str):
+    """场景：纯免费版老老实实开自定义API再关掉 → coreApi/assistApi 仍是 free。"""
+    _open_free_settings(mock_page, running_server)
+
+    mock_page.evaluate(
+        """() => {
+            const cb = document.getElementById('enableCustomApi');
+            cb.checked = true;  cb.dispatchEvent(new Event('change', {bubbles:true}));
+            cb.checked = false; cb.dispatchEvent(new Event('change', {bubbles:true}));
+        }"""
+    )
+
+    payload = mock_page.evaluate(
+        """async () => {
+            window.__captured = null;
+            window.saveApiKey = async (p) => { window.__captured = JSON.parse(JSON.stringify(p)); };
+            const div = document.getElementById('current-api-key');
+            if (div) div.dataset.hasKey = 'false';
+            await save_button_down({ preventDefault() {} });
+            return window.__captured;
+        }"""
+    )
+    assert payload is not None, "纯免费版正常开关不应被拦截"
+    assert payload["coreApi"] == "free", f"core 漂移: {payload['coreApi']!r}"
+    assert payload["assistApi"] == "free", f"assist 漂移: {payload['assistApi']!r}"
+
+
+@pytest.mark.frontend
+def test_empty_dropdown_save_is_blocked(mock_page: Page, running_server: str):
+    """A1 回归：下拉为空（加载竞态）+ 开着自定义API 点保存 → 必须被前端拦截，
+    不产生任何写盘 payload。"""
+    _open_free_settings(mock_page, running_server)
+
+    blocked = mock_page.evaluate(
+        """async () => {
+            const core = document.getElementById('coreApiSelect');
+            const assist = document.getElementById('assistApiSelect');
+            core.value = '';      // 模拟 loadCurrentApiKey 起手清空后的竞态窗口
+            assist.value = '';
+            const cb = document.getElementById('enableCustomApi');
+            cb.checked = true; cb.dispatchEvent(new Event('change', {bubbles:true}));  // 开自定义绕过空Key校验
+
+            window.__captured = null;
+            window.saveApiKey = async (p) => { window.__captured = JSON.parse(JSON.stringify(p)); };
+            const div = document.getElementById('current-api-key');
+            if (div) div.dataset.hasKey = 'false';
+            await save_button_down({ preventDefault() {} });
+            return window.__captured === null;   // true = 保存被拦截，未写盘
+        }"""
+    )
+    assert blocked, "空 coreApi 仍被写盘——A1 守卫失效，会被后端兜底成阿里"
+
+    # 基线未被污染：后端仍是 free
+    readback = mock_page.evaluate("async () => await (await fetch('/api/config/core_api')).json()")
+    assert readback["coreApi"] == "free"
+    assert readback["assistApi"] == "free"
+
+
+@pytest.mark.frontend
+def test_backend_ignores_empty_core_api_on_save(mock_page: Page, running_server: str):
+    """A2 回归：即使前端被绕过、直接 POST 空 coreApi，后端也不能用空值覆盖已存的 free，
+    重新读取必须仍是 free（绝不变成 qwen）。"""
+    _open_free_settings(mock_page, running_server)
+
+    readback = mock_page.evaluate(
+        """async () => {
+            await fetch('/api/config/core_api', {
+                method:'POST', headers:{'Content-Type':'application/json'},
+                body: JSON.stringify({coreApiKey:'', coreApi:'', assistApi:'', enableCustomApi:true})
+            });
+            return await (await fetch('/api/config/core_api')).json();
+        }"""
+    )
+    assert readback["coreApi"] == "free", f"空 coreApi 覆盖了已存值: {readback['coreApi']!r}"
+    assert readback["assistApi"] == "free"

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -374,6 +374,50 @@ class TestAssistFollowsCore:
 
 
 # ---------------------------------------------------------------------------
+# 3b. 兜底安全：coreApi 为空/缺失/损坏时必须落到免费版，绝不静默切到付费的阿里 qwen
+#     （回归：自定义 API 开关曾把空 coreApi 写盘，旧逻辑会兜底成 qwen 偷偷消耗额度）
+# ---------------------------------------------------------------------------
+class TestEmptyCoreApiFallsBackToFreeNotPaid:
+
+    @pytest.mark.unit
+    def test_empty_core_api_falls_back_to_free_not_qwen(self, config_manager):
+        """coreApi/assistApi='' → 兜底到 free（lanlan），不能解析成付费阿里 dashscope。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'free-access',
+            'coreApi': '',
+            'assistApi': '',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['CORE_API_TYPE'] == 'free', '空 coreApi 必须兜底成 free，不能是 qwen'
+        assert cfg['assistApi'] == 'free'
+        assert 'dashscope.aliyuncs.com' not in (cfg.get('CORE_URL') or ''), \
+            '免费版绝不能被静默路由到付费阿里 dashscope'
+
+    @pytest.mark.unit
+    def test_missing_core_api_keys_fall_back_to_free(self, config_manager):
+        """core_config.json 缺少 coreApi/assistApi 字段 → 兜底 free，不是 qwen。"""
+        _write_core_config(config_manager, {'coreApiKey': 'free-access'})
+        cfg = config_manager.get_core_config()
+
+        assert cfg['CORE_API_TYPE'] == 'free'
+        assert 'dashscope.aliyuncs.com' not in (cfg.get('CORE_URL') or '')
+
+    @pytest.mark.unit
+    def test_explicit_paid_provider_still_honored(self, config_manager):
+        """反向保护：用户显式选了付费 qwen 必须被尊重，不能被兜底误改成 free。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'sk-real-qwen',
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['CORE_API_TYPE'] == 'qwen'
+        assert 'dashscope.aliyuncs.com' in (cfg.get('CORE_URL') or '')
+
+
+# ---------------------------------------------------------------------------
 # 4. MiniMax key: no fallback to CORE_API_KEY
 # ---------------------------------------------------------------------------
 class TestMinimaxKeyIsolation:

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3468,7 +3468,8 @@ class ConfigManager:
             'MCP_ROUTER_API_KEY': DEFAULT_MCP_ROUTER_API_KEY,
             'CORE_URL': DEFAULT_CORE_URL,
             'CORE_MODEL': DEFAULT_CORE_MODEL,
-            'CORE_API_TYPE': 'qwen',
+            # coreApi 为空串时的兜底服务商：用免费版而非付费阿里 qwen，避免悄悄消耗额度。
+            'CORE_API_TYPE': 'free',
             'OPENROUTER_URL': DEFAULT_OPENROUTER_URL,
             'CONVERSATION_MODEL': DEFAULT_CONVERSATION_MODEL,
             'SUMMARY_MODEL': DEFAULT_SUMMARY_MODEL,


### PR DESCRIPTION
- Removed the compactMinimizeCancelSeq property from chatWindowPropsSchema to simplify state management.
- Cleaned up CSS by removing unused animations related to compact chat state transitions.
- Updated core API configuration logic to prevent silent fallback to paid providers when coreApi is empty or invalid.
- Added frontend validation to block saving when coreApi is not ready, preventing unintended changes to API settings.
- Enhanced unit tests to cover scenarios where coreApi is empty or missing, ensuring it defaults to free provider.
- Updated localization files to include new error messages for configuration loading states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加配置加载状态提示，防止误操作。

* **缺陷修复**
  * 修复配置保存逻辑，防止无意中清空已保存的服务商设置。
  * 调整默认服务路由，优先使用免费版服务。

* **界面优化**
  * 简化对话框最小化交互流程。
  * 移除紧凑模式的部分动画效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->