### PR TITLE
polish: refine chat and glass UI surfaces

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -359,6 +359,85 @@ describe('App', () => {
     }
   });
 
+  it('keeps local compact resize width during desktop compact surface resize', async () => {
+    (window as typeof window & {
+      __nekoDesktopCompactLayout?: unknown;
+    }).__nekoDesktopCompactLayout = {
+      windowBounds: { x: 100, y: 200, width: 460, height: 90 },
+      surfaceScreenRect: { left: 108, top: 208, width: 430, height: 58, right: 538, bottom: 266 },
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+    };
+
+    const { container } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" />,
+    );
+
+    try {
+      const rightHandle = container.querySelector<HTMLDivElement>('[data-compact-resize-side="right"]');
+      expect(rightHandle).not.toBeNull();
+
+      fireEvent.pointerDown(rightHandle!, {
+        pointerId: 24,
+        clientX: 430,
+        screenX: 538,
+        button: 0,
+        buttons: 1,
+        pointerType: 'mouse',
+      });
+      fireEvent.pointerMove(rightHandle!, {
+        pointerId: 24,
+        clientX: 550,
+        screenX: 658,
+        buttons: 1,
+        pointerType: 'mouse',
+      });
+
+      await waitFor(() => {
+        expect(document.documentElement.style.getPropertyValue('--compact-surface-resize-width')).toBe('550px');
+      });
+      expect((container.querySelector('.compact-chat-surface-shell') as HTMLElement).style
+        .getPropertyValue('--compact-surface-resize-width')).toBe('550px');
+
+      fireEvent.pointerUp(rightHandle!, {
+        pointerId: 24,
+        clientX: 550,
+        screenX: 658,
+        buttons: 0,
+        pointerType: 'mouse',
+      });
+
+      expect(document.documentElement.style.getPropertyValue('--compact-surface-resize-width')).toBe('550px');
+      expect((container.querySelector('.compact-chat-surface-shell') as HTMLElement).style
+        .getPropertyValue('--compact-surface-resize-width')).toBe('550px');
+
+      (window as typeof window & {
+        __nekoDesktopCompactLayout?: unknown;
+      }).__nekoDesktopCompactLayout = {
+        windowBounds: { x: 100, y: 200, width: 580, height: 90 },
+        surfaceScreenRect: { left: 108, top: 208, width: 550, height: 58, right: 658, bottom: 266 },
+        workArea: { x: 0, y: 0, width: 1440, height: 900 },
+        resizeActive: false,
+      };
+      act(() => {
+        window.dispatchEvent(new CustomEvent('neko:desktop-compact-layout-change', {
+          detail: (window as typeof window & {
+            __nekoDesktopCompactLayout?: unknown;
+          }).__nekoDesktopCompactLayout,
+        }));
+      });
+
+      await waitFor(() => {
+        expect(document.documentElement.style.getPropertyValue('--compact-surface-resize-width')).toBe('');
+      });
+      expect((container.querySelector('.compact-chat-surface-shell') as HTMLElement).style
+        .getPropertyValue('--compact-surface-resize-width')).toBe('');
+    } finally {
+      delete (window as typeof window & {
+        __nekoDesktopCompactLayout?: unknown;
+      }).__nekoDesktopCompactLayout;
+    }
+  });
+
   it('defaults compact history open and preserves history controls through visibility toggles', async () => {
     const onExportConversationClick = vi.fn();
     const message = parseChatMessage({
@@ -628,6 +707,29 @@ describe('App', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('keeps compact history open when the first press causes the handle to leave before click', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+
+    const { container } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" />,
+    );
+
+    const handle = container.querySelector<HTMLButtonElement>('.compact-history-visibility-handle');
+    expect(handle).not.toBeNull();
+    expect(handle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.pointerDown(handle!, { pointerType: 'mouse', button: 0, buttons: 1 });
+    expect(handle).toHaveAttribute('aria-expanded', 'true');
+    expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
+
+    fireEvent.pointerLeave(handle!, { pointerType: 'mouse', buttons: 1 });
+    fireEvent.click(handle!);
+
+    expect(handle).toHaveAttribute('aria-expanded', 'true');
+    expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-export-history-visibility', 'open');
+    expect(window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY)).toBe('true');
   });
 
   it('keeps compact export history message actions read-only', async () => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2612,11 +2612,6 @@ function CompactChatApp({
 
   const applyCompactSurfaceResizeWidthVar = useCallback((width: number | null) => {
     const shell = compactInputShellRef.current;
-    if (isDesktopCompactSurfaceLayoutActive()) {
-      document.documentElement.style.removeProperty('--compact-surface-resize-width');
-      shell?.style.removeProperty('--compact-surface-resize-width');
-      return;
-    }
     if (width === null) {
       document.documentElement.style.removeProperty('--compact-surface-resize-width');
       shell?.style.removeProperty('--compact-surface-resize-width');
@@ -2651,8 +2646,10 @@ function CompactChatApp({
     if (!resizeState) return;
     if (event && resizeState.pointerId !== event.pointerId) return;
     dispatchCompactSurfaceResizeRequest(resizeState.side, resizeState.lastWidth, 'end');
-    applyCompactSurfaceResizeWidthVar(null);
-    setCompactSurfaceResizeWidth(null);
+    if (!isDesktopCompactSurfaceLayoutActive()) {
+      applyCompactSurfaceResizeWidthVar(null);
+      setCompactSurfaceResizeWidth(null);
+    }
     const captureTarget = resizeState.captureTarget;
     if (captureTarget && typeof captureTarget.releasePointerCapture === 'function') {
       try {
@@ -2919,6 +2916,7 @@ function CompactChatApp({
     if (!isCompactSurface) return undefined;
     const clampExistingWidth = () => {
       if (isDesktopCompactSurfaceLayoutActive()) {
+        if (compactSurfaceResizeStateRef.current) return;
         setCompactSurfaceResizeWidth(null);
         applyCompactSurfaceResizeWidthVar(null);
         return;
@@ -2938,12 +2936,13 @@ function CompactChatApp({
   useEffect(() => {
     if (!isCompactSurface) return undefined;
     const syncAppliedResizeWidth = (event: Event) => {
+      const resizeState = compactSurfaceResizeStateRef.current;
       if (isDesktopCompactSurfaceLayoutActive()) {
+        if (resizeState) return;
         setCompactSurfaceResizeWidth(null);
         applyCompactSurfaceResizeWidthVar(null);
         return;
       }
-      const resizeState = compactSurfaceResizeStateRef.current;
       if (!resizeState) return;
       const width = Number((event as CustomEvent).detail?.width);
       if (!Number.isFinite(width) || width <= 0) return;
@@ -5451,7 +5450,6 @@ function CompactChatApp({
       data-compact-history-open={compactExportHistoryOpen ? 'true' : 'false'}
       onPointerDown={handleCompactHistoryVisibilityPress}
       onPointerCancel={handleCompactHistoryVisibilityPointerCancel}
-      onPointerLeave={handleCompactHistoryVisibilityPointerCancel}
       onClick={handleCompactHistoryVisibilityClick}
     >
       <span className="compact-history-visibility-handle-triangle" aria-hidden="true" />

--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -281,6 +281,20 @@ async def get_chat_page(request: Request):
     templates = get_templates()
     return templates.TemplateResponse("templates/chat.html", {
         "request": request,
+        "initial_chat_surface_mode": "compact",
+        **_vrm_defaults_ctx(),
+        **_static_assets_ctx(),
+        **_react_chat_assets_ctx(),
+    })
+
+
+@router.get("/chat_full", response_class=HTMLResponse)
+async def get_chat_full_page(request: Request):
+    """Web 专用完整聊天窗口页面"""
+    templates = get_templates()
+    return templates.TemplateResponse("templates/chat.html", {
+        "request": request,
+        "initial_chat_surface_mode": "full",
         **_vrm_defaults_ctx(),
         **_static_assets_ctx(),
         **_react_chat_assets_ctx(),

--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -137,6 +137,7 @@ async def get_default_index(request: Request):
     templates = get_templates()
     return templates.TemplateResponse("templates/index.html", {
         "request": request,
+        "initial_chat_surface_mode": "compact",
         **_vrm_defaults_ctx(),
         **_static_assets_ctx(),
         **_react_chat_assets_ctx(),
@@ -290,9 +291,9 @@ async def get_chat_page(request: Request):
 
 @router.get("/chat_full", response_class=HTMLResponse)
 async def get_chat_full_page(request: Request):
-    """Web 专用完整聊天窗口页面"""
+    """Web 首页入口：打开主页并让 React Chat 以 full 模式启动。"""
     templates = get_templates()
-    return templates.TemplateResponse("templates/chat.html", {
+    return templates.TemplateResponse("templates/index.html", {
         "request": request,
         "initial_chat_surface_mode": "full",
         **_vrm_defaults_ctx(),
@@ -354,6 +355,7 @@ async def get_index(request: Request, lanlan_name: str):
     templates = get_templates()
     return templates.TemplateResponse("templates/index.html", {
         "request": request,
+        "initial_chat_surface_mode": "compact",
         **_vrm_defaults_ctx(),
         **_static_assets_ctx(),
         **_react_chat_assets_ctx(),

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -184,6 +184,17 @@
         }
     }
 
+    function readInitialChatSurfaceMode() {
+        var body = document.body;
+        var declaredMode = body
+            ? normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))
+            : 'compact';
+        if (declaredMode === 'full') {
+            return 'full';
+        }
+        return readChatSurfaceModePreference();
+    }
+
     function persistChatSurfaceModePreference(mode) {
         // Persist only the restorable surfaces (compact/full); minimized restores
         // to lastRestorableChatSurfaceMode rather than being persisted directly.
@@ -5451,7 +5462,7 @@
         var avatarHeaderButton = $('avatarPreviewHeaderButton');
 
         ensureViewProps();
-        state.chatSurfaceMode = readChatSurfaceModePreference();
+        state.chatSurfaceMode = readInitialChatSurfaceMode();
         lastRestorableChatSurfaceMode = state.chatSurfaceMode;
         resetCompactChatState();
         state.viewProps = Object.assign({}, ensureViewProps(), {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -186,9 +186,10 @@
 
     function readInitialChatSurfaceMode() {
         var body = document.body;
-        var declaredMode = body
-            ? normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))
-            : 'compact';
+        var declaredModeAttr = body
+            ? body.getAttribute('data-initial-chat-surface-mode')
+            : '';
+        var declaredMode = declaredModeAttr ? normalizeChatSurfaceMode(declaredModeAttr) : '';
         if (declaredMode === 'compact' || declaredMode === 'full') {
             return declaredMode;
         }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -189,8 +189,8 @@
         var declaredMode = body
             ? normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))
             : 'compact';
-        if (declaredMode === 'full') {
-            return 'full';
+        if (declaredMode === 'compact' || declaredMode === 'full') {
+            return declaredMode;
         }
         return readChatSurfaceModePreference();
     }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -334,6 +334,7 @@
 
     function handleDesktopCompactLayoutChange(layout) {
         compactSurfaceDesktopDragActive = !!(layout && layout.dragging);
+        compactSurfaceDesktopResizeActive = !!(layout && layout.resizeActive);
         var nextAnchorSnapshot = getCompactDesktopLayoutAnchorSnapshot(layout);
         var baseAnchorChanged = false;
         if (!nextAnchorSnapshot) {

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -7510,6 +7510,15 @@ margin-top: 10px;
 /* 入口按钮上方已有 .btn.sm.ai-assist 样式，保留不动 */
 
 .card-companion-panel {
+    --companion-glass-border: rgba(255, 255, 255, 0.62);
+    --companion-glass-highlight: rgba(255, 255, 255, 0.9);
+    --companion-glass-shadow:
+        0 30px 76px rgba(11, 43, 66, 0.22),
+        0 16px 38px rgba(32, 70, 90, 0.08),
+        0 1px 0 rgba(255, 255, 255, 0.62) inset,
+        0 16px 36px rgba(255, 255, 255, 0.14) inset,
+        0 -24px 52px rgba(28, 95, 130, 0.12) inset,
+        0 0 0 1px rgba(255, 255, 255, 0.32) inset;
     position: fixed;
     top: 24px;
     right: 24px;
@@ -7519,10 +7528,18 @@ margin-top: 10px;
     height: min(720px, calc(100vh - 48px));
     min-height: min(360px, calc(100vh - 16px));
     max-height: calc(100vh - 16px);
-    background: linear-gradient(180deg, #ffffff 0%, #f8fcff 100%);
-    border: 2px solid #b3e5fc;
+    isolation: isolate;
+    background:
+        linear-gradient(116deg, rgba(255, 255, 255, 0.36) 0%, rgba(255, 255, 255, 0.08) 16%, transparent 38%),
+        radial-gradient(circle at 18% 4%, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0.06) 26%, transparent 50%),
+        radial-gradient(circle at 94% 86%, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.02) 28%, transparent 52%),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.2), rgba(245, 248, 250, 0.055) 50%, rgba(255, 255, 255, 0.12)),
+        rgba(255, 255, 255, 0.07);
+    border: 1px solid var(--companion-glass-border);
     border-radius: 28px;
-    box-shadow: 0 18px 44px rgba(64, 197, 241, 0.24);
+    box-shadow: var(--companion-glass-shadow);
+    backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
+    -webkit-backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
     display: flex;
     flex-direction: column;
     z-index: 10100;
@@ -7532,6 +7549,40 @@ margin-top: 10px;
     transition: box-shadow 0.22s ease, background 0.22s ease, opacity 0.22s ease;
     resize: both;
     -webkit-app-region: no-drag;
+}
+
+.card-companion-panel::before,
+.card-companion-panel::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.card-companion-panel::before {
+    inset: 1px;
+    border-radius: 27px;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.54), rgba(255, 255, 255, 0.1) 16%, rgba(255, 255, 255, 0) 34%),
+        linear-gradient(315deg, rgba(255, 255, 255, 0.26), rgba(255, 255, 255, 0) 32%),
+        linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(245, 248, 250, 0.02) 44%, rgba(255, 255, 255, 0.08) 100%);
+    box-shadow:
+        inset 0 1px 0 var(--companion-glass-highlight),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.36),
+        inset 0 -1px 0 rgba(31, 146, 192, 0.2);
+    opacity: 0.86;
+}
+
+.card-companion-panel::after {
+    top: -42%;
+    left: -30%;
+    width: 70%;
+    height: 86%;
+    border-radius: 999px;
+    background: linear-gradient(118deg, rgba(255, 255, 255, 0.32), rgba(255, 255, 255, 0.05) 46%, transparent 68%);
+    filter: blur(1px);
+    transform: rotate(-18deg);
+    opacity: 0.78;
 }
 
 @keyframes cardCompanionWindowIn {
@@ -7585,6 +7636,12 @@ margin-top: 10px;
 
 .card-companion-panel.card-companion-minimized::before {
     inset: 3px;
+    top: 3px;
+    left: 3px;
+    width: auto;
+    height: auto;
+    transform: none;
+    filter: none;
     z-index: 2;
     background:
         radial-gradient(circle at 32% 22%, rgba(255, 255, 255, 0.7) 0 11%, rgba(255, 255, 255, 0) 30%),
@@ -7594,6 +7651,14 @@ margin-top: 10px;
 
 .card-companion-panel.card-companion-minimized::after {
     inset: 0;
+    top: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    transform: none;
+    filter: none;
+    background: transparent;
+    opacity: 1;
     z-index: 3;
     border: 1px solid rgba(255, 255, 255, 0.7);
     box-shadow: inset 0 -8px 14px rgba(64, 197, 241, 0.18);
@@ -7622,7 +7687,10 @@ margin-top: 10px;
 .card-companion-panel.card-companion-dragging {
     user-select: none;
     z-index: 100100;
-    box-shadow: 0 22px 52px rgba(64, 197, 241, 0.3);
+    box-shadow:
+        0 34px 82px rgba(11, 43, 66, 0.28),
+        0 18px 44px rgba(32, 70, 90, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.68);
     animation-play-state: paused;
     will-change: left, top;
     transition: none;
@@ -7693,18 +7761,33 @@ margin-top: 10px;
 }
 
 .card-companion-header {
+    position: relative;
+    z-index: 1;
     display: flex;
     align-items: center;
     gap: 12px;
     min-height: 76px;
     padding: 12px 18px 11px;
-    border-bottom: 2px solid #d5f2ff;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.46);
     background:
-        linear-gradient(135deg, rgba(224, 247, 255, 0.96), rgba(255, 255, 255, 0.98) 62%),
-        url('/static/icons/dropdown_item_hover_bg.png') center / cover no-repeat;
+        linear-gradient(135deg, rgba(255, 255, 255, 0.32), rgba(245, 251, 255, 0.1) 58%, rgba(255, 255, 255, 0.18)),
+        rgba(255, 255, 255, 0.1);
     flex-shrink: 0;
     cursor: grab;
     touch-action: none;
+    overflow: hidden;
+}
+
+.card-companion-header::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    height: 64%;
+    pointer-events: none;
+    background:
+        linear-gradient(112deg, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.08) 42%, transparent 68%),
+        radial-gradient(circle at 12% 0%, rgba(255, 255, 255, 0.42), transparent 34%);
+    opacity: 0.74;
 }
 
 .card-companion-panel.card-companion-dragging .card-companion-header {
@@ -7712,17 +7795,23 @@ margin-top: 10px;
 }
 
 .card-companion-avatar {
+    position: relative;
+    z-index: 1;
     width: 56px;
     height: 56px;
     border-radius: 50%;
     overflow: hidden;
     flex-shrink: 0;
-    background: linear-gradient(135deg, #e0f7ff, #b3e5fc);
+    background:
+        radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.78), transparent 38%),
+        linear-gradient(135deg, rgba(224, 247, 255, 0.72), rgba(179, 229, 252, 0.38));
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 2px solid rgba(179, 229, 252, 0.95);
-    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.78);
+    box-shadow:
+        0 8px 18px rgba(28, 120, 170, 0.13),
+        inset 0 1px 0 rgba(255, 255, 255, 0.72);
     cursor: pointer;
     transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
 }
@@ -7740,13 +7829,13 @@ margin-top: 10px;
 }
 
 .card-companion-avatar img {
-    width: 130%;
-    height: 130%;
+    width: 148%;
+    height: 148%;
     max-width: none;
     flex-shrink: 0;
     object-fit: cover;
-    object-position: 50% 8%;
-    transform: translateY(3px) scale(1.02);
+    object-position: 50% 46%;
+    transform: translateY(5px);
     transform-origin: center center;
 }
 
@@ -7758,6 +7847,8 @@ margin-top: 10px;
 }
 
 .card-companion-title {
+    position: relative;
+    z-index: 1;
     flex: 1;
     min-width: 0;
 }
@@ -7777,6 +7868,8 @@ margin-top: 10px;
 }
 
 .card-companion-header-paw {
+    position: relative;
+    z-index: 1;
     width: 30px;
     height: 30px;
     object-fit: contain;
@@ -7785,8 +7878,10 @@ margin-top: 10px;
 }
 
 .card-companion-close {
+    position: relative;
+    z-index: 1;
     background: transparent;
-    border: none;
+    border: 1px solid transparent;
     width: 34px;
     height: 34px;
     border-radius: 999px;
@@ -7804,11 +7899,14 @@ margin-top: 10px;
 }
 
 .card-companion-close:hover {
-    background: rgba(64, 197, 241, 0.16);
+    background: rgba(255, 255, 255, 0.34);
+    border-color: rgba(255, 255, 255, 0.62);
     color: #27b8ea;
 }
 
 .card-companion-thread {
+    position: relative;
+    z-index: 1;
     flex: 1 1 auto;
     overflow-y: auto;
     padding: 18px 20px 22px;
@@ -7816,9 +7914,25 @@ margin-top: 10px;
     flex-direction: column;
     gap: 12px;
     background:
-        radial-gradient(circle at 18px 18px, rgba(179, 229, 252, 0.24) 0 2px, transparent 3px) 0 0 / 34px 34px,
-        linear-gradient(180deg, #ffffff 0%, #f5fcff 100%);
+        radial-gradient(circle at 18px 18px, rgba(255, 255, 255, 0.24) 0 2px, transparent 3px) 0 0 / 34px 34px,
+        linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(245, 251, 255, 0.045));
     min-height: 0;
+}
+
+.card-companion-thread::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 12% 8%, rgba(255, 255, 255, 0.18), transparent 34%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.16), transparent 28%);
+    opacity: 0.62;
+}
+
+.card-companion-thread > * {
+    position: relative;
+    z-index: 1;
 }
 
 .card-companion-thread::-webkit-scrollbar,
@@ -7854,7 +7968,9 @@ margin-top: 10px;
     line-height: 1.55;
     word-wrap: break-word;
     animation: cardCompanionBubbleIn 0.18s ease-out;
-    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.09);
+    box-shadow:
+        0 10px 22px rgba(28, 120, 170, 0.09),
+        inset 0 1px 0 rgba(255, 255, 255, 0.56);
 }
 
 @keyframes cardCompanionBubbleIn {
@@ -7864,19 +7980,27 @@ margin-top: 10px;
 
 .card-companion-bubble-assistant {
     align-self: flex-start;
-    background: #fff;
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.18)),
+        rgba(255, 255, 255, 0.22);
     color: #263241;
-    border: 2px solid #d5f2ff;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-bottom-left-radius: 8px;
+    backdrop-filter: blur(4px) saturate(1.08);
+    -webkit-backdrop-filter: blur(4px) saturate(1.08);
 }
 
 .card-companion-bubble-user {
     align-self: flex-end;
-    background: linear-gradient(135deg, #40C5F1, #6bdcff);
+    background:
+        linear-gradient(135deg, rgba(64, 197, 241, 0.86), rgba(107, 220, 255, 0.72)),
+        rgba(255, 255, 255, 0.12);
     color: #fff;
-    border: 2px solid rgba(255, 255, 255, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.78);
     border-bottom-right-radius: 8px;
-    box-shadow: 0 8px 18px rgba(64, 197, 241, 0.18);
+    box-shadow:
+        0 12px 24px rgba(64, 197, 241, 0.2),
+        inset 0 1px 0 rgba(255, 255, 255, 0.56);
 }
 
 .card-companion-bubble-system {
@@ -7920,9 +8044,9 @@ margin-top: 10px;
 }
 
 .card-companion-chip {
-    background: #f0fbff;
+    background: rgba(255, 255, 255, 0.3);
     color: #257da5;
-    border: 2px solid #b3e5fc;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-radius: 999px;
     padding: 4px 12px;
     font-size: 11.5px;
@@ -7950,12 +8074,12 @@ margin-top: 10px;
 .card-companion-bubble-custom-input {
     width: 100%;
     padding: 6px 12px;
-    border: 2px solid #b3e5fc;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-radius: 999px;
     font-size: 12px;
     box-sizing: border-box;
     font-family: inherit;
-    background: #fff;
+    background: rgba(255, 255, 255, 0.36);
     color: #257da5;
 }
 
@@ -7985,16 +8109,61 @@ margin-top: 10px;
 }
 
 .card-companion-input-bar {
-    border-top: 2px solid #d5f2ff;
+    position: relative;
+    z-index: 1;
+    border-top: 1px solid rgba(255, 255, 255, 0.46);
     padding: 16px 18px 18px;
-    background: linear-gradient(180deg, #f8fcff 0%, #ffffff 100%);
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.24)),
+        rgba(245, 251, 255, 0.06);
     flex-shrink: 0;
+    overflow: hidden;
+}
+
+.card-companion-input-bar::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    height: 54%;
+    pointer-events: none;
+    background: linear-gradient(112deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.05) 50%, transparent 76%);
+    opacity: 0.7;
+}
+
+.card-companion-input-bar::after {
+    content: "";
+    position: absolute;
+    left: 24px;
+    right: 24px;
+    bottom: 12px;
+    height: 38px;
+    pointer-events: none;
+    border-radius: 999px;
+    background: radial-gradient(ellipse at center, rgba(64, 197, 241, 0.24), rgba(64, 197, 241, 0) 68%);
+    filter: blur(10px);
+    opacity: 0.78;
 }
 
 .card-companion-input-row {
+    position: relative;
+    z-index: 1;
     display: flex;
     gap: 12px;
     align-items: flex-end;
+}
+
+.card-companion-input-row::before {
+    content: "";
+    position: absolute;
+    inset: -6px -7px;
+    pointer-events: none;
+    border-radius: 999px;
+    border: 1px solid rgba(125, 211, 252, 0.52);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(64, 197, 241, 0.08));
+    box-shadow:
+        0 0 0 2px rgba(64, 197, 241, 0.18),
+        0 10px 26px rgba(28, 120, 170, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.58);
 }
 
 .card-companion-input {
@@ -8002,7 +8171,7 @@ margin-top: 10px;
     min-height: 46px;
     max-height: 120px;
     padding: 11px 16px;
-    border: 2px solid #b3e5fc;
+    border: 1px solid rgba(125, 211, 252, 0.72);
     border-radius: 999px;
     font-size: 15px;
     box-sizing: border-box;
@@ -8011,13 +8180,24 @@ margin-top: 10px;
     line-height: 1.5;
     overflow-y: auto;
     color: #257da5;
-    background: #fff;
+    background: rgba(255, 255, 255, 0.46);
+    box-shadow:
+        0 0 0 2px rgba(64, 197, 241, 0.12),
+        0 10px 24px rgba(28, 120, 170, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.76);
+    backdrop-filter: blur(3px) saturate(1.08);
+    -webkit-backdrop-filter: blur(3px) saturate(1.08);
 }
 
 .card-companion-input:focus {
     outline: none;
     border-color: #40C5F1;
-    box-shadow: 0 0 0 3px rgba(64, 197, 241, 0.16);
+    background: rgba(255, 255, 255, 0.7);
+    box-shadow:
+        0 0 0 3px rgba(64, 197, 241, 0.2),
+        0 0 22px rgba(64, 197, 241, 0.32),
+        0 12px 28px rgba(28, 120, 170, 0.14),
+        inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 .card-companion-input::placeholder {
@@ -8052,6 +8232,8 @@ margin-top: 10px;
 }
 
 .card-companion-quick-row {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
@@ -8059,9 +8241,9 @@ margin-top: 10px;
 }
 
 .card-companion-quick-chip {
-    background: #f0fbff;
+    background: rgba(255, 255, 255, 0.34);
     color: #1686c2;
-    border: 2px solid #d5f2ff;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-radius: 999px;
     padding: 5px 12px;
     font-size: 12px;

--- a/static/css/character_personality_onboarding.css
+++ b/static/css/character_personality_onboarding.css
@@ -5,28 +5,43 @@
 }
 
 .character-personality-overlay {
-    --jelly-blue-50: #f0f9ff;
-    --jelly-blue-100: #e0f2fe;
-    --jelly-blue-200: #bae6fd;
-    --jelly-blue-300: #7dd3fc;
-    --jelly-blue-400: #38bdf8;
-    --jelly-blue-500: #0ea5e9;
-    --jelly-blue-600: #0284c7;
+    --jelly-blue-50: #f4fbff;
+    --jelly-blue-100: #d8f2ff;
+    --jelly-blue-200: #aee5ff;
+    --jelly-blue-300: #7bd9ff;
+    --jelly-blue-400: #40c5f1;
+    --jelly-blue-500: #25afe2;
+    --jelly-blue-600: #1689bd;
     --text-main: #334155;
     --text-sub: #64748b;
-    --surface: #ffffff;
-    --surface-soft: #f8fbff;
+    --surface: rgba(245, 251, 255, 0.24);
+    --surface-solid: #ffffff;
+    --surface-soft: rgba(248, 253, 255, 0.2);
     --danger-bg: #fff1f2;
     --danger-border: #fecdd3;
     --danger-text: #e11d48;
     --radius-pill: 999px;
     --radius-sm: 12px;
-    --radius-md: 20px;
-    --radius-lg: 28px;
-    --shadow-shell: 0 24px 48px -12px rgba(14, 165, 233, 0.22);
-    --shadow-card: 0 10px 0 rgba(186, 230, 253, 0.9);
-    --shadow-card-hover: 0 16px 0 rgba(125, 211, 252, 0.95);
-    --shadow-button: 0 6px 0 rgba(2, 132, 199, 0.95);
+    --radius-md: 18px;
+    --radius-lg: 30px;
+    --glass-border: rgba(255, 255, 255, 0.62);
+    --glass-highlight: rgba(255, 255, 255, 0.9);
+    --shadow-shell:
+        0 30px 76px rgba(11, 43, 66, 0.24),
+        0 16px 38px rgba(32, 70, 90, 0.08),
+        0 1px 0 rgba(255, 255, 255, 0.62) inset,
+        0 16px 36px rgba(255, 255, 255, 0.14) inset,
+        0 -24px 52px rgba(28, 95, 130, 0.12) inset,
+        0 0 0 1px rgba(255, 255, 255, 0.32) inset;
+    --shadow-card:
+        0 14px 30px rgba(16, 70, 100, 0.16),
+        inset 0 1px 0 rgba(255, 255, 255, 0.72),
+        inset 0 -14px 26px rgba(28, 95, 130, 0.08);
+    --shadow-card-hover:
+        0 18px 36px rgba(28, 120, 170, 0.22),
+        inset 0 1px 0 rgba(255, 255, 255, 0.86),
+        inset 0 -12px 26px rgba(32, 70, 90, 0.05);
+    --shadow-button: 0 8px 18px rgba(64, 197, 241, 0.24);
     position: fixed;
     inset: 0;
     z-index: 2147483000;
@@ -34,8 +49,9 @@
     align-items: center;
     justify-content: center;
     padding: 24px;
-    background: rgba(240, 249, 255, 0.7);
-    backdrop-filter: blur(12px);
+    background: rgba(18, 42, 58, 0.08);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
     pointer-events: auto;
 }
 
@@ -44,33 +60,70 @@
 }
 
 .character-personality-shell {
-    width: min(920px, 100%);
+    position: relative;
+    width: min(900px, 100%);
     max-height: min(860px, calc(100vh - 48px));
     overflow: auto;
-    border: 4px solid rgba(255, 255, 255, 0.96);
-    border-radius: 36px;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.99), rgba(244, 251, 255, 0.98));
+    isolation: isolate;
+    border: 1px solid rgba(255, 255, 255, 0.68);
+    border-radius: 32px;
+    background:
+        linear-gradient(116deg, rgba(255, 255, 255, 0.34) 0%, rgba(255, 255, 255, 0.08) 15%, transparent 36%),
+        radial-gradient(circle at 18% 6%, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.05) 24%, transparent 48%),
+        radial-gradient(circle at 94% 84%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02) 28%, transparent 50%),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.18), rgba(245, 248, 250, 0.045) 48%, rgba(255, 255, 255, 0.1)),
+        rgba(255, 255, 255, 0.045);
+    backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
+    -webkit-backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
     box-shadow: var(--shadow-shell);
     color: var(--text-main);
 }
 
+.character-personality-shell::before {
+    content: "";
+    position: absolute;
+    inset: 1px;
+    border-radius: 31px;
+    pointer-events: none;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.1) 16%, rgba(255, 255, 255, 0) 34%),
+        linear-gradient(315deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0) 30%),
+        linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(245, 248, 250, 0.02) 44%, rgba(255, 255, 255, 0.06) 100%);
+    box-shadow:
+        inset 0 1px 0 var(--glass-highlight),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.36),
+        inset 0 -1px 0 rgba(31, 146, 192, 0.22);
+    opacity: 0.86;
+}
+
+.character-personality-shell::after {
+    display: none;
+}
+
 .shell-deco-bar {
-    height: 12px;
+    height: 0;
     width: 100%;
-    background: linear-gradient(
-        90deg,
-        var(--jelly-blue-300),
-        var(--jelly-blue-400)
-    );
+    border: 0;
+    background: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
 }
 
 .character-personality-body {
+    position: relative;
+    z-index: 1;
     min-height: 480px;
 }
 
+.character-personality-body::before {
+    display: none;
+}
+
 .character-personality-stage {
+    position: relative;
+    z-index: 1;
     min-height: 480px;
-    padding: 40px 48px 32px;
+    padding: 36px 48px 30px;
 }
 
 .character-personality-stage-two {
@@ -94,11 +147,12 @@
 .character-personality-eyebrow {
     display: inline-flex;
     align-items: center;
-    min-height: 32px;
-    padding: 0 14px;
-    border: 2px solid var(--jelly-blue-100);
+    min-height: 30px;
+    padding: 0 13px;
+    border: 1px solid rgba(255, 255, 255, 0.72);
     border-radius: var(--radius-pill);
-    background: var(--jelly-blue-50);
+    background: rgba(244, 251, 255, 0.42);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
     color: var(--jelly-blue-500);
     font-size: 13px;
     font-weight: 800;
@@ -111,13 +165,15 @@
     justify-content: center;
     min-height: 34px;
     padding: 0 16px;
-    border: 2px solid var(--jelly-blue-100);
+    border: 1px solid rgba(255, 255, 255, 0.72);
     border-radius: var(--radius-pill);
-    background: var(--surface);
+    background: rgba(255, 255, 255, 0.42);
     color: var(--jelly-blue-600);
     font-size: 14px;
     font-weight: 800;
-    box-shadow: 0 4px 0 rgba(186, 230, 253, 0.92);
+    box-shadow:
+        0 8px 18px rgba(28, 120, 170, 0.1),
+        inset 0 1px 0 rgba(255, 255, 255, 0.48);
 }
 
 .cph-title,
@@ -137,7 +193,7 @@
 }
 
 .character-personality-intro {
-    margin-bottom: 24px;
+    margin-bottom: 20px;
     color: var(--text-sub);
     font-size: 15px;
     line-height: 1.7;
@@ -147,14 +203,20 @@
     display: block;
     margin: 18px 0 20px;
     padding: 14px 16px;
-    border: 2px solid var(--jelly-blue-200);
-    border-radius: 18px;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(224, 242, 254, 0.92));
+    border: 1px solid rgba(255, 255, 255, 0.72);
+    border-radius: 16px;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.24), rgba(245, 248, 250, 0.045)),
+        rgba(245, 251, 255, 0.12);
+    backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
+    -webkit-backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
     color: var(--text-main);
     font-size: 14px;
     font-weight: 700;
     line-height: 1.7;
-    box-shadow: 0 8px 20px rgba(14, 165, 233, 0.08);
+    box-shadow:
+        0 10px 24px rgba(28, 120, 170, 0.08),
+        inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
 .character-personality-warning-stage-two {
@@ -164,7 +226,7 @@
 .character-personality-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 24px;
+    gap: 20px;
 }
 
 .character-personality-card {
@@ -172,11 +234,15 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    min-height: 264px;
-    padding: 28px 20px 24px;
-    border: 3px solid var(--jelly-blue-100);
+    min-height: 238px;
+    padding: 24px 20px 22px;
+    border: 1px solid rgba(255, 255, 255, 0.72);
     border-radius: var(--radius-lg);
-    background: linear-gradient(180deg, var(--surface), var(--jelly-blue-50));
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.25), rgba(245, 248, 250, 0.045) 54%, rgba(255, 255, 255, 0.1)),
+        rgba(255, 255, 255, 0.085);
+    backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
+    -webkit-backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
     box-shadow: var(--shadow-card);
     color: inherit;
     text-align: left;
@@ -194,26 +260,52 @@
     position: absolute;
     top: 0;
     left: 50%;
-    width: 44px;
-    height: 6px;
+    width: 58px;
+    height: 7px;
     transform: translateX(-50%);
-    border-radius: 0 0 8px 8px;
-    background: var(--jelly-blue-200);
+    border: 1px solid rgba(255, 255, 255, 0.34);
+    border-top: 0;
+    border-radius: 0 0 10px 10px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.44), rgba(255, 255, 255, 0.08)),
+        rgba(245, 251, 255, 0.12);
+    box-shadow:
+        0 8px 18px rgba(32, 70, 90, 0.08),
+        inset 0 1px 0 rgba(255, 255, 255, 0.58);
+    opacity: 0.78;
+}
+
+.character-personality-card::after {
+    content: "";
+    position: absolute;
+    inset: 1px;
+    border-radius: 29px;
+    pointer-events: none;
+    background:
+        linear-gradient(118deg, rgba(255, 255, 255, 0.46), rgba(255, 255, 255, 0.1) 18%, rgba(255, 255, 255, 0) 38%),
+        radial-gradient(circle at 92% 18%, rgba(255, 255, 255, 0.3), transparent 28%),
+        linear-gradient(315deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 32%);
+    opacity: 0.66;
 }
 
 .character-personality-card:hover,
 .character-personality-card:focus-visible {
-    transform: translateY(-8px);
-    border-color: var(--jelly-blue-400);
+    transform: translateY(-3px);
+    border-color: rgba(255, 255, 255, 0.88);
     box-shadow:
         var(--shadow-card-hover),
-        0 20px 30px rgba(14, 165, 233, 0.1);
+        inset 0 1px 0 rgba(255, 255, 255, 0.96);
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.34), rgba(245, 248, 250, 0.06) 54%, rgba(255, 255, 255, 0.12)),
+        rgba(255, 255, 255, 0.13);
     outline: none;
 }
 
 .character-personality-card:active {
-    transform: translateY(3px);
-    box-shadow: 0 0 0 rgba(186, 230, 253, 0);
+    transform: translateY(1px);
+    box-shadow:
+        0 6px 16px rgba(28, 120, 170, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
 .card-watermark {
@@ -223,9 +315,23 @@
     color: var(--jelly-blue-400);
     font-size: 48px;
     font-weight: 900;
-    opacity: 0.08;
+    opacity: 0.06;
     transform: rotate(10deg);
     pointer-events: none;
+    transition:
+        opacity 180ms ease,
+        text-shadow 180ms ease,
+        transform 180ms ease;
+}
+
+.character-personality-card:hover .card-watermark,
+.character-personality-card:focus-visible .card-watermark {
+    opacity: 0.22;
+    text-shadow:
+        0 0 12px rgba(255, 255, 255, 0.7),
+        0 0 22px rgba(64, 197, 241, 0.48),
+        0 0 34px rgba(64, 197, 241, 0.3);
+    transform: rotate(8deg) scale(1.04);
 }
 
 .cpc-pill {
@@ -235,9 +341,10 @@
     align-items: center;
     min-height: 32px;
     padding: 0 12px;
-    border: 2px solid var(--jelly-blue-100);
-    border-radius: 10px;
-    background: var(--surface);
+    border: 1px solid var(--jelly-blue-100);
+    border-radius: 999px;
+    background: rgba(244, 251, 255, 0.34);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
     color: var(--jelly-blue-500);
     font-size: 13px;
     font-weight: 800;
@@ -247,7 +354,7 @@
 .character-personality-card-name {
     position: relative;
     z-index: 1;
-    margin: 16px 0 0;
+    margin: 15px 0 0;
     color: var(--text-main);
     font-size: 20px;
     font-weight: 800;
@@ -271,9 +378,11 @@
     z-index: 1;
     margin-top: auto;
     padding: 14px 16px;
-    border: 2px solid var(--jelly-blue-100);
-    border-radius: 12px 12px 12px 4px;
-    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid var(--jelly-blue-100);
+    border-radius: 16px;
+    background: rgba(244, 251, 255, 0.32);
+    backdrop-filter: blur(10px) saturate(1.3);
+    -webkit-backdrop-filter: blur(10px) saturate(1.3);
     color: var(--jelly-blue-600);
     font-size: 13px;
     font-weight: 700;
@@ -293,11 +402,11 @@
     justify-content: center;
     width: 44px;
     height: 44px;
-    border: 3px solid var(--jelly-blue-100);
+    border: 2px solid var(--jelly-blue-100);
     border-radius: 14px;
     background: var(--surface);
     color: var(--text-sub);
-    box-shadow: 0 4px 0 rgba(186, 230, 253, 0.92);
+    box-shadow: 0 6px 14px rgba(64, 197, 241, 0.14);
     cursor: pointer;
     transition:
         transform 160ms ease,
@@ -308,16 +417,16 @@
 
 .btn-back-icon:hover,
 .btn-back-icon:focus-visible {
-    transform: translateY(-3px);
+    transform: translateY(-2px);
     border-color: var(--jelly-blue-300);
-    box-shadow: 0 8px 0 rgba(125, 211, 252, 0.92);
+    box-shadow: 0 10px 20px rgba(64, 197, 241, 0.2);
     color: var(--jelly-blue-600);
     outline: none;
 }
 
 .btn-back-icon:active {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 rgba(125, 211, 252, 0);
+    transform: translateY(1px);
+    box-shadow: 0 3px 8px rgba(64, 197, 241, 0.16);
 }
 
 .stage-two-title {
@@ -335,7 +444,7 @@
     padding: 0 16px;
     border: 2px solid var(--jelly-blue-200);
     border-radius: var(--radius-pill);
-    background: var(--jelly-blue-50);
+    background: rgba(244, 251, 255, 0.34);
     color: var(--jelly-blue-600);
     font-size: 14px;
     font-weight: 800;
@@ -349,10 +458,32 @@
 }
 
 .preview-section {
-    border: 3px solid var(--jelly-blue-100);
-    border-radius: 24px;
-    background: var(--surface);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.58);
+    border-radius: 22px;
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.24), rgba(245, 248, 250, 0.045)),
+        rgba(255, 255, 255, 0.085);
     padding: 24px;
+    backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
+    -webkit-backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
+    box-shadow:
+        0 8px 20px rgba(32, 70, 90, 0.07),
+        inset 0 1px 0 rgba(255, 255, 255, 0.52);
+}
+
+.preview-section::before,
+.detail-group::before {
+    content: "";
+    position: absolute;
+    inset: 1px;
+    border-radius: inherit;
+    pointer-events: none;
+    background:
+        linear-gradient(125deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.08) 20%, rgba(255, 255, 255, 0) 42%),
+        linear-gradient(315deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0) 32%);
+    opacity: 0.64;
 }
 
 .preview-label,
@@ -362,7 +493,7 @@
     min-height: 32px;
     padding: 0 12px;
     border-radius: 10px;
-    background: var(--jelly-blue-50);
+    background: rgba(244, 251, 255, 0.3);
     color: var(--jelly-blue-600);
     font-size: 14px;
     font-weight: 800;
@@ -380,26 +511,48 @@
     align-items: center;
     justify-content: center;
     width: 64px;
-    min-height: 64px;
-    padding: 8px;
-    border: 3px solid #ffffff;
-    border-radius: 18px;
-    background: linear-gradient(180deg, var(--jelly-blue-300), var(--jelly-blue-500));
-    color: #ffffff;
-    font-size: 15px;
-    font-weight: 900;
-    line-height: 1.2;
-    text-align: center;
-    box-shadow: 0 6px 0 rgba(186, 230, 253, 0.92);
+    height: 64px;
+    flex: 0 0 64px;
+    padding: 3px;
+    border: 1px solid rgba(255, 255, 255, 0.78);
+    border-radius: 50%;
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.58), rgba(244, 251, 255, 0.16)),
+        rgba(245, 251, 255, 0.22);
+    box-shadow:
+        0 10px 22px rgba(28, 120, 170, 0.18),
+        inset 0 1px 0 rgba(255, 255, 255, 0.82),
+        inset 0 -10px 18px rgba(32, 70, 90, 0.05);
+    overflow: hidden;
+}
+
+.preview-avatar-img {
+    display: block;
+    width: 118%;
+    height: 118%;
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: 50% 18%;
+}
+
+.preview-avatar.is-empty::before {
+    content: "";
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: rgba(64, 197, 241, 0.32);
+    box-shadow: 0 0 18px rgba(64, 197, 241, 0.28);
 }
 
 .preview-bubble {
     flex: 1;
     min-height: 180px;
     padding: 20px;
-    border: 3px solid var(--jelly-blue-200);
-    border-radius: 20px 20px 20px 4px;
-    background: var(--jelly-blue-50);
+    border: 2px solid var(--jelly-blue-200);
+    border-radius: 18px 18px 18px 6px;
+    background: rgba(244, 251, 255, 0.28);
+    backdrop-filter: blur(5px) saturate(1.12);
+    -webkit-backdrop-filter: blur(5px) saturate(1.12);
 }
 
 .character-personality-preview-stream {
@@ -431,15 +584,22 @@
 .details-section {
     display: flex;
     flex-direction: column;
-    gap: 24px;
+    gap: 18px;
     padding-top: 4px;
 }
 
 .detail-group {
-    border: 2px solid rgba(186, 230, 253, 0.9);
-    border-radius: 22px;
-    background: rgba(255, 255, 255, 0.94);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.58);
+    border-radius: 20px;
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.24), rgba(245, 248, 250, 0.045)),
+        rgba(255, 255, 255, 0.085);
     padding: 18px 18px 16px;
+    backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
+    -webkit-backdrop-filter: blur(5px) saturate(1.12) contrast(1.03) brightness(1.04);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.52);
 }
 
 .detail-group-title {
@@ -463,16 +623,16 @@
     padding: 0 14px;
     border: 2px solid var(--jelly-blue-100);
     border-radius: var(--radius-pill);
-    background: var(--surface);
+    background: rgba(255, 255, 255, 0.3);
     color: var(--text-sub);
     font-size: 13px;
     font-weight: 700;
-    box-shadow: 0 3px 0 rgba(240, 249, 255, 0.96);
+    box-shadow: 0 4px 10px rgba(64, 197, 241, 0.08);
 }
 
 .detail-group.danger {
     border-color: rgba(254, 205, 211, 0.96);
-    background: rgba(255, 250, 251, 0.96);
+    background: rgba(255, 250, 251, 0.38);
 }
 
 .detail-group.danger .detail-pill {
@@ -487,7 +647,7 @@
     justify-content: center;
     align-items: center;
     gap: 20px;
-    margin-top: 28px;
+    margin-top: 26px;
 }
 
 .character-personality-button {
@@ -495,7 +655,7 @@
     align-items: center;
     justify-content: center;
     min-width: 140px;
-    min-height: 48px;
+    min-height: 46px;
     padding: 0 28px;
     border: 0;
     border-radius: var(--radius-pill);
@@ -511,44 +671,46 @@
 
 .character-personality-button:hover,
 .character-personality-button:focus-visible {
-    transform: translateY(-3px);
+    transform: translateY(-2px);
     outline: none;
 }
 
 .character-personality-button:active {
-    transform: translateY(2px);
+    transform: translateY(1px);
 }
 
 .btn-ghost-jelly {
-    border: 3px solid var(--jelly-blue-100);
+    border: 2px solid var(--jelly-blue-100);
     background: var(--surface);
     color: var(--text-sub);
-    box-shadow: 0 6px 0 rgba(224, 242, 254, 0.96);
+    box-shadow: 0 6px 14px rgba(64, 197, 241, 0.12);
 }
 
 .btn-ghost-jelly:hover,
 .btn-ghost-jelly:focus-visible {
-    box-shadow: 0 10px 0 rgba(186, 230, 253, 0.96);
+    box-shadow: 0 10px 20px rgba(64, 197, 241, 0.18);
     color: var(--text-main);
 }
 
 .btn-ghost-jelly:active {
-    box-shadow: 0 0 0 rgba(224, 242, 254, 0);
+    box-shadow: 0 3px 8px rgba(64, 197, 241, 0.12);
 }
 
 .btn-primary-jelly {
     color: #ffffff;
-    background: linear-gradient(180deg, var(--jelly-blue-400), var(--jelly-blue-500));
-    box-shadow: var(--shadow-button), 0 14px 20px rgba(14, 165, 233, 0.18);
+    background: var(--jelly-blue-400);
+    box-shadow: var(--shadow-button);
 }
 
 .btn-primary-jelly:hover,
 .btn-primary-jelly:focus-visible {
-    box-shadow: 0 10px 0 rgba(2, 132, 199, 0.95), 0 18px 24px rgba(14, 165, 233, 0.2);
+    background: #3ab8e0;
+    box-shadow: 0 10px 22px rgba(64, 197, 241, 0.3);
 }
 
 .btn-primary-jelly:active {
-    box-shadow: 0 0 0 rgba(2, 132, 199, 0);
+    background: #2fa8d0;
+    box-shadow: 0 3px 8px rgba(64, 197, 241, 0.2);
 }
 
 .btn-primary-jelly.success,

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -100,6 +100,43 @@
         return element;
     }
 
+    function findLoadedCharacterAvatarSrc(characterName) {
+        const targetName = String(characterName || '').trim();
+        if (!targetName || typeof document === 'undefined') {
+            return '';
+        }
+        const imageSrc = (image) => {
+            const src = image && image.getAttribute && image.getAttribute('src');
+            if (!src) {
+                return '';
+            }
+            if (/default_character_card\.png|sidebar_logo|paw_ui\.png/i.test(src)) {
+                return '';
+            }
+            return image.src || src;
+        };
+
+        const panelImg = Array.from(document.querySelectorAll('.catgirl-panel-wrapper')).find((wrapper) => {
+            return String(wrapper && wrapper.dataset && wrapper.dataset.catgirlName || '').trim() === targetName;
+        })?.querySelector('.catgirl-panel-card-image img.card-face-img');
+        const panelSrc = imageSrc(panelImg);
+        if (panelSrc) {
+            return panelSrc;
+        }
+
+        const gridCard = Array.from(document.querySelectorAll('.chara-card-item')).find((card) => {
+            const nameEl = card.querySelector('.card-name');
+            return String(nameEl && nameEl.textContent || '').trim() === targetName;
+        });
+        const gridImg = gridCard ? gridCard.querySelector('.card-avatar img.card-face-img') : null;
+        const gridSrc = imageSrc(gridImg);
+        if (gridSrc) {
+            return gridSrc;
+        }
+
+        return '';
+    }
+
     class CharacterPersonalityOnboardingManager {
         constructor() {
             this.overlay = null;
@@ -1043,11 +1080,33 @@
             previewSection.appendChild(previewLabel);
 
             const bubbleWrapper = createElement('div', 'preview-bubble-wrapper');
-            const avatar = createElement(
-                'div',
-                'preview-avatar',
-                this.currentCharacterName || translate('memory.characterSelection.currentCharacterEmpty', '当前角色')
-            );
+            const avatar = createElement('div', 'preview-avatar');
+            const avatarLabel = this.currentCharacterName
+                ? translate(
+                    'memory.characterSelection.currentCharacterAvatarAlt',
+                    '{{characterName}} 的头像',
+                    { characterName: this.currentCharacterName }
+                )
+                : translate('memory.characterSelection.currentCharacterEmpty', '当前角色');
+            avatar.setAttribute('aria-label', avatarLabel);
+            avatar.title = avatarLabel;
+            if (this.currentCharacterName) {
+                const avatarImg = document.createElement('img');
+                avatarImg.className = 'preview-avatar-img';
+                avatarImg.alt = avatarLabel;
+                avatarImg.draggable = false;
+                avatarImg.src = (
+                    findLoadedCharacterAvatarSrc(this.currentCharacterName)
+                    || `/api/characters/catgirl/${encodeURIComponent(this.currentCharacterName)}/card-face`
+                );
+                avatarImg.addEventListener('error', () => {
+                    avatarImg.remove();
+                    avatar.classList.add('is-empty');
+                }, { once: true });
+                avatar.appendChild(avatarImg);
+            } else {
+                avatar.classList.add('is-empty');
+            }
             bubbleWrapper.appendChild(avatar);
 
             const bubble = createElement('div', 'preview-bubble');

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -6,6 +6,21 @@
 let lanlan_config = {
     lanlan_name: ""
 };
+
+const RESERVED_PAGE_PATHS = new Set([
+    'api',
+    'chat',
+    'chat_full',
+    'focus',
+    'static',
+    'templates',
+    'toast',
+]);
+
+function isReservedPagePath(pathname) {
+    const pathParts = String(pathname || '').split('/').filter(Boolean);
+    return pathParts.length > 0 && RESERVED_PAGE_PATHS.has(pathParts[0]);
+}
 window.lanlan_config = lanlan_config;
 let cubism4Model = "";
 let vrmModel = "";
@@ -68,7 +83,7 @@ async function loadPageConfig() {
         // 从路径中提取 lanlan_name (例如 /{lanlan_name})
         if (!lanlanNameFromUrl) {
             const pathParts = window.location.pathname.split('/').filter(Boolean);
-            if (pathParts.length > 0 && !['focus', 'api', 'static', 'templates', 'chat', 'toast'].includes(pathParts[0])) {
+            if (pathParts.length > 0 && !RESERVED_PAGE_PATHS.has(pathParts[0])) {
                 lanlanNameFromUrl = decodeURIComponent(pathParts[0]);
             }
         }
@@ -300,7 +315,7 @@ window.startPageConfigLoad = function startPageConfigLoad() {
                 await window.__nekoStorageLocationStartupBarrier;
             }
 
-            if (window.__NEKO_MULTI_WINDOW__ && window.location.pathname === '/chat') {
+            if (window.__NEKO_MULTI_WINDOW__ && isReservedPagePath(window.location.pathname)) {
                 return resolvePageConfig(await startMultiWindowPageConfigLoad());
             }
 

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -879,7 +879,7 @@
     <script src="/static/live2d-init.js"></script>
     
     <script src="/static/js/reserved_fields_utils.js"></script>
-    <script src="/static/js/character_personality_onboarding.js"></script>
+    <script src="/static/js/character_personality_onboarding.js?v={{ static_asset_version | default('0') }}"></script>
     <script src="/static/js/character_card_manager.js?v={{ static_asset_version | default('0') }}"></script>
 
     <!-- Three.js 核心库和importmap（用于VRM/MMD模型预览）-->

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -472,7 +472,8 @@
         }
     </style>
 </head>
-<body class="electron-chat-window subtitle-web-host">
+<body class="electron-chat-window subtitle-web-host"
+      data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default('compact', true) }}">
 
     <div id="status-toast"></div>
     <div id="yui-guide-chat-spotlight" hidden>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="/static/css/index.css?v={{ static_asset_version }}">
     <link rel="stylesheet" href="/static/css/subtitle.css?v={{ static_asset_version }}">
     <link rel="stylesheet" href="/static/css/dark-mode.css?v={{ static_asset_version }}">
-    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ static_asset_version }}">
+    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ react_chat_asset_version }}">
     <script src="/static/theme-manager.js?v={{ static_asset_version }}"></script>
     <link rel="stylesheet" href="/static/libs/APlayer.min.css?v={{ static_asset_version }}">
     <script src="/static/libs/APlayer.min.js?v={{ static_asset_version }}"></script>
@@ -676,7 +676,7 @@
          mutation 共用 window.nekoLocalMutationSecurity 拿 X-CSRF-Token；必须
          在 app-react-chat-window.js 之前加载，与 index.html 同序。 -->
     <script src="/static/app-prompt-shared.js?v={{ static_asset_version }}"></script>
-    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ static_asset_version }}"></script>
+    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ react_chat_asset_version }}"></script>
     <script src="/static/app-react-chat-window.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-chat-adapter.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-chat-export.js?v={{ static_asset_version }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
     <link rel="stylesheet" href="/static/css/subtitle.css?v={{ static_asset_version }}">
     <style>/* React chat adapter: hide old chat */
     #chat-container { display: none !important; visibility: hidden !important; }</style>
-    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ static_asset_version }}">
+    <link rel="stylesheet" href="/static/react/neko-chat/neko-chat-window.css?v={{ react_chat_asset_version }}">
     <link rel="stylesheet" href="/static/css/avatar-reaction-bubble.css?v={{ static_asset_version }}">
     <!-- 暗色模式样式 -->
     <link rel="stylesheet" href="/static/css/dark-mode.css?v={{ static_asset_version }}">
@@ -61,7 +61,8 @@
     <script src="/static/libs/APlayer.min.js?v={{ static_asset_version }}"></script>
 </head>
 
-<body class="subtitle-web-host">
+<body class="subtitle-web-host"
+      data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default('compact', true) }}">
     <!-- 同步把 Electron Pet 标记补到 body（head 脚本执行时 body 尚不存在）；
          在 chat-container 等内容解析之前执行，避免窄窗口下手机布局闪一帧。 -->
     <script>(function () {
@@ -395,7 +396,7 @@
     <script src="/static/app-autostart-prompt.js?v={{ static_asset_version }}"></script>
     <script src="/static/js/character_personality_onboarding.js?v={{ static_asset_version }}"></script>
     <script src="/static/app.js?v={{ static_asset_version }}"></script>
-    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ static_asset_version }}"></script>
+    <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ react_chat_asset_version }}"></script>
     <script src="/static/app-react-chat-window.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-chat-export.js?v={{ static_asset_version }}"></script>
 

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -1611,8 +1611,8 @@ def test_character_card_manager_card_assist_avatar_toggles_companion(
     assert state["titleDisplayWhenMinimized"] == "none"
     assert state["closeDisplayWhenMinimized"] == "none"
     assert state["avatarSrc"].endswith("/api/characters/catgirl/YUI/card-face")
-    assert state["avatarImgObjectPosition"] == "50% 8%"
-    assert state["avatarImgTransform"] == "matrix(1.02, 0, 0, 1.02, 0, 3)"
+    assert state["avatarImgObjectPosition"] == "50% 46%"
+    assert state["avatarImgTransform"] == "matrix(1, 0, 0, 1, 0, 5)"
     assert state["avatarRole"] == "button"
     assert state["avatarTabIndex"] == "0"
     assert state["ariaAfterFirstClick"] == "false"

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -1779,11 +1780,33 @@ def test_onboarding_uses_dynamic_character_name_and_split_detail_pills(mock_page
     )
 
     expect(mock_page.locator(".cph-badge")).to_have_text("小天")
+    mock_page.evaluate(
+        """
+        () => {
+            const card = document.createElement('div');
+            card.className = 'chara-card-item active';
+            const avatar = document.createElement('div');
+            avatar.className = 'card-avatar';
+            const img = document.createElement('img');
+            img.className = 'card-face-img';
+            img.src = '/mock-current-avatar.png';
+            avatar.appendChild(img);
+            const name = document.createElement('div');
+            name.className = 'card-name';
+            name.textContent = '小天';
+            card.appendChild(avatar);
+            card.appendChild(name);
+            document.body.appendChild(card);
+        }
+        """
+    )
 
     mock_page.locator("[data-testid='character-personality-preset-classic_genki']").click()
 
     expect(mock_page.locator("#previewTitleBadge")).to_have_text("经典元气猫娘")
-    expect(mock_page.locator(".preview-avatar")).to_have_text("小天")
+    expect(mock_page.locator(".preview-avatar")).to_have_text("")
+    avatar_img = mock_page.locator(".preview-avatar-img")
+    expect(avatar_img).to_have_attribute("src", re.compile(r"/mock-current-avatar\.png$"))
 
     speech_pills = mock_page.locator("#detailCatchphrases .detail-pill")
     expect(speech_pills).to_have_count(2)
@@ -1794,6 +1817,56 @@ def test_onboarding_uses_dynamic_character_name_and_split_detail_pills(mock_page
     expect(hobby_pills).to_have_count(2)
     expect(hobby_pills.nth(0)).to_have_text("陪伴")
     expect(hobby_pills.nth(1)).to_have_text("温暖")
+
+
+@pytest.mark.frontend
+def test_onboarding_avatar_ignores_other_character_images_when_card_face_img_is_missing(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate("() => { window.universalTutorialManager.isTutorialRunning = false; }")
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    expect(mock_page.locator(".cph-badge")).to_have_text("小天")
+    mock_page.evaluate(
+        """
+        () => {
+            const otherCard = document.createElement('div');
+            otherCard.className = 'chara-card-item active';
+            const otherAvatar = document.createElement('div');
+            otherAvatar.className = 'card-avatar';
+            const otherImg = document.createElement('img');
+            otherImg.className = 'card-face-img';
+            otherImg.src = '/other-character-avatar.png';
+            otherAvatar.appendChild(otherImg);
+            const otherName = document.createElement('div');
+            otherName.className = 'card-name';
+            otherName.textContent = '其他角色';
+            otherCard.appendChild(otherAvatar);
+            otherCard.appendChild(otherName);
+            document.body.appendChild(otherCard);
+
+            const cover = document.createElement('img');
+            cover.id = 'character-card-cover-img';
+            cover.src = '/visible-cover-avatar.png';
+            document.body.appendChild(cover);
+        }
+        """
+    )
+
+    mock_page.locator("[data-testid='character-personality-preset-classic_genki']").click()
+
+    expect(mock_page.locator(".preview-avatar")).to_have_text("")
+    expect(mock_page.locator(".preview-avatar-img")).to_have_attribute(
+        "src",
+        re.compile(r"/api/characters/catgirl/%E5%B0%8F%E5%A4%A9/card-face$"),
+    )
 
 
 @pytest.mark.frontend

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1216,6 +1216,25 @@ def test_character_card_manager_cloudsave_button_uses_icon_badge():
         assert expected in css_source
 
 
+def test_character_card_companion_uses_liquid_glass_surface():
+    css_source = Path("static/css/character_card_manager.css").read_text(encoding="utf-8")
+
+    for expected in (
+        "--companion-glass-border",
+        "--companion-glass-highlight",
+        ".card-companion-panel::before",
+        ".card-companion-panel::after",
+        "backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);",
+        "inset 0 1px 0 var(--companion-glass-highlight)",
+        ".card-companion-header::before",
+        ".card-companion-thread::before",
+        ".card-companion-input-bar::before",
+        ".card-companion-input-row::before",
+        "0 0 0 2px rgba(64, 197, 241, 0.18)",
+    ):
+        assert expected in css_source
+
+
 def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
     avatar_reload_source = Path("static/tutorial-avatar-reload-controller.js").read_text(encoding="utf-8")

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -8,6 +8,7 @@ MUSIC_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "music_ui.js"
 MUSIC_UI_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "music_ui.css"
 STATIC_INDEX_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "index.css"
 STATIC_DARK_MODE_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "dark-mode.css"
+STATIC_INDEX_JS_PATH = Path(__file__).resolve().parents[2] / "static" / "js" / "index.js"
 REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "styles.css"
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
 CHAT_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "chat.html"
@@ -103,6 +104,16 @@ def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
     )[0]
     assert '"initial_chat_surface_mode": "compact"' in chat_route_block
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
+
+
+def test_chat_full_is_reserved_from_character_page_config_routing():
+    source = STATIC_INDEX_JS_PATH.read_text(encoding="utf-8")
+
+    assert "const RESERVED_PAGE_PATHS = new Set([" in source
+    assert "'chat'" in source
+    assert "'chat_full'" in source
+    assert "RESERVED_PAGE_PATHS.has(pathParts[0])" in source
+    assert "isReservedPagePath(window.location.pathname)" in source
 
 
 def test_chat_host_initial_surface_mode_prefers_template_override_before_storage():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -106,6 +106,13 @@ def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
 
 
+def test_chat_templates_version_react_chat_bundle_from_react_assets():
+    chat_template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert 'neko-chat-window.css?v={{ react_chat_asset_version }}' in chat_template
+    assert 'neko-chat-window.iife.js?v={{ react_chat_asset_version }}' in chat_template
+
+
 def test_chat_full_is_reserved_from_character_page_config_routing():
     source = STATIC_INDEX_JS_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -109,6 +109,13 @@ def test_chat_host_initial_surface_mode_prefers_template_override_before_storage
     source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 
     assert "function readInitialChatSurfaceMode()" in source
+    initial_reader_block = source.split("function readInitialChatSurfaceMode()", 1)[1].split(
+        "function persistChatSurfaceModePreference",
+        1,
+    )[0]
+    assert "if (declaredMode === 'compact' || declaredMode === 'full')" in initial_reader_block
+    assert "return declaredMode;" in initial_reader_block
+
     init_block = source.split("function init()", 1)[1].split(
         "function initAfterStorageBarrier()",
         1,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -12,6 +12,7 @@ REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "rea
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
 CHAT_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "chat.html"
 SUBTITLE_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "subtitle.html"
+PAGES_ROUTER_PATH = Path(__file__).resolve().parents[2] / "main_routers" / "pages_router.py"
 COMPACT_EXPORT_HISTORY_PANEL_PATH = (
     Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "CompactExportHistoryPanel.tsx"
 )
@@ -85,6 +86,39 @@ def test_chat_surface_mode_preference_is_shared_with_electron():
     # never does — it restores via lastRestorableChatSurfaceMode.
     assert "if (mode !== 'compact' && mode !== 'full') return;" in persist_block
     assert "localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode)" in persist_block
+
+
+def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
+    router_source = PAGES_ROUTER_PATH.read_text(encoding="utf-8")
+    template_source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    assert '@router.get("/chat_full", response_class=HTMLResponse)' in router_source
+    assert '"initial_chat_surface_mode": "full"' in router_source
+    assert '"initial_chat_surface_mode": "compact"' in router_source
+    assert 'data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default(\'compact\', true) }}"' in template_source
+
+    chat_route_block = router_source.split('async def get_chat_page', 1)[1].split(
+        '@router.get("/chat_full"',
+        1,
+    )[0]
+    assert '"initial_chat_surface_mode": "compact"' in chat_route_block
+    assert '"initial_chat_surface_mode": "full"' not in chat_route_block
+
+
+def test_chat_host_initial_surface_mode_prefers_template_override_before_storage():
+    source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    assert "function readInitialChatSurfaceMode()" in source
+    init_block = source.split("function init()", 1)[1].split(
+        "function initAfterStorageBarrier()",
+        1,
+    )[0]
+    initial_assignment = "state.chatSurfaceMode = readInitialChatSurfaceMode();"
+    storage_read = "readChatSurfaceModePreference()"
+
+    assert initial_assignment in init_block
+    assert init_block.index(initial_assignment) < init_block.index("lastRestorableChatSurfaceMode = state.chatSurfaceMode;")
+    assert storage_read not in init_block.split(initial_assignment, 1)[0]
 
 
 def test_close_from_minimized_preserves_compact_surface_mode():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -12,6 +12,7 @@ STATIC_INDEX_JS_PATH = Path(__file__).resolve().parents[2] / "static" / "js" / "
 REACT_CHAT_STYLES_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "styles.css"
 REACT_CHAT_APP_PATH = Path(__file__).resolve().parents[2] / "frontend" / "react-neko-chat" / "src" / "App.tsx"
 CHAT_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "chat.html"
+INDEX_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "index.html"
 SUBTITLE_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "subtitle.html"
 PAGES_ROUTER_PATH = Path(__file__).resolve().parents[2] / "main_routers" / "pages_router.py"
 COMPACT_EXPORT_HISTORY_PANEL_PATH = (
@@ -89,28 +90,46 @@ def test_chat_surface_mode_preference_is_shared_with_electron():
     assert "localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode)" in persist_block
 
 
-def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
+def test_chat_full_endpoint_uses_index_template_with_initial_full_surface():
     router_source = PAGES_ROUTER_PATH.read_text(encoding="utf-8")
-    template_source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    index_template = INDEX_TEMPLATE_PATH.read_text(encoding="utf-8")
 
     assert '@router.get("/chat_full", response_class=HTMLResponse)' in router_source
-    assert '"initial_chat_surface_mode": "full"' in router_source
-    assert '"initial_chat_surface_mode": "compact"' in router_source
-    assert 'data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default(\'compact\', true) }}"' in template_source
+    assert 'data-initial-chat-surface-mode="{{ initial_chat_surface_mode|default(\'compact\', true) }}"' in index_template
+
+    root_route_block = router_source.split('async def get_default_index', 1)[1].split(
+        'def _render_model_manager',
+        1,
+    )[0]
+    assert 'TemplateResponse("templates/index.html"' in root_route_block
+    assert '"initial_chat_surface_mode": "compact"' in root_route_block
 
     chat_route_block = router_source.split('async def get_chat_page', 1)[1].split(
         '@router.get("/chat_full"',
         1,
     )[0]
+    assert 'TemplateResponse("templates/chat.html"' in chat_route_block
     assert '"initial_chat_surface_mode": "compact"' in chat_route_block
     assert '"initial_chat_surface_mode": "full"' not in chat_route_block
+
+    chat_full_route_block = router_source.split('async def get_chat_full_page', 1)[1].split(
+        '@router.get("/subtitle"',
+        1,
+    )[0]
+    assert 'TemplateResponse("templates/index.html"' in chat_full_route_block
+    assert 'TemplateResponse("templates/chat.html"' not in chat_full_route_block
+    assert '"initial_chat_surface_mode": "full"' in chat_full_route_block
+    assert '"initial_chat_surface_mode": "compact"' not in chat_full_route_block
 
 
 def test_chat_templates_version_react_chat_bundle_from_react_assets():
     chat_template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    index_template = INDEX_TEMPLATE_PATH.read_text(encoding="utf-8")
 
     assert 'neko-chat-window.css?v={{ react_chat_asset_version }}' in chat_template
     assert 'neko-chat-window.iife.js?v={{ react_chat_asset_version }}' in chat_template
+    assert 'neko-chat-window.css?v={{ react_chat_asset_version }}' in index_template
+    assert 'neko-chat-window.iife.js?v={{ react_chat_asset_version }}' in index_template
 
 
 def test_chat_full_is_reserved_from_character_page_config_routing():
@@ -344,6 +363,12 @@ def test_compact_surface_resize_handles_keep_width_in_dom_geometry_contract():
     assert "var compactSurfaceDesktopResizeActive = false;" in script
     assert "if (isElectronChatWindow() && detail && detail.screenRect)" in script
     assert "compactSurfaceDesktopResizeActive = phase !== 'end';" in script
+    desktop_layout_change_block = script.split("function handleDesktopCompactLayoutChange(layout)", 1)[1].split(
+        "function normalizeCompactDesktopWorkArea",
+        1,
+    )[0]
+    assert "compactSurfaceDesktopResizeActive = !!(layout && layout.resizeActive);" in desktop_layout_change_block
+    assert "compactSurfaceDesktopResizeActive = !!(layout && layout.dragging);" not in desktop_layout_change_block
     assert "if (compactSurfaceDesktopResizeActive && isElectronChatWindow())" in script
     assert "function handleDesktopCompactLayoutChange(layout)" in script
     assert "if (baseAnchorChanged && !compactSurfaceDesktopResizeActive)" in script
@@ -372,14 +397,39 @@ def test_compact_surface_resize_handles_keep_width_in_dom_geometry_contract():
     assert "neko:compact-surface-resize-width-change" in script
     assert "function isDesktopCompactSurfaceLayoutActive()" in app_source
     assert "document.documentElement.style.removeProperty('--compact-surface-resize-width');" in app_source
+    apply_resize_width_block = app_source.split(
+        "const applyCompactSurfaceResizeWidthVar = useCallback((width: number | null) => {",
+        1,
+    )[1].split(
+        "const dispatchCompactSurfaceResizeRequest = useCallback(",
+        1,
+    )[0]
+    assert "isDesktopCompactSurfaceLayoutActive()" not in apply_resize_width_block
     assert "&& !isDesktopCompactSurfaceLayoutActive()" in app_source
     assert "const getClampedCompactSurfaceResizeWidthForSide = useCallback" in app_source
     assert "resizeState.anchorRightScreen - areaLeft" in app_source
     assert "areaRight - resizeState.anchorLeftScreen" in app_source
     assert "if (!isDesktopCompactSurfaceLayoutActive()) {\n      setCompactSurfaceResizeWidth(startWidth);" in app_source
     assert "if (!isDesktopCompactSurfaceLayoutActive()) {\n      setCompactSurfaceResizeWidth(nextWidth);" in app_source
-    assert "if (isDesktopCompactSurfaceLayoutActive()) {\n        setCompactSurfaceResizeWidth(null);" in app_source
-    assert "applyCompactSurfaceResizeWidthVar(null);\n        return;\n      }\n      const resizeState = compactSurfaceResizeStateRef.current;" in app_source
+    assert "if (compactSurfaceResizeStateRef.current) return;" in app_source
+    finish_resize_block = app_source.split(
+        "const finishCompactSurfaceResize = useCallback((event?: ReactPointerEvent<HTMLDivElement>) => {",
+        1,
+    )[1].split(
+        "const handleCompactSurfaceResizePointerDown = useCallback(",
+        1,
+    )[0]
+    assert "if (!isDesktopCompactSurfaceLayoutActive()) {\n      applyCompactSurfaceResizeWidthVar(null);" in finish_resize_block
+    clamp_width_block = app_source.split(
+        "const clampExistingWidth = () => {",
+        1,
+    )[1].split(
+        "window.addEventListener('resize', clampExistingWidth);",
+        1,
+    )[0]
+    assert "if (compactSurfaceResizeStateRef.current) return;" in clamp_width_block
+    assert "setCompactSurfaceResizeWidth(null);" in clamp_width_block
+    assert "if (resizeState) return;\n        setCompactSurfaceResizeWidth(null);" in app_source
 
     assert "--compact-surface-active-width: var(--compact-surface-resize-width, var(--compact-surface-width, 430px));" in resize_shell_block
     assert "width: var(--compact-surface-active-width);" in resize_shell_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -113,8 +113,13 @@ def test_chat_host_initial_surface_mode_prefers_template_override_before_storage
         "function persistChatSurfaceModePreference",
         1,
     )[0]
+    assert "var declaredModeAttr = body" in initial_reader_block
+    assert "body.getAttribute('data-initial-chat-surface-mode')" in initial_reader_block
+    assert "declaredModeAttr ? normalizeChatSurfaceMode(declaredModeAttr) : ''" in initial_reader_block
+    assert "normalizeChatSurfaceMode(body.getAttribute('data-initial-chat-surface-mode'))" not in initial_reader_block
     assert "if (declaredMode === 'compact' || declaredMode === 'full')" in initial_reader_block
     assert "return declaredMode;" in initial_reader_block
+    assert initial_reader_block.index("return declaredMode;") < initial_reader_block.index("return readChatSurfaceModePreference();")
 
     init_block = source.split("function init()", 1)[1].split(
         "function initAfterStorageBarrier()",


### PR DESCRIPTION
## Summary
- 补充 Web/full chat 入口与独立聊天页资源版本处理，避免旧资源或路径覆盖导致聊天界面异常。
- 优化人格选择弹框为液态玻璃风格，并完善当前角色头像复用与兜底逻辑。
- 优化猫猫辅助生成面板、头像裁切和输入框视觉层级，让辅助聊天区域更容易被用户识别和操作。

## Test Plan
- [x] `git diff --check`
- [x] `uv run pytest tests/test_agent_rewrite_regression.py::test_character_card_companion_uses_liquid_glass_surface tests/frontend/test_initial_personality_onboarding.py tests/unit/test_react_chat_window_static.py tests/frontend/test_character_card_manager_regressions.py::test_character_card_manager_card_assist_avatar_toggles_companion`
- [x] `cd frontend/react-neko-chat && npm test -- --run`

## Notes
- Vitest 仍输出已有的 React `act(...)` 和 `HTMLMediaElement.play()` warning；本次测试结果为通过。
- Pytest 仍输出现有依赖/框架 deprecation warnings；本次 focused suite 结果为通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `/chat_full` 路由，提供全屏聊天界面选项
  * 支持在页面加载时设置初始聊天界面模式（紧凑或全屏）

* **改进**
  * 优化紧凑模式下的尺寸调整与状态保留逻辑
  * 增强历史面板可见性切换的指针交互处理
  * 角色卡片面板视觉重设，采用玻璃质感设计
  * 改进角色预览区头像加载与显示

* **测试**
  * 新增紧凑布局尺寸变更与历史面板交互覆盖
  * 扩展页面路由与资源初始化验证

<!-- end of auto-generated comment: release notes by coderabbit.ai -->