### PR TITLE
fix(ui): improve personality onboarding scrim readability

### DIFF
--- a/static/css/character_personality_onboarding.css
+++ b/static/css/character_personality_onboarding.css
@@ -49,7 +49,7 @@
     align-items: center;
     justify-content: center;
     padding: 24px;
-    background: rgba(18, 42, 58, 0.08);
+    background: rgba(18, 42, 58, 0.34);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     pointer-events: auto;
@@ -71,10 +71,10 @@
         linear-gradient(116deg, rgba(255, 255, 255, 0.34) 0%, rgba(255, 255, 255, 0.08) 15%, transparent 36%),
         radial-gradient(circle at 18% 6%, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.05) 24%, transparent 48%),
         radial-gradient(circle at 94% 84%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02) 28%, transparent 50%),
-        linear-gradient(145deg, rgba(255, 255, 255, 0.18), rgba(245, 248, 250, 0.045) 48%, rgba(255, 255, 255, 0.1)),
-        rgba(255, 255, 255, 0.045);
-    backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
-    -webkit-backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
+        linear-gradient(145deg, rgba(255, 255, 255, 0.3), rgba(245, 248, 250, 0.12) 48%, rgba(255, 255, 255, 0.2)),
+        rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(14px) saturate(1.2) contrast(1.05) brightness(1.06);
+    -webkit-backdrop-filter: blur(14px) saturate(1.2) contrast(1.05) brightness(1.06);
     box-shadow: var(--shadow-shell);
     color: var(--text-main);
 }

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -1071,6 +1071,43 @@ def test_onboarding_marks_overlay_controls_as_no_drag_for_desktop_clicks(mock_pa
 
 
 @pytest.mark.frontend
+def test_onboarding_overlay_uses_non_blurred_scrim_for_readability(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static" / "css" / "character_personality_onboarding.css"))
+    mock_page.evaluate("() => { window.universalTutorialManager.isTutorialRunning = false; }")
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+    overlay_style = mock_page.evaluate(
+        """
+        () => {
+            const overlay = document.querySelector("[data-testid='character-personality-overlay']");
+            const style = getComputedStyle(overlay);
+            return {
+                backgroundColor: style.backgroundColor,
+                backdropFilter: style.backdropFilter,
+                webkitBackdropFilter: style.webkitBackdropFilter,
+            };
+        }
+        """
+    )
+
+    assert re.match(r"rgba?\(18, 42, 58(?:,|\s*/)", overlay_style["backgroundColor"]) is not None
+    assert "0.34" in overlay_style["backgroundColor"]
+    assert "blur(" not in (
+        overlay_style["backdropFilter"] or overlay_style["webkitBackdropFilter"] or ""
+    )
+
+
+@pytest.mark.frontend
 def test_manual_character_personality_reselect_opens_directly_on_home_refresh(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(


### PR DESCRIPTION
## Summary
- 调整初始人格选择弹框外层遮罩为非模糊压暗层，避免整屏背景被糊掉
- 提高弹框玻璃壳体不透明度与内部模糊强度，降低背景文字干扰
- 增加前端回归测试，锁定外层不模糊且遮罩足够压暗的可读性契约

## Test Plan
- [x] uv run pytest tests/frontend/test_initial_personality_onboarding.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式**
  * 优化了角色性格引导界面的视觉效果，增强了覆盖层的玻璃效果与清晰度。

* **测试**
  * 新增前端测试用例，确保引导界面的可读性表现符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->