### PR TITLE
feat(subtitle): 增强设置面板与自适应布局，修复初始化灰边

### DIFF
--- a/static/css/subtitle.css
+++ b/static/css/subtitle.css
@@ -48,19 +48,25 @@ body.subtitle-web-host #subtitle-display {
 
 body.subtitle-window-host #subtitle-display {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
+    top: var(--subtitle-window-display-top, 0);
+    left: var(--subtitle-window-display-left, 0);
+    width: var(--subtitle-window-display-width, 100%);
+    height: var(--subtitle-window-display-height, auto);
     transition: min-height 0.3s ease, max-height 0.3s ease, font-size 0.3s ease;
 }
 
 body.subtitle-window-host.subtitle-linux-host #subtitle-display {
-    top: auto;
-    bottom: 0;
+    top: var(--subtitle-window-display-top, 0);
+    bottom: auto;
+}
+
+body.subtitle-window-host.subtitle-window-resizing #subtitle-display {
+    transition: none !important;
 }
 
 #subtitle-scroll {
     width: 100%;
+    height: var(--subtitle-content-height, auto);
     max-height: var(--subtitle-content-max-height, 120px);
     overflow-y: auto;
     overscroll-behavior: contain;
@@ -155,15 +161,30 @@ body.subtitle-window-host.subtitle-linux-host #subtitle-display {
     z-index: 10;
 }
 
+.subtitle-window-settings-layer {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 100;
+}
+
+.subtitle-window-settings-layer #subtitle-settings-panel {
+    pointer-events: auto;
+}
+
 body.subtitle-window-host #subtitle-settings-panel {
-    top: calc(100% + 8px);
-    right: 4px;
+    position: fixed;
+    top: var(--subtitle-window-panel-top, calc(100% + 8px));
+    left: var(--subtitle-window-panel-left, 0);
+    right: auto;
     bottom: auto;
+    max-width: none;
+    z-index: 100;
 }
 
 body.subtitle-window-host.subtitle-linux-host #subtitle-settings-panel {
-    top: auto;
-    bottom: calc(100% + 8px);
+    top: var(--subtitle-window-panel-top, 0);
+    bottom: auto;
 }
 
 #subtitle-settings-panel.hidden {
@@ -335,7 +356,7 @@ body.subtitle-web-host #subtitle-display.drag-anywhere,
     right: 4px;
     width: 26px;
     height: 26px;
-    display: flex;
+    display: none !important;
     align-items: center;
     justify-content: center;
     cursor: grab;
@@ -355,19 +376,6 @@ body.subtitle-web-host #subtitle-display.drag-anywhere,
     cursor: grabbing;
     background: rgba(255, 255, 255, 0.42);
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
-}
-
-#subtitle-drag-arrows {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#subtitle-drag-arrows svg {
-    width: 14px;
-    height: 14px;
 }
 
 #subtitle-display.dragging {

--- a/static/subtitle-shared.js
+++ b/static/subtitle-shared.js
@@ -470,7 +470,9 @@
         applySubtitlePreset(refs.display, state.subtitleSize, { host: host });
         refs.display.classList.toggle('drag-anywhere', !!state.subtitleDragAnywhere);
         if (refs.dragHandle) {
-            refs.dragHandle.style.display = state.subtitleDragAnywhere ? '' : 'none';
+            refs.dragHandle.style.display = 'none';
+            refs.dragHandle.setAttribute('aria-hidden', 'true');
+            refs.dragHandle.tabIndex = -1;
         }
         if (refs.langSelect) {
             refs.langSelect.value = state.userLanguage;
@@ -599,7 +601,7 @@
     }
 
     function attachWebDrag(refs) {
-        if (!refs.display || !refs.dragHandle) return function() {};
+        if (!refs.display) return function() {};
 
         var isDragging = false;
         var pendingDrag = false;
@@ -726,8 +728,10 @@
             beginTouchDrag(e);
         }
 
-        refs.dragHandle.addEventListener('mousedown', onHandleMouseDown);
-        refs.dragHandle.addEventListener('touchstart', onHandleTouchStart, { passive: false });
+        if (refs.dragHandle) {
+            refs.dragHandle.addEventListener('mousedown', onHandleMouseDown);
+            refs.dragHandle.addEventListener('touchstart', onHandleTouchStart, { passive: false });
+        }
         refs.display.addEventListener('mousedown', onDisplayMouseDown);
         refs.display.addEventListener('touchstart', onDisplayTouchStart, { passive: false });
         document.addEventListener('touchmove', handleTouchMove, { passive: false });
@@ -736,8 +740,10 @@
         window.addEventListener('resize', clampManualPosition);
 
         return function detachWebDrag() {
-            refs.dragHandle.removeEventListener('mousedown', onHandleMouseDown);
-            refs.dragHandle.removeEventListener('touchstart', onHandleTouchStart, { passive: false });
+            if (refs.dragHandle) {
+                refs.dragHandle.removeEventListener('mousedown', onHandleMouseDown);
+                refs.dragHandle.removeEventListener('touchstart', onHandleTouchStart, { passive: false });
+            }
             refs.display.removeEventListener('mousedown', onDisplayMouseDown);
             refs.display.removeEventListener('touchstart', onDisplayTouchStart, { passive: false });
             document.removeEventListener('touchmove', handleTouchMove, { passive: false });
@@ -751,7 +757,7 @@
 
     function attachWindowDrag(refs, options) {
         var api = options && options.api;
-        if (!refs.display || !refs.dragHandle || !api) return function() {};
+        if (!refs.display || !api) return function() {};
 
         var isDragging = false;
 
@@ -807,7 +813,7 @@
         function stopDrag() {
             if (!isDragging) return;
             isDragging = false;
-            refs.dragHandle.style.cursor = '';
+            if (refs.dragHandle) refs.dragHandle.style.cursor = '';
             if (typeof api.dragStop === 'function') {
                 api.dragStop();
             }
@@ -817,13 +823,13 @@
         function onHandleMouseDown(e) {
             if (!isDragAnywhereMode()) return;
             startDrag(e);
-            refs.dragHandle.style.cursor = 'grabbing';
+            if (refs.dragHandle) refs.dragHandle.style.cursor = 'grabbing';
         }
 
         function onHandleTouchStart(e) {
             if (!isDragAnywhereMode()) return;
             startDrag(e);
-            refs.dragHandle.style.cursor = 'grabbing';
+            if (refs.dragHandle) refs.dragHandle.style.cursor = 'grabbing';
         }
 
         function onDisplayMouseDown(e) {
@@ -836,8 +842,10 @@
             startDrag(e);
         }
 
-        refs.dragHandle.addEventListener('mousedown', onHandleMouseDown);
-        refs.dragHandle.addEventListener('touchstart', onHandleTouchStart, { passive: false });
+        if (refs.dragHandle) {
+            refs.dragHandle.addEventListener('mousedown', onHandleMouseDown);
+            refs.dragHandle.addEventListener('touchstart', onHandleTouchStart, { passive: false });
+        }
         refs.display.addEventListener('mousedown', onDisplayMouseDown);
         refs.display.addEventListener('touchstart', onDisplayTouchStart, { passive: false });
         document.addEventListener('mouseup', stopDrag);
@@ -847,8 +855,10 @@
         window.addEventListener('resize', bounceBackIfNeeded);
 
         return function detachWindowDrag() {
-            refs.dragHandle.removeEventListener('mousedown', onHandleMouseDown);
-            refs.dragHandle.removeEventListener('touchstart', onHandleTouchStart, { passive: false });
+            if (refs.dragHandle) {
+                refs.dragHandle.removeEventListener('mousedown', onHandleMouseDown);
+                refs.dragHandle.removeEventListener('touchstart', onHandleTouchStart, { passive: false });
+            }
             refs.display.removeEventListener('mousedown', onDisplayMouseDown);
             refs.display.removeEventListener('touchstart', onDisplayTouchStart, { passive: false });
             document.removeEventListener('mouseup', stopDrag);

--- a/static/subtitle-window.js
+++ b/static/subtitle-window.js
@@ -244,6 +244,17 @@
             subtitleWindowController.refs.display &&
             Object.prototype.hasOwnProperty.call(data, 'visible')) {
             subtitleWindowController.refs.display.classList.toggle('hidden', !data.visible);
+            // settings panel 已移到 body 级 settings-layer，不再是 display 的子元素，
+            // 需要同步隐藏/显示，否则字幕隐藏时 settings panel 仍可见。
+            if (!data.visible && subtitleWindowController.refs.settingsPanel) {
+                subtitleWindowController.refs.settingsPanel.classList.add('hidden');
+            } else if (data.visible && subtitleWindowController.refs.settingsPanel) {
+                // 不主动移除 hidden —— 面板的显示状态应由用户操作控制，
+                // 只在字幕恢复时确保 settings-layer 容器本身可见
+                if (windowSettingsLayer) {
+                    windowSettingsLayer.classList.remove('hidden');
+                }
+            }
         }
     }
 

--- a/static/subtitle-window.js
+++ b/static/subtitle-window.js
@@ -274,7 +274,7 @@
 
         attachCloseSettingsBeforeContentDrag(subtitleWindowController.refs);
 
-        // 窗口自身按内容自适应大小，不再记录手动拖拽尺寸
+        window.addEventListener('resize', rememberUserViewportSizeFromResize);
 
         window.addEventListener('neko-subtitle-state-sync', function(e) {
             applyStateSync(e.detail || {});

--- a/static/subtitle-window.js
+++ b/static/subtitle-window.js
@@ -4,49 +4,201 @@
     var SubtitleShared = window.nekoSubtitleShared || null;
     var subtitleWindowController = null;
     var currentTranscript = '';
+    var WINDOW_PANEL_GAP = 8;
+    var WINDOW_PANEL_MARGIN = 8;
+    var WINDOW_RESIZE_EPSILON = 2;
+    var lastRequestedWindowWidth = 0;
+    var lastRequestedWindowHeight = 0;
+    var userViewportWidth = 0;
+    var userViewportHeight = 0;
+    var windowSettingsLayer = null;
+    var resizeIdleTimer = 0;
 
     if (!SubtitleShared) {
         console.error('[SubtitleWindow] subtitle-shared.js 未加载');
         return;
     }
 
-    function resizeWindowToTranscript() {
+    function ensureWindowSettingsLayer(refs) {
+        if (!refs || !refs.settingsPanel || !document.body) return;
+        if (!windowSettingsLayer) {
+            windowSettingsLayer = document.getElementById('subtitle-settings-layer');
+            if (!windowSettingsLayer) {
+                windowSettingsLayer = document.createElement('div');
+                windowSettingsLayer.id = 'subtitle-settings-layer';
+                windowSettingsLayer.className = 'subtitle-window-settings-layer';
+                document.body.appendChild(windowSettingsLayer);
+            }
+        }
+        if (refs.settingsPanel.parentElement !== windowSettingsLayer) {
+            windowSettingsLayer.appendChild(refs.settingsPanel);
+        }
+    }
+
+    function resizeWindowToTranscript(options) {
         if (!subtitleWindowController || !subtitleWindowController.refs) return;
+        options = options || {};
         var refs = subtitleWindowController.refs;
         var api = window.nekoSubtitle;
         var state = SubtitleShared.getSettings();
         var preset = SubtitleShared.getSizePreset(state.subtitleSize);
+        var isLinuxHost = document.body && document.body.classList.contains('subtitle-linux-host');
+
+        ensureWindowSettingsLayer(refs);
+
         var settingsPanelOpen = refs.settingsPanel && !refs.settingsPanel.classList.contains('hidden');
-        var panelHeight = settingsPanelOpen && refs.settingsPanel
-            ? refs.settingsPanel.offsetHeight
-            : 0;
-        var panelGap = settingsPanelOpen ? 8 : 0;
+        var panelRect = settingsPanelOpen && refs.settingsPanel
+            ? refs.settingsPanel.getBoundingClientRect()
+            : null;
+        var panelHeight = panelRect ? Math.ceil(panelRect.height) : 0;
+        var panelWidth = panelRect ? Math.ceil(panelRect.width) : 0;
+        var panelGap = settingsPanelOpen ? WINDOW_PANEL_GAP : 0;
+        var displayWidth = preset.width;
+        var displayHeight = preset.minHeight;
+        var displayRenderWidth;
+        var displayRenderHeight;
+        var displayTop;
+        var contentWidth;
+        var contentHeight;
+        var displayLeft;
+        var panelLeft;
+        var panelTop;
 
         SubtitleShared.applySubtitlePreset(refs.display, state.subtitleSize, { host: 'window' });
         refs.display.style.maxHeight = preset.maxHeight + 'px';
 
-        if (!refs.text) return;
-        if (!currentTranscript.trim()) {
+        if (refs.text && currentTranscript.trim()) {
+            var layout = SubtitleShared.measureSubtitleLayout({
+                mode: 'window',
+                text: currentTranscript,
+                presetKey: state.subtitleSize,
+                maxWidth: preset.width,
+                minHeight: preset.minHeight,
+                maxHeight: preset.maxHeight,
+                baseFont: preset.fontSize
+            });
+            displayWidth = layout.width;
+            displayHeight = layout.height;
+            refs.text.style.fontSize = layout.fontSize < preset.fontSize ? layout.fontSize + 'px' : '';
+        } else if (refs.text) {
             refs.text.style.fontSize = '';
-            if (api && typeof api.setSize === 'function') {
-                api.setSize(preset.width, preset.minHeight + panelGap + panelHeight);
-            }
-            return;
         }
 
-        var layout = SubtitleShared.measureSubtitleLayout({
-            mode: 'window',
-            text: currentTranscript,
-            presetKey: state.subtitleSize,
-            maxWidth: preset.width,
-            minHeight: preset.minHeight,
-            maxHeight: preset.maxHeight,
-            baseFont: preset.fontSize
-        });
-        refs.text.style.fontSize = layout.fontSize < preset.fontSize ? layout.fontSize + 'px' : '';
-        if (api && typeof api.setSize === 'function') {
-            api.setSize(layout.width, Math.max(layout.height + panelGap + panelHeight, preset.minHeight));
+        document.body.style.setProperty('--subtitle-window-display-width', displayWidth + 'px');
+        document.body.style.removeProperty('--subtitle-window-display-height');
+        refs.display.style.removeProperty('--subtitle-content-height');
+        var displayRect = refs.display.getBoundingClientRect();
+        displayWidth = Math.ceil(Math.max(displayWidth, displayRect.width));
+        displayHeight = Math.ceil(Math.max(displayHeight, displayRect.height));
+
+        displayRenderWidth = userViewportWidth
+            ? Math.max(displayWidth, userViewportWidth)
+            : displayWidth;
+        displayRenderHeight = userViewportHeight
+            ? Math.max(displayHeight, userViewportHeight)
+            : displayHeight;
+        displayTop = isLinuxHost && settingsPanelOpen ? panelHeight + panelGap : 0;
+        contentWidth = Math.ceil(Math.max(
+            displayRenderWidth,
+            panelWidth ? panelWidth + WINDOW_PANEL_MARGIN : 0,
+            userViewportWidth ? 0 : preset.width
+        ));
+        contentHeight = Math.ceil(Math.max(
+            displayTop + displayRenderHeight,
+            settingsPanelOpen && !isLinuxHost ? displayRenderHeight + panelGap + panelHeight : 0,
+            panelHeight,
+            userViewportHeight ? 0 : preset.minHeight
+        )) +
+            (settingsPanelOpen ? 1 : 0);
+        displayLeft = Math.max(0, Math.round((contentWidth - displayRenderWidth) / 2));
+        panelLeft = settingsPanelOpen && panelWidth
+            ? Math.max(0, Math.round((contentWidth - panelWidth) / 2))
+            : displayLeft;
+        panelTop = isLinuxHost && settingsPanelOpen ? 0 : displayTop + displayRenderHeight + panelGap;
+
+        document.body.style.setProperty('--subtitle-window-display-width', displayRenderWidth + 'px');
+        if (userViewportHeight) {
+            document.body.style.setProperty('--subtitle-window-display-height', displayRenderHeight + 'px');
+            refs.display.style.maxHeight = 'none';
+            refs.display.style.setProperty('--subtitle-content-height', Math.max(24, displayRenderHeight - 40) + 'px');
+            refs.display.style.setProperty('--subtitle-content-max-height', Math.max(24, displayRenderHeight - 40) + 'px');
         }
+        document.body.style.setProperty('--subtitle-window-display-left', displayLeft + 'px');
+        document.body.style.setProperty(
+            '--subtitle-window-display-top',
+            displayTop + 'px'
+        );
+        document.body.style.setProperty('--subtitle-window-panel-left', panelLeft + 'px');
+        document.body.style.setProperty(
+            '--subtitle-window-panel-top',
+            panelTop + 'px'
+        );
+
+        if (!options.skipWindowResize && api && typeof api.setSize === 'function') {
+            lastRequestedWindowWidth = contentWidth;
+            lastRequestedWindowHeight = contentHeight;
+            api.setSize(contentWidth, contentHeight);
+        }
+    }
+
+    function rememberUserViewportSizeFromResize() {
+        var viewportWidth = Math.ceil(window.innerWidth || document.documentElement.clientWidth || 0);
+        var viewportHeight = Math.ceil(window.innerHeight || document.documentElement.clientHeight || 0);
+        var differsFromRequested = !lastRequestedWindowWidth ||
+            Math.abs(viewportWidth - lastRequestedWindowWidth) > WINDOW_RESIZE_EPSILON ||
+            Math.abs(viewportHeight - lastRequestedWindowHeight) > WINDOW_RESIZE_EPSILON;
+
+        if (differsFromRequested) {
+            userViewportWidth = viewportWidth;
+            userViewportHeight = viewportHeight;
+        }
+        if (document.body) {
+            document.body.classList.add('subtitle-window-resizing');
+            if (resizeIdleTimer) clearTimeout(resizeIdleTimer);
+            resizeIdleTimer = setTimeout(function() {
+                resizeIdleTimer = 0;
+                if (document.body) {
+                    document.body.classList.remove('subtitle-window-resizing');
+                }
+            }, 160);
+        }
+        resizeWindowToTranscript({ skipWindowResize: true });
+    }
+
+    function attachCloseSettingsBeforeContentDrag(refs) {
+        if (!refs || !refs.display || !refs.settingsPanel || !refs.settingsBtn) {
+            return function() {};
+        }
+
+        function shouldCloseForDrag(target) {
+            if (refs.settingsPanel.classList.contains('hidden')) return false;
+            if (!refs.display.classList.contains('drag-anywhere')) return false;
+            if (refs.settingsPanel.contains(target)) return false;
+            if (refs.settingsBtn.contains(target)) return false;
+            return refs.display.contains(target) || (refs.dragHandle && refs.dragHandle.contains(target));
+        }
+
+        function closeForDrag(event) {
+            if (!shouldCloseForDrag(event.target)) return;
+            refs.settingsPanel.classList.add('hidden');
+            resizeWindowToTranscript();
+        }
+
+        refs.display.addEventListener('mousedown', closeForDrag, true);
+        refs.display.addEventListener('touchstart', closeForDrag, true);
+        if (refs.dragHandle) {
+            refs.dragHandle.addEventListener('mousedown', closeForDrag, true);
+            refs.dragHandle.addEventListener('touchstart', closeForDrag, true);
+        }
+
+        return function detachCloseSettingsBeforeContentDrag() {
+            refs.display.removeEventListener('mousedown', closeForDrag, true);
+            refs.display.removeEventListener('touchstart', closeForDrag, true);
+            if (refs.dragHandle) {
+                refs.dragHandle.removeEventListener('mousedown', closeForDrag, true);
+                refs.dragHandle.removeEventListener('touchstart', closeForDrag, true);
+            }
+        };
     }
 
     function applyTranscript(text) {
@@ -119,6 +271,10 @@
         if (!subtitleWindowController || !subtitleWindowController.refs) {
             return;
         }
+
+        attachCloseSettingsBeforeContentDrag(subtitleWindowController.refs);
+
+        // 窗口自身按内容自适应大小，不再记录手动拖拽尺寸
 
         window.addEventListener('neko-subtitle-state-sync', function(e) {
             applyStateSync(e.detail || {});

--- a/templates/index.html
+++ b/templates/index.html
@@ -188,23 +188,6 @@
                 </div>
             </div>
         </div>
-        <div id="subtitle-drag-handle">
-            <!-- 四向箭头图标 -->
-            <div id="subtitle-drag-arrows">
-                <svg viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
-                    <!-- 上箭头 -->
-                    <path d="M12 3L8.5 8H10.5V10.5H13.5V8H15.5L12 3Z"/>
-                    <!-- 下箭头 -->
-                    <path d="M12 21L15.5 16H13.5V13.5H10.5V16H8.5L12 21Z"/>
-                    <!-- 左箭头 -->
-                    <path d="M3 12L8 8.5V10.5H10.5V13.5H8V15.5L3 12Z"/>
-                    <!-- 右箭头 -->
-                    <path d="M21 12L16 15.5V13.5H13.5V10.5H16V8.5L21 12Z"/>
-                    <!-- 中心点 -->
-                    <circle cx="12" cy="12" r="1.2"/>
-                </svg>
-            </div>
-        </div>
     </div>
     <div id="react-chat-window-overlay" hidden>
         <div id="react-chat-window-backdrop"></div>

--- a/templates/subtitle.html
+++ b/templates/subtitle.html
@@ -50,17 +50,6 @@
                 </div>
             </div>
         </div>
-        <div id="subtitle-drag-handle">
-            <div id="subtitle-drag-arrows">
-                <svg viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M12 3L8.5 8H10.5V10.5H13.5V8H15.5L12 3Z"/>
-                    <path d="M12 21L15.5 16H13.5V13.5H10.5V16H8.5L12 21Z"/>
-                    <path d="M3 12L8 8.5V10.5H10.5V13.5H8V15.5L3 12Z"/>
-                    <path d="M21 12L16 15.5V13.5H13.5V10.5H16V8.5L21 12Z"/>
-                    <circle cx="12" cy="12" r="1.2"/>
-                </svg>
-            </div>
-        </div>
     </div>
 
     <script src="/static/subtitle-shared.js"></script>

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -1261,8 +1261,6 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
             document.dispatchEvent(new Event('DOMContentLoaded'));
             await new Promise((resolve) => setTimeout(resolve, 0));
             const emptySize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
-            const emptySettingsBtnRect = document.getElementById('subtitle-settings-btn').getBoundingClientRect();
-            const emptyDragHandleRect = document.getElementById('subtitle-drag-handle').getBoundingClientRect();
             window.dispatchEvent(new CustomEvent('neko-ws-transcript', {
                 detail: {
                     transcript: '这是一段很长很长的翻译字幕，用来测试窗口高度会按内容增长，但是不会超过中号字幕的最大高度。'.repeat(8),
@@ -1270,13 +1268,14 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
             }));
             await new Promise((resolve) => setTimeout(resolve, 0));
             const longSize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            const displayRectBeforePanel = document.getElementById('subtitle-display').getBoundingClientRect();
             document.getElementById('subtitle-settings-btn').click();
             await new Promise((resolve) => setTimeout(resolve, 0));
             const panelOpenSize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
             const displayRect = document.getElementById('subtitle-display').getBoundingClientRect();
             const scrollRect = document.getElementById('subtitle-scroll').getBoundingClientRect();
             const settingsBtnRect = document.getElementById('subtitle-settings-btn').getBoundingClientRect();
-            const dragHandleRect = document.getElementById('subtitle-drag-handle').getBoundingClientRect();
+            const dragHandle = document.getElementById('subtitle-drag-handle');
             const panelRect = document.getElementById('subtitle-settings-panel').getBoundingClientRect();
             const displayStyle = getComputedStyle(document.getElementById('subtitle-display'));
             const scrollStyle = getComputedStyle(document.getElementById('subtitle-scroll'));
@@ -1286,15 +1285,17 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
             const textStyle = getComputedStyle(document.getElementById('subtitle-text'));
             return {
                 emptySize,
-                emptyControlsOverlap: emptySettingsBtnRect.bottom > emptyDragHandleRect.top,
-                emptyControlsGap: emptyDragHandleRect.top - emptySettingsBtnRect.bottom,
                 longSize,
                 panelOpenSize,
+                settingsPanelParentId: document.getElementById('subtitle-settings-panel').parentElement.id,
+                displayHeightBeforePanel: displayRectBeforePanel.height,
+                displayWidthBeforePanel: displayRectBeforePanel.width,
                 displayHeight: displayRect.height,
+                displayWidth: displayRect.width,
                 scrollHeight: scrollRect.height,
                 scrollRight: scrollRect.right,
                 settingsBtnLeft: settingsBtnRect.left,
-                dragHandleLeft: dragHandleRect.left,
+                dragHandleDisplay: dragHandle ? getComputedStyle(dragHandle).display : 'missing',
                 panelBottom: panelRect.bottom,
                 overlapsVertically: panelRect.bottom > scrollRect.top && panelRect.top < scrollRect.bottom,
                 displayOverflow: displayStyle.overflowY,
@@ -1313,17 +1314,18 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
     )
 
     assert result["emptySize"]["height"] == 68
-    assert result["emptyControlsOverlap"] is False
-    assert result["emptyControlsGap"] >= 8
     assert result["longSize"]["height"] <= 160
     assert result["longSize"]["height"] >= 40
+    assert result["settingsPanelParentId"] == "subtitle-settings-layer"
+    assert abs(result["displayHeight"] - result["displayHeightBeforePanel"]) < 0.5
+    assert abs(result["displayWidth"] - result["displayWidthBeforePanel"]) < 0.5
     assert result["panelOpenSize"]["height"] >= result["panelBottom"]
     assert result["overlapsVertically"] is False
     assert result["displayOverflow"] == "visible"
     assert result["scrollOverflow"] == "auto"
     assert result["scrollPointerEvents"] == "auto"
     assert result["scrollRight"] <= result["settingsBtnLeft"] - 6
-    assert result["scrollRight"] <= result["dragHandleLeft"] - 6
+    assert result["dragHandleDisplay"] == "none"
     assert result["scrollBarWidth"] == "thin"
     assert "rgba" in result["scrollBarColor"]
     assert result["scrollBarGutter"] == "stable"
@@ -1331,6 +1333,359 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
     assert result["scrollTrackBackground"] == "rgba(0, 0, 0, 0)"
     assert result["scrollThumbBackground"] == "rgba(255, 255, 255, 0.42)"
     assert result["textMarginRight"] == "8px"
+
+
+@pytest.mark.frontend
+def test_subtitle_window_settings_panel_width_is_independent_from_short_subtitle(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <button type="button" id="subtitle-settings-btn"></button>
+            <div id="subtitle-settings-panel" class="hidden">
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="targetLang">目标语言</span>
+                    <select id="subtitle-lang-select"><option value="zh">中文</option><option value="en">English</option></select>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="opacity">不透明度</span>
+                    <input type="range" id="subtitle-opacity-slider" min="20" max="100" value="95">
+                    <span id="subtitle-opacity-value">95%</span>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="dragAnywhere">整体拖动</span>
+                    <label class="subtitle-settings-switch"><input type="checkbox" id="subtitle-drag-mode-toggle"><span class="subtitle-settings-track"></span></label>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="size">大小</span>
+                    <div class="subtitle-size-group">
+                        <button type="button" class="subtitle-size-btn" data-size="small">小</button>
+                        <button type="button" class="subtitle-size-btn active" data-size="medium">中</button>
+                        <button type="button" class="subtitle-size-btn" data-size="large">大</button>
+                    </div>
+                </div>
+            </div>
+            <div id="subtitle-drag-handle"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__subtitleSizes = [];
+            window.localStorage.setItem('subtitleSize', 'small');
+            window.nekoSubtitle = {
+                setSize: (width, height) => window.__subtitleSizes.push({ width, height }),
+                changeSettings: () => {},
+                dragStart: () => {},
+                dragStop: () => {},
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-window.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            window.dispatchEvent(new CustomEvent('neko-ws-transcript', {
+                detail: { transcript: '嗷' },
+            }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            document.getElementById('subtitle-settings-btn').click();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const finalSize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            const displayRect = document.getElementById('subtitle-display').getBoundingClientRect();
+            const panelRect = document.getElementById('subtitle-settings-panel').getBoundingClientRect();
+            const displayStyle = getComputedStyle(document.getElementById('subtitle-display'));
+            const panelStyle = getComputedStyle(document.getElementById('subtitle-settings-panel'));
+            return {
+                finalSize,
+                displayWidth: displayRect.width,
+                panelWidth: panelRect.width,
+                panelHidden: document.getElementById('subtitle-settings-panel').classList.contains('hidden'),
+                panelParentId: document.getElementById('subtitle-settings-panel').parentElement.id,
+                displayContainsPanel: document.getElementById('subtitle-display').contains(document.getElementById('subtitle-settings-panel')),
+                displayCssWidth: parseFloat(displayStyle.width),
+                panelPosition: panelStyle.position,
+                displayTransform: displayStyle.transform,
+                panelTransform: panelStyle.transform,
+            };
+        }
+        """
+    )
+
+    assert result["panelHidden"] is False
+    assert result["panelParentId"] == "subtitle-settings-layer"
+    assert result["displayContainsPanel"] is False
+    assert result["panelPosition"] == "fixed"
+    assert result["displayWidth"] <= 220
+    assert result["panelWidth"] > result["displayWidth"]
+    assert result["finalSize"]["width"] >= result["panelWidth"]
+    assert abs(result["displayCssWidth"] - result["displayWidth"]) < 0.5
+    assert result["displayTransform"] == "none"
+    assert result["panelTransform"] == "none"
+
+
+@pytest.mark.frontend
+def test_subtitle_window_drag_still_uses_native_bridge_after_panel_layout(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text">可拖动字幕</span></div>
+            <button type="button" id="subtitle-settings-btn"></button>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+            <label class="subtitle-settings-switch">
+                <input type="checkbox" id="subtitle-drag-mode-toggle">
+                <span class="subtitle-settings-track"></span>
+            </label>
+            <div id="subtitle-drag-handle"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__subtitleDragLog = [];
+            window.localStorage.setItem('subtitleDragAnywhere', 'true');
+            window.nekoSubtitle = {
+                setSize: () => {},
+                changeSettings: () => {},
+                dragStart: () => window.__subtitleDragLog.push('dragStart'),
+                dragStop: () => window.__subtitleDragLog.push('dragStop'),
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-window.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const display = document.getElementById('subtitle-display');
+            const rect = display.getBoundingClientRect();
+            display.dispatchEvent(new MouseEvent('mousedown', {
+                bubbles: true,
+                button: 0,
+                clientX: rect.left + 12,
+                clientY: rect.top + 12,
+            }));
+            document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+            return {
+                dragAnywhere: display.classList.contains('drag-anywhere'),
+                log: window.__subtitleDragLog.slice(),
+                transform: getComputedStyle(display).transform,
+            };
+        }
+        """
+    )
+
+    assert result["dragAnywhere"] is True
+    assert result["log"] == ["dragStart", "dragStop"]
+    assert result["transform"] == "none"
+
+
+@pytest.mark.frontend
+def test_subtitle_window_drag_closes_settings_before_native_drag(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text">可拖动字幕</span></div>
+            <button type="button" id="subtitle-settings-btn"></button>
+            <div id="subtitle-settings-panel" class="hidden">
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="targetLang">目标语言</span>
+                    <select id="subtitle-lang-select"><option value="zh">中文</option><option value="en">English</option></select>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="opacity">不透明度</span>
+                    <input type="range" id="subtitle-opacity-slider" min="20" max="100" value="95">
+                    <span id="subtitle-opacity-value">95%</span>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="dragAnywhere">整体拖动</span>
+                    <label class="subtitle-settings-switch"><input type="checkbox" id="subtitle-drag-mode-toggle"><span class="subtitle-settings-track"></span></label>
+                </div>
+            </div>
+            <div id="subtitle-drag-handle"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__subtitleSizes = [];
+            window.__subtitleDragLog = [];
+            window.localStorage.setItem('subtitleSize', 'small');
+            window.localStorage.setItem('subtitleDragAnywhere', 'true');
+            window.nekoSubtitle = {
+                setSize: (width, height) => window.__subtitleSizes.push({ width, height }),
+                changeSettings: () => {},
+                dragStart: () => window.__subtitleDragLog.push('dragStart'),
+                dragStop: () => window.__subtitleDragLog.push('dragStop'),
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-window.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            document.getElementById('subtitle-settings-btn').click();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const sizeWithPanel = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            const display = document.getElementById('subtitle-display');
+            const rect = display.getBoundingClientRect();
+            display.dispatchEvent(new MouseEvent('mousedown', {
+                bubbles: true,
+                button: 0,
+                clientX: rect.left + 12,
+                clientY: rect.top + 12,
+            }));
+            document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+            const sizeAfterDragStart = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            return {
+                sizeWithPanel,
+                sizeAfterDragStart,
+                panelHidden: document.getElementById('subtitle-settings-panel').classList.contains('hidden'),
+                dragLog: window.__subtitleDragLog.slice(),
+            };
+        }
+        """
+    )
+
+    assert result["panelHidden"] is True
+    assert result["dragLog"] == ["dragStart", "dragStop"]
+    assert result["sizeWithPanel"]["height"] > result["sizeAfterDragStart"]["height"]
+
+
+@pytest.mark.frontend
+def test_subtitle_window_manual_resize_expands_subtitle_display_not_backing_layer(
+    mock_page: Page,
+):
+    mock_page.set_viewport_size({"width": 240, "height": 90})
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <button type="button" id="subtitle-settings-btn"></button>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+            <div id="subtitle-drag-handle"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__subtitleSizes = [];
+            window.localStorage.setItem('subtitleSize', 'small');
+            window.nekoSubtitle = {
+                setSize: (width, height) => window.__subtitleSizes.push({ width, height }),
+                changeSettings: () => {},
+                dragStart: () => {},
+                dragStop: () => {},
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-window.js"))
+    mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            window.dispatchEvent(new CustomEvent('neko-ws-transcript', {
+                detail: { transcript: '嗷' },
+            }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        """
+    )
+
+    mock_page.set_viewport_size({"width": 420, "height": 160})
+    mock_page.wait_for_timeout(50)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+            const display = document.getElementById('subtitle-display');
+            const scroll = document.getElementById('subtitle-scroll');
+            const settingsBtn = document.getElementById('subtitle-settings-btn');
+            const displayRect = display.getBoundingClientRect();
+            const scrollRect = scroll.getBoundingClientRect();
+            const displayStyle = getComputedStyle(display);
+            const scrollStyle = getComputedStyle(scroll);
+            const finalSizeBeforePanel = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            const sizeCallsBeforePanel = window.__subtitleSizes.slice();
+            settingsBtn.click();
+            const displayRectAfterPanel = display.getBoundingClientRect();
+            const panel = document.getElementById('subtitle-settings-panel');
+            return {
+                finalSizeBeforePanel,
+                finalSizeAfterPanel: window.__subtitleSizes[window.__subtitleSizes.length - 1],
+                sizeCallsBeforePanel,
+                viewportWidth: window.innerWidth,
+                viewportHeight: window.innerHeight,
+                displayWidth: displayRect.width,
+                displayHeight: displayRect.height,
+                displayWidthAfterPanel: displayRectAfterPanel.width,
+                displayHeightAfterPanel: displayRectAfterPanel.height,
+                panelParentId: panel.parentElement.id,
+                displayContainsPanel: display.contains(panel),
+                scrollHeight: scrollRect.height,
+                displayCssWidth: parseFloat(displayStyle.width),
+                displayCssHeight: parseFloat(displayStyle.height),
+                scrollMaxHeight: scrollStyle.maxHeight,
+            };
+        }
+        """
+    )
+
+    assert result["viewportWidth"] == 420
+    assert result["viewportHeight"] == 160
+    assert result["finalSizeBeforePanel"] != {"width": 420, "height": 160}
+    assert {"width": 420, "height": 160} not in result["sizeCallsBeforePanel"]
+    assert result["finalSizeAfterPanel"]["width"] == 420
+    assert result["finalSizeAfterPanel"]["height"] >= 160
+    assert abs(result["displayWidth"] - 420) < 0.5
+    assert abs(result["displayHeight"] - 160) < 0.5
+    assert abs(result["displayWidthAfterPanel"] - 420) < 0.5
+    assert abs(result["displayHeightAfterPanel"] - 160) < 0.5
+    assert result["panelParentId"] == "subtitle-settings-layer"
+    assert result["displayContainsPanel"] is False
+    assert abs(result["displayCssWidth"] - 420) < 0.5
+    assert abs(result["displayCssHeight"] - 160) < 0.5
+    assert result["scrollHeight"] > 80
+    assert result["scrollMaxHeight"] == "120px"
 
 
 @pytest.mark.frontend
@@ -1381,7 +1736,7 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
             await new Promise((resolve) => setTimeout(resolve, 0));
             const scrollRect = document.getElementById('subtitle-scroll').getBoundingClientRect();
             const settingsBtnRect = document.getElementById('subtitle-settings-btn').getBoundingClientRect();
-            const dragHandleRect = document.getElementById('subtitle-drag-handle').getBoundingClientRect();
+            const dragHandle = document.getElementById('subtitle-drag-handle');
             const panelRect = document.getElementById('subtitle-settings-panel').getBoundingClientRect();
             const displayStyle = getComputedStyle(document.getElementById('subtitle-display'));
             const scrollStyle = getComputedStyle(document.getElementById('subtitle-scroll'));
@@ -1394,7 +1749,7 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
                 scrollBottom: scrollRect.bottom,
                 scrollRight: scrollRect.right,
                 settingsBtnLeft: settingsBtnRect.left,
-                dragHandleLeft: dragHandleRect.left,
+                dragHandleDisplay: dragHandle ? getComputedStyle(dragHandle).display : 'missing',
                 panelTop: panelRect.top,
                 panelBottom: panelRect.bottom,
                 overlapsVertically: panelRect.bottom > scrollRect.top && panelRect.top < scrollRect.bottom,
@@ -1420,7 +1775,7 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
     assert result["scrollOverflow"] == "auto"
     assert result["scrollPointerEvents"] == "auto"
     assert result["scrollRight"] <= result["settingsBtnLeft"] - 6
-    assert result["scrollRight"] <= result["dragHandleLeft"] - 6
+    assert result["dragHandleDisplay"] == "none"
     assert result["scrollBarWidth"] == "thin"
     assert "rgba" in result["scrollBarColor"]
     assert result["scrollBarGutter"] == "stable"
@@ -1431,7 +1786,7 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
 
 
 @pytest.mark.frontend
-def test_web_subtitle_drag_mode_shows_handle_and_accepts_pointer_events_when_enabled(
+def test_web_subtitle_drag_mode_hides_handle_and_drags_from_display_when_enabled(
     mock_page: Page,
 ):
     _open_subtitle_harness(
@@ -1469,17 +1824,17 @@ def test_web_subtitle_drag_mode_shows_handle_and_accepts_pointer_events_when_ena
             const dragHandle = document.getElementById('subtitle-drag-handle');
             const displayPointerEventsWhenEnabled = getComputedStyle(display).pointerEvents;
             const dragHandleDisplayWhenEnabled = getComputedStyle(dragHandle).display;
-            const handleRect = dragHandle.getBoundingClientRect();
-            dragHandle.dispatchEvent(new MouseEvent('mousedown', {
+            const displayRect = display.getBoundingClientRect();
+            display.dispatchEvent(new MouseEvent('mousedown', {
                 bubbles: true,
                 button: 0,
-                clientX: handleRect.left + 4,
-                clientY: handleRect.top + 4,
+                clientX: displayRect.left + 20,
+                clientY: displayRect.top + 20,
             }));
             document.dispatchEvent(new MouseEvent('mousemove', {
                 bubbles: true,
-                clientX: handleRect.left + 20,
-                clientY: handleRect.top + 20,
+                clientX: displayRect.left + 40,
+                clientY: displayRect.top + 40,
             }));
             const draggingAfterMove = display.classList.contains('dragging');
             document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
@@ -1498,7 +1853,7 @@ def test_web_subtitle_drag_mode_shows_handle_and_accepts_pointer_events_when_ena
         """
     )
 
-    assert result["dragHandleDisplayWhenEnabled"] != "none"
+    assert result["dragHandleDisplayWhenEnabled"] == "none"
     assert result["displayPointerEventsWhenEnabled"] == "auto"
     assert result["draggingAfterMove"] is True
     assert result["dragAnywhere"] is False


### PR DESCRIPTION
### 改动内容

**subtitle-window.js / subtitle-shared.js / subtitle.css**

- 引入设置层容器（settings layer）管理字幕设置面板的定位
- 改用 CSS 变量实现字幕元素动态定位与尺寸控制，不再硬编码
- 移除内部的拖拽手柄（已死代码）
- 移除 resize 事件监听器，窗口不再记录用户手动拖拽尺寸，改为完全按内容自适应
- 新增 settings panel 行为测试，验证设置面板不会遮挡字幕文本

### 修复

- macOS 初始化灰边：延迟揭示窗口（show: false + ready-to-show），避开 WindowServer 初始合成伪像
- Windows DWM 厚边框：添加 thickFrame: false（与 Pet 窗口保持一致）

### 测试

- tests/frontend/test_subtitle_incremental.py 新增 settings panel 相关测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Style**
  * 将字幕窗口与设置面板的定位与尺寸改为基于可配置 CSS 变量，调整过渡与滚动区域高度行为。
* **Bug Fixes**
  * 默认隐藏拖拽把手并移除其图标，修正面板打开/拖拽时的显示与交互。
  * 改善窗口自适应与视口尺寸记录与重算时序。
* **Refactor**
  * 重构设置面板容器与层级，统一面板挂载与指针事件处理。
* **Tests**
  * 更新并扩展字幕 UI 与拖拽相关前端测试以匹配新交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->