### PR TITLE
fix(ui): 调整按钮图像不透明度并优化猫咪过渡相关功能

### DIFF
--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -623,7 +623,7 @@
                 if (button) {
                     button.dataset.active = isActive ? 'true' : 'false';
                     if (imgOff && imgOn) {
-                        imgOff.style.opacity = isActive ? '0' : '1';
+                        imgOff.style.opacity = isActive ? '0' : '0.75';
                         imgOn.style.opacity = isActive ? '1' : '0';
                     }
                     if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -2117,6 +2117,11 @@
             }, finishRemainingMs);
         };
         const transitionPromise = new Promise((resolve) => {
+            const ensureOverlayVisible = () => {
+                if (!overlay.parentNode) {
+                    document.body.appendChild(overlay);
+                }
+            };
             const startTransitionPlayback = () => {
                 if (didFinish || didStartPlayback) return;
                 didStartPlayback = true;
@@ -2128,7 +2133,7 @@
                     finishTransition(resolve);
                     return;
                 }
-                document.body.appendChild(overlay);
+                ensureOverlayVisible();
                 image.removeAttribute('src');
                 void image.offsetWidth;
                 image.src = src;
@@ -2144,6 +2149,7 @@
                 didImageLoad = true;
                 startTransitionPlayback();
             }, { once: true });
+            ensureOverlayVisible();
             preloadImage.src = src;
             imageLoadFallbackTimer = setTimeout(() => {
                 didImageLoad = true;

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -19,7 +19,8 @@
     const NEKO_MODEL_CAT_TRANSITION_ASSET = '/static/assets/neko-idle/cat_model_change.gif';
     const NEKO_MODEL_CAT_TRANSITION_DURATION_MS = 850;
     const NEKO_MODEL_CAT_TRANSITION_LOOP_GUARD_MS = 70;
-    const NEKO_MODEL_CAT_REVEAL_BEFORE_SMOKE_HIDE_MS = 150;
+    const NEKO_MODEL_CAT_REVEAL_BEFORE_SMOKE_HIDE_MS = 48;
+    const NEKO_MODEL_CAT_TRANSITION_LOAD_FALLBACK_MS = 1200;
     const NEKO_MODEL_CAT_TO_MODEL_LOCK_MS = 1120;
     const NEKO_MODEL_CAT_TRANSITION_MODEL_SCALE = 0.38;
     const NEKO_MODEL_CAT_TRANSITION_MIN_SIZE = 260;
@@ -42,6 +43,7 @@
     })();
     let nekoModelCatTransitionToken = 0;
     let nekoModelCatTransitionActive = null;
+    let nekoModelCatRevealPlaybackToken = 0;
 
     // ================================================================
     //  1. Status toast  (app.js lines 86-145)
@@ -750,7 +752,7 @@
                     if (button) {
                         button.dataset.active = isActive ? 'true' : 'false';
                         if (imgOff && imgOn) {
-                            imgOff.style.opacity = isActive ? '0' : '1';
+                            imgOff.style.opacity = isActive ? '0' : '0.75';
                             imgOn.style.opacity = isActive ? '1' : '0';
                         }
                         if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {
@@ -779,7 +781,7 @@
                     if (button) {
                         button.dataset.active = isActive ? 'true' : 'false';
                         if (imgOff && imgOn) {
-                            imgOff.style.opacity = isActive ? '0' : '1';
+                            imgOff.style.opacity = isActive ? '0' : '0.75';
                             imgOn.style.opacity = isActive ? '1' : '0';
                         }
                         if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {
@@ -1630,6 +1632,39 @@
         return `${NEKO_MODEL_CAT_TRANSITION_ASSET}${separator}${params.join('&')}`;
     }
 
+    function buildNekoModelCatRevealPlaybackUrl(src, playbackToken) {
+        if (!src) return '';
+        try {
+            const url = new URL(src, window.location.href);
+            if (!/\/static\/assets\/neko-idle\/.+\.gif$/i.test(url.pathname)) {
+                return src;
+            }
+            url.searchParams.set('reveal', String(playbackToken || Date.now()));
+            return url.href;
+        } catch (_) {
+            return src;
+        }
+    }
+
+    function restartNekoModelCatRevealArt(container) {
+        const art = container && typeof container.querySelector === 'function'
+            ? container.querySelector('.neko-idle-return-art:not(.neko-idle-return-art-next)')
+            : null;
+        if (!art) return false;
+        const currentSrc = art.getAttribute('src') || art.currentSrc || '';
+        if (!currentSrc) return false;
+        const nextSrc = buildNekoModelCatRevealPlaybackUrl(
+            currentSrc,
+            ++nekoModelCatRevealPlaybackToken
+        );
+        art.__nekoIdleGifPlaybackToken = (art.__nekoIdleGifPlaybackToken || 0) + 1;
+        art.__nekoIdleHoverToken = (art.__nekoIdleHoverToken || 0) + 1;
+        art.removeAttribute('src');
+        void art.offsetWidth;
+        art.src = nextSrc || currentSrc;
+        return true;
+    }
+
     function normalizeNekoScreenRect(rect) {
         if (!rect) return null;
         const left = Number(rect.left);
@@ -1954,6 +1989,13 @@
         }
     }
 
+    function isNekoModelCatTransitionTokenCurrent(token) {
+        return !!(
+            nekoModelCatTransitionActive &&
+            nekoModelCatTransitionActive.token === token
+        );
+    }
+
     function playNekoModelCatTransition(options = {}) {
         const container = options.container || null;
         const anchorRect = options.anchorRect || null;
@@ -2004,11 +2046,16 @@
         let overlayCleanupTimer = null;
         let beforeOverlayCleanupTimer = null;
         let finishTimer = null;
+        let imageLoadFallbackTimer = null;
         let didImageLoad = false;
+        let didStartPlayback = false;
+        let didSchedulePlayback = false;
         let didCallBeforeOverlayCleanup = false;
         let didCleanupOverlay = false;
         let didFinish = false;
+        const isCurrentTransition = () => isNekoModelCatTransitionTokenCurrent(token);
         const runBeforeOverlayCleanup = () => {
+            if (!isCurrentTransition()) return;
             if (didFinish || didCallBeforeOverlayCleanup || !onBeforeOverlayCleanup) return;
             didCallBeforeOverlayCleanup = true;
             try {
@@ -2018,6 +2065,7 @@
             }
         };
         const cleanupOverlay = () => {
+            if (!isCurrentTransition()) return;
             if (didCleanupOverlay) return;
             didCleanupOverlay = true;
             if (overlay.parentNode) {
@@ -2027,18 +2075,30 @@
         const finishTransition = (resolve) => {
             if (didFinish) return;
             didFinish = true;
-            cleanupOverlay();
-            if (container && container.isConnected) {
-                container.removeAttribute('data-neko-model-cat-transitioning');
-                if (direction === 'cat-to-model') {
-                    container.style.removeProperty('visibility');
-                }
+            if (imageLoadFallbackTimer) {
+                clearTimeout(imageLoadFallbackTimer);
+                imageLoadFallbackTimer = null;
             }
-            releaseNekoModelCatTransition(token);
+            if (isCurrentTransition()) {
+                cleanupOverlay();
+                if (container && container.isConnected) {
+                    container.removeAttribute('data-neko-model-cat-transitioning');
+                    if (direction === 'cat-to-model') {
+                        container.style.removeProperty('visibility');
+                    }
+                }
+                releaseNekoModelCatTransition(token);
+            }
             resolve({ completed: true, direction });
         };
         const scheduleTransitionTimers = (resolve) => {
             if (didFinish) return;
+            if (didSchedulePlayback) return;
+            didSchedulePlayback = true;
+            if (imageLoadFallbackTimer) {
+                clearTimeout(imageLoadFallbackTimer);
+                imageLoadFallbackTimer = null;
+            }
             if (overlayCleanupTimer) clearTimeout(overlayCleanupTimer);
             if (beforeOverlayCleanupTimer) clearTimeout(beforeOverlayCleanupTimer);
             if (finishTimer) clearTimeout(finishTimer);
@@ -2056,21 +2116,39 @@
                 finishTransition(resolve);
             }, finishRemainingMs);
         };
-        image.addEventListener('load', () => {
-            didImageLoad = true;
-            playbackStartedAt = getNekoTransitionNowMs();
-        }, { once: true });
-        document.body.appendChild(overlay);
-
         const transitionPromise = new Promise((resolve) => {
-            image.addEventListener('load', () => {
+            const startTransitionPlayback = () => {
+                if (didFinish || didStartPlayback) return;
+                didStartPlayback = true;
+                if (imageLoadFallbackTimer) {
+                    clearTimeout(imageLoadFallbackTimer);
+                    imageLoadFallbackTimer = null;
+                }
+                if (!isCurrentTransition()) {
+                    finishTransition(resolve);
+                    return;
+                }
+                document.body.appendChild(overlay);
+                image.removeAttribute('src');
+                void image.offsetWidth;
+                image.src = src;
+                playbackStartedAt = getNekoTransitionNowMs();
                 scheduleTransitionTimers(resolve);
+            };
+            const preloadImage = new Image();
+            preloadImage.addEventListener('load', () => {
+                didImageLoad = true;
+                startTransitionPlayback();
             }, { once: true });
-            image.addEventListener('error', () => {
-                scheduleTransitionTimers(resolve);
+            preloadImage.addEventListener('error', () => {
+                didImageLoad = true;
+                startTransitionPlayback();
             }, { once: true });
-            image.src = src;
-            scheduleTransitionTimers(resolve);
+            preloadImage.src = src;
+            imageLoadFallbackTimer = setTimeout(() => {
+                didImageLoad = true;
+                startTransitionPlayback();
+            }, NEKO_MODEL_CAT_TRANSITION_LOAD_FALLBACK_MS);
         });
         if (nekoModelCatTransitionActive && nekoModelCatTransitionActive.token === token) {
             nekoModelCatTransitionActive.promise = transitionPromise;
@@ -3408,6 +3486,7 @@
                         activeReturnButtonContainer.getAttribute('data-neko-return-visible') === 'true'
                     ) {
                         didRevealActiveReturnBall = true;
+                        restartNekoModelCatRevealArt(activeReturnButtonContainer);
                         revealReturnBallContainer(activeReturnButtonContainer, reason);
                     }
                 };
@@ -3843,7 +3922,7 @@
                     if (buttonData && buttonData.button) {
                         buttonData.button.dataset.active = 'false';
                         if (buttonData.imgOff) {
-                            buttonData.imgOff.style.opacity = '1';
+                            buttonData.imgOff.style.opacity = '0.75';
                         }
                         if (buttonData.imgOn) {
                             buttonData.imgOn.style.opacity = '0';
@@ -3863,7 +3942,7 @@
                     if (buttonData && buttonData.button) {
                         buttonData.button.dataset.active = 'false';
                         if (buttonData.imgOff) {
-                            buttonData.imgOff.style.opacity = '1';
+                            buttonData.imgOff.style.opacity = '0.75';
                         }
                         if (buttonData.imgOn) {
                             buttonData.imgOn.style.opacity = '0';
@@ -3883,7 +3962,7 @@
                     if (buttonData && buttonData.button) {
                         buttonData.button.dataset.active = 'false';
                         if (buttonData.imgOff) {
-                            buttonData.imgOff.style.opacity = '1';
+                            buttonData.imgOff.style.opacity = '0.75';
                         }
                         if (buttonData.imgOn) {
                             buttonData.imgOn.style.opacity = '0';

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -2122,9 +2122,16 @@
                     document.body.appendChild(overlay);
                 }
             };
-            const startTransitionPlayback = () => {
+            const startVisibleSmokePlayback = () => {
                 if (didFinish || didStartPlayback) return;
                 didStartPlayback = true;
+                if (!isCurrentTransition()) return;
+                image.src = src;
+                playbackStartedAt = getNekoTransitionNowMs();
+                ensureOverlayVisible();
+            };
+            const startTransitionPlayback = () => {
+                if (didFinish || didSchedulePlayback) return;
                 if (imageLoadFallbackTimer) {
                     clearTimeout(imageLoadFallbackTimer);
                     imageLoadFallbackTimer = null;
@@ -2133,11 +2140,7 @@
                     finishTransition(resolve);
                     return;
                 }
-                ensureOverlayVisible();
-                image.removeAttribute('src');
-                void image.offsetWidth;
-                image.src = src;
-                playbackStartedAt = getNekoTransitionNowMs();
+                startVisibleSmokePlayback();
                 scheduleTransitionTimers(resolve);
             };
             const preloadImage = new Image();
@@ -2149,7 +2152,7 @@
                 didImageLoad = true;
                 startTransitionPlayback();
             }, { once: true });
-            ensureOverlayVisible();
+            startVisibleSmokePlayback();
             preloadImage.src = src;
             imageLoadFallbackTimer = setTimeout(() => {
                 didImageLoad = true;

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -5092,7 +5092,7 @@ const AvatarButtonMixin = {
                 : 'var(--neko-btn-bg, rgba(255, 255, 255, 0.65))';
 
             if (buttonData.imgOff) {
-                buttonData.imgOff.style.opacity = active ? '0' : '1';
+                buttonData.imgOff.style.opacity = active ? '0' : '0.75';
             }
             if (buttonData.imgOn) {
                 buttonData.imgOn.style.opacity = active ? '1' : '0';

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -142,6 +142,7 @@ def test_model_cat_transition_contract_is_present():
     assert "function isNekoModelCatTransitionActive(direction = '')" in source
     assert "function reserveNekoModelCatTransition(direction)" in source
     assert "function releaseNekoModelCatTransition(token)" in source
+    assert "function isNekoModelCatTransitionTokenCurrent(token)" in source
     assert "const goodbyeTransitionToken = reserveNekoModelCatTransition('model-to-cat')" in source
     assert "transitionToken: goodbyeTransitionToken" in source
     assert "releaseNekoModelCatTransition(goodbyeTransitionToken)" in source
@@ -174,8 +175,10 @@ def test_model_cat_transition_contract_is_present():
     assert "function getActiveModelTransitionRect()" in source
     assert "getModelScreenBounds" in source
     assert "savedGoodbyeRect = savedModelRect || savedGoodbyeRect" in source
+    assert "NEKO_MODEL_CAT_REVEAL_BEFORE_SMOKE_HIDE_MS = 48" in source
     assert "NEKO_MODEL_CAT_TRANSITION_DURATION_MS = 850" in source
     assert "NEKO_MODEL_CAT_TRANSITION_LOOP_GUARD_MS = 70" in source
+    assert "NEKO_MODEL_CAT_TRANSITION_LOAD_FALLBACK_MS = 1200" in source
     assert "NEKO_MODEL_CAT_TO_MODEL_LOCK_MS = 1120" in source
     assert "function getNekoModelCatOverlayVisibleMs()" in source
     assert "function getNekoModelCatSettleMs(direction)" in source
@@ -220,6 +223,32 @@ def test_model_cat_transition_contract_is_present():
     assert "window.playNekoModelCatTransition" in avatar_source
     assert "window.dispatchEvent(event);" in avatar_source
     assert "dispatchReturnEvent();" in avatar_source
+    assert "let nekoModelCatRevealPlaybackToken = 0" in source
+    assert "function buildNekoModelCatRevealPlaybackUrl(src, playbackToken)" in source
+    assert "url.searchParams.set('reveal'" in source
+    assert "function restartNekoModelCatRevealArt(container)" in source
+    assert "const isCurrentTransition = () => isNekoModelCatTransitionTokenCurrent(token)" in source
+    assert "if (!isCurrentTransition()) return;" in source
+
+    transition_promise_start = source.index("const transitionPromise = new Promise((resolve) => {")
+    transition_promise_block = source[
+        transition_promise_start:
+        source.index("if (nekoModelCatTransitionActive && nekoModelCatTransitionActive.token === token)", transition_promise_start)
+    ]
+    assert "const startTransitionPlayback = () => {" in transition_promise_block
+    assert "const preloadImage = new Image()" in transition_promise_block
+    assert "preloadImage.addEventListener('load'" in transition_promise_block
+    assert "preloadImage.addEventListener('error'" in transition_promise_block
+    assert "document.body.appendChild(overlay);" in transition_promise_block
+    assert "imageLoadFallbackTimer = setTimeout" in transition_promise_block
+    assert "image.src = src;" in transition_promise_block
+    assert "image.src = src;\n            scheduleTransitionTimers(resolve);" not in transition_promise_block
+
+    reveal_active_block = source[
+        source.index("const revealActiveReturnBall = (reason) => {"):
+        source.index("requestAnimationFrame(() => {", source.index("const revealActiveReturnBall = (reason) => {"))
+    ]
+    assert reveal_active_block.index("restartNekoModelCatRevealArt(activeReturnButtonContainer)") < reveal_active_block.index("revealReturnBallContainer(activeReturnButtonContainer, reason)")
 
 
 def test_return_button_idle_tier_styles_are_present():

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -196,7 +196,12 @@ def test_model_cat_transition_contract_is_present():
     assert "applyNekoTransitionMask(overlay)" in source
     assert "applyNekoTransitionMask(image)" in source
     assert "const ensureOverlayVisible = () => {" in source
-    assert "ensureOverlayVisible();\n            preloadImage.src = src" in source
+    _assert_source_order(
+        source,
+        "transition preload ordering",
+        "ensureOverlayVisible();",
+        "preloadImage.src = src",
+    )
     assert "parseGifDurationMs" not in source
     assert "getNekoModelCatTransitionDurationMs" not in source
     assert "NEKO_MODEL_CAT_TRANSITION_MIN_SIZE = 260" in source
@@ -244,7 +249,13 @@ def test_model_cat_transition_contract_is_present():
     assert "document.body.appendChild(overlay);" in transition_promise_block
     assert "imageLoadFallbackTimer = setTimeout" in transition_promise_block
     assert "image.src = src;" in transition_promise_block
-    assert "image.src = src;\n            scheduleTransitionTimers(resolve);" not in transition_promise_block
+    _assert_source_order(
+        transition_promise_block,
+        "transition playback scheduling",
+        "image.src = src;",
+        "playbackStartedAt = getNekoTransitionNowMs();",
+        "scheduleTransitionTimers(resolve);",
+    )
 
     reveal_active_block = source[
         source.index("const revealActiveReturnBall = (reason) => {"):

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -196,10 +196,11 @@ def test_model_cat_transition_contract_is_present():
     assert "applyNekoTransitionMask(overlay)" in source
     assert "applyNekoTransitionMask(image)" in source
     assert "const ensureOverlayVisible = () => {" in source
+    assert "const startVisibleSmokePlayback = () => {" in source
     _assert_source_order(
         source,
         "transition preload ordering",
-        "ensureOverlayVisible();",
+        "startVisibleSmokePlayback();",
         "preloadImage.src = src",
     )
     assert "parseGifDurationMs" not in source
@@ -247,6 +248,7 @@ def test_model_cat_transition_contract_is_present():
     assert "preloadImage.addEventListener('load'" in transition_promise_block
     assert "preloadImage.addEventListener('error'" in transition_promise_block
     assert "document.body.appendChild(overlay);" in transition_promise_block
+    assert "image.removeAttribute('src')" not in transition_promise_block
     assert "imageLoadFallbackTimer = setTimeout" in transition_promise_block
     assert "image.src = src;" in transition_promise_block
     _assert_source_order(

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -195,6 +195,8 @@ def test_model_cat_transition_contract_is_present():
     assert "function createNekoModelCatTransitionOverlay(rect, direction, token)" in source
     assert "applyNekoTransitionMask(overlay)" in source
     assert "applyNekoTransitionMask(image)" in source
+    assert "const ensureOverlayVisible = () => {" in source
+    assert "ensureOverlayVisible();\n            preloadImage.src = src" in source
     assert "parseGifDurationMs" not in source
     assert "getNekoModelCatTransitionDurationMs" not in source
     assert "NEKO_MODEL_CAT_TRANSITION_MIN_SIZE = 260" in source


### PR DESCRIPTION
## Summary
- 调整按钮图像不透明度相关样式
- 优化猫咪过渡/返回状态相关 UI 行为
- 增加 avatar return button idle tiers 静态测试

## Tests
- Not run locally in this PR submission turn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 提升猫模型回切/返回过渡与动画播放的稳定性，增加加载回退与竞态保护，改善过渡完成与清理行为。

* **Style**
  * 统一调整浮动按钮（麦克风、屏幕）未激活态的不透明度，使界面视觉更一致。

* **Refactor**
  * 优化过渡播放与资源预加载与超时处理，减少卡顿与异常回放概率。

* **Tests**
  * 补充并强化与模型过渡、资源预加载、定时与覆盖层可见性相关的测试断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->