### PR TITLE
Fix custom API close assist provider fallback

### DIFF
--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -20,6 +20,7 @@ let _resolvedProviderUrls = {};
 let _coreApiKeyInputDirty = false;
 // 保存/检测期间锁住设置页，避免用户中途关闭或重复操作
 let _apiSaveInProgress = false;
+let _lastEligibleAssistProvider = '';
 // 本页已提醒过的阿里美国 API URL，避免同一轮检测重复弹窗。
 const _aliyunUsApiWarningShownKeys = new Set();
 
@@ -1265,6 +1266,7 @@ async function loadCurrentApiKey() {
                     const optionExists = Array.from(assistApiSelect.options).some(opt => opt.value === data.assistApi);
                     if (optionExists) {
                         assistApiSelect.value = data.assistApi;
+                        rememberEligibleAssistProvider(data.assistApi);
                         syncProviderSelectDropdowns(assistApiSelect);
                     }
                 } else {
@@ -1686,6 +1688,12 @@ function updateAssistApiKeyInputAvailability() {
     assistApiKeyInput.placeholder = window.t ? window.t('api.assistApiKeyPlaceholder') : '留空使用管理簿对应 Key';
     if (isFreeVersionText(getRealKey(assistApiKeyInput))) {
         setMaskedInput(assistApiKeyInput, '');
+    }
+}
+
+function rememberEligibleAssistProvider(providerKey) {
+    if (providerKey && providerKey !== 'free') {
+        _lastEligibleAssistProvider = providerKey;
     }
 }
 
@@ -2361,15 +2369,23 @@ function updateAssistApiRecommendation(options = {}) {
             freeOption.textContent = window.t ? window.t('api.freeVersionOnlyWhenCoreFree') : '免费版（仅核心API为免费版时可用）';
         }
         // If assist is still stuck on 'free' (now disabled), switch to a valid provider
-        if (!preserveAssistProvider && assistApiSelect.value === 'free') {
-            // Prefer qwen as default, otherwise pick first non-free enabled option
-            const qwenOpt = assistApiSelect.querySelector('option[value="qwen"]');
-            if (qwenOpt && !qwenOpt.disabled) {
-                assistApiSelect.value = 'qwen';
+        if (assistApiSelect.value === 'free') {
+            const rememberedOpt = preserveAssistProvider && _lastEligibleAssistProvider
+                ? assistApiSelect.querySelector(`option[value="${_lastEligibleAssistProvider}"]`)
+                : null;
+            if (rememberedOpt && !rememberedOpt.disabled) {
+                assistApiSelect.value = _lastEligibleAssistProvider;
             } else {
-                const validOpt = Array.from(assistApiSelect.options).find(o => !o.disabled && o.value !== 'free');
-                if (validOpt) assistApiSelect.value = validOpt.value;
+                // Prefer qwen as default, otherwise pick first non-free enabled option
+                const qwenOpt = assistApiSelect.querySelector('option[value="qwen"]');
+                if (qwenOpt && !qwenOpt.disabled) {
+                    assistApiSelect.value = 'qwen';
+                } else {
+                    const validOpt = Array.from(assistApiSelect.options).find(o => !o.disabled && o.value !== 'free');
+                    if (validOpt) assistApiSelect.value = validOpt.value;
+                }
             }
+            rememberEligibleAssistProvider(assistApiSelect.value);
             autoFillAssistApiKey(true);
             // Directly recompute follow_assist slots (avoid redundant handler call)
             MODEL_TYPES.forEach(mt => {
@@ -2378,6 +2394,8 @@ function updateAssistApiRecommendation(options = {}) {
                     onCustomModelProviderChange(mt);
                 }
             });
+        } else {
+            rememberEligibleAssistProvider(assistApiSelect.value);
         }
     }
 

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1748,7 +1748,7 @@ function toggleCustomApi(skipAutoFill) {
     if (!isCustomEnabled && !skipAutoFill) {
         autoFillCoreApiKey(true);
         autoFillAssistApiKey(true);
-        updateAssistApiRecommendation();
+        updateAssistApiRecommendation({ preserveAssistProvider: true });
     }
 
     syncProviderSelectDropdowns();
@@ -2294,12 +2294,13 @@ function isFreeVersionText(value) {
 }
 
 // 根据核心API选择更新辅助API的提示和建议
-function updateAssistApiRecommendation() {
+function updateAssistApiRecommendation(options = {}) {
     const coreApiSelect = document.getElementById('coreApiSelect');
     const assistApiSelect = document.getElementById('assistApiSelect');
 
     if (!coreApiSelect || !assistApiSelect) return;
 
+    const preserveAssistProvider = options && options.preserveAssistProvider === true;
     const selectedCoreApi = coreApiSelect.value;
 
     // 控制API Key输入框和免费版提示
@@ -2360,7 +2361,7 @@ function updateAssistApiRecommendation() {
             freeOption.textContent = window.t ? window.t('api.freeVersionOnlyWhenCoreFree') : '免费版（仅核心API为免费版时可用）';
         }
         // If assist is still stuck on 'free' (now disabled), switch to a valid provider
-        if (assistApiSelect.value === 'free') {
+        if (!preserveAssistProvider && assistApiSelect.value === 'free') {
             // Prefer qwen as default, otherwise pick first non-free enabled option
             const qwenOpt = assistApiSelect.querySelector('option[value="qwen"]');
             if (qwenOpt && !qwenOpt.disabled) {
@@ -2578,7 +2579,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // 根据自定义API启用状态设置初始折叠状态
     const enableCustomApi = document.getElementById('enableCustomApi');
     if (enableCustomApi) {
-        toggleCustomApi();
+        toggleCustomApi(true);
     }
 });
 
@@ -4010,7 +4011,7 @@ async function initializePage() {
             }
             updateAssistApiKeyInputAvailability();
 
-            updateAssistApiRecommendation();
+            updateAssistApiRecommendation({ preserveAssistProvider: true });
             autoFillCoreApiKey(true);
             // 不再调用 autoFillAssistApiKey(true)，因为 loadCurrentApiKey()
             // 已从后端数据直接设置辅助API Key，此处再次从管理簿读取会覆盖正确值
@@ -4048,7 +4049,7 @@ async function initializePage() {
             });
         }
 
-        updateAssistApiRecommendation();
+        updateAssistApiRecommendation({ preserveAssistProvider: true });
 
         // 监听语言切换事件，更新下拉选项（保留用户未保存的输入）
         window.addEventListener('localechange', async () => {

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -155,6 +155,59 @@ def test_custom_api_close_does_not_trigger_assist_provider_fallback(mock_page: P
     mock_page.wait_for_selector("#assistApiSelect option[value='free']", state="attached", timeout=10000)
     mock_page.wait_for_selector("#assistApiSelect option[value='qwen']", state="attached", timeout=10000)
 
+    alternate_assist = mock_page.evaluate("""
+        () => {
+            const options = Array.from(document.querySelectorAll('#assistApiSelect option'));
+            const option = options.find(opt => opt.value && opt.value !== 'free' && opt.value !== 'qwen' && !opt.disabled);
+            return option ? option.value : '';
+        }
+    """)
+    if not alternate_assist:
+        pytest.skip("No alternate non-free assist provider is available")
+
+    result = mock_page.evaluate("""
+        (alternateAssist) => {
+            const core = document.getElementById('coreApiSelect');
+            const assist = document.getElementById('assistApiSelect');
+            const enableCustomApi = document.getElementById('enableCustomApi');
+
+            core.value = 'qwen';
+            assist.value = alternateAssist;
+            updateAssistApiRecommendation({ preserveAssistProvider: true });
+
+            enableCustomApi.checked = true;
+            toggleCustomApi();
+            const afterOpen = assist.value;
+
+            assist.value = 'free';
+            enableCustomApi.checked = false;
+            toggleCustomApi();
+            const afterClose = assist.value;
+
+            assist.value = 'free';
+            updateAssistApiRecommendation();
+            const intentionalFallback = assist.value;
+
+            return { afterOpen, afterClose, intentionalFallback };
+        }
+    """, alternate_assist)
+
+    assert result["afterOpen"] == alternate_assist
+    assert result["afterClose"] == alternate_assist
+    assert result["intentionalFallback"] == "qwen"
+
+
+@pytest.mark.frontend
+def test_custom_api_close_does_not_preserve_ineligible_free_assist(mock_page: Page, running_server: str):
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    url = f"{running_server}/api_key"
+    mock_page.goto(url)
+
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
+    mock_page.wait_for_selector("#coreApiSelect option[value='qwen']", state="attached", timeout=10000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='free']", state="attached", timeout=10000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='qwen']", state="attached", timeout=10000)
+
     result = mock_page.evaluate("""
         () => {
             const core = document.getElementById('coreApiSelect');
@@ -180,5 +233,5 @@ def test_custom_api_close_does_not_trigger_assist_provider_fallback(mock_page: P
     """)
 
     assert result["afterOpen"] == "free"
-    assert result["afterClose"] == "free"
+    assert result["afterClose"] == "qwen"
     assert result["intentionalFallback"] == "qwen"

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -142,3 +142,43 @@ def test_assist_free_disables_assist_api_key_input(mock_page: Page, running_serv
     assert mock_page.evaluate(
         "isFreeVersionText(getRealKey(document.getElementById('assistApiKeyInput')))"
     ) is False
+
+
+@pytest.mark.frontend
+def test_custom_api_close_does_not_trigger_assist_provider_fallback(mock_page: Page, running_server: str):
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    url = f"{running_server}/api_key"
+    mock_page.goto(url)
+
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=10000)
+    mock_page.wait_for_selector("#coreApiSelect option[value='qwen']", state="attached", timeout=10000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='free']", state="attached", timeout=10000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='qwen']", state="attached", timeout=10000)
+
+    result = mock_page.evaluate("""
+        () => {
+            const core = document.getElementById('coreApiSelect');
+            const assist = document.getElementById('assistApiSelect');
+            const enableCustomApi = document.getElementById('enableCustomApi');
+
+            core.value = 'qwen';
+            assist.value = 'free';
+            enableCustomApi.checked = true;
+            toggleCustomApi();
+            const afterOpen = assist.value;
+
+            enableCustomApi.checked = false;
+            toggleCustomApi();
+            const afterClose = assist.value;
+
+            assist.value = 'free';
+            updateAssistApiRecommendation();
+            const intentionalFallback = assist.value;
+
+            return { afterOpen, afterClose, intentionalFallback };
+        }
+    """)
+
+    assert result["afterOpen"] == "free"
+    assert result["afterClose"] == "free"
+    assert result["intentionalFallback"] == "qwen"


### PR DESCRIPTION
## Summary
- preserve the selected assist provider when closing or initializing the custom API UI
- keep the existing qwen recommendation fallback for explicit provider recommendation flows
- add a frontend regression test for opening and then closing custom API settings

## Tests
- node --check static/js/api_key_settings.js
- uv run pytest tests/frontend/test_api_settings.py::test_custom_api_close_does_not_trigger_assist_provider_fallback -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化 API 设置逻辑：在切换自定义 API 时保留先前“合格”的辅助提供商优先回填，避免被初始化或自动填充意外覆盖；在不可用/锁定为免费时按既定回退策略处理。
* **测试**
  * 新增前端用例，覆盖自定义 API 开关期间辅助提供商保留与回退的多种场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->