### PR TITLE
fix(plugin-cli): panel context 校验改为非空字符串，移除过时的放置枚举

### DIFF
--- a/plugin/neko_plugin_cli/commands/validate_cmd.py
+++ b/plugin/neko_plugin_cli/commands/validate_cmd.py
@@ -425,8 +425,10 @@ def _check_ui_surface(plugin_dir: Path, value: object, label: str, issues: list[
     if open_in is not None:
         _check_enum(open_in, f"{label}.open_in", {"iframe", "new_tab", "same_tab"}, issues)
     context = value.get("context")
-    if context is not None:
-        _check_enum(context, f"{label}.context", {"dashboard", "chat", "settings", "plugin_detail"}, issues)
+    if context is not None and (not isinstance(context, str) or not context.strip()):
+        # context is the plugin-defined @ui.context provider id resolved via
+        # host.get_ui_context(), not a placement enum
+        issues.append(("error", f"{label}.context must be a non-empty string"))
     permissions = value.get("permissions")
     if permissions is not None:
         _check_string_list(permissions, f"{label}.permissions", issues, required=False)


### PR DESCRIPTION
## 背景

[#1713](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1713) 的 Codex review 报了一条「`context` 必须是 dashboard/chat/settings/plugin_detail」。核对后发现是 validator 自身的枚举过时了：

- `[[plugin.ui.panel]].context` 的实际语义是插件自定义的 `@ui.context(id=...)` provider id，服务端经 `host.get_ui_context(context_id)` 解析（`ui_query_service.py:769`），缺省时回退到 surface id
- 内置插件 game_agent_minecraft 即用 `context = "quickstart"`（其 plugin.toml 内有注释说明该语义），按原枚举 `check --release` 直接报 error
- 若按枚举把 context 改成 `dashboard`，插件没有同名 provider，面板会 "UI context not found"

## 改动

`validate_cmd.py` 中 `_check_ui_surface` 的 context 校验由枚举改为非空字符串检查（与同函数 `entry` 的检查风格一致）。

## 验证

- `check --release plugin/plugins/game_agent_minecraft`：context 误报消失（其余 error 为独立仓库脚手架要求，与本改动无关）
- `pytest plugin/tests/unit/test_neko_plugin_cli_cli.py`：22 passed
- 手测五种取值：自定义 id 通过、旧枚举值兼容通过、空串/非字符串报 error、缺省通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了插件 UI 配置验证逻辑：调整了 `context` 字段的校验规则，现在要求其为有效的非空字符串标识符，提供更灵活的插件提供方配置支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->