### PR TITLE
fix(Linux):  throttle desktop pair move bounds sync

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -240,6 +240,7 @@ const _NEKO_IDLE_CAT1_PAIR_MOVE_MIN_USABLE_DISTANCE_PX = 36;
 const _NEKO_IDLE_CAT1_PAIR_MOVE_SPEED_PX_PER_SEC = 82;
 const _NEKO_IDLE_CAT1_PAIR_MOVE_MIN_DURATION_MS = 720;
 const _NEKO_IDLE_CAT1_PAIR_MOVE_MAX_DURATION_MS = 2200;
+const _NEKO_IDLE_CAT1_DESKTOP_PAIR_MOVE_SYNC_MIN_MS = 50;
 const _NEKO_IDLE_DESKTOP_CHAT_RECT_STALE_MS = 2500;
 const _NEKO_IDLE_DESKTOP_COMPACT_SURFACE_RECT_STALE_MS = 10 * 1000;
 const _NEKO_IDLE_RETURN_DRAG_ACTION_CLASS = 'is-drag-action';
@@ -790,6 +791,8 @@ let _nekoIdleDesktopCompactSurfaceState = {
     updatedAt: 0,
     sourceUpdatedAt: 0
 };
+let _nekoIdleDesktopChatPairMoveLastDispatchAt = 0;
+let _nekoIdleDesktopChatPairMoveLastDispatchSignature = '';
 let _nekoIdleCompactSurfaceDragging = false;
 let _nekoIdleCompactSurfaceSettleTimer = 0;
 
@@ -2463,11 +2466,31 @@ function _rememberNekoIdleDesktopChatPairMoveRect(screenRect) {
     return normalized;
 }
 
-function _dispatchNekoIdleDesktopChatPairMoveBounds(screenRect) {
+function _getNekoIdleDesktopChatPairMoveSignature(screenRect) {
+    const normalized = _normalizeNekoIdleScreenRect(screenRect);
+    if (!normalized) return '';
+    return [
+        normalized.left,
+        normalized.top,
+        normalized.width,
+        normalized.height
+    ].join(':');
+}
+
+function _dispatchNekoIdleDesktopChatPairMoveBounds(screenRect, options = {}) {
     const normalized = _rememberNekoIdleDesktopChatPairMoveRect(screenRect);
     if (!normalized) return false;
     const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
     if (!channel || typeof channel.postMessage !== 'function') return false;
+    const now = Date.now();
+    const force = !!(options && options.force);
+    const signature = _getNekoIdleDesktopChatPairMoveSignature(normalized);
+    if (!force) {
+        if (signature && signature === _nekoIdleDesktopChatPairMoveLastDispatchSignature) return false;
+        if (now - _nekoIdleDesktopChatPairMoveLastDispatchAt < _NEKO_IDLE_CAT1_DESKTOP_PAIR_MOVE_SYNC_MIN_MS) return false;
+    }
+    _nekoIdleDesktopChatPairMoveLastDispatchAt = now;
+    _nekoIdleDesktopChatPairMoveLastDispatchSignature = signature;
     channel.postMessage({
         action: 'idle_chat_pair_move_bounds',
         source: 'cat1-pair-move',
@@ -2478,7 +2501,7 @@ function _dispatchNekoIdleDesktopChatPairMoveBounds(screenRect) {
             width: normalized.width,
             height: normalized.height
         },
-        timestamp: Date.now()
+        timestamp: now
     });
     return true;
 }
@@ -2631,6 +2654,8 @@ function _applyNekoIdleCat1PairMovePlan(plan, progress) {
             top: plan.chatStartScreenTop + offsetY,
             width: plan.chatWidth,
             height: plan.chatHeight
+        }, {
+            force: progress >= 1
         });
     } else if (plan.chatMode === 'dom') {
         _setNekoIdleCat1PairMoveChatPosition(plan.shell, plan.chatStartLeft + offsetX, plan.chatStartTop + offsetY);

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -189,7 +189,7 @@ def test_desktop_cat1_minimized_and_compact_surface_state_are_timestamp_ordered(
     pair_move_block = _between(
         source,
         "function _rememberNekoIdleDesktopChatPairMoveRect(screenRect) {",
-        "function _dispatchNekoIdleDesktopChatPairMoveBounds(screenRect) {",
+        "function _getNekoIdleDesktopChatPairMoveSignature(screenRect) {",
     )
     assert "_nekoIdleDesktopChatMinimizedState = _makeNekoIdleDesktopChatMinimizedState(" in pair_move_block
     assert "_nekoIdleDesktopCompactSurfaceState = _makeNekoIdleDesktopCompactSurfaceState(" in pair_move_block
@@ -266,6 +266,36 @@ def test_react_chat_applies_desktop_cat1_pair_move_bounds_when_collapsed():
     assert "if (hasElectronIdleDockPendingOrActive()) return;" in source
     assert "bridge.idleDockCommitCollapsedBounds(targetBounds)" in source
     assert "scheduleElectronChatMinimizedState('cat1-pair-move')" in source
+
+
+def test_cat1_desktop_pair_move_throttles_native_bounds_sync_and_forces_final_frame():
+    source = _read(AVATAR_UI_BUTTONS_PATH)
+
+    assert "_NEKO_IDLE_CAT1_DESKTOP_PAIR_MOVE_SYNC_MIN_MS = 50" in source
+    assert "let _nekoIdleDesktopChatPairMoveLastDispatchAt = 0;" in source
+    assert "let _nekoIdleDesktopChatPairMoveLastDispatchSignature = '';" in source
+    assert "function _getNekoIdleDesktopChatPairMoveSignature(screenRect)" in source
+
+    dispatch_block = _between(
+        source,
+        "function _dispatchNekoIdleDesktopChatPairMoveBounds(screenRect, options = {}) {",
+        "function _getNekoIdleCat1PairMoveChatTarget() {",
+    )
+    assert "_rememberNekoIdleDesktopChatPairMoveRect(screenRect)" in dispatch_block
+    assert "const force = !!(options && options.force);" in dispatch_block
+    assert "if (!force) {" in dispatch_block
+    assert "signature === _nekoIdleDesktopChatPairMoveLastDispatchSignature" in dispatch_block
+    assert "now - _nekoIdleDesktopChatPairMoveLastDispatchAt < _NEKO_IDLE_CAT1_DESKTOP_PAIR_MOVE_SYNC_MIN_MS" in dispatch_block
+    assert "_nekoIdleDesktopChatPairMoveLastDispatchAt = now;" in dispatch_block
+    assert "_nekoIdleDesktopChatPairMoveLastDispatchSignature = signature;" in dispatch_block
+    assert "timestamp: now" in dispatch_block
+
+    pair_move_block = _between(
+        source,
+        "function _applyNekoIdleCat1PairMovePlan(plan, progress) {",
+        "function _setNekoIdleCat1Substate(button, substate, options = {}) {",
+    )
+    assert "force: progress >= 1" in pair_move_block
 
 
 def test_idle_dock_uses_mutation_observer_to_detect_minimize_completion():


### PR DESCRIPTION
- 为桌面端 cat1 pair move 的聊天窗口边界广播增加签名去重和 50ms 节流，避免拖移动画期间过于频繁地同步原生窗口位置。
- 最终帧使用 force 同步，确保动画结束后桌面聊天窗口位置能落到目标边界。-
- 补充静态单测覆盖节流状态、签名去重和最终帧强制同步逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 优化桌面端聊天窗口成对移动的同步机制，避免过于频繁的位置更新，降低网络开销
  * 确保窗口移动完成时最终帧的位置信息正确同步

* **测试**
  * 增强相关功能测试覆盖率

<!-- end of auto-generated comment: release notes by coderabbit.ai -->