### PR TITLE
fix(cat1): 根除返回猫走向毛线球时贴着球抽搐

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -200,6 +200,8 @@ const _NEKO_IDLE_CAT1_SUBSTATE_STRETCH = 'stretch-near-chat';
 const _NEKO_IDLE_CAT1_CHAT_GAP_PX = -12;
 const _NEKO_IDLE_CAT1_MINIMIZED_RIGHT_TO_LEFT_APPROACH_PX = 35;
 const _NEKO_IDLE_CAT1_MINIMIZED_BACKWARD_RETREAT_TOLERANCE_PX = 2;
+// 容器属性名：本次走路提交的接近侧（true=站毛球左侧/朝右，false=站毛球右侧/朝左）。
+const _NEKO_IDLE_CAT1_WALK_SIDE_COMMIT_PROP = '__nekoIdleCat1WalkApproachLookRight';
 const _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE = 'compact-top-edge';
 const _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE = 'minimized-side';
 const _NEKO_IDLE_CAT1_COMPACT_TOP_EDGE_OVERLAP_PX = 28;
@@ -2051,6 +2053,7 @@ function _cancelNekoIdleCat1Journey(button, options = {}) {
     _cancelNekoIdleReturnSubactionState(state, {
         preserveObservers: options.preserveObservers === true
     });
+    _clearNekoIdleCat1WalkApproachSide(_getNekoIdleReturnContainerFromButton(button));
     const profile = state.profile || _NEKO_IDLE_RETURN_SUBACTION_CAT1_CHAT_FOLLOW;
     state.substate = profile.idleSubstate;
     state.target = null;
@@ -2643,43 +2646,75 @@ function _makeNekoIdleCat1SideTarget(rect, chatRect, options) {
     };
 }
 
