### PR TITLE
修复 Web/宿主路径下完整聊天框收起时提前切到 minimized，导致 full DOM 被卸载、收起动画消失的问题

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3813,6 +3813,7 @@
     var isMinimizeTransitioning = false;
     var activeAnimationCleanup = null; // 当前进行中动画的清理函数
     var pendingChatSurfaceMode = null;
+    var pendingMinimizedSurfaceCommit = null;
 
     // ── Idle-dock: independent orchestration (Phase 4) ──────────
     // Positions the minimized ball next to CAT2/CAT3 return-ball.
@@ -4689,6 +4690,7 @@
         // 也走这里），避免该回调在窗口关闭/重开后幽灵触发 setChatSurfaceMode('minimized')。
         clearCompactMinimizePressTimer();
         pendingChatSurfaceMode = null;
+        pendingMinimizedSurfaceCommit = null;
     }
 
     // 最小化球皮肤跟随可恢复形态；紧凑 Electron 宿主会把历史 full 规整回 compact。
@@ -4747,6 +4749,22 @@
         return normalized;
     }
 
+    function commitPendingMinimizedSurfaceMode() {
+        if (!pendingMinimizedSurfaceCommit) return false;
+
+        var commit = pendingMinimizedSurfaceCommit;
+        pendingMinimizedSurfaceCommit = null;
+        state.chatSurfaceMode = commit.mode;
+        resetCompactChatState();
+        renderWindow();
+        syncChatSurfaceModeUI();
+        dispatchHostEvent('chat-surface-mode-change', {
+            mode: commit.mode,
+            previousMode: commit.previousMode
+        });
+        return true;
+    }
+
     function setChatSurfaceMode(nextMode) {
         var normalized = coerceChatSurfaceModeForHost(nextMode);
         var previousMode = getCurrentChatSurfaceMode();
@@ -4783,6 +4801,17 @@
         }
 
         resetCompactChatState();
+
+        if (!previousMinimized && nextMinimized && previousMode === 'full' && !isElectronChatWindow() && getShell()) {
+            pendingMinimizedSurfaceCommit = {
+                mode: normalized,
+                previousMode: previousMode
+            };
+            setMinimized(true);
+            return normalized;
+        }
+
+        pendingMinimizedSurfaceCommit = null;
         state.chatSurfaceMode = normalized;
         persistChatSurfaceModePreference(normalized);
         if (normalized === 'compact') {
@@ -4927,6 +4956,7 @@
                 // minimize from the revived legacy full shows its breathing-light
                 // orb instead of the stale compact yarn ball.
                 applyMinimizedBallSkin(ensureMinimizedBallIcon());
+                commitPendingMinimizedSurfaceMode();
                 isMinimizeTransitioning = false;
                 flushPendingChatSurfaceModeIfNeeded();
             };
@@ -4944,6 +4974,7 @@
                 shell.classList.remove('is-collapsing');
                 shell.style.transform = 'none';
                 shell.style.removeProperty('transform-origin');
+                pendingMinimizedSurfaceCommit = null;
                 handled = true;
             };
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -45,7 +45,7 @@
         #react-chat-window-backdrop { display: none !important; }
         /* Electron 缩/展窗期间主进程会先 setBounds，再由 renderer 收到 resize 后更新
            React compact 几何。隐藏这段中间态，避免透明窗口左上角画出一帧旧布局。 */
-        body.neko-electron-runtime #react-chat-window-shell.neko-e-animating {
+        body.neko-electron-runtime #react-chat-window-shell[data-chat-surface-mode="compact"].neko-e-animating {
             visibility: hidden !important;
         }
         /* Electron 独立 full 窗口（part B）：full shell 改用「固定 30px inset 充满窗口」定位 +


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 优化了窗口最小化动画时序，确保状态变更与视觉效果正确同步
  * 调整了窗口隐藏样式在不同状态下的应用逻辑，提升视觉表现的准确性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->