### PR TITLE
feat(chat): enhance export history and floating scrollbar

### DIFF
--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.test.tsx
@@ -415,6 +415,7 @@ describe('CompactExportHistoryPanel', () => {
       await waitFor(() => {
         expect(screen.getByTitle('Export Preview')).toBeInTheDocument();
       });
+      expect(screen.getByTitle('Export Preview')).toHaveAttribute('sandbox', 'allow-scripts');
 
       const copyButton = screen.getByRole('button', { name: 'Copy to Clipboard' });
       fireEvent.click(copyButton);
@@ -433,6 +434,58 @@ describe('CompactExportHistoryPanel', () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  it('restores Markdown as an export format for preview, copy, and download', async () => {
+    const onBuildPreview = vi.fn().mockResolvedValue({
+      previewKind: 'document',
+      previewDocument: '<!doctype html><html><body>Markdown Preview</body></html>',
+    });
+    const onCopyExport = vi.fn();
+    const onDownloadExport = vi.fn();
+
+    renderPanel({ onBuildPreview, onCopyExport, onDownloadExport });
+
+    await waitFor(() => {
+      expect(onBuildPreview).toHaveBeenCalledWith({
+        messageIds: [message.id],
+        format: 'image',
+        imageStyle: 'neko',
+        imageFormat: 'png',
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown' }));
+
+    await waitFor(() => {
+      expect(onBuildPreview).toHaveBeenCalledWith({
+        messageIds: [message.id],
+        format: 'markdown',
+        imageStyle: 'neko',
+        imageFormat: 'png',
+      });
+    });
+    expect(screen.queryByRole('button', { name: 'N.E.K.O' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to Clipboard' }));
+    await waitFor(() => {
+      expect(onCopyExport).toHaveBeenCalledWith({
+        messageIds: [message.id],
+        format: 'markdown',
+        imageStyle: 'neko',
+        imageFormat: 'png',
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    await waitFor(() => {
+      expect(onDownloadExport).toHaveBeenCalledWith({
+        messageIds: [message.id],
+        format: 'markdown',
+        imageStyle: 'neko',
+        imageFormat: 'png',
+      });
+    });
   });
 
   it('clears rejected export action errors when the preview closes', async () => {

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -96,6 +96,12 @@ type ScrollbarDragState = {
   draggableTrackHeight: number;
 };
 
+type CompactHistoryScrollbarThumbState = {
+  top: number;
+  height: number;
+  scrollable: boolean;
+};
+
 type CompactHistoryBubbleTone = {
   group: 'first' | 'same' | 'switch';
   complexity: 'plain' | 'rich';
@@ -249,6 +255,11 @@ export default function CompactExportHistoryPanel({
   const [exportActionError, setExportActionError] = useState<string | null>(null);
   const [previewState, setPreviewState] = useState<CompactExportPreviewState>({ status: 'idle' });
   const [scrollbarVisible, setScrollbarVisible] = useState(false);
+  const [scrollbarThumbState, setScrollbarThumbState] = useState<CompactHistoryScrollbarThumbState>({
+    top: 0,
+    height: 0,
+    scrollable: false,
+  });
   const selectedMessages = messages.filter(message => selectedIds.has(message.id));
   const previewHasSelection = selectedMessages.length > 0;
   const selectedMessageIds = selectedMessages.map(message => message.id);
@@ -298,9 +309,27 @@ export default function CompactExportHistoryPanel({
     scrollbarVisibleTimerRef.current = null;
   }
 
+  function updateScrollbarThumbState() {
+    const scrollNode = scrollRef.current;
+    const metrics = scrollNode ? getCompactHistoryScrollbarMetrics(scrollNode) : null;
+    if (!scrollNode || !metrics) {
+      setScrollbarThumbState(prev => (
+        prev.scrollable ? { top: 0, height: 0, scrollable: false } : prev
+      ));
+      return;
+    }
+    const top = Math.round(metrics.draggableTrackHeight * (scrollNode.scrollTop / metrics.scrollableHeight));
+    const height = Math.round(metrics.thumbHeight);
+    setScrollbarThumbState(prev => {
+      if (prev.scrollable && prev.top === top && prev.height === height) return prev;
+      return { top, height, scrollable: true };
+    });
+  }
+
   function revealScrollbarForWheel() {
     if (!historyInteractive) return;
     clearScrollbarVisibleTimer();
+    updateScrollbarThumbState();
     setScrollbarVisible(true);
     if (desktopHistoryHoverActiveRef.current) return;
     scrollbarVisibleTimerRef.current = window.setTimeout(() => {
@@ -397,6 +426,9 @@ export default function CompactExportHistoryPanel({
     if (historyInteractive) return;
     clearScrollbarVisibleTimer();
     setScrollbarVisible(false);
+    setScrollbarThumbState(prev => (
+      prev.scrollable ? { top: 0, height: 0, scrollable: false } : prev
+    ));
     scrollbarDragRef.current = null;
     desktopHistoryHoverActiveRef.current = false;
   }, [historyInteractive]);
@@ -407,6 +439,9 @@ export default function CompactExportHistoryPanel({
       const detail = (event as CustomEvent<{ active?: boolean }>).detail;
       desktopHistoryHoverActiveRef.current = detail?.active === true;
       clearScrollbarVisibleTimer();
+      if (desktopHistoryHoverActiveRef.current) {
+        updateScrollbarThumbState();
+      }
       setScrollbarVisible(desktopHistoryHoverActiveRef.current);
     }
 
@@ -545,6 +580,7 @@ export default function CompactExportHistoryPanel({
     if (!scrollNode) return;
     const distanceToBottom = scrollNode.scrollHeight - scrollNode.scrollTop - scrollNode.clientHeight;
     onAutoScrollToBottomChange(distanceToBottom <= COMPACT_EXPORT_BOTTOM_THRESHOLD);
+    updateScrollbarThumbState();
   }
 
   function handleClick(event: ReactMouseEvent<HTMLElement>, message: ChatMessage, selectable: boolean) {
@@ -943,6 +979,10 @@ export default function CompactExportHistoryPanel({
             <div
               className="compact-export-history-scrollbar-hit"
               data-compact-scrollbar-hit="true"
+              style={{
+                '--compact-history-scroll-thumb-top': `${scrollbarThumbState.top}px`,
+                '--compact-history-scroll-thumb-height': `${scrollbarThumbState.height}px`,
+              } as CSSProperties}
               aria-hidden="true"
               onWheel={handleScrollbarWheel}
               onPointerDown={handleScrollbarPointerDown}

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -37,7 +37,7 @@ export function computeCompactHistoryExitDelay(index: number): string {
   return `${Math.min(index * COMPACT_HISTORY_EXIT_DELAY_STEP_MS, COMPACT_HISTORY_EXIT_DELAY_MAX_MS)}ms`;
 }
 
-export type CompactExportFormat = 'image';
+export type CompactExportFormat = 'image' | 'markdown';
 export type CompactExportImageStyle = 'neko' | 'original' | 'poster' | 'lyrics';
 export type CompactExportImageFormat = 'png' | 'jpeg' | 'webp';
 
@@ -596,6 +596,7 @@ export default function CompactExportHistoryPanel({
 
   const exportFormatOptions: { id: CompactExportFormat; label: string }[] = [
     { id: 'image', label: i18n('chat.exportFormatImage', 'Image') },
+    { id: 'markdown', label: i18n('chat.exportFormatMarkdown', 'Markdown') },
   ];
   const imageStyleOptions: { id: CompactExportImageStyle; label: string }[] = [
     { id: 'neko', label: i18n('chat.exportImageStyleNeko', 'N.E.K.O') },
@@ -700,7 +701,7 @@ export default function CompactExportHistoryPanel({
           className="compact-export-preview-frame"
           title={i18n('chat.exportPreviewTitle', 'Export Preview')}
           srcDoc={previewState.result.previewDocument}
-          sandbox=""
+          sandbox="allow-scripts"
         />
       </div>
     );

--- a/frontend/react-neko-chat/src/MessageList.tsx
+++ b/frontend/react-neko-chat/src/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo } from 'react';
+import { useRef, useEffect, useMemo, useState } from 'react';
 import MessageBubble from './MessageBubble';
 import { i18n } from './i18n';
 import { type ChatMessage, type MessageAction } from './message-schema';
@@ -33,6 +33,13 @@ export default function MessageList({
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const shouldScrollRef = useRef(true);
+  const scrollbarTimerRef = useRef<number | null>(null);
+  const [scrollbarState, setScrollbarState] = useState({
+    visible: false,
+    top: 0,
+    height: 0,
+    scrollable: false,
+  });
 
   const displayMessages = useMemo(
     () => messages.length > MAX_DISPLAY_MESSAGES
@@ -50,6 +57,49 @@ export default function MessageList({
     container.scrollTop = container.scrollHeight;
   }, [displayMessages]);
 
+  function clearScrollbarTimer() {
+    if (scrollbarTimerRef.current === null) return;
+    window.clearTimeout(scrollbarTimerRef.current);
+    scrollbarTimerRef.current = null;
+  }
+
+  function updateFloatingScrollbar(show: boolean) {
+    const container = containerRef.current;
+    if (!container) return;
+    const scrollableHeight = container.scrollHeight - container.clientHeight;
+    if (scrollableHeight <= 1 || container.clientHeight <= 0 || container.scrollHeight <= 0) {
+      clearScrollbarTimer();
+      setScrollbarState(prev => (
+        prev.scrollable || prev.visible
+          ? { visible: false, top: 0, height: 0, scrollable: false }
+          : prev
+      ));
+      return;
+    }
+    const height = Math.max(28, Math.round((container.clientHeight / container.scrollHeight) * container.clientHeight));
+    const top = Math.round((container.scrollTop / scrollableHeight) * (container.clientHeight - height));
+    setScrollbarState(prev => {
+      if (
+        prev.visible === show
+        && prev.scrollable
+        && prev.top === top
+        && prev.height === height
+      ) {
+        return prev;
+      }
+      return { visible: show, top, height, scrollable: true };
+    });
+  }
+
+  function revealFloatingScrollbar() {
+    updateFloatingScrollbar(true);
+    clearScrollbarTimer();
+    scrollbarTimerRef.current = window.setTimeout(() => {
+      scrollbarTimerRef.current = null;
+      updateFloatingScrollbar(false);
+    }, 760);
+  }
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -58,6 +108,7 @@ export default function MessageList({
       if (shouldScrollRef.current) {
         container.scrollTop = container.scrollHeight;
       }
+      updateFloatingScrollbar(false);
     });
 
     // 同时观察容器自身：galgame 模式开关 / 选项面板展开收起时
@@ -71,6 +122,14 @@ export default function MessageList({
     return () => observer.disconnect();
   }, [displayMessages.length]);
 
+  useEffect(() => {
+    updateFloatingScrollbar(false);
+  }, [displayMessages]);
+
+  useEffect(() => () => {
+    clearScrollbarTimer();
+  }, []);
+
   const handleScroll = () => {
     const container = containerRef.current;
     if (!container) return;
@@ -78,26 +137,52 @@ export default function MessageList({
     const isNearBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight < 60;
     shouldScrollRef.current = isNearBottom;
+    revealFloatingScrollbar();
+  };
+
+  const scrollThumbStyle = {
+    height: `${scrollbarState.height}px`,
+    transform: `translateY(${scrollbarState.top}px)`,
   };
 
   if (displayMessages.length === 0) {
     return (
-      <div className="message-list" ref={containerRef} aria-label={ariaLabel}>
+      <div className="message-list-shell">
+        <div className="message-list" ref={containerRef} aria-label={ariaLabel}>
+        </div>
+        {scrollbarState.scrollable ? (
+          <div
+            className="message-list-scroll-thumb"
+            data-message-list-scrollbar-visible={scrollbarState.visible ? 'true' : undefined}
+            style={scrollThumbStyle}
+            aria-hidden="true"
+          />
+        ) : null}
       </div>
     );
   }
 
   return (
-    <div className="message-list" ref={containerRef} aria-label={ariaLabel} onScroll={handleScroll}>
-      {displayMessages.map((message, index) => (
-        <MessageBubble
-          key={message.id}
-          message={message}
-          isGroupedWithPrevious={shouldGroupWithPrevious(message, displayMessages[index - 1])}
-          failedStatusLabel={failedStatusLabel}
-          onAction={onAction}
+    <div className="message-list-shell">
+      <div className="message-list" ref={containerRef} aria-label={ariaLabel} onScroll={handleScroll}>
+        {displayMessages.map((message, index) => (
+          <MessageBubble
+            key={message.id}
+            message={message}
+            isGroupedWithPrevious={shouldGroupWithPrevious(message, displayMessages[index - 1])}
+            failedStatusLabel={failedStatusLabel}
+            onAction={onAction}
+          />
+        ))}
+      </div>
+      {scrollbarState.scrollable ? (
+        <div
+          className="message-list-scroll-thumb"
+          data-message-list-scrollbar-visible={scrollbarState.visible ? 'true' : undefined}
+          style={scrollThumbStyle}
+          aria-hidden="true"
         />
-      ))}
+      ) : null}
     </div>
   );
 }

--- a/frontend/react-neko-chat/src/MessageList.tsx
+++ b/frontend/react-neko-chat/src/MessageList.tsx
@@ -48,6 +48,11 @@ export default function MessageList({
     [messages],
   );
 
+  const observedMessageKey = useMemo(
+    () => displayMessages.map(message => message.id).join('|'),
+    [displayMessages],
+  );
+
   // Always instant scroll: behavior:'smooth' is silently broken in our Electron
   // host (window.scrollTo / element.scrollTo with behavior:'smooth' is a no-op),
   // which left the chat stuck at scrollTop=0 on mount and after each new message.
@@ -120,7 +125,7 @@ export default function MessageList({
     }
 
     return () => observer.disconnect();
-  }, [displayMessages.length]);
+  }, [observedMessageKey]);
 
   useEffect(() => {
     updateFloatingScrollbar(false);

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -19,8 +19,10 @@
 html,
 body,
 #root {
-  min-height: 100%;
+  width: 100%;
+  height: 100%;
   margin: 0;
+  overflow: hidden;
 }
 
 body {
@@ -547,20 +549,25 @@ svg {
   pointer-events: none;
 }
 
+.message-list-shell {
+  position: relative;
+  height: 100%;
+  min-height: 0;
+}
+
 .message-list {
   height: 100%;
   overflow: auto;
-  padding: 50px 12px 16px;
+  padding: 50px 24px 16px 12px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  /* 滚动条：细线 + 半透明，参考 Discord / Slack */
-  scrollbar-width: thin;
-  scrollbar-color: rgba(140, 152, 172, 0.25) transparent;
+  scrollbar-width: none;
 }
 
 .message-list::-webkit-scrollbar {
-  width: 5px;
+  width: 0;
+  height: 0;
 }
 
 .message-list::-webkit-scrollbar-track {
@@ -568,12 +575,25 @@ svg {
 }
 
 .message-list::-webkit-scrollbar-thumb {
-  background: rgba(140, 152, 172, 0.25);
-  border-radius: 3px;
+  background: transparent;
 }
 
-.message-list::-webkit-scrollbar-thumb:hover {
-  background: rgba(140, 152, 172, 0.45);
+.message-list-scroll-thumb {
+  position: absolute;
+  top: 0;
+  right: 7px;
+  width: 4px;
+  min-height: 28px;
+  border-radius: 999px;
+  background: rgba(140, 152, 172, 0.38);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 3;
+  transition: opacity 0.16s ease;
+}
+
+.message-list-scroll-thumb[data-message-list-scrollbar-visible="true"] {
+  opacity: 1;
 }
 
 .message-empty-state {
@@ -2415,9 +2435,8 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
      下沿只到气泡实体底以下~16px(此处 alpha≈3/255≈1.2%,再往下不可察)；清晰可见段(alpha≥8)仅~9px、
      可感知段(alpha≥5)~13px,均落在 16px 内。压到 16 让气泡实体底更贴输入框(实体底到输入框由~28px→~18px)、
      同时可见阴影完整不裁。再小(如12)会切到可感知段,不取。 */
-  padding: 4px 6px 16px;
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
+  padding: 4px 24px 16px 6px;
+  scrollbar-width: none;
   pointer-events: none;
   -webkit-app-region: no-drag;
   -webkit-mask-image: linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.78) 12px, #000 28px);
@@ -2446,35 +2465,13 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   margin-top: auto;
 }
 
-.compact-export-history-scroll[data-compact-scrollbar-visible="true"] {
-  scrollbar-color: rgba(70, 160, 255, 0.42) transparent;
-}
-
 .compact-export-history-scroll::-webkit-scrollbar {
-  width: 6px;
+  width: 0;
+  height: 0;
 }
 
 .compact-export-history-scroll::-webkit-scrollbar-track {
   background: transparent;
-}
-
-.compact-export-history-scroll::-webkit-scrollbar-thumb {
-  border: 1.5px solid transparent;
-  border-radius: 999px;
-  background: transparent;
-  background-clip: padding-box;
-}
-
-.compact-export-history-scroll[data-compact-scrollbar-visible="true"]::-webkit-scrollbar-thumb {
-  background:
-    linear-gradient(180deg, rgba(86, 188, 255, 0.64), rgba(42, 140, 214, 0.42))
-    padding-box;
-}
-
-.compact-export-history-scroll[data-compact-scrollbar-visible="true"]::-webkit-scrollbar-thumb:hover {
-  background:
-    linear-gradient(180deg, rgba(103, 202, 255, 0.82), rgba(36, 151, 217, 0.62))
-    padding-box;
 }
 
 .compact-export-history-scrollbar-hit {
@@ -2490,6 +2487,20 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background: transparent;
   z-index: 2;
   -webkit-app-region: no-drag;
+}
+
+.compact-export-history-scrollbar-hit::before {
+  content: "";
+  position: absolute;
+  top: var(--compact-history-scroll-thumb-top, 0px);
+  right: 7px;
+  width: 4px;
+  height: var(--compact-history-scroll-thumb-height, 24px);
+  min-height: 24px;
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, rgba(86, 188, 255, 0.64), rgba(42, 140, 214, 0.42));
+  pointer-events: none;
 }
 
 .compact-export-history-message {
@@ -4117,15 +4128,11 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 /* --- 消息列表滚动条 --- */
 [data-theme="dark"] .message-list {
-  scrollbar-color: rgba(200, 210, 230, 0.15) transparent;
+  scrollbar-width: none;
 }
 
-[data-theme="dark"] .message-list::-webkit-scrollbar-thumb {
-  background: rgba(200, 210, 230, 0.15);
-}
-
-[data-theme="dark"] .message-list::-webkit-scrollbar-thumb:hover {
-  background: rgba(200, 210, 230, 0.3);
+[data-theme="dark"] .message-list-scroll-thumb {
+  background: rgba(200, 210, 230, 0.32);
 }
 
 /* --- 消息列表 --- */
@@ -4574,23 +4581,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 }
 
 [data-theme="dark"] .compact-export-history-scroll {
-  scrollbar-color: transparent transparent;
+  scrollbar-width: none;
 }
 
-[data-theme="dark"] .compact-export-history-scroll[data-compact-scrollbar-visible="true"] {
-  scrollbar-color: rgba(68, 183, 254, 0.46) transparent;
-}
-
-[data-theme="dark"] .compact-export-history-scroll[data-compact-scrollbar-visible="true"]::-webkit-scrollbar-thumb {
+[data-theme="dark"] .compact-export-history-scrollbar-hit::before {
   background:
-    linear-gradient(180deg, rgba(95, 199, 255, 0.68), rgba(47, 145, 224, 0.48))
-    padding-box;
-}
-
-[data-theme="dark"] .compact-export-history-scroll[data-compact-scrollbar-visible="true"]::-webkit-scrollbar-thumb:hover {
-  background:
-    linear-gradient(180deg, rgba(125, 214, 255, 0.86), rgba(59, 171, 246, 0.68))
-    padding-box;
+    linear-gradient(180deg, rgba(95, 199, 255, 0.68), rgba(47, 145, 224, 0.48));
 }
 
 [data-theme="dark"] .compact-export-history-bubble {

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2110,7 +2110,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 
 .compact-chat-surface-frame[data-compact-chat-state="input"] {
   gap: 0;
-  padding: 5px 62px 5px 2px;
+  padding: 5px 62px 5px 8px;
 }
 
 /* compact 输入框/胶囊左侧毛绒球（minimize 折叠入口）：点按=折叠为 minimized 毛绒球小窗口，
@@ -2158,7 +2158,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 
 .compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"]) {
   padding-right: 62px;
-  padding-left: 2px;
+  padding-left: 8px;
 }
 
 .compact-chat-surface-frame::before {

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -2579,7 +2579,7 @@
         var frame = doc.createElement('iframe');
         frame.className = 'chat-export-preview-frame';
         frame.hidden = true;
-        frame.setAttribute('sandbox', 'allow-same-origin');
+        frame.setAttribute('sandbox', 'allow-scripts');
         frame.setAttribute('title', translateLabel('chat.exportPreviewTitle', 'Export Preview'));
 
         var previewImageWrap = doc.createElement('div');

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -473,6 +473,12 @@
                 extension: 'png',
                 mimeType: 'image/png',
                 label: translateLabel('chat.exportFormatImage', 'Image')
+            },
+            {
+                id: 'markdown',
+                extension: 'md',
+                mimeType: 'text/markdown;charset=utf-8',
+                label: translateLabel('chat.exportFormatMarkdown', 'Markdown')
             }
         ];
     }
@@ -631,6 +637,11 @@
             'html,body{margin:0;padding:0;background:#fafbfc;color:#1f2933;',
             'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif;',
             'font-size:14px;line-height:1.7;}',
+            'html{color-scheme:light;scrollbar-width:none;}',
+            'html::-webkit-scrollbar,body::-webkit-scrollbar{width:0;height:0;background:transparent;}',
+            'html::-webkit-scrollbar-track,body::-webkit-scrollbar-track,html::-webkit-scrollbar-corner,body::-webkit-scrollbar-corner{background:transparent;}',
+            '.neko-md-scrollbar-thumb{position:fixed;right:5px;top:0;width:4px;min-height:24px;border-radius:999px;background:rgba(89,101,120,0.5);opacity:0;pointer-events:none;z-index:10;transition:opacity 0.16s ease;}',
+            'html.neko-md-scrollbar-visible .neko-md-scrollbar-thumb{opacity:1;}',
             '.preview-wrap{max-width:780px;margin:0 auto;padding:28px 32px;}',
             '.preview-wrap h1{font-size:1.72rem;padding-bottom:0.32em;border-bottom:1px solid #e2e8f0;margin-top:0;}',
             '.preview-wrap h2{font-size:1.3rem;margin-top:1.4em;color:#334155;}',
@@ -642,19 +653,56 @@
             '.preview-wrap img{max-width:100%;height:auto;border-radius:6px;margin:0.5em 0;}',
             '.preview-wrap a{color:#2563eb;text-decoration:none;}',
             '.preview-wrap a:hover{text-decoration:underline;}',
-            '[data-theme="dark"],[data-theme="dark"] body{background:#111827;color:#e5e7eb;}',
+            '[data-theme="dark"],[data-theme="dark"] body{color-scheme:dark;background:#111827;color:#e5e7eb;}',
+            '[data-theme="dark"] .neko-md-scrollbar-thumb{background:rgba(210,222,240,0.38);}',
             '[data-theme="dark"] .preview-wrap h1{border-color:#374151;}',
             '[data-theme="dark"] .preview-wrap h2{color:#cbd5e1;}',
             '[data-theme="dark"] .preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}',
             '[data-theme="dark"] .preview-wrap code{background:#1f2937;}',
             '[data-theme="dark"] .preview-wrap a{color:#93c5fd;}',
-            '@media (prefers-color-scheme:dark){html:not([data-theme]),html:not([data-theme]) body{background:#111827;color:#e5e7eb;}html:not([data-theme]) .preview-wrap h1{border-color:#374151;}html:not([data-theme]) .preview-wrap h2{color:#cbd5e1;}html:not([data-theme]) .preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}html:not([data-theme]) .preview-wrap code{background:#1f2937;}}'
+            '@media (prefers-color-scheme:dark){html:not([data-theme]),html:not([data-theme]) body{color-scheme:dark;background:#111827;color:#e5e7eb;}html:not([data-theme]) .neko-md-scrollbar-thumb{background:rgba(210,222,240,0.38);}html:not([data-theme]) .preview-wrap h1{border-color:#374151;}html:not([data-theme]) .preview-wrap h2{color:#cbd5e1;}html:not([data-theme]) .preview-wrap blockquote{background:#1f2937;color:#9ca3af;border-color:#4b5563;}html:not([data-theme]) .preview-wrap code{background:#1f2937;}}'
+        ].join('');
+        var script = [
+            '<script>',
+            '(function(){',
+            'var root=document.documentElement;',
+            'var thumb=document.createElement("div");',
+            'thumb.className="neko-md-scrollbar-thumb";',
+            'document.body.appendChild(thumb);',
+            'var timer=null;',
+            'function update(){',
+            'var scroller=document.scrollingElement||root;',
+            'var scrollable=scroller.scrollHeight-window.innerHeight;',
+            'if(scrollable<=1){thumb.style.display="none";return false;}',
+            'thumb.style.display="block";',
+            'var viewport=window.innerHeight;',
+            'var height=Math.max(24,Math.round((viewport/scroller.scrollHeight)*viewport));',
+            'var top=Math.round((scroller.scrollTop/scrollable)*(viewport-height));',
+            'thumb.style.height=height+"px";',
+            'thumb.style.transform="translateY("+top+"px)";',
+            'return true;',
+            '}',
+            'function show(){',
+            'if(!update())return;',
+            'root.classList.add("neko-md-scrollbar-visible");',
+            'if(timer)window.clearTimeout(timer);',
+            'timer=window.setTimeout(function(){root.classList.remove("neko-md-scrollbar-visible");},760);',
+            '}',
+            'window.addEventListener("resize",update,{passive:true});',
+            'window.addEventListener("scroll",show,{passive:true});',
+            'window.addEventListener("wheel",show,{passive:true});',
+            'window.addEventListener("touchmove",show,{passive:true});',
+            'window.addEventListener("keydown",function(event){',
+            'if(["ArrowDown","ArrowUp","PageDown","PageUp","Home","End"," "].indexOf(event.key)!==-1)show();',
+            '});',
+            '}());',
+            '</script>'
         ].join('');
         return '<!DOCTYPE html><html lang="' + escapeHtml(document.documentElement.lang || 'en')
             + '"' + getPreviewThemeAttributesHtml() + '><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>'
             + escapeHtml(translateLabel('chat.exportFileTitle', 'Project N.E.K.O Conversation Export'))
             + '</title><style>' + css + '</style></head><body><div class="preview-wrap">'
-            + bodyHtml + '</div></body></html>';
+            + bodyHtml + '</div>' + script + '</body></html>';
     }
 
     // ======================== Image export — shared utilities ========================
@@ -2223,6 +2271,9 @@
 
     async function buildExportDocument(entries, formatId) {
         var now = new Date();
+        if (formatId === 'markdown') {
+            return buildMarkdownExportDocument(entries, now);
+        }
         return buildImageExportDocument(entries, now);
     }
 
@@ -3186,6 +3237,12 @@
                 return { previewKind: 'empty' };
             }
             var exportData = await buildExportDocument(entries, state.exportFormat);
+            if (state.exportFormat === 'markdown') {
+                return {
+                    previewKind: 'document',
+                    previewDocument: buildMarkdownPreviewDocument(exportData.content)
+                };
+            }
             return {
                 previewKind: 'image',
                 previewUrl: URL.createObjectURL(exportData.previewBlob)
@@ -3217,9 +3274,17 @@
 
     async function copyCompactInlineSelection(options) {
         if (state.isCopying) return;
+        var requestedFormat = normalizeExportFormatId(options && options.format);
         state.isCopying = true;
         try {
             await runCompactInlineExportAction(options, async function (entries) {
+                if (state.exportFormat === 'markdown') {
+                    var markdownData = await buildExportDocument(entries, 'markdown');
+                    var markdownOk = await copyTextToClipboard(markdownData.content);
+                    if (markdownOk) showToast('chat.copyMarkdownSuccess', 'Markdown copied to clipboard.');
+                    else showToast('chat.copyMarkdownFailed', 'Failed to copy Markdown.', 4000);
+                    return;
+                }
                 var imgData = await buildExportDocument(entries, 'image');
                 var imgBlob = imgData.previewBlob || imgData.content;
                 var imgOk = await copyImageToClipboard(imgBlob);
@@ -3228,7 +3293,11 @@
             });
         } catch (error) {
             logExportError('copyCompactInlineSelection', error);
-            showToast('chat.copyImageFailed', 'Failed to copy image to clipboard.', 4000);
+            if (requestedFormat === 'markdown') {
+                showToast('chat.copyMarkdownFailed', 'Failed to copy Markdown.', 4000);
+            } else {
+                showToast('chat.copyImageFailed', 'Failed to copy image to clipboard.', 4000);
+            }
         } finally {
             state.isCopying = false;
         }
@@ -3288,6 +3357,13 @@
         var modal = state.previewModal;
         if (modal) modal.copyButton.disabled = true;
         try {
+            if (state.exportFormat === 'markdown') {
+                var markdownPayload = await getOrBuildPreviewPayload(entries, 'markdown');
+                var markdownOk = await copyTextToClipboard(markdownPayload.exportData.content);
+                if (markdownOk) showToast('chat.copyMarkdownSuccess', 'Markdown copied to clipboard.');
+                else showToast('chat.copyMarkdownFailed', 'Failed to copy Markdown.', 4000);
+                return;
+            }
             var imgPayload = await getOrBuildPreviewPayload(entries, 'image');
             var imgBlob = imgPayload.exportData.previewBlob || imgPayload.exportData.content;
             var imgOk = await copyImageToClipboard(imgBlob);
@@ -3295,7 +3371,11 @@
             else showToast('chat.copyImageFailed', 'Failed to copy image to clipboard.', 4000);
         } catch (error) {
             logExportError('handleCopyClick', error);
-            showToast('chat.copyImageFailed', 'Failed to copy image to clipboard.', 4000);
+            if (state.exportFormat === 'markdown') {
+                showToast('chat.copyMarkdownFailed', 'Failed to copy Markdown.', 4000);
+            } else {
+                showToast('chat.copyImageFailed', 'Failed to copy image to clipboard.', 4000);
+            }
         } finally {
             state.isCopying = false;
             if (modal) modal.copyButton.disabled = false;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -961,6 +961,10 @@
     function seedCompactSurfaceAnchorForRender() {
         var shell = getShell();
         if (!shell || getCurrentChatSurfaceMode() !== 'compact') return;
+        if (compactSurfaceAnchorLocked) return;
+        if (compactSurfaceDesktopResizeActive || compactSurfaceResizeSession) return;
+        if ((dragState && dragState.compactSurface) || compactSurfaceDesktopDragActive) return;
+        if (shell.hasAttribute('data-compact-surface-anchor-ready')) return;
         var layoutOverride = getElectronCompactLayoutOverride();
         var target = getCompactSurfaceTarget(layoutOverride);
         if (!target) {
@@ -2544,7 +2548,7 @@
     function renderWindow() {
         var overlay = getOverlay();
         if (!overlay || overlay.hidden) return;
-        if (getCurrentChatSurfaceMode() === 'compact') {
+        if (!mounted && getCurrentChatSurfaceMode() === 'compact') {
             seedCompactSurfaceAnchorForRender();
         }
         mountWindow();

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -948,6 +948,7 @@
             document.documentElement.style.setProperty('--desktop-compact-surface-width', rect.width + 'px');
             document.documentElement.style.setProperty('--desktop-compact-surface-height', rect.height + 'px');
         }
+        shell.setAttribute('data-compact-surface-anchor-ready', 'true');
         shell.style.transform = 'none';
         if (options && options.persist && !isElectronChatWindow()) {
             saveCompactSurfacePosition(rect.left, rect.top, rect.width);
@@ -955,6 +956,44 @@
         dispatchCompactSurfaceLayoutChange(rect);
         syncCompactInteractionGeometry();
         return rect;
+    }
+
+    function seedCompactSurfaceAnchorForRender() {
+        var shell = getShell();
+        if (!shell || getCurrentChatSurfaceMode() !== 'compact') return;
+        var layoutOverride = getElectronCompactLayoutOverride();
+        var target = getCompactSurfaceTarget(layoutOverride);
+        if (!target) {
+            shell.removeAttribute('data-compact-surface-anchor-ready');
+            return;
+        }
+        var left = Math.round(target.left);
+        var top = Math.round(target.top);
+        var width = Math.round(target.width);
+        var height = Math.round(target.height || COMPACT_SURFACE_DEFAULT_HEIGHT);
+        shell.style.setProperty('--compact-surface-left', left + 'px');
+        shell.style.setProperty('--compact-surface-top', top + 'px');
+        shell.style.setProperty('--compact-surface-width', width + 'px');
+        shell.style.setProperty('--compact-surface-height', height + 'px');
+        document.documentElement.style.setProperty('--compact-surface-left', left + 'px');
+        document.documentElement.style.setProperty('--compact-surface-top', top + 'px');
+        document.documentElement.style.setProperty('--compact-surface-width', width + 'px');
+        document.documentElement.style.setProperty('--compact-surface-height', height + 'px');
+        if (isElectronChatWindow() || (layoutOverride && layoutOverride.surface)) {
+            shell.style.setProperty('--desktop-compact-surface-left', left + 'px');
+            shell.style.setProperty('--desktop-compact-surface-top', top + 'px');
+            shell.style.setProperty('--desktop-compact-surface-width', width + 'px');
+            shell.style.setProperty('--desktop-compact-surface-height', height + 'px');
+            document.documentElement.style.setProperty('--desktop-compact-surface-left', left + 'px');
+            document.documentElement.style.setProperty('--desktop-compact-surface-top', top + 'px');
+            document.documentElement.style.setProperty('--desktop-compact-surface-width', width + 'px');
+            document.documentElement.style.setProperty('--desktop-compact-surface-height', height + 'px');
+        }
+        if (layoutOverride && layoutOverride.workArea) {
+            document.documentElement.style.setProperty('--compact-desktop-workarea-width', Math.round(layoutOverride.workArea.width) + 'px');
+            document.documentElement.style.setProperty('--compact-desktop-workarea-height', Math.round(layoutOverride.workArea.height) + 'px');
+        }
+        shell.setAttribute('data-compact-surface-anchor-ready', 'true');
     }
 
     function getCurrentCompactSurfaceRect() {
@@ -1646,6 +1685,7 @@
         shell.style.removeProperty('--desktop-compact-surface-top');
         shell.style.removeProperty('--desktop-compact-surface-width');
         shell.style.removeProperty('--desktop-compact-surface-height');
+        shell.removeAttribute('data-compact-surface-anchor-ready');
         document.documentElement.style.removeProperty('--compact-surface-left');
         document.documentElement.style.removeProperty('--compact-surface-top');
         document.documentElement.style.removeProperty('--compact-surface-width');
@@ -1722,6 +1762,7 @@
             document.documentElement.style.removeProperty('--compact-desktop-workarea-width');
             document.documentElement.style.removeProperty('--compact-desktop-workarea-height');
         }
+        shell.setAttribute('data-compact-surface-anchor-ready', 'true');
         dispatchCompactSurfaceLayoutChange({
             left: Math.round(target.left),
             top: Math.round(target.top),
@@ -2503,6 +2544,9 @@
     function renderWindow() {
         var overlay = getOverlay();
         if (!overlay || overlay.hidden) return;
+        if (getCurrentChatSurfaceMode() === 'compact') {
+            seedCompactSurfaceAnchorForRender();
+        }
         mountWindow();
         scheduleMobileContentLayout();
     }
@@ -4575,6 +4619,9 @@
         resetCompactChatState();
         state.chatSurfaceMode = normalized;
         persistChatSurfaceModePreference(normalized);
+        if (normalized === 'compact') {
+            seedCompactSurfaceAnchorForRender();
+        }
         renderWindow();
 
         if (nextMinimized !== previousMinimized) {
@@ -4722,6 +4769,22 @@
             var ballBottom = curRect.top + (curRect.height || MINIMIZED_SIZE);
 
             // 恢复保存的尺寸
+            var previousSetupVisibility = shell.style.visibility;
+            var setupVisibilityHidden = true;
+            var restoreSetupVisibility = function () {
+                if (!setupVisibilityHidden) return;
+                setupVisibilityHidden = false;
+                if (previousSetupVisibility) {
+                    shell.style.visibility = previousSetupVisibility;
+                } else {
+                    shell.style.removeProperty('visibility');
+                }
+            };
+            // Removing .is-minimized makes the full React surface visible again.
+            // Keep it hidden while we restore/measure geometry so the browser
+            // cannot paint one frame at the measurement position before the
+            // scale-from-ball transform is ready.
+            shell.style.visibility = 'hidden';
             shell.classList.remove('is-minimized');
             shell.style.removeProperty('right');
             shell.style.removeProperty('bottom');
@@ -4746,9 +4809,7 @@
             }
 
             // 以球的位置为展开后对话框的左下角来计算展开位置
-            // 先设临时位置以获取真实尺寸
-            shell.style.left = '0px';
-            shell.style.top = '0px';
+            // 先落到最终目标位置获取真实尺寸，避免 (0,0) 测量态被绘制出来。
             var expandedTarget = getExpandedTargetFromSavedState();
             if (expandedTarget) {
                 shell.style.left = expandedTarget.left + 'px';
@@ -4771,6 +4832,7 @@
                 savedShellSize = null;
                 savedShellPosition = null;
                 isMinimizeTransitioning = false;
+                restoreSetupVisibility();
                 requestAnimationFrame(function () {
                     var r = shell.getBoundingClientRect();
                     var clamped = clampPosition(r.left, r.top);
@@ -4807,6 +4869,7 @@
             shell.style.transform = 'scale(' + sx2 + ', ' + sy2 + ')';
             shell.classList.add('is-expanding');
             void shell.offsetHeight; // 强制 reflow
+            restoreSetupVisibility();
 
             // 动画到 identity（展开到完整尺寸）
             requestAnimationFrame(function () {
@@ -4874,6 +4937,7 @@
                 shell.removeEventListener('transitionend', onExpandEnd);
                 shell.classList.remove('is-expanding');
                 shell.style.transform = 'none';
+                restoreSetupVisibility();
                 expandHandled = true;
             };
 
@@ -4993,6 +5057,9 @@
                     // the minimized shell.
                     state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
                     resetCompactChatState();
+                }
+                if (getCurrentChatSurfaceMode() === 'compact') {
+                    seedCompactSurfaceAnchorForRender();
                 }
                 if (!mountWindow()) {
                     showToast(getI18nText('chat.reactWindowMountFailed', '聊天框挂载失败'), 3000);

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -43,6 +43,11 @@
             background: transparent !important;
         }
         #react-chat-window-backdrop { display: none !important; }
+        /* Electron 缩/展窗期间主进程会先 setBounds，再由 renderer 收到 resize 后更新
+           React compact 几何。隐藏这段中间态，避免透明窗口左上角画出一帧旧布局。 */
+        body.neko-electron-runtime #react-chat-window-shell.neko-e-animating {
+            visibility: hidden !important;
+        }
         /* Electron 独立 full 窗口（part B）：full shell 改用「固定 30px inset 充满窗口」定位 +
            收敛阴影，取代基础规则的 translate(-50%,-50%) 居中 + 0 30px 100px(~130px) 巨阴影。
            两个目的：


### PR DESCRIPTION
## Summary
- add Markdown export preview/copy support for chat history
- add floating scrollbar behavior for message list and export history panel
- wire chat window pages with updated export/scrollbar assets

## Tests
- Not run (PR creation only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Markdown 导出选项，支持预览、复制与下载。

* **改进**
  * 引入浮动滚动条拇指，提升消息列表与历史记录的滚动交互与可见性。
  * 增强 Markdown 预览样式与深色模式适配。
  * 优化窗口渲染与展开流程，消除缩放/展开时的视觉闪烁。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->