### PR TITLE
fix(chat): align compact choices with resized surface

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -1339,6 +1339,85 @@ describe('App', () => {
     }
   });
 
+  it('positions compact galgame options after pending screenshot attachments', async () => {
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 900,
+    });
+
+    try {
+      const { container } = render(
+        <App
+          chatSurfaceMode="compact"
+          composerAttachments={[
+            { id: 'screenshot-1', url: 'data:image/png;base64,aaa', alt: 'Screenshot 1' },
+          ]}
+          galgameModeEnabled
+          galgameOptions={[
+            { label: 'A', text: 'Option A' },
+            { label: 'B', text: 'Option B' },
+          ]}
+        />,
+      );
+
+      const shell = container.querySelector('.compact-chat-surface-shell');
+      const choiceLayer = document.body.querySelector<HTMLElement>('body > .compact-chat-choice-anchor');
+      expect(shell).not.toBeNull();
+      expect(choiceLayer).not.toBeNull();
+
+      Object.defineProperty(shell!, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({
+          x: 0,
+          y: 100,
+          top: 100,
+          left: 24,
+          right: 454,
+          bottom: 248,
+          width: 430,
+          height: 148,
+          toJSON: () => ({}),
+        }),
+      });
+      Object.defineProperty(choiceLayer!, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: 420,
+          bottom: 112,
+          width: 420,
+          height: 112,
+          toJSON: () => ({}),
+        }),
+      });
+      Object.defineProperty(choiceLayer!, 'scrollHeight', {
+        configurable: true,
+        value: 112,
+      });
+
+      fireEvent(window, new Event('resize'));
+
+      await waitFor(() => {
+        expect(choiceLayer).toHaveAttribute('data-compact-choice-placement', 'below');
+        expect(choiceLayer).toHaveStyle({
+          '--compact-choice-surface-top': '100px',
+          '--compact-choice-surface-left': '24px',
+          '--compact-choice-surface-width': '430px',
+          '--compact-choice-surface-height': '148px',
+        });
+      });
+    } finally {
+      Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+    }
+  });
+
   it('places compact galgame options above the surface when the lower viewport space is insufficient', async () => {
     const originalInnerHeight = window.innerHeight;
     Object.defineProperty(window, 'innerHeight', {

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -1712,6 +1712,61 @@ describe('App', () => {
     }
   });
 
+  it('updates compact choice surface vars before applying forced desktop placement', async () => {
+    const desktopWindow = window as typeof window & { __nekoDesktopCompactLayout?: unknown };
+    const originalDesktopLayout = desktopWindow.__nekoDesktopCompactLayout;
+    desktopWindow.__nekoDesktopCompactLayout = {
+      compactChoicePlacement: 'above',
+    };
+
+    try {
+      const { container } = render(
+        <App
+          chatSurfaceMode="compact"
+          galgameModeEnabled
+          galgameOptions={[
+            { label: 'A', text: 'Option A' },
+            { label: 'B', text: 'Option B' },
+          ]}
+        />,
+      );
+
+      const shell = container.querySelector('.compact-chat-surface-shell');
+      const choiceLayer = document.body.querySelector<HTMLElement>('body > .compact-chat-choice-anchor');
+      expect(shell).not.toBeNull();
+      expect(choiceLayer).not.toBeNull();
+
+      Object.defineProperty(shell!, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({
+          x: 0,
+          y: 0,
+          top: 72,
+          left: 18,
+          right: 448,
+          bottom: 154,
+          width: 430,
+          height: 82,
+          toJSON: () => ({}),
+        }),
+      });
+
+      fireEvent(window, new Event('resize'));
+
+      await waitFor(() => {
+        expect(choiceLayer).toHaveAttribute('data-compact-choice-placement', 'above');
+        expect(choiceLayer).toHaveStyle({
+          '--compact-choice-surface-top': '72px',
+          '--compact-choice-surface-left': '18px',
+          '--compact-choice-surface-width': '430px',
+          '--compact-choice-surface-height': '82px',
+        });
+      });
+    } finally {
+      desktopWindow.__nekoDesktopCompactLayout = originalDesktopLayout;
+    }
+  });
+
   it('repositions compact galgame options when the compact surface moves after opening', async () => {
     const originalInnerHeight = window.innerHeight;
     Object.defineProperty(window, 'innerHeight', {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2610,6 +2610,13 @@ function CompactChatApp({
     const gap = 16;
     let frameId: number | null = null;
 
+    const syncChoiceLayerSurfaceVars = (shellRect: DOMRect, layerNode: HTMLElement) => {
+      layerNode.style.setProperty('--compact-choice-surface-left', `${shellRect.left}px`);
+      layerNode.style.setProperty('--compact-choice-surface-top', `${shellRect.top}px`);
+      layerNode.style.setProperty('--compact-choice-surface-width', `${Math.max(1, shellRect.width)}px`);
+      layerNode.style.setProperty('--compact-choice-surface-height', `${Math.max(1, shellRect.height)}px`);
+    };
+
     const getDesktopPlacementSpace = (shellRect: DOMRect) => {
       const layout = (window as typeof window & {
         __nekoDesktopCompactLayout?: DesktopCompactChoicePlacementLayout | null;
@@ -2628,11 +2635,15 @@ function CompactChatApp({
         return null;
       }
 
-      const surfaceTop = Number(layout?.surface?.top);
-      const surfaceHeight = Number(layout?.surface?.height);
-      const surfaceScreenTop = windowY + (Number.isFinite(surfaceTop) ? surfaceTop : shellRect.top);
+      const layoutSurfaceTop = Number(layout?.surface?.top);
+      const layoutSurfaceHeight = Number(layout?.surface?.height);
+      const measuredTop = Number.isFinite(shellRect.top) ? shellRect.top : layoutSurfaceTop;
+      const measuredHeight = Number.isFinite(shellRect.height) && shellRect.height > 0
+        ? shellRect.height
+        : layoutSurfaceHeight;
+      const surfaceScreenTop = windowY + (Number.isFinite(measuredTop) ? measuredTop : 0);
       const surfaceScreenBottom = surfaceScreenTop
-        + (Number.isFinite(surfaceHeight) && surfaceHeight > 0 ? surfaceHeight : shellRect.height);
+        + (Number.isFinite(measuredHeight) && measuredHeight > 0 ? measuredHeight : Math.max(1, shellRect.height));
       const workAreaBottom = workAreaY + workAreaHeight;
       return {
         availableAbove: Math.max(0, surfaceScreenTop - workAreaY),
@@ -2653,6 +2664,7 @@ function CompactChatApp({
         return;
       }
       const shellRect = nextShellNode.getBoundingClientRect();
+      syncChoiceLayerSurfaceVars(shellRect, nextLayerNode);
       const layerRect = nextLayerNode.getBoundingClientRect();
       const layerHeight = Math.max(layerRect.height, nextLayerNode.scrollHeight);
       const viewportHeight = window.visualViewport?.height ?? window.innerHeight;

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2659,12 +2659,12 @@ function CompactChatApp({
       const desktopForcedPlacement = ((window as typeof window & {
         __nekoDesktopCompactLayout?: DesktopCompactChoicePlacementLayout | null;
       }).__nekoDesktopCompactLayout?.compactChoicePlacement);
+      const shellRect = nextShellNode.getBoundingClientRect();
+      syncChoiceLayerSurfaceVars(shellRect, nextLayerNode);
       if (desktopForcedPlacement === 'above' || desktopForcedPlacement === 'below') {
         setCompactChoiceLayerPlacement(current => (current === desktopForcedPlacement ? current : desktopForcedPlacement));
         return;
       }
-      const shellRect = nextShellNode.getBoundingClientRect();
-      syncChoiceLayerSurfaceVars(shellRect, nextLayerNode);
       const layerRect = nextLayerNode.getBoundingClientRect();
       const layerHeight = Math.max(layerRect.height, nextLayerNode.scrollHeight);
       const viewportHeight = window.visualViewport?.height ?? window.innerHeight;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1964,8 +1964,8 @@ svg {
 
 body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {
   position: fixed;
-  left: calc(var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw)) + (var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)) / 2));
-  width: min(var(--desktop-compact-surface-width, var(--compact-surface-width, 430px)), 420px);
+  left: calc(var(--compact-choice-surface-left, var(--desktop-compact-surface-left, var(--compact-surface-left, 50vw))) + (var(--compact-choice-surface-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px))) / 2));
+  width: min(var(--compact-choice-surface-width, var(--desktop-compact-surface-width, var(--compact-surface-width, 430px))), 420px);
   max-height: min(240px, calc(100vh - 96px));
   height: max-content;
   transform: translateX(-50%);
@@ -2035,11 +2035,11 @@ body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-choice
 
 body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="above"] {
   top: auto;
-  bottom: calc(100vh - var(--desktop-compact-surface-top, var(--compact-surface-top, 0px)) + 16px);
+  bottom: calc(100vh - var(--compact-choice-surface-top, var(--desktop-compact-surface-top, var(--compact-surface-top, 0px))) + 16px);
 }
 
 body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="below"] {
-  top: calc(var(--desktop-compact-surface-top, var(--compact-surface-top, 0px)) + var(--desktop-compact-surface-height, var(--compact-surface-height, 58px)) + 16px);
+  top: calc(var(--compact-choice-surface-top, var(--desktop-compact-surface-top, var(--compact-surface-top, 0px))) + var(--compact-choice-surface-height, var(--desktop-compact-surface-height, var(--compact-surface-height, 58px))) + 16px);
   bottom: auto;
 }
 

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -19,6 +19,7 @@
     const NEKO_MODEL_CAT_TRANSITION_ASSET = '/static/assets/neko-idle/cat_model_change.gif';
     const NEKO_MODEL_CAT_TRANSITION_DURATION_MS = 850;
     const NEKO_MODEL_CAT_TRANSITION_LOOP_GUARD_MS = 70;
+    const NEKO_MODEL_CAT_REVEAL_BEFORE_SMOKE_HIDE_MS = 150;
     const NEKO_MODEL_CAT_TO_MODEL_LOCK_MS = 1120;
     const NEKO_MODEL_CAT_TRANSITION_MODEL_SCALE = 0.38;
     const NEKO_MODEL_CAT_TRANSITION_MIN_SIZE = 260;
@@ -1614,11 +1615,19 @@
         return true;
     }
 
-    function buildNekoModelCatTransitionAssetUrl() {
-        if (!NEKO_MODEL_CAT_TRANSITION_VERSION) {
+    function buildNekoModelCatTransitionAssetUrl(playbackToken = '') {
+        const params = [];
+        if (NEKO_MODEL_CAT_TRANSITION_VERSION) {
+            params.push(`v=${encodeURIComponent(NEKO_MODEL_CAT_TRANSITION_VERSION)}`);
+        }
+        if (playbackToken) {
+            params.push(`play=${encodeURIComponent(String(playbackToken))}`);
+        }
+        if (!params.length) {
             return NEKO_MODEL_CAT_TRANSITION_ASSET;
         }
-        return `${NEKO_MODEL_CAT_TRANSITION_ASSET}?v=${encodeURIComponent(NEKO_MODEL_CAT_TRANSITION_VERSION)}`;
+        const separator = NEKO_MODEL_CAT_TRANSITION_ASSET.includes('?') ? '&' : '?';
+        return `${NEKO_MODEL_CAT_TRANSITION_ASSET}${separator}${params.join('&')}`;
     }
 
     function normalizeNekoScreenRect(rect) {
@@ -1862,11 +1871,15 @@
         };
     }
 
-    function clearNekoModelCatTransitionOverlay() {
-        const existing = document.getElementById('neko-model-cat-transition');
-        if (existing && existing.parentNode) {
-            existing.parentNode.removeChild(existing);
-        }
+    function clearNekoModelCatTransitionOverlay(keepToken = '') {
+        document.querySelectorAll('#neko-model-cat-transition').forEach((existing) => {
+            if (keepToken && existing.getAttribute('data-neko-model-cat-transition-token') === String(keepToken)) {
+                return;
+            }
+            if (existing.parentNode) {
+                existing.parentNode.removeChild(existing);
+            }
+        });
     }
 
     function getNekoModelCatOverlayVisibleMs() {
@@ -1879,10 +1892,11 @@
             : NEKO_MODEL_CAT_TRANSITION_DURATION_MS;
     }
 
-    function createNekoModelCatTransitionOverlay(rect, direction) {
+    function createNekoModelCatTransitionOverlay(rect, direction, token) {
         const overlay = document.createElement('div');
         overlay.id = 'neko-model-cat-transition';
         overlay.setAttribute('data-neko-model-cat-transition-direction', direction);
+        overlay.setAttribute('data-neko-model-cat-transition-token', String(token || ''));
         Object.assign(overlay.style, {
             position: 'fixed',
             left: `${rect.left}px`,
@@ -1946,6 +1960,12 @@
         const coverRect = options.coverRect || null;
         const direction = options.direction || 'model-to-cat';
         const transitionToken = options.transitionToken || null;
+        const onBeforeOverlayCleanup = typeof options.onBeforeOverlayCleanup === 'function'
+            ? options.onBeforeOverlayCleanup
+            : null;
+        const beforeOverlayCleanupMs = Number.isFinite(Number(options.beforeOverlayCleanupMs))
+            ? Math.max(0, Number(options.beforeOverlayCleanupMs))
+            : NEKO_MODEL_CAT_REVEAL_BEFORE_SMOKE_HIDE_MS;
         let token = transitionToken;
         if (nekoModelCatTransitionActive) {
             const ownsActiveTransition = transitionToken &&
@@ -1967,7 +1987,7 @@
             });
         }
         const rect = normalizeNekoTransitionRect(anchorRect, container, coverRect);
-        const src = buildNekoModelCatTransitionAssetUrl();
+        const src = buildNekoModelCatTransitionAssetUrl(token);
 
         if (container) {
             container.setAttribute('data-neko-model-cat-transitioning', direction);
@@ -1978,13 +1998,25 @@
             }
         }
 
-        clearNekoModelCatTransitionOverlay();
-        const { overlay, image } = createNekoModelCatTransitionOverlay(rect, direction);
+        clearNekoModelCatTransitionOverlay(token);
+        const { overlay, image } = createNekoModelCatTransitionOverlay(rect, direction, token);
         let playbackStartedAt = getNekoTransitionNowMs();
         let overlayCleanupTimer = null;
+        let beforeOverlayCleanupTimer = null;
         let finishTimer = null;
+        let didImageLoad = false;
+        let didCallBeforeOverlayCleanup = false;
         let didCleanupOverlay = false;
         let didFinish = false;
+        const runBeforeOverlayCleanup = () => {
+            if (didFinish || didCallBeforeOverlayCleanup || !onBeforeOverlayCleanup) return;
+            didCallBeforeOverlayCleanup = true;
+            try {
+                onBeforeOverlayCleanup();
+            } catch (error) {
+                console.warn('[App] model/cat transition before-overlay-cleanup callback failed:', error);
+            }
+        };
         const cleanupOverlay = () => {
             if (didCleanupOverlay) return;
             didCleanupOverlay = true;
@@ -2008,18 +2040,24 @@
         const scheduleTransitionTimers = (resolve) => {
             if (didFinish) return;
             if (overlayCleanupTimer) clearTimeout(overlayCleanupTimer);
+            if (beforeOverlayCleanupTimer) clearTimeout(beforeOverlayCleanupTimer);
             if (finishTimer) clearTimeout(finishTimer);
             const elapsedMs = Math.max(0, getNekoTransitionNowMs() - playbackStartedAt);
             const visibleDurationMs = getNekoModelCatOverlayVisibleMs();
             const settleDurationMs = getNekoModelCatSettleMs(direction);
             const overlayRemainingMs = Math.max(0, visibleDurationMs - elapsedMs);
             const finishRemainingMs = Math.max(0, settleDurationMs - elapsedMs);
+            if (onBeforeOverlayCleanup && didImageLoad && !didCallBeforeOverlayCleanup) {
+                const revealRemainingMs = Math.max(0, overlayRemainingMs - beforeOverlayCleanupMs);
+                beforeOverlayCleanupTimer = setTimeout(runBeforeOverlayCleanup, revealRemainingMs);
+            }
             overlayCleanupTimer = setTimeout(cleanupOverlay, overlayRemainingMs);
             finishTimer = setTimeout(() => {
                 finishTransition(resolve);
             }, finishRemainingMs);
         };
         image.addEventListener('load', () => {
+            didImageLoad = true;
             playbackStartedAt = getNekoTransitionNowMs();
         }, { once: true });
         document.body.appendChild(overlay);
@@ -2102,7 +2140,7 @@
         scheduleIdleReturnBallDesktopBridge(reason, container);
     }
 
-    function showReturnBallContainer(container, anchorRect) {
+    function showReturnBallContainer(container, anchorRect, options = {}) {
         if (!container) return null;
 
         cancelReturnBallReveal(container);
@@ -2120,12 +2158,14 @@
 
         void container.offsetWidth;
 
-        const revealFrameId = requestAnimationFrame(() => {
-            if (container.__nekoReturnBallRevealFrame !== revealFrameId) return;
-            revealReturnBallContainer(container, 'return-ball-revealed');
-        });
-        container.__nekoReturnBallRevealFrame = revealFrameId;
-        scheduleIdleReturnBallDesktopBridge('return-ball-show', container);
+        if (!options.deferReveal) {
+            const revealFrameId = requestAnimationFrame(() => {
+                if (container.__nekoReturnBallRevealFrame !== revealFrameId) return;
+                revealReturnBallContainer(container, 'return-ball-revealed');
+            });
+            container.__nekoReturnBallRevealFrame = revealFrameId;
+            scheduleIdleReturnBallDesktopBridge('return-ball-show', container);
+        }
         return container;
     }
 
@@ -2157,7 +2197,11 @@
     function postIdleReturnBallDesktopState(reason, container, overrideScreenRect) {
         if (!canPostIdleReturnBallDesktopState()) return;
         const target = container || getVisibleIdleReturnBallContainer();
-        const visible = !!(target && target.getAttribute('data-neko-return-visible') === 'true' && target.style.display !== 'none');
+        const visible = !!(target &&
+            target.getAttribute('data-neko-return-visible') === 'true' &&
+            target.style.display !== 'none' &&
+            target.style.visibility !== 'hidden' &&
+            target.style.opacity !== '0');
         const tier = visible
             ? (target.getAttribute('data-neko-idle-tier') || 'none')
             : 'none';
@@ -3317,14 +3361,14 @@
                 }
             }
             if (useMmdReturn && mmdReturnButtonContainer) {
-                activeReturnButtonContainer = showReturnBallContainer(mmdReturnButtonContainer, savedGoodbyeRect);
+                activeReturnButtonContainer = showReturnBallContainer(mmdReturnButtonContainer, savedGoodbyeRect, { deferReveal: true });
             } else {
                 hideReturnBallContainer(mmdReturnButtonContainer);
             }
 
             // 显示Live2D的返回按钮（仅在非VRM/非MMD模式时显示）
             if (!useVrmReturn && !useMmdReturn && live2dReturnButtonContainer) {
-                activeReturnButtonContainer = showReturnBallContainer(live2dReturnButtonContainer, savedGoodbyeRect);
+                activeReturnButtonContainer = showReturnBallContainer(live2dReturnButtonContainer, savedGoodbyeRect, { deferReveal: true });
             } else {
                 hideReturnBallContainer(live2dReturnButtonContainer);
             }
@@ -3342,13 +3386,26 @@
             }
 
             if (useVrmReturn && vrmReturnButtonContainer) {
-                activeReturnButtonContainer = showReturnBallContainer(vrmReturnButtonContainer, savedGoodbyeRect);
+                activeReturnButtonContainer = showReturnBallContainer(vrmReturnButtonContainer, savedGoodbyeRect, { deferReveal: true });
             } else {
                 hideReturnBallContainer(vrmReturnButtonContainer);
             }
 
             ensureMultiWindowReturnBallDrag(activeReturnButtonContainer);
             if (activeReturnButtonContainer) {
+                let didRevealActiveReturnBall = false;
+                const revealActiveReturnBall = (reason) => {
+                    if (didRevealActiveReturnBall) return;
+                    if (
+                        activeReturnButtonContainer &&
+                        activeReturnButtonContainer.isConnected &&
+                        activeReturnButtonContainer.style.display !== 'none' &&
+                        activeReturnButtonContainer.getAttribute('data-neko-return-visible') === 'true'
+                    ) {
+                        didRevealActiveReturnBall = true;
+                        revealReturnBallContainer(activeReturnButtonContainer, reason);
+                    }
+                };
                 requestAnimationFrame(() => {
                     if (
                         activeReturnButtonContainer &&
@@ -3361,26 +3418,15 @@
                             direction: 'model-to-cat',
                             anchorRect: transitionAnchorRect,
                             transitionToken: goodbyeTransitionToken,
-                            container: activeReturnButtonContainer
+                            container: activeReturnButtonContainer,
+                            onBeforeOverlayCleanup: () => {
+                                revealActiveReturnBall('return-ball-model-cat-transition-smoke-cover');
+                            }
                         }).then((transitionResult) => {
                             if (transitionResult && transitionResult.blocked) return;
-                            if (
-                                activeReturnButtonContainer &&
-                                activeReturnButtonContainer.isConnected &&
-                                activeReturnButtonContainer.style.display !== 'none' &&
-                                activeReturnButtonContainer.getAttribute('data-neko-return-visible') === 'true'
-                            ) {
-                                revealReturnBallContainer(activeReturnButtonContainer, 'return-ball-model-cat-transition-done');
-                            }
+                            revealActiveReturnBall('return-ball-model-cat-transition-done');
                         }).catch(() => {
-                            if (
-                                activeReturnButtonContainer &&
-                                activeReturnButtonContainer.isConnected &&
-                                activeReturnButtonContainer.style.display !== 'none' &&
-                                activeReturnButtonContainer.getAttribute('data-neko-return-visible') === 'true'
-                            ) {
-                                revealReturnBallContainer(activeReturnButtonContainer, 'return-ball-model-cat-transition-fallback');
-                            }
+                            revealActiveReturnBall('return-ball-model-cat-transition-fallback');
                         });
                     } else {
                         releaseNekoModelCatTransition(goodbyeTransitionToken);


### PR DESCRIPTION
## Summary
- sync compact choice layer bounds from the measured chat surface before placement
- use measured choice surface CSS variables so options stay aligned after attachments resize the compact composer
- add a regression test for pending screenshot attachments affecting compact galgame option placement

## Tests
- npm test -- --run src/App.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化角色切换与遮罩时序，新增可延迟揭示机制与基于播放实例的覆盖层管理，使回球显示更平滑可控。  
* **Bug 修复**
  * 改进紧凑模式下选项框的几何同步与定位优先级，提升 above/below 放置的稳定性并修正表面相关定位值。  
  * 改进回球可见性判定，避免隐藏或透明状态被误判。  
* **Tests**
  * 新增紧凑模式选项框在特殊布局与附件场景下的定位测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->