### PR TITLE
fix(agent): 修复猫爪任务卡死后 ✕ 关不掉 + browser_use 并发互斥

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -5506,8 +5506,8 @@ async def admin_control(payload: Dict[str, Any]):
                           "end_time": _now_iso(), "params": info.get("params", {}),
                           "error": "Cancelled by user"},
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("[Agent] end_all: emit task_update(cancelled) failed: task_id=%s error=%s", tid, exc)
 
         # Cancel any in-flight background analyzer/dispatch tasks. Include the
         # per-task dispatch handles explicitly so a handle that fell out of

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -5413,8 +5413,14 @@ async def browser_use_run(payload: Dict[str, Any]):
     instruction = (payload or {}).get("instruction", "").strip()
     if not instruction:
         raise HTTPException(400, "instruction required")
+    # Debug/API entry: must share the dispatch mutex with the analyzer path —
+    # the adapter is a singleton whose cancel flag and browser session cannot
+    # tolerate concurrent run_instruction calls.
+    if Modules.browser_use_dispatch_lock is None:
+        Modules.browser_use_dispatch_lock = asyncio.Lock()
     try:
-        result = await Modules.browser_use.run_instruction(instruction)
+        async with Modules.browser_use_dispatch_lock:
+            result = await Modules.browser_use.run_instruction(instruction)
         return {"success": bool(result.get("success", False)), "result": result}
     except Exception as e:
         return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -2832,6 +2832,17 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 bu_info["status"] = "cancelled"
                                 bu_info["end_time"] = _now_iso()
                                 bu_info["error"] = "browser_use disabled before dispatch"
+                                # Close out the record_assigned entry; otherwise
+                                # the tracker keeps showing [ASSIGNED] and later
+                                # analyzer passes treat the same user request as
+                                # still in flight instead of retrying it.
+                                _task_tracker.record_completed(
+                                    lanlan_name, task_id=bu_task_id, method="browser_use",
+                                    desc=result.task_description or "",
+                                    detail="browser_use disabled before dispatch",
+                                    success=False, cancelled=True,
+                                    trigger_user_fingerprint=trigger_user_msg_sig,
+                                )
                                 try:
                                     await _emit_main_event(
                                         "task_update", lanlan_name,

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -2824,6 +2824,24 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             # scheduler's queued guard).
                             if bu_info.get("status") != "queued":
                                 return
+                            # Recheck the feature flag: the user may have
+                            # disabled browser_use while this task waited for
+                            # the slot (mirrors the computer-use scheduler's
+                            # disabled-drop path).
+                            if not Modules.analyzer_enabled or not Modules.agent_flags.get("browser_use_enabled", False):
+                                bu_info["status"] = "cancelled"
+                                bu_info["end_time"] = _now_iso()
+                                bu_info["error"] = "browser_use disabled before dispatch"
+                                try:
+                                    await _emit_main_event(
+                                        "task_update", lanlan_name,
+                                        task={"id": bu_task_id, "status": "cancelled", "type": "browser_use",
+                                              "end_time": bu_info["end_time"], "error": bu_info["error"],
+                                              "session_id": bu_session.session_id},
+                                    )
+                                except Exception as emit_err:
+                                    logger.debug("[BrowserUse] emit task_update(disabled-drop) failed: task_id=%s error=%s", bu_task_id, emit_err)
+                                return
                             bu_info["status"] = "running"
                             bu_info["start_time"] = _now_iso()
                             Modules.active_browser_use_task_id = bu_task_id
@@ -3982,7 +4000,9 @@ async def cancel_task(task_id: str):
     if not info:
         raise HTTPException(404, "task not found")
     if info.get("status") not in ("queued", "running"):
-        return {"success": False, "error": "task is not active"}
+        # Include the real terminal status so the HUD's local fallback can
+        # mirror it instead of mislabeling the card "cancelled".
+        return {"success": False, "error": "task is not active", "status": info.get("status")}
 
     task_type = info.get("type")
     # Mark cancelled up front so any late terminal writes from the dispatch
@@ -5418,10 +5438,26 @@ async def browser_use_run(payload: Dict[str, Any]):
     # tolerate concurrent run_instruction calls.
     if Modules.browser_use_dispatch_lock is None:
         Modules.browser_use_dispatch_lock = asyncio.Lock()
-    try:
+
+    async def _locked_run():
         async with Modules.browser_use_dispatch_lock:
-            result = await Modules.browser_use.run_instruction(instruction)
+            return await Modules.browser_use.run_instruction(instruction)
+
+    # Run as a tracked background task so end_all can cancel a wedged direct
+    # run (otherwise it would survive end_all still holding the mutex).
+    run_task = asyncio.create_task(_locked_run())
+    Modules._background_tasks.add(run_task)
+    run_task.add_done_callback(Modules._background_tasks.discard)
+    try:
+        result = await run_task
         return {"success": bool(result.get("success", False)), "result": result}
+    except asyncio.CancelledError:
+        if run_task.cancelled():
+            # end_all tore this direct run down.
+            return JSONResponse(content={"success": False, "error": "cancelled by end_all"}, status_code=500)
+        # The HTTP request itself was cancelled — don't leak the inner task.
+        run_task.cancel()
+        raise
     except Exception as e:
         return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
 

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -5484,30 +5484,33 @@ async def admin_control(payload: Dict[str, Any]):
         # registry is cleared. Dispatch coroutines that do wake up emit the
         # same terminal event again; duplicate cancel records are tolerated
         # by design (see get_cancelled_user_sigs).
-        for tid, info in list(Modules.task_registry.items()):
-            if info.get("status") not in ("queued", "running"):
-                continue
-            info["status"] = "cancelled"
-            info["error"] = "Cancelled by user"
-            _task_tracker.record_completed(
-                info.get("lanlan_name"),
-                task_id=tid,
-                method=str(info.get("type") or ""),
-                desc=_tracker_desc_for_task_info(info),
-                detail="Cancelled by user",
-                success=False,
-                cancelled=True,
-                trigger_user_fingerprint=info.get("_trigger_user_fingerprint"),
-            )
-            try:
-                await _emit_main_event(
-                    "task_update", info.get("lanlan_name"),
-                    task={"id": tid, "status": "cancelled", "type": info.get("type"),
-                          "end_time": _now_iso(), "params": info.get("params", {}),
-                          "error": "Cancelled by user"},
+        async def _mark_and_emit_cancelled() -> None:
+            for tid, info in list(Modules.task_registry.items()):
+                if info.get("status") not in ("queued", "running"):
+                    continue
+                info["status"] = "cancelled"
+                info["error"] = "Cancelled by user"
+                _task_tracker.record_completed(
+                    info.get("lanlan_name"),
+                    task_id=tid,
+                    method=str(info.get("type") or ""),
+                    desc=_tracker_desc_for_task_info(info),
+                    detail="Cancelled by user",
+                    success=False,
+                    cancelled=True,
+                    trigger_user_fingerprint=info.get("_trigger_user_fingerprint"),
                 )
-            except Exception as exc:
-                logger.debug("[Agent] end_all: emit task_update(cancelled) failed: task_id=%s error=%s", tid, exc)
+                try:
+                    await _emit_main_event(
+                        "task_update", info.get("lanlan_name"),
+                        task={"id": tid, "status": "cancelled", "type": info.get("type"),
+                              "end_time": _now_iso(), "params": info.get("params", {}),
+                              "error": "Cancelled by user"},
+                    )
+                except Exception as exc:
+                    logger.debug("[Agent] end_all: emit task_update(cancelled) failed: task_id=%s error=%s", tid, exc)
+
+        await _mark_and_emit_cancelled()
 
         # Cancel any in-flight background analyzer/dispatch tasks. Include the
         # per-task dispatch handles explicitly so a handle that fell out of
@@ -5527,6 +5530,15 @@ async def admin_control(payload: Dict[str, Any]):
                     "[Agent] end_all: %d task(s) still not finished 10s after cancel; continuing teardown",
                     len(pending),
                 )
+                # A wedged dispatch coroutine may still hold the browser-use
+                # mutex; future tasks would queue on it forever. Every known
+                # handle was cancelled above (the ghost raises CancelledError
+                # at its next await) and the browser session is torn down
+                # below, so handing fresh tasks a new lock is safe.
+                lock = Modules.browser_use_dispatch_lock
+                if lock is not None and lock.locked():
+                    logger.warning("[Agent] end_all: browser_use dispatch lock still held after timeout; resetting")
+                    Modules.browser_use_dispatch_lock = asyncio.Lock()
             for res in done:
                 try:
                     exc = res.exception()
@@ -5558,6 +5570,12 @@ async def admin_control(payload: Dict[str, Any]):
             finished = await loop.run_in_executor(None, cu.wait_for_completion, 10.0)
             if not finished:
                 logger.warning("[Agent] CUA thread did not stop within 10s during end_all")
+
+        # Rescan right before wiping the registry: an in-flight analyzer may
+        # have registered a new task while any of the awaits above yielded.
+        # Its dispatch handle was cancelled above (or its scheduler guard
+        # skips it), but the frontend still needs the terminal event.
+        await _mark_and_emit_cancelled()
 
         Modules.task_registry.clear()
         Modules.last_user_turn_fingerprint.clear()

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -113,6 +113,11 @@ class Modules:
     # Browser-use task tracking
     active_browser_use_task_id: Optional[str] = None
     active_browser_use_bg_task: Optional[asyncio.Task] = None
+    # Browser-use exclusivity: the adapter is a singleton whose cancel flag
+    # and browser session are shared state, so dispatches must not overlap
+    # (mirrors computer-use exclusivity, implemented as a lock instead of a
+    # scheduler loop). Lazily created on the running event loop.
+    browser_use_dispatch_lock: Optional[asyncio.Lock] = None
     # OpenClaw/QwenPaw is an external service. Enabling keeps the user's intent
     # while a bounded background probe waits for the external health endpoint.
     openclaw_enable_task: Optional[asyncio.Task] = None
@@ -2779,7 +2784,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                 bu_info = {
                     "id": bu_task_id,
                     "type": "browser_use",
-                    "status": "running",
+                    "status": "queued",
                     "start_time": bu_start,
                     "params": {"instruction": result.task_description},
                     "lanlan_name": lanlan_name,
@@ -2790,7 +2795,6 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                 }
                 _set_internal_correction_context(bu_info, result)
                 Modules.task_registry[bu_task_id] = bu_info
-                Modules.active_browser_use_task_id = bu_task_id
                 _task_tracker.record_assigned(
                     lanlan_name, task_id=bu_task_id, method="browser_use",
                     desc=result.task_description or "",
@@ -2798,12 +2802,12 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                 try:
                     await _emit_main_event(
                         "task_update", lanlan_name,
-                        task={"id": bu_task_id, "status": "running", "type": "browser_use",
+                        task={"id": bu_task_id, "status": "queued", "type": "browser_use",
                               "start_time": bu_start, "params": {"instruction": result.task_description},
                               "session_id": bu_session.session_id},
                     )
                 except Exception as e:
-                    logger.debug("[BrowserUse] emit task_update(running) failed: task_id=%s error=%s", bu_task_id, e)
+                    logger.debug("[BrowserUse] emit task_update(queued) failed: task_id=%s error=%s", bu_task_id, e)
                 async def _run_browser_use_dispatch():
                     try:
                         from utils.instrument import counter as _ic
@@ -2811,10 +2815,32 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                     except Exception:
                         pass  # 埋点 best-effort
                     try:
-                        bres = await Modules.browser_use.run_instruction(
-                            result.task_description,
-                            session_id=bu_session.session_id,
-                        )
+                        if Modules.browser_use_dispatch_lock is None:
+                            Modules.browser_use_dispatch_lock = asyncio.Lock()
+                        async with Modules.browser_use_dispatch_lock:
+                            # cancel_task may have flipped the entry to
+                            # "cancelled" while it sat waiting for the slot —
+                            # don't resurrect it (mirrors the computer-use
+                            # scheduler's queued guard).
+                            if bu_info.get("status") != "queued":
+                                return
+                            bu_info["status"] = "running"
+                            bu_info["start_time"] = _now_iso()
+                            Modules.active_browser_use_task_id = bu_task_id
+                            try:
+                                await _emit_main_event(
+                                    "task_update", lanlan_name,
+                                    task={"id": bu_task_id, "status": "running", "type": "browser_use",
+                                          "start_time": bu_info["start_time"],
+                                          "params": {"instruction": result.task_description},
+                                          "session_id": bu_session.session_id},
+                                )
+                            except Exception as e:
+                                logger.debug("[BrowserUse] emit task_update(running) failed: task_id=%s error=%s", bu_task_id, e)
+                            bres = await Modules.browser_use.run_instruction(
+                                result.task_description,
+                                session_id=bu_session.session_id,
+                            )
                         if bu_info.get("status") == "cancelled":
                             # cancel_task set the terminal state before run_instruction
                             # returned (e.g. via fire-and-forget CDP teardown winning
@@ -2927,7 +2953,11 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         except Exception as emit_err:
                             logger.debug("[BrowserUse] emit task_update(failed) failed: task_id=%s error=%s", bu_task_id, emit_err)
                     finally:
-                        Modules.active_browser_use_task_id = None
+                        # Only the slot owner may clear it: a queued dispatch
+                        # cancelled while waiting for the lock must not wipe
+                        # the running task's id.
+                        if Modules.active_browser_use_task_id == bu_task_id:
+                            Modules.active_browser_use_task_id = None
 
                 bu_task = asyncio.create_task(_run_browser_use_dispatch())
                 Modules.task_async_handles[bu_task_id] = bu_task
@@ -3982,11 +4012,15 @@ async def cancel_task(task_id: str):
         if Modules.active_computer_use_task_id == task_id and Modules.active_computer_use_async_task:
             Modules.active_computer_use_async_task.cancel()
     elif task_type == "browser_use":
-        if Modules.browser_use:
-            _spawn_background_cancel(
-                Modules.browser_use.cancel(), label=f"browser_use:{task_id}"
-            )
+        # Tear down the shared browser only for the task that owns the slot.
+        # A queued task's dispatch coroutine dies at the lock via bg.cancel()
+        # above; ripping the browser for it would kill the unrelated running
+        # task that is actually using it.
         if Modules.active_browser_use_task_id == task_id:
+            if Modules.browser_use:
+                _spawn_background_cancel(
+                    Modules.browser_use.cancel(), label=f"browser_use:{task_id}"
+                )
             Modules.active_browser_use_task_id = None
     elif task_type == "openfang":
         if Modules.openfang:
@@ -5436,17 +5470,64 @@ async def list_tasks():
 async def admin_control(payload: Dict[str, Any]):
     action = (payload or {}).get("action")
     if action == "end_all":
-        # Cancel any in-flight background analyzer tasks
+        # Mark every active registry task cancelled and notify the frontend
+        # BEFORE the potentially-slow teardown below. The task HUD is purely
+        # event-driven (no HTTP polling), so without these emits the cards of
+        # tasks whose dispatch coroutine is stuck (e.g. a browser-use agent
+        # wedged inside an LLM call) would stay "running" forever once the
+        # registry is cleared. Dispatch coroutines that do wake up emit the
+        # same terminal event again; duplicate cancel records are tolerated
+        # by design (see get_cancelled_user_sigs).
+        for tid, info in list(Modules.task_registry.items()):
+            if info.get("status") not in ("queued", "running"):
+                continue
+            info["status"] = "cancelled"
+            info["error"] = "Cancelled by user"
+            _task_tracker.record_completed(
+                info.get("lanlan_name"),
+                task_id=tid,
+                method=str(info.get("type") or ""),
+                desc=_tracker_desc_for_task_info(info),
+                detail="Cancelled by user",
+                success=False,
+                cancelled=True,
+                trigger_user_fingerprint=info.get("_trigger_user_fingerprint"),
+            )
+            try:
+                await _emit_main_event(
+                    "task_update", info.get("lanlan_name"),
+                    task={"id": tid, "status": "cancelled", "type": info.get("type"),
+                          "end_time": _now_iso(), "params": info.get("params", {}),
+                          "error": "Cancelled by user"},
+                )
+            except Exception:
+                pass
+
+        # Cancel any in-flight background analyzer/dispatch tasks. Include the
+        # per-task dispatch handles explicitly so a handle that fell out of
+        # _background_tasks bookkeeping still receives the cancel.
         tasks_to_await = []
-        for t in list(Modules._background_tasks):
+        for t in set(Modules._background_tasks) | set(Modules.task_async_handles.values()):
             if not t.done():
                 t.cancel()
                 tasks_to_await.append(t)
         if tasks_to_await:
-            results = await asyncio.gather(*tasks_to_await, return_exceptions=True)
-            for res in results:
-                if isinstance(res, Exception) and not isinstance(res, asyncio.CancelledError):
-                    logger.warning(f"[Agent] Error awaiting cancelled background task: {res}")
+            # Bounded wait: a dispatch coroutine stuck in an uncancellable
+            # spot must not wedge end_all itself (the frontend proxy gives up
+            # after 5s and the user sees the ✕ do nothing).
+            done, pending = await asyncio.wait(tasks_to_await, timeout=10.0)
+            if pending:
+                logger.warning(
+                    "[Agent] end_all: %d task(s) still not finished 10s after cancel; continuing teardown",
+                    len(pending),
+                )
+            for res in done:
+                try:
+                    exc = res.exception()
+                except asyncio.CancelledError:
+                    continue
+                if exc is not None:
+                    logger.warning(f"[Agent] Error awaiting cancelled background task: {exc}")
         Modules._background_tasks.clear()
 
         # Signal computer-use adapter to cancel at next step boundary

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -570,14 +570,15 @@ async def proxy_task_cancel(task_id: str):
             # so the HUD can tell an orphan card from a proxy-layer failure.
             return JSONResponse({"success": False, "error": f"tool_server responded {r.status_code}"}, status_code=r.status_code)
         return r.json()
-    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as e:
-        # Request never reached the tool server.
-        return JSONResponse({"success": False, "error": f"proxy error: {e}"}, status_code=502)
-    except httpx.TimeoutException as e:
-        # Timed out after forwarding: the tool server received the cancel but
-        # responded too slowly. 504 tells the HUD the request did land, so
-        # its local terminal fallback is safe to apply.
+    except httpx.ReadTimeout as e:
+        # Timed out waiting for the response: the tool server received the
+        # cancel but responded too slowly. 504 tells the HUD the request did
+        # land, so its local terminal fallback is safe to apply.
         return JSONResponse({"success": False, "error": f"proxy timeout: {e}"}, status_code=504)
+    except (httpx.ConnectError, httpx.TimeoutException) as e:
+        # Connect failure or connect/write/pool timeout: the request cannot
+        # be proven to have reached the tool server.
+        return JSONResponse({"success": False, "error": f"proxy error: {e}"}, status_code=502)
     except Exception as e:
         return JSONResponse({"success": False, "error": f"proxy error: {e}"}, status_code=502)
 
@@ -598,20 +599,21 @@ async def proxy_admin_control(payload: dict = Body(...)):
         logger.info(f"Admin control result: {result}")
         return result
 
-    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as e:
-        # Request never reached the tool server — nothing was cancelled.
-        return JSONResponse({
-            "success": False,
-            "error": f"Failed to execute admin control: {str(e)}"
-        }, status_code=500)
-    except httpx.TimeoutException as e:
-        # Timed out after forwarding: end_all keeps running to completion on
-        # the tool server. 504 tells the HUD the request did land, so its
-        # local terminal fallback is safe to apply.
+    except httpx.ReadTimeout as e:
+        # Timed out waiting for the response: end_all keeps running to
+        # completion on the tool server. 504 tells the HUD the request did
+        # land, so its local terminal fallback is safe to apply.
         return JSONResponse({
             "success": False,
             "error": f"admin control timed out after forwarding: {str(e)}"
         }, status_code=504)
+    except (httpx.ConnectError, httpx.TimeoutException) as e:
+        # Connect failure or connect/write/pool timeout: the request cannot
+        # be proven to have reached the tool server — nothing was cancelled.
+        return JSONResponse({
+            "success": False,
+            "error": f"Failed to execute admin control: {str(e)}"
+        }, status_code=500)
     except Exception as e:
         return JSONResponse({
             "success": False,

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -566,8 +566,18 @@ async def proxy_task_cancel(task_id: str):
         client = _get_http_client()
         r = await client.post(f"{TOOL_SERVER_BASE}/tasks/{task_id}/cancel", timeout=5.0)
         if not r.is_success:
-            return JSONResponse({"success": False, "error": f"tool_server responded {r.status_code}"}, status_code=502)
+            # Pass the tool server's status through (e.g. 404 task-not-found)
+            # so the HUD can tell an orphan card from a proxy-layer failure.
+            return JSONResponse({"success": False, "error": f"tool_server responded {r.status_code}"}, status_code=r.status_code)
         return r.json()
+    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as e:
+        # Request never reached the tool server.
+        return JSONResponse({"success": False, "error": f"proxy error: {e}"}, status_code=502)
+    except httpx.TimeoutException as e:
+        # Timed out after forwarding: the tool server received the cancel but
+        # responded too slowly. 504 tells the HUD the request did land, so
+        # its local terminal fallback is safe to apply.
+        return JSONResponse({"success": False, "error": f"proxy timeout: {e}"}, status_code=504)
     except Exception as e:
         return JSONResponse({"success": False, "error": f"proxy error: {e}"}, status_code=502)
 
@@ -583,11 +593,25 @@ async def proxy_admin_control(payload: dict = Body(...)):
         r = await client.post(f"{TOOL_SERVER_BASE}/admin/control", json=payload, timeout=5.0)
         if not r.is_success:
             return JSONResponse({"success": False, "error": f"tool_server responded {r.status_code}"}, status_code=502)
-        
+
         result = r.json()
         logger.info(f"Admin control result: {result}")
         return result
-        
+
+    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as e:
+        # Request never reached the tool server — nothing was cancelled.
+        return JSONResponse({
+            "success": False,
+            "error": f"Failed to execute admin control: {str(e)}"
+        }, status_code=500)
+    except httpx.TimeoutException as e:
+        # Timed out after forwarding: end_all keeps running to completion on
+        # the tool server. 504 tells the HUD the request did land, so its
+        # local terminal fallback is safe to apply.
+        return JSONResponse({
+            "success": False,
+            "error": f"admin control timed out after forwarding: {str(e)}"
+        }, status_code=504)
     except Exception as e:
         return JSONResponse({
             "success": False,

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -796,17 +796,20 @@ window.AgentHUD.updateAgentTaskHUD = function (tasksData) {
 // click handlers below call this after reaching the server so the UI always
 // converges. Backend events for the same tasks merge idempotently in
 // app-websocket.js.
-window.AgentHUD._markTasksCancelledLocally = function (taskIds) {
+window.AgentHUD._markTasksCancelledLocally = function (taskIds, status) {
     const map = window._agentTaskMap;
     if (!map || typeof map.forEach !== 'function' || map.size === 0) return;
     if (!window._agentTaskRemoveTimers) window._agentTaskRemoveTimers = new Map();
     const ids = Array.isArray(taskIds) ? new Set(taskIds) : null;
+    // Optional status override: when the backend reports the task already
+    // reached a different terminal state, mirror it instead of "cancelled".
+    const terminalStatus = status || 'cancelled';
     const now = Date.now();
     let changed = false;
     map.forEach((t, id) => {
         if (!t || (ids && !ids.has(id))) return;
         if (t.status !== 'running' && t.status !== 'queued') return;
-        map.set(id, Object.assign({}, t, { status: 'cancelled', terminal_at: now }));
+        map.set(id, Object.assign({}, t, { status: terminalStatus, terminal_at: now }));
         changed = true;
         // Schedule the same 10s map removal as the websocket event path —
         // otherwise the entry outlives the HUD's 30s terminal cache and a
@@ -819,7 +822,7 @@ window.AgentHUD._markTasksCancelledLocally = function (taskIds) {
         window._agentTaskRemoveTimers.set(id, setTimeout(() => {
             window._agentTaskRemoveTimers.delete(id);
             const current = window._agentTaskMap && window._agentTaskMap.get(id);
-            if (!current || current.status !== 'cancelled') return;
+            if (!current || current.status !== terminalStatus) return;
             window._agentTaskMap.delete(id);
             const remaining = Array.from(window._agentTaskMap.values());
             window.AgentHUD.updateAgentTaskHUD({
@@ -1319,8 +1322,21 @@ window.AgentHUD._createTaskCard = function (task) {
             // request never reached the tool server — keep the card and
             // re-enable the button for retry.
             if (r.ok || r.status === 404 || r.status === 504) {
+                // "task is not active" (200 + success:false) means the task
+                // hit a different terminal state right before the click —
+                // mirror that status instead of faking "cancelled".
+                let realStatus = null;
+                if (r.ok) {
+                    try {
+                        const body = await r.json();
+                        if (body && body.success === false
+                            && ['completed', 'failed', 'cancelled'].indexOf(body.status) !== -1) {
+                            realStatus = body.status;
+                        }
+                    } catch (_) { /* empty or non-JSON body */ }
+                }
                 if (window.AgentHUD._markTasksCancelledLocally) {
-                    window.AgentHUD._markTasksCancelledLocally([task.id]);
+                    window.AgentHUD._markTasksCancelledLocally([task.id], realStatus || undefined);
                 }
             } else {
                 taskCancelBtn.style.opacity = '1';

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -552,12 +552,13 @@ window.AgentHUD.createAgentTaskHUD = function () {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ action: 'end_all' })
             });
-            // 2xx → end_all ran; 500/502 → the proxy timed out but the tool
-            // server keeps executing end_all to completion. Either way the
-            // backend registry ends up cleared, so apply the terminal state
-            // locally in case its task_update events never arrive (stuck
-            // dispatch). 501 (remote backend block) means nothing happened.
-            if (r.ok || r.status === 500 || r.status === 502) {
+            // 2xx → end_all ran; 504 → the proxy timed out AFTER forwarding,
+            // so the tool server keeps executing end_all to completion.
+            // Either way the backend registry ends up cleared — apply the
+            // terminal state locally in case its task_update events never
+            // arrive (stuck dispatch). Other failures (500 connect error,
+            // 501 remote block) mean the request never landed: don't lie.
+            if (r.ok || r.status === 504) {
                 if (window.AgentHUD._markTasksCancelledLocally) {
                     window.AgentHUD._markTasksCancelledLocally();
                 }
@@ -1309,14 +1310,21 @@ window.AgentHUD._createTaskCard = function (task) {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' }
             });
-            // Success → the backend emitted task_update(cancelled); marking
-            // locally is an idempotent fallback for when that event can't
-            // arrive (stuck backend). A 404/"not active"/502 failure means
-            // the backend no longer tracks this task, so the card is an
-            // orphan (e.g. left behind by an earlier end_all) — clear it
-            // locally too. 501 (remote backend block) changes nothing.
-            if (r.status !== 501 && window.AgentHUD._markTasksCancelledLocally) {
-                window.AgentHUD._markTasksCancelledLocally([task.id]);
+            // 2xx → the backend handled the cancel (marking locally is an
+            // idempotent fallback for when its event can't arrive);
+            // 404 → the backend no longer tracks this task, the card is an
+            // orphan (e.g. left behind by an earlier end_all) — clear it;
+            // 504 → proxy timed out AFTER forwarding, the cancel did land.
+            // Anything else (502 connect error, 501 remote block) means the
+            // request never reached the tool server — keep the card and
+            // re-enable the button for retry.
+            if (r.ok || r.status === 404 || r.status === 504) {
+                if (window.AgentHUD._markTasksCancelledLocally) {
+                    window.AgentHUD._markTasksCancelledLocally([task.id]);
+                }
+            } else {
+                taskCancelBtn.style.opacity = '1';
+                taskCancelBtn.style.pointerEvents = 'auto';
             }
         } catch (err) {
             console.error('[AgentHUD] Cancel task failed:', err);

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -798,6 +798,7 @@ window.AgentHUD.updateAgentTaskHUD = function (tasksData) {
 window.AgentHUD._markTasksCancelledLocally = function (taskIds) {
     const map = window._agentTaskMap;
     if (!map || typeof map.forEach !== 'function' || map.size === 0) return;
+    if (!window._agentTaskRemoveTimers) window._agentTaskRemoveTimers = new Map();
     const ids = Array.isArray(taskIds) ? new Set(taskIds) : null;
     const now = Date.now();
     let changed = false;
@@ -806,6 +807,31 @@ window.AgentHUD._markTasksCancelledLocally = function (taskIds) {
         if (t.status !== 'running' && t.status !== 'queued') return;
         map.set(id, Object.assign({}, t, { status: 'cancelled', terminal_at: now }));
         changed = true;
+        // Schedule the same 10s map removal as the websocket event path —
+        // otherwise the entry outlives the HUD's 30s terminal cache and a
+        // later full-map refresh would re-show it as a "new" terminal task.
+        // If the backend's own cancelled event arrives later, app-websocket
+        // clears this timer and installs its own (idempotent handoff).
+        if (window._agentTaskRemoveTimers.has(id)) {
+            clearTimeout(window._agentTaskRemoveTimers.get(id));
+        }
+        window._agentTaskRemoveTimers.set(id, setTimeout(() => {
+            window._agentTaskRemoveTimers.delete(id);
+            const current = window._agentTaskMap && window._agentTaskMap.get(id);
+            if (!current || current.status !== 'cancelled') return;
+            window._agentTaskMap.delete(id);
+            const remaining = Array.from(window._agentTaskMap.values());
+            window.AgentHUD.updateAgentTaskHUD({
+                success: true,
+                tasks: remaining,
+                total_count: remaining.length,
+                running_count: remaining.filter(t2 => t2.status === 'running').length,
+                queued_count: remaining.filter(t2 => t2.status === 'queued').length,
+                completed_count: remaining.filter(t2 => t2.status === 'completed').length,
+                failed_count: remaining.filter(t2 => t2.status === 'failed').length,
+                timestamp: new Date().toISOString()
+            });
+        }, 10000));
     });
     if (!changed) return;
     const tasks = Array.from(map.values());

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -547,11 +547,21 @@ window.AgentHUD.createAgentTaskHUD = function () {
         try {
             cancelBtn.style.opacity = '0.5';
             cancelBtn.style.pointerEvents = 'none';
-            await fetch('/api/agent/admin/control', {
+            const r = await fetch('/api/agent/admin/control', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ action: 'end_all' })
             });
+            // 2xx → end_all ran; 500/502 → the proxy timed out but the tool
+            // server keeps executing end_all to completion. Either way the
+            // backend registry ends up cleared, so apply the terminal state
+            // locally in case its task_update events never arrive (stuck
+            // dispatch). 501 (remote backend block) means nothing happened.
+            if (r.ok || r.status === 500 || r.status === 502) {
+                if (window.AgentHUD._markTasksCancelledLocally) {
+                    window.AgentHUD._markTasksCancelledLocally();
+                }
+            }
         } catch (err) {
             console.error('[AgentHUD] Cancel all tasks failed:', err);
         } finally {
@@ -775,6 +785,39 @@ window.AgentHUD.updateAgentTaskHUD = function (tasksData) {
     this._updateRafId = requestAnimationFrame(() => {
         this._updateRafId = null;
         this._doUpdateAgentTaskHUD();
+    });
+};
+
+// Local fallback: mark tasks cancelled in the shared task map and re-render.
+// The HUD is purely event-driven; when the backend is wedged (the very
+// situation the user is cancelling out of) its task_update(cancelled) events
+// may never arrive, leaving cards stuck on "running" forever. The cancel
+// click handlers below call this after reaching the server so the UI always
+// converges. Backend events for the same tasks merge idempotently in
+// app-websocket.js.
+window.AgentHUD._markTasksCancelledLocally = function (taskIds) {
+    const map = window._agentTaskMap;
+    if (!map || typeof map.forEach !== 'function' || map.size === 0) return;
+    const ids = Array.isArray(taskIds) ? new Set(taskIds) : null;
+    const now = Date.now();
+    let changed = false;
+    map.forEach((t, id) => {
+        if (!t || (ids && !ids.has(id))) return;
+        if (t.status !== 'running' && t.status !== 'queued') return;
+        map.set(id, Object.assign({}, t, { status: 'cancelled', terminal_at: now }));
+        changed = true;
+    });
+    if (!changed) return;
+    const tasks = Array.from(map.values());
+    this.updateAgentTaskHUD({
+        success: true,
+        tasks: tasks,
+        total_count: tasks.length,
+        running_count: tasks.filter(t => t.status === 'running').length,
+        queued_count: tasks.filter(t => t.status === 'queued').length,
+        completed_count: tasks.filter(t => t.status === 'completed').length,
+        failed_count: tasks.filter(t => t.status === 'failed').length,
+        timestamp: new Date().toISOString()
     });
 };
 
@@ -1236,12 +1279,25 @@ window.AgentHUD._createTaskCard = function (task) {
         taskCancelBtn.style.opacity = '0.4';
         taskCancelBtn.style.pointerEvents = 'none';
         try {
-            await fetch(`/api/agent/tasks/${encodeURIComponent(task.id)}/cancel`, {
+            const r = await fetch(`/api/agent/tasks/${encodeURIComponent(task.id)}/cancel`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' }
             });
+            // Success → the backend emitted task_update(cancelled); marking
+            // locally is an idempotent fallback for when that event can't
+            // arrive (stuck backend). A 404/"not active"/502 failure means
+            // the backend no longer tracks this task, so the card is an
+            // orphan (e.g. left behind by an earlier end_all) — clear it
+            // locally too. 501 (remote backend block) changes nothing.
+            if (r.status !== 501 && window.AgentHUD._markTasksCancelledLocally) {
+                window.AgentHUD._markTasksCancelledLocally([task.id]);
+            }
         } catch (err) {
             console.error('[AgentHUD] Cancel task failed:', err);
+            // Network-level failure: the request never reached the server.
+            // Re-enable the button so the user can retry.
+            taskCancelBtn.style.opacity = '1';
+            taskCancelBtn.style.pointerEvents = 'auto';
         }
     });
 

--- a/tests/unit/test_agent_cancel_proxy_status.py
+++ b/tests/unit/test_agent_cancel_proxy_status.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Cancel-proxy status classification.
+
+The HUD's local cancel fallback keys off the proxy status code: it may only
+apply the terminal state when the request provably reached the tool server
+(2xx, 404 pass-through, 504 timeout-after-forwarding). Connect-level failures
+must stay 502/500 so the HUD does not hide tasks the tool server is still
+running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def router(monkeypatch: pytest.MonkeyPatch):
+    from main_routers import agent_router
+
+    monkeypatch.setattr(agent_router, "_remote_backend_block", lambda: None)
+    yield agent_router
+
+
+def _client_raising(exc: Exception) -> MagicMock:
+    client = MagicMock()
+
+    async def _post(*args, **kwargs):
+        raise exc
+
+    client.post = _post
+    return client
+
+
+def _client_responding(status_code: int) -> MagicMock:
+    client = MagicMock()
+    response = MagicMock()
+    response.is_success = 200 <= status_code < 300
+    response.status_code = status_code
+    response.json = MagicMock(return_value={"success": response.is_success})
+
+    async def _post(*args, **kwargs):
+        return response
+
+    client.post = _post
+    return client
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (httpx.ConnectError("refused"), 502),
+        (httpx.ConnectTimeout("connect timed out"), 502),
+        (httpx.ReadTimeout("read timed out"), 504),
+    ],
+)
+def test_task_cancel_proxy_classifies_failures(router, monkeypatch, exc, expected):
+    monkeypatch.setattr(router, "_get_http_client", lambda: _client_raising(exc))
+    resp = asyncio.run(router.proxy_task_cancel("abc"))
+    assert resp.status_code == expected
+
+
+def test_task_cancel_proxy_passes_through_tool_server_status(router, monkeypatch):
+    monkeypatch.setattr(router, "_get_http_client", lambda: _client_responding(404))
+    resp = asyncio.run(router.proxy_task_cancel("abc"))
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (httpx.ConnectError("refused"), 500),
+        (httpx.ConnectTimeout("connect timed out"), 500),
+        (httpx.ReadTimeout("read timed out"), 504),
+    ],
+)
+def test_admin_control_proxy_classifies_failures(router, monkeypatch, exc, expected):
+    monkeypatch.setattr(router, "_get_http_client", lambda: _client_raising(exc))
+    resp = asyncio.run(router.proxy_admin_control({"action": "end_all"}))
+    assert resp.status_code == expected

--- a/tests/unit/test_agent_cancel_proxy_status.py
+++ b/tests/unit/test_agent_cancel_proxy_status.py
@@ -54,6 +54,8 @@ def _client_responding(status_code: int) -> MagicMock:
     [
         (httpx.ConnectError("refused"), 502),
         (httpx.ConnectTimeout("connect timed out"), 502),
+        (httpx.WriteTimeout("write timed out"), 502),
+        (httpx.PoolTimeout("pool timed out"), 502),
         (httpx.ReadTimeout("read timed out"), 504),
     ],
 )
@@ -74,6 +76,8 @@ def test_task_cancel_proxy_passes_through_tool_server_status(router, monkeypatch
     [
         (httpx.ConnectError("refused"), 500),
         (httpx.ConnectTimeout("connect timed out"), 500),
+        (httpx.WriteTimeout("write timed out"), 500),
+        (httpx.PoolTimeout("pool timed out"), 500),
         (httpx.ReadTimeout("read timed out"), 504),
     ],
 )

--- a/tests/unit/test_agent_end_all_notify.py
+++ b/tests/unit/test_agent_end_all_notify.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""``admin_control(end_all)`` must notify the frontend about every task it clears.
+
+The task HUD is purely event-driven (no HTTP polling). A dispatch coroutine
+wedged inside an LLM call never emits its own terminal event, so end_all must
+emit ``task_update(cancelled)`` for every queued/running registry entry before
+clearing the registry — otherwise the HUD card stays "running" forever and the
+cancel button appears to do nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def srv(monkeypatch: pytest.MonkeyPatch):
+    from app import agent_server as agent_srv
+
+    M = agent_srv.Modules
+    saved_registry = dict(M.task_registry)
+    saved_handles = dict(M.task_async_handles)
+    saved_background = set(M._background_tasks)
+    saved_browser_use = M.browser_use
+    saved_active_bu = M.active_browser_use_task_id
+    M.task_registry.clear()
+    M.task_async_handles.clear()
+    M._background_tasks.clear()
+
+    monkeypatch.setattr(agent_srv, "_emit_main_event", AsyncMock())
+    monkeypatch.setattr(agent_srv._task_tracker, "record_completed", MagicMock())
+
+    yield agent_srv
+
+    M.task_registry.clear()
+    M.task_registry.update(saved_registry)
+    M.task_async_handles.clear()
+    M.task_async_handles.update(saved_handles)
+    M._background_tasks.clear()
+    M._background_tasks.update(saved_background)
+    M.browser_use = saved_browser_use
+    M.active_browser_use_task_id = saved_active_bu
+
+
+def test_end_all_emits_cancelled_for_every_active_task(srv):
+    M = srv.Modules
+    M.task_registry["t-running"] = {
+        "id": "t-running", "type": "browser_use", "status": "running",
+        "params": {"instruction": "x"}, "lanlan_name": "lanlan",
+    }
+    M.task_registry["t-queued"] = {
+        "id": "t-queued", "type": "computer_use", "status": "queued",
+        "params": {}, "lanlan_name": "lanlan",
+    }
+    M.task_registry["t-done"] = {
+        "id": "t-done", "type": "browser_use", "status": "completed",
+        "params": {}, "lanlan_name": "lanlan",
+    }
+
+    result = asyncio.run(srv.admin_control({"action": "end_all"}))
+
+    assert result["success"] is True
+    assert M.task_registry == {}
+
+    emitted = {}
+    for call in srv._emit_main_event.await_args_list:
+        if call.args and call.args[0] == "task_update":
+            task = call.kwargs.get("task") or {}
+            emitted[task.get("id")] = task.get("status")
+    assert emitted.get("t-running") == "cancelled"
+    assert emitted.get("t-queued") == "cancelled"
+    # Already-terminal tasks must not be re-announced.
+    assert "t-done" not in emitted
+
+
+def test_cancel_queued_browser_task_keeps_shared_browser_alive(srv):
+    """Cancelling a browser_use task that is still waiting for the dispatch
+    slot must NOT tear down the shared browser session — that would kill the
+    unrelated task currently using it."""
+    M = srv.Modules
+    M.browser_use = MagicMock()
+    M.browser_use.cancel = AsyncMock()
+    M.active_browser_use_task_id = "t-running"
+    M.task_registry["t-queued"] = {
+        "id": "t-queued", "type": "browser_use", "status": "queued",
+        "params": {"instruction": "x"}, "lanlan_name": "lanlan",
+    }
+
+    result = asyncio.run(srv.cancel_task("t-queued"))
+
+    assert result["success"] is True
+    assert M.task_registry["t-queued"]["status"] == "cancelled"
+    M.browser_use.cancel.assert_not_called()
+    assert M.active_browser_use_task_id == "t-running"
+
+
+def test_cancel_active_browser_task_tears_down_browser(srv):
+    M = srv.Modules
+    M.browser_use = MagicMock()
+    M.browser_use.cancel = AsyncMock()
+    M.active_browser_use_task_id = "t-active"
+    M.task_registry["t-active"] = {
+        "id": "t-active", "type": "browser_use", "status": "running",
+        "params": {"instruction": "x"}, "lanlan_name": "lanlan",
+    }
+
+    async def _scenario():
+        result = await srv.cancel_task("t-active")
+        # let the fire-and-forget teardown runner execute
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return result
+
+    result = asyncio.run(_scenario())
+
+    assert result["success"] is True
+    assert M.task_registry["t-active"]["status"] == "cancelled"
+    M.browser_use.cancel.assert_called_once()
+    assert M.active_browser_use_task_id is None
+
+
+def test_end_all_cancels_orphan_dispatch_handles(srv):
+    """Handles registered only in task_async_handles (not _background_tasks)
+    must still receive the cancel."""
+    M = srv.Modules
+
+    async def _scenario():
+        orphan = asyncio.create_task(asyncio.sleep(3600))
+        M.task_async_handles["t-orphan"] = orphan
+        await asyncio.sleep(0)  # let the task start
+
+        result = await srv.admin_control({"action": "end_all"})
+        assert result["success"] is True
+        assert orphan.cancelled()
+
+    asyncio.run(_scenario())

--- a/tests/unit/test_agent_end_all_notify.py
+++ b/tests/unit/test_agent_end_all_notify.py
@@ -122,6 +122,40 @@ def test_cancel_active_browser_task_tears_down_browser(srv):
     assert M.active_browser_use_task_id is None
 
 
+def test_end_all_cancels_untracked_direct_browser_run(srv):
+    """A direct /browser_use/run call must be tracked in _background_tasks so
+    end_all can cancel it — otherwise it would survive end_all still holding
+    the dispatch mutex and every later browser task would queue forever."""
+    M = srv.Modules
+    saved_lock = M.browser_use_dispatch_lock
+    M.browser_use_dispatch_lock = None
+    M.browser_use = MagicMock()
+    M.browser_use._browser_session = None
+
+    async def _stall(instruction, **kwargs):
+        await asyncio.sleep(3600)
+
+    M.browser_use.run_instruction = _stall
+
+    async def _scenario():
+        run = asyncio.create_task(srv.browser_use_run({"instruction": "x"}))
+        await asyncio.sleep(0.05)  # let it acquire the lock and stall
+        assert M.browser_use_dispatch_lock is not None
+        assert M.browser_use_dispatch_lock.locked()
+
+        result = await srv.admin_control({"action": "end_all"})
+        assert result["success"] is True
+
+        resp = await run
+        assert resp.status_code == 500
+        assert not M.browser_use_dispatch_lock.locked()
+
+    try:
+        asyncio.run(_scenario())
+    finally:
+        M.browser_use_dispatch_lock = saved_lock
+
+
 def test_end_all_cancels_orphan_dispatch_handles(srv):
     """Handles registered only in task_async_handles (not _background_tasks)
     must still receive the cancel."""


### PR DESCRIPTION
## 问题

浏览器控制任务有时卡住后，点 HUD 右上角 ✕（终止所有）或单卡片 ✕ 都关不掉，卡片永远停在「运行中」。

## 根因

任务 HUD 纯靠 WebSocket 事件更新（无 HTTP 轮询兜底），取消链路上有多处不发事件、前端也无任何兜底：

1. **end_all 不发通知**：`/admin/control` 的 end_all 直接 `task_registry.clear()`，指望「被取消的 dispatch 协程自己发 cancelled 事件」——但浏览器控制卡死时协程正堵在 LLM 调用里发不出来；排队中的任务更是从来没有协程。
2. **end_all 自己也会被挂住**：无超时 `gather` 等待所有被取消的协程，前端代理 5 秒即超时，用户看到「点了没反应」。
3. **前端不看响应**：end_all 清掉 registry 后再点单卡片 ✕ 返回 404，前端不处理失败、不更新 UI，还把按钮永久置灰——孤儿卡片从此点什么都没用。
4. **browser_use 无并发互斥**（截图里两个任务同时「运行中」的来源）：适配器是单例，`run_instruction` 开头 `self._cancelled = False` 会清掉并发任务刚收到的取消信号；取消一个任务会拆共享浏览器，把另一个无辜任务连带杀死。

## 修复

**后端 `app/agent_server.py`**
- end_all 清 registry 前先为所有 queued/running 任务标记 cancelled 并逐个发 `task_update`（与单任务取消对偶）；取消范围补上 `task_async_handles` 中的孤儿协程；等待协程退出改为 10s 有界等待。
- browser_use dispatch 串行化：对偶 computer_use 的独占语义，用 `asyncio.Lock` 实现（不复制 scheduler loop，取消路径天然复用 `bg.cancel()`）。任务先以 queued 入册并通知前端，拿到锁才转 running；进锁后有防复活检查（对偶 CU scheduler 的 queued guard）。
- `cancel_task` 只在被取消任务确实持有浏览器（`active_browser_use_task_id` 匹配）时才拆共享浏览器；排队协程被取消时不再清掉正在跑任务的 active id。

**前端 `static/common-ui-hud.js`**
- 新增 `_markTasksCancelledLocally` 本地兜底：取消请求只要到达服务器就把卡片本地标记为已取消（与后端事件幂等合并，沿用 10s linger 消失）；顺带解除幽灵 running 卡片对 auto-goodbye 的永久阻塞。
- 单卡片 ✕ 收到 404 / not active / 502 时清掉孤儿卡片；仅网络层失败才恢复按钮供重试。501（远端后端禁用）不做本地变更。

## 验证

- 新增 `tests/unit/test_agent_end_all_notify.py` 4 个用例：end_all 为每个活跃任务发 cancelled 事件、不重播已终止任务、孤儿 handle 被取消、取消排队任务不动共享浏览器/取消持有者才拆。
- agent 相关回归（router remote block、runtime intent、callback origin、rewrite regression）232 个全过；无其他测试依赖旧的「创建即 running」行为。
- 前端 helper 经 node harness 验证三种场景；「队列中」文案/样式 HUD 已有，无新增 i18n 字符串。

已知接受的窄边角：取消正在跑的任务后，后台拆浏览器与下一个排队任务起浏览器可能短暂重叠，极端情况下后者首连失败——`run_instruction` 自带 launch 重试和 stale session 检测兜底。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 串行化共享浏览器任务的派单与执行，修复并发覆盖与错误清理；增强 “终止所有任务” 的标记、取消、超时与日志处理，必要时重置被阻塞的调度锁；代理端取消/管理控制的错误码与超时映射更精细。

* **UI**
  * 取消操作根据后端响应做本地兜底标记，新增本地任务终态写入、延迟移除与 HUD 刷新，提升前端反馈一致性。

* **Tests**
  * 新增单元测试，覆盖 end_all、取消行为、代理状态分类及未跟踪派单的取消处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->