### PR TITLE
fix(cat): stop minimized ball contact jitter

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -68,11 +68,15 @@ jobs:
         # affected tests mock or skip that cohort.
         run: uv sync
 
-      - name: Run plugin and static contract tests
+      - name: Run plugin test suite
         # Explicit path (not bare `pytest` under plugin/tests): passing the
         # directory overrides the testpaths whitelist in plugin/tests/
         # pytest.ini, so unit/plugins — where the silent drift lived — is
         # collected too.
-        # The avatar static contract lives under repo-root tests/, so list it
-        # explicitly instead of relying on plugin/tests discovery.
-        run: uv run pytest plugin/tests tests/unit/test_avatar_return_button_idle_tiers_static.py -q
+        run: uv run pytest plugin/tests -q
+
+      - name: Run avatar static contract tests
+        # Keep this in a separate pytest process so plugin/tests continues to
+        # use its own pytest.ini while repo-root static contracts are still
+        # covered by CI.
+        run: uv run pytest tests/unit/test_avatar_return_button_idle_tiers_static.py -q

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -10,6 +10,8 @@ on:
     branches: [main]
     paths:
       - 'plugin/**'
+      - 'static/avatar-ui-buttons.js'
+      - 'tests/unit/test_avatar_return_button_idle_tiers_static.py'
       - '.github/workflows/plugin-tests.yml'
       # Dependency changes alter the plugin test/runtime environment (e.g.
       # removing a dev dep plugin/tests needs) — without these a deps-only
@@ -20,6 +22,8 @@ on:
     branches: [main]
     paths:
       - 'plugin/**'
+      - 'static/avatar-ui-buttons.js'
+      - 'tests/unit/test_avatar_return_button_idle_tiers_static.py'
       - '.github/workflows/plugin-tests.yml'
       - 'pyproject.toml'
       - 'uv.lock'
@@ -64,9 +68,11 @@ jobs:
         # affected tests mock or skip that cohort.
         run: uv sync
 
-      - name: Run plugin test suite
+      - name: Run plugin and static contract tests
         # Explicit path (not bare `pytest` under plugin/tests): passing the
         # directory overrides the testpaths whitelist in plugin/tests/
         # pytest.ini, so unit/plugins — where the silent drift lived — is
         # collected too.
-        run: uv run pytest plugin/tests -q
+        # The avatar static contract lives under repo-root tests/, so list it
+        # explicitly instead of relying on plugin/tests discovery.
+        run: uv run pytest plugin/tests tests/unit/test_avatar_return_button_idle_tiers_static.py -q

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2599,45 +2599,6 @@ function _getNekoIdleCat1TargetMoveDirection(rect, targetLeft) {
     return dx > 0;
 }
 
-function _getNekoIdleRectDirectionalOverlapPx(rect, targetRect, facingRight) {
-    if (!rect || !targetRect) {
-        return -Infinity;
-    }
-    const left = Number(rect.left);
-    const top = Number(rect.top);
-    const width = Number(rect.width);
-    const height = Number(rect.height);
-    const targetLeft = Number(targetRect.left);
-    const targetTop = Number(targetRect.top);
-    const targetWidth = Number(targetRect.width);
-    const targetHeight = Number(targetRect.height);
-    if (!Number.isFinite(left) || !Number.isFinite(top) ||
-        !Number.isFinite(width) || !Number.isFinite(height) ||
-        !Number.isFinite(targetLeft) || !Number.isFinite(targetTop) ||
-        !Number.isFinite(targetWidth) || !Number.isFinite(targetHeight) ||
-        width <= 0 || height <= 0 || targetWidth <= 0 || targetHeight <= 0) {
-        return -Infinity;
-    }
-
-    const right = Number.isFinite(Number(rect.right)) ? Number(rect.right) : left + width;
-    const bottom = Number.isFinite(Number(rect.bottom)) ? Number(rect.bottom) : top + height;
-    const targetRight = Number.isFinite(Number(targetRect.right)) ? Number(targetRect.right) : targetLeft + targetWidth;
-    const targetBottom = Number.isFinite(Number(targetRect.bottom)) ? Number(targetRect.bottom) : targetTop + targetHeight;
-    const verticalOverlap = Math.min(bottom, targetBottom) - Math.max(top, targetTop);
-    if (verticalOverlap <= 0) return -Infinity;
-    return facingRight
-        ? right - targetLeft
-        : targetRight - left;
-}
-
-function _getNekoIdleCat1MinimizedContactTargetOverlapPx(facingRight, approachOffsetPx, profile) {
-    const gapPx = Number(profile && profile.target && profile.target.gapPx) || 0;
-    const targetOverlapPx = facingRight
-        ? -gapPx
-        : Math.max(0, Number(approachOffsetPx) || 0) - gapPx;
-    return Math.max(0, targetOverlapPx);
-}
-
 function _resolveNekoIdleCat1TargetFacing(rect, target) {
     if (!target) return false;
     const moveFacingRight = _getNekoIdleCat1TargetMoveDirection(rect, target.left);
@@ -2682,7 +2643,32 @@ function _makeNekoIdleCat1SideTarget(rect, chatRect, options) {
     };
 }
 
-function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options) {
+function _isNekoIdleRectCenterInsideRect(innerRect, outerRect) {
+    if (!innerRect || !outerRect) return false;
+    const innerLeft = Number(innerRect.left);
+    const innerTop = Number(innerRect.top);
+    const innerWidth = Number(innerRect.width);
+    const innerHeight = Number(innerRect.height);
+    const outerLeft = Number(outerRect.left);
+    const outerTop = Number(outerRect.top);
+    const outerWidth = Number(outerRect.width);
+    const outerHeight = Number(outerRect.height);
+    if (!Number.isFinite(innerLeft) || !Number.isFinite(innerTop) ||
+        !Number.isFinite(innerWidth) || !Number.isFinite(innerHeight) ||
+        !Number.isFinite(outerLeft) || !Number.isFinite(outerTop) ||
+        !Number.isFinite(outerWidth) || !Number.isFinite(outerHeight) ||
+        innerWidth <= 0 || innerHeight <= 0 || outerWidth <= 0 || outerHeight <= 0) {
+        return false;
+    }
+    const outerRight = Number.isFinite(Number(outerRect.right)) ? Number(outerRect.right) : outerLeft + outerWidth;
+    const outerBottom = Number.isFinite(Number(outerRect.bottom)) ? Number(outerRect.bottom) : outerTop + outerHeight;
+    const innerCenterX = innerLeft + innerWidth / 2;
+    const innerCenterY = innerTop + innerHeight / 2;
+    return innerCenterX >= outerLeft && innerCenterX <= outerRight &&
+        innerCenterY >= outerTop && innerCenterY <= outerBottom;
+}
+
+function _makeNekoIdleCat1CurrentSideTarget(rect, chatRect, options) {
     const facingRight = !!(options && options.facingRight);
     return {
         left: rect.left,
@@ -2706,12 +2692,6 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
     const chatCenterX = chatRect.left + chatRect.width / 2;
     const lookFacingRight = chatCenterX > catCenterX;
     const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);
-    const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);
-    const targetContactOverlapPx = _getNekoIdleCat1MinimizedContactTargetOverlapPx(
-        lookFacingRight,
-        approachOffsetPx,
-        profile
-    );
     const rawLeft = lookFacingRight
         ? chatRect.left - rect.width - profile.target.gapPx
         : chatRect.right + profile.target.gapPx - approachOffsetPx;
@@ -2720,14 +2700,11 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
         rawLeft: rawLeft,
         approachOffsetPx: approachOffsetPx
     });
-    const exitDistancePx = Math.max(0, Number(profile.target && profile.target.exitDistancePx) || 0);
-    const verticalTargetDistancePx = sideTarget
-        ? Math.abs(Number(sideTarget.top) - Number(rect.top))
-        : Infinity;
-    const horizontalTargetDistancePx = Math.max(0, targetContactOverlapPx - contactOverlapPx);
-    const contactTargetDistancePx = Math.hypot(horizontalTargetDistancePx, verticalTargetDistancePx);
-    if (contactTargetDistancePx <= exitDistancePx) {
-        return _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, {
+    if (_isNekoIdleRectCenterInsideRect(chatRect, rect) &&
+        sideTarget &&
+        sideTarget.moveFacingRight !== null &&
+        sideTarget.moveFacingRight !== lookFacingRight) {
+        return _makeNekoIdleCat1CurrentSideTarget(rect, chatRect, {
             facingRight: lookFacingRight
         });
     }

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2599,6 +2599,46 @@ function _getNekoIdleCat1TargetMoveDirection(rect, targetLeft) {
     return dx > 0;
 }
 
+function _getNekoIdleRectDirectionalOverlapPx(rect, targetRect, facingRight) {
+    if (!rect || !targetRect) {
+        return -Infinity;
+    }
+    const left = Number(rect.left);
+    const top = Number(rect.top);
+    const width = Number(rect.width);
+    const height = Number(rect.height);
+    const targetLeft = Number(targetRect.left);
+    const targetTop = Number(targetRect.top);
+    const targetWidth = Number(targetRect.width);
+    const targetHeight = Number(targetRect.height);
+    if (!Number.isFinite(left) || !Number.isFinite(top) ||
+        !Number.isFinite(width) || !Number.isFinite(height) ||
+        !Number.isFinite(targetLeft) || !Number.isFinite(targetTop) ||
+        !Number.isFinite(targetWidth) || !Number.isFinite(targetHeight) ||
+        width <= 0 || height <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+        return -Infinity;
+    }
+
+    const right = Number.isFinite(Number(rect.right)) ? Number(rect.right) : left + width;
+    const bottom = Number.isFinite(Number(rect.bottom)) ? Number(rect.bottom) : top + height;
+    const targetRight = Number.isFinite(Number(targetRect.right)) ? Number(targetRect.right) : targetLeft + targetWidth;
+    const targetBottom = Number.isFinite(Number(targetRect.bottom)) ? Number(targetRect.bottom) : targetTop + targetHeight;
+    const verticalOverlap = Math.min(bottom, targetBottom) - Math.max(top, targetTop);
+    if (verticalOverlap <= 0) return -Infinity;
+    return facingRight
+        ? right - targetLeft
+        : targetRight - left;
+}
+
+function _getNekoIdleCat1MinimizedContactOverlapPx(facingRight, approachOffsetPx, profile) {
+    const gapPx = Number(profile && profile.target && profile.target.gapPx) || 0;
+    const exitDistancePx = Math.max(0, Number(profile && profile.target && profile.target.exitDistancePx) || 0);
+    const targetOverlapPx = facingRight
+        ? -gapPx
+        : Math.max(0, Number(approachOffsetPx) || 0) - gapPx;
+    return Math.max(0, targetOverlapPx - exitDistancePx);
+}
+
 function _resolveNekoIdleCat1TargetFacing(rect, target) {
     if (!target) return false;
     const moveFacingRight = _getNekoIdleCat1TargetMoveDirection(rect, target.left);
@@ -2643,6 +2683,20 @@ function _makeNekoIdleCat1SideTarget(rect, chatRect, options) {
     };
 }
 
+function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options) {
+    const facingRight = !!(options && options.facingRight);
+    return {
+        left: rect.left,
+        top: rect.top,
+        distance: 0,
+        facingRight: facingRight,
+        lookFacingRight: facingRight,
+        moveFacingRight: null,
+        approachOffsetPx: _getNekoIdleCat1MinimizedSideApproachOffsetPx(facingRight, chatRect),
+        kind: _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE
+    };
+}
+
 function _getNekoIdleCat1SideTarget(container, chatRect) {
     if (!container || !chatRect || typeof container.getBoundingClientRect !== 'function') return null;
     const profile = _NEKO_IDLE_RETURN_SUBACTION_CAT1_CHAT_FOLLOW;
@@ -2653,6 +2707,18 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
     const chatCenterX = chatRect.left + chatRect.width / 2;
     const lookFacingRight = chatCenterX > catCenterX;
     const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);
+    const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);
+    const requiredContactOverlapPx = _getNekoIdleCat1MinimizedContactOverlapPx(
+        lookFacingRight,
+        approachOffsetPx,
+        profile
+    );
+    if (contactOverlapPx >= requiredContactOverlapPx) {
+        return _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, {
+            facingRight: lookFacingRight
+        });
+    }
+
     const rawLeft = lookFacingRight
         ? chatRect.left - rect.width - profile.target.gapPx
         : chatRect.right + profile.target.gapPx - approachOffsetPx;

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2630,13 +2630,12 @@ function _getNekoIdleRectDirectionalOverlapPx(rect, targetRect, facingRight) {
         : targetRight - left;
 }
 
-function _getNekoIdleCat1MinimizedContactOverlapPx(facingRight, approachOffsetPx, profile) {
+function _getNekoIdleCat1MinimizedContactTargetOverlapPx(facingRight, approachOffsetPx, profile) {
     const gapPx = Number(profile && profile.target && profile.target.gapPx) || 0;
-    const exitDistancePx = Math.max(0, Number(profile && profile.target && profile.target.exitDistancePx) || 0);
     const targetOverlapPx = facingRight
         ? -gapPx
         : Math.max(0, Number(approachOffsetPx) || 0) - gapPx;
-    return Math.max(0, targetOverlapPx - exitDistancePx);
+    return Math.max(0, targetOverlapPx);
 }
 
 function _resolveNekoIdleCat1TargetFacing(rect, target) {
@@ -2708,7 +2707,7 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
     const lookFacingRight = chatCenterX > catCenterX;
     const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);
     const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);
-    const requiredContactOverlapPx = _getNekoIdleCat1MinimizedContactOverlapPx(
+    const targetContactOverlapPx = _getNekoIdleCat1MinimizedContactTargetOverlapPx(
         lookFacingRight,
         approachOffsetPx,
         profile
@@ -2725,8 +2724,9 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
     const verticalTargetDistancePx = sideTarget
         ? Math.abs(Number(sideTarget.top) - Number(rect.top))
         : Infinity;
-    if (verticalTargetDistancePx <= exitDistancePx &&
-        contactOverlapPx >= requiredContactOverlapPx) {
+    const horizontalTargetDistancePx = Math.max(0, targetContactOverlapPx - contactOverlapPx);
+    const contactTargetDistancePx = Math.hypot(horizontalTargetDistancePx, verticalTargetDistancePx);
+    if (contactTargetDistancePx <= exitDistancePx) {
         return _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, {
             facingRight: lookFacingRight
         });

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2713,12 +2713,6 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
         approachOffsetPx,
         profile
     );
-    if (contactOverlapPx >= requiredContactOverlapPx) {
-        return _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, {
-            facingRight: lookFacingRight
-        });
-    }
-
     const rawLeft = lookFacingRight
         ? chatRect.left - rect.width - profile.target.gapPx
         : chatRect.right + profile.target.gapPx - approachOffsetPx;
@@ -2727,6 +2721,16 @@ function _getNekoIdleCat1SideTarget(container, chatRect) {
         rawLeft: rawLeft,
         approachOffsetPx: approachOffsetPx
     });
+    const exitDistancePx = Math.max(0, Number(profile.target && profile.target.exitDistancePx) || 0);
+    const verticalTargetDistancePx = sideTarget
+        ? Math.abs(Number(sideTarget.top) - Number(rect.top))
+        : Infinity;
+    if (verticalTargetDistancePx <= exitDistancePx &&
+        contactOverlapPx >= requiredContactOverlapPx) {
+        return _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, {
+            facingRight: lookFacingRight
+        });
+    }
     if (!sideTarget || sideTarget.moveFacingRight === null || sideTarget.moveFacingRight === lookFacingRight) {
         return sideTarget;
     }

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1183,54 +1183,52 @@ def test_return_button_local_no_move_release_clears_pending_drag_state():
     )
 
 
-def test_cat1_minimized_ball_contact_finishes_without_side_retarget_jitter():
+def test_cat1_minimized_ball_inside_cat_finishes_without_side_retarget_jitter():
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
-    assert "function _getNekoIdleRectDirectionalOverlapPx(rect, targetRect, facingRight)" in source
-    assert "function _getNekoIdleCat1MinimizedContactTargetOverlapPx(facingRight, approachOffsetPx, profile)" in source
-    assert "function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options)" in source
+    assert "function _isNekoIdleRectCenterInsideRect(innerRect, outerRect)" in source
+    assert "function _makeNekoIdleCat1CurrentSideTarget(rect, chatRect, options)" in source
+    assert "function _getNekoIdleRectDirectionalOverlapPx" not in source
+    assert "function _getNekoIdleCat1MinimizedContactTargetOverlapPx" not in source
 
     side_target_block = source.split("function _getNekoIdleCat1SideTarget(container, chatRect)", 1)[1].split(
         "function _getNekoIdleCat1CompactTopEdgeBounds",
         1,
     )[0]
     assert "const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);" in side_target_block
-    assert "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);" in side_target_block
-    assert "const targetContactOverlapPx = _getNekoIdleCat1MinimizedContactTargetOverlapPx(" in side_target_block
-    assert "const verticalTargetDistancePx = sideTarget" in side_target_block
-    assert "Math.abs(Number(sideTarget.top) - Number(rect.top))" in side_target_block
-    assert "const horizontalTargetDistancePx = Math.max(0, targetContactOverlapPx - contactOverlapPx);" in side_target_block
-    assert "const contactTargetDistancePx = Math.hypot(horizontalTargetDistancePx, verticalTargetDistancePx);" in side_target_block
-    assert "contactTargetDistancePx <= exitDistancePx" in side_target_block
+    assert "const sideTarget = _makeNekoIdleCat1SideTarget(rect, chatRect" in side_target_block
+    assert "_isNekoIdleRectCenterInsideRect(chatRect, rect)" in side_target_block
+    assert "sideTarget.moveFacingRight !== lookFacingRight" in side_target_block
+    assert "_makeNekoIdleCat1CurrentSideTarget(rect, chatRect" in side_target_block
     assert "contactDistance <= profile.target.exitDistancePx" not in side_target_block
-    assert "_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect" in side_target_block
     assert side_target_block.index("const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);") < side_target_block.index(
-        "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);"
+        "const rawLeft = lookFacingRight"
     )
     assert side_target_block.index("const rawLeft = lookFacingRight") < side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget")
-    assert side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget") < side_target_block.index("const contactTargetDistancePx = Math.hypot")
-    assert side_target_block.index("contactTargetDistancePx <= exitDistancePx") < side_target_block.index("_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect")
+    assert side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget") < side_target_block.index("_isNekoIdleRectCenterInsideRect(chatRect, rect)")
+    assert side_target_block.index("sideTarget.moveFacingRight !== lookFacingRight") < side_target_block.index("_makeNekoIdleCat1CurrentSideTarget(rect, chatRect")
+    assert side_target_block.index("_isNekoIdleRectCenterInsideRect(chatRect, rect)") < side_target_block.index("if (!sideTarget || sideTarget.moveFacingRight === null || sideTarget.moveFacingRight === lookFacingRight)")
 
-    contact_overlap_block = source.split("function _getNekoIdleCat1MinimizedContactTargetOverlapPx(facingRight, approachOffsetPx, profile)", 1)[1].split(
-        "function _resolveNekoIdleCat1TargetFacing",
+    center_inside_block = source.split("function _isNekoIdleRectCenterInsideRect(innerRect, outerRect)", 1)[1].split(
+        "function _makeNekoIdleCat1CurrentSideTarget",
         1,
     )[0]
-    assert "const targetOverlapPx = facingRight" in contact_overlap_block
-    assert "? -gapPx" in contact_overlap_block
-    assert ": Math.max(0, Number(approachOffsetPx) || 0) - gapPx" in contact_overlap_block
-    assert "return Math.max(0, targetOverlapPx);" in contact_overlap_block
+    assert "const innerCenterX = innerLeft + innerWidth / 2;" in center_inside_block
+    assert "const innerCenterY = innerTop + innerHeight / 2;" in center_inside_block
+    assert "return innerCenterX >= outerLeft && innerCenterX <= outerRight &&" in center_inside_block
+    assert "innerCenterY >= outerTop && innerCenterY <= outerBottom;" in center_inside_block
 
-    contact_target_block = source.split("function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options)", 1)[1].split(
+    current_target_block = source.split("function _makeNekoIdleCat1CurrentSideTarget(rect, chatRect, options)", 1)[1].split(
         "function _getNekoIdleCat1SideTarget",
         1,
     )[0]
-    assert "left: rect.left" in contact_target_block
-    assert "top: rect.top" in contact_target_block
-    assert "distance: 0" in contact_target_block
-    assert "moveFacingRight: null" in contact_target_block
-    assert "approachOffsetPx" in contact_target_block
-    assert "approachOffsetPx: _getNekoIdleCat1MinimizedSideApproachOffsetPx(facingRight, chatRect)" in contact_target_block
-    assert "kind: _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in contact_target_block
+    assert "left: rect.left" in current_target_block
+    assert "top: rect.top" in current_target_block
+    assert "distance: 0" in current_target_block
+    assert "moveFacingRight: null" in current_target_block
+    assert "approachOffsetPx" in current_target_block
+    assert "approachOffsetPx: _getNekoIdleCat1MinimizedSideApproachOffsetPx(facingRight, chatRect)" in current_target_block
+    assert "kind: _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in current_target_block
 
 
 def test_return_button_idle_tier_assets_are_version_tracked():

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1197,13 +1197,18 @@ def test_cat1_minimized_ball_contact_finishes_without_side_retarget_jitter():
     assert "const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);" in side_target_block
     assert "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);" in side_target_block
     assert "const requiredContactOverlapPx = _getNekoIdleCat1MinimizedContactOverlapPx(" in side_target_block
+    assert "const verticalTargetDistancePx = sideTarget" in side_target_block
+    assert "Math.abs(Number(sideTarget.top) - Number(rect.top))" in side_target_block
+    assert "verticalTargetDistancePx <= exitDistancePx" in side_target_block
     assert "contactOverlapPx >= requiredContactOverlapPx" in side_target_block
     assert "contactDistance <= profile.target.exitDistancePx" not in side_target_block
     assert "_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect" in side_target_block
     assert side_target_block.index("const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);") < side_target_block.index(
         "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);"
     )
-    assert side_target_block.index("contactOverlapPx >= requiredContactOverlapPx") < side_target_block.index("const rawLeft = lookFacingRight")
+    assert side_target_block.index("const rawLeft = lookFacingRight") < side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget")
+    assert side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget") < side_target_block.index("verticalTargetDistancePx <= exitDistancePx")
+    assert side_target_block.index("verticalTargetDistancePx <= exitDistancePx") < side_target_block.index("_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect")
 
     contact_overlap_block = source.split("function _getNekoIdleCat1MinimizedContactOverlapPx(facingRight, approachOffsetPx, profile)", 1)[1].split(
         "function _resolveNekoIdleCat1TargetFacing",

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1183,6 +1183,48 @@ def test_return_button_local_no_move_release_clears_pending_drag_state():
     )
 
 
+def test_cat1_minimized_ball_contact_finishes_without_side_retarget_jitter():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    assert "function _getNekoIdleRectDirectionalOverlapPx(rect, targetRect, facingRight)" in source
+    assert "function _getNekoIdleCat1MinimizedContactOverlapPx(facingRight, approachOffsetPx, profile)" in source
+    assert "function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options)" in source
+
+    side_target_block = source.split("function _getNekoIdleCat1SideTarget(container, chatRect)", 1)[1].split(
+        "function _getNekoIdleCat1CompactTopEdgeBounds",
+        1,
+    )[0]
+    assert "const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);" in side_target_block
+    assert "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);" in side_target_block
+    assert "const requiredContactOverlapPx = _getNekoIdleCat1MinimizedContactOverlapPx(" in side_target_block
+    assert "contactOverlapPx >= requiredContactOverlapPx" in side_target_block
+    assert "contactDistance <= profile.target.exitDistancePx" not in side_target_block
+    assert "_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect" in side_target_block
+    assert side_target_block.index("const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);") < side_target_block.index(
+        "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);"
+    )
+    assert side_target_block.index("contactOverlapPx >= requiredContactOverlapPx") < side_target_block.index("const rawLeft = lookFacingRight")
+
+    contact_overlap_block = source.split("function _getNekoIdleCat1MinimizedContactOverlapPx(facingRight, approachOffsetPx, profile)", 1)[1].split(
+        "function _resolveNekoIdleCat1TargetFacing",
+        1,
+    )[0]
+    assert "const targetOverlapPx = facingRight" in contact_overlap_block
+    assert "? -gapPx" in contact_overlap_block
+    assert ": Math.max(0, Number(approachOffsetPx) || 0) - gapPx" in contact_overlap_block
+    assert "return Math.max(0, targetOverlapPx - exitDistancePx);" in contact_overlap_block
+
+    contact_target_block = source.split("function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options)", 1)[1].split(
+        "function _getNekoIdleCat1SideTarget",
+        1,
+    )[0]
+    assert "left: rect.left" in contact_target_block
+    assert "top: rect.top" in contact_target_block
+    assert "distance: 0" in contact_target_block
+    assert "moveFacingRight: null" in contact_target_block
+    assert "kind: _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in contact_target_block
+
+
 def test_return_button_idle_tier_assets_are_version_tracked():
     for path in (APP_UI_PATH, APP_INTERPAGE_PATH, COMMON_UI_HUD_PATH,
                  APP_REACT_CHAT_WINDOW_PATH,

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1187,7 +1187,7 @@ def test_cat1_minimized_ball_contact_finishes_without_side_retarget_jitter():
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
     assert "function _getNekoIdleRectDirectionalOverlapPx(rect, targetRect, facingRight)" in source
-    assert "function _getNekoIdleCat1MinimizedContactOverlapPx(facingRight, approachOffsetPx, profile)" in source
+    assert "function _getNekoIdleCat1MinimizedContactTargetOverlapPx(facingRight, approachOffsetPx, profile)" in source
     assert "function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options)" in source
 
     side_target_block = source.split("function _getNekoIdleCat1SideTarget(container, chatRect)", 1)[1].split(
@@ -1196,28 +1196,29 @@ def test_cat1_minimized_ball_contact_finishes_without_side_retarget_jitter():
     )[0]
     assert "const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);" in side_target_block
     assert "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);" in side_target_block
-    assert "const requiredContactOverlapPx = _getNekoIdleCat1MinimizedContactOverlapPx(" in side_target_block
+    assert "const targetContactOverlapPx = _getNekoIdleCat1MinimizedContactTargetOverlapPx(" in side_target_block
     assert "const verticalTargetDistancePx = sideTarget" in side_target_block
     assert "Math.abs(Number(sideTarget.top) - Number(rect.top))" in side_target_block
-    assert "verticalTargetDistancePx <= exitDistancePx" in side_target_block
-    assert "contactOverlapPx >= requiredContactOverlapPx" in side_target_block
+    assert "const horizontalTargetDistancePx = Math.max(0, targetContactOverlapPx - contactOverlapPx);" in side_target_block
+    assert "const contactTargetDistancePx = Math.hypot(horizontalTargetDistancePx, verticalTargetDistancePx);" in side_target_block
+    assert "contactTargetDistancePx <= exitDistancePx" in side_target_block
     assert "contactDistance <= profile.target.exitDistancePx" not in side_target_block
     assert "_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect" in side_target_block
     assert side_target_block.index("const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);") < side_target_block.index(
         "const contactOverlapPx = _getNekoIdleRectDirectionalOverlapPx(rect, chatRect, lookFacingRight);"
     )
     assert side_target_block.index("const rawLeft = lookFacingRight") < side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget")
-    assert side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget") < side_target_block.index("verticalTargetDistancePx <= exitDistancePx")
-    assert side_target_block.index("verticalTargetDistancePx <= exitDistancePx") < side_target_block.index("_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect")
+    assert side_target_block.index("const sideTarget = _makeNekoIdleCat1SideTarget") < side_target_block.index("const contactTargetDistancePx = Math.hypot")
+    assert side_target_block.index("contactTargetDistancePx <= exitDistancePx") < side_target_block.index("_makeNekoIdleCat1MinimizedContactTarget(rect, chatRect")
 
-    contact_overlap_block = source.split("function _getNekoIdleCat1MinimizedContactOverlapPx(facingRight, approachOffsetPx, profile)", 1)[1].split(
+    contact_overlap_block = source.split("function _getNekoIdleCat1MinimizedContactTargetOverlapPx(facingRight, approachOffsetPx, profile)", 1)[1].split(
         "function _resolveNekoIdleCat1TargetFacing",
         1,
     )[0]
     assert "const targetOverlapPx = facingRight" in contact_overlap_block
     assert "? -gapPx" in contact_overlap_block
     assert ": Math.max(0, Number(approachOffsetPx) || 0) - gapPx" in contact_overlap_block
-    assert "return Math.max(0, targetOverlapPx - exitDistancePx);" in contact_overlap_block
+    assert "return Math.max(0, targetOverlapPx);" in contact_overlap_block
 
     contact_target_block = source.split("function _makeNekoIdleCat1MinimizedContactTarget(rect, chatRect, options)", 1)[1].split(
         "function _getNekoIdleCat1SideTarget",

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1222,6 +1222,8 @@ def test_cat1_minimized_ball_contact_finishes_without_side_retarget_jitter():
     assert "top: rect.top" in contact_target_block
     assert "distance: 0" in contact_target_block
     assert "moveFacingRight: null" in contact_target_block
+    assert "approachOffsetPx" in contact_target_block
+    assert "approachOffsetPx: _getNekoIdleCat1MinimizedSideApproachOffsetPx(facingRight, chatRect)" in contact_target_block
     assert "kind: _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in contact_target_block
 
 


### PR DESCRIPTION
修复 CAT1 追最小化毛线球时，球被拖进猫 GIF 容器内部后仍按左右侧站位持续重算目标，导致猫原地走动/抖动的问题。

新增猫与毛线球矩形 gap 判定：进入现有退出距离后直接返回当前位置 contact target，让既有 walk finish 链路触发 stretch 并停下。

补充静态合同测试，锁定接触优先于 side retarget 的行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化头像在最小化聊天框侧向停靠时的目标判定与接近偏移：当头像中心位于聊天区域内时更准确地锁定当前侧向目标，减少不必要的重定向与抖动，提升停靠稳定性与过渡平滑度。

* **测试**
  * 增加单元测试，验证上述情形下不会触发侧向重定向抖动，确保移动与接触过渡更稳定。

* **Chores**
  * 更新 CI 工作流以包含并运行新增静态用例测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->