### PR TITLE
ci(lint): docstring 禁 CJK 守卫（diff 增量制，plugin/local_server 豁免）

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -131,7 +131,13 @@ jobs:
         # ranges across all languages. Skipped on direct push to main —
         # there's nothing to diff against.
         if: github.event_name == 'pull_request'
-        run: python scripts/check_i18n_sync.py --base "origin/${{ github.base_ref }}"
+        env:
+          # Indirection instead of inlining ${{ github.base_ref }} into the
+          # shell line: with the `pull_request: branches: [main]` trigger the
+          # ref is always `main`, but zizmor flags the inline form as
+          # template-injection, and env-var expansion is inert either way.
+          BASE_REF: ${{ github.base_ref }}
+        run: python scripts/check_i18n_sync.py --base "origin/${BASE_REF}"
 
       - name: Forbid CJK in new/modified Python docstrings (PR-only)
         # Convention: docstrings in the main program are written in English.
@@ -145,7 +151,10 @@ jobs:
         # fixtures whose CJK content is itself under test). Skipped on direct
         # push to main — nothing to diff against.
         if: github.event_name == 'pull_request'
-        run: python scripts/check_docstring_no_cjk.py --base "origin/${{ github.base_ref }}"
+        env:
+          # Same zizmor template-injection indirection as the i18n-sync step.
+          BASE_REF: ${{ github.base_ref }}
+        run: python scripts/check_docstring_no_cjk.py --base "origin/${BASE_REF}"
 
       - name: Forbid relative-up markdown links inside docs/
         # docs/ ships through VitePress with itself as the deploy root;

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -101,7 +101,7 @@ jobs:
         run: python scripts/check_prompt_hygiene.py
 
   python-conventions:
-    name: Python conventions (i18n-sync + docs + api-trailing-slash×2 + module-layering)
+    name: Python conventions (i18n-sync + docs + api-trailing-slash×2 + module-layering + docstring-cjk)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -132,6 +132,20 @@ jobs:
         # there's nothing to diff against.
         if: github.event_name == 'pull_request'
         run: python scripts/check_i18n_sync.py --base "origin/${{ github.base_ref }}"
+
+      - name: Forbid CJK in new/modified Python docstrings (PR-only)
+        # Convention: docstrings in the main program are written in English.
+        # The repo carries a large legacy stock of CJK docstrings, so this is
+        # a diff-ratchet: only docstrings whose line span overlaps lines
+        # added/modified in this PR (vs the merge-base) are checked — touch
+        # it, translate it. plugin/ and local_server/ are policy-exempt
+        # (plugin internals follow their own conventions; local_server is a
+        # semi-independent unit). `--full` exists for local migration sweeps.
+        # Suppress a single docstring with `# noqa: DOCSTRING_CJK` (e.g.
+        # fixtures whose CJK content is itself under test). Skipped on direct
+        # push to main — nothing to diff against.
+        if: github.event_name == 'pull_request'
+        run: python scripts/check_docstring_no_cjk.py --base "origin/${{ github.base_ref }}"
 
       - name: Forbid relative-up markdown links inside docs/
         # docs/ ships through VitePress with itself as the deploy root;

