### PR TITLE
修复角色重命名时目标 memory 目录被提前创建导致的合并冲突，旧角色记忆优先迁移并备份冲突文件；同时在重命名和回滚前释放 SQLite…

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -65,6 +65,7 @@ from utils.elevenlabs_tts_voices import (
 )
 from .agent_router import force_disable_agent_for_character_switch
 from utils.character_memory import (
+    character_memory_exists,
     delete_character_memory_storage,
     list_character_memory_paths,
     rename_character_memory_storage,
@@ -1529,9 +1530,21 @@ async def _rollback_character_operation(
     characters_snapshot: dict,
     memory_snapshot_records,
     tombstone_snapshot: dict | None = None,
+    release_character_names: list[str] | None = None,
     reason: str,
 ) -> str:
     rollback_errors: list[str] = []
+
+    for character_name in dict.fromkeys(release_character_names or []):
+        try:
+            released = await release_memory_server_character(
+                character_name,
+                reason=f"{reason} rollback restore",
+            )
+            if not released:
+                rollback_errors.append(f"release memory handle failed: {character_name}")
+        except Exception as exc:
+            rollback_errors.append(f"release memory handle failed: {character_name}: {exc}")
 
     try:
         await asyncio.to_thread(_restore_snapshot_paths, memory_snapshot_records)
@@ -2704,6 +2717,30 @@ async def rename_catgirl(old_name: str, request: Request):
             status_code=503,
         )
 
+    target_memory_exists = character_memory_exists(_config_manager, new_name)
+    target_memory_server_released = True
+    if target_memory_exists:
+        target_memory_server_released = await release_memory_server_character(
+            new_name,
+            reason=f"release target memory handles before character rename: {old_name} -> {new_name}",
+        )
+        if not target_memory_server_released:
+            logger.warning(
+                "Failed to release target memory handle before rename, blocked rename: %s -> %s",
+                old_name,
+                new_name,
+            )
+            return JSONResponse(
+                {
+                    "success": False,
+                    "code": "MEMORY_SERVER_RELEASE_FAILED",
+                    "error": "release target character memory handle failed; rename was blocked, please retry later",
+                    "memory_server_released": released_memory_handle,
+                    "target_memory_server_released": False,
+                },
+                status_code=503,
+            )
+
     characters_snapshot = copy.deepcopy(characters)
     memory_targets = list_character_memory_paths(_config_manager, old_name)
     memory_targets.extend(list_character_memory_paths(_config_manager, new_name))
@@ -2767,6 +2804,7 @@ async def rename_catgirl(old_name: str, request: Request):
                     _config_manager,
                     characters_snapshot=characters_snapshot,
                     memory_snapshot_records=memory_snapshot_records,
+                    release_character_names=[old_name, new_name],
                     reason=f"角色重命名回滚（memory_server 重载失败）: {old_name} -> {new_name}",
                 )
                 logger.error(
@@ -2790,6 +2828,7 @@ async def rename_catgirl(old_name: str, request: Request):
                 _config_manager,
                 characters_snapshot=characters_snapshot,
                 memory_snapshot_records=memory_snapshot_records,
+                release_character_names=[old_name, new_name],
                 reason=f"维护模式：角色重命名回滚 {old_name} -> {new_name}",
             )
             if rollback_error:
@@ -2800,6 +2839,7 @@ async def rename_catgirl(old_name: str, request: Request):
                 _config_manager,
                 characters_snapshot=characters_snapshot,
                 memory_snapshot_records=memory_snapshot_records,
+                release_character_names=[old_name, new_name],
                 reason=f"角色重命名回滚: {old_name} -> {new_name}",
             )
             logger.exception("重命名角色失败，已尝试回滚: %s -> %s", old_name, new_name)
@@ -3637,6 +3677,7 @@ async def delete_catgirl(name: str):
                 characters_snapshot=characters_snapshot,
                 memory_snapshot_records=memory_snapshot_records,
                 tombstone_snapshot=tombstone_snapshot,
+                release_character_names=[name],
                 reason=f"维护模式：删除角色回滚 {name}",
             )
             if rollback_error:
@@ -3648,6 +3689,7 @@ async def delete_catgirl(name: str):
                 characters_snapshot=characters_snapshot,
                 memory_snapshot_records=memory_snapshot_records,
                 tombstone_snapshot=tombstone_snapshot,
+                release_character_names=[name],
                 reason=f"删除角色回滚: {name}",
             )
             logger.exception("删除角色失败，已尝试回滚: %s", name)

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -3029,6 +3029,44 @@ def test_rename_character_memory_storage_source_wins_over_precreated_target_dir(
 
 
 @pytest.mark.unit
+def test_rename_character_memory_storage_runtime_wins_over_project_fallback(tmp_path):
+    from utils.character_memory import rename_character_memory_storage
+
+    memory_dir = tmp_path / "memory"
+    project_memory_dir = tmp_path / "project_memory"
+    runtime_old_dir = memory_dir / "YUI"
+    project_old_dir = project_memory_dir / "YUI"
+    target_dir = memory_dir / "YUI1"
+    runtime_old_dir.mkdir(parents=True)
+    project_old_dir.mkdir(parents=True)
+
+    (runtime_old_dir / "persona.json").write_text('{"source":"runtime"}', encoding="utf-8")
+    (project_old_dir / "persona.json").write_text('{"source":"project-fallback"}', encoding="utf-8")
+    (project_memory_dir / "facts_YUI.json").write_text(
+        '[{"id":"fallback-fact"}]',
+        encoding="utf-8",
+    )
+
+    cm = SimpleNamespace(memory_dir=memory_dir, project_memory_dir=project_memory_dir)
+
+    result = rename_character_memory_storage(cm, "YUI", "YUI1")
+
+    assert result["changed"] is True
+    assert (target_dir / "persona.json").read_text(encoding="utf-8") == '{"source":"runtime"}'
+    assert (target_dir / "facts.json").read_text(encoding="utf-8") == '[{"id":"fallback-fact"}]'
+    assert not runtime_old_dir.exists()
+    assert not project_old_dir.exists()
+    assert not (project_memory_dir / "facts_YUI.json").exists()
+
+    conflict_files = [
+        path
+        for path in (memory_dir / ".YUI1.rename_conflicts").rglob("persona.json")
+        if path.read_text(encoding="utf-8") == '{"source":"project-fallback"}'
+    ]
+    assert len(conflict_files) == 1
+
+
+@pytest.mark.unit
 def test_renamed_time_indexed_db_reopens_under_new_character(tmp_path, monkeypatch):
     from datetime import datetime
 

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -2991,6 +2991,163 @@ async def test_character_rollback_reports_notify_reload_false_as_failure():
 
 
 @pytest.mark.unit
+def test_rename_character_memory_storage_source_wins_over_precreated_target_dir(tmp_path):
+    from utils.character_memory import rename_character_memory_storage
+
+    memory_dir = tmp_path / "memory"
+    project_memory_dir = tmp_path / "project_memory"
+    old_dir = memory_dir / "YUI"
+    target_dir = memory_dir / "YUI1"
+    old_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    project_memory_dir.mkdir(parents=True)
+
+    (old_dir / "persona.json").write_text('{"source":"old"}', encoding="utf-8")
+    (old_dir / "recent.json").write_text(
+        json.dumps([{"speaker": "YUI", "data": {"content": "YUI: hi"}}]),
+        encoding="utf-8",
+    )
+    (target_dir / "persona.json").write_text('{"source":"precreated"}', encoding="utf-8")
+    (target_dir / "target_only.json").write_text('{"kept":true}', encoding="utf-8")
+
+    cm = SimpleNamespace(memory_dir=memory_dir, project_memory_dir=project_memory_dir)
+
+    result = rename_character_memory_storage(cm, "YUI", "YUI1")
+
+    assert result["changed"] is True
+    assert not old_dir.exists()
+    assert (target_dir / "persona.json").read_text(encoding="utf-8") == '{"source":"old"}'
+    assert (target_dir / "target_only.json").is_file()
+
+    recent_payload = json.loads((target_dir / "recent.json").read_text(encoding="utf-8"))
+    assert recent_payload[0]["speaker"] == "YUI1"
+    assert recent_payload[0]["data"]["content"].startswith("YUI1:")
+
+    conflict_files = list((memory_dir / ".YUI1.rename_conflicts").glob("*/persona.json"))
+    assert len(conflict_files) == 1
+    assert conflict_files[0].read_text(encoding="utf-8") == '{"source":"precreated"}'
+
+
+@pytest.mark.unit
+def test_renamed_time_indexed_db_reopens_under_new_character(tmp_path, monkeypatch):
+    from datetime import datetime
+
+    from memory.timeindex import TimeIndexedMemory
+    from utils.character_memory import rename_character_memory_storage
+    from utils.llm_client import SystemMessage
+
+    memory_dir = tmp_path / "memory"
+    project_memory_dir = tmp_path / "project_memory"
+    memory_dir.mkdir(parents=True)
+    project_memory_dir.mkdir(parents=True)
+
+    fake_config_manager = SimpleNamespace(
+        memory_dir=memory_dir,
+        project_memory_dir=project_memory_dir,
+        get_character_data=lambda: ({}, {}, {}, {}, {}, {}, {}, {}, {}),
+    )
+    monkeypatch.setattr("memory.timeindex.get_config_manager", lambda: fake_config_manager)
+    monkeypatch.setattr("memory.timeindex.assert_cloudsave_writable", lambda *args, **kwargs: None)
+
+    original_manager = TimeIndexedMemory(recent_history_manager=None)
+    timestamp = datetime(2026, 1, 2, 3, 4, 5)
+    original_manager.store_conversation(
+        "session-1",
+        [SystemMessage(content="hello from old role")],
+        "YUI",
+        timestamp=timestamp,
+    )
+    original_manager.dispose_engine("YUI")
+
+    old_db_path = memory_dir / "YUI" / "time_indexed.db"
+    new_db_path = memory_dir / "YUI1" / "time_indexed.db"
+    assert old_db_path.is_file()
+
+    rename_character_memory_storage(fake_config_manager, "YUI", "YUI1")
+
+    assert not old_db_path.exists()
+    assert new_db_path.is_file()
+
+    renamed_manager = TimeIndexedMemory(recent_history_manager=None)
+    rows = renamed_manager.retrieve_original_by_timeframe(
+        "YUI1",
+        datetime(2026, 1, 1),
+        datetime(2026, 1, 3),
+    )
+    assert len(rows) == 1
+    assert rows[0][1] == "session-1"
+    assert "hello from old role" in rows[0][2]
+    assert renamed_manager.get_last_conversation_time("YUI1") == timestamp
+
+    assert renamed_manager.retrieve_original_by_timeframe(
+        "YUI",
+        datetime(2026, 1, 1),
+        datetime(2026, 1, 3),
+    ) == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_character_rollback_releases_memory_handles_before_restore():
+    with TemporaryDirectory() as td:
+        cm = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(cm)
+
+        async def _noop_init():
+            return None
+
+        async def _noop_any(*args, **kwargs):
+            return None
+
+        with patch("utils.config_manager._config_manager", cm):
+            init_shared_state(
+                role_state={},
+                steamworks=None,
+                templates=None,
+                config_manager=cm,
+                logger=None,
+                initialize_character_data=_noop_init,
+                switch_current_catgirl_fast=_noop_any,
+                init_one_catgirl=_noop_any,
+                remove_one_catgirl=_noop_any,
+            )
+
+            characters_router_module = reload_module("main_routers.characters_router")
+            calls = []
+
+            async def _fake_release(character_name, *, reason=""):
+                calls.append(("release", character_name))
+                return True
+
+            def _fake_restore(records):
+                calls.append(("restore", len(records)))
+
+            with (
+                patch.object(characters_router_module, "release_memory_server_character", _fake_release),
+                patch.object(characters_router_module, "_restore_snapshot_paths", side_effect=_fake_restore),
+                patch.object(
+                    characters_router_module,
+                    "notify_memory_server_reload",
+                    AsyncMock(return_value=True),
+                ),
+            ):
+                rollback_error = await characters_router_module._rollback_character_operation(
+                    cm,
+                    characters_snapshot=cm.load_characters(),
+                    memory_snapshot_records=[],
+                    release_character_names=["YUI", "YUI1"],
+                    reason="unit-test rollback",
+                )
+
+    assert rollback_error == ""
+    assert calls[:3] == [
+        ("release", "YUI"),
+        ("release", "YUI1"),
+        ("restore", 0),
+    ]
+
+
+@pytest.mark.unit
 def test_rewrite_recent_file_character_name_does_not_rewrite_role_fields(tmp_path):
     from utils.character_memory import rewrite_recent_file_character_name
 

--- a/utils/character_memory.py
+++ b/utils/character_memory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -100,45 +101,112 @@ def character_memory_exists(config_manager, character_name: str) -> bool:
     return bool(list_character_memory_paths(config_manager, character_name))
 
 
-def _move_path(source_path: Path, target_path: Path) -> bool:
+def _conflict_backup_root(target_dir: Path) -> Path:
+    return target_dir.parent / f".{target_dir.name}.rename_conflicts" / uuid.uuid4().hex
+
+
+def _move_conflicting_target(target_path: Path, backup_root: Path) -> None:
+    backup_path = backup_root / target_path.name
+    counter = 1
+    while backup_path.exists():
+        backup_path = backup_root / f"{target_path.name}.{counter}"
+        counter += 1
+
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(target_path), str(backup_path))
+
+
+def _move_path(
+    source_path: Path,
+    target_path: Path,
+    *,
+    replace_existing: bool = False,
+    conflict_backup_root: Path | None = None,
+) -> bool:
     if not source_path.exists():
         return False
+    try:
+        if source_path.resolve() == target_path.resolve():
+            return False
+    except OSError:
+        pass
 
     if source_path.is_dir():
-        return _merge_directories(source_path, target_path)
+        return _merge_directories(
+            source_path,
+            target_path,
+            replace_existing=replace_existing,
+            conflict_backup_root=conflict_backup_root,
+        )
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
     if target_path.exists():
-        raise FileExistsError(
-            f"Refusing to overwrite existing memory file while moving "
-            f"{source_path} -> {target_path}"
-        )
+        if not replace_existing:
+            raise FileExistsError(
+                f"Refusing to overwrite existing memory file while moving "
+                f"{source_path} -> {target_path}"
+            )
+        if conflict_backup_root is None:
+            conflict_backup_root = _conflict_backup_root(target_path.parent)
+        _move_conflicting_target(target_path, conflict_backup_root)
 
     shutil.move(str(source_path), str(target_path))
     return True
 
 
-def _merge_directories(source_dir: Path, target_dir: Path) -> bool:
+def _merge_directories(
+    source_dir: Path,
+    target_dir: Path,
+    *,
+    replace_existing: bool = False,
+    conflict_backup_root: Path | None = None,
+) -> bool:
     if not source_dir.exists():
         return False
+    try:
+        if source_dir.resolve() == target_dir.resolve():
+            return False
+    except OSError:
+        pass
 
     if not target_dir.exists():
         target_dir.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(source_dir), str(target_dir))
         return True
 
-    # Pre-flight: check for conflicts before moving anything
-    for child in source_dir.iterdir():
-        candidate = target_dir / child.name
-        if candidate.exists():
+    if not target_dir.is_dir():
+        if not replace_existing:
             raise FileExistsError(
                 f"Refusing to overwrite existing path while merging directories "
-                f"{source_dir} -> {target_dir}: conflict at {child.name}"
+                f"{source_dir} -> {target_dir}: target is not a directory"
             )
+        if conflict_backup_root is None:
+            conflict_backup_root = _conflict_backup_root(target_dir.parent)
+        _move_conflicting_target(target_dir, conflict_backup_root)
+        shutil.move(str(source_dir), str(target_dir))
+        return True
+
+    if not replace_existing:
+        # Pre-flight: check for conflicts before moving anything.
+        for child in source_dir.iterdir():
+            candidate = target_dir / child.name
+            if candidate.exists():
+                raise FileExistsError(
+                    f"Refusing to overwrite existing path while merging directories "
+                    f"{source_dir} -> {target_dir}: conflict at {child.name}"
+                )
+
+    if conflict_backup_root is None:
+        conflict_backup_root = _conflict_backup_root(target_dir)
 
     changed = False
     for child in sorted(source_dir.iterdir(), key=lambda item: item.name):
-        changed = _move_path(child, target_dir / child.name) or changed
+        changed = _move_path(
+            child,
+            target_dir / child.name,
+            replace_existing=replace_existing,
+            conflict_backup_root=conflict_backup_root,
+        ) or changed
 
     try:
         source_dir.rmdir()
@@ -213,18 +281,34 @@ def rename_character_memory_storage(config_manager, old_name: str, new_name: str
     changed = False
 
     for base_dir in iter_character_memory_roots(config_manager):
-        changed = _merge_directories(base_dir / old_name, runtime_target_dir) or changed
+        conflict_backup_root = _conflict_backup_root(runtime_target_dir)
+        changed = _merge_directories(
+            base_dir / old_name,
+            runtime_target_dir,
+            replace_existing=True,
+            conflict_backup_root=conflict_backup_root,
+        ) or changed
 
         for legacy_name, target_name in LEGACY_CHARACTER_MEMORY_FILE_MAP.items():
             source_path = base_dir / legacy_name.format(name=old_name)
             target_path = runtime_target_dir / target_name
-            changed = _move_path(source_path, target_path) or changed
+            changed = _move_path(
+                source_path,
+                target_path,
+                replace_existing=True,
+                conflict_backup_root=conflict_backup_root,
+            ) or changed
 
         for legacy_name in LEGACY_CHARACTER_MEMORY_EXTRA_ENTRIES:
             source_path = base_dir / legacy_name.format(name=old_name)
             if source_path.exists():
                 target_path = runtime_target_dir / "semantic_memory_legacy"
-                changed = _move_path(source_path, target_path) or changed
+                changed = _move_path(
+                    source_path,
+                    target_path,
+                    replace_existing=True,
+                    conflict_backup_root=conflict_backup_root,
+                ) or changed
 
     changed = rewrite_recent_file_character_name(
         runtime_target_dir / "recent.json",

--- a/utils/character_memory.py
+++ b/utils/character_memory.py
@@ -105,6 +105,22 @@ def _conflict_backup_root(target_dir: Path) -> Path:
     return target_dir.parent / f".{target_dir.name}.rename_conflicts" / uuid.uuid4().hex
 
 
+def _path_key(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
+def _mark_protected_target(path: Path, protected_targets: set[str] | None) -> None:
+    if protected_targets is None:
+        return
+    protected_targets.add(_path_key(path))
+    if path.is_dir():
+        for descendant in path.rglob("*"):
+            protected_targets.add(_path_key(descendant))
+
+
 def _move_conflicting_target(target_path: Path, backup_root: Path) -> None:
     backup_path = backup_root / target_path.name
     counter = 1
@@ -122,6 +138,7 @@ def _move_path(
     *,
     replace_existing: bool = False,
     conflict_backup_root: Path | None = None,
+    protected_targets: set[str] | None = None,
 ) -> bool:
     if not source_path.exists():
         return False
@@ -137,10 +154,16 @@ def _move_path(
             target_path,
             replace_existing=replace_existing,
             conflict_backup_root=conflict_backup_root,
+            protected_targets=protected_targets,
         )
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
     if target_path.exists():
+        if protected_targets is not None and _path_key(target_path) in protected_targets:
+            if conflict_backup_root is None:
+                conflict_backup_root = _conflict_backup_root(target_path.parent)
+            _move_conflicting_target(source_path, conflict_backup_root)
+            return True
         if not replace_existing:
             raise FileExistsError(
                 f"Refusing to overwrite existing memory file while moving "
@@ -151,6 +174,7 @@ def _move_path(
         _move_conflicting_target(target_path, conflict_backup_root)
 
     shutil.move(str(source_path), str(target_path))
+    _mark_protected_target(target_path, protected_targets)
     return True
 
 
@@ -160,6 +184,7 @@ def _merge_directories(
     *,
     replace_existing: bool = False,
     conflict_backup_root: Path | None = None,
+    protected_targets: set[str] | None = None,
 ) -> bool:
     if not source_dir.exists():
         return False
@@ -172,9 +197,15 @@ def _merge_directories(
     if not target_dir.exists():
         target_dir.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(source_dir), str(target_dir))
+        _mark_protected_target(target_dir, protected_targets)
         return True
 
     if not target_dir.is_dir():
+        if protected_targets is not None and _path_key(target_dir) in protected_targets:
+            if conflict_backup_root is None:
+                conflict_backup_root = _conflict_backup_root(target_dir.parent)
+            _move_conflicting_target(source_dir, conflict_backup_root)
+            return True
         if not replace_existing:
             raise FileExistsError(
                 f"Refusing to overwrite existing path while merging directories "
@@ -184,6 +215,7 @@ def _merge_directories(
             conflict_backup_root = _conflict_backup_root(target_dir.parent)
         _move_conflicting_target(target_dir, conflict_backup_root)
         shutil.move(str(source_dir), str(target_dir))
+        _mark_protected_target(target_dir, protected_targets)
         return True
 
     if not replace_existing:
@@ -206,6 +238,7 @@ def _merge_directories(
             target_dir / child.name,
             replace_existing=replace_existing,
             conflict_backup_root=conflict_backup_root,
+            protected_targets=protected_targets,
         ) or changed
 
     try:
@@ -279,6 +312,7 @@ def rewrite_recent_file_character_name(recent_path: Path, old_name: str, new_nam
 def rename_character_memory_storage(config_manager, old_name: str, new_name: str) -> dict[str, Any]:
     runtime_target_dir = get_runtime_character_memory_dir(config_manager, new_name)
     changed = False
+    protected_targets: set[str] = set()
 
     for base_dir in iter_character_memory_roots(config_manager):
         conflict_backup_root = _conflict_backup_root(runtime_target_dir)
@@ -287,6 +321,7 @@ def rename_character_memory_storage(config_manager, old_name: str, new_name: str
             runtime_target_dir,
             replace_existing=True,
             conflict_backup_root=conflict_backup_root,
+            protected_targets=protected_targets,
         ) or changed
 
         for legacy_name, target_name in LEGACY_CHARACTER_MEMORY_FILE_MAP.items():
@@ -297,6 +332,7 @@ def rename_character_memory_storage(config_manager, old_name: str, new_name: str
                 target_path,
                 replace_existing=True,
                 conflict_backup_root=conflict_backup_root,
+                protected_targets=protected_targets,
             ) or changed
 
         for legacy_name in LEGACY_CHARACTER_MEMORY_EXTRA_ENTRIES:
@@ -308,6 +344,7 @@ def rename_character_memory_storage(config_manager, old_name: str, new_name: str
                     target_path,
                     replace_existing=True,
                     conflict_backup_root=conflict_backup_root,
+                    protected_targets=protected_targets,
                 ) or changed
 
     changed = rewrite_recent_file_character_name(


### PR DESCRIPTION
… 句柄，避免 Windows 下 time_indexed.db 文件锁导致回滚失败

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 在角色重命名/删除的回滚流程中新增对目标记忆句柄的释放与顺序控制，改进失败处理与错误记录。
  * 重命名流程在目标名已存在时先尝试释放目标记忆句柄，避免冲突导致不一致。

* **改进**
  * 重构角色记忆存储迁移策略：在目标已存在时采用冲突备份并可替换以避免数据覆盖，提升迁移稳健性。

* **测试**
  * 新增多项单元测试，覆盖重命名、迁移、检索与回滚顺序与结果验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->