-function _getNekoIdleCat1SideTarget(container, chatRect) {
-    if (!container || !chatRect || typeof container.getBoundingClientRect !== 'function') return null;
+function _computeNekoIdleCat1SideTargetForLook(rect, chatRect, lookFacingRight) {
     const profile = _NEKO_IDLE_RETURN_SUBACTION_CAT1_CHAT_FOLLOW;
-    const rect = container.getBoundingClientRect();
-    if (!rect || rect.width <= 0 || rect.height <= 0) return null;
-
-    const catCenterX = rect.left + rect.width / 2;
-    const chatCenterX = chatRect.left + chatRect.width / 2;
-    const lookFacingRight = chatCenterX > catCenterX;
     const approachOffsetPx = _getNekoIdleCat1MinimizedSideApproachOffsetPx(lookFacingRight, chatRect);
     const rawLeft = lookFacingRight
         ? chatRect.left - rect.width - profile.target.gapPx
         : chatRect.right + profile.target.gapPx - approachOffsetPx;
-    const sideTarget = _makeNekoIdleCat1SideTarget(rect, chatRect, {
+    return _makeNekoIdleCat1SideTarget(rect, chatRect, {
         facingRight: lookFacingRight,
         rawLeft: rawLeft,
         approachOffsetPx: approachOffsetPx
     });
+}
+
+// #1749 的本意：在毛球两侧站位点里挑“朝毛球前进即可到达”的那个，避免明显倒退。
+// 仅用于本次走路“首次”决定接近侧；之后由提交侧 + 滞回保持，避免每帧重判导致横跳。
+function _pickNekoIdleCat1ForwardSideTarget(rect, chatRect) {
+    const catCenterX = rect.left + rect.width / 2;
+    const chatCenterX = chatRect.left + chatRect.width / 2;
+    const lookFacingRight = chatCenterX > catCenterX;
+    const sideTarget = _computeNekoIdleCat1SideTargetForLook(rect, chatRect, lookFacingRight);
     if (!sideTarget || sideTarget.moveFacingRight === null || sideTarget.moveFacingRight === lookFacingRight) {
         return sideTarget;
     }
-
-    const alternateRawLeft = lookFacingRight
-        ? chatRect.right + profile.target.gapPx - _getNekoIdleCat1MinimizedSideApproachOffsetPx(false, chatRect)
-        : chatRect.left - rect.width - profile.target.gapPx;
-    const alternateTarget = _makeNekoIdleCat1SideTarget(rect, chatRect, {
-        facingRight: !lookFacingRight,
-        rawLeft: alternateRawLeft,
-        approachOffsetPx: lookFacingRight
-            ? _getNekoIdleCat1MinimizedSideApproachOffsetPx(false, chatRect)
-            : 0
-    });
+    const alternateTarget = _computeNekoIdleCat1SideTargetForLook(rect, chatRect, !lookFacingRight);
     if (alternateTarget &&
         (alternateTarget.moveFacingRight === null || alternateTarget.moveFacingRight === lookFacingRight)) {
         return alternateTarget;
     }
     return sideTarget;
+}
+
+function _clearNekoIdleCat1WalkApproachSide(container) {
+    if (container && _NEKO_IDLE_CAT1_WALK_SIDE_COMMIT_PROP in container) {
+        delete container[_NEKO_IDLE_CAT1_WALK_SIDE_COMMIT_PROP];
+    }
+}
+
+function _getNekoIdleCat1SideTarget(container, chatRect) {
+    if (!container || !chatRect || typeof container.getBoundingClientRect !== 'function') return null;
+    const rect = container.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) return null;
+
+    // 提交本次走路的接近侧，且只在“猫已整体越到毛球另一侧”时才重选。
+    // 若像旧实现那样每帧用 catCenter vs chatCenter 重判接近侧：两侧站位点都落在毛球“对侧”，
+    // 猫一旦进入两站位点之间的区间，每帧目标都被指到对面 → 跨过球心就翻面、永不收敛，
+    // 表现为返回猫贴着毛球一直抽搐（#1749 残留）。提交侧 + 滞回即可根除该横跳。
+    const catCenterX = rect.left + rect.width / 2;
+    const committed = container[_NEKO_IDLE_CAT1_WALK_SIDE_COMMIT_PROP];
+    const hasCommitted = committed === true || committed === false;
+    let lookFacingRight = null;
+    if (hasCommitted) {
+        if (catCenterX >= chatRect.left && catCenterX <= chatRect.right) {
+            lookFacingRight = committed; // 仍在毛球水平跨度内：保持提交侧，不在球心附近翻面
+        } else if (committed === true && catCenterX > chatRect.right) {
+            lookFacingRight = false; // 已整体越到毛球右侧 → 重选接近侧
+        } else if (committed === false && catCenterX < chatRect.left) {
+            lookFacingRight = true; // 已整体越到毛球左侧 → 重选接近侧
+        } else {
+            lookFacingRight = committed; // 在毛球外、且就处于提交侧 → 保持
+        }
+    }
+
+    const target = lookFacingRight === null
+        ? _pickNekoIdleCat1ForwardSideTarget(rect, chatRect)
+        : _computeNekoIdleCat1SideTargetForLook(rect, chatRect, lookFacingRight);
+    if (target) {
+        container[_NEKO_IDLE_CAT1_WALK_SIDE_COMMIT_PROP] = !!target.lookFacingRight;
+    }
+    return target;
 }
 
 function _getNekoIdleCat1CompactTopEdgeBounds(surfaceRect) {
@@ -3074,6 +3109,7 @@ function _finishNekoIdleCat1Walk(button) {
     const state = _getNekoIdleCat1Journey(button);
     if (!state) return;
     _cancelNekoIdleCat1Frame(state);
+    _clearNekoIdleCat1WalkApproachSide(_getNekoIdleReturnContainerFromButton(button));
     _dispatchNekoIdleCat1MotionInputRegionState(state, false, 'cat1-walk-finish');
     state.target = null;
     state.lastStepAt = 0;
@@ -3242,14 +3278,26 @@ function _updateNekoIdleCat1WalkSpeedRate(button, state, distance) {
     const threshold = Math.max(0, Number(targetConfig.distanceIncreaseThresholdPx) || 0);
     const growthForMaxRate = Math.max(1, Number(targetConfig.distanceGrowthForMaxRatePx) || 1);
 
-    if (previousDistance > 0 && currentDistance > previousDistance + threshold) {
-        state.walkDistanceGrowthPx = Math.max(
-            0,
-            (Number(state.walkDistanceGrowthPx) || 0) + (currentDistance - previousDistance)
-        );
-        const progress = Math.min(1, state.walkDistanceGrowthPx / growthForMaxRate);
-        state.walkSpeedRate = Math.min(maxRate, 1 + (maxRate - 1) * progress);
-        _setNekoIdleCat1Classes(button, state);
+    if (previousDistance > 0) {
+        if (currentDistance > previousDistance + threshold) {
+            // 落后了（毛球被移远）：累计落后量，提升追赶倍率
+            state.walkDistanceGrowthPx = Math.max(
+                0,
+                (Number(state.walkDistanceGrowthPx) || 0) + (currentDistance - previousDistance)
+            );
+        } else if (currentDistance < previousDistance) {
+            // 正在收敛：回落累计落后量，避免一次瞬时变远把倍率永久钉死在 maxRate
+            state.walkDistanceGrowthPx = Math.max(
+                0,
+                (Number(state.walkDistanceGrowthPx) || 0) - (previousDistance - currentDistance)
+            );
+        }
+        const progress = Math.min(1, (Number(state.walkDistanceGrowthPx) || 0) / growthForMaxRate);
+        const nextRate = Math.min(maxRate, 1 + (maxRate - 1) * progress);
+        if (nextRate !== state.walkSpeedRate) {
+            state.walkSpeedRate = nextRate;
+            _setNekoIdleCat1Classes(button, state);
+        }
     }
 
     state.walkPreviousDistance = currentDistance;

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -49,7 +49,7 @@ def test_cat1_minimized_side_target_separates_look_and_move_direction():
 
 
 def test_cat1_minimized_side_target_commits_approach_side_to_prevent_center_straddle():
-    """接近侧必须提交并带滞回，禁止每帧用 catCenter vs chatCenter 重判导致跨球心横跳（贴着毛球抽搐）。"""
+    """Approach side must be committed with hysteresis, never re-judged each frame via catCenter vs chatCenter (which makes the cat straddle the ball center and jitter against it)."""
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
     side_target_block = source.split("function _getNekoIdleCat1SideTarget", 1)[1].split(
@@ -75,7 +75,7 @@ def test_cat1_minimized_side_target_commits_approach_side_to_prevent_center_stra
 
 
 def test_cat1_walk_speed_rate_relaxes_when_converging():
-    """追赶倍率必须在收敛时回落，避免一次瞬时变远把速度永久钉死在 maxRate。"""
+    """Catch-up speed rate must relax while converging, so one momentary distance spike does not pin the speed at maxRate forever."""
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
     speed_block = source.split("function _updateNekoIdleCat1WalkSpeedRate", 1)[1].split(

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -35,16 +35,55 @@ def test_cat1_return_button_assets_are_version_tracked():
 def test_cat1_minimized_side_target_separates_look_and_move_direction():
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 
+    # #1749 的“朝毛球前进、避免倒退”的取侧逻辑只用于本次走路首次决策，已抽到 forward picker。
+    forward_pick_block = source.split("function _pickNekoIdleCat1ForwardSideTarget", 1)[1].split(
+        "function _clearNekoIdleCat1WalkApproachSide",
+        1,
+    )[0]
+    assert "const lookFacingRight = chatCenterX > catCenterX;" in forward_pick_block
+    assert "sideTarget.moveFacingRight === lookFacingRight" in forward_pick_block
+    assert "alternateTarget.moveFacingRight === null || alternateTarget.moveFacingRight === lookFacingRight" in forward_pick_block
+    assert "facingRight: facingRight," in source
+    assert "lookFacingRight: facingRight" in source
+    assert "moveFacingRight: moveFacingRight" in source
+
+
+def test_cat1_minimized_side_target_commits_approach_side_to_prevent_center_straddle():
+    """接近侧必须提交并带滞回，禁止每帧用 catCenter vs chatCenter 重判导致跨球心横跳（贴着毛球抽搐）。"""
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
     side_target_block = source.split("function _getNekoIdleCat1SideTarget", 1)[1].split(
         "function _getNekoIdleCat1CompactTopEdgeBounds",
         1,
     )[0]
-    assert "const lookFacingRight = chatCenterX > catCenterX;" in side_target_block
-    assert "sideTarget.moveFacingRight === lookFacingRight" in side_target_block
-    assert "alternateTarget.moveFacingRight === null || alternateTarget.moveFacingRight === lookFacingRight" in side_target_block
-    assert "facingRight: facingRight," in source
-    assert "lookFacingRight: facingRight" in source
-    assert "moveFacingRight: moveFacingRight" in source
+    assert "_NEKO_IDLE_CAT1_WALK_SIDE_COMMIT_PROP" in side_target_block
+    # 仍在毛球水平跨度内 -> 保持提交侧，不在球心附近翻面
+    assert "catCenterX >= chatRect.left && catCenterX <= chatRect.right" in side_target_block
+    # 只在猫已整体越到毛球另一侧时才重选接近侧
+    assert "committed === true && catCenterX > chatRect.right" in side_target_block
+    assert "committed === false && catCenterX < chatRect.left" in side_target_block
+    # 提交侧持有期间，禁止再出现旧的“每帧重判 lookFacingRight”
+    assert "const lookFacingRight = chatCenterX > catCenterX;" not in side_target_block
+
+    # 走完/取消时必须清掉提交侧，便于下次重新决策
+    assert "function _clearNekoIdleCat1WalkApproachSide" in source
+    finish_block = source.split("function _finishNekoIdleCat1Walk", 1)[1].split(
+        "function _finishNekoIdleCat1CompactTopEdgeWalk",
+        1,
+    )[0]
+    assert "_clearNekoIdleCat1WalkApproachSide(" in finish_block
+
+
+def test_cat1_walk_speed_rate_relaxes_when_converging():
+    """追赶倍率必须在收敛时回落，避免一次瞬时变远把速度永久钉死在 maxRate。"""
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    speed_block = source.split("function _updateNekoIdleCat1WalkSpeedRate", 1)[1].split(
+        "function _stepNekoIdleCat1Walk",
+        1,
+    )[0]
+    assert "currentDistance < previousDistance" in speed_block
+    assert "(previousDistance - currentDistance)" in speed_block
 
 
 def test_cat1_walk_uses_resolved_target_facing_instead_of_raw_chat_side():
@@ -91,4 +130,4 @@ def test_cat1_external_chat_position_updates_interrupt_pair_move_for_retarget():
         "function _shouldRecheckNekoIdleCat1AfterManualMove",
         1,
     )[0]
-    assert "_interruptNekoIdleCat1PairMovesForRetarget({ scheduleSync: !dragging });" in compact_move_block
+    assert "_interruptNekoIdleCat1PairMovesForRetarget({ scheduleSync: !activeSurfaceAdjustment });" in compact_move_block


### PR DESCRIPTION
## 问题
"请她离开"后，返回猫（CAT1）走向最小化毛线球时，会贴着球**持续抽搐**、永不停下。

## 根因
CAT1 走路每帧用 `catCenter vs chatCenter` 重判接近哪一侧，而两侧站位点都落在毛球的**对侧**。猫一旦进入两站位点之间的区间，目标每帧被指到对面 —— 跨过球心就翻面、永不收敛，表现为贴着毛球抽搐。这是 #1749 的残留：#1749 的 alternate 取侧逻辑引入了这个 center-straddle 横跳。

## 修复
- #1749 的「朝毛球前进、避免倒退」取侧逻辑只用于本次走路**首次决策**；之后**提交接近侧并带滞回**，只在猫已整体越到毛球另一侧时才重选 —— 消除跨球心横跳。
- 顺带让追赶倍率在收敛时回落，避免一次瞬时变远把走路速度永久钉死在 1.5x。

## 验证
- `node --check static/avatar-ui-buttons.js`
- `pytest tests/unit/test_avatar_return_button_cat1_static.py`（含新增回归断言：提交侧 + 滞回、速率回落）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复猫咪横跳与朝向抖动，走路时朝向与移动方向更一致，避免贴球后回退导致抽搐或中心来回抖动。
  * 引入“接近侧提交”机制，减少每帧重判侧目标，仅在越过对侧区域后才重新选侧。
  * 平滑追赶速度倍率：累积落后并平滑提升，收敛时平滑回退，避免瞬时跳变并同步触发样式更新。

* **Tests**
  * 新增/调整单元测试，覆盖侧目标提交行为、朝向与移动一致性及速度收敛回退逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->