--- a/scripts/check_docstring_no_cjk.py
+++ b/scripts/check_docstring_no_cjk.py
@@ -91,8 +91,11 @@ def _first_cjk(s: str) -> str | None:
 def _has_noqa(line: str, code: str) -> bool:
     """True if `line` contains `# noqa` (bare) or `# noqa: ...,CODE,...`.
 
-    Tolerates a trailing explanatory comment after the noqa. Matches the
-    behaviour of scripts/check_prompt_hygiene.py."""
+    Tolerates a trailing explanatory comment after the noqa, but it must
+    start with ``#`` (``# noqa: CODE  # rationale``) — the codes block
+    stops only at the next ``#`` or end-of-line, so other separators like
+    ``— rationale`` break the match. Same behaviour as
+    scripts/check_prompt_hygiene.py (and ruff/flake8)."""
     m = re.search(r"#\s*noqa\b(?:\s*:\s*([A-Za-z0-9_,\s]+?))?(?=#|$)", line)
     if not m:
         return False

--- a/scripts/check_docstring_no_cjk.py
+++ b/scripts/check_docstring_no_cjk.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Static check: new/modified Python docstrings must be English-only (no CJK).
+
+DOCSTRING_CJK
+   Any module / class / function docstring containing CJK characters
+   (CJK Unified Ideographs, Hiragana, Katakana, Hangul Syllables) is
+   flagged. Comments and non-docstring strings are out of scope — those
+   are covered by other conventions (prompt hygiene, i18n-in-config).
+
+Diff-ratchet enforcement
+------------------------
+The repo carries thousands of legacy CJK docstrings, so full enforcement
+would light up every file at once. Instead the check is diff-based: in the
+default mode it only flags docstrings whose line span overlaps lines
+added/modified in HEAD relative to the merge-base with ``--base``
+(default ``origin/main``). Touch a docstring → rewrite it in English.
+The legacy stock converges file by file as code gets edited.
+
+``--full`` scans every docstring regardless of the diff — useful for
+migration sweeps and stats, not wired into CI.
+
+Note: diff mode reads file contents from the working tree but line ranges
+from ``git diff <base>...HEAD``; it assumes the working tree matches HEAD,
+which is always true in CI (and after ``git commit`` locally).
+
+Suppression
+-----------
+Append ``# noqa: DOCSTRING_CJK`` to any line spanned by the docstring
+(start line through end line). Bare ``# noqa`` also matches. Use sparingly
+— e.g. test fixtures whose CJK content is itself the thing under test.
+
+Output
+------
+Every violation prints as ``path:line:col  DOCSTRING_CJK  message``.
+Exit 1 on any violation, 0 otherwise (2 on git failure).
+
+Usage:
+    python scripts/check_docstring_no_cjk.py [--base origin/main]
+    python scripts/check_docstring_no_cjk.py --full [paths...]
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Junk dirs plus two deliberate policy exemptions:
+#   plugin/       — plugin internals follow their own conventions (same
+#                   rationale as check_prompt_hygiene.py / the review-scope
+#                   convention: the framework doesn't police plugin bodies).
+#   local_server/ — subprocess-spawned TTS / telemetry servers, maintained
+#                   as a semi-independent unit.
+# Unlike check_prompt_hygiene.py, config/ and tests/ ARE covered: the rule
+# is about the language of documentation, which applies to them the same.
+EXCLUDE_DIRS = {
+    ".venv", "venv",
+    ".git", "__pycache__", ".tox", ".mypy_cache", ".ruff_cache", ".pytest_cache",
+    "dist", "build", "node_modules",
+    ".claude",
+    "plugin", "local_server",
+}
+
+# CJK ranges: CJK Unified, Hiragana, Katakana, Hangul Syllables.
+# Kept in sync with scripts/check_prompt_hygiene.py.
+CJK_RANGES = (
+    ("一", "鿿"),
+    ("぀", "ゟ"),
+    ("゠", "ヿ"),
+    ("가", "힣"),
+)
+
+CODE = "DOCSTRING_CJK"
+
+
+def _first_cjk(s: str) -> str | None:
+    """Return the first CJK character in `s`, or None."""
+    for ch in s:
+        for lo, hi in CJK_RANGES:
+            if lo <= ch <= hi:
+                return ch
+    return None
+
+
+def _has_noqa(line: str, code: str) -> bool:
+    """True if `line` contains `# noqa` (bare) or `# noqa: ...,CODE,...`.
+
+    Tolerates a trailing explanatory comment after the noqa. Matches the
+    behaviour of scripts/check_prompt_hygiene.py."""
+    m = re.search(r"#\s*noqa\b(?:\s*:\s*([A-Za-z0-9_,\s]+?))?(?=#|$)", line)
+    if not m:
+        return False
+    raw = m.group(1)
+    if raw is None or not raw.strip():
+        return True
+    codes = {c.strip() for c in raw.split(",") if c.strip()}
+    return code in codes
+
+
+def _docstring_nodes(tree: ast.Module) -> Iterator[tuple[ast.AST, ast.Constant]]:
+    """Yield (owner, docstring Constant node) for every module / class /
+    function docstring in the tree. We need the node (not just the text from
+    ``ast.get_docstring``) to know its line span."""
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = node.body
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            yield node, first.value
+
+
+def find_violations(
+    tree: ast.Module,
+    source_lines: list[str],
+    changed_lines: set[int] | None,
+) -> list[tuple[int, int, str]]:
+    """Return (lineno, col, message) for each CJK docstring.
+
+    ``changed_lines`` is the set of 1-based line numbers added/modified in
+    the diff; a docstring is only flagged if its span intersects the set.
+    ``None`` means full-scan mode (every docstring is in scope).
+    """
+    violations: list[tuple[int, int, str]] = []
+    for owner, doc in _docstring_nodes(tree):
+        text = doc.value
+        ch = _first_cjk(text)
+        if ch is None:
+            continue
+        start = doc.lineno
+        end = doc.end_lineno or start
+        if changed_lines is not None and not any(
+            ln in changed_lines for ln in range(start, end + 1)
+        ):
+            continue
+        last = min(end, len(source_lines))
+        if any(
+            _has_noqa(source_lines[ln - 1], CODE) for ln in range(start, last + 1)
+        ):
+            continue
+        owner_name = getattr(owner, "name", None) or "<module>"
+        violations.append((
+            start,
+            (doc.col_offset or 0) + 1,
+            f"docstring of {owner_name} contains CJK characters "
+            f"(first: '{ch}'); write docstrings in English, or append "
+            f"`# noqa: {CODE}` if the CJK content is intentional.",
+        ))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# git diff plumbing (mirrors scripts/check_i18n_sync.py)
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        sys.exit(2)
+    return result.stdout
+
+
+def _changed_py_files(base: str) -> list[str]:
+    """Python files changed in HEAD relative to merge-base with `base`.
+    Posix-style repo-relative paths; deletions drop out naturally because
+    the path no longer exists on disk (filtered by the caller)."""
+    out = _git("diff", "--name-only", f"{base}...HEAD")
+    return [
+        ln.strip().replace("\\", "/")
+        for ln in out.splitlines()
+        if ln.strip().endswith(".py")
+    ]
+
+
+_HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def _added_lines(base: str, path: str) -> set[int]:
+    """1-based line numbers in the NEW file touched by the diff.
+    Implicit count is ``1`` per the unified-diff spec (matching ``git diff``);
+    pure-deletion hunks have count 0 and contribute nothing."""
+    diff = _git("diff", "--unified=0", f"{base}...HEAD", "--", path)
+    lines: set[int] = set()
+    for ln in diff.splitlines():
+        m = _HUNK_HEADER_RE.match(ln)
+        if not m:
+            continue
+        start = int(m.group(1))
+        count = int(m.group(2)) if m.group(2) is not None else 1
+        lines.update(range(start, start + count))
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# File iteration / parsing
+# ---------------------------------------------------------------------------
+
+
+def _is_excluded(path: Path) -> bool:
+    try:
+        rel_parts = path.relative_to(REPO_ROOT).parts
+    except ValueError:
+        rel_parts = path.parts
+    return bool(set(rel_parts) & EXCLUDE_DIRS)
+
+
+def _iter_python_files(paths: Iterable[Path]) -> Iterator[Path]:
+    for p in paths:
+        if p.is_file():
+            if p.suffix == ".py" and not _is_excluded(p):
+                yield p
+        elif p.is_dir():
+            for f in sorted(p.rglob("*.py")):
+                if not _is_excluded(f):
+                    yield f
+
+
+def _parse_file(path: Path) -> tuple[ast.Module | None, list[str]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: skipped — {e}", file=sys.stderr)
+        return None, []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as e:
+        print(f"{path}:{e.lineno}: syntax error — {e.msg}", file=sys.stderr)
+        return None, []
+    return tree, source.splitlines()
+
+
+def _report(path: Path, violations: list[tuple[int, int, str]]) -> int:
+    try:
+        rel = path.relative_to(REPO_ROOT)
+    except ValueError:
+        rel = path
+    for lineno, col, msg in violations:
+        print(f"{rel.as_posix()}:{lineno}:{col}  {CODE}  {msg}")
+    return len(violations)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Forbid CJK characters in new/modified Python docstrings "
+            "(diff-ratchet against --base; --full scans everything)."
+        )
+    )
+    parser.add_argument(
+        "--base",
+        default=os.environ.get("DOCSTRING_CJK_BASE", "origin/main"),
+        help="Base ref to diff against (default: origin/main, "
+             "override via $DOCSTRING_CJK_BASE).",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Scan ALL docstrings instead of only diff-touched ones "
+             "(migration aid; the legacy stock is large).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files/directories to scan in --full mode (default: repo root).",
+    )
+    args = parser.parse_args(argv)
+
+    total = 0
+
+    if args.full:
+        raw = args.paths or ["."]
+        targets = [
+            Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw
+        ]
+        for file in _iter_python_files(targets):
+            tree, lines = _parse_file(file)
+            if tree is None:
+                continue
+            total += _report(file, find_violations(tree, lines, None))
+    else:
+        # If base ref doesn't exist the whole check is moot — skip with a
+        # warning (e.g. shallow local clone without origin/main).
+        rev_check = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", args.base],
+            cwd=REPO_ROOT,
+            capture_output=True, text=True, check=False,
+        )
+        if rev_check.returncode != 0:
+            print(
+                f"docstring-cjk: base ref `{args.base}` not found; skipping. "
+                f"(Set $DOCSTRING_CJK_BASE or pass --base to override.)",
+                file=sys.stderr,
+            )
+            return 0
+        for rel in _changed_py_files(args.base):
+            file = REPO_ROOT / rel
+            if not file.is_file() or _is_excluded(file):
+                continue
+            changed = _added_lines(args.base, rel)
+            if not changed:
+                continue
+            tree, lines = _parse_file(file)
+            if tree is None:
+                continue
+            total += _report(file, find_violations(tree, lines, changed))
+
+    if total:
+        print(
+            f"\n{total} docstring-language violation(s) found.\n"
+            "Docstrings touched by this change must be written in English. "
+            f"To override a single docstring, append `# noqa: {CODE}` to one "
+            "of its lines.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_docstring_no_cjk.py
+++ b/tests/unit/test_check_docstring_no_cjk.py
@@ -1,0 +1,186 @@
+"""Unit tests for ``scripts/check_docstring_no_cjk.py``.
+
+Synthetic-source coverage of ``find_violations`` (the diff-aware core):
+docstring kinds (module / class / def / async def), the changed-lines
+gate, noqa suppression, the docstring-vs-other-strings boundary, and the
+plugin/ + local_server/ policy exemptions. The git plumbing is exercised
+separately with ``--base HEAD`` (empty diff → exit 0) so CI smoke-tests
+the CLI path without depending on the branch state.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "check_docstring_no_cjk.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_docstring_no_cjk", SCRIPT_PATH,
+    )
+    assert spec and spec.loader, f"failed to load spec for {SCRIPT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = _load_script_module()
+
+
+def _violations(source: str, changed_lines: set[int] | None):
+    source = textwrap.dedent(source)
+    tree = ast.parse(source)
+    return MOD.find_violations(tree, source.splitlines(), changed_lines)
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def test_flags_cjk_in_function_docstring_full_scan():
+    src = '''
+    def f():
+        """中文 docstring."""
+        return 1
+    '''
+    out = _violations(src, None)
+    assert len(out) == 1
+    assert "docstring of f" in out[0][2]
+
+
+def test_flags_module_class_and_async_docstrings():
+    src = '''
+    """モジュール docstring."""
+
+    class C:
+        """클래스 docstring."""
+
+        async def g(self):
+            """中文 docstring."""
+    '''
+    out = _violations(src, None)
+    owners = {msg.split("docstring of ")[1].split(" ")[0] for _, _, msg in out}
+    assert owners == {"<module>", "C", "g"}
+
+
+def test_english_docstring_and_non_docstring_cjk_pass():
+    src = '''
+    def f():
+        """English docstring."""
+        x = "中文字符串字面量不是 docstring"  # 中文注释也不管
+        return x
+    '''
+    assert _violations(src, None) == []
+
+
+def test_string_statement_not_in_first_position_is_not_a_docstring():
+    src = '''
+    def f():
+        x = 1
+        "中文裸字符串，不是 docstring"
+        return x
+    '''
+    assert _violations(src, None) == []
+
+
+# ---------------------------------------------------------------------------
+# Diff gate
+# ---------------------------------------------------------------------------
+
+
+def test_diff_gate_flags_only_overlapping_docstrings():
+    src = '''
+    def touched():
+        """中文 A."""
+
+    def untouched():
+        """中文 B."""
+    '''
+    # Docstring of `touched` sits on line 3 of the dedented source.
+    out = _violations(src, {3})
+    assert len(out) == 1
+    assert "docstring of touched" in out[0][2]
+
+
+def test_diff_gate_multiline_span_overlap():
+    src = '''
+    def f():
+        """First line is English.
+
+        中文在第三行。
+        """
+    '''
+    # Span is lines 3-6; touching any line of it (here: 5) flags it.
+    assert len(_violations(src, {5})) == 1
+    # Touching lines outside the span does not.
+    assert _violations(src, {2}) == []
+
+
+# ---------------------------------------------------------------------------
+# noqa
+# ---------------------------------------------------------------------------
+
+
+def test_noqa_on_docstring_line_suppresses():
+    src = '''
+    def f():
+        """中文 docstring."""  # noqa: DOCSTRING_CJK  # fixture content
+    '''
+    assert _violations(src, None) == []
+
+
+def test_noqa_with_other_code_does_not_suppress():
+    src = '''
+    def f():
+        """中文 docstring."""  # noqa: SOME_OTHER_CODE
+    '''
+    assert len(_violations(src, None)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Policy exemptions
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_and_local_server_are_exempt():
+    assert MOD._is_excluded(MOD.REPO_ROOT / "plugin" / "host.py")
+    assert MOD._is_excluded(
+        MOD.REPO_ROOT / "plugin" / "plugins" / "x" / "main.py"
+    )
+    assert MOD._is_excluded(MOD.REPO_ROOT / "local_server" / "tts.py")
+
+
+def test_main_program_dirs_are_covered():
+    for top in ("utils", "memory", "main_routers", "config", "tests", "scripts"):
+        assert not MOD._is_excluded(MOD.REPO_ROOT / top / "x.py"), top
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_diff_mode_empty_diff_exits_zero():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--base", "HEAD"],
+        cwd=PROJECT_ROOT,
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_cli_missing_base_ref_skips_with_warning():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--base", "no-such-ref-xyz"],
+        cwd=PROJECT_ROOT,
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "skipping" in result.stderr


### PR DESCRIPTION
## 改了什么

新增 `scripts/check_docstring_no_cjk.py`，挂进 `analyze.yml` 的 `python-conventions` job（PR-only，复用该 job 现成的 `fetch-depth: 0`）：**PR 改动行覆盖到的 Python docstring 不得包含 CJK 字符**（CJK Unified + 假名 + 谚文，与 `check_prompt_hygiene.py` 的 CJK_RANGES 同步）。

## 为什么是 diff 增量制

全仓存量约 4194 处中文 docstring（豁免目录外约 2700），全量硬卡第一天 CI 就全红。所以仿照 `check_i18n_sync.py` 的先例做成 ratchet：

- 只查 merge-base diff 中新增/修改行所覆盖的 docstring（新文件全查），碰到哪条翻译哪条，存量逐步收敛；
- 直推 main 跳过（无 diff 基准），与 i18n-sync 同模式；
- 本地可用 `--full` 全量扫描做迁移清账。

## 豁免

- **目录豁免**：`plugin/`、`local_server/` 整目录不查（plugin 内部按惯例不归框架管，local_server 是半独立单元）；
- **单条豁免**：`# noqa: DOCSTRING_CJK`（如测试 fixture 的 CJK 内容本身是被测对象）。

## 验证

- 12 个单测（`tests/unit/test_check_docstring_no_cjk.py`）：检测各类 docstring、diff 门控、noqa、plugin/local_server 豁免、CLI smoke；
- e2e：真实 git diff 下，根目录中文 docstring 探针被抓（exit 1），plugin/ 与 local_server/ 同样探针安静通过，存量文件只改无关行不误伤；
- 新文件本身过 ruff 0.15.4 与 prompt-hygiene。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 更新 CI 流程：在 PR 触发时新增仅针对本次变更的文档字符串 CJK 校验，并调整 i18n 同步基准引用方式。

* **New Features**
  * 增加可在本地/CI 运行的文档字符串 CJK 检查工具，支持按差异检测或全量扫描。

* **Tests**
  * 添加单元测试覆盖文档字符串检查与差异门控、豁免与 CLI 行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->