### PR TITLE
修复请她离开状态下切换紧凑/完整聊天框后，聊天输入框和功能按钮未同步隐藏的问题。独立聊天页会在初始化、复显、配置注入和形态切换时重新请求当…

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1449,6 +1449,11 @@
     var _voiceConfigSwitchWaiters = [];
 
     function getCurrentLanlanName() {
+        try {
+            if (window.appState && typeof window.appState.lanlan_name === 'string' && window.appState.lanlan_name) {
+                return window.appState.lanlan_name;
+            }
+        } catch (_) {}
         return (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
     }
 
@@ -1539,6 +1544,18 @@
             nekoBroadcastChannel.postMessage(payload);
         }
         postGoodbyeChatComposerHiddenElectron(payload);
+    }
+
+    function requestGoodbyeChatComposerHiddenState(reason) {
+        var lanlanName = getCurrentLanlanName();
+        if (!lanlanName) return false;
+        postGoodbyeChatComposerHiddenPayload({
+            action: 'request_goodbye_chat_composer_hidden',
+            reason: reason || 'request-goodbye-chat-composer-hidden',
+            lanlan_name: lanlanName,
+            timestamp: Date.now()
+        });
+        return true;
     }
 
     function isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data) {
@@ -2525,24 +2542,39 @@
 
     // Chat 窗口初始化时，向 Pet 窗口请求当前已缓存的头像
     if (isStandaloneChatPage() && (nekoBroadcastChannel || getGoodbyeChatComposerHiddenElectronBridge())) {
-        var initialLanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+        var initialLanlanName = getCurrentLanlanName();
+        var GOODBYE_COMPOSER_REQUEST_RETRY_DELAYS_MS = [100, 300, 700, 1500, 3000, 5000];
+        var goodbyeComposerRequestRetryIndex = 0;
+        var goodbyeComposerRequestTimer = 0;
         var postAvatarRequest = function () {
             if (!nekoBroadcastChannel) return;
             nekoBroadcastChannel.postMessage({
                 action: 'request_avatar',
-                lanlan_name: (window.lanlan_config && window.lanlan_config.lanlan_name) || '',
+                lanlan_name: getCurrentLanlanName(),
                 timestamp: Date.now()
             });
         };
+        var scheduleGoodbyeComposerRequest = function (delayMs) {
+            clearTimeout(goodbyeComposerRequestTimer);
+            goodbyeComposerRequestTimer = setTimeout(function () {
+                goodbyeComposerRequestTimer = 0;
+                postGoodbyeComposerRequest();
+            }, Math.max(0, delayMs || 0));
+        };
         var postGoodbyeComposerRequest = function () {
-            var lanlanName = getCurrentLanlanName();
-            if (!lanlanName) return;
-            var payload = {
-                action: 'request_goodbye_chat_composer_hidden',
-                lanlan_name: lanlanName,
-                timestamp: Date.now()
-            };
-            postGoodbyeChatComposerHiddenPayload(payload);
+            if (requestGoodbyeChatComposerHiddenState('standalone-chat-state-request')) {
+                goodbyeComposerRequestRetryIndex = 0;
+                return;
+            }
+            if (goodbyeComposerRequestRetryIndex < GOODBYE_COMPOSER_REQUEST_RETRY_DELAYS_MS.length) {
+                scheduleGoodbyeComposerRequest(
+                    GOODBYE_COMPOSER_REQUEST_RETRY_DELAYS_MS[goodbyeComposerRequestRetryIndex++]
+                );
+            }
+        };
+        var postStandaloneChatStateRequests = function () {
+            postAvatarRequest();
+            scheduleGoodbyeComposerRequest(0);
         };
         postAvatarRequest();
         postGoodbyeComposerRequest();
@@ -2561,6 +2593,18 @@
             window.addEventListener('neko:config-injected', postAvatarRequest, { once: true });
             window.addEventListener('neko:config-injected', postGoodbyeComposerRequest, { once: true });
         }
+        window.addEventListener('neko:config-injected', postStandaloneChatStateRequests);
+        window.addEventListener('neko:request-goodbye-chat-composer-hidden-state', function () {
+            scheduleGoodbyeComposerRequest(0);
+        });
+        window.addEventListener('focus', function () {
+            scheduleGoodbyeComposerRequest(0);
+        });
+        document.addEventListener('visibilitychange', function () {
+            if (!document.hidden) {
+                scheduleGoodbyeComposerRequest(0);
+            }
+        });
     }
 
     // =====================================================================
@@ -2761,6 +2805,7 @@
     mod.postGoodbyeChatComposerHiddenElectron = postGoodbyeChatComposerHiddenElectron;
     mod.handleGoodbyeChatComposerHiddenMessage = handleGoodbyeChatComposerHiddenMessage;
     mod.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;
+    mod.requestGoodbyeChatComposerHiddenState = requestGoodbyeChatComposerHiddenState;
     mod.isVoiceConfigSwitching = isVoiceConfigSwitching;
     mod.waitForVoiceConfigSwitchReady = waitForVoiceConfigSwitchReady;
     mod.applyTutorialChatIdentityOverride = applyTutorialChatIdentityOverride;
@@ -2778,6 +2823,7 @@
     window.shouldKeepVoiceComposerHidden = shouldKeepVoiceComposerHidden;
     window.applyGoodbyeChatComposerHidden = applyGoodbyeChatComposerHidden;
     window.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;
+    window.requestGoodbyeChatComposerHiddenState = requestGoodbyeChatComposerHiddenState;
     window.isVoiceConfigSwitching = isVoiceConfigSwitching;
     window.waitForVoiceConfigSwitchReady = waitForVoiceConfigSwitchReady;
 

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -2542,7 +2542,6 @@
 
     // Chat 窗口初始化时，向 Pet 窗口请求当前已缓存的头像
     if (isStandaloneChatPage() && (nekoBroadcastChannel || getGoodbyeChatComposerHiddenElectronBridge())) {
-        var initialLanlanName = getCurrentLanlanName();
         var GOODBYE_COMPOSER_REQUEST_RETRY_DELAYS_MS = [100, 300, 700, 1500, 3000, 5000];
         var goodbyeComposerRequestRetryIndex = 0;
         var goodbyeComposerRequestTimer = 0;
@@ -2588,11 +2587,7 @@
                 timestamp: Date.now()
             });
         }
-        // 配置可能尚未注入（lanlan_name 为空），等 IPC 注入后补发一次
-        if (!initialLanlanName) {
-            window.addEventListener('neko:config-injected', postAvatarRequest, { once: true });
-            window.addEventListener('neko:config-injected', postGoodbyeComposerRequest, { once: true });
-        }
+        // 配置注入后统一重新请求状态（postStandaloneChatStateRequests 内部已含头像与 goodbye composer 隐藏状态请求，避免重复补发）
         window.addEventListener('neko:config-injected', postStandaloneChatStateRequests);
         window.addEventListener('neko:request-goodbye-chat-composer-hidden-state', function () {
             scheduleGoodbyeComposerRequest(0);

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3837,6 +3837,28 @@
         setGoodbyeComposerHidden(getNekoGoodbyeModeActive(), reason || 'sync');
     }
 
+    function requestGoodbyeComposerHiddenState(reason) {
+        var resolvedReason = reason || 'react-chat-window';
+        try {
+            if (typeof window.requestGoodbyeChatComposerHiddenState === 'function') {
+                if (window.requestGoodbyeChatComposerHiddenState(resolvedReason)) {
+                    return true;
+                }
+            }
+        } catch (_) {}
+        try {
+            window.dispatchEvent(new CustomEvent('neko:request-goodbye-chat-composer-hidden-state', {
+                detail: {
+                    reason: resolvedReason,
+                    timestamp: Date.now()
+                }
+            }));
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
     function setHomeTutorialInteractionLocked(locked, reason) {
         var next = !!locked;
         if (state.homeTutorialInteractionLocked === next) {
@@ -4943,6 +4965,7 @@
 
         resetCompactChatState();
         syncGoodbyeComposerHidden('chat-surface-mode-change', { localOnly: true });
+        requestGoodbyeComposerHiddenState('chat-surface-mode-change');
 
         if (!previousMinimized && nextMinimized && previousMode === 'full' && !isElectronChatWindow() && getShell()) {
             pendingMinimizedSurfaceCommit = {
@@ -6290,6 +6313,7 @@
             } else {
                 syncGoodbyeComposerHidden('initial-goodbye-state');
             }
+            requestGoodbyeComposerHiddenState('initial-goodbye-state');
         } catch (_) {
             // 首绘兜底失败不影响后续 session_started 同步
         }

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -743,7 +743,15 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
     assert "nekoBroadcastChannel || getGoodbyeChatComposerHiddenElectronBridge()" in interpage_source
     assert "postGoodbyeChatComposerHiddenPayload({" in interpage_source
     assert "postGoodbyeComposerRequest();" in interpage_source
-    assert "window.addEventListener('neko:config-injected', postGoodbyeComposerRequest" in interpage_source
+    # config 注入后只通过 postStandaloneChatStateRequests 统一补发，不再单独注册 once 监听，避免重复请求
+    assert (
+        "window.addEventListener('neko:config-injected', postGoodbyeComposerRequest"
+        not in interpage_source
+    )
+    assert (
+        "window.addEventListener('neko:config-injected', postAvatarRequest"
+        not in interpage_source
+    )
     assert "window.addEventListener('neko:config-injected', postStandaloneChatStateRequests);" in interpage_source
     assert "window.addEventListener('neko:request-goodbye-chat-composer-hidden-state'" in interpage_source
     assert "window.addEventListener('focus', function ()" in interpage_source

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -690,6 +690,10 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
         "function isGoodbyeChatComposerHiddenMessageForCurrentLanlan(data)",
         1,
     )[1].split("function handleGoodbyeChatComposerHiddenMessage", 1)[0]
+    goodbye_request_block = interpage_source.split(
+        "function requestGoodbyeChatComposerHiddenState(reason)",
+        1,
+    )[1].split("function isGoodbyeChatComposerHiddenMessageForCurrentLanlan", 1)[0]
     goodbye_post_block = interpage_source.split(
         "function postGoodbyeChatComposerHiddenState(hidden, reason)",
         1,
@@ -723,18 +727,27 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
     assert "var lanlanName = getCurrentLanlanName();" in goodbye_post_block
     assert "if (!lanlanName) return;" in goodbye_post_block
     assert "lanlan_name: lanlanName" in goodbye_post_block
-    assert "var lanlanName = getCurrentLanlanName();" in goodbye_initial_request_block
-    assert "if (!lanlanName) return;" in goodbye_initial_request_block
-    assert "lanlan_name: lanlanName" in goodbye_initial_request_block
+    assert "window.appState && typeof window.appState.lanlan_name === 'string'" in interpage_source
+    assert "var lanlanName = getCurrentLanlanName();" in goodbye_request_block
+    assert "if (!lanlanName) return false;" in goodbye_request_block
+    assert "reason: reason || 'request-goodbye-chat-composer-hidden'" in goodbye_request_block
+    assert "lanlan_name: lanlanName" in goodbye_request_block
+    assert "requestGoodbyeChatComposerHiddenState('standalone-chat-state-request')" in goodbye_initial_request_block
+    assert "GOODBYE_COMPOSER_REQUEST_RETRY_DELAYS_MS[goodbyeComposerRequestRetryIndex++]" in interpage_source
+    assert "scheduleGoodbyeComposerRequest(0);" in interpage_source
     assert "if (isStandaloneChatPage()) return true;" in goodbye_handler_block
     assert (
         "postGoodbyeChatComposerHiddenState(undefined, 'request-goodbye-chat-composer-hidden');"
         in goodbye_handler_block
     )
     assert "nekoBroadcastChannel || getGoodbyeChatComposerHiddenElectronBridge()" in interpage_source
-    assert "postGoodbyeChatComposerHiddenPayload(payload);" in interpage_source
+    assert "postGoodbyeChatComposerHiddenPayload({" in interpage_source
     assert "postGoodbyeComposerRequest();" in interpage_source
     assert "window.addEventListener('neko:config-injected', postGoodbyeComposerRequest" in interpage_source
+    assert "window.addEventListener('neko:config-injected', postStandaloneChatStateRequests);" in interpage_source
+    assert "window.addEventListener('neko:request-goodbye-chat-composer-hidden-state'" in interpage_source
+    assert "window.addEventListener('focus', function ()" in interpage_source
+    assert "document.addEventListener('visibilitychange', function ()" in interpage_source
     assert (
         "mod.postGoodbyeChatComposerHiddenElectron = postGoodbyeChatComposerHiddenElectron;"
         in interpage_source
@@ -744,7 +757,9 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
         in interpage_source
     )
     assert "mod.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;" in interpage_source
+    assert "mod.requestGoodbyeChatComposerHiddenState = requestGoodbyeChatComposerHiddenState;" in interpage_source
     assert "window.postGoodbyeChatComposerHiddenState = postGoodbyeChatComposerHiddenState;" in interpage_source
+    assert "window.requestGoodbyeChatComposerHiddenState = requestGoodbyeChatComposerHiddenState;" in interpage_source
     assert "postGoodbyeChatComposerHiddenState(true, 'live2d-goodbye-click')" in app_ui_source
     assert "postGoodbyeChatComposerHiddenState(false, 'return-click')" in app_ui_source
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -145,7 +145,12 @@ def test_goodbye_composer_hidden_survives_surface_mode_switches():
     assert "composerHidden: getEffectiveComposerHidden()" in build_render_block
     assert "state.homeTutorialInteractionLocked || getEffectiveComposerHidden()" in submit_block
     assert "syncGoodbyeComposerHidden('chat-surface-mode-change', { localOnly: true });" in set_mode_block
+    assert "requestGoodbyeComposerHiddenState('chat-surface-mode-change');" in set_mode_block
     assert "options && options.localOnly && !hasLocalGoodbyeModeSource()" in source
+    assert "function requestGoodbyeComposerHiddenState(reason)" in source
+    assert "window.requestGoodbyeChatComposerHiddenState(resolvedReason)" in source
+    assert "neko:request-goodbye-chat-composer-hidden-state" in source
+    assert "requestGoodbyeComposerHiddenState('initial-goodbye-state');" in source
     assert "syncComposerAttachmentsVisibility(previousAttachmentsVisible);" in goodbye_set_block
     assert "restoredEffectiveComposer && getEffectiveGalgameEnabled()" in goodbye_set_block
     assert "fetchGalgameOptionsForLatestTurn();" in goodbye_set_block


### PR DESCRIPTION
…前隐藏状态，并在角色名未就绪时自动重试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **重构**
  * 增强了跨窗口聊天输入栏隐藏/显示状态的同步：加入重试调度与延迟序列、在窗口聚焦、页面可见性恢复、配置注入及自定义事件时补发同步请求，并在发起前尝试头像/缓存相关准备；同时将请求能力暴露为可被外部触发的全局入口。

* **测试**
  * 扩展并强化了相关单元测试，覆盖请求内容、重试逻辑、监听器注册与全局暴露行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->