### PR TITLE
fix(chat): split companion empty-state copy

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -55,10 +55,12 @@ describe('App', () => {
     expect(getChatEmptyStateFallback('zh-MO')).toBe('現在開始跟我聊天吧！');
     expect(getChatEmptyStateFallback('zh-Hant')).toBe('現在開始跟我聊天吧！');
     expect(getChatEmptyStateFallback('en-US')).toBe('Start chatting with me now!');
-    expect(getChatCompanionEmptyStateFallback('zh-CN')).toBe('我就在这陪着你哦');
-    expect(getChatCompanionEmptyStateFallback('zh-TW')).toBe('我就在這陪著你喔');
-    expect(getChatCompanionEmptyStateFallback('zh-HK')).toBe('我就在這陪著你喔');
-    expect(getChatCompanionEmptyStateFallback('en-US')).toBe("I'm right here with you.");
+    expect(getChatCompanionEmptyStateFallback('zh-CN')).toBe('（我就在这陪着你哦）');
+    expect(getChatCompanionEmptyStateFallback('zh-TW')).toBe('（我就在這陪著你喔）');
+    expect(getChatCompanionEmptyStateFallback('zh-HK')).toBe('（我就在這陪著你喔）');
+    expect(getChatCompanionEmptyStateFallback('zh-MO')).toBe('（我就在這陪著你喔）');
+    expect(getChatCompanionEmptyStateFallback('zh-Hant')).toBe('（我就在這陪著你喔）');
+    expect(getChatCompanionEmptyStateFallback('en-US')).toBe("(I'm right here with you.)");
   });
 
   const mockHoverCapableMatchMedia = (hoverCapable = true) => {

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -7,13 +7,14 @@ import {
   computeCompactHistoryExitDelay,
 } from './CompactExportHistoryPanel';
 import MessageList from './MessageList';
-import { getChatEmptyStateFallback } from './chat-copy';
+import { getChatCompanionEmptyStateFallback, getChatEmptyStateFallback } from './chat-copy';
 import { parseChatMessage, type CompactChatState } from './message-schema';
 
 describe('App', () => {
   const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
   const COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY = 'neko.reactChatWindow.compactInputToolWheelIndex';
   const DEFAULT_CHAT_EMPTY_STATE_FALLBACK = getChatEmptyStateFallback('en');
+  const DEFAULT_CHAT_COMPANION_EMPTY_STATE_FALLBACK = getChatCompanionEmptyStateFallback('en');
   beforeEach(() => {
     window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
     window.localStorage.removeItem(COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY);
@@ -54,6 +55,10 @@ describe('App', () => {
     expect(getChatEmptyStateFallback('zh-MO')).toBe('現在開始跟我聊天吧！');
     expect(getChatEmptyStateFallback('zh-Hant')).toBe('現在開始跟我聊天吧！');
     expect(getChatEmptyStateFallback('en-US')).toBe('Start chatting with me now!');
+    expect(getChatCompanionEmptyStateFallback('zh-CN')).toBe('我就在这陪着你哦');
+    expect(getChatCompanionEmptyStateFallback('zh-TW')).toBe('我就在這陪著你喔');
+    expect(getChatCompanionEmptyStateFallback('zh-HK')).toBe('我就在這陪著你喔');
+    expect(getChatCompanionEmptyStateFallback('en-US')).toBe("I'm right here with you.");
   });
 
   const mockHoverCapableMatchMedia = (hoverCapable = true) => {
@@ -94,6 +99,7 @@ describe('App', () => {
     expect(screen.queryByPlaceholderText('Type a message...')).toBeNull();
     expect(document.body.querySelector('.compact-chat-stage-default')).not.toBeNull();
     expect(document.body.querySelector('.compact-chat-capsule-button')).not.toBeNull();
+    expect(document.body.querySelector('.compact-chat-capsule-button')).toHaveTextContent(DEFAULT_CHAT_EMPTY_STATE_FALLBACK);
     expect(screen.getByRole('button', { name: '更多工具' })).toBeInTheDocument();
     expect(document.body.querySelector('.compact-input-tool-fan')).not.toBeNull();
   });
@@ -2037,7 +2043,7 @@ describe('App', () => {
       <App chatSurfaceMode="compact" composerHidden messages={[assistantMessage, userMessage]} />,
     );
 
-    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent(DEFAULT_CHAT_EMPTY_STATE_FALLBACK);
+    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent(DEFAULT_CHAT_COMPANION_EMPTY_STATE_FALLBACK);
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('先看我这边的引导内容');
     expect(container.querySelector('.compact-chat-capsule-button')).not.toHaveTextContent('这是我刚刚发出的内容');
   });
@@ -3502,6 +3508,7 @@ describe('App', () => {
     expect(container.querySelector('.compact-chat-surface-shell')).not.toBeNull();
     expect(container.querySelector('.compact-chat-surface-frame')).toHaveAttribute('data-compact-geometry-item', 'capsule');
     expect(container.querySelector('.composer-input')).toBeNull();
+    expect(container.querySelector('.compact-chat-capsule-button')).toHaveTextContent(DEFAULT_CHAT_COMPANION_EMPTY_STATE_FALLBACK);
   });
 
   it('does not expose compact galgame choices while voice mode hides the composer', () => {
@@ -3548,7 +3555,7 @@ describe('App', () => {
     );
 
     const capsule = container.querySelector('.compact-chat-capsule-button');
-    expect(capsule).toHaveTextContent(DEFAULT_CHAT_EMPTY_STATE_FALLBACK);
+    expect(capsule).toHaveTextContent(DEFAULT_CHAT_COMPANION_EMPTY_STATE_FALLBACK);
     fireEvent.click(capsule as Element);
 
     expect(container.querySelector('.app-shell')).toHaveAttribute('data-compact-chat-state', 'default');

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -19,7 +19,7 @@ import CompactExportHistoryPanel, {
   type CompactExportActionRequest,
   type CompactExportPreviewResult,
 } from './CompactExportHistoryPanel';
-import { getChatEmptyStateFallback } from './chat-copy';
+import { getChatCompanionEmptyStateFallback, getChatEmptyStateFallback } from './chat-copy';
 import { i18n } from './i18n';
 import {
   type ChatMessage,
@@ -1928,6 +1928,9 @@ function CompactChatApp({
   const compactSpeechPreservedText = (compactSpeechModeActive && !compactMessagePreview?.isStreaming)
     ? compactSpeechPreviewTextRef.current
     : '';
+  const compactEmptyStateText = composerHidden
+    ? i18n('chat.companionEmptyState', getChatCompanionEmptyStateFallback())
+    : i18n('chat.emptyState', getChatEmptyStateFallback());
   const compactPreviewText = compactSuppressAssistantFallback
     ? ''
     : compactSpeechModeActive
@@ -1937,7 +1940,7 @@ function CompactChatApp({
           : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
       )
       : compactMessagePreview?.text
-      || i18n('chat.emptyState', getChatEmptyStateFallback());
+      || compactEmptyStateText;
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewAllowsScroll = compactPreviewIsStreaming || !!compactMessagePreview?.isGuide;
   const compactPreviewSpeechDuration = useMemo(() => {

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -26,7 +26,7 @@ import CompactExportHistoryPanel, {
   type CompactExportActionRequest,
   type CompactExportPreviewResult,
 } from './CompactExportHistoryPanel';
-import { getChatEmptyStateFallback } from './chat-copy';
+import { getChatCompanionEmptyStateFallback, getChatEmptyStateFallback } from './chat-copy';
 import { i18n } from './i18n';
 import {
   type ChatMessage,
@@ -1406,6 +1406,9 @@ export default function FullChatSurface({
   const compactSpeechPreservedText = compactSpeechModeActive && !compactMessagePreview?.isStreaming
     ? compactSpeechPreviewTextRef.current
     : '';
+  const compactEmptyStateText = composerHidden
+    ? i18n('chat.companionEmptyState', getChatCompanionEmptyStateFallback())
+    : i18n('chat.emptyState', getChatEmptyStateFallback());
   const compactPreviewText = compactSpeechModeActive
     ? (
       compactMessagePreview?.isStreaming
@@ -1413,7 +1416,7 @@ export default function FullChatSurface({
         : compactSpeechPreservedText || compactMessagePreview?.fullText || ''
     )
     : compactMessagePreview?.text
-    || i18n('chat.emptyState', getChatEmptyStateFallback());
+    || compactEmptyStateText;
   const compactPreviewIsStreaming = compactSpeechModeActive;
   const compactPreviewSpeechDuration = useMemo(() => {
     if (!compactPreviewIsStreaming || !speechPlaybackState) {

--- a/frontend/react-neko-chat/src/chat-copy.ts
+++ b/frontend/react-neko-chat/src/chat-copy.ts
@@ -55,10 +55,10 @@ export function getChatEmptyStateFallback(locale = getRuntimeLocale()): string {
 export function getChatCompanionEmptyStateFallback(locale = getRuntimeLocale()): string {
   switch (normalizeChatLocale(locale)) {
     case 'zh-CN':
-      return '我就在这陪着你哦';
+      return '（我就在这陪着你哦）';
     case 'zh-TW':
-      return '我就在這陪著你喔';
+      return '（我就在這陪著你喔）';
     default:
-      return "I'm right here with you.";
+      return "(I'm right here with you.)";
   }
 }

--- a/frontend/react-neko-chat/src/chat-copy.ts
+++ b/frontend/react-neko-chat/src/chat-copy.ts
@@ -51,3 +51,14 @@ export function getChatEmptyStateFallback(locale = getRuntimeLocale()): string {
       return 'Start chatting with me now!';
   }
 }
+
+export function getChatCompanionEmptyStateFallback(locale = getRuntimeLocale()): string {
+  switch (normalizeChatLocale(locale)) {
+    case 'zh-CN':
+      return '我就在这陪着你哦';
+    case 'zh-TW':
+      return '我就在這陪著你喔';
+    default:
+      return "I'm right here with you.";
+  }
+}

--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -42,6 +42,7 @@ _YUI_GUIDE_ASSET_VERSION_PATHS = (
     _PROJECT_ROOT / "static/app-interpage.js",
     _PROJECT_ROOT / "static/common_ui.js",
     _PROJECT_ROOT / "static/common-ui-hud.js",
+    _PROJECT_ROOT / "static/i18n-i18next.js",
     _PROJECT_ROOT / "static/app-react-chat-window.js",
     _PROJECT_ROOT / "static/app-chat-export.js",
     _PROJECT_ROOT / "static/avatar-ui-buttons.js",

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -30,7 +30,7 @@
 
     // locale 资源版本（用于 cache-busting，避免客户端长期缓存旧语言包导致新增 key 不生效）
     // 更新语言包内容时可以递增此值
-    const LOCALE_VERSION = '2026-05-03-1';
+    const LOCALE_VERSION = '2026-06-12-1';
 
     function initDecorativeImageDragGuard() {
         const markImage = (img) => {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "Cancel",
         "avatarCropSave": "Save",
         "emptyState":  "Messages will appear here after the chat feed is connected.",
+        "companionEmptyState": "I'm right here with you.",
         "messageStreaming": "Generating",
         "messageFailed": "Send failed",
         "reactWindowOpen": "Open chat window",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "Cancel",
         "avatarCropSave": "Save",
         "emptyState":  "Messages will appear here after the chat feed is connected.",
-        "companionEmptyState": "I'm right here with you.",
+        "companionEmptyState": "(I'm right here with you.)",
         "messageStreaming": "Generating",
         "messageFailed": "Send failed",
         "reactWindowOpen": "Open chat window",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Guardar",
         "emptyState":  "Los mensajes aparecerán aquí después de que se conecte la transmisión del chat.",
+        "companionEmptyState": "Estoy aquí contigo.",
         "messageStreaming": "generando",
         "messageFailed": "Envío fallido",
         "reactWindowOpen": "Abrir ventana de chat",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Guardar",
         "emptyState":  "Los mensajes aparecerán aquí después de que se conecte la transmisión del chat.",
-        "companionEmptyState": "Estoy aquí contigo.",
+        "companionEmptyState": "(Estoy aquí contigo.)",
         "messageStreaming": "generando",
         "messageFailed": "Envío fallido",
         "reactWindowOpen": "Abrir ventana de chat",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "キャンセル",
         "avatarCropSave": "保存",
         "emptyState":  "チャット内容が接続されると、ここに表示されます。",
-        "companionEmptyState": "ここでそばにいるよ。",
+        "companionEmptyState": "（ここでそばにいるよ。）",
         "messageStreaming": "生成中",
         "messageFailed": "送信失敗",
         "reactWindowOpen": "チャットウィンドウを開く",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "キャンセル",
         "avatarCropSave": "保存",
         "emptyState":  "チャット内容が接続されると、ここに表示されます。",
+        "companionEmptyState": "ここでそばにいるよ。",
         "messageStreaming": "生成中",
         "messageFailed": "送信失敗",
         "reactWindowOpen": "チャットウィンドウを開く",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "취소",
         "avatarCropSave": "저장",
         "emptyState":  "채팅 내용이 연결되면 여기에 표시됩니다.",
+        "companionEmptyState": "여기서 곁에 있을게요.",
         "messageStreaming": "생성 중",
         "messageFailed": "전송 실패",
         "reactWindowOpen": "채팅 창 열기",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "취소",
         "avatarCropSave": "저장",
         "emptyState":  "채팅 내용이 연결되면 여기에 표시됩니다.",
-        "companionEmptyState": "여기서 곁에 있을게요.",
+        "companionEmptyState": "（여기서 곁에 있을게요.）",
         "messageStreaming": "생성 중",
         "messageFailed": "전송 실패",
         "reactWindowOpen": "채팅 창 열기",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Salvar",
         "emptyState":  "As mensagens aparecerão aqui depois que o feed do bate-papo for conectado.",
-        "companionEmptyState": "Estou aqui com você.",
+        "companionEmptyState": "(Estou aqui com você.)",
         "messageStreaming": "Gerando",
         "messageFailed": "Falha no envio",
         "reactWindowOpen": "Abra a janela de bate-papo",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "Cancelar",
         "avatarCropSave": "Salvar",
         "emptyState":  "As mensagens aparecerão aqui depois que o feed do bate-papo for conectado.",
+        "companionEmptyState": "Estou aqui com você.",
         "messageStreaming": "Gerando",
         "messageFailed": "Falha no envio",
         "reactWindowOpen": "Abra a janela de bate-papo",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "Отмена",
         "avatarCropSave": "Сохранить",
         "emptyState":  "Сообщения появятся здесь после подключения чата.",
-        "companionEmptyState": "Я рядом с тобой.",
+        "companionEmptyState": "(Я рядом с тобой.)",
         "messageStreaming": "Генерация",
         "messageFailed": "Ошибка отправки",
         "reactWindowOpen": "Открыть окно чата",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "Отмена",
         "avatarCropSave": "Сохранить",
         "emptyState":  "Сообщения появятся здесь после подключения чата.",
+        "companionEmptyState": "Я рядом с тобой.",
         "messageStreaming": "Генерация",
         "messageFailed": "Ошибка отправки",
         "reactWindowOpen": "Открыть окно чата",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "取消",
         "avatarCropSave": "保存",
         "emptyState": "现在开始跟我聊天吧！",
-        "companionEmptyState": "我就在这陪着你哦",
+        "companionEmptyState": "（我就在这陪着你哦）",
         "messageStreaming": "生成中",
         "messageFailed": "发送失败",
         "reactWindowOpen": "打开聊天框",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "取消",
         "avatarCropSave": "保存",
         "emptyState": "现在开始跟我聊天吧！",
+        "companionEmptyState": "我就在这陪着你哦",
         "messageStreaming": "生成中",
         "messageFailed": "发送失败",
         "reactWindowOpen": "打开聊天框",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -753,7 +753,7 @@
         "avatarCropCancel": "取消",
         "avatarCropSave": "儲存",
         "emptyState": "現在開始跟我聊天吧！",
-        "companionEmptyState": "我就在這陪著你喔",
+        "companionEmptyState": "（我就在這陪著你喔）",
         "messageStreaming": "生成中",
         "messageFailed": "發送失敗",
         "reactWindowOpen": "打開聊天框",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -753,6 +753,7 @@
         "avatarCropCancel": "取消",
         "avatarCropSave": "儲存",
         "emptyState": "現在開始跟我聊天吧！",
+        "companionEmptyState": "我就在這陪著你喔",
         "messageStreaming": "生成中",
         "messageFailed": "發送失敗",
         "reactWindowOpen": "打開聊天框",


### PR DESCRIPTION
## Summary
- Keep the normal compact chat empty state as the existing “start chatting” copy.
- Add a separate `chat.companionEmptyState` copy for composer-hidden companion mode.
- Cover the split across App, FullChatSurface, fallback copy, and all 8 locale files.

## Test Plan
- [x] `npx vitest run src/App.test.tsx -t "selects locale-aware chat empty state fallbacks|renders compact subtitle capsule by default|keeps compact speech focused|keeps the compact chat surface visible|does not request compact input"`
- [x] locale JSON parse + key-set alignment check for `en`, `es`, `ja`, `ko`, `pt`, `ru`, `zh-CN`, `zh-TW`
- [x] `git diff --check`
- [x] `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在聊天空态中新增“陪伴/伴侣”空状态提示，隐藏输入或紧凑模式下会显示对应文案。

* **本地化**
  * 为陪伴空状态新增多语言翻译：英文、西班牙文、日文、韩文、葡萄牙文、俄文、简体中文与繁体中文。

* **测试**
  * 更新测试覆盖，验证陪伴空态文案在多语言与不同界面模式（含语音/隐藏输入）下的展示与回退逻辑。

* **杂项**
  * 更新语言资源版本以确保新文案生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->