### PR TITLE
fix(chat): sync desktop cat during compact resize

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1137,6 +1137,14 @@
             if (phase === 'end') {
                 compactSurfaceResizeSession = null;
             }
+            window.dispatchEvent(new CustomEvent('neko:compact-surface-layout-change', {
+                detail: {
+                    screenRect: detail.screenRect,
+                    resizeActive: phase !== 'end',
+                    dragging: false,
+                    reason: phase === 'end' ? 'resize-end' : 'resize'
+                }
+            }));
             return;
         }
         var currentRect = getCurrentCompactSurfaceRect();

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2134,14 +2134,16 @@ function _scheduleNekoIdleCompactSurfaceSettledSync(delayMs) {
 
 function _handleNekoIdleCompactSurfaceMoveState(detail) {
     const dragging = !!(detail && detail.dragging);
+    const resizeActive = !!(detail && detail.resizeActive);
+    const activeSurfaceAdjustment = dragging || resizeActive;
     const heartbeat = !!(detail && detail.heartbeat);
-    _nekoIdleCompactSurfaceDragging = dragging;
+    _nekoIdleCompactSurfaceDragging = activeSurfaceAdjustment;
     const followedCompactSurface = _syncNekoIdleCat1CompactTopEdgeSurfaceFollow(detail);
     if (!heartbeat) {
-        _interruptNekoIdleCat1PairMovesForRetarget({ scheduleSync: !dragging });
+        _interruptNekoIdleCat1PairMovesForRetarget({ scheduleSync: !activeSurfaceAdjustment });
     }
     if (heartbeat) return;
-    if (dragging) {
+    if (activeSurfaceAdjustment) {
         if (_nekoIdleCompactSurfaceSettleTimer) {
             clearTimeout(_nekoIdleCompactSurfaceSettleTimer);
             _nekoIdleCompactSurfaceSettleTimer = 0;
@@ -2290,6 +2292,9 @@ function _syncNekoIdleCat1CompactTopEdgeSurfaceFollow(detail) {
     const surfaceRect = _getNekoIdleCompactSurfaceFollowRect(detail);
     if (!surfaceRect) return false;
     const nowMs = _getNekoIdleNowMs();
+    const dragging = !!(detail && detail.dragging);
+    const resizeActive = !!(detail && detail.resizeActive);
+    const activeSurfaceAdjustment = dragging || resizeActive;
     let handled = false;
 
     _forEachNekoIdleReturnButton((button) => {
@@ -2313,7 +2318,7 @@ function _syncNekoIdleCat1CompactTopEdgeSurfaceFollow(detail) {
         }
 
         const motion = _getNekoIdleCat1CompactFollowSpeed(state, surfaceRect, nowMs);
-        const fastMove = motion.hasPrevious && (
+        const fastMove = !resizeActive && motion.hasPrevious && (
             motion.speedPxPerSec > _NEKO_IDLE_CAT1_COMPACT_TOP_EDGE_STICK_MAX_SPEED_PX_PER_SEC ||
             (motion.elapsedMs <= 240 && motion.distancePx > _NEKO_IDLE_CAT1_COMPACT_TOP_EDGE_STICK_MAX_STEP_PX)
         );
@@ -2341,9 +2346,9 @@ function _syncNekoIdleCat1CompactTopEdgeSurfaceFollow(detail) {
         _setNekoIdleCat1ContainerPosition(container, target.left, target.top);
         _setNekoIdleCat1Classes(button, state);
         _reassertNekoIdleCat1LayerForFollow(container);
-        if (detail && detail.dragging) {
+        if (activeSurfaceAdjustment) {
             _setNekoIdleCat1CompactMirrorActive(button, container, true, {
-                reason: 'compact-surface-drag',
+                reason: resizeActive ? 'compact-surface-resize' : 'compact-surface-drag',
                 surfaceRect: surfaceRect,
                 target: target
             });

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -359,6 +359,44 @@ def test_cat1_compact_mirror_uses_stable_native_reserve_rect():
     assert "nativeRect: mirrorNativeRect || mirrorRect" in collect_block
 
 
+def test_desktop_compact_resize_broadcasts_surface_state_for_cat1_follow():
+    source = _read(APP_REACT_CHAT_WINDOW_PATH)
+
+    resize_block = _between(
+        source,
+        "function applyCompactSurfaceResizeRequest(detail) {",
+        "function getCompactSurfaceTarget(layoutOverride) {",
+    )
+    assert "isElectronChatWindow() && detail && detail.screenRect" in resize_block
+    assert "new CustomEvent('neko:compact-surface-layout-change'" in resize_block
+    assert "screenRect: detail.screenRect" in resize_block
+    assert "resizeActive: phase !== 'end'" in resize_block
+    assert "reason: phase === 'end' ? 'resize-end' : 'resize'" in resize_block
+
+
+def test_cat1_compact_follow_treats_resize_as_active_surface_adjustment():
+    source = _read(AVATAR_UI_BUTTONS_PATH)
+
+    move_state_block = _between(
+        source,
+        "function _handleNekoIdleCompactSurfaceMoveState(detail) {",
+        "function _shouldRecheckNekoIdleCat1AfterManualMove(detail) {",
+    )
+    assert "const resizeActive = !!(detail && detail.resizeActive);" in move_state_block
+    assert "const activeSurfaceAdjustment = dragging || resizeActive;" in move_state_block
+    assert "_nekoIdleCompactSurfaceDragging = activeSurfaceAdjustment;" in move_state_block
+    assert "_interruptNekoIdleCat1PairMovesForRetarget({ scheduleSync: !activeSurfaceAdjustment });" in move_state_block
+
+    follow_block = _between(
+        source,
+        "function _syncNekoIdleCat1CompactTopEdgeSurfaceFollow(detail) {",
+        "function _isNekoIdleCat1Walking(button) {",
+    )
+    assert "const resizeActive = !!(detail && detail.resizeActive);" in follow_block
+    assert "const fastMove = !resizeActive && motion.hasPrevious" in follow_block
+    assert "reason: resizeActive ? 'compact-surface-resize' : 'compact-surface-drag'" in follow_block
+
+
 def test_idle_dock_uses_mutation_observer_to_detect_minimize_completion():
     source = _read(APP_REACT_CHAT_WINDOW_PATH)
 


### PR DESCRIPTION
修复桌面端 compact 聊天框缩放时，CAT1 已贴附在聊天框上缘但松手前不跟随的问题。

桌面 resize 现在会把实时 screenRect 广播给 pet 页，CAT1 compact-top-edge 将 resizeActive 视为活动中的 surface 调整并同步镜像位置；缩放期间禁用快速甩落判定，避免宽度变化被误判。

补充静态测试锁定桌面 resize 广播与 CAT1 resize 跟随合同。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **功能改进**
  * 优化了聊天窗口在调整大小时的布局状态通知机制，确保调整完成时能够准确广播状态更新。
  * 改进了用户交互处理，现在对拖拽和调整大小操作进行统一的识别与响应。

* **测试**
  * 新增单元测试覆盖窗口调整大小的状态广播功能。
  * 新增单元测试验证表面调整操作的识别逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->