### PR TITLE
[codex] update health check servers

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -11,34 +11,8 @@ jobs:
     if: github.repository == 'Project-N-E-K-O/N.E.K.O' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      # ── 检查 lanlan.app (US, old) ──
-      - name: Check lanlan.app (old)
-        id: check_app
-        run: |
-          CURL_EXIT=0
-          HTTP_CODE=$(curl -s -o /tmp/resp_app.json -w "%{http_code}" \
-            --max-time 30 --connect-timeout 10 \
-            -X POST "https://lanlan.app/text/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer free-access" \
-            -d '{"model":"free-mini-model","messages":[{"role":"user","content":"sends some useful information"}],"max_completion_tokens":5}' \
-            2>/dev/null) || CURL_EXIT=$?
-          BODY=$(cat /tmp/resp_app.json 2>/dev/null || echo "{}")
-          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
-          echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message | has("content"))' >/dev/null 2>&1; then
-              echo "healthy=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "healthy=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "healthy=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # ── 检查 www.lanlan.app (US, new) ──
-      - name: Check www.lanlan.app (new)
+      # ── 检查 www.lanlan.app (US) ──
+      - name: Check www.lanlan.app
         id: check_api_app
         run: |
           CURL_EXIT=0
@@ -63,8 +37,8 @@ jobs:
             echo "healthy=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── 检查 www.lanlan.tech (China, new) ──
-      - name: Check www.lanlan.tech (new)
+      # ── 检查 www.lanlan.tech (China) ──
+      - name: Check www.lanlan.tech
         id: check_api_tech
         run: |
           CURL_EXIT=0
@@ -97,15 +71,11 @@ jobs:
         run: |
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          APP_HEALTHY="${{ steps.check_app.outputs.healthy }}"
-          APP_CODE="${{ steps.check_app.outputs.http_code }}"
-
           API_APP_HEALTHY="${{ steps.check_api_app.outputs.healthy }}"
           API_TECH_HEALTHY="${{ steps.check_api_tech.outputs.healthy }}"
           API_APP_CODE="${{ steps.check_api_app.outputs.http_code }}"
           API_TECH_CODE="${{ steps.check_api_tech.outputs.http_code }}"
 
-          APP_EXIT="${{ steps.check_app.outputs.curl_exit }}"
           API_APP_EXIT="${{ steps.check_api_app.outputs.curl_exit }}"
           API_TECH_EXIT="${{ steps.check_api_tech.outputs.curl_exit }}"
 
@@ -117,13 +87,12 @@ jobs:
               echo "$1"
             fi
           }
-          APP_CODE_DISP=$(fmt_code "$APP_CODE" "$APP_EXIT")
           API_APP_CODE_DISP=$(fmt_code "$API_APP_CODE" "$API_APP_EXIT")
           API_TECH_CODE_DISP=$(fmt_code "$API_TECH_CODE" "$API_TECH_EXIT")
 
           ALL_HEALTHY="true"
           ANY_DOWN="false"
-          for h in "$APP_HEALTHY" "$API_APP_HEALTHY" "$API_TECH_HEALTHY"; do
+          for h in "$API_APP_HEALTHY" "$API_TECH_HEALTHY"; do
             if [ "$h" = "false" ]; then
               ALL_HEALTHY="false"
               ANY_DOWN="true"
@@ -133,18 +102,12 @@ jobs:
           if [ "$ALL_HEALTHY" = "true" ]; then
             COLOR=3066993  # green
             TITLE="All Servers Healthy"
-          elif [ "$APP_HEALTHY" = "false" ] && [ "$API_APP_HEALTHY" = "false" ] && [ "$API_TECH_HEALTHY" = "false" ]; then
+          elif [ "$API_APP_HEALTHY" = "false" ] && [ "$API_TECH_HEALTHY" = "false" ]; then
             COLOR=15158332 # red
             TITLE="All Servers Down"
           else
             COLOR=15105570 # orange
             TITLE="Partial Outage"
-          fi
-
-          if [ "$APP_HEALTHY" = "true" ]; then
-            APP_STATUS=":white_check_mark: OK (HTTP $APP_CODE_DISP)"
-          else
-            APP_STATUS=":x: DOWN (HTTP $APP_CODE_DISP)"
           fi
 
           if [ "$API_APP_HEALTHY" = "true" ]; then
@@ -169,7 +132,6 @@ jobs:
             --arg content "$CONTENT" \
             --arg title "$TITLE" \
             --argjson color "$COLOR" \
-            --arg app_status "$APP_STATUS" \
             --arg api_app_status "$API_APP_STATUS" \
             --arg api_tech_status "$API_TECH_STATUS" \
             --arg timestamp "$TIMESTAMP" \
@@ -179,10 +141,8 @@ jobs:
                 title: $title,
                 color: $color,
                 fields: [
-                  {name: "lanlan.app (US, old)", value: $app_status, inline: true},
-                  {name: "\u200b", value: "\u200b", inline: false},
-                  {name: "www.lanlan.app (US, new)", value: $api_app_status, inline: true},
-                  {name: "www.lanlan.tech (China, new)", value: $api_tech_status, inline: true}
+                  {name: "www.lanlan.app (US)", value: $api_app_status, inline: true},
+                  {name: "www.lanlan.tech (China)", value: $api_tech_status, inline: true}
                 ],
                 footer: {text: "N.E.K.O Health Monitor"},
                 timestamp: $timestamp

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -28,7 +28,7 @@ jobs:
           echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
 
           if [ "$HTTP_CODE" = "200" ]; then
-            if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message | has("content"))' >/dev/null 2>&1; then
+            if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message.content | type) == "string" and (.choices[0].message.content | length) > 0' >/dev/null 2>&1; then
               echo "healthy=true" >> "$GITHUB_OUTPUT"
             else
               echo "healthy=false" >> "$GITHUB_OUTPUT"
@@ -54,7 +54,7 @@ jobs:
           echo "curl_exit=$CURL_EXIT" >> "$GITHUB_OUTPUT"
 
           if [ "$HTTP_CODE" = "200" ]; then
-            if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message | has("content"))' >/dev/null 2>&1; then
+            if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message.content | type) == "string" and (.choices[0].message.content | length) > 0' >/dev/null 2>&1; then
               echo "healthy=true" >> "$GITHUB_OUTPUT"
             else
               echo "healthy=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Retire the old non-www lanlan.app health check.
- Keep only www.lanlan.app and www.lanlan.tech in the workflow.
- Remove the obsolete new labels from job names and Discord notification fields.

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 调整系统健康检查工作流：监控点改为 www.lanlan.app 与 www.lanlan.tech 两个 API 端点。
  * 收紧健康判定：要求响应角色为 assistant 且 message.content 为非空字符串。
  * 通知逻辑更新：移除对旧检查输出的依赖，基于各 API 的健康标志、HTTP 码与 curl 结果计算整体状态与通知标题/颜色。
  * 通知内容精简为两个服务器状态展示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->