### PR TITLE
polish: refine card companion glass UI

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -7511,6 +7511,15 @@ margin-top: 10px;
 /* 入口按钮上方已有 .btn.sm.ai-assist 样式，保留不动 */
 
 .card-companion-panel {
+    --companion-glass-border: rgba(255, 255, 255, 0.62);
+    --companion-glass-highlight: rgba(255, 255, 255, 0.9);
+    --companion-glass-shadow:
+        0 30px 76px rgba(11, 43, 66, 0.22),
+        0 16px 38px rgba(32, 70, 90, 0.08),
+        0 1px 0 rgba(255, 255, 255, 0.62) inset,
+        0 16px 36px rgba(255, 255, 255, 0.14) inset,
+        0 -24px 52px rgba(28, 95, 130, 0.12) inset,
+        0 0 0 1px rgba(255, 255, 255, 0.32) inset;
     position: fixed;
     top: 24px;
     right: 24px;
@@ -7520,10 +7529,18 @@ margin-top: 10px;
     height: min(720px, calc(100vh - 48px));
     min-height: min(360px, calc(100vh - 16px));
     max-height: calc(100vh - 16px);
-    background: linear-gradient(180deg, #ffffff 0%, #f8fcff 100%);
-    border: 2px solid #b3e5fc;
+    isolation: isolate;
+    background:
+        linear-gradient(116deg, rgba(255, 255, 255, 0.36) 0%, rgba(255, 255, 255, 0.08) 16%, transparent 38%),
+        radial-gradient(circle at 18% 4%, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0.06) 26%, transparent 50%),
+        radial-gradient(circle at 94% 86%, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.02) 28%, transparent 52%),
+        linear-gradient(145deg, rgba(255, 255, 255, 0.2), rgba(245, 248, 250, 0.055) 50%, rgba(255, 255, 255, 0.12)),
+        rgba(255, 255, 255, 0.07);
+    border: 1px solid var(--companion-glass-border);
     border-radius: 28px;
-    box-shadow: 0 18px 44px rgba(64, 197, 241, 0.24);
+    box-shadow: var(--companion-glass-shadow);
+    backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
+    -webkit-backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
     display: flex;
     flex-direction: column;
     z-index: 10100;
@@ -7533,6 +7550,40 @@ margin-top: 10px;
     transition: box-shadow 0.22s ease, background 0.22s ease, opacity 0.22s ease;
     resize: both;
     -webkit-app-region: no-drag;
+}
+
+.card-companion-panel::before,
+.card-companion-panel::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.card-companion-panel::before {
+    inset: 1px;
+    border-radius: 27px;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.54), rgba(255, 255, 255, 0.1) 16%, rgba(255, 255, 255, 0) 34%),
+        linear-gradient(315deg, rgba(255, 255, 255, 0.26), rgba(255, 255, 255, 0) 32%),
+        linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(245, 248, 250, 0.02) 44%, rgba(255, 255, 255, 0.08) 100%);
+    box-shadow:
+        inset 0 1px 0 var(--companion-glass-highlight),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.36),
+        inset 0 -1px 0 rgba(31, 146, 192, 0.2);
+    opacity: 0.86;
+}
+
+.card-companion-panel::after {
+    top: -42%;
+    left: -30%;
+    width: 70%;
+    height: 86%;
+    border-radius: 999px;
+    background: linear-gradient(118deg, rgba(255, 255, 255, 0.32), rgba(255, 255, 255, 0.05) 46%, transparent 68%);
+    filter: blur(1px);
+    transform: rotate(-18deg);
+    opacity: 0.78;
 }
 
 @keyframes cardCompanionWindowIn {
@@ -7586,6 +7637,12 @@ margin-top: 10px;
 
 .card-companion-panel.card-companion-minimized::before {
     inset: 3px;
+    top: 3px;
+    left: 3px;
+    width: auto;
+    height: auto;
+    transform: none;
+    filter: none;
     z-index: 2;
     background:
         radial-gradient(circle at 32% 22%, rgba(255, 255, 255, 0.7) 0 11%, rgba(255, 255, 255, 0) 30%),
@@ -7595,6 +7652,14 @@ margin-top: 10px;
 
 .card-companion-panel.card-companion-minimized::after {
     inset: 0;
+    top: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    transform: none;
+    filter: none;
+    background: transparent;
+    opacity: 1;
     z-index: 3;
     border: 1px solid rgba(255, 255, 255, 0.7);
     box-shadow: inset 0 -8px 14px rgba(64, 197, 241, 0.18);
@@ -7623,10 +7688,18 @@ margin-top: 10px;
 .card-companion-panel.card-companion-dragging {
     user-select: none;
     z-index: 100100;
-    box-shadow: 0 22px 52px rgba(64, 197, 241, 0.3);
+    box-shadow: 0 18px 42px rgba(11, 43, 66, 0.24);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
     animation-play-state: paused;
     will-change: left, top;
     transition: none;
+}
+
+.card-companion-panel.card-companion-dragging::before,
+.card-companion-panel.card-companion-dragging::after {
+    filter: none;
+    opacity: 0.38;
 }
 
 .card-companion-panel.card-companion-collapsing {
@@ -7694,18 +7767,33 @@ margin-top: 10px;
 }
 
 .card-companion-header {
+    position: relative;
+    z-index: 1;
     display: flex;
     align-items: center;
     gap: 12px;
     min-height: 76px;
     padding: 12px 18px 11px;
-    border-bottom: 2px solid #d5f2ff;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.46);
     background:
-        linear-gradient(135deg, rgba(224, 247, 255, 0.96), rgba(255, 255, 255, 0.98) 62%),
-        url('/static/icons/dropdown_item_hover_bg.png') center / cover no-repeat;
+        linear-gradient(135deg, rgba(255, 255, 255, 0.32), rgba(245, 251, 255, 0.1) 58%, rgba(255, 255, 255, 0.18)),
+        rgba(255, 255, 255, 0.1);
     flex-shrink: 0;
     cursor: grab;
     touch-action: none;
+    overflow: hidden;
+}
+
+.card-companion-header::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    height: 64%;
+    pointer-events: none;
+    background:
+        linear-gradient(112deg, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.08) 42%, transparent 68%),
+        radial-gradient(circle at 12% 0%, rgba(255, 255, 255, 0.42), transparent 34%);
+    opacity: 0.74;
 }
 
 .card-companion-panel.card-companion-dragging .card-companion-header {
@@ -7713,17 +7801,23 @@ margin-top: 10px;
 }
 
 .card-companion-avatar {
+    position: relative;
+    z-index: 1;
     width: 56px;
     height: 56px;
     border-radius: 50%;
     overflow: hidden;
     flex-shrink: 0;
-    background: linear-gradient(135deg, #e0f7ff, #b3e5fc);
+    background:
+        radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.78), transparent 38%),
+        linear-gradient(135deg, rgba(224, 247, 255, 0.72), rgba(179, 229, 252, 0.38));
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 2px solid rgba(179, 229, 252, 0.95);
-    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.78);
+    box-shadow:
+        0 8px 18px rgba(28, 120, 170, 0.13),
+        inset 0 1px 0 rgba(255, 255, 255, 0.72);
     cursor: pointer;
     transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
 }
@@ -7759,6 +7853,8 @@ margin-top: 10px;
 }
 
 .card-companion-title {
+    position: relative;
+    z-index: 1;
     flex: 1;
     min-width: 0;
 }
@@ -7778,6 +7874,8 @@ margin-top: 10px;
 }
 
 .card-companion-header-paw {
+    position: relative;
+    z-index: 1;
     width: 30px;
     height: 30px;
     object-fit: contain;
@@ -7786,8 +7884,10 @@ margin-top: 10px;
 }
 
 .card-companion-close {
+    position: relative;
+    z-index: 1;
     background: transparent;
-    border: none;
+    border: 1px solid transparent;
     width: 34px;
     height: 34px;
     border-radius: 999px;
@@ -7805,11 +7905,14 @@ margin-top: 10px;
 }
 
 .card-companion-close:hover {
-    background: rgba(64, 197, 241, 0.16);
+    background: rgba(255, 255, 255, 0.34);
+    border-color: rgba(255, 255, 255, 0.62);
     color: #27b8ea;
 }
 
 .card-companion-thread {
+    position: relative;
+    z-index: 1;
     flex: 1 1 auto;
     overflow-y: auto;
     padding: 18px 20px 22px;
@@ -7817,9 +7920,25 @@ margin-top: 10px;
     flex-direction: column;
     gap: 12px;
     background:
-        radial-gradient(circle at 18px 18px, rgba(179, 229, 252, 0.24) 0 2px, transparent 3px) 0 0 / 34px 34px,
-        linear-gradient(180deg, #ffffff 0%, #f5fcff 100%);
+        radial-gradient(circle at 18px 18px, rgba(255, 255, 255, 0.24) 0 2px, transparent 3px) 0 0 / 34px 34px,
+        linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(245, 251, 255, 0.045));
     min-height: 0;
+}
+
+.card-companion-thread::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 12% 8%, rgba(255, 255, 255, 0.18), transparent 34%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.16), transparent 28%);
+    opacity: 0.62;
+}
+
+.card-companion-thread > * {
+    position: relative;
+    z-index: 1;
 }
 
 .card-companion-thread::-webkit-scrollbar,
@@ -7855,7 +7974,9 @@ margin-top: 10px;
     line-height: 1.55;
     word-wrap: break-word;
     animation: cardCompanionBubbleIn 0.18s ease-out;
-    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.09);
+    box-shadow:
+        0 10px 22px rgba(28, 120, 170, 0.09),
+        inset 0 1px 0 rgba(255, 255, 255, 0.56);
 }
 
 @keyframes cardCompanionBubbleIn {
@@ -7865,19 +7986,27 @@ margin-top: 10px;
 
 .card-companion-bubble-assistant {
     align-self: flex-start;
-    background: #fff;
+    background:
+        linear-gradient(145deg, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.18)),
+        rgba(255, 255, 255, 0.22);
     color: #263241;
-    border: 2px solid #d5f2ff;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-bottom-left-radius: 8px;
+    backdrop-filter: blur(4px) saturate(1.08);
+    -webkit-backdrop-filter: blur(4px) saturate(1.08);
 }
 
 .card-companion-bubble-user {
     align-self: flex-end;
-    background: linear-gradient(135deg, #40C5F1, #6bdcff);
+    background:
+        linear-gradient(135deg, rgba(64, 197, 241, 0.86), rgba(107, 220, 255, 0.72)),
+        rgba(255, 255, 255, 0.12);
     color: #fff;
-    border: 2px solid rgba(255, 255, 255, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.78);
     border-bottom-right-radius: 8px;
-    box-shadow: 0 8px 18px rgba(64, 197, 241, 0.18);
+    box-shadow:
+        0 12px 24px rgba(64, 197, 241, 0.2),
+        inset 0 1px 0 rgba(255, 255, 255, 0.56);
 }
 
 .card-companion-bubble-system {
@@ -7921,9 +8050,9 @@ margin-top: 10px;
 }
 
 .card-companion-chip {
-    background: #f0fbff;
+    background: rgba(255, 255, 255, 0.3);
     color: #257da5;
-    border: 2px solid #b3e5fc;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-radius: 999px;
     padding: 4px 12px;
     font-size: 11.5px;
@@ -7951,12 +8080,12 @@ margin-top: 10px;
 .card-companion-bubble-custom-input {
     width: 100%;
     padding: 6px 12px;
-    border: 2px solid #b3e5fc;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-radius: 999px;
     font-size: 12px;
     box-sizing: border-box;
     font-family: inherit;
-    background: #fff;
+    background: rgba(255, 255, 255, 0.36);
     color: #257da5;
 }
 
@@ -7986,16 +8115,61 @@ margin-top: 10px;
 }
 
 .card-companion-input-bar {
-    border-top: 2px solid #d5f2ff;
+    position: relative;
+    z-index: 1;
+    border-top: 1px solid rgba(255, 255, 255, 0.46);
     padding: 16px 18px 18px;
-    background: linear-gradient(180deg, #f8fcff 0%, #ffffff 100%);
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.24)),
+        rgba(245, 251, 255, 0.06);
     flex-shrink: 0;
+    overflow: hidden;
+}
+
+.card-companion-input-bar::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    height: 54%;
+    pointer-events: none;
+    background: linear-gradient(112deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.05) 50%, transparent 76%);
+    opacity: 0.7;
+}
+
+.card-companion-input-bar::after {
+    content: "";
+    position: absolute;
+    left: 24px;
+    right: 24px;
+    bottom: 12px;
+    height: 38px;
+    pointer-events: none;
+    border-radius: 999px;
+    background: radial-gradient(ellipse at center, rgba(64, 197, 241, 0.24), rgba(64, 197, 241, 0) 68%);
+    filter: blur(10px);
+    opacity: 0.78;
 }
 
 .card-companion-input-row {
+    position: relative;
+    z-index: 1;
     display: flex;
     gap: 12px;
     align-items: flex-end;
+}
+
+.card-companion-input-row::before {
+    content: "";
+    position: absolute;
+    inset: -6px -7px;
+    pointer-events: none;
+    border-radius: 999px;
+    border: 1px solid rgba(125, 211, 252, 0.52);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(64, 197, 241, 0.08));
+    box-shadow:
+        0 0 0 2px rgba(64, 197, 241, 0.18),
+        0 10px 26px rgba(28, 120, 170, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.58);
 }
 
 .card-companion-input {
@@ -8003,7 +8177,7 @@ margin-top: 10px;
     min-height: 46px;
     max-height: 120px;
     padding: 11px 16px;
-    border: 2px solid #b3e5fc;
+    border: 1px solid rgba(125, 211, 252, 0.72);
     border-radius: 999px;
     font-size: 15px;
     box-sizing: border-box;
@@ -8012,13 +8186,24 @@ margin-top: 10px;
     line-height: 1.5;
     overflow-y: auto;
     color: #257da5;
-    background: #fff;
+    background: rgba(255, 255, 255, 0.46);
+    box-shadow:
+        0 0 0 2px rgba(64, 197, 241, 0.12),
+        0 10px 24px rgba(28, 120, 170, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.76);
+    backdrop-filter: blur(3px) saturate(1.08);
+    -webkit-backdrop-filter: blur(3px) saturate(1.08);
 }
 
 .card-companion-input:focus {
     outline: none;
     border-color: #40C5F1;
-    box-shadow: 0 0 0 3px rgba(64, 197, 241, 0.16);
+    background: rgba(255, 255, 255, 0.7);
+    box-shadow:
+        0 0 0 3px rgba(64, 197, 241, 0.2),
+        0 0 22px rgba(64, 197, 241, 0.32),
+        0 12px 28px rgba(28, 120, 170, 0.14),
+        inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
 .card-companion-input::placeholder {
@@ -8053,6 +8238,8 @@ margin-top: 10px;
 }
 
 .card-companion-quick-row {
+    position: relative;
+    z-index: 1;
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
@@ -8060,9 +8247,9 @@ margin-top: 10px;
 }
 
 .card-companion-quick-chip {
-    background: #f0fbff;
+    background: rgba(255, 255, 255, 0.34);
     color: #1686c2;
-    border: 2px solid #d5f2ff;
+    border: 1px solid rgba(255, 255, 255, 0.62);
     border-radius: 999px;
     padding: 5px 12px;
     font-size: 12px;
@@ -8092,7 +8279,22 @@ margin-top: 10px;
 }
 
 [data-theme="dark"] .card-companion-panel.card-companion-dragging {
-    box-shadow: 0 22px 56px rgba(0, 0, 0, 0.62);
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.58);
+}
+
+[data-theme="dark"] .card-companion-panel::before {
+    background:
+        linear-gradient(135deg, rgba(125, 211, 252, 0.12), rgba(15, 23, 42, 0.08) 22%, rgba(15, 23, 42, 0) 42%),
+        linear-gradient(315deg, rgba(125, 211, 252, 0.07), rgba(15, 23, 42, 0) 38%);
+    box-shadow:
+        inset 0 1px 0 rgba(148, 197, 223, 0.24),
+        inset 0 0 0 1px rgba(125, 211, 252, 0.12);
+    opacity: 0.56;
+}
+
+[data-theme="dark"] .card-companion-panel::after {
+    background: linear-gradient(118deg, rgba(125, 211, 252, 0.12), rgba(125, 211, 252, 0.03) 46%, transparent 68%);
+    opacity: 0.42;
 }
 
 [data-theme="dark"] .card-companion-header {
@@ -8100,6 +8302,13 @@ margin-top: 10px;
         linear-gradient(135deg, rgba(14, 116, 144, 0.24), rgba(15, 23, 42, 0.98) 62%),
         url('/static/icons/dropdown_item_hover_bg.png') center / cover no-repeat;
     border-bottom-color: rgba(125, 211, 252, 0.2);
+}
+
+[data-theme="dark"] .card-companion-header::before {
+    background:
+        linear-gradient(112deg, rgba(125, 211, 252, 0.12), rgba(15, 23, 42, 0.04) 44%, transparent 70%),
+        radial-gradient(circle at 12% 0%, rgba(125, 211, 252, 0.1), transparent 36%);
+    opacity: 0.48;
 }
 
 [data-theme="dark"] .card-companion-name { color: #e5e7eb; }
@@ -8127,6 +8336,13 @@ margin-top: 10px;
     background:
         radial-gradient(circle at 18px 18px, rgba(56, 189, 248, 0.08) 0 2px, transparent 3px) 0 0 / 34px 34px,
         linear-gradient(180deg, #111827 0%, #101d2a 100%);
+}
+
+[data-theme="dark"] .card-companion-thread::before {
+    background:
+        radial-gradient(circle at 12% 8%, rgba(125, 211, 252, 0.08), transparent 34%),
+        linear-gradient(180deg, rgba(125, 211, 252, 0.05), transparent 30%);
+    opacity: 0.42;
 }
 
 [data-theme="dark"] .card-companion-bubble-assistant {
@@ -8177,6 +8393,25 @@ margin-top: 10px;
 [data-theme="dark"] .card-companion-input-bar {
     background: linear-gradient(180deg, #101d2a 0%, #0f172a 100%);
     border-top-color: rgba(125, 211, 252, 0.2);
+}
+
+[data-theme="dark"] .card-companion-input-bar::before {
+    background: linear-gradient(112deg, rgba(125, 211, 252, 0.08), rgba(15, 23, 42, 0.04) 52%, transparent 78%);
+    opacity: 0.42;
+}
+
+[data-theme="dark"] .card-companion-input-bar::after {
+    background: radial-gradient(ellipse at center, rgba(56, 189, 248, 0.14), rgba(56, 189, 248, 0) 68%);
+    opacity: 0.52;
+}
+
+[data-theme="dark"] .card-companion-input-row::before {
+    border-color: rgba(125, 211, 252, 0.28);
+    background: linear-gradient(135deg, rgba(125, 211, 252, 0.08), rgba(15, 23, 42, 0.14));
+    box-shadow:
+        0 0 0 2px rgba(56, 189, 248, 0.1),
+        0 10px 24px rgba(0, 0, 0, 0.28),
+        inset 0 1px 0 rgba(125, 211, 252, 0.18);
 }
 
 [data-theme="dark"] .card-companion-input {

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -1611,8 +1611,8 @@ def test_character_card_manager_card_assist_avatar_toggles_companion(
     assert state["titleDisplayWhenMinimized"] == "none"
     assert state["closeDisplayWhenMinimized"] == "none"
     assert state["avatarSrc"].endswith("/api/characters/catgirl/YUI/card-face")
-    assert state["avatarImgObjectPosition"] == "50% 8%"
-    assert state["avatarImgTransform"] == "matrix(1.02, 0, 0, 1.02, 0, 3)"
+    assert state["avatarImgObjectPosition"] == "50% 46%"
+    assert state["avatarImgTransform"] == "matrix(1, 0, 0, 1, 0, 5)"
     assert state["avatarRole"] == "button"
     assert state["avatarTabIndex"] == "0"
     assert state["ariaAfterFirstClick"] == "false"

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1216,6 +1216,35 @@ def test_character_card_manager_cloudsave_button_uses_icon_badge():
         assert expected in css_source
 
 
+def test_character_card_companion_uses_liquid_glass_surface():
+    css_source = Path("static/css/character_card_manager.css").read_text(encoding="utf-8")
+
+    for expected in (
+        "--companion-glass-border",
+        "--companion-glass-highlight",
+        ".card-companion-panel::before",
+        ".card-companion-panel::after",
+        "backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);",
+        "inset 0 1px 0 var(--companion-glass-highlight)",
+        ".card-companion-header::before",
+        ".card-companion-thread::before",
+        ".card-companion-input-bar::before",
+        ".card-companion-input-row::before",
+        "0 0 0 2px rgba(64, 197, 241, 0.18)",
+        ".card-companion-panel.card-companion-dragging::before",
+        ".card-companion-panel.card-companion-dragging::after",
+        "backdrop-filter: none;",
+        "[data-theme=\"dark\"] .card-companion-panel::before",
+        "[data-theme=\"dark\"] .card-companion-panel::after",
+        "[data-theme=\"dark\"] .card-companion-header::before",
+        "[data-theme=\"dark\"] .card-companion-thread::before",
+        "[data-theme=\"dark\"] .card-companion-input-bar::before",
+        "[data-theme=\"dark\"] .card-companion-input-bar::after",
+        "[data-theme=\"dark\"] .card-companion-input-row::before",
+    ):
+        assert expected in css_source
+
+
 def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
     avatar_reload_source = Path("static/tutorial-avatar-reload-controller.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- 将猫猫辅助生成面板调整为液态玻璃风格，补充透明质感、反光、高光边缘和拖拽态阴影。
- 强化猫猫辅助生成输入区域的高亮与层级，让用户更容易看到可输入位置。
- 微调辅助面板头像裁切，并同步更新回归测试断言。

## Test Plan
- [x] `git diff --check`
- [x] `uv run pytest tests/test_agent_rewrite_regression.py::test_character_card_companion_uses_liquid_glass_surface tests/frontend/test_character_card_manager_regressions.py::test_character_card_manager_card_assist_avatar_toggles_companion`

## Scope
- 仅包含猫猫辅助生成面板 UI 与对应测试，不包含人格选择弹框和 Web/full chat 改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **视觉改进**
  * 全面引入玻璃拟态面板视觉：多层渐变、高光与阴影，增强面板、头部、头像及气泡的层次感。
  * 优化最小化与拖拽交互下的装饰一致性与视觉反馈；输入区 focus 态与快速芯片视觉细化。
  * 深色模式下同步调整玻璃纹理与阴影语义。

* **测试**
  * 更新伴侣头像位置相关断言预期值。
  * 新增“液态玻璃”视觉样式验证测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->