### PR TITLE
fix(cat): preserve first native drag after focus loss

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -3013,7 +3013,10 @@
             );
         };
         state.handleWindowBlur = () => {
-            cancelActiveDrag('window-blur');
+            if (!state.isDragging) return;
+            // Native return-ball dragging may legitimately blur the Pet window when
+            // the companion chat layer has focus; stale recovery handles lost release.
+            scheduleReturnBallDragRecoveryCheck();
         };
         state.handlePageHide = () => {
             cancelActiveDrag('pagehide');

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -378,7 +378,11 @@ def test_desktop_return_ball_drag_recovers_when_mouse_release_is_lost():
     assert "function finishDragIfMouseButtonReleased(event, reason)" in source
     assert "event.pointerType && event.pointerType !== 'mouse'" in source
     assert "event.buttons !== 0" in source
-    assert "cancelActiveDrag('window-blur')" in source
+    window_blur_start = source.index("state.handleWindowBlur = () => {")
+    window_blur_end = source.index("};", window_blur_start)
+    window_blur_block = source[window_blur_start:window_blur_end]
+    assert "cancelActiveDrag(" not in window_blur_block
+    assert "scheduleReturnBallDragRecoveryCheck();" in window_blur_block
     assert "cancelActiveDrag('visibility-hidden')" in source
     assert "cancelActiveDrag('pagehide')" in source
     assert "cancelActiveDrag('pointercancel')" in source


### PR DESCRIPTION
- 修复桌面端猫 GIF 在刷新或对话框交互后首次拖拽被 Pet 窗口 blur 立即取消的问题。
- 现在 native 拖拽期间 window blur 只重新挂恢复检查，不再直接结束拖拽；真正中断仍由 pointercancel、pagehide、visibility hidden 和 stale timeout 兜底。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 改进了多窗口拖拽操作的窗口失焦处理和恢复机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->