### PR TITLE
  修复 compact 聊天毛线球对齐与空态文案本地化

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -7,12 +7,13 @@ import {
   computeCompactHistoryExitDelay,
 } from './CompactExportHistoryPanel';
 import MessageList from './MessageList';
-import { CHAT_EMPTY_STATE_FALLBACK } from './chat-copy';
+import { getChatEmptyStateFallback } from './chat-copy';
 import { parseChatMessage, type CompactChatState } from './message-schema';
 
 describe('App', () => {
   const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
   const COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY = 'neko.reactChatWindow.compactInputToolWheelIndex';
+  const DEFAULT_CHAT_EMPTY_STATE_FALLBACK = getChatEmptyStateFallback('en');
   beforeEach(() => {
     window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
     window.localStorage.removeItem(COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY);
@@ -45,6 +46,12 @@ describe('App', () => {
     fireEvent.click(exportButton!);
     return exportButton!;
   };
+
+  it('selects locale-aware chat empty state fallbacks', () => {
+    expect(getChatEmptyStateFallback('zh-CN')).toBe('现在开始跟我聊天吧！');
+    expect(getChatEmptyStateFallback('zh-TW')).toBe('現在開始跟我聊天吧！');
+    expect(getChatEmptyStateFallback('en-US')).toBe('Start chatting with me now!');
+  });
 
   const mockHoverCapableMatchMedia = (hoverCapable = true) => {
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -1876,7 +1883,7 @@ describe('App', () => {
       <App chatSurfaceMode="compact" composerHidden messages={[assistantMessage, userMessage]} />,
     );
 
-    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent(CHAT_EMPTY_STATE_FALLBACK);
+    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent(DEFAULT_CHAT_EMPTY_STATE_FALLBACK);
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('先看我这边的引导内容');
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('这是我刚刚发出的内容');
   });
@@ -3162,7 +3169,7 @@ describe('App', () => {
 
     const preview = container.querySelector('.compact-chat-capsule-text');
     expect(preview).toHaveAttribute('data-compact-preview-streaming', 'false');
-    expect(preview).toHaveTextContent(CHAT_EMPTY_STATE_FALLBACK);
+    expect(preview).toHaveTextContent(DEFAULT_CHAT_EMPTY_STATE_FALLBACK);
     expect(preview).not.toHaveTextContent(settledText.slice(0, 20));
   });
 
@@ -3387,7 +3394,7 @@ describe('App', () => {
     );
 
     const capsule = container.querySelector('.compact-chat-capsule-button');
-    expect(capsule).toHaveTextContent(CHAT_EMPTY_STATE_FALLBACK);
+    expect(capsule).toHaveTextContent(DEFAULT_CHAT_EMPTY_STATE_FALLBACK);
     fireEvent.click(capsule as Element);
 
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -7,12 +7,12 @@ import {
   computeCompactHistoryExitDelay,
 } from './CompactExportHistoryPanel';
 import MessageList from './MessageList';
+import { CHAT_EMPTY_STATE_FALLBACK } from './chat-copy';
 import { parseChatMessage, type CompactChatState } from './message-schema';
 
 describe('App', () => {
   const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
   const COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY = 'neko.reactChatWindow.compactInputToolWheelIndex';
-
   beforeEach(() => {
     window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
     window.localStorage.removeItem(COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY);
@@ -1876,7 +1876,7 @@ describe('App', () => {
       <App chatSurfaceMode="compact" composerHidden messages={[assistantMessage, userMessage]} />,
     );
 
-    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent('现在开始跟我聊天吧！');
+    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent(CHAT_EMPTY_STATE_FALLBACK);
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('先看我这边的引导内容');
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('这是我刚刚发出的内容');
   });
@@ -3162,7 +3162,7 @@ describe('App', () => {
 
     const preview = container.querySelector('.compact-chat-capsule-text');
     expect(preview).toHaveAttribute('data-compact-preview-streaming', 'false');
-    expect(preview).toHaveTextContent('现在开始跟我聊天吧！');
+    expect(preview).toHaveTextContent(CHAT_EMPTY_STATE_FALLBACK);
     expect(preview).not.toHaveTextContent(settledText.slice(0, 20));
   });
 
@@ -3387,7 +3387,7 @@ describe('App', () => {
     );
 
     const capsule = container.querySelector('.compact-chat-capsule-button');
-    expect(capsule).toHaveTextContent('现在开始跟我聊天吧！');
+    expect(capsule).toHaveTextContent(CHAT_EMPTY_STATE_FALLBACK);
     fireEvent.click(capsule as Element);
 
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -50,6 +50,9 @@ describe('App', () => {
   it('selects locale-aware chat empty state fallbacks', () => {
     expect(getChatEmptyStateFallback('zh-CN')).toBe('现在开始跟我聊天吧！');
     expect(getChatEmptyStateFallback('zh-TW')).toBe('現在開始跟我聊天吧！');
+    expect(getChatEmptyStateFallback('zh-HK')).toBe('現在開始跟我聊天吧！');
+    expect(getChatEmptyStateFallback('zh-MO')).toBe('現在開始跟我聊天吧！');
+    expect(getChatEmptyStateFallback('zh-Hant')).toBe('現在開始跟我聊天吧！');
     expect(getChatEmptyStateFallback('en-US')).toBe('Start chatting with me now!');
   });
 

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -1876,7 +1876,7 @@ describe('App', () => {
       <App chatSurfaceMode="compact" composerHidden messages={[assistantMessage, userMessage]} />,
     );
 
-    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent('Chat content will appear here.');
+    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent('现在开始跟我聊天吧！');
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('先看我这边的引导内容');
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('这是我刚刚发出的内容');
   });
@@ -3162,7 +3162,7 @@ describe('App', () => {
 
     const preview = container.querySelector('.compact-chat-capsule-text');
     expect(preview).toHaveAttribute('data-compact-preview-streaming', 'false');
-    expect(preview).toHaveTextContent('Chat content will appear here.');
+    expect(preview).toHaveTextContent('现在开始跟我聊天吧！');
     expect(preview).not.toHaveTextContent(settledText.slice(0, 20));
   });
 
@@ -3387,7 +3387,7 @@ describe('App', () => {
     );
 
     const capsule = container.querySelector('.compact-chat-capsule-button');
-    expect(capsule).toHaveTextContent('Chat content will appear here.');
+    expect(capsule).toHaveTextContent('现在开始跟我聊天吧！');
     fireEvent.click(capsule as Element);
 
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1936,7 +1936,7 @@ function CompactChatApp({
           : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
       )
       : compactMessagePreview?.text
-      || i18n('chat.emptyState', 'Chat content will appear here.');
+      || i18n('chat.emptyState', '现在开始跟我聊天吧！');
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewAllowsScroll = compactPreviewIsStreaming || !!compactMessagePreview?.isGuide;
   const compactPreviewSpeechDuration = useMemo(() => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -19,6 +19,7 @@ import CompactExportHistoryPanel, {
   type CompactExportActionRequest,
   type CompactExportPreviewResult,
 } from './CompactExportHistoryPanel';
+import { CHAT_EMPTY_STATE_FALLBACK } from './chat-copy';
 import { i18n } from './i18n';
 import {
   type ChatMessage,
@@ -1936,7 +1937,7 @@ function CompactChatApp({
           : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
       )
       : compactMessagePreview?.text
-      || i18n('chat.emptyState', '现在开始跟我聊天吧！');
+      || i18n('chat.emptyState', CHAT_EMPTY_STATE_FALLBACK);
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewAllowsScroll = compactPreviewIsStreaming || !!compactMessagePreview?.isGuide;
   const compactPreviewSpeechDuration = useMemo(() => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -19,7 +19,7 @@ import CompactExportHistoryPanel, {
   type CompactExportActionRequest,
   type CompactExportPreviewResult,
 } from './CompactExportHistoryPanel';
-import { CHAT_EMPTY_STATE_FALLBACK } from './chat-copy';
+import { getChatEmptyStateFallback } from './chat-copy';
 import { i18n } from './i18n';
 import {
   type ChatMessage,
@@ -1937,7 +1937,7 @@ function CompactChatApp({
           : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
       )
       : compactMessagePreview?.text
-      || i18n('chat.emptyState', CHAT_EMPTY_STATE_FALLBACK);
+      || i18n('chat.emptyState', getChatEmptyStateFallback());
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewAllowsScroll = compactPreviewIsStreaming || !!compactMessagePreview?.isGuide;
   const compactPreviewSpeechDuration = useMemo(() => {

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -26,6 +26,7 @@ import CompactExportHistoryPanel, {
   type CompactExportActionRequest,
   type CompactExportPreviewResult,
 } from './CompactExportHistoryPanel';
+import { CHAT_EMPTY_STATE_FALLBACK } from './chat-copy';
 import { i18n } from './i18n';
 import {
   type ChatMessage,
@@ -1411,7 +1412,7 @@ export default function FullChatSurface({
         : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
     )
     : compactMessagePreview?.text
-    || i18n('chat.emptyState', '现在开始跟我聊天吧！');
+    || i18n('chat.emptyState', CHAT_EMPTY_STATE_FALLBACK);
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewSpeechDuration = useMemo(() => {
     if (!compactPreviewIsStreaming || !speechPlaybackState) {

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -26,7 +26,7 @@ import CompactExportHistoryPanel, {
   type CompactExportActionRequest,
   type CompactExportPreviewResult,
 } from './CompactExportHistoryPanel';
-import { CHAT_EMPTY_STATE_FALLBACK } from './chat-copy';
+import { getChatEmptyStateFallback } from './chat-copy';
 import { i18n } from './i18n';
 import {
   type ChatMessage,
@@ -1412,7 +1412,7 @@ export default function FullChatSurface({
         : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
     )
     : compactMessagePreview?.text
-    || i18n('chat.emptyState', CHAT_EMPTY_STATE_FALLBACK);
+    || i18n('chat.emptyState', getChatEmptyStateFallback());
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewSpeechDuration = useMemo(() => {
     if (!compactPreviewIsStreaming || !speechPlaybackState) {

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -1411,7 +1411,7 @@ export default function FullChatSurface({
         : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
     )
     : compactMessagePreview?.text
-    || i18n('chat.emptyState', 'Chat content will appear here.');
+    || i18n('chat.emptyState', '现在开始跟我聊天吧！');
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewSpeechDuration = useMemo(() => {
     if (!compactPreviewIsStreaming || !speechPlaybackState) {

--- a/frontend/react-neko-chat/src/chat-copy.ts
+++ b/frontend/react-neko-chat/src/chat-copy.ts
@@ -1,0 +1,1 @@
+export const CHAT_EMPTY_STATE_FALLBACK = '现在开始跟我聊天吧！';

--- a/frontend/react-neko-chat/src/chat-copy.ts
+++ b/frontend/react-neko-chat/src/chat-copy.ts
@@ -1,1 +1,45 @@
-export const CHAT_EMPTY_STATE_FALLBACK = '现在开始跟我聊天吧！';
+function normalizeChatLocale(locale?: string): 'zh-CN' | 'zh-TW' | 'default' {
+  const normalized = (locale || '').trim().toLowerCase();
+  if (!normalized) return 'default';
+  if (normalized === 'zh-tw' || normalized.startsWith('zh-tw') || normalized.includes('hant')) {
+    return 'zh-TW';
+  }
+  if (
+    normalized === 'zh-cn'
+    || normalized.startsWith('zh-cn')
+    || normalized.includes('hans')
+    || normalized === 'zh'
+    || normalized.startsWith('zh-')
+  ) {
+    return 'zh-CN';
+  }
+  return 'default';
+}
+
+function getRuntimeLocale(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const w = window as unknown as {
+    i18next?: { language?: unknown };
+    localStorage?: Storage;
+    navigator?: Navigator;
+  };
+  if (typeof w.i18next?.language === 'string' && w.i18next.language) {
+    return w.i18next.language;
+  }
+  try {
+    const stored = w.localStorage?.getItem('i18nextLng');
+    if (stored) return stored;
+  } catch {}
+  return w.navigator?.language;
+}
+
+export function getChatEmptyStateFallback(locale = getRuntimeLocale()): string {
+  switch (normalizeChatLocale(locale)) {
+    case 'zh-CN':
+      return '现在开始跟我聊天吧！';
+    case 'zh-TW':
+      return '現在開始跟我聊天吧！';
+    default:
+      return 'Start chatting with me now!';
+  }
+}

--- a/frontend/react-neko-chat/src/chat-copy.ts
+++ b/frontend/react-neko-chat/src/chat-copy.ts
@@ -1,7 +1,15 @@
 function normalizeChatLocale(locale?: string): 'zh-CN' | 'zh-TW' | 'default' {
   const normalized = (locale || '').trim().toLowerCase();
   if (!normalized) return 'default';
-  if (normalized === 'zh-tw' || normalized.startsWith('zh-tw') || normalized.includes('hant')) {
+  if (
+    normalized === 'zh-tw'
+    || normalized.startsWith('zh-tw')
+    || normalized === 'zh-hk'
+    || normalized.startsWith('zh-hk')
+    || normalized === 'zh-mo'
+    || normalized.startsWith('zh-mo')
+    || normalized.includes('hant')
+  ) {
     return 'zh-TW';
   }
   if (

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2082,6 +2082,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 }
 
 .compact-chat-surface-frame {
+  --compact-chat-minimize-ball-slot: 51px;
   --compact-chat-surface-bg:
     linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(247, 251, 255, 0.6) 58%, rgba(232, 243, 255, 0.54));
   --compact-chat-surface-edge: rgba(255, 255, 255, 0.5);
@@ -2097,7 +2098,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   min-height: 54px;
   max-height: 54px;
   box-sizing: border-box;
-  padding: 0 20px;
+  padding: 0 20px 0 var(--compact-chat-minimize-ball-slot);
   border: 1px solid var(--compact-chat-surface-edge);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
@@ -2110,7 +2111,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 
 .compact-chat-surface-frame[data-compact-chat-state="input"] {
   gap: 0;
-  padding: 5px 62px 5px 2px;
+  padding: 5px 62px 5px var(--compact-chat-minimize-ball-slot);
 }
 
 /* compact 输入框/胶囊左侧毛绒球（minimize 折叠入口）：点按=折叠为 minimized 毛绒球小窗口，
@@ -2119,7 +2120,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 .compact-chat-minimize-ball {
   flex: 0 0 auto;
   align-self: center;
-  margin-right: 8px;
+  margin-right: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2158,7 +2159,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 
 .compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"]) {
   padding-right: 62px;
-  padding-left: 2px;
+  padding-left: var(--compact-chat-minimize-ball-slot);
 }
 
 .compact-chat-surface-frame::before {
@@ -2187,6 +2188,14 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 .compact-chat-surface-frame > * {
   position: relative;
   z-index: 2;
+}
+
+.compact-chat-surface-frame > .compact-chat-minimize-ball {
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  z-index: 5;
+  transform: translateY(-50%);
 }
 
 .compact-chat-capsule-button {
@@ -4031,7 +4040,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   .compact-chat-surface-frame[data-compact-chat-state="default"],
   .compact-chat-surface-frame[data-compact-chat-state="options"] {
     min-height: 54px;
-    padding: 0 18px;
+    padding: 0 18px 0 var(--compact-chat-minimize-ball-slot);
   }
 
   /* 工具轮盘按钮在字幕/选项态依旧绝对定位在右侧，需保留右侧内边距，
@@ -4042,7 +4051,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   }
 
   .compact-chat-surface-frame[data-compact-chat-state="input"] {
-    padding: 5px 62px 5px 18px;
+    padding: 5px 62px 5px var(--compact-chat-minimize-ball-slot);
   }
 
   /* Only use the phone fallback when the original wheel geometry would overflow the viewport. */

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2082,7 +2082,14 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
 }
 
 .compact-chat-surface-frame {
-  --compact-chat-minimize-ball-slot: 51px;
+  --compact-chat-minimize-ball-size: 41px;
+  --compact-chat-minimize-ball-inset: 2px;
+  --compact-chat-minimize-ball-gap: 8px;
+  --compact-chat-minimize-ball-slot: calc(
+    var(--compact-chat-minimize-ball-size)
+    + var(--compact-chat-minimize-ball-inset)
+    + var(--compact-chat-minimize-ball-gap)
+  );
   --compact-chat-surface-bg:
     linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(247, 251, 255, 0.6) 58%, rgba(232, 243, 255, 0.54));
   --compact-chat-surface-edge: rgba(255, 255, 255, 0.5);
@@ -2124,8 +2131,8 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 41px;
-  height: 41px;
+  width: var(--compact-chat-minimize-ball-size);
+  height: var(--compact-chat-minimize-ball-size);
   padding: 0;
   border: 0;
   background: transparent;
@@ -2190,9 +2197,9 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   z-index: 2;
 }
 
-.compact-chat-surface-frame > .compact-chat-minimize-ball {
+.compact-chat-surface-frame .compact-chat-minimize-ball {
   position: absolute;
-  left: 2px;
+  left: var(--compact-chat-minimize-ball-inset);
   top: 50%;
   z-index: 5;
   transform: translateY(-50%);

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3210,7 +3210,7 @@
     var COMPACT_MINIMIZE_PRESS_MS = 280; // = neko-compact-collapse-wipe 擦除时长：擦完再瞬时折叠
     var compactMinimizePressTimer = 0;
     var compactMinimizeCancelSeq = 0; // 折叠取消序号（见 clearCompactMinimizePressTimer），传给 React
-    var compactMinimizeBallIconAnchor = null;
+    var compactMinimizeBallTargetAnchor = null;
     // 清掉挂起的「按下挤压→瞬时折叠」延时。窗口关闭/动画取消时必须调用，否则这个
     // 跨 280ms 存活的回调会在窗口已关闭/重开后仍 setChatSurfaceMode('minimized')，
     // 把更新后的状态覆盖成「幽灵最小化」（CodeRabbit Minor / Codex P2）。
@@ -3218,7 +3218,7 @@
         if (!compactMinimizePressTimer) return;
         window.clearTimeout(compactMinimizePressTimer);
         compactMinimizePressTimer = 0;
-        compactMinimizeBallIconAnchor = null;
+        compactMinimizeBallTargetAnchor = null;
         // 真清掉一个 pending 折叠延时 = 一次进行中的折叠被取消（如 280ms 内 closeWindow）。
         // 递增序号；buildRenderProps 把它当 prop 传给 React，让组件在重开时立即复位
         // compactCollapsing，而不必等 600ms 兜底——否则快速「关→重开」会让 compact 表面带着擦除
@@ -3226,7 +3226,7 @@
         compactMinimizeCancelSeq += 1;
     }
     function handleCompactMinimizeRequest() {
-        rememberCompactMinimizeBallIconAnchor();
+        rememberCompactMinimizeBallTargetAnchor();
         // reduced-motion：折叠擦除/按压挤压动画已被 CSS（@media prefers-reduced-motion: reduce）
         // 禁用，此时再延时 COMPACT_MINIMIZE_PRESS_MS(280ms) 才折叠，只会让窗口「点了没反应」一段，
         // 无任何动画反馈。无障碍模式下直接立即折叠，保持即时响应（Codex P2）。
@@ -4481,45 +4481,52 @@
 
     // ── End idle-dock ────────────────────────────────────────────
 
-    function getCompactMinimizeBallIconRect() {
+    function getCompactMinimizeBallTargetRect() {
         var root = getRoot();
-        var icon = root
-            ? root.querySelector('.compact-chat-minimize-ball-icon')
-            : document.querySelector('.compact-chat-minimize-ball-icon');
-        if (!icon || typeof icon.getBoundingClientRect !== 'function') return null;
-        return normalizeCompactDomRect(icon.getBoundingClientRect());
+        var button = root
+            ? root.querySelector('.compact-chat-minimize-ball')
+            : document.querySelector('.compact-chat-minimize-ball');
+        if (!button || typeof button.getBoundingClientRect !== 'function') return null;
+        var buttonRect = normalizeCompactDomRect(button.getBoundingClientRect());
+        if (!buttonRect) return null;
+        return {
+            width: MINIMIZED_SIZE,
+            height: MINIMIZED_SIZE,
+            left: buttonRect.left + buttonRect.width / 2 - MINIMIZED_SIZE / 2,
+            top: buttonRect.top + buttonRect.height / 2 - MINIMIZED_SIZE / 2
+        };
     }
 
-    function rememberCompactMinimizeBallIconAnchor() {
-        compactMinimizeBallIconAnchor = null;
+    function rememberCompactMinimizeBallTargetAnchor() {
+        compactMinimizeBallTargetAnchor = null;
         if (getCurrentChatSurfaceMode() !== 'compact') return null;
-        compactMinimizeBallIconAnchor = getCompactMinimizeBallIconRect();
-        return compactMinimizeBallIconAnchor;
+        compactMinimizeBallTargetAnchor = getCompactMinimizeBallTargetRect();
+        return compactMinimizeBallTargetAnchor;
     }
 
-    function consumeCompactMinimizeBallIconAnchor() {
-        var iconRect = normalizeCompactDomRect(compactMinimizeBallIconAnchor);
-        compactMinimizeBallIconAnchor = null;
-        return iconRect;
+    function consumeCompactMinimizeBallTargetAnchor() {
+        var targetRect = normalizeCompactDomRect(compactMinimizeBallTargetAnchor);
+        compactMinimizeBallTargetAnchor = null;
+        return targetRect;
     }
 
-    function getMinimizedTargetFromCompactIcon(iconRect) {
-        iconRect = normalizeCompactDomRect(iconRect);
-        if (!iconRect) return null;
+    function getMinimizedTargetFromCompactAnchor(anchorRect) {
+        anchorRect = normalizeCompactDomRect(anchorRect);
+        if (!anchorRect) return null;
         return {
             width: MINIMIZED_SIZE,
             height: MINIMIZED_SIZE,
             left: Math.max(
                 0,
                 Math.min(
-                    Math.round(iconRect.left + iconRect.width / 2 - MINIMIZED_SIZE / 2),
+                    Math.round(anchorRect.left),
                     window.innerWidth - MINIMIZED_SIZE
                 )
             ),
             top: Math.max(
                 0,
                 Math.min(
-                    Math.round(iconRect.top + iconRect.height / 2 - MINIMIZED_SIZE / 2),
+                    Math.round(anchorRect.top),
                     window.innerHeight - MINIMIZED_SIZE
                 )
             )
@@ -4527,14 +4534,14 @@
     }
 
     // 返回最小化后 shell 应达到的像素几何。
-    // compact 折叠时，优先锚定到 React frame 内的毛线球图标本身；React 在切到 minimized
-    // 后会卸载 compact surface，所以点击入口要先记录 icon rect。拿不到 icon rect 时才退回
+    // compact 折叠时，优先锚定到 React frame 内的毛线球按钮中心；React 在切到 minimized
+    // 后会卸载 compact surface，所以点击入口要先记录 target rect。拿不到 target rect 时才退回
     // shell 左下角 fallback。
     function getMinimizedTarget(rect) {
-        var iconTarget = isLegacyFullMinimizedBall()
+        var compactTarget = isLegacyFullMinimizedBall()
             ? null
-            : getMinimizedTargetFromCompactIcon(consumeCompactMinimizeBallIconAnchor());
-        if (iconTarget) return iconTarget;
+            : getMinimizedTargetFromCompactAnchor(consumeCompactMinimizeBallTargetAnchor());
+        if (compactTarget) return compactTarget;
 
         // Fallback: collapse to the surface's own bottom-left corner. This keeps
         // legacy full behavior and covers compact cases where the inline yarn
@@ -4763,27 +4770,34 @@
             var targetLeft = target.left;
             var targetTop = target.top;
 
-            // 3. 计算缩放比（transform-origin 为 0% 100% 即左下角，无需 translate）
+            // 3. 计算缩放比，并反推 transform-origin，使缩放后的 shell
+            //    视觉终点落在 target 上。fallback 的 shell 左下角目标会自然得到
+            //    0px 100% 等价原点；compact 的毛线球槽位目标则不会再从左下角跳过去。
             var sx = rect.width > 0 ? target.width / rect.width : 1;
             var sy = rect.height > 0 ? target.height / rect.height : 1;
+            var originX = 0;
+            var originY = rect.height;
+            var originDenomX = 1 - sx;
+            var originDenomY = 1 - sy;
+            if (Math.abs(originDenomX) > 0.0001) {
+                originX = (targetLeft - rect.left) / originDenomX;
+            }
+            if (Math.abs(originDenomY) > 0.0001) {
+                originY = (targetTop - rect.top) / originDenomY;
+            }
+            if (!Number.isFinite(originX)) originX = 0;
+            if (!Number.isFinite(originY)) originY = rect.height;
 
             // 4. 初始 transform = identity，添加过渡类
             shell.style.transform = 'scale(1, 1)';
+            shell.style.transformOrigin = originX + 'px ' + originY + 'px';
             shell.classList.add('is-collapsing');
             void shell.offsetHeight; // 强制 reflow
 
             // 5. 设置目标 transform，触发动画
-            //    full + compact 都：动画期间 left/top **不动**，只缩放（origin 左下角），
-            //    让对话框以自己的左下角为支点原地收缩成球；finishCollapse 再把（已缩成
-            //    球大小的）shell snap 到左下角球位置，视觉无缝。这是 #1506 三态重构前的
-            //    原地折叠行为（best effort：compact 折叠原地、不再滑去贴模型/猫）。
-            var collapseHoldsPosition = true;
+            //    动画期间 left/top 不动，只通过动态 origin 缩放到 target。
             requestAnimationFrame(function () {
                 requestAnimationFrame(function () {
-                    if (!collapseHoldsPosition) {
-                        shell.style.left = targetLeft + 'px';
-                        shell.style.top = targetTop + 'px';
-                    }
                     shell.style.transform = 'scale(' + sx + ', ' + sy + ')';
                 });
             });
@@ -4799,6 +4813,7 @@
                 activeAnimationCleanup = null;
                 shell.classList.remove('is-collapsing');
                 shell.style.transform = 'none';
+                shell.style.removeProperty('transform-origin');
                 // 清除内联尺寸，让 .is-minimized 的 CSS 生效
                 shell.style.removeProperty('width');
                 shell.style.removeProperty('height');
@@ -4829,6 +4844,7 @@
                 shell.removeEventListener('transitionend', onEnd);
                 shell.classList.remove('is-collapsing');
                 shell.style.transform = 'none';
+                shell.style.removeProperty('transform-origin');
                 handled = true;
             };
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3210,6 +3210,7 @@
     var COMPACT_MINIMIZE_PRESS_MS = 280; // = neko-compact-collapse-wipe 擦除时长：擦完再瞬时折叠
     var compactMinimizePressTimer = 0;
     var compactMinimizeCancelSeq = 0; // 折叠取消序号（见 clearCompactMinimizePressTimer），传给 React
+    var compactMinimizeBallIconAnchor = null;
     // 清掉挂起的「按下挤压→瞬时折叠」延时。窗口关闭/动画取消时必须调用，否则这个
     // 跨 280ms 存活的回调会在窗口已关闭/重开后仍 setChatSurfaceMode('minimized')，
     // 把更新后的状态覆盖成「幽灵最小化」（CodeRabbit Minor / Codex P2）。
@@ -3217,6 +3218,7 @@
         if (!compactMinimizePressTimer) return;
         window.clearTimeout(compactMinimizePressTimer);
         compactMinimizePressTimer = 0;
+        compactMinimizeBallIconAnchor = null;
         // 真清掉一个 pending 折叠延时 = 一次进行中的折叠被取消（如 280ms 内 closeWindow）。
         // 递增序号；buildRenderProps 把它当 prop 传给 React，让组件在重开时立即复位
         // compactCollapsing，而不必等 600ms 兜底——否则快速「关→重开」会让 compact 表面带着擦除
@@ -3224,6 +3226,7 @@
         compactMinimizeCancelSeq += 1;
     }
     function handleCompactMinimizeRequest() {
+        rememberCompactMinimizeBallIconAnchor();
         // reduced-motion：折叠擦除/按压挤压动画已被 CSS（@media prefers-reduced-motion: reduce）
         // 禁用，此时再延时 COMPACT_MINIMIZE_PRESS_MS(280ms) 才折叠，只会让窗口「点了没反应」一段，
         // 无任何动画反馈。无障碍模式下直接立即折叠，保持即时响应（Codex P2）。
@@ -4478,22 +4481,64 @@
 
     // ── End idle-dock ────────────────────────────────────────────
 
+    function getCompactMinimizeBallIconRect() {
+        var root = getRoot();
+        var icon = root
+            ? root.querySelector('.compact-chat-minimize-ball-icon')
+            : document.querySelector('.compact-chat-minimize-ball-icon');
+        if (!icon || typeof icon.getBoundingClientRect !== 'function') return null;
+        return normalizeCompactDomRect(icon.getBoundingClientRect());
+    }
+
+    function rememberCompactMinimizeBallIconAnchor() {
+        compactMinimizeBallIconAnchor = null;
+        if (getCurrentChatSurfaceMode() !== 'compact') return null;
+        compactMinimizeBallIconAnchor = getCompactMinimizeBallIconRect();
+        return compactMinimizeBallIconAnchor;
+    }
+
+    function consumeCompactMinimizeBallIconAnchor() {
+        var iconRect = normalizeCompactDomRect(compactMinimizeBallIconAnchor);
+        compactMinimizeBallIconAnchor = null;
+        return iconRect;
+    }
+
+    function getMinimizedTargetFromCompactIcon(iconRect) {
+        iconRect = normalizeCompactDomRect(iconRect);
+        if (!iconRect) return null;
+        return {
+            width: MINIMIZED_SIZE,
+            height: MINIMIZED_SIZE,
+            left: Math.max(
+                0,
+                Math.min(
+                    Math.round(iconRect.left + iconRect.width / 2 - MINIMIZED_SIZE / 2),
+                    window.innerWidth - MINIMIZED_SIZE
+                )
+            ),
+            top: Math.max(
+                0,
+                Math.min(
+                    Math.round(iconRect.top + iconRect.height / 2 - MINIMIZED_SIZE / 2),
+                    window.innerHeight - MINIMIZED_SIZE
+                )
+            )
+        };
+    }
+
     // 返回最小化后 shell 应达到的像素几何。
-    // 桌面：50x50 圆球，锚定在对话框原左下角（clamp 到视口内）。
-    // 手机：全宽底部胶囊，贴屏幕底边（类似移动 App 的底栏收起态）。
-    // 由于 collapse/expand 动画的 transform-origin = 0% 100%（左下角），
-    // target.left 应等于 rect.left 同列，target 底边应与 rect 底边对齐
-    // （即 target.top = rect.bottom - target.height），这样动画过程中底边不漂移。
+    // compact 折叠时，优先锚定到 React frame 内的毛线球图标本身；React 在切到 minimized
+    // 后会卸载 compact surface，所以点击入口要先记录 icon rect。拿不到 icon rect 时才退回
+    // shell 左下角 fallback。
     function getMinimizedTarget(rect) {
-        // Both full and compact collapse to the surface's OWN bottom-left corner:
-        // the dialog folds toward its bottom-left pivot (transform-origin 0% 100%)
-        // and the orb appears right there — NOT compact's avatar/cat dock
-        // (getCompactMinimizeBallTarget) and without the cat-leaning
-        // MINIMIZED_DOWN_OFFSET. This is the pre-#1506 in-place behaviour.
-        // Best-effort for compact: the orb stays where the bar was; carrying a
-        // dragged-orb position into the next expand is the deferred follow-up
-        // (needs the compact surface to become a free-positioned window).
-        // Web-only — Electron short-circuits in setMinimized before this runs.
+        var iconTarget = isLegacyFullMinimizedBall()
+            ? null
+            : getMinimizedTargetFromCompactIcon(consumeCompactMinimizeBallIconAnchor());
+        if (iconTarget) return iconTarget;
+
+        // Fallback: collapse to the surface's own bottom-left corner. This keeps
+        // legacy full behavior and covers compact cases where the inline yarn
+        // icon was not measurable.
         return {
             width: MINIMIZED_SIZE,
             height: MINIMIZED_SIZE,

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -4483,9 +4483,8 @@
 
     function getCompactMinimizeBallTargetRect() {
         var root = getRoot();
-        var button = root
-            ? root.querySelector('.compact-chat-minimize-ball')
-            : document.querySelector('.compact-chat-minimize-ball');
+        if (!root || typeof root.querySelector !== 'function') return null;
+        var button = root.querySelector('.compact-chat-minimize-ball');
         if (!button || typeof button.getBoundingClientRect !== 'function') return null;
         var buttonRect = normalizeCompactDomRect(button.getBoundingClientRect());
         if (!buttonRect) return null;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -4739,6 +4739,10 @@
         // minimize 调用此时 timer 已=0，clear 为 no-op，不影响正常折叠。
         clearCompactMinimizePressTimer();
 
+        if (!previousMinimized && nextMinimized && previousMode === 'compact') {
+            rememberCompactMinimizeBallTargetAnchor();
+        }
+
         if (!nextMinimized) {
             lastRestorableChatSurfaceMode = normalized;
         } else if (!previousMinimized) {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Zoom out",
         "avatarCropCancel": "Cancel",
         "avatarCropSave": "Save",
-        "emptyState": "Messages will appear here after the chat feed is connected.",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "Generating",
         "messageFailed": "Send failed",
         "reactWindowOpen": "Open chat window",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Zoom out",
         "avatarCropCancel": "Cancel",
         "avatarCropSave": "Save",
-        "emptyState": "Start chatting with me now!",
+        "emptyState":  "Messages will appear here after the chat feed is connected.",
         "messageStreaming": "Generating",
         "messageFailed": "Send failed",
         "reactWindowOpen": "Open chat window",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Zoom out",
         "avatarCropCancel": "Cancel",
         "avatarCropSave": "Save",
-        "emptyState": "Messages will appear here after the chat feed is connected.",
+        "emptyState": "Start chatting with me now!",
         "messageStreaming": "Generating",
         "messageFailed": "Send failed",
         "reactWindowOpen": "Open chat window",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Zoom out",
         "avatarCropCancel": "Cancel",
         "avatarCropSave": "Save",
-        "emptyState": "现在开始跟我聊天吧！",
+        "emptyState": "Messages will appear here after the chat feed is connected.",
         "messageStreaming": "Generating",
         "messageFailed": "Send failed",
         "reactWindowOpen": "Open chat window",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "alejar",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Guardar",
-        "emptyState": "Los mensajes aparecerán aquí después de que se conecte la transmisión del chat.",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "generando",
         "messageFailed": "Envío fallido",
         "reactWindowOpen": "Abrir ventana de chat",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "alejar",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Guardar",
-        "emptyState": "现在开始跟我聊天吧！",
+        "emptyState": "Los mensajes aparecerán aquí después de que se conecte la transmisión del chat.",
         "messageStreaming": "generando",
         "messageFailed": "Envío fallido",
         "reactWindowOpen": "Abrir ventana de chat",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "alejar",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Guardar",
-        "emptyState": "¡Empieza a chatear conmigo ahora!",
+        "emptyState":  "Los mensajes aparecerán aquí después de que se conecte la transmisión del chat.",
         "messageStreaming": "generando",
         "messageFailed": "Envío fallido",
         "reactWindowOpen": "Abrir ventana de chat",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "alejar",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Guardar",
-        "emptyState": "Los mensajes aparecerán aquí después de que se conecte la transmisión del chat.",
+        "emptyState": "¡Empieza a chatear conmigo ahora!",
         "messageStreaming": "generando",
         "messageFailed": "Envío fallido",
         "reactWindowOpen": "Abrir ventana de chat",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "縮小",
         "avatarCropCancel": "キャンセル",
         "avatarCropSave": "保存",
-        "emptyState": "今すぐ私とチャットしよう！",
+        "emptyState":  "チャット内容が接続されると、ここに表示されます。",
         "messageStreaming": "生成中",
         "messageFailed": "送信失敗",
         "reactWindowOpen": "チャットウィンドウを開く",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "縮小",
         "avatarCropCancel": "キャンセル",
         "avatarCropSave": "保存",
-        "emptyState": "现在开始跟我聊天吧！",
+        "emptyState": "チャット内容が接続されると、ここに表示されます。",
         "messageStreaming": "生成中",
         "messageFailed": "送信失敗",
         "reactWindowOpen": "チャットウィンドウを開く",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "縮小",
         "avatarCropCancel": "キャンセル",
         "avatarCropSave": "保存",
-        "emptyState": "チャット内容が接続されると、ここに表示されます。",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "生成中",
         "messageFailed": "送信失敗",
         "reactWindowOpen": "チャットウィンドウを開く",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "縮小",
         "avatarCropCancel": "キャンセル",
         "avatarCropSave": "保存",
-        "emptyState": "チャット内容が接続されると、ここに表示されます。",
+        "emptyState": "今すぐ私とチャットしよう！",
         "messageStreaming": "生成中",
         "messageFailed": "送信失敗",
         "reactWindowOpen": "チャットウィンドウを開く",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "축소",
         "avatarCropCancel": "취소",
         "avatarCropSave": "저장",
-        "emptyState": "现在开始跟我聊天吧！",
+        "emptyState": "채팅 내용이 연결되면 여기에 표시됩니다.",
         "messageStreaming": "생성 중",
         "messageFailed": "전송 실패",
         "reactWindowOpen": "채팅 창 열기",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "축소",
         "avatarCropCancel": "취소",
         "avatarCropSave": "저장",
-        "emptyState": "채팅 내용이 연결되면 여기에 표시됩니다.",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "생성 중",
         "messageFailed": "전송 실패",
         "reactWindowOpen": "채팅 창 열기",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "축소",
         "avatarCropCancel": "취소",
         "avatarCropSave": "저장",
-        "emptyState": "지금 저와 채팅을 시작해 보세요!",
+        "emptyState":  "채팅 내용이 연결되면 여기에 표시됩니다.",
         "messageStreaming": "생성 중",
         "messageFailed": "전송 실패",
         "reactWindowOpen": "채팅 창 열기",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "축소",
         "avatarCropCancel": "취소",
         "avatarCropSave": "저장",
-        "emptyState": "채팅 내용이 연결되면 여기에 표시됩니다.",
+        "emptyState": "지금 저와 채팅을 시작해 보세요!",
         "messageStreaming": "생성 중",
         "messageFailed": "전송 실패",
         "reactWindowOpen": "채팅 창 열기",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Diminuir zoom",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Salvar",
-        "emptyState": "现在开始跟我聊天吧！",
+        "emptyState": "As mensagens aparecerão aqui depois que o feed do bate-papo for conectado.",
         "messageStreaming": "Gerando",
         "messageFailed": "Falha no envio",
         "reactWindowOpen": "Abra a janela de bate-papo",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Diminuir zoom",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Salvar",
-        "emptyState": "As mensagens aparecerão aqui depois que o feed do bate-papo for conectado.",
+        "emptyState": "Comece a conversar comigo agora!",
         "messageStreaming": "Gerando",
         "messageFailed": "Falha no envio",
         "reactWindowOpen": "Abra a janela de bate-papo",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Diminuir zoom",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Salvar",
-        "emptyState": "Comece a conversar comigo agora!",
+        "emptyState":  "As mensagens aparecerão aqui depois que o feed do bate-papo for conectado.",
         "messageStreaming": "Gerando",
         "messageFailed": "Falha no envio",
         "reactWindowOpen": "Abra a janela de bate-papo",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Diminuir zoom",
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Salvar",
-        "emptyState": "As mensagens aparecerão aqui depois que o feed do bate-papo for conectado.",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "Gerando",
         "messageFailed": "Falha no envio",
         "reactWindowOpen": "Abra a janela de bate-papo",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Уменьшить",
         "avatarCropCancel": "Отмена",
         "avatarCropSave": "Сохранить",
-        "emptyState": "Начните чат со мной прямо сейчас!",
+        "emptyState":  "Сообщения появятся здесь после подключения чата.",
         "messageStreaming": "Генерация",
         "messageFailed": "Ошибка отправки",
         "reactWindowOpen": "Открыть окно чата",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Уменьшить",
         "avatarCropCancel": "Отмена",
         "avatarCropSave": "Сохранить",
-        "emptyState": "Сообщения появятся здесь после подключения чата.",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "Генерация",
         "messageFailed": "Ошибка отправки",
         "reactWindowOpen": "Открыть окно чата",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Уменьшить",
         "avatarCropCancel": "Отмена",
         "avatarCropSave": "Сохранить",
-        "emptyState": "Сообщения появятся здесь после подключения чата.",
+        "emptyState": "Начните чат со мной прямо сейчас!",
         "messageStreaming": "Генерация",
         "messageFailed": "Ошибка отправки",
         "reactWindowOpen": "Открыть окно чата",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "Уменьшить",
         "avatarCropCancel": "Отмена",
         "avatarCropSave": "Сохранить",
-        "emptyState": "现在开始跟我聊天吧！",
+        "emptyState": "Сообщения появятся здесь после подключения чата.",
         "messageStreaming": "Генерация",
         "messageFailed": "Ошибка отправки",
         "reactWindowOpen": "Открыть окно чата",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "缩小",
         "avatarCropCancel": "取消",
         "avatarCropSave": "保存",
-        "emptyState": "聊天内容接入后会显示在这里。",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "生成中",
         "messageFailed": "发送失败",
         "reactWindowOpen": "打开聊天框",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "縮小",
         "avatarCropCancel": "取消",
         "avatarCropSave": "儲存",
-        "emptyState": "现在开始跟我聊天吧！",
+        "emptyState": "現在開始跟我聊天吧！",
         "messageStreaming": "生成中",
         "messageFailed": "發送失敗",
         "reactWindowOpen": "打開聊天框",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -752,7 +752,7 @@
         "avatarCropZoomOut": "縮小",
         "avatarCropCancel": "取消",
         "avatarCropSave": "儲存",
-        "emptyState": "聊天內容接入後會顯示在這裡。",
+        "emptyState": "现在开始跟我聊天吧！",
         "messageStreaming": "生成中",
         "messageFailed": "發送失敗",
         "reactWindowOpen": "打開聊天框",

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -562,12 +562,22 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
         '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] '
         '.compact-input-tool-toggle:hover'
     ) in styles
+    assert "--compact-chat-minimize-ball-slot: 51px;" in styles
+    fixed_ball_block = css_block(
+        styles,
+        ".compact-chat-surface-frame > .compact-chat-minimize-ball {",
+        ".compact-chat-capsule-button",
+    )
+    assert "position: absolute;" in fixed_ball_block
+    assert "left: 2px;" in fixed_ball_block
+    assert "top: 50%;" in fixed_ball_block
+    assert "transform: translateY(-50%);" in fixed_ball_block
     assert "width: auto;" in compact_input_block
     assert "min-width: 0;" in compact_input_block
     assert "padding: 10px 8px 10px 0;" in compact_input_block
-    assert 'padding: 5px 62px 5px 2px;' in styles
+    assert 'padding: 5px 62px 5px var(--compact-chat-minimize-ball-slot);' in styles
     assert '.compact-chat-surface-frame[data-compact-chat-state="input"]' in compact_mobile_block
-    assert 'padding: 5px 62px 5px 18px;' in compact_mobile_block
+    assert 'padding: 5px 62px 5px var(--compact-chat-minimize-ball-slot);' in compact_mobile_block
     assert 'padding: 5px 8px 5px 18px;' not in compact_mobile_block
     assert '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"]:not([data-compact-chat-state="input"])' in styles
     assert 'padding-right: 62px;' in styles
@@ -783,6 +793,36 @@ def test_moved_drag_suppresses_trailing_release_click():
         1,
     )[1]
     assert "document.addEventListener('click', consumeDragReleaseClickGuard, true);" in listeners_block
+
+
+def test_compact_minimize_targets_inline_yarn_ball_icon():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    assert "var compactMinimizeBallIconAnchor = null;" in script
+    assert "function getCompactMinimizeBallIconRect()" in script
+    assert "root.querySelector('.compact-chat-minimize-ball-icon')" in script
+    assert "function getMinimizedTargetFromCompactIcon(iconRect)" in script
+    assert "Math.round(iconRect.left + iconRect.width / 2 - MINIMIZED_SIZE / 2)" in script
+    assert "Math.round(iconRect.top + iconRect.height / 2 - MINIMIZED_SIZE / 2)" in script
+
+    cancel_block = script.split("function clearCompactMinimizePressTimer()", 1)[1].split(
+        "function handleCompactMinimizeRequest()",
+        1,
+    )[0]
+    assert "compactMinimizeBallIconAnchor = null;" in cancel_block
+
+    minimize_block = script.split("function handleCompactMinimizeRequest()", 1)[1].split(
+        "function handleMiniGameInviteChoice(option)",
+        1,
+    )[0]
+    assert "rememberCompactMinimizeBallIconAnchor();" in minimize_block
+
+    target_block = script.split("function getMinimizedTarget(rect)", 1)[1].split(
+        "function getExpandedTargetFromSavedState()",
+        1,
+    )[0]
+    assert "getMinimizedTargetFromCompactIcon(consumeCompactMinimizeBallIconAnchor())" in target_block
+    assert "if (iconTarget) return iconTarget;" in target_block
 
 
 def test_desktop_compact_layout_change_resets_anchor_only_when_base_surface_changes():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -829,6 +829,19 @@ def test_compact_minimize_targets_inline_yarn_ball_button_center():
     )[0]
     assert "rememberCompactMinimizeBallTargetAnchor();" in minimize_block
 
+    set_mode_block = script.split("function setChatSurfaceMode(nextMode)", 1)[1].split(
+        "function cycleChatSurfaceMode()",
+        1,
+    )[0]
+    assert "if (!previousMinimized && nextMinimized && previousMode === 'compact')" in set_mode_block
+    assert "rememberCompactMinimizeBallTargetAnchor();" in set_mode_block
+    assert set_mode_block.index("clearCompactMinimizePressTimer();") < set_mode_block.index(
+        "rememberCompactMinimizeBallTargetAnchor();"
+    )
+    assert set_mode_block.index("rememberCompactMinimizeBallTargetAnchor();") < set_mode_block.index(
+        "state.chatSurfaceMode = normalized;"
+    )
+
     target_block = script.split("function getMinimizedTarget(rect)", 1)[1].split(
         "function getExpandedTargetFromSavedState()",
         1,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -562,14 +562,17 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
         '.compact-chat-surface-frame[data-compact-tool-toggle-visible="true"] '
         '.compact-input-tool-toggle:hover'
     ) in styles
-    assert "--compact-chat-minimize-ball-slot: 51px;" in styles
+    assert "--compact-chat-minimize-ball-size: 41px;" in styles
+    assert "--compact-chat-minimize-ball-inset: 2px;" in styles
+    assert "--compact-chat-minimize-ball-gap: 8px;" in styles
+    assert "--compact-chat-minimize-ball-slot: calc(" in styles
     fixed_ball_block = css_block(
         styles,
-        ".compact-chat-surface-frame > .compact-chat-minimize-ball {",
+        ".compact-chat-surface-frame .compact-chat-minimize-ball {",
         ".compact-chat-capsule-button",
     )
     assert "position: absolute;" in fixed_ball_block
-    assert "left: 2px;" in fixed_ball_block
+    assert "left: var(--compact-chat-minimize-ball-inset);" in fixed_ball_block
     assert "top: 50%;" in fixed_ball_block
     assert "transform: translateY(-50%);" in fixed_ball_block
     assert "width: auto;" in compact_input_block
@@ -805,6 +808,11 @@ def test_compact_minimize_targets_inline_yarn_ball_button_center():
     assert "height: MINIMIZED_SIZE" in script
     assert "left: buttonRect.left + buttonRect.width / 2 - MINIMIZED_SIZE / 2" in script
     assert "top: buttonRect.top + buttonRect.height / 2 - MINIMIZED_SIZE / 2" in script
+    target_rect_block = script.split("function getCompactMinimizeBallTargetRect()", 1)[1].split(
+        "function rememberCompactMinimizeBallTargetAnchor()",
+        1,
+    )[0]
+    assert "document.querySelector('.compact-chat-minimize-ball')" not in target_rect_block
     assert "function getMinimizedTargetFromCompactAnchor(anchorRect)" in script
     assert "Math.round(anchorRect.left)" in script
     assert "Math.round(anchorRect.top)" in script

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -795,34 +795,52 @@ def test_moved_drag_suppresses_trailing_release_click():
     assert "document.addEventListener('click', consumeDragReleaseClickGuard, true);" in listeners_block
 
 
-def test_compact_minimize_targets_inline_yarn_ball_icon():
+def test_compact_minimize_targets_inline_yarn_ball_button_center():
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 
-    assert "var compactMinimizeBallIconAnchor = null;" in script
-    assert "function getCompactMinimizeBallIconRect()" in script
-    assert "root.querySelector('.compact-chat-minimize-ball-icon')" in script
-    assert "function getMinimizedTargetFromCompactIcon(iconRect)" in script
-    assert "Math.round(iconRect.left + iconRect.width / 2 - MINIMIZED_SIZE / 2)" in script
-    assert "Math.round(iconRect.top + iconRect.height / 2 - MINIMIZED_SIZE / 2)" in script
+    assert "var compactMinimizeBallTargetAnchor = null;" in script
+    assert "function getCompactMinimizeBallTargetRect()" in script
+    assert "root.querySelector('.compact-chat-minimize-ball')" in script
+    assert "width: MINIMIZED_SIZE" in script
+    assert "height: MINIMIZED_SIZE" in script
+    assert "left: buttonRect.left + buttonRect.width / 2 - MINIMIZED_SIZE / 2" in script
+    assert "top: buttonRect.top + buttonRect.height / 2 - MINIMIZED_SIZE / 2" in script
+    assert "function getMinimizedTargetFromCompactAnchor(anchorRect)" in script
+    assert "Math.round(anchorRect.left)" in script
+    assert "Math.round(anchorRect.top)" in script
 
     cancel_block = script.split("function clearCompactMinimizePressTimer()", 1)[1].split(
         "function handleCompactMinimizeRequest()",
         1,
     )[0]
-    assert "compactMinimizeBallIconAnchor = null;" in cancel_block
+    assert "compactMinimizeBallTargetAnchor = null;" in cancel_block
 
     minimize_block = script.split("function handleCompactMinimizeRequest()", 1)[1].split(
         "function handleMiniGameInviteChoice(option)",
         1,
     )[0]
-    assert "rememberCompactMinimizeBallIconAnchor();" in minimize_block
+    assert "rememberCompactMinimizeBallTargetAnchor();" in minimize_block
 
     target_block = script.split("function getMinimizedTarget(rect)", 1)[1].split(
         "function getExpandedTargetFromSavedState()",
         1,
     )[0]
-    assert "getMinimizedTargetFromCompactIcon(consumeCompactMinimizeBallIconAnchor())" in target_block
-    assert "if (iconTarget) return iconTarget;" in target_block
+    assert "getMinimizedTargetFromCompactAnchor(consumeCompactMinimizeBallTargetAnchor())" in target_block
+    assert "if (compactTarget) return compactTarget;" in target_block
+
+
+def test_compact_minimize_collapse_origin_matches_target():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+    collapse_block = script.split("// ---- 折叠动画", 1)[1].split(
+        "// ---- 展开动画",
+        1,
+    )[0]
+
+    assert "var originDenomX = 1 - sx;" in collapse_block
+    assert "originX = (targetLeft - rect.left) / originDenomX;" in collapse_block
+    assert "originY = (targetTop - rect.top) / originDenomY;" in collapse_block
+    assert "shell.style.transformOrigin = originX + 'px ' + originY + 'px';" in collapse_block
+    assert "shell.style.removeProperty('transform-origin');" in collapse_block
 
 
 def test_desktop_compact_layout_change_resets_anchor_only_when_base_surface_changes():


### PR DESCRIPTION
## 变更内容

  - 修复 compact 聊天框折叠为毛线球时的目标位置计算
    - 改为以 frame 内毛线球按钮中心作为折叠目标
    - 动态计算 transform-origin，减少折叠动画跳位
  - 优化 compact frame 内毛线球按钮槽位
    - CSS slot 改为基于按钮尺寸变量计算
    - 去掉对直接子元素选择器的结构耦合
  - 将 compact 空态 fallback 文案统一为“现在开始跟我聊天吧！”
  - 修复 locale 回归
    - 非中文 locale 恢复原本本地化 emptyState
    - zh-CN 保留“现在开始跟我聊天吧！”
    - zh-TW 使用“現在開始跟我聊天吧！”
  - 提取 `CHAT_EMPTY_STATE_FALLBACK`，避免组件和测试重复硬编码

  ## 验证

  - `uv run pytest tests/unit/test_react_chat_window_static.py -q`
  - 相关 `App.test.tsx` 空态用例
  - locale JSON parse
  - `bash build_frontend.sh`
  - `node --check static/app-react-chat-window.js`
  - `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 聊天空状态提示改为按语言回退的本地化文案，紧凑预览、胶囊与语音模式下均使用统一兜底文本。

* **优化**
  * 改进最小化/折叠动画，提升目标对齐与视觉一致性。
  * 紧凑模式布局与间距调整，毛绒球占位与容器 padding 更一致。

* **文档**
  * 更新中文（简/繁）空状态文案。

* **测试**
  * 新增紧凑最小化几何与折叠 origin 的测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->