### PR TITLE
fix(cat1): stabilize yarn ball follow direction

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -199,6 +199,7 @@ const _NEKO_IDLE_CAT1_SUBSTATE_WALKING = 'walking-to-chat';
 const _NEKO_IDLE_CAT1_SUBSTATE_STRETCH = 'stretch-near-chat';
 const _NEKO_IDLE_CAT1_CHAT_GAP_PX = -12;
 const _NEKO_IDLE_CAT1_MINIMIZED_RIGHT_TO_LEFT_APPROACH_PX = 35;
+const _NEKO_IDLE_CAT1_MINIMIZED_BACKWARD_RETREAT_TOLERANCE_PX = 2;
 const _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE = 'compact-top-edge';
 const _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE = 'minimized-side';
 const _NEKO_IDLE_CAT1_COMPACT_TOP_EDGE_OVERLAP_PX = 28;
@@ -1686,6 +1687,24 @@ function _cancelNekoIdleCat1PairMove(state) {
     state.pairMovePlan = null;
 }
 
+function _interruptNekoIdleCat1PairMoveForRetarget(button, state) {
+    if (!button || !state || (!state.pairMovePlan && !state.pairMoveFrame)) return false;
+    const profile = state.profile || _NEKO_IDLE_RETURN_SUBACTION_CAT1_CHAT_FOLLOW;
+    _cancelNekoIdleCat1PairMove(state);
+    if (state.substate === profile.idleSubstate) {
+        state.target = null;
+        state.targetKind = '';
+        state.actionSettled = false;
+        _resetNekoIdleCat1WalkSpeed(state);
+        _setNekoIdleCat1Classes(button, state);
+        const art = button.querySelector('.neko-idle-return-art');
+        if (art) {
+            _setNekoIdleReturnArtSource(art, profile.assets.idle(), profile.tier, { animate: false });
+        }
+    }
+    return true;
+}
+
 function _resetNekoIdleCat1WalkSpeed(state) {
     if (!state) return;
     state.walkSpeedRate = 1;
@@ -1841,6 +1860,20 @@ function _forEachNekoIdleReturnButton(callback) {
     document.querySelectorAll(_NEKO_IDLE_RETURN_BUTTON_SELECTOR).forEach(callback);
 }
 
+function _interruptNekoIdleCat1PairMovesForRetarget(options = {}) {
+    const scheduleSync = options.scheduleSync !== false;
+    let interrupted = false;
+    _forEachNekoIdleReturnButton((button) => {
+        const state = button.__nekoIdleReturnSubactionState || button.__nekoIdleCat1Journey;
+        if (!_interruptNekoIdleCat1PairMoveForRetarget(button, state)) return;
+        interrupted = true;
+        if (scheduleSync) {
+            _scheduleNekoIdleCat1JourneySync(button);
+        }
+    });
+    return interrupted;
+}
+
 function _isNekoIdleCompactSurfaceDragging() {
     const body = document && document.body;
     return !!(_nekoIdleCompactSurfaceDragging ||
@@ -1870,6 +1903,9 @@ function _handleNekoIdleCompactSurfaceMoveState(detail) {
     const heartbeat = !!(detail && detail.heartbeat);
     _nekoIdleCompactSurfaceDragging = dragging;
     const followedCompactSurface = _syncNekoIdleCat1CompactTopEdgeSurfaceFollow(detail);
+    if (!heartbeat) {
+        _interruptNekoIdleCat1PairMovesForRetarget({ scheduleSync: !dragging });
+    }
     if (heartbeat) return;
     if (dragging) {
         if (_nekoIdleCompactSurfaceSettleTimer) {
@@ -2317,19 +2353,28 @@ function _getNekoIdleCat1MinimizedSideApproachOffsetPx(facingRight, chatRect) {
     return Math.max(0, Math.min(width, _NEKO_IDLE_CAT1_MINIMIZED_RIGHT_TO_LEFT_APPROACH_PX));
 }
 
-function _getNekoIdleCat1SideTarget(container, chatRect) {
-    if (!container || !chatRect || typeof container.getBoundingClientRect !== 'function') return null;
-    const profile = _NEKO_IDLE_RETURN_SUBACTION_CAT1_CHAT_FOLLOW;
-    const rect = container.getBoundingClientRect();
-    if (!rect || rect.width <= 0 || rect.height <= 0) return null;
+function _getNekoIdleCat1TargetMoveDirection(rect, targetLeft) {
+    if (!rect || !Number.isFinite(Number(targetLeft))) return null;
+    const dx = Number(targetLeft) - rect.left;
+    if (Math.abs(dx) <= _NEKO_IDLE_CAT1_MINIMIZED_BACKWARD_RETREAT_TOLERANCE_PX) return null;
+    return dx > 0;
+}
 
-    const catCenterX = rect.left + rect.width / 2;
-    const chatCenterX = chatRect.left + chatRect.width / 2;
-    const facingRight = chatCenterX > catCenterX;
-    const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(facingRight, chatRect);
-    const rawLeft = facingRight
-        ? chatRect.left - rect.width - profile.target.gapPx
-        : chatRect.right + profile.target.gapPx - approachOffsetPx;
+function _resolveNekoIdleCat1TargetFacing(rect, target) {
+    if (!target) return false;
+    const moveFacingRight = _getNekoIdleCat1TargetMoveDirection(rect, target.left);
+    if (moveFacingRight !== null) return moveFacingRight;
+    if (Object.prototype.hasOwnProperty.call(target, 'lookFacingRight')) {
+        return !!target.lookFacingRight;
+    }
+    return !!target.facingRight;
+}
+
+function _makeNekoIdleCat1SideTarget(rect, chatRect, options) {
+    const facingRight = !!(options && options.facingRight);
+    const rawLeft = Number(options && options.rawLeft);
+    const approachOffsetPx = Number(options && options.approachOffsetPx) || 0;
+    if (!Number.isFinite(rawLeft)) return null;
     const rawTop = chatRect.top + (chatRect.height - rect.height) / 2;
     const clamped = _clampNekoIdleCat1Position(rawLeft, rawTop, rect.width, rect.height);
     const targetCenterX = clamped.left + rect.width / 2;
@@ -2338,14 +2383,56 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
     const currentCenterY = rect.top + rect.height / 2;
     const dx = targetCenterX - currentCenterX;
     const dy = targetCenterY - currentCenterY;
+    const moveFacingRight = _getNekoIdleCat1TargetMoveDirection(rect, clamped.left);
     return {
         left: clamped.left,
         top: clamped.top,
         distance: Math.hypot(dx, dy),
-        facingRight: facingRight,
+        facingRight: moveFacingRight !== null ? moveFacingRight : facingRight,
+        lookFacingRight: facingRight,
+        moveFacingRight: moveFacingRight,
         approachOffsetPx: approachOffsetPx,
         kind: _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE
     };
+}
+
+function _getNekoIdleCat1SideTarget(container, chatRect) {
+    if (!container || !chatRect || typeof container.getBoundingClientRect !== 'function') return null;
+    const profile = _NEKO_IDLE_RETURN_SUBACTION_CAT1_CHAT_FOLLOW;
+    const rect = container.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) return null;
+
+    const catCenterX = rect.left + rect.width / 2;
+    const chatCenterX = chatRect.left + chatRect.width / 2;
+    const lookFacingRight = chatCenterX > catCenterX;
+    const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);
+    const rawLeft = lookFacingRight
+        ? chatRect.left - rect.width - profile.target.gapPx
+        : chatRect.right + profile.target.gapPx - approachOffsetPx;
+    const sideTarget = _makeNekoIdleCat1SideTarget(rect, chatRect, {
+        facingRight: lookFacingRight,
+        rawLeft: rawLeft,
+        approachOffsetPx: approachOffsetPx
+    });
+    if (!sideTarget || sideTarget.moveFacingRight === null || sideTarget.moveFacingRight === lookFacingRight) {
+        return sideTarget;
+    }
+
+    const alternateRawLeft = lookFacingRight
+        ? chatRect.right + profile.target.gapPx - _getNekoIdleCat1MinimizedSideApproachOffsetPx(false, chatRect)
+        : chatRect.left - rect.width - profile.target.gapPx;
+    const alternateTarget = _makeNekoIdleCat1SideTarget(rect, chatRect, {
+        facingRight: !lookFacingRight,
+        rawLeft: alternateRawLeft,
+        approachOffsetPx: lookFacingRight
+            ? _getNekoIdleCat1MinimizedSideApproachOffsetPx(false, chatRect)
+            : 0
+    });
+    if (alternateTarget &&
+        (alternateTarget.moveFacingRight === null || alternateTarget.moveFacingRight === lookFacingRight)) {
+        return alternateTarget;
+    }
+    return sideTarget;
 }
 
 function _getNekoIdleCat1CompactTopEdgeBounds(surfaceRect) {
@@ -2922,7 +3009,8 @@ function _stepNekoIdleCat1Walk(button, timestamp) {
 
     state.target = target;
     state.targetKind = target.kind || '';
-    state.facingRight = target.facingRight;
+    const rect = container.getBoundingClientRect();
+    state.facingRight = _resolveNekoIdleCat1TargetFacing(rect, target);
     _setNekoIdleCat1Classes(button, state);
     const speedRate = _updateNekoIdleCat1WalkSpeedRate(button, state, target.distance);
     if (target.distance <= profile.target.exitDistancePx) {
@@ -2935,7 +3023,6 @@ function _stepNekoIdleCat1Walk(button, timestamp) {
         return;
     }
 
-    const rect = container.getBoundingClientRect();
     const lastStepAt = state.lastStepAt || timestamp;
     const elapsedMs = Math.max(
         profile.target.minStepMs,
@@ -2961,9 +3048,12 @@ function _startNekoIdleCat1Walk(button, target) {
     const walkDragging = walkContainer && walkContainer.getAttribute('data-dragging');
     if (walkDragging && walkDragging !== 'false') return;
     const profile = state.profile;
+    const currentRect = walkContainer && walkContainer.getBoundingClientRect
+        ? walkContainer.getBoundingClientRect()
+        : null;
     state.target = target;
     state.targetKind = target && target.kind ? target.kind : '';
-    state.facingRight = !!(target && target.facingRight);
+    state.facingRight = _resolveNekoIdleCat1TargetFacing(currentRect, target);
     if (state.substate !== profile.walkingSubstate) {
         state.lastStepAt = 0;
         _resetNekoIdleCat1WalkSpeed(state);
@@ -2992,7 +3082,9 @@ function _scheduleNekoIdleCat1WalkStart(button, target) {
 
     state.target = target;
     state.targetKind = target && target.kind ? target.kind : '';
-    state.facingRight = !!(target && target.facingRight);
+    const container = _getNekoIdleReturnContainerFromButton(button);
+    const rect = container && container.getBoundingClientRect ? container.getBoundingClientRect() : null;
+    state.facingRight = _resolveNekoIdleCat1TargetFacing(rect, target);
     _setNekoIdleCat1Classes(button, state);
     const art = button.querySelector('.neko-idle-return-art');
     if (art && art.__nekoIdleHoverSrc) {
@@ -3653,9 +3745,16 @@ function _ensureNekoIdleReturnPresentationBridge() {
                 sourceUpdatedAt
             );
         }
+        const pairMoveFeedback = !!(detail && detail.reason === 'cat1-pair-move');
         document.querySelectorAll(_NEKO_IDLE_RETURN_BUTTON_SELECTOR).forEach((button) => {
             const currentState = button.__nekoIdleReturnSubactionState || button.__nekoIdleCat1Journey;
-            if (currentState && (currentState.pairMovePlan || currentState.pairMoveFrame)) return;
+            if (currentState && (currentState.pairMovePlan || currentState.pairMoveFrame)) {
+                if (pairMoveFeedback) return;
+                const interrupted = _interruptNekoIdleCat1PairMoveForRetarget(button, currentState);
+                if (isSmallDesktopChatMove && !interrupted && !_isNekoIdleCat1Walking(button)) return;
+                _scheduleNekoIdleCat1JourneySync(button);
+                return;
+            }
             if (isSmallDesktopChatMove && !_isNekoIdleCat1Walking(button)) return;
             _scheduleNekoIdleCat1JourneySync(button);
         });

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2387,6 +2387,14 @@ function _resolveNekoIdleCat1TargetFacing(rect, target) {
     return !!target.facingRight;
 }
 
+function _resolveNekoIdleCat1FinalTargetFacing(target) {
+    if (!target) return false;
+    if (Object.prototype.hasOwnProperty.call(target, 'lookFacingRight')) {
+        return !!target.lookFacingRight;
+    }
+    return !!target.facingRight;
+}
+
 function _makeNekoIdleCat1SideTarget(rect, chatRect, options) {
     const facingRight = !!(options && options.facingRight);
     const rawLeft = Number(options && options.rawLeft);
@@ -2405,7 +2413,7 @@ function _makeNekoIdleCat1SideTarget(rect, chatRect, options) {
         left: clamped.left,
         top: clamped.top,
         distance: Math.hypot(dx, dy),
-        facingRight: moveFacingRight !== null ? moveFacingRight : facingRight,
+        facingRight: facingRight,
         lookFacingRight: facingRight,
         moveFacingRight: moveFacingRight,
         approachOffsetPx: approachOffsetPx,
@@ -3062,6 +3070,7 @@ function _stepNekoIdleCat1Walk(button, timestamp) {
         if (target.kind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE) {
             _finishNekoIdleCat1CompactTopEdgeWalk(button);
         } else {
+            state.facingRight = _resolveNekoIdleCat1FinalTargetFacing(target);
             _finishNekoIdleCat1Walk(button);
         }
         return;
@@ -3448,17 +3457,18 @@ function _syncNekoIdleCat1Journey(button, tier) {
     if (state.substate === profile.walkingSubstate) {
         _cancelNekoIdleReturnPendingWalk(state);
         if (compactTopEdgeTarget) {
-            state.facingRight = target.facingRight;
+            state.facingRight = _resolveNekoIdleCat1FinalTargetFacing(target);
             _setNekoIdleCat1ContainerPosition(container, target.left, target.top);
             _finishNekoIdleCat1CompactTopEdgeWalk(button);
         } else {
+            state.facingRight = _resolveNekoIdleCat1FinalTargetFacing(target);
             _finishNekoIdleCat1Walk(button);
         }
         return;
     }
 
     if (state.substate === profile.finishingSubstate) {
-        state.facingRight = target.facingRight;
+        state.facingRight = _resolveNekoIdleCat1FinalTargetFacing(target);
         _setNekoIdleCat1Classes(button, state);
         _scheduleNekoIdleReturnSubactionSettle(button);
         return;
@@ -3469,7 +3479,7 @@ function _syncNekoIdleCat1Journey(button, tier) {
             _setNekoIdleCat1ContainerPosition(container, target.left, target.top);
         }
         state.target = null;
-        state.facingRight = target.facingRight;
+        state.facingRight = _resolveNekoIdleCat1FinalTargetFacing(target);
         state.actionSettled = true;
         _resetNekoIdleCat1WalkSpeed(state);
         _setNekoIdleCat1Classes(button, state);

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -42,6 +42,7 @@ def test_cat1_minimized_side_target_separates_look_and_move_direction():
     assert "const lookFacingRight = chatCenterX > catCenterX;" in side_target_block
     assert "sideTarget.moveFacingRight === lookFacingRight" in side_target_block
     assert "alternateTarget.moveFacingRight === null || alternateTarget.moveFacingRight === lookFacingRight" in side_target_block
+    assert "facingRight: facingRight," in source
     assert "lookFacingRight: facingRight" in source
     assert "moveFacingRight: moveFacingRight" in source
 
@@ -50,11 +51,13 @@ def test_cat1_walk_uses_resolved_target_facing_instead_of_raw_chat_side():
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
     assert "function _resolveNekoIdleCat1TargetFacing" in source
+    assert "function _resolveNekoIdleCat1FinalTargetFacing" in source
     walk_step_block = source.split("function _stepNekoIdleCat1Walk", 1)[1].split(
         "function _startNekoIdleCat1Walk",
         1,
     )[0]
     assert "state.facingRight = _resolveNekoIdleCat1TargetFacing(rect, target);" in walk_step_block
+    assert "state.facingRight = _resolveNekoIdleCat1FinalTargetFacing(target);" in walk_step_block
     assert "state.facingRight = target.facingRight;" not in walk_step_block
 
     walk_start_block = source.split("function _startNekoIdleCat1Walk", 1)[1].split(
@@ -63,6 +66,13 @@ def test_cat1_walk_uses_resolved_target_facing_instead_of_raw_chat_side():
     )[0]
     assert "state.facingRight = _resolveNekoIdleCat1TargetFacing(currentRect, target);" in walk_start_block
     assert "state.facingRight = !!(target && target.facingRight);" not in walk_start_block
+
+    journey_sync_block = source.split("function _syncNekoIdleCat1Journey", 1)[1].split(
+        "function _scheduleNekoIdleCat1JourneySync",
+        1,
+    )[0]
+    assert "_resolveNekoIdleCat1FinalTargetFacing(target)" in journey_sync_block
+    assert "state.facingRight = target.facingRight;" not in journey_sync_block
 
 
 def test_cat1_external_chat_position_updates_interrupt_pair_move_for_retarget():

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -30,3 +30,55 @@ def test_cat1_return_button_assets_are_version_tracked():
     assert INDEX_CSS_PATH in pages_router._YUI_GUIDE_ASSET_VERSION_PATHS
     assert CAT1_ASSET_PATH in pages_router._YUI_GUIDE_ASSET_VERSION_PATHS
     assert CAT1_ASSET_PATH.is_file()
+
+
+def test_cat1_minimized_side_target_separates_look_and_move_direction():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    side_target_block = source.split("function _getNekoIdleCat1SideTarget", 1)[1].split(
+        "function _getNekoIdleCat1CompactTopEdgeBounds",
+        1,
+    )[0]
+    assert "const lookFacingRight = chatCenterX > catCenterX;" in side_target_block
+    assert "sideTarget.moveFacingRight === lookFacingRight" in side_target_block
+    assert "alternateTarget.moveFacingRight === null || alternateTarget.moveFacingRight === lookFacingRight" in side_target_block
+    assert "lookFacingRight: facingRight" in source
+    assert "moveFacingRight: moveFacingRight" in source
+
+
+def test_cat1_walk_uses_resolved_target_facing_instead_of_raw_chat_side():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    assert "function _resolveNekoIdleCat1TargetFacing" in source
+    walk_step_block = source.split("function _stepNekoIdleCat1Walk", 1)[1].split(
+        "function _startNekoIdleCat1Walk",
+        1,
+    )[0]
+    assert "state.facingRight = _resolveNekoIdleCat1TargetFacing(rect, target);" in walk_step_block
+    assert "state.facingRight = target.facingRight;" not in walk_step_block
+
+    walk_start_block = source.split("function _startNekoIdleCat1Walk", 1)[1].split(
+        "function _scheduleNekoIdleCat1WalkStart",
+        1,
+    )[0]
+    assert "state.facingRight = _resolveNekoIdleCat1TargetFacing(currentRect, target);" in walk_start_block
+    assert "state.facingRight = !!(target && target.facingRight);" not in walk_start_block
+
+
+def test_cat1_external_chat_position_updates_interrupt_pair_move_for_retarget():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    assert "function _interruptNekoIdleCat1PairMoveForRetarget" in source
+    minimized_state_block = source.split("window.addEventListener('neko:idle-chat-minimized-state'", 1)[1].split(
+        "window.addEventListener('neko:idle-chat-compact-surface-state'",
+        1,
+    )[0]
+    assert "const pairMoveFeedback = !!(detail && detail.reason === 'cat1-pair-move');" in minimized_state_block
+    assert "if (pairMoveFeedback) return;" in minimized_state_block
+    assert "_interruptNekoIdleCat1PairMoveForRetarget(button, currentState)" in minimized_state_block
+
+    compact_move_block = source.split("function _handleNekoIdleCompactSurfaceMoveState", 1)[1].split(
+        "function _shouldRecheckNekoIdleCat1AfterManualMove",
+        1,
+    )[0]
+    assert "_interruptNekoIdleCat1PairMovesForRetarget({ scheduleSync: !dragging });" in compact_move_block


### PR DESCRIPTION
## Summary
- separate CAT1 minimized-side look direction from movement direction when choosing yarn-ball follow targets
- avoid choosing a side target that makes CAT1 visibly retreat opposite the yarn ball when a forward candidate is available
- interrupt pairMove on external minimized/compact position updates while preserving cat1-pair-move self feedback

## Verification
- node --check static/avatar-ui-buttons.js
- uv run pytest tests/unit/test_avatar_return_button_cat1_static.py
- bash build_frontend.sh
- manual test passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化最小化状态下的侧向目标与朝向解析，分离“观察方向”和“移动方向”，到达后朝向更准确自然。
  * 行走推进与调度改为基于容器位置解析目标朝向，提升移动行为稳定性与一致性。

* **新功能**
  * 增强成对移动的重定向中断：外部位置更新或紧凑移动时可中断并重置移动与视觉状态，支持批量中断与可选同步。

* **测试**
  * 新增单元测试覆盖侧向目标区分、行走朝向解析及重定向中断行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->