### PR TITLE
fix(config): legacy core_config.json 缺 assistApi 时跟随 free core

### DIFF
--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -343,10 +343,11 @@ class TestAssistFollowsCore:
 
     @pytest.mark.unit
     def test_free_core_defaults_assist_to_free_when_key_missing(self, config_manager):
-        """legacy 文件只有 coreApi=free、从未保存 assistApi → assist 跟随 free。
+        """Legacy file with only coreApi=free and no saved assistApi: assist follows free.
 
-        模板默认 assistApi='qwen' 在 merge 时会吞掉"缺失"信号，若不特判，
-        assist 会落到无 key 的 qwen（语音正常、文本/记忆等全 401）。
+        The template default assistApi='qwen' swallows the "key missing" signal
+        during merge; without the special case, assist lands on qwen with no
+        API key (voice works, but text/memory etc. all fail auth).
         """
         _write_core_config(config_manager, {
             'coreApi': 'free',
@@ -358,7 +359,7 @@ class TestAssistFollowsCore:
 
     @pytest.mark.unit
     def test_non_free_core_keeps_template_assist_when_key_missing(self, config_manager):
-        """coreApi=qwen 且文件缺 assistApi → 维持模板默认 qwen，不受特判影响。"""
+        """coreApi=qwen with assistApi key missing keeps template default qwen."""
         _write_core_config(config_manager, {
             'coreApiKey': 'sk-core',
             'coreApi': 'qwen',

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -342,6 +342,32 @@ class TestAssistFollowsCore:
         assert response['assistApiKeyQwen'] == ''
 
     @pytest.mark.unit
+    def test_free_core_defaults_assist_to_free_when_key_missing(self, config_manager):
+        """legacy 文件只有 coreApi=free、从未保存 assistApi → assist 跟随 free。
+
+        模板默认 assistApi='qwen' 在 merge 时会吞掉"缺失"信号，若不特判，
+        assist 会落到无 key 的 qwen（语音正常、文本/记忆等全 401）。
+        """
+        _write_core_config(config_manager, {
+            'coreApi': 'free',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['assistApi'] == 'free'
+        assert cfg.get('CORE_API_TYPE') == 'free'
+
+    @pytest.mark.unit
+    def test_non_free_core_keeps_template_assist_when_key_missing(self, config_manager):
+        """coreApi=qwen 且文件缺 assistApi → 维持模板默认 qwen，不受特判影响。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'sk-core',
+            'coreApi': 'qwen',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['assistApi'] == 'qwen'
+
+    @pytest.mark.unit
     def test_free_core_honors_explicit_assist(self, config_manager):
         """coreApi=free + assistApi=silicon → 显式选择被保留，agent/text 走 silicon。"""
         _write_core_config(config_manager, {

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3520,6 +3520,12 @@ class ConfigManager:
                 file_data = json.load(f)
             if isinstance(file_data, dict):
                 core_cfg.update(file_data)
+                # 模板默认 assistApi='qwen' 会把文件里从未保存过的 assistApi 填
+                # 上，导致下方「core=free 时 assist 默认 free」的跟随逻辑收不到
+                # 缺失信号。仅当文件显式选了 core=free 且从未保存 assistApi 时
+                # 恢复跟随语义；其余缺失场景维持模板默认。
+                if 'assistApi' not in file_data and file_data.get('coreApi') == 'free':
+                    core_cfg['assistApi'] = 'free'
             else:
                 logger.warning("core_config.json 格式异常，使用默认配置。")
 


### PR DESCRIPTION
## 问题

`core_config.json` 由 `DEFAULT_CORE_CONFIG` 模板打底再 merge 文件内容，模板里写死 `assistApi='qwen'`，会把文件中从未保存过的 `assistApi` 键填上。导致 `get_core_config()` 里「core=free 时 assist 默认 free」的跟随逻辑（config_manager.py:3643 附近）永远收不到缺失信号。

legacy 配置（文件里仅有 `coreApi: free`）的实际症状：实时语音正常，但 assist 链路落到 **qwen + 空 API key**，文本/总结/记忆/情绪/视觉/Agent 全部认证失败；设置页里还显示成「阿里百炼」，看起来像用户自己选过。

## 修复（narrow 语义）

仅当文件**显式** `coreApi == 'free'` 且文件中**不含** `assistApi` 键（用户从未保存过）时，assist 跟随 free。判断基于原始 `file_data` 而非 merge 后的 dict：

- 文件里显式存过 `assistApi`（含空串、silicon 等）→ 一律尊重用户保存值，原逻辑不变
- `coreApi` 非 free 或缺失 → 维持模板默认 qwen，零行为变化
- 不引入任何「出错回退 free」的宽泛行为

settings API 路径（config_router.py 读原始文件）本就正确，本修复使 runtime 与 settings 两条路径语义对齐。

## 测试

- 新增：legacy 文件仅 `coreApi=free` → `assistApi == 'free'`
- 新增：`coreApi=qwen` 缺 `assistApi` → 维持 `qwen`（对照组）
- `test_api_config_manager.py` 62 passed；`test_config_manager_follow_urls.py` + `test_yui_free_api_default_voice.py` 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复旧版配置在缺失助手API字段时的回填逻辑：当核心API为“free”时，助手API会正确回填为“free”；其它核心API场景仍保留模板默认行为。

* **Tests**
  * 新增单元测试覆盖上述合并与回填行为，验证 free 与 非 free 情况的差异化处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->