### PR TITLE
fix(plugin-manager): 指标 watcher 纳入 isRunning，修复状态切换后空态滞留

### DIFF
--- a/frontend/plugin-manager/src/components/plugin/PluginMetricsInline.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginMetricsInline.vue
@@ -174,8 +174,10 @@ onMounted(() => {
   }
 })
 
-watch(() => props.pluginId, (newId) => {
-  if (isRunning.value) {
+// 当 stopped → running 时 pluginId 不变，仅靠 pluginId watcher 不会触发拉取，
+// 空态要等全局 5s 轮询才补齐。把 isRunning 一并纳入监听走即时拉取的 fast-path。
+watch([() => props.pluginId, isRunning], ([newId, running]) => {
+  if (running) {
     void loadMetrics(newId)
   }
 })


### PR DESCRIPTION
## 背景

Follow-up of #1715（已合并到 main）。该 PR 重构了 `PluginMetricsInline.vue`，CodeRabbit 在 review 里指出 watcher 只监听 `pluginId` 的问题，但合并时未包含修复，本 PR 补上。

## 问题

`PluginMetricsInline` 的 watcher 原本只监听 `props.pluginId`。插件卡片列表以 `plugin.id` 为 `:key`（`GridSection.vue`），状态变化不会重挂卡片，所以同一插件 `stopped → running` 时既不重跑 `onMounted`、也不触发这个 watcher → 不走「立即拉一次指标」的 fast-path。

实际影响：有 `PluginList.vue` 每 5s 的 `fetchAllMetrics()` 轮询兜底，所以**不是永久空态**，而是切到 running 后空态最多滞留约 5 秒才显示指标。

## 改动

把 `isRunning` 一并纳入监听，running 时即时拉取。`loadMetrics` 内已有「已有缓存就跳过」的 guard，多触发不会重复请求：

```js
watch([() => props.pluginId, isRunning], ([newId, running]) => {
  if (running) {
    void loadMetrics(newId)
  }
})
```

## 验证

- `npm run type-check`（vue-tsc）✅ exit 0
- `eslint PluginMetricsInline.vue` ✅ 无 warning

单文件改动，diff 仅 `PluginMetricsInline.vue`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了插件指标的加载机制，当插件状态从停止转为运行时，指标数据现在会立即刷新显示，无需等待定时轮询更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->