### PR TITLE
限制 Electron 紧凑宿主恢复 full 状态

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -283,6 +283,7 @@ async def get_chat_page(request: Request):
     return templates.TemplateResponse("templates/chat.html", {
         "request": request,
         "initial_chat_surface_mode": "compact",
+        "initial_chat_host_kind": "compact",
         **_vrm_defaults_ctx(),
         **_static_assets_ctx(),
         **_react_chat_assets_ctx(),
@@ -296,6 +297,7 @@ async def get_chat_full_page(request: Request):
     return templates.TemplateResponse("templates/chat.html", {
         "request": request,
         "initial_chat_surface_mode": "full",
+        "initial_chat_host_kind": "full",
         **_vrm_defaults_ctx(),
         **_static_assets_ctx(),
         **_react_chat_assets_ctx(),

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -115,12 +115,30 @@
         return CHAT_SURFACE_MODES.indexOf(mode) >= 0 ? mode : 'compact';
     }
 
+    function isCompactOnlyElectronChatHost() {
+        var body = document.body;
+        return !!(
+            body
+            && isElectronChatWindow()
+            && body.getAttribute('data-initial-chat-surface-mode') === 'compact'
+        );
+    }
+
+    function coerceChatSurfaceModeForHost(mode) {
+        var normalized = normalizeChatSurfaceMode(mode);
+        // /chat 是 Electron 紧凑宿主；full 由 /chat_full 独立窗口承载，避免历史 full 状态污染透明承载窗。
+        if (normalized === 'full' && isCompactOnlyElectronChatHost()) {
+            return 'compact';
+        }
+        return normalized;
+    }
+
     function normalizeCompactChatState(mode) {
         return COMPACT_CHAT_STATES.indexOf(mode) >= 0 ? mode : 'default';
     }
 
     function getCurrentChatSurfaceMode() {
-        return normalizeChatSurfaceMode(state.chatSurfaceMode);
+        return coerceChatSurfaceModeForHost(state.chatSurfaceMode);
     }
 
     function getCurrentCompactChatState() {
@@ -147,9 +165,9 @@
     }
 
     function getNextChatSurfaceMode(mode) {
-        var normalized = normalizeChatSurfaceMode(mode);
+        var normalized = coerceChatSurfaceModeForHost(mode);
         if (normalized === 'minimized') {
-            return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
+            return coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode);
         }
         // Any real surface — compact or the revived legacy full — minimizes to the
         // ball; restoring returns to the last real surface via the branch above.
@@ -195,7 +213,7 @@
     }
 
     function readChatSurfaceModePreference() {
-        var fallback = getDefaultChatSurfaceMode();
+        var fallback = coerceChatSurfaceModeForHost(getDefaultChatSurfaceMode());
         if (!shouldPersistChatSurfaceModePreference()) {
             return fallback;
         }
@@ -205,8 +223,8 @@
             // revived legacy 'full'. An explicit stored choice wins; otherwise we
             // fall back to the per-runtime default (web=full / Electron=compact).
             // A stray 'minimized' never lingers — rewrite it to the fallback.
-            if (raw === 'full') return 'full';
-            if (raw === 'compact') return 'compact';
+            if (raw === 'full') return coerceChatSurfaceModeForHost('full');
+            if (raw === 'compact') return coerceChatSurfaceModeForHost('compact');
             if (raw === 'minimized') {
                 localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, fallback);
             }
@@ -223,6 +241,9 @@
             : '';
         var declaredMode = declaredModeAttr ? normalizeChatSurfaceMode(declaredModeAttr) : '';
         if (declaredMode === 'compact' || declaredMode === 'full') {
+            if (declaredMode === 'full' && isCompactOnlyElectronChatHost()) {
+                return 'compact';
+            }
             return declaredMode;
         }
         return readChatSurfaceModePreference();
@@ -3562,7 +3583,7 @@
         var nextProps = nextViewProps || {};
         var surfaceModeChanged = false;
         if (Object.prototype.hasOwnProperty.call(nextProps, 'chatSurfaceMode')) {
-            var normalizedChatSurfaceMode = normalizeChatSurfaceMode(nextProps.chatSurfaceMode);
+            var normalizedChatSurfaceMode = coerceChatSurfaceModeForHost(nextProps.chatSurfaceMode);
             var previousChatSurfaceMode = getCurrentChatSurfaceMode();
             surfaceModeChanged = normalizedChatSurfaceMode !== previousChatSurfaceMode;
             if (surfaceModeChanged
@@ -4515,7 +4536,7 @@
             }
             savedShellSize = null;
             savedShellPosition = null;
-            state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
+            state.chatSurfaceMode = coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode);
             renderWindow();
             syncMinimizeUI();
             syncChatSurfaceModeUI();
@@ -4528,7 +4549,7 @@
         }
 
         if (wasActive && triggered && minimized) {
-            setChatSurfaceMode(normalizeChatSurfaceMode(lastRestorableChatSurfaceMode));
+            setChatSurfaceMode(coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode));
         }
     }
 
@@ -4670,12 +4691,9 @@
         pendingChatSurfaceMode = null;
     }
 
-    // The minimized ball belongs to the surface we'll restore to: the revived
-    // legacy full uses its breathing-light orb, every other surface (compact)
-    // keeps the yarn ball. Gated purely on lastRestorableChatSurfaceMode so the
-    // compact path never sees a behavior change.
+    // 最小化球皮肤跟随可恢复形态；紧凑 Electron 宿主会把历史 full 规整回 compact。
     function isLegacyFullMinimizedBall() {
-        return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode) === 'full';
+        return coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode) === 'full';
     }
 
     function applyMinimizedBallSkin(ballIcon) {
@@ -4730,7 +4748,7 @@
     }
 
     function setChatSurfaceMode(nextMode) {
-        var normalized = normalizeChatSurfaceMode(nextMode);
+        var normalized = coerceChatSurfaceModeForHost(nextMode);
         var previousMode = getCurrentChatSurfaceMode();
         var nextMinimized = normalized === 'minimized';
         var previousMinimized = previousMode === 'minimized';
@@ -5227,7 +5245,7 @@
                     // rebuilds the compact body instead of the (blank) minimized
                     // surface; closeWindow performs the same reset when it clears
                     // the minimized shell.
-                    state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
+                    state.chatSurfaceMode = coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode);
                     resetCompactChatState();
                 }
                 if (getCurrentChatSurfaceMode() === 'compact') {
@@ -5327,7 +5345,7 @@
             // openWindow() rebuilds the React props with chatSurfaceMode:
             // 'minimized', rendering a blank body over a no-longer-minimized
             // shell.
-            state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);
+            state.chatSurfaceMode = coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode);
             resetCompactChatState();
             savedShellSize = null;
             savedShellPosition = null;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -120,7 +120,7 @@
         return !!(
             body
             && isElectronChatWindow()
-            && body.getAttribute('data-initial-chat-surface-mode') === 'compact'
+            && body.getAttribute('data-chat-host-kind') === 'compact'
         );
     }
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -616,6 +616,7 @@
     </style>
 </head>
 <body class="electron-chat-window subtitle-web-host"
+      data-chat-host-kind="{{ initial_chat_host_kind|default('compact', true) }}"
       data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default('compact', true) }}">
 
     <!-- Electron 运行时标记：/chat_full 与 /chat 共用本模板，body.electron-chat-window 是静态写入，

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -87,7 +87,7 @@ def test_idle_dock_enters_minimized_surface_mode_without_setminimized_options():
 
     # exitIdleDock restores the previous real surface mode without adding
     # idle-dock options or branches to setMinimized itself.
-    assert "setChatSurfaceMode(normalizeChatSurfaceMode(lastRestorableChatSurfaceMode));" in source
+    assert "setChatSurfaceMode(coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode));" in source
     assert "setMinimized(false, {" not in source
 
 
@@ -337,4 +337,4 @@ def test_idle_dock_exit_clears_cat2_to_cat1_drag_binding():
     assert "await commitElectronIdleDockCollapsedBounds(bridge, preserveBounds, exitGeneration)" in source
     assert "wasActive && saved && !preserveCurrentPosition" in source
     assert "wasActive && triggered && minimized && preserveCurrentPosition" in source
-    assert "setChatSurfaceMode(normalizeChatSurfaceMode(lastRestorableChatSurfaceMode));" in source
+    assert "setChatSurfaceMode(coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode));" in source

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -175,8 +175,15 @@ def test_chat_host_initial_surface_mode_prefers_template_override_before_storage
     assert "declaredModeAttr ? normalizeChatSurfaceMode(declaredModeAttr) : ''" in initial_reader_block
     assert "normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))" not in initial_reader_block
     assert "if (declaredMode === 'compact' || declaredMode === 'full')" in initial_reader_block
+    assert "if (declaredMode === 'full' && isCompactOnlyElectronChatHost())" in initial_reader_block
+    assert "return 'compact';" in initial_reader_block
     assert "return declaredMode;" in initial_reader_block
     assert initial_reader_block.index("return declaredMode;") < initial_reader_block.index("return readChatSurfaceModePreference();")
+
+    assert "function isCompactOnlyElectronChatHost()" in source
+    assert "body.getAttribute('data-initial-chat-surface-mode') === 'compact'" in source
+    assert "function coerceChatSurfaceModeForHost(mode)" in source
+    assert "normalized === 'full' && isCompactOnlyElectronChatHost()" in source
 
     init_block = source.split("function init()", 1)[1].split(
         "function initAfterStorageBarrier()",
@@ -206,7 +213,7 @@ def test_close_from_minimized_preserves_compact_surface_mode():
     # restorable mode. Otherwise the next openWindow() rebuilds the React props
     # with chatSurfaceMode:'minimized' and renders a blank body.
     assert (
-        "state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);"
+        "state.chatSurfaceMode = coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode);"
         in minimized_block
     )
     assert "syncChatSurfaceModeUI();" in minimized_block
@@ -225,7 +232,7 @@ def test_open_from_minimized_restores_surface_mode_before_mounting():
     # mountWindow() so React rebuilds the compact body instead of the blank
     # minimized surface — symmetric with closeWindow's reset.
     restore_assignment = (
-        "state.chatSurfaceMode = normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);"
+        "state.chatSurfaceMode = coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode);"
     )
     assert restore_assignment in open_block
     assert open_block.index(restore_assignment) < open_block.index("if (!mountWindow())")
@@ -260,7 +267,7 @@ def test_minimized_restore_uses_previous_real_surface_mode():
 
     assert "if (normalized === 'minimized')" in next_mode_block
     assert "lastRestorableChatSurfaceMode" in next_mode_block
-    assert "return normalizeChatSurfaceMode(lastRestorableChatSurfaceMode);" in next_mode_block
+    assert "return coerceChatSurfaceModeForHost(lastRestorableChatSurfaceMode);" in next_mode_block
     assert "lastRestorableChatSurfaceMode = normalized;" in set_mode_block
     assert "lastRestorableChatSurfaceMode = previousMode;" in set_mode_block
     assert "lastRestorableChatSurfaceMode = normalizedChatSurfaceMode;" in set_view_props_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -112,6 +112,9 @@ def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
     assert '@router.get("/chat_full", response_class=HTMLResponse)' in router_source
     assert '"initial_chat_surface_mode": "full"' in router_source
     assert '"initial_chat_surface_mode": "compact"' in router_source
+    assert '"initial_chat_host_kind": "full"' in router_source
+    assert '"initial_chat_host_kind": "compact"' in router_source
+    assert 'data-chat-host-kind="{{ initial_chat_host_kind|default(\'compact\', true) }}"' in template_source
     assert 'data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default(\'compact\', true) }}"' in template_source
 
     chat_route_block = router_source.split('async def get_chat_page', 1)[1].split(
@@ -119,7 +122,9 @@ def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
         1,
     )[0]
     assert '"initial_chat_surface_mode": "compact"' in chat_route_block
+    assert '"initial_chat_host_kind": "compact"' in chat_route_block
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
+    assert '"initial_chat_host_kind": "full"' not in chat_route_block
 
 
 def test_full_inset_layout_gated_by_electron_runtime_marker():
@@ -181,7 +186,8 @@ def test_chat_host_initial_surface_mode_prefers_template_override_before_storage
     assert initial_reader_block.index("return declaredMode;") < initial_reader_block.index("return readChatSurfaceModePreference();")
 
     assert "function isCompactOnlyElectronChatHost()" in source
-    assert "body.getAttribute('data-initial-chat-surface-mode') === 'compact'" in source
+    assert "body.getAttribute('data-chat-host-kind') === 'compact'" in source
+    assert "body.getAttribute('data-initial-chat-surface-mode') === 'compact'" not in source
     assert "function coerceChatSurfaceModeForHost(mode)" in source
     assert "normalized === 'full' && isCompactOnlyElectronChatHost()" in source
 


### PR DESCRIPTION
- 为 Electron /chat 紧凑宿主增加 surface mode 规整逻辑，避免历史 full 状态污染 compact 承载窗口
- 将 compact-only 宿主中的 full/minimized 恢复路径统一回 compact
- 更新 React Chat 静态契约测试，覆盖初始 surface mode、最小化恢复和打开窗口路径

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 在仅紧凑模式的 Electron 宿主中强制将聊天面板恢复/切换为紧凑显示，修复了从最小化或恢复时的显示异常，提升显示一致性。
* **New Features**
  * 页面模板增加宿主类型标记（默认紧凑），前端据此选择合适的面板模式以改善跨平台体验。
* **Tests**
  * 更新相关测试以覆盖宿主约束下的显示行为验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->