### PR TITLE
fix(tools): callback_url 校验接受 IPv4-mapped IPv6 loopback

### DIFF
--- a/main_routers/tool_router.py
+++ b/main_routers/tool_router.py
@@ -99,7 +99,11 @@ def _validate_local_callback_url(url: str) -> str:
             f"callback_url host 必须是 loopback 地址（127.0.0.0/8、::1、"
             f"localhost），实际是非 IP 域名：{host!r}"
         ) from None
-    if not ip.is_loopback:
+    # Python < 3.13 下 IPv4-mapped IPv6 的 is_loopback 不穿透映射
+    # （ipaddress.ip_address('::ffff:127.0.0.1').is_loopback == False），
+    # 需手动解包 ipv4_mapped 再判一次。
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if not (ip.is_loopback or (mapped is not None and mapped.is_loopback)):
         raise ValueError(
             f"callback_url host 必须是 loopback 地址，实际：{host!r}"
         )

--- a/main_routers/tool_router.py
+++ b/main_routers/tool_router.py
@@ -99,8 +99,9 @@ def _validate_local_callback_url(url: str) -> str:
             f"callback_url host 必须是 loopback 地址（127.0.0.0/8、::1、"
             f"localhost），实际是非 IP 域名：{host!r}"
         ) from None
-    # Python < 3.13 下 IPv4-mapped IPv6 的 is_loopback 不穿透映射
-    # （ipaddress.ip_address('::ffff:127.0.0.1').is_loopback == False），
+    # is_loopback 对 IPv4-mapped IPv6 不穿透映射的行为 CPython 3.11.11
+    # 才修（gh-117566 backport，::ffff:127.0.0.1 在此前版本返回 False）。
+    # 项目允许 ==3.11.* 且不钉 patch（Debian 12 系统 Python 是 3.11.2），
     # 需手动解包 ipv4_mapped 再判一次。
     mapped = getattr(ip, "ipv4_mapped", None)
     if not (ip.is_loopback or (mapped is not None and mapped.is_loopback)):

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -758,8 +758,8 @@ def test_tool_register_request_rejects_non_loopback_callback_url():
         "http://[::1]:9000/cb",
         "http://127.0.0.5/cb",  # 127.0.0.0/8 整段都是 loopback
         "https://localhost/cb",
-        # IPv4-mapped IPv6 loopback：Python < 3.13 的 is_loopback 不穿透
-        # 映射，validator 需手动解包 ipv4_mapped 判断
+        # IPv4-mapped IPv6 loopback：CPython < 3.11.11 的 is_loopback
+        # 不穿透映射，validator 需手动解包 ipv4_mapped 判断
         "http://[::ffff:127.0.0.1]:9000/cb",
     ]:
         ToolRegisterRequest(**{**base, "callback_url": url})

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -758,6 +758,9 @@ def test_tool_register_request_rejects_non_loopback_callback_url():
         "http://[::1]:9000/cb",
         "http://127.0.0.5/cb",  # 127.0.0.0/8 整段都是 loopback
         "https://localhost/cb",
+        # IPv4-mapped IPv6 loopback：Python < 3.13 的 is_loopback 不穿透
+        # 映射，validator 需手动解包 ipv4_mapped 判断
+        "http://[::ffff:127.0.0.1]:9000/cb",
     ]:
         ToolRegisterRequest(**{**base, "callback_url": url})
 
@@ -770,6 +773,7 @@ def test_tool_register_request_rejects_non_loopback_callback_url():
         "ftp://127.0.0.1/cb",  # 错误 scheme
         "http:///cb",  # 缺 host
         "http://[2001:db8::1]/cb",  # 公网 IPv6
+        "http://[::ffff:8.8.8.8]/cb",  # IPv4-mapped 公网 IP 仍须拒绝
     ]
     for url in illegal_urls:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## 问题

`main_routers/tool_router.py` 的 `_validate_local_callback_url` 注释声称正确处理 IPv4-mapped IPv6（`::ffff:127.0.0.1`），但实现只判 `ip.is_loopback`。CPython 的 `IPv6Address.is_loopback` 对 IPv4-mapped 地址穿透映射的行为是 **3.11.11 才 backport**（gh-117566），此前版本返回 `False`，导致这种合法 loopback 形式被 `ValueError` 拒绝。

影响范围：本项目 `requires-python = "==3.11.*"` 且不钉 patch 版本，uv 可复用系统 Python——Debian 12 系统 Python 即 3.11.2，3.11.0–3.11.10 均复现。这是过严的 false-negative（合法本机回调被拒），不是安全漏洞。

## 修复

在 `is_loopback` 为假时用 `getattr(ip, "ipv4_mapped", None)` 解包映射地址再判一次：映射回 loopback（`::ffff:127.0.0.1`）放行，映射回公网 IP（`::ffff:8.8.8.8`）维持拒绝。行为不再依赖 stdlib patch 版本。

## 测试

`tests/unit/test_tool_calling.py::test_tool_register_request_rejects_non_loopback_callback_url` 新增两个 case：

- `http://[::ffff:127.0.0.1]:9000/cb` → 接受
- `http://[::ffff:8.8.8.8]/cb` → 拒绝

全文件 56 passed。

## 出处

CodeRabbit 在 #1723 的 outside-diff 评论，因该 PR 是 relicense/docstring-only 拆出独立修复。其「Python 3.13 才改」的说法经核实不准确，实际 3.11.11 已 backport，已据实修正注释。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了本地回环地址的识别逻辑，提高了不同IPv6地址格式的处理一致性，确保本地回调URL验证的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->