### PR TITLE
修复请她离开状态下聊天输入区同步隐藏

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -120,6 +120,23 @@ describe('App', () => {
     expect(container.querySelector('.compact-chat-stage')).toBeNull();
   });
 
+  it('hides the full composer and tools when composerHidden is true', () => {
+    const message = parseChatMessage({
+      id: 'm-full-hidden',
+      role: 'assistant',
+      author: 'Neko',
+      time: '12:01',
+      blocks: [{ type: 'text', text: 'goodbye state' }],
+    });
+    const { container } = render(<App chatSurfaceMode="full" composerHidden messages={[message]} />);
+
+    expect(container.querySelector('.message-list')).not.toBeNull();
+    expect(screen.queryByPlaceholderText('Type a message...')).toBeNull();
+    expect(container.querySelector('.composer-panel')).toBeNull();
+    expect(container.querySelector('.composer-bottom-tools')).toBeNull();
+    expect(container.querySelector('.send-button-circle')).toBeNull();
+  });
+
   it('enters compact input from the subtitle capsule when used uncontrolled', () => {
     const { container } = render(<App chatSurfaceMode="compact" />);
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5733,6 +5733,7 @@ function CompactChatApp({
       </div>
     </section>
   ) : null;
+  const shouldRenderComposerPanel = isCompactSurface || !composerHidden;
 
   return (
     <main
@@ -5811,132 +5812,133 @@ function CompactChatApp({
 
         {chatBodyNode}
 
-        <footer
-          className={`composer-panel ${surfaceModeClassName}${galgameModeEnabled ? ' is-galgame-mode' : ''}`}
-          style={composerHidden && !isCompactSurface ? { display: 'none' } : undefined}
-          data-chat-surface-mode={chatSurfaceMode}
-          data-compact-chat-state={effectiveCompactChatState}
-        >
-          {!isCompactSurface ? <div id="music-player-mount" className="composer-music-player-mount" /> : null}
-          <form className="composer" onSubmit={(event) => {
-            event.preventDefault();
-            submitDraft();
-          }}>
-            {isCompactSurface ? (
-              <div
-                className={`compact-chat-surface-shell${
-                  compactCollapsing
-                    ? ' neko-compact-collapsing'
-                    : compactExpanding
-                      ? ' neko-compact-expanding'
-                      : ''
-                }`}
-                ref={compactInputShellRef}
-                data-compact-chat-state={effectiveCompactChatState}
-                data-compact-tool-layer-open={compactToolToggleVisible && compactInputToolFanOpen ? 'true' : 'false'}
-                style={compactSurfaceShellStyle}
-                onBlurCapture={effectiveCompactChatState === 'input' ? scheduleCompactInputCollapse : undefined}
-              >
+        {shouldRenderComposerPanel ? (
+          <footer
+            className={`composer-panel ${surfaceModeClassName}${galgameModeEnabled ? ' is-galgame-mode' : ''}`}
+            data-chat-surface-mode={chatSurfaceMode}
+            data-compact-chat-state={effectiveCompactChatState}
+          >
+            {!isCompactSurface ? <div id="music-player-mount" className="composer-music-player-mount" /> : null}
+            <form className="composer" onSubmit={(event) => {
+              event.preventDefault();
+              submitDraft();
+            }}>
+              {isCompactSurface ? (
                 <div
-                  className="compact-chat-resize-handle compact-chat-resize-handle-left"
-                  data-compact-resize-side="left"
-                  data-compact-geometry-item="resizeHandle"
-                  data-compact-geometry-owner="surface"
-                  data-compact-no-drag="true"
-                  aria-hidden="true"
-                  onPointerDown={(event) => handleCompactSurfaceResizePointerDown('left', event)}
-                  onPointerMove={handleCompactSurfaceResizePointerMove}
-                  onPointerUp={handleCompactSurfaceResizePointerUp}
-                  onPointerCancel={handleCompactSurfaceResizePointerCancel}
-                  onLostPointerCapture={handleCompactSurfaceResizePointerCancel}
-                />
-                <div
-                  className="compact-chat-resize-handle compact-chat-resize-handle-right"
-                  data-compact-resize-side="right"
-                  data-compact-geometry-item="resizeHandle"
-                  data-compact-geometry-owner="surface"
-                  data-compact-no-drag="true"
-                  aria-hidden="true"
-                  onPointerDown={(event) => handleCompactSurfaceResizePointerDown('right', event)}
-                  onPointerMove={handleCompactSurfaceResizePointerMove}
-                  onPointerUp={handleCompactSurfaceResizePointerUp}
-                  onPointerCancel={handleCompactSurfaceResizePointerCancel}
-                  onLostPointerCapture={handleCompactSurfaceResizePointerCancel}
-                />
-                <div
-                  className="compact-chat-surface-frame"
-                  data-compact-geometry-item={effectiveCompactChatState === 'input' ? 'input' : 'capsule'}
-                  data-compact-geometry-owner="surface"
-                  data-compact-drag-surface="true"
+                  className={`compact-chat-surface-shell${
+                    compactCollapsing
+                      ? ' neko-compact-collapsing'
+                      : compactExpanding
+                        ? ' neko-compact-expanding'
+                        : ''
+                  }`}
+                  ref={compactInputShellRef}
                   data-compact-chat-state={effectiveCompactChatState}
-                  data-compact-geometry-part={effectiveCompactChatState === 'input' ? 'inputBody' : 'capsuleBody'}
-                  data-compact-tool-toggle-visible={compactToolToggleVisible ? 'true' : 'false'}
+                  data-compact-tool-layer-open={compactToolToggleVisible && compactInputToolFanOpen ? 'true' : 'false'}
+                  style={compactSurfaceShellStyle}
+                  onBlurCapture={effectiveCompactChatState === 'input' ? scheduleCompactInputCollapse : undefined}
                 >
-                  {effectiveCompactChatState === 'input' ? (
-                    <>
-                      {/* 输入态左侧毛绒球：点按折叠为 minimized，按住拖动整个输入框（见 compactMinimizeButton 定义）。
-                          按住把手不会让 textarea 失焦收起输入态——宿主 mousedown 会 preventDefault。 */}
-                      {compactMinimizeButton}
-                      <textarea
-                        className="composer-input"
-                        ref={compactInputRef}
-                        data-compact-no-drag="true"
-                        placeholder={inputPlaceholder}
-                        aria-label={inputPlaceholder}
-                        rows={1}
-                        value={draft}
-                        readOnly={composerDisabled}
-                        disabled={composerDisabled}
-                        onChange={(event) => {
-                          setDraft(event.target.value);
-                          if (event.target.value.trim().length > 0) {
-                            closeCompactInputToolFan();
-                          }
-                        }}
-                        onBlur={scheduleCompactInputCollapse}
-                        onKeyDown={(event) => {
-                          if (event.nativeEvent.isComposing) return;
-                          if (event.key === 'Enter' && !event.shiftKey) {
-                            event.preventDefault();
-                            submitDraft();
-                          }
-                        }}
-                      />
-                      {compactInputToolToggleButton}
-                    </>
-                  ) : (
-                    <>
-                      {compactMinimizeButton}
-                      <button
-                        className="compact-chat-capsule-button"
-                        type="button"
-                        disabled={composerDisabled}
-                        onClick={() => {
-                          if (composerHidden) return;
-                          if (isGuideChatButtonLockActive()) return;
-                          requestCompactChatState('input');
-                        }}
-                      >
-                        <span
-                          ref={compactPreviewTextRef}
-                          className="compact-chat-capsule-text"
-                          data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
-                          data-compact-preview-scrollable={compactPreviewAllowsScroll ? 'true' : 'false'}
-                          onWheel={handleCompactPreviewWheel}
+                  <div
+                    className="compact-chat-resize-handle compact-chat-resize-handle-left"
+                    data-compact-resize-side="left"
+                    data-compact-geometry-item="resizeHandle"
+                    data-compact-geometry-owner="surface"
+                    data-compact-no-drag="true"
+                    aria-hidden="true"
+                    onPointerDown={(event) => handleCompactSurfaceResizePointerDown('left', event)}
+                    onPointerMove={handleCompactSurfaceResizePointerMove}
+                    onPointerUp={handleCompactSurfaceResizePointerUp}
+                    onPointerCancel={handleCompactSurfaceResizePointerCancel}
+                    onLostPointerCapture={handleCompactSurfaceResizePointerCancel}
+                  />
+                  <div
+                    className="compact-chat-resize-handle compact-chat-resize-handle-right"
+                    data-compact-resize-side="right"
+                    data-compact-geometry-item="resizeHandle"
+                    data-compact-geometry-owner="surface"
+                    data-compact-no-drag="true"
+                    aria-hidden="true"
+                    onPointerDown={(event) => handleCompactSurfaceResizePointerDown('right', event)}
+                    onPointerMove={handleCompactSurfaceResizePointerMove}
+                    onPointerUp={handleCompactSurfaceResizePointerUp}
+                    onPointerCancel={handleCompactSurfaceResizePointerCancel}
+                    onLostPointerCapture={handleCompactSurfaceResizePointerCancel}
+                  />
+                  <div
+                    className="compact-chat-surface-frame"
+                    data-compact-geometry-item={effectiveCompactChatState === 'input' ? 'input' : 'capsule'}
+                    data-compact-geometry-owner="surface"
+                    data-compact-drag-surface="true"
+                    data-compact-chat-state={effectiveCompactChatState}
+                    data-compact-geometry-part={effectiveCompactChatState === 'input' ? 'inputBody' : 'capsuleBody'}
+                    data-compact-tool-toggle-visible={compactToolToggleVisible ? 'true' : 'false'}
+                  >
+                    {effectiveCompactChatState === 'input' ? (
+                      <>
+                        {/* 输入态左侧毛绒球：点按折叠为 minimized，按住拖动整个输入框（见 compactMinimizeButton 定义）。
+                            按住把手不会让 textarea 失焦收起输入态——宿主 mousedown 会 preventDefault。 */}
+                        {compactMinimizeButton}
+                        <textarea
+                          className="composer-input"
+                          ref={compactInputRef}
+                          data-compact-no-drag="true"
+                          placeholder={inputPlaceholder}
+                          aria-label={inputPlaceholder}
+                          rows={1}
+                          value={draft}
+                          readOnly={composerDisabled}
+                          disabled={composerDisabled}
+                          onChange={(event) => {
+                            setDraft(event.target.value);
+                            if (event.target.value.trim().length > 0) {
+                              closeCompactInputToolFan();
+                            }
+                          }}
+                          onBlur={scheduleCompactInputCollapse}
+                          onKeyDown={(event) => {
+                            if (event.nativeEvent.isComposing) return;
+                            if (event.key === 'Enter' && !event.shiftKey) {
+                              event.preventDefault();
+                              submitDraft();
+                            }
+                          }}
+                        />
+                        {compactInputToolToggleButton}
+                      </>
+                    ) : (
+                      <>
+                        {compactMinimizeButton}
+                        <button
+                          className="compact-chat-capsule-button"
+                          type="button"
+                          disabled={composerDisabled}
+                          onClick={() => {
+                            if (composerHidden) return;
+                            if (isGuideChatButtonLockActive()) return;
+                            requestCompactChatState('input');
+                          }}
                         >
-                          {compactPreviewDisplayContent}
-                        </span>
-                      </button>
-                      {compactInputToolToggleButton}
-                    </>
-                  )}
+                          <span
+                            ref={compactPreviewTextRef}
+                            className="compact-chat-capsule-text"
+                            data-compact-preview-streaming={compactPreviewIsStreaming ? 'true' : 'false'}
+                            data-compact-preview-scrollable={compactPreviewAllowsScroll ? 'true' : 'false'}
+                            onWheel={handleCompactPreviewWheel}
+                          >
+                            {compactPreviewDisplayContent}
+                          </span>
+                        </button>
+                        {compactInputToolToggleButton}
+                      </>
+                    )}
+                  </div>
+                  {composerAttachmentPreviewNode}
+                  {compactInputToolFanNode}
                 </div>
-                {composerAttachmentPreviewNode}
-                {compactInputToolFanNode}
-              </div>
-            ) : null}
-          </form>
-        </footer>
+              ) : null}
+            </form>
+          </footer>
+        ) : null}
       </section>
     </main>
   );

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -1060,7 +1060,8 @@ export default function FullChatSurface({
   const lastRollbackKeyRef = useRef('');
   const lastToolCursorResetKeyRef = useRef('');
   const compactInputHasPayload = draft.trim().length > 0 || composerAttachments.length > 0;
-  const canSubmit = !composerDisabled && compactInputHasPayload;
+  const composerInteractionsDisabled = composerDisabled || composerHidden;
+  const canSubmit = !composerInteractionsDisabled && compactInputHasPayload;
   const clearActiveCursorToolSelection = useCallback(() => {
     clearGlobalToolCursorState();
     latestPointerTargetRef.current = null;
@@ -1813,14 +1814,14 @@ export default function FullChatSurface({
   useEffect(() => {
     if (!isCompactSurface) return;
     if (effectiveCompactChatState !== 'input') return;
-    if (composerDisabled) return;
+    if (composerInteractionsDisabled) return;
     const inputNode = compactInputRef.current;
     if (!inputNode) return;
     if (document.activeElement === inputNode) return;
     inputNode.focus();
     const selectionEnd = inputNode.value.length;
     inputNode.setSelectionRange(selectionEnd, selectionEnd);
-  }, [composerDisabled, effectiveCompactChatState, isCompactSurface]);
+  }, [composerInteractionsDisabled, effectiveCompactChatState, isCompactSurface]);
 
   useEffect(() => {
     if (!isCompactSurface) return;
@@ -2222,7 +2223,7 @@ export default function FullChatSurface({
   }, [clearCompactInputToolFanCloseTimer, closeCompactInputToolFan]);
 
   const openCompactInputToolFan = useCallback((intent: 'click' | 'hover') => {
-    if (composerDisabled || compactInputHasPayload) return;
+    if (composerInteractionsDisabled || compactInputHasPayload) return;
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
     compactInputToolFanOpenIntentRef.current = intent;
@@ -2239,7 +2240,7 @@ export default function FullChatSurface({
     clearCompactInputToolFanCloseTimer,
     clearCompactInputToolFanInteractiveTimer,
     compactInputHasPayload,
-    composerDisabled,
+    composerInteractionsDisabled,
     setCompactInputToolFanInteractiveState,
     updateCompactInputToolFanPosition,
   ]);
@@ -2495,15 +2496,14 @@ export default function FullChatSurface({
 
   useEffect(() => {
     if (!compactInputToolFanOpen) return;
-    if (!isCompactSurface || effectiveCompactChatState !== 'input' || composerHidden || composerDisabled || compactInputHasPayload) {
+    if (!isCompactSurface || effectiveCompactChatState !== 'input' || composerInteractionsDisabled || compactInputHasPayload) {
       closeCompactInputToolFan();
     }
   }, [
     closeCompactInputToolFan,
     compactInputHasPayload,
     compactInputToolFanOpen,
-    composerDisabled,
-    composerHidden,
+    composerInteractionsDisabled,
     effectiveCompactChatState,
     isCompactSurface,
   ]);
@@ -3267,10 +3267,10 @@ export default function FullChatSurface({
   }, [hammerCursorOverlayActive, hammerSwingPhase]);
 
   useEffect(() => {
-    if (composerHidden || composerDisabled) {
+    if (composerInteractionsDisabled) {
       clearActiveCursorToolSelection();
     }
-  }, [clearActiveCursorToolSelection, composerHidden, composerDisabled]);
+  }, [clearActiveCursorToolSelection, composerInteractionsDisabled]);
 
   useEffect(() => {
     function handleDeactivate() {
@@ -3291,7 +3291,7 @@ export default function FullChatSurface({
   }
 
   function submitDraft() {
-    if (composerDisabled) return;
+    if (composerInteractionsDisabled) return;
     if (submittingRef.current) return;
     const text = draft.trim();
     if (!text && composerAttachments.length === 0) return;
@@ -3335,7 +3335,7 @@ export default function FullChatSurface({
       aria-label={resolvedTranslateAriaLabel}
       aria-pressed={translateEnabled}
       title={translateButtonLabel}
-      disabled={composerDisabled}
+      disabled={composerInteractionsDisabled}
       onClick={() => onTranslateToggle?.()}
     >
       <img src="/static/icons/translate_icon.png" alt="" aria-hidden="true" />
@@ -3348,7 +3348,7 @@ export default function FullChatSurface({
       type="button"
       aria-label={jukeboxButtonAriaLabel}
       title={jukeboxButtonLabel}
-      disabled={composerDisabled}
+      disabled={composerInteractionsDisabled}
       onClick={() => onJukeboxClick?.()}
     >
       <img src="/static/icons/jukebox_icon.png" alt="" aria-hidden="true" />
@@ -3362,7 +3362,7 @@ export default function FullChatSurface({
       aria-label={resolvedGalgameAriaLabel}
       aria-pressed={galgameModeEnabled}
       title={galgameToggleButtonLabel}
-      disabled={composerDisabled}
+      disabled={composerInteractionsDisabled}
       onClick={() => onGalgameModeToggle?.()}
     >
       <span className="composer-galgame-btn-glyph" aria-hidden="true">G</span>
@@ -3378,7 +3378,7 @@ export default function FullChatSurface({
         title={selectedEmojiButtonAriaLabel}
         aria-controls={toolMenuOpen ? 'composer-tool-popover' : undefined}
         aria-expanded={toolMenuOpen}
-        disabled={composerDisabled}
+        disabled={composerInteractionsDisabled}
         onClick={() => {
           if (activeToolItem) {
             clearActiveCursorToolSelection();
@@ -3402,7 +3402,7 @@ export default function FullChatSurface({
           type="button"
           aria-label={clearCursorToolAriaLabel}
           title={clearCursorToolAriaLabel}
-          disabled={composerDisabled}
+          disabled={composerInteractionsDisabled}
           onClick={(event) => {
             event.stopPropagation();
             setIsCursorInsideHostWindow(true);
@@ -3434,7 +3434,7 @@ export default function FullChatSurface({
               aria-pressed={activeCursorToolId === item.id}
               aria-label={itemLabel}
               title={itemLabel}
-              disabled={composerDisabled}
+              disabled={composerInteractionsDisabled}
               onClick={(event) => {
                 latestPointerPositionRef.current = {
                   x: event.clientX,
@@ -3525,7 +3525,7 @@ export default function FullChatSurface({
     return slot === null ? 'hidden' : String(slot);
   };
 
-  const compactInputToolFanActionsDisabled = composerDisabled
+  const compactInputToolFanActionsDisabled = composerInteractionsDisabled
     || !compactInputToolFanOpen
     || !compactInputToolFanInteractive;
 
@@ -3895,7 +3895,7 @@ export default function FullChatSurface({
                     type="button"
                     className="composer-galgame-option"
                     title={option.text}
-                    disabled={composerDisabled || galgameOptionsLoading}
+                    disabled={composerInteractionsDisabled || galgameOptionsLoading}
                     tabIndex={compactChoiceLayerOpen && galgameOptionsVisible ? 0 : -1}
                     onClick={() => {
                       if (submittingRef.current) return;
@@ -3949,7 +3949,7 @@ export default function FullChatSurface({
                 type="button"
                 className="composer-galgame-option composer-choice-option"
                 title={option.label}
-                disabled={composerDisabled}
+                disabled={composerInteractionsDisabled}
                 onClick={() => {
                   if (submittingRef.current) return;
                   submittingRef.current = true;
@@ -4112,6 +4112,7 @@ export default function FullChatSurface({
       {messageListNode}
     </section>
   );
+  const shouldRenderComposerPanel = isCompactSurface || !composerHidden;
 
   return (
     <main
@@ -4186,9 +4187,9 @@ export default function FullChatSurface({
 
         {chatBodyNode}
 
+        {shouldRenderComposerPanel ? (
         <footer
           className={`composer-panel ${surfaceModeClassName}${galgameModeEnabled ? ' is-galgame-mode' : ''}`}
-          style={composerHidden && !isCompactSurface ? { display: 'none' } : undefined}
           data-chat-surface-mode={chatSurfaceMode}
           data-compact-chat-state={effectiveCompactChatState}
         >
@@ -4207,10 +4208,10 @@ export default function FullChatSurface({
                     className="composer-attachment-remove"
                     type="button"
                     aria-label={`${removeAttachmentButtonAriaLabel}: ${attachment.alt || attachment.id}`}
-                    aria-disabled={composerDisabled}
-                    disabled={composerDisabled}
+                    aria-disabled={composerInteractionsDisabled}
+                    disabled={composerInteractionsDisabled}
                     onClick={() => {
-                      if (!composerDisabled) {
+                      if (!composerInteractionsDisabled) {
                         onComposerRemoveAttachment?.(attachment.id);
                       }
                     }}
@@ -4280,8 +4281,8 @@ export default function FullChatSurface({
                         aria-label={inputPlaceholder}
                         rows={1}
                         value={draft}
-                        readOnly={composerDisabled}
-                        disabled={composerDisabled}
+                        readOnly={composerInteractionsDisabled}
+                        disabled={composerInteractionsDisabled}
                         onChange={(event) => {
                           setDraft(event.target.value);
                           if (event.target.value.trim().length > 0) {
@@ -4304,7 +4305,7 @@ export default function FullChatSurface({
                         aria-label={compactInputHasPayload ? sendButtonLabel : overflowMenuAriaLabel}
                         aria-haspopup={compactInputHasPayload ? undefined : 'true'}
                         aria-expanded={compactInputHasPayload ? undefined : compactInputToolFanOpen}
-                        disabled={compactInputHasPayload ? !canSubmit : composerDisabled}
+                        disabled={compactInputHasPayload ? !canSubmit : composerInteractionsDisabled}
                         onPointerDown={compactInputHasPayload ? undefined : (event) => {
                           event.preventDefault();
                           compactInputToolTogglePointerHandledRef.current = true;
@@ -4337,7 +4338,7 @@ export default function FullChatSurface({
                     <button
                       className="compact-chat-capsule-button"
                       type="button"
-                      disabled={composerDisabled}
+                      disabled={composerInteractionsDisabled}
                       onClick={() => {
                         if (composerHidden) return;
                         requestCompactChatState('input');
@@ -4366,8 +4367,8 @@ export default function FullChatSurface({
                 aria-label={inputPlaceholder}
                 rows={1}
                 value={draft}
-                readOnly={composerDisabled}
-                disabled={composerDisabled}
+                readOnly={composerInteractionsDisabled}
+                disabled={composerInteractionsDisabled}
                 onChange={(event) => { setDraft(event.target.value); }}
                 onKeyDown={(event) => {
                   if (event.nativeEvent.isComposing) return;
@@ -4388,7 +4389,7 @@ export default function FullChatSurface({
                     type="button"
                     aria-label={resolvedImportImageAriaLabel}
                     title={importImageButtonLabel}
-                    disabled={composerDisabled}
+                    disabled={composerInteractionsDisabled}
                     onClick={() => onComposerImportImage?.()}
                   >
                     <img src="/static/icons/import_image_icon.png" alt="" aria-hidden="true" />
@@ -4399,7 +4400,7 @@ export default function FullChatSurface({
                     type="button"
                     aria-label={resolvedScreenshotAriaLabel}
                     title={screenshotButtonLabel}
-                    disabled={composerDisabled}
+                    disabled={composerInteractionsDisabled}
                     onClick={() => onComposerScreenshot?.()}
                   >
                     <img src="/static/icons/screenshot_new_icon.png" alt="" aria-hidden="true" />
@@ -4438,7 +4439,7 @@ export default function FullChatSurface({
                         title={overflowMenuAriaLabel}
                         aria-haspopup="true"
                         aria-expanded={overflowMenuOpen}
-                        disabled={composerDisabled}
+                        disabled={composerInteractionsDisabled}
                         onClick={() => setOverflowMenuOpen(open => !open)}
                       >
                         <svg
@@ -4477,6 +4478,7 @@ export default function FullChatSurface({
             )}
           </form>
         </footer>
+        ) : null}
       </section>
     </main>
   );

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1480,13 +1480,15 @@
 
     function readGoodbyeChatComposerHidden() {
         try {
-            if (typeof window.isNekoGoodbyeModeActive === 'function') {
-                return !!window.isNekoGoodbyeModeActive();
+            if (typeof window.isNekoGoodbyeModeActive === 'function'
+                && window.isNekoGoodbyeModeActive()) {
+                return true;
             }
         } catch (_) {}
         if (window.__nekoGoodbyeChatComposerHidden
-            && typeof window.__nekoGoodbyeChatComposerHidden === 'object') {
-            return !!window.__nekoGoodbyeChatComposerHidden.hidden;
+            && typeof window.__nekoGoodbyeChatComposerHidden === 'object'
+            && window.__nekoGoodbyeChatComposerHidden.hidden === true) {
+            return true;
         }
         return !!(
             (window.live2dManager && window.live2dManager._goodbyeClicked)

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1478,6 +1478,101 @@
         }
     }
 
+    function readGoodbyeChatComposerHidden() {
+        try {
+            if (typeof window.isNekoGoodbyeModeActive === 'function') {
+                return !!window.isNekoGoodbyeModeActive();
+            }
+        } catch (_) {}
+        if (window.__nekoGoodbyeChatComposerHidden
+            && typeof window.__nekoGoodbyeChatComposerHidden === 'object') {
+            return !!window.__nekoGoodbyeChatComposerHidden.hidden;
+        }
+        return !!(
+            (window.live2dManager && window.live2dManager._goodbyeClicked)
+            || (window.vrmManager && window.vrmManager._goodbyeClicked)
+            || (window.mmdManager && window.mmdManager._goodbyeClicked)
+            || (window.__nekoGoodbyeSilentState && window.__nekoGoodbyeSilentState.active === true)
+        );
+    }
+
+    function applyGoodbyeChatComposerHidden(hidden, reason) {
+        hidden = !!hidden;
+        var detail = {
+            hidden: hidden,
+            reason: reason || (hidden ? 'goodbye' : 'return'),
+            timestamp: Date.now()
+        };
+        window.__nekoGoodbyeChatComposerHidden = detail;
+        if (window.reactChatWindowHost && typeof window.reactChatWindowHost.setGoodbyeComposerHidden === 'function') {
+            window.reactChatWindowHost.setGoodbyeComposerHidden(hidden, detail.reason);
+        } else {
+            try {
+                window.dispatchEvent(new CustomEvent('react-chat-window:set-goodbye-composer-hidden', {
+                    detail: detail
+                }));
+            } catch (_) {}
+        }
+    }
+
+    function getGoodbyeChatComposerHiddenElectronBridge() {
+        var bridge = window.nekoElectronGoodbyeChatComposerHidden;
+        return bridge && typeof bridge.send === 'function' ? bridge : null;
+    }
+
+    function postGoodbyeChatComposerHiddenElectron(payload) {
+        var bridge = getGoodbyeChatComposerHiddenElectronBridge();
+        if (!bridge) return false;
+        try {
+            bridge.send(payload || {});
+            return true;
+        } catch (err) {
+            console.warn('[Goodbye] Electron composer hidden bridge failed:', err);
+            return false;
+        }
+    }
+
+    function postGoodbyeChatComposerHiddenPayload(payload) {
+        if (nekoBroadcastChannel) {
+            nekoBroadcastChannel.postMessage(payload);
+        }
+        postGoodbyeChatComposerHiddenElectron(payload);
+    }
+
+    function isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data) {
+        var currentName = getCurrentLanlanName();
+        return !(data && data.lanlan_name && currentName && data.lanlan_name !== currentName);
+    }
+
+    function handleGoodbyeChatComposerHiddenMessage(data, via) {
+        if (!data || !data.action) return false;
+        if (data.action === 'goodbye_chat_composer_hidden') {
+            if (!isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data)) return true;
+            applyGoodbyeChatComposerHidden(!!data.hidden, data.reason || via || 'broadcast');
+            return true;
+        }
+        if (data.action === 'request_goodbye_chat_composer_hidden') {
+            if (isStandaloneChatPage()) return true;
+            if (!isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data)) return true;
+            postGoodbyeChatComposerHiddenState(undefined, 'request-goodbye-chat-composer-hidden');
+            return true;
+        }
+        return false;
+    }
+
+    function postGoodbyeChatComposerHiddenState(hidden, reason) {
+        var nextHidden = hidden === undefined ? readGoodbyeChatComposerHidden() : !!hidden;
+        var nextReason = reason || (nextHidden ? 'goodbye' : 'return');
+        applyGoodbyeChatComposerHidden(nextHidden, nextReason);
+        postGoodbyeChatComposerHiddenPayload({
+            action: 'goodbye_chat_composer_hidden',
+            hidden: nextHidden,
+            reason: nextReason,
+            lanlan_name: getCurrentLanlanName(),
+            timestamp: Date.now()
+        });
+    }
+
     function pruneVoiceConfigSwitchOps(now) {
         now = now || Date.now();
         Object.keys(_voiceConfigSwitchOps).forEach(function (opId) {
@@ -1849,6 +1944,14 @@
                         applyVoiceChatComposerHidden(vcEffectiveHidden);
                         break;
                     }
+                    case 'goodbye_chat_composer_hidden': {
+                        handleGoodbyeChatComposerHiddenMessage(event.data, 'broadcast');
+                        break;
+                    }
+                    case 'request_goodbye_chat_composer_hidden': {
+                        handleGoodbyeChatComposerHiddenMessage(event.data, 'broadcast-request');
+                        break;
+                    }
                     case 'idle_activity': {
                         var idleCurrentName = getCurrentLanlanName();
                         if (event.data.lanlan_name && (!idleCurrentName || event.data.lanlan_name !== idleCurrentName)) break;
@@ -2133,7 +2236,7 @@
 
     function isStandaloneChatPage() {
         var pathname = (window.location && window.location.pathname) || '';
-        return pathname === '/chat' || pathname === '/chat/';
+        return pathname === '/chat' || pathname === '/chat/' || pathname === '/chat_full' || pathname === '/chat_full/';
     }
 
     function dispatchCrossWindowIdleActivity(detail) {
@@ -2416,27 +2519,40 @@
     });
 
     // Chat 窗口初始化时，向 Pet 窗口请求当前已缓存的头像
-    if (isStandaloneChatPage() && nekoBroadcastChannel) {
+    if (isStandaloneChatPage() && (nekoBroadcastChannel || getGoodbyeChatComposerHiddenElectronBridge())) {
         var initialLanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
         var postAvatarRequest = function () {
+            if (!nekoBroadcastChannel) return;
             nekoBroadcastChannel.postMessage({
                 action: 'request_avatar',
                 lanlan_name: (window.lanlan_config && window.lanlan_config.lanlan_name) || '',
                 timestamp: Date.now()
             });
         };
+        var postGoodbyeComposerRequest = function () {
+            var payload = {
+                action: 'request_goodbye_chat_composer_hidden',
+                lanlan_name: (window.lanlan_config && window.lanlan_config.lanlan_name) || '',
+                timestamp: Date.now()
+            };
+            postGoodbyeChatComposerHiddenPayload(payload);
+        };
         postAvatarRequest();
-        nekoBroadcastChannel.postMessage({
-            action: 'request_tutorial_chat_identity',
-            timestamp: Date.now()
-        });
-        nekoBroadcastChannel.postMessage({
-            action: 'yui_guide_chat_ready',
-            timestamp: Date.now()
-        });
+        postGoodbyeComposerRequest();
+        if (nekoBroadcastChannel) {
+            nekoBroadcastChannel.postMessage({
+                action: 'request_tutorial_chat_identity',
+                timestamp: Date.now()
+            });
+            nekoBroadcastChannel.postMessage({
+                action: 'yui_guide_chat_ready',
+                timestamp: Date.now()
+            });
+        }
         // 配置可能尚未注入（lanlan_name 为空），等 IPC 注入后补发一次
         if (!initialLanlanName) {
             window.addEventListener('neko:config-injected', postAvatarRequest, { once: true });
+            window.addEventListener('neko:config-injected', postGoodbyeComposerRequest, { once: true });
         }
     }
 
@@ -2493,6 +2609,10 @@
             return;
         }
         handleVoiceConfigSwitchingMessage(data);
+    });
+
+    window.addEventListener('neko:electron-goodbye-chat-composer-hidden', function (event) {
+        handleGoodbyeChatComposerHiddenMessage((event && event.detail) || {}, 'electron-ipc');
     });
 
     window.addEventListener('message', function (event) {
@@ -2630,6 +2750,10 @@
     mod.cleanupMMDOverlayUI = cleanupMMDOverlayUI;
     mod.syncVoiceChatComposerHidden = syncVoiceChatComposerHidden;
     mod.shouldKeepVoiceComposerHidden = shouldKeepVoiceComposerHidden;
+    mod.applyGoodbyeChatComposerHidden = applyGoodbyeChatComposerHidden;
+    mod.postGoodbyeChatComposerHiddenElectron = postGoodbyeChatComposerHiddenElectron;
+    mod.handleGoodbyeChatComposerHiddenMessage = handleGoodbyeChatComposerHiddenMessage;
+    mod.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;
     mod.isVoiceConfigSwitching = isVoiceConfigSwitching;
     mod.waitForVoiceConfigSwitchReady = waitForVoiceConfigSwitchReady;
     mod.applyTutorialChatIdentityOverride = applyTutorialChatIdentityOverride;
@@ -2645,6 +2769,8 @@
     window.cleanupMMDOverlayUI = cleanupMMDOverlayUI;
     window.syncVoiceChatComposerHidden = syncVoiceChatComposerHidden;
     window.shouldKeepVoiceComposerHidden = shouldKeepVoiceComposerHidden;
+    window.applyGoodbyeChatComposerHidden = applyGoodbyeChatComposerHidden;
+    window.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;
     window.isVoiceConfigSwitching = isVoiceConfigSwitching;
     window.waitForVoiceConfigSwitchReady = waitForVoiceConfigSwitchReady;
 

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1540,8 +1540,9 @@
     }
 
     function isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data) {
+        if (!data || !data.lanlan_name) return false;
         var currentName = getCurrentLanlanName();
-        return !(data && data.lanlan_name && currentName && data.lanlan_name !== currentName);
+        return !!currentName && data.lanlan_name === currentName;
     }
 
     function handleGoodbyeChatComposerHiddenMessage(data, via) {
@@ -1561,14 +1562,16 @@
     }
 
     function postGoodbyeChatComposerHiddenState(hidden, reason) {
+        var lanlanName = getCurrentLanlanName();
         var nextHidden = hidden === undefined ? readGoodbyeChatComposerHidden() : !!hidden;
         var nextReason = reason || (nextHidden ? 'goodbye' : 'return');
         applyGoodbyeChatComposerHidden(nextHidden, nextReason);
+        if (!lanlanName) return;
         postGoodbyeChatComposerHiddenPayload({
             action: 'goodbye_chat_composer_hidden',
             hidden: nextHidden,
             reason: nextReason,
-            lanlan_name: getCurrentLanlanName(),
+            lanlan_name: lanlanName,
             timestamp: Date.now()
         });
     }
@@ -2530,9 +2533,11 @@
             });
         };
         var postGoodbyeComposerRequest = function () {
+            var lanlanName = getCurrentLanlanName();
+            if (!lanlanName) return;
             var payload = {
                 action: 'request_goodbye_chat_composer_hidden',
-                lanlan_name: (window.lanlan_config && window.lanlan_config.lanlan_name) || '',
+                lanlan_name: lanlanName,
                 timestamp: Date.now()
             };
             postGoodbyeChatComposerHiddenPayload(payload);

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -299,6 +299,17 @@
     }
 
     function hasLocalGoodbyeModeSource() {
+        // Standalone chat pages inherit window.isNekoGoodbyeModeActive from
+        // app-state.js even though they do not own model managers. A false
+        // hook result is therefore not authoritative here; only a true hook
+        // result or an actual local manager/silent-state object can safely
+        // drive localOnly goodbye recomputation.
+        try {
+            if (typeof window.isNekoGoodbyeModeActive === 'function'
+                && window.isNekoGoodbyeModeActive()) {
+                return true;
+            }
+        } catch (_) {}
         return !!(
             window.live2dManager
             || window.vrmManager

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -78,6 +78,7 @@
         messages: [],
         composerAttachments: [],
         composerHidden: false,
+        goodbyeComposerHidden: false,
         onMessageAction: null,
         onComposerImportImage: null,
         onComposerScreenshot: null,
@@ -279,8 +280,26 @@
     // 但摘掉 body class，让 chat.html / preload-chat-react 里依赖该 class 的
     // 高最小高度 / 窗口最小高度 CSS 不再撑住空白输入区。
     // body class 切换、change 事件 payload 都走这个 helper，避免逻辑分叉。
+    function getEffectiveComposerHidden() {
+        return !!(state.composerHidden || state.goodbyeComposerHidden);
+    }
+
+    function getNekoGoodbyeModeActive() {
+        try {
+            if (typeof window.isNekoGoodbyeModeActive === 'function') {
+                return !!window.isNekoGoodbyeModeActive();
+            }
+        } catch (_) {}
+        return !!(
+            (window.live2dManager && window.live2dManager._goodbyeClicked)
+            || (window.vrmManager && window.vrmManager._goodbyeClicked)
+            || (window.mmdManager && window.mmdManager._goodbyeClicked)
+            || (window.__nekoGoodbyeSilentState && window.__nekoGoodbyeSilentState.active === true)
+        );
+    }
+
     function getEffectiveGalgameEnabled() {
-        return !!state.galgameModeEnabled && !state.composerHidden;
+        return !!state.galgameModeEnabled && !getEffectiveComposerHidden();
     }
 
     function applyGalgameBodyClass() {
@@ -2328,7 +2347,7 @@
             rollbackDraft: state.rollbackDraft || undefined,
             _rollbackKey: state._rollbackKey || undefined,
             _toolCursorResetKey: state._toolCursorResetKey || undefined,
-            composerHidden: state.composerHidden,
+            composerHidden: getEffectiveComposerHidden(),
             chatSurfaceMode: getCurrentChatSurfaceMode(),
             compactMinimizeCancelSeq: compactMinimizeCancelSeq,
             compactChatState: getCurrentCompactChatState(),
@@ -2640,7 +2659,7 @@
     }
 
     function handleComposerSubmit(payload) {
-        if (state.homeTutorialInteractionLocked) {
+        if (state.homeTutorialInteractionLocked || getEffectiveComposerHidden()) {
             return;
         }
         var requestId = payload && typeof payload.requestId === 'string' && payload.requestId
@@ -3259,7 +3278,7 @@
     }
 
     function handleGalgameOptionSelect(option) {
-        if (isHomeTutorialInteractionLocked()) return;
+        if (isHomeTutorialInteractionLocked() || getEffectiveComposerHidden()) return;
         if (!option || typeof option.text !== 'string') return;
         var text = option.text.trim();
         if (!text) return;
@@ -3286,7 +3305,7 @@
     // 直接 callback；这里只是 BC 兜底）；source==='mini_game_invite' 走新逻辑。
 
     function handleChoiceSelect(option, source) {
-        if (isHomeTutorialInteractionLocked()) return;
+        if (isHomeTutorialInteractionLocked() || getEffectiveComposerHidden()) return;
         if (!option || typeof option.choice !== 'string') return;
         if (source === 'galgame') {
             // Forward to legacy galgame handler if it shows up here
@@ -3717,9 +3736,10 @@
 
     function setComposerHidden(hidden) {
         var next = !!hidden;
-        var changed = state.composerHidden !== next;
+        var wasEffectiveHidden = getEffectiveComposerHidden();
         state.composerHidden = next;
-        if (changed) {
+        var effectiveChanged = wasEffectiveHidden !== getEffectiveComposerHidden();
+        if (effectiveChanged) {
             // composer 隐藏/显示切换会改变 effective galgame body class（参见
             // applyGalgameBodyClass），同步刷新一次；否则在 galgame ON 期间
             // 触发请她离开，body 仍带 galgame-mode-enabled，min-height:385px 撑住
@@ -3730,6 +3750,38 @@
             dispatchHostEvent('galgame-mode-change', { enabled: getEffectiveGalgameEnabled() });
         }
         renderWindow();
+    }
+
+    function setGoodbyeComposerHidden(hidden, reason) {
+        var next = !!hidden;
+        var wasEffectiveHidden = getEffectiveComposerHidden();
+        try {
+            window.__nekoGoodbyeChatComposerHidden = {
+                hidden: next,
+                reason: reason || (next ? 'goodbye' : 'return'),
+                timestamp: Date.now()
+            };
+        } catch (_) {}
+        if (state.goodbyeComposerHidden === next) {
+            if (wasEffectiveHidden !== getEffectiveComposerHidden()) {
+                renderWindow();
+            }
+            return;
+        }
+        state.goodbyeComposerHidden = next;
+        if (next) {
+            resetCompactChatState();
+            invalidatePendingGalgameRequest();
+        }
+        if (wasEffectiveHidden !== getEffectiveComposerHidden()) {
+            applyGalgameBodyClass();
+            dispatchHostEvent('galgame-mode-change', { enabled: getEffectiveGalgameEnabled() });
+        }
+        renderWindow();
+    }
+
+    function syncGoodbyeComposerHidden(reason) {
+        setGoodbyeComposerHidden(getNekoGoodbyeModeActive(), reason || 'sync');
     }
 
     function setHomeTutorialInteractionLocked(locked, reason) {
@@ -3843,7 +3895,9 @@
             viewProps: Object.assign({}, ensureViewProps()),
             messages: state.messages.map(cloneMessage),
             composerAttachments: state.composerAttachments.slice(),
-            composerHidden: state.composerHidden
+            composerHidden: getEffectiveComposerHidden(),
+            composerHiddenRequested: state.composerHidden,
+            goodbyeComposerHidden: state.goodbyeComposerHidden
         };
     }
 
@@ -4842,6 +4896,7 @@
         }
 
         resetCompactChatState();
+        syncGoodbyeComposerHidden('chat-surface-mode-change');
 
         if (!previousMinimized && nextMinimized && previousMode === 'full' && !isElectronChatWindow() && getShell()) {
             pendingMinimizedSurfaceCommit = {
@@ -5854,6 +5909,11 @@
             setComposerHidden(event.detail && event.detail.hidden);
         });
 
+        window.addEventListener(EVENT_PREFIX + 'set-goodbye-composer-hidden', function (event) {
+            var detail = event && event.detail && typeof event.detail === 'object' ? event.detail : {};
+            setGoodbyeComposerHidden(!!detail.hidden, detail.reason || 'bridge');
+        });
+
         window.addEventListener(EVENT_PREFIX + 'set-galgame-mode', function (event) {
             var detail = event.detail || {};
             setGalgameModeEnabled(!!detail.enabled, { persist: detail.persist !== false });
@@ -6077,6 +6137,8 @@
             var detail = event && event.detail && typeof event.detail === 'object' ? event.detail : null;
             if (!detail || detail.type !== 'visual-tier') return;
 
+            setGoodbyeComposerHidden(detail.tier !== IDLE_DOCK_TIER_NONE, detail.source || 'visual-tier');
+
             idleDockTier = detail.tier === IDLE_DOCK_TIER_CAT2 || detail.tier === IDLE_DOCK_TIER_CAT3
                 ? detail.tier
                 : IDLE_DOCK_TIER_NONE;
@@ -6111,17 +6173,23 @@
             scheduleElectronCat1PairMoveBounds(detail.screenRect || detail.bounds);
         });
         window.addEventListener('neko:idle-cat1-compact-mirror-state', handleIdleCat1CompactMirrorState);
+        window.addEventListener('live2d-goodbye-click', function () {
+            setGoodbyeComposerHidden(true, 'live2d-goodbye-click');
+        });
         window.addEventListener('live2d-return-click', function () {
+            setGoodbyeComposerHidden(false, 'live2d-return-click');
             if (hasElectronIdleDockPendingOrActive()) { exitElectronIdleDock(); }
             if (hasIdleDockPendingOrActive()) { exitIdleDock(); return; }
             clearIdleDockState();
         });
         window.addEventListener('vrm-return-click', function () {
+            setGoodbyeComposerHidden(false, 'vrm-return-click');
             if (hasElectronIdleDockPendingOrActive()) { exitElectronIdleDock(); }
             if (hasIdleDockPendingOrActive()) { exitIdleDock(); return; }
             clearIdleDockState();
         });
         window.addEventListener('mmd-return-click', function () {
+            setGoodbyeComposerHidden(false, 'mmd-return-click');
             if (hasElectronIdleDockPendingOrActive()) { exitElectronIdleDock(); }
             if (hasIdleDockPendingOrActive()) { exitIdleDock(); return; }
             clearIdleDockState();
@@ -6166,6 +6234,15 @@
             }
             if (initialComposerShouldHide) {
                 setComposerHidden(true);
+            }
+            if (window.__nekoGoodbyeChatComposerHidden
+                && typeof window.__nekoGoodbyeChatComposerHidden === 'object') {
+                setGoodbyeComposerHidden(
+                    !!window.__nekoGoodbyeChatComposerHidden.hidden,
+                    window.__nekoGoodbyeChatComposerHidden.reason || 'initial-goodbye-cache'
+                );
+            } else {
+                syncGoodbyeComposerHidden('initial-goodbye-state');
             }
         } catch (_) {
             // 首绘兜底失败不影响后续 session_started 同步
@@ -6235,6 +6312,8 @@
         setChatSurfaceMode: setChatSurfaceMode,
         cycleChatSurfaceMode: cycleChatSurfaceMode,
         setCompactChatState: setCompactChatState,
+        setGoodbyeComposerHidden: setGoodbyeComposerHidden,
+        syncGoodbyeComposerHidden: syncGoodbyeComposerHidden,
         setGalgameModeEnabled: function (enabled, options) {
             setGalgameModeEnabled(enabled, options || {});
         },

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -324,6 +324,23 @@
         if (typeof document === 'undefined' || !document.body) return;
         document.body.classList.toggle('composer-has-attachments', !!hasAttachments);
     }
+
+    function getEffectiveComposerAttachmentsVisible() {
+        return !!(
+            state.composerAttachments
+            && state.composerAttachments.length > 0
+            && !getEffectiveComposerHidden()
+        );
+    }
+
+    function syncComposerAttachmentsVisibility(previousVisible) {
+        var nextVisible = getEffectiveComposerAttachmentsVisible();
+        applyAttachmentsBodyClass(nextVisible);
+        if (previousVisible !== undefined && previousVisible !== nextVisible) {
+            dispatchHostEvent('composer-attachments-change', { hasAttachments: nextVisible });
+        }
+        return nextVisible;
+    }
     // No module-eval apply: state defaults to off here; init() resolves the
     // persisted preference and calls setGalgameModeEnabled(...) which flips
     // the class and fires the change event chat.html listens to.
@@ -3746,9 +3763,11 @@
     function setComposerHidden(hidden) {
         var next = !!hidden;
         var wasEffectiveHidden = getEffectiveComposerHidden();
+        var previousAttachmentsVisible = getEffectiveComposerAttachmentsVisible();
         state.composerHidden = next;
         var effectiveChanged = wasEffectiveHidden !== getEffectiveComposerHidden();
         if (effectiveChanged) {
+            syncComposerAttachmentsVisibility(previousAttachmentsVisible);
             // composer 隐藏/显示切换会改变 effective galgame body class（参见
             // applyGalgameBodyClass），同步刷新一次；否则在 galgame ON 期间
             // 触发请她离开，body 仍带 galgame-mode-enabled，min-height:385px 撑住
@@ -3764,6 +3783,7 @@
     function setGoodbyeComposerHidden(hidden, reason) {
         var next = !!hidden;
         var wasEffectiveHidden = getEffectiveComposerHidden();
+        var previousAttachmentsVisible = getEffectiveComposerAttachmentsVisible();
         try {
             window.__nekoGoodbyeChatComposerHidden = {
                 hidden: next,
@@ -3773,18 +3793,28 @@
         } catch (_) {}
         if (state.goodbyeComposerHidden === next) {
             if (wasEffectiveHidden !== getEffectiveComposerHidden()) {
+                syncComposerAttachmentsVisibility(previousAttachmentsVisible);
                 renderWindow();
             }
             return;
         }
         state.goodbyeComposerHidden = next;
+        var isEffectiveHidden = getEffectiveComposerHidden();
+        var restoredEffectiveComposer = wasEffectiveHidden && !isEffectiveHidden;
+        syncComposerAttachmentsVisibility(previousAttachmentsVisible);
         if (next) {
             resetCompactChatState();
             invalidatePendingGalgameRequest();
         }
-        if (wasEffectiveHidden !== getEffectiveComposerHidden()) {
+        if (wasEffectiveHidden !== isEffectiveHidden) {
             applyGalgameBodyClass();
             dispatchHostEvent('galgame-mode-change', { enabled: getEffectiveGalgameEnabled() });
+            if (restoredEffectiveComposer && getEffectiveGalgameEnabled()) {
+                var overlay = getOverlay();
+                if (overlay && !overlay.hidden) {
+                    fetchGalgameOptionsForLatestTurn();
+                }
+            }
         }
         renderWindow();
     }
@@ -3814,7 +3844,7 @@
     }
 
     function setComposerAttachments(attachments) {
-        var prevHas = state.composerAttachments && state.composerAttachments.length > 0;
+        var previousVisible = getEffectiveComposerAttachmentsVisible();
         state.composerAttachments = Array.isArray(attachments)
             ? attachments.map(function (attachment, index) {
                 if (!attachment || typeof attachment !== 'object' || !attachment.url) return null;
@@ -3825,15 +3855,8 @@
                 };
             }).filter(Boolean)
             : [];
-        var nextHas = state.composerAttachments.length > 0;
-        applyAttachmentsBodyClass(nextHas);
+        syncComposerAttachmentsVisibility(previousVisible);
         renderWindow();
-        if (prevHas !== nextHas) {
-            // chat.html 的 syncWindowToAttachmentsMin 监听这条事件，0→N 时
-            // 主动 setBounds 把 Electron 窗口撑高到能容纳附件 + 输入框，避免
-            // 附件刚贴上来就把输入区顶出可视区。和 galgame-mode-change 对称。
-            dispatchHostEvent('composer-attachments-change', { hasAttachments: nextHas });
-        }
         return state.composerAttachments;
     }
 
@@ -5704,7 +5727,7 @@
     var RESIZE_DIRECTIONS = ['n', 's', 'w', 'e', 'nw', 'ne', 'sw', 'se'];
 
     function getDesktopMinHeight() {
-        if (!state.galgameModeEnabled) return MIN_HEIGHT;
+        if (!getEffectiveGalgameEnabled()) return MIN_HEIGHT;
         // 与 CSS 的 galgame min-height 对齐，避免拖拽时 JS 先把高度压到 280px。
         return Math.min(GALGAME_MIN_HEIGHT, Math.max(MIN_HEIGHT, window.innerHeight - 22));
     }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -298,6 +298,15 @@
         );
     }
 
+    function hasLocalGoodbyeModeSource() {
+        return !!(
+            window.live2dManager
+            || window.vrmManager
+            || window.mmdManager
+            || (window.__nekoGoodbyeSilentState && typeof window.__nekoGoodbyeSilentState === 'object')
+        );
+    }
+
     function getEffectiveGalgameEnabled() {
         return !!state.galgameModeEnabled && !getEffectiveComposerHidden();
     }
@@ -3780,7 +3789,10 @@
         renderWindow();
     }
 
-    function syncGoodbyeComposerHidden(reason) {
+    function syncGoodbyeComposerHidden(reason, options) {
+        if (options && options.localOnly && !hasLocalGoodbyeModeSource()) {
+            return;
+        }
         setGoodbyeComposerHidden(getNekoGoodbyeModeActive(), reason || 'sync');
     }
 
@@ -4896,7 +4908,7 @@
         }
 
         resetCompactChatState();
-        syncGoodbyeComposerHidden('chat-surface-mode-change');
+        syncGoodbyeComposerHidden('chat-surface-mode-change', { localOnly: true });
 
         if (!previousMinimized && nextMinimized && previousMode === 'full' && !isElectronChatWindow() && getShell()) {
             pendingMinimizedSurfaceCommit = {

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -3150,6 +3150,11 @@
             if (window.mmdManager) {
                 window.mmdManager._goodbyeClicked = true;
             }
+            if (window.appInterpage && typeof window.appInterpage.postGoodbyeChatComposerHiddenState === 'function') {
+                window.appInterpage.postGoodbyeChatComposerHiddenState(true, 'live2d-goodbye-click');
+            } else if (typeof window.postGoodbyeChatComposerHiddenState === 'function') {
+                window.postGoodbyeChatComposerHiddenState(true, 'live2d-goodbye-click');
+            }
             console.log('[App] 设置 goodbyeClicked 为 true，当前状态:', window.live2dManager ? window.live2dManager._goodbyeClicked : 'undefined', 'VRM:', window.vrmManager ? window.vrmManager._goodbyeClicked : 'undefined');
 
             // 立即关闭所有弹窗
@@ -3554,6 +3559,11 @@
             }
             if (window.mmdManager) {
                 window.mmdManager._goodbyeClicked = false;
+            }
+            if (window.appInterpage && typeof window.appInterpage.postGoodbyeChatComposerHiddenState === 'function') {
+                window.appInterpage.postGoodbyeChatComposerHiddenState(false, 'return-click');
+            } else if (typeof window.postGoodbyeChatComposerHiddenState === 'function') {
+                window.postGoodbyeChatComposerHiddenState(false, 'return-click');
             }
 
             console.log('[App] 标志清除后 - live2dManager._goodbyeClicked:', window.live2dManager?._goodbyeClicked);

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -682,6 +682,10 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
         "function handleGoodbyeChatComposerHiddenMessage(data, via)",
         1,
     )[1].split("function postGoodbyeChatComposerHiddenState", 1)[0]
+    goodbye_read_block = interpage_source.split(
+        "function readGoodbyeChatComposerHidden()",
+        1,
+    )[1].split("function applyGoodbyeChatComposerHidden", 1)[0]
     goodbye_filter_block = interpage_source.split(
         "function isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data)",
         1,
@@ -707,6 +711,13 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
     assert "case 'request_goodbye_chat_composer_hidden':" in interpage_source
     assert "pathname === '/chat_full'" in standalone_block
     assert "pathname === '/chat_full/'" in standalone_block
+    assert (
+        "typeof window.isNekoGoodbyeModeActive === 'function'\n"
+        "                && window.isNekoGoodbyeModeActive()"
+        in goodbye_read_block
+    )
+    assert "window.__nekoGoodbyeChatComposerHidden.hidden === true" in goodbye_read_block
+    assert "window.__nekoGoodbyeSilentState && window.__nekoGoodbyeSilentState.active === true" in goodbye_read_block
     assert "if (!data || !data.lanlan_name) return false;" in goodbye_filter_block
     assert "return !!currentName && data.lanlan_name === currentName;" in goodbye_filter_block
     assert "var lanlanName = getCurrentLanlanName();" in goodbye_post_block

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -682,6 +682,18 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
         "function handleGoodbyeChatComposerHiddenMessage(data, via)",
         1,
     )[1].split("function postGoodbyeChatComposerHiddenState", 1)[0]
+    goodbye_filter_block = interpage_source.split(
+        "function isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data)",
+        1,
+    )[1].split("function handleGoodbyeChatComposerHiddenMessage", 1)[0]
+    goodbye_post_block = interpage_source.split(
+        "function postGoodbyeChatComposerHiddenState(hidden, reason)",
+        1,
+    )[1].split("function pruneVoiceConfigSwitchOps", 1)[0]
+    goodbye_initial_request_block = interpage_source.split(
+        "var postGoodbyeComposerRequest = function ()",
+        1,
+    )[1].split("postAvatarRequest();", 1)[0]
 
     assert "function applyGoodbyeChatComposerHidden(hidden, reason)" in interpage_source
     assert "function getGoodbyeChatComposerHiddenElectronBridge()" in interpage_source
@@ -695,6 +707,14 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
     assert "case 'request_goodbye_chat_composer_hidden':" in interpage_source
     assert "pathname === '/chat_full'" in standalone_block
     assert "pathname === '/chat_full/'" in standalone_block
+    assert "if (!data || !data.lanlan_name) return false;" in goodbye_filter_block
+    assert "return !!currentName && data.lanlan_name === currentName;" in goodbye_filter_block
+    assert "var lanlanName = getCurrentLanlanName();" in goodbye_post_block
+    assert "if (!lanlanName) return;" in goodbye_post_block
+    assert "lanlan_name: lanlanName" in goodbye_post_block
+    assert "var lanlanName = getCurrentLanlanName();" in goodbye_initial_request_block
+    assert "if (!lanlanName) return;" in goodbye_initial_request_block
+    assert "lanlan_name: lanlanName" in goodbye_initial_request_block
     assert "if (isStandaloneChatPage()) return true;" in goodbye_handler_block
     assert (
         "postGoodbyeChatComposerHiddenState(undefined, 'request-goodbye-chat-composer-hidden');"

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -671,6 +671,53 @@ def test_app_interpage_relays_idle_return_ball_state_to_chat_window():
     assert "new CustomEvent('neko:idle-return-ball-state'" in source
 
 
+def test_goodbye_composer_hidden_syncs_to_chat_window():
+    interpage_source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+    app_ui_source = (PROJECT_ROOT / "static" / "app-ui.js").read_text(encoding="utf-8")
+    standalone_block = interpage_source.split("function isStandaloneChatPage()", 1)[1].split(
+        "function dispatchCrossWindowIdleActivity",
+        1,
+    )[0]
+    goodbye_handler_block = interpage_source.split(
+        "function handleGoodbyeChatComposerHiddenMessage(data, via)",
+        1,
+    )[1].split("function postGoodbyeChatComposerHiddenState", 1)[0]
+
+    assert "function applyGoodbyeChatComposerHidden(hidden, reason)" in interpage_source
+    assert "function getGoodbyeChatComposerHiddenElectronBridge()" in interpage_source
+    assert "function postGoodbyeChatComposerHiddenElectron(payload)" in interpage_source
+    assert "function handleGoodbyeChatComposerHiddenMessage(data, via)" in interpage_source
+    assert "function postGoodbyeChatComposerHiddenState(hidden, reason)" in interpage_source
+    assert "window.nekoElectronGoodbyeChatComposerHidden" in interpage_source
+    assert "neko:electron-goodbye-chat-composer-hidden" in interpage_source
+    assert "action: 'goodbye_chat_composer_hidden'" in interpage_source
+    assert "case 'goodbye_chat_composer_hidden':" in interpage_source
+    assert "case 'request_goodbye_chat_composer_hidden':" in interpage_source
+    assert "pathname === '/chat_full'" in standalone_block
+    assert "pathname === '/chat_full/'" in standalone_block
+    assert "if (isStandaloneChatPage()) return true;" in goodbye_handler_block
+    assert (
+        "postGoodbyeChatComposerHiddenState(undefined, 'request-goodbye-chat-composer-hidden');"
+        in goodbye_handler_block
+    )
+    assert "nekoBroadcastChannel || getGoodbyeChatComposerHiddenElectronBridge()" in interpage_source
+    assert "postGoodbyeChatComposerHiddenPayload(payload);" in interpage_source
+    assert "postGoodbyeComposerRequest();" in interpage_source
+    assert "window.addEventListener('neko:config-injected', postGoodbyeComposerRequest" in interpage_source
+    assert (
+        "mod.postGoodbyeChatComposerHiddenElectron = postGoodbyeChatComposerHiddenElectron;"
+        in interpage_source
+    )
+    assert (
+        "mod.handleGoodbyeChatComposerHiddenMessage = handleGoodbyeChatComposerHiddenMessage;"
+        in interpage_source
+    )
+    assert "mod.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;" in interpage_source
+    assert "window.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;" in interpage_source
+    assert "postGoodbyeChatComposerHiddenState(true, 'live2d-goodbye-click')" in app_ui_source
+    assert "postGoodbyeChatComposerHiddenState(false, 'return-click')" in app_ui_source
+
+
 def test_app_interpage_relays_idle_chat_minimized_state_to_pet_window():
     source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_react_chat_idle_dock_static.py
+++ b/tests/unit/test_react_chat_idle_dock_static.py
@@ -28,7 +28,14 @@ def test_idle_dock_is_limited_to_cat2_and_cat3_tiers():
     assert "var IDLE_DOCK_TIER_CAT3 = 'cat3';" in source
     assert "function isIdleDockTierActive()" in source
     assert "detail.tier === IDLE_DOCK_TIER_CAT2 || detail.tier === IDLE_DOCK_TIER_CAT3" in source
-    assert "window.addEventListener('live2d-goodbye-click'" not in source
+    goodbye_click_block = _between(
+        source,
+        "window.addEventListener('live2d-goodbye-click'",
+        "window.addEventListener('live2d-return-click'",
+    )
+    assert "setGoodbyeComposerHidden(true, 'live2d-goodbye-click')" in goodbye_click_block
+    assert "enterIdleDock" not in goodbye_click_block
+    assert "setChatSurfaceMode('minimized')" not in goodbye_click_block
 
 
 def test_idle_dock_does_not_pollute_normal_minimize_export_or_app_ui():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -123,10 +123,12 @@ def test_goodbye_composer_hidden_survives_surface_mode_switches():
 
     assert "goodbyeComposerHidden: false" in source
     assert "function getEffectiveComposerHidden()" in source
+    assert "function hasLocalGoodbyeModeSource()" in source
     assert "return !!(state.composerHidden || state.goodbyeComposerHidden);" in source
     assert "composerHidden: getEffectiveComposerHidden()" in build_render_block
     assert "state.homeTutorialInteractionLocked || getEffectiveComposerHidden()" in submit_block
-    assert "syncGoodbyeComposerHidden('chat-surface-mode-change');" in set_mode_block
+    assert "syncGoodbyeComposerHidden('chat-surface-mode-change', { localOnly: true });" in set_mode_block
+    assert "options && options.localOnly && !hasLocalGoodbyeModeSource()" in source
     assert "EVENT_PREFIX + 'set-goodbye-composer-hidden'" in source
     assert "window.addEventListener('live2d-goodbye-click'" in source
     assert "setGoodbyeComposerHidden(true, 'live2d-goodbye-click')" in source

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -136,6 +136,9 @@ def test_goodbye_composer_hidden_survives_surface_mode_switches():
     assert "goodbyeComposerHidden: false" in source
     assert "function getEffectiveComposerHidden()" in source
     assert "function hasLocalGoodbyeModeSource()" in source
+    assert "Standalone chat pages inherit window.isNekoGoodbyeModeActive" in source
+    assert "typeof window.isNekoGoodbyeModeActive === 'function'" in source
+    assert "&& window.isNekoGoodbyeModeActive()" in source
     assert "function getEffectiveComposerAttachmentsVisible()" in source
     assert "function syncComposerAttachmentsVisibility(previousVisible)" in source
     assert "return !!(state.composerHidden || state.goodbyeComposerHidden);" in source

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -105,6 +105,34 @@ def test_chat_surface_mode_preference_is_shared_with_electron():
     assert "localStorage.setItem(CHAT_SURFACE_MODE_STORAGE_KEY, mode)" in persist_block
 
 
+def test_goodbye_composer_hidden_survives_surface_mode_switches():
+    source = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    build_render_block = source.split("function buildRenderProps()", 1)[1].split(
+        "function showToast",
+        1,
+    )[0]
+    submit_block = source.split("function handleComposerSubmit(payload)", 1)[1].split(
+        "function prepareCompactHistoryDropSubmit",
+        1,
+    )[0]
+    set_mode_block = source.split("function setChatSurfaceMode(nextMode)", 1)[1].split(
+        "function cycleChatSurfaceMode()",
+        1,
+    )[0]
+
+    assert "goodbyeComposerHidden: false" in source
+    assert "function getEffectiveComposerHidden()" in source
+    assert "return !!(state.composerHidden || state.goodbyeComposerHidden);" in source
+    assert "composerHidden: getEffectiveComposerHidden()" in build_render_block
+    assert "state.homeTutorialInteractionLocked || getEffectiveComposerHidden()" in submit_block
+    assert "syncGoodbyeComposerHidden('chat-surface-mode-change');" in set_mode_block
+    assert "EVENT_PREFIX + 'set-goodbye-composer-hidden'" in source
+    assert "window.addEventListener('live2d-goodbye-click'" in source
+    assert "setGoodbyeComposerHidden(true, 'live2d-goodbye-click')" in source
+    assert "setGoodbyeComposerHidden(false, 'live2d-return-click')" in source
+
+
 def test_chat_full_endpoint_uses_chat_template_with_initial_full_surface():
     router_source = PAGES_ROUTER_PATH.read_text(encoding="utf-8")
     template_source = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -120,15 +120,35 @@ def test_goodbye_composer_hidden_survives_surface_mode_switches():
         "function cycleChatSurfaceMode()",
         1,
     )[0]
+    goodbye_set_block = source.split("function setGoodbyeComposerHidden(hidden, reason)", 1)[1].split(
+        "function syncGoodbyeComposerHidden",
+        1,
+    )[0]
+    attachments_set_block = source.split("function setComposerAttachments(attachments)", 1)[1].split(
+        "var MAX_MESSAGES",
+        1,
+    )[0]
+    desktop_min_height_block = source.split("function getDesktopMinHeight()", 1)[1].split(
+        "function createResizeEdges",
+        1,
+    )[0]
 
     assert "goodbyeComposerHidden: false" in source
     assert "function getEffectiveComposerHidden()" in source
     assert "function hasLocalGoodbyeModeSource()" in source
+    assert "function getEffectiveComposerAttachmentsVisible()" in source
+    assert "function syncComposerAttachmentsVisibility(previousVisible)" in source
     assert "return !!(state.composerHidden || state.goodbyeComposerHidden);" in source
     assert "composerHidden: getEffectiveComposerHidden()" in build_render_block
     assert "state.homeTutorialInteractionLocked || getEffectiveComposerHidden()" in submit_block
     assert "syncGoodbyeComposerHidden('chat-surface-mode-change', { localOnly: true });" in set_mode_block
     assert "options && options.localOnly && !hasLocalGoodbyeModeSource()" in source
+    assert "syncComposerAttachmentsVisibility(previousAttachmentsVisible);" in goodbye_set_block
+    assert "restoredEffectiveComposer && getEffectiveGalgameEnabled()" in goodbye_set_block
+    assert "fetchGalgameOptionsForLatestTurn();" in goodbye_set_block
+    assert "var previousVisible = getEffectiveComposerAttachmentsVisible();" in attachments_set_block
+    assert "syncComposerAttachmentsVisibility(previousVisible);" in attachments_set_block
+    assert "if (!getEffectiveGalgameEnabled()) return MIN_HEIGHT;" in desktop_min_height_block
     assert "EVENT_PREFIX + 'set-goodbye-composer-hidden'" in source
     assert "window.addEventListener('live2d-goodbye-click'" in source
     assert "setGoodbyeComposerHidden(true, 'live2d-goodbye-click')" in source


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * “再见”模式下可完整隐藏并禁用聊天输入区与交互，输入面板按条件从界面树中移除以减少渲染。

* **同步**
  * 隐藏/恢复状态在窗口间与原生桥接间进行跨端同步，支持请求/广播与路由匹配。

* **界面**
  * 发送、工具与选项在隐藏或禁用时不可交互，阻止聚焦与提交行为，附件/工具显隐与布局同步。

* **测试**
  * 新增多项单元测试，覆盖隐藏状态同步、表单提交阻断及界面保护机制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->