### PR TITLE
feat(chat): compact 对话条最小宽度降到 180px

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -308,7 +308,7 @@ describe('App', () => {
       });
 
       await waitFor(() => {
-        expect(document.documentElement.style.getPropertyValue('--compact-surface-resize-width')).toBe('280px');
+        expect(document.documentElement.style.getPropertyValue('--compact-surface-resize-width')).toBe('180px');
       });
       fireEvent.pointerUp(rightHandle!, {
         pointerId: 22,

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -142,11 +142,11 @@ const compactInputToolWheelViewportFitVisibleSlots = [
   { angleDeg: -110, scale: 0.98 },
   { angleDeg: -80, scale: 0.86 },
 ] as const;
-const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 280;
+const COMPACT_SURFACE_RESIZE_MIN_WIDTH = 180;
 // compact 对话条默认/初始宽度（无法从 rect/CSS 量到时的回退值）。与 resize 下限解耦：
 // 减小最短宽度只动 RESIZE_MIN_WIDTH，默认仍是这个值，保证「默认宽度不变」。
 const COMPACT_SURFACE_DEFAULT_WIDTH = 430;
-const COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280;
+const COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 180;
 const COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
 const COMPACT_SURFACE_RESIZE_VIEWPORT_GUTTER = 32;
 const COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER = 16;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -292,10 +292,12 @@
     var COMPACT_MINIMIZE_BALL_AVATAR_VERTICAL_RATIO = 0.58;
     var COMPACT_SURFACE_MAX_WIDTH = 430;
     var COMPACT_SURFACE_RESIZE_MAX_WIDTH = 720;
-    var COMPACT_SURFACE_MOBILE_MIN_WIDTH = 280;
+    var COMPACT_SURFACE_MOBILE_MIN_WIDTH = 180;
     // 桌面端 compact surface 可拖到的最短宽度。默认/初始宽度仍为 COMPACT_SURFACE_MAX_WIDTH=430
     // （见 getCompactSurfaceMetrics），这里只放宽 resize 下限，让用户能把对话条拖得更窄。
-    var COMPACT_SURFACE_DESKTOP_MIN_WIDTH = 280;
+    // 须与 react-neko-chat App.tsx 的 COMPACT_SURFACE_RESIZE_(MOBILE_)MIN_WIDTH 同步，
+    // 否则 React 侧拖到的宽度会在 phase=end 时被 host 这份 clamp 顶回去。
+    var COMPACT_SURFACE_DESKTOP_MIN_WIDTH = 180;
     var COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER = 16;
     var COMPACT_SURFACE_VIEWPORT_PAD_X = 16;
     var COMPACT_SURFACE_VIEWPORT_PAD_TOP = 12;

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -465,7 +465,7 @@ def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
         1,
     )[0]
 
-    assert "COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 280" in app_source
+    assert "COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH = 180" in app_source
     assert "COMPACT_SURFACE_RESIZE_MOBILE_VIEWPORT_GUTTER = 16" in app_source
     assert "getCompactSurfaceResizeMinAvailableWidth" in app_source
     assert "getCompactSurfaceResizeViewportGutter" in app_source
@@ -473,7 +473,7 @@ def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
     assert "window.innerWidth <= 768" in app_source
     assert "lanlan-pet-mode" in app_source
     assert "__LANLAN_IS_ELECTRON_PET__" in app_source
-    assert "COMPACT_SURFACE_MOBILE_MIN_WIDTH = 280" in script
+    assert "COMPACT_SURFACE_MOBILE_MIN_WIDTH = 180" in script
     assert "COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER" in script
     assert "COMPACT_SURFACE_RESIZE_MAX_WIDTH" in mobile_width_bounds_block
     assert "viewportWidth - COMPACT_SURFACE_MOBILE_VIEWPORT_GUTTER" in mobile_width_bounds_block


### PR DESCRIPTION
## 改动

用户反馈 compact 模式下对话条能拖到的最小宽度（280px）还是太宽。把拖拽下限从 280px 降到 180px：

- `COMPACT_SURFACE_RESIZE_MIN_WIDTH`: 280 → 180（桌面/Electron 路径）
- `COMPACT_SURFACE_RESIZE_MOBILE_MIN_WIDTH`: 280 → 180（窄屏 web 路径，与桌面保持一致）
- 默认/初始宽度 `COMPACT_SURFACE_DEFAULT_WIDTH = 430` 不变，仅放宽下限
- App.test.tsx 钳位断言同步更新

## 验证

- vite dev 实测：模拟指针拖拽 clamp 正确停在 180px
- 180px 输入态逐元素量过盒模型：毛绒球(41px) + 输入区(65px，约 4 个汉字) + 发送键(42px) 完整在位，无裁切
- frame 既有的 5px scrollWidth 溢出在 430/280/180 三档均存在，与本次改动无关
- 177 个单测全过，tsc --noEmit 干净
- FullChatSurface（legacy full 界面）的 430 下限按隔离原则未动

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 缩小紧凑对话条的最小宽度限制（从更保守值下调），在窄屏或拖拽调整时提供更灵活的布局表现，避免界面元素异常收缩。

* **Tests**
  * 更新并同步测试以验证新的最小宽度约束在不同视口和交互下生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->