### PR TITLE
fix(chat): stabilize avatar tool cursor geometry

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -6112,6 +6112,7 @@ describe('App', () => {
       active: true,
       toolId: 'hammer',
       variant: 'primary',
+      imageKind: 'cursor',
       tool: expect.objectContaining({
         id: 'hammer',
         cursorImagePath: '/static/icons/chat_hammer1_cursor.png',

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -423,6 +423,9 @@ describe('App', () => {
     expect(container.querySelector('.compact-export-history-anchor')).not.toBeNull();
     expect(container.querySelector('.compact-export-history-anchor')).toHaveAttribute('data-compact-geometry-hit-scope', 'children');
     expect(container.querySelector('.compact-export-history-anchor')).not.toHaveAttribute('data-compact-hit-region');
+    expect(container.querySelector('.compact-export-history-scroll')).toHaveAttribute('data-compact-hit-region', 'true');
+    expect(container.querySelector('.compact-export-history-scroll')).toHaveAttribute('data-compact-hit-region-id', 'history:scroll');
+    expect(container.querySelector('.compact-export-history-scroll')).toHaveAttribute('data-compact-hit-region-kind', 'scroll');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region', 'true');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-id', 'history:message:assistant-history-1');
     expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('data-compact-hit-region-kind', 'message');
@@ -479,6 +482,7 @@ describe('App', () => {
       expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('aria-disabled', 'true');
       expect(container.querySelector('.compact-export-history-bubble')).toHaveAttribute('tabindex', '-1');
       expect(container.querySelector('.compact-export-history-bubble')).not.toHaveAttribute('data-compact-hit-region');
+      expect(container.querySelector('.compact-export-history-scroll')).not.toHaveAttribute('data-compact-hit-region');
       expect(container.querySelector('.compact-export-history-music-mount')).toBeNull();
       expect(container.querySelector('.compact-export-history-controls')).toHaveAttribute('aria-disabled', 'true');
       expect(container.querySelector('.compact-export-history-controls')).not.toHaveAttribute('data-compact-hit-region');

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -3331,7 +3331,7 @@ describe('App', () => {
 
     const preview = container.querySelector('.compact-chat-capsule-text');
     expect(preview).toHaveAttribute('data-compact-preview-streaming', 'false');
-    expect(preview).toHaveTextContent(DEFAULT_CHAT_EMPTY_STATE_FALLBACK);
+    expect(preview).toHaveTextContent(DEFAULT_CHAT_COMPANION_EMPTY_STATE_FALLBACK);
     expect(preview).not.toHaveTextContent(settledText.slice(0, 20));
   });
 
@@ -3492,6 +3492,13 @@ describe('App', () => {
     const { container } = render(<App chatSurfaceMode="compact" compactChatState="input" />);
 
     expect(container.querySelector('[data-compact-geometry-part="inputBody"]')).not.toBeNull();
+    expect(container.querySelector('[data-compact-geometry-part="inputBody"]')).toHaveAttribute('data-compact-geometry-hit-scope', 'children');
+    expect(container.querySelector('.composer-input')).toHaveAttribute('data-compact-hit-region-id', 'input:text');
+    expect(container.querySelector('.composer-input')).toHaveAttribute('data-compact-hit-region-kind', 'input-text');
+    expect(container.querySelector('.compact-chat-minimize-ball')).toHaveAttribute('data-compact-hit-region-id', 'input:minimize');
+    expect(container.querySelector('.compact-chat-minimize-ball')).toHaveAttribute('data-compact-hit-region-kind', 'input-minimize');
+    expect(container.querySelector('.compact-input-tool-toggle')).toHaveAttribute('data-compact-hit-region-id', 'input:tool-toggle');
+    expect(container.querySelector('.compact-input-tool-toggle')).toHaveAttribute('data-compact-hit-region-kind', 'input-tool-toggle');
     expect(container.querySelector('.compact-chat-capsule-button')).toBeNull();
     expect(container.querySelector('.composer-bottom-bar')).toBeNull();
     expect(container.querySelectorAll('.send-button-circle')).toHaveLength(1);
@@ -4289,6 +4296,14 @@ describe('App', () => {
       expect(emojiButton).toHaveClass('is-active');
 
       fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
+
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+      expect(fan.querySelector('#composer-tool-popover-compact')).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(240);
+      });
 
       expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
       expect(avatarTool).toHaveAttribute('data-compact-tool-active', 'true');
@@ -5840,7 +5855,7 @@ describe('App', () => {
     }
   });
 
-  it('keeps the lollipop avatar-range image through transient avatar bounds loss', async () => {
+  it('keeps the lollipop desktop cursor image stable across avatar range changes', async () => {
     vi.useFakeTimers();
     const live2dContainer = document.createElement('div');
     live2dContainer.id = 'live2d-container';
@@ -5883,7 +5898,7 @@ describe('App', () => {
       });
 
       const avatarImage = () => document.body.querySelector('.avatar-cursor-overlay-image-lollipop');
-      expect(avatarImage()).toHaveAttribute('src', '/static/icons/chat_sugar1.png');
+      expect(avatarImage()).toHaveAttribute('src', '/static/icons/chat_sugar1_cursor.png');
 
       boundsAvailable = false;
       fireEvent.pointerMove(window, { clientX: 150, clientY: 150 });
@@ -5892,7 +5907,7 @@ describe('App', () => {
         await vi.advanceTimersByTimeAsync(90);
       });
 
-      expect(avatarImage()).toHaveAttribute('src', '/static/icons/chat_sugar1.png');
+      expect(avatarImage()).toHaveAttribute('src', '/static/icons/chat_sugar1_cursor.png');
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(200);
@@ -6042,6 +6057,20 @@ describe('App', () => {
     expect(screen.queryByRole('button', { name: 'Emoji: 棒棒糖' })).not.toBeInTheDocument();
   });
 
+  it('closes the transparent compact tool fan after selecting an avatar cursor tool', async () => {
+    renderInputApp();
+
+    await openCompactInputTools();
+    fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
+    fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
+
+    const fan = document.body.querySelector<HTMLElement>('.compact-input-tool-fan');
+    expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+    expect(fan).toHaveAttribute('aria-hidden', 'true');
+    expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
+    expect(queryAvatarCursorOverlay()).not.toBeNull();
+  });
+
   it('clears the selected avatar tool from the icon badge', async () => {
     renderInputApp();
 
@@ -6084,6 +6113,10 @@ describe('App', () => {
         cursorImagePath: '/static/icons/chat_hammer1_cursor.png',
         cursorHotspotX: 50,
         cursorHotspotY: 54,
+        cursorNaturalWidth: 100,
+        cursorNaturalHeight: 96,
+        cursorDisplayWidth: 100,
+        cursorDisplayHeight: 96,
       }),
     }));
   });
@@ -6100,7 +6133,25 @@ describe('App', () => {
 
     const overlay = queryAvatarCursorOverlay();
     expect(overlay).not.toBeNull();
-    expect((overlay as HTMLDivElement).style.transform).toBe('translate3d(201px, 274px, 0)');
+    expect((overlay as HTMLDivElement).style.transform).toBe('translate3d(218.16px, 294.24px, 0)');
+  });
+
+  it('moves the desktop cursor overlay synchronously with pointer movement', async () => {
+    renderInputApp();
+
+    await openCompactInputTools();
+    fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
+    fireEvent.click(screen.getByRole('button', { name: '猫爪' }), {
+      clientX: 240,
+      clientY: 320,
+    });
+
+    const overlay = queryAvatarCursorOverlay();
+    expect(overlay).not.toBeNull();
+
+    fireEvent.pointerMove(window, { clientX: 420, clientY: 360 });
+
+    expect((overlay as HTMLDivElement).style.transform).toBe('translate3d(398.16px, 334.24px, 0)');
   });
 
   it('clears the tool cursor when the composer is hidden for voice mode', async () => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2110,9 +2110,6 @@ function CompactChatApp({
   const isCursorWithinAvatarToolRange = isCursorInsideHostWindow
     && isCursorOverAvatarRange
     && !isCursorOverCompactCursorZone;
-  const avatarToolImageKind = activeToolItem
-    ? (isCursorWithinAvatarToolRange ? 'icon' : 'cursor')
-    : 'cursor';
 
   useEffect(() => {
     draftRef.current = draft;
@@ -4308,7 +4305,7 @@ function CompactChatApp({
       variant: effectiveCursorVariant,
       avatarRangeVariant: avatarRangeCursorVariant,
       outsideRangeVariant,
-      imageKind: avatarToolImageKind,
+      imageKind: 'cursor',
       withinAvatarRange: isCursorWithinAvatarToolRange,
       overCompactZone: isCursorOverCompactCursorZone,
       insideHostWindow: isCursorInsideHostWindow,
@@ -4340,7 +4337,6 @@ function CompactChatApp({
     avatarRangeCursorVariant,
     draft,
     effectiveCursorVariant,
-    avatarToolImageKind,
     isCursorInsideHostWindow,
     isCursorOverCompactCursorZone,
     isCursorWithinAvatarToolRange,

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -591,6 +591,10 @@ type ToolIconItem = {
   cursorImagePathAlt2?: string;
   cursorHotspotX?: number;
   cursorHotspotY?: number;
+  cursorNaturalWidth?: number;
+  cursorNaturalHeight?: number;
+  cursorDisplayWidth?: number;
+  cursorDisplayHeight?: number;
 };
 
 const toolIconItems: ToolIconItem[] = [
@@ -606,6 +610,10 @@ const toolIconItems: ToolIconItem[] = [
     menuIconScale: 1.18,
     cursorHotspotX: 27,
     cursorHotspotY: 46,
+    cursorNaturalWidth: 55,
+    cursorNaturalHeight: 80,
+    cursorDisplayWidth: 74,
+    cursorDisplayHeight: 108,
   },
   {
     id: 'fist',
@@ -617,6 +625,10 @@ const toolIconItems: ToolIconItem[] = [
     cursorImagePathAlt: '/static/icons/cat_claw2_cursor.png',
     cursorHotspotX: 39,
     cursorHotspotY: 46,
+    cursorNaturalWidth: 78,
+    cursorNaturalHeight: 80,
+    cursorDisplayWidth: 78,
+    cursorDisplayHeight: 80,
   },
   {
     id: 'hammer',
@@ -633,6 +645,10 @@ const toolIconItems: ToolIconItem[] = [
     menuIconOffsetYAlt: -1,
     cursorHotspotX: 50,
     cursorHotspotY: 54,
+    cursorNaturalWidth: 100,
+    cursorNaturalHeight: 96,
+    cursorDisplayWidth: 100,
+    cursorDisplayHeight: 96,
   },
 ];
 
@@ -911,6 +927,38 @@ function resolveCursorValue(item: ToolIconItem, variant: CursorVariant): string 
   const hotspotX = typeof item.cursorHotspotX === 'number' ? item.cursorHotspotX : 18;
   const hotspotY = typeof item.cursorHotspotY === 'number' ? item.cursorHotspotY : 18;
   return `url("${imagePath}") ${hotspotX} ${hotspotY}, auto`;
+}
+
+function getToolCursorOverlayScale(toolId: AvatarInteractionToolId | null, compact: boolean): number {
+  if (!compact) return 1;
+  return toolId === 'hammer' ? 0.52 : 0.56;
+}
+
+function getPositiveCursorMetric(value: number | undefined, fallback: number): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function getScaledToolCursorHotspot(
+  item: Pick<ToolIconItem, 'cursorHotspotX' | 'cursorHotspotY' | 'cursorNaturalWidth' | 'cursorNaturalHeight' | 'cursorDisplayWidth' | 'cursorDisplayHeight'>,
+  scale: number,
+) {
+  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  const naturalWidth = getPositiveCursorMetric(item.cursorNaturalWidth, 0);
+  const naturalHeight = getPositiveCursorMetric(item.cursorNaturalHeight, 0);
+  const displayWidth = getPositiveCursorMetric(item.cursorDisplayWidth, naturalWidth);
+  const displayHeight = getPositiveCursorMetric(item.cursorDisplayHeight, naturalHeight);
+  const displayRatioX = naturalWidth > 0 && displayWidth > 0 ? displayWidth / naturalWidth : 1;
+  const displayRatioY = naturalHeight > 0 && displayHeight > 0 ? displayHeight / naturalHeight : 1;
+  return {
+    x: (item.cursorHotspotX ?? 18) * displayRatioX * safeScale,
+    y: (item.cursorHotspotY ?? 18) * displayRatioY * safeScale,
+  };
+}
+
+function formatCursorOverlayPx(value: number): string {
+  const rounded = Math.round(value * 100) / 100;
+  return `${Object.is(rounded, -0) ? 0 : rounded}px`;
 }
 
 function playAvatarToolSound(soundPath: string) {
@@ -2025,28 +2073,27 @@ function CompactChatApp({
     && !isElectronMultiWindow;
   const shouldRenderLocalDesktopCursorOverlay = shouldUseLocalDesktopCursorOverlay
     && isCursorInsideHostWindow;
-  const shouldRenderAvatarRangeOverlay = isCursorOverAvatarRange && !isCursorOverCompactCursorZone;
   const avatarCursorOverlayActive = !!activeToolItem
     && activeCursorToolId !== 'hammer'
     && shouldRenderLocalDesktopCursorOverlay;
-  const avatarCursorOverlayCompact = avatarCursorOverlayActive && !shouldRenderAvatarRangeOverlay;
+  const avatarCursorOverlayCompact = avatarCursorOverlayActive;
   const hammerCursorOverlayActive = activeCursorToolId === 'hammer' && shouldRenderLocalDesktopCursorOverlay;
-  const hammerCursorOverlayCompact = hammerCursorOverlayActive && !shouldRenderAvatarRangeOverlay;
   const hammerCursorOverlayMotionActive = hammerSwingPhase !== 'idle';
+  const hammerCursorOverlayCompact = hammerCursorOverlayActive && !hammerCursorOverlayMotionActive;
   const hammerCompactImagePaths = hammerToolItem
     ? resolveToolImagePaths(hammerToolItem, effectiveCursorVariant)
     : null;
   const hammerCursorOverlayUsesCompactImage = hammerCursorOverlayCompact && !hammerCursorOverlayMotionActive;
   const avatarCursorOverlayImagePath = activeToolItem && activeCursorToolId !== 'hammer'
-    ? (
-      avatarCursorOverlayCompact
-        ? (activeToolImagePaths?.cursorImagePath ?? '')
-        : (activeToolImagePaths?.iconImagePath ?? '')
-    )
+    ? (activeToolImagePaths?.cursorImagePath ?? '')
     : '';
+  const avatarCursorOverlayScale = activeToolItem
+    ? getToolCursorOverlayScale(activeToolItem.id, avatarCursorOverlayCompact)
+    : 1;
   const hammerCursorOverlayCompactImagePath = hammerCursorOverlayUsesCompactImage
     ? (hammerCompactImagePaths?.cursorImagePath ?? '')
     : '';
+  const hammerCursorOverlayScale = getToolCursorOverlayScale('hammer', hammerCursorOverlayCompact);
   const hammerCursorOverlayPrimaryImagePath = hammerToolItem
     ? resolveToolImagePaths(hammerToolItem, 'primary').iconImagePath
     : '';
@@ -4274,6 +4321,10 @@ function CompactChatApp({
           cursorImagePathAlt2: activeToolItem.cursorImagePathAlt2,
           cursorHotspotX: activeToolItem.cursorHotspotX,
           cursorHotspotY: activeToolItem.cursorHotspotY,
+          cursorNaturalWidth: activeToolItem.cursorNaturalWidth,
+          cursorNaturalHeight: activeToolItem.cursorNaturalHeight,
+          cursorDisplayWidth: activeToolItem.cursorDisplayWidth,
+          cursorDisplayHeight: activeToolItem.cursorDisplayHeight,
           menuIconScale: activeToolItem.menuIconScale,
         }
         : null,
@@ -4366,18 +4417,16 @@ function CompactChatApp({
     latestPointerPositionRef.current = { x: clientX, y: clientY };
     const overlayNode = hammerCursorOverlayRef.current;
     if (!overlayNode || !hammerToolItem) return;
-    const hotspotX = hammerToolItem.cursorHotspotX ?? 18;
-    const hotspotY = hammerToolItem.cursorHotspotY ?? 18;
-    overlayNode.style.transform = `translate3d(${clientX - hotspotX}px, ${clientY - hotspotY}px, 0)`;
+    const hotspot = getScaledToolCursorHotspot(hammerToolItem, hammerCursorOverlayScale);
+    overlayNode.style.transform = `translate3d(${formatCursorOverlayPx(clientX - hotspot.x)}, ${formatCursorOverlayPx(clientY - hotspot.y)}, 0)`;
   }
 
   function updateAvatarCursorOverlayPosition(clientX: number, clientY: number) {
     latestPointerPositionRef.current = { x: clientX, y: clientY };
     const overlayNode = avatarCursorOverlayRef.current;
     if (!overlayNode || !activeToolItem) return;
-    const hotspotX = activeToolItem.cursorHotspotX ?? 18;
-    const hotspotY = activeToolItem.cursorHotspotY ?? 18;
-    overlayNode.style.transform = `translate3d(${clientX - hotspotX}px, ${clientY - hotspotY}px, 0)`;
+    const hotspot = getScaledToolCursorHotspot(activeToolItem, avatarCursorOverlayScale);
+    overlayNode.style.transform = `translate3d(${formatCursorOverlayPx(clientX - hotspot.x)}, ${formatCursorOverlayPx(clientY - hotspot.y)}, 0)`;
   }
 
   function emitAvatarInteraction<T extends AvatarInteractionToolId>(
@@ -4653,17 +4702,17 @@ function CompactChatApp({
       setIsCursorInsideHostWindow(true);
       latestPointerPositionRef.current = { x: event.clientX, y: event.clientY };
       latestPointerTargetRef.current = event.target;
+      if (activeCursorToolId === 'hammer') {
+        updateHammerCursorOverlayPosition(event.clientX, event.clientY);
+      } else if (activeCursorToolId) {
+        updateAvatarCursorOverlayPosition(event.clientX, event.clientY);
+      }
       if (frameId) return;
 
       frameId = window.requestAnimationFrame(() => {
         frameId = 0;
         const { x, y } = latestPointerPositionRef.current;
         const isOverCompactCursorZone = isPointerOverCompactCursorZone(latestPointerTargetRef.current);
-        if (activeCursorToolId === 'hammer') {
-          updateHammerCursorOverlayPosition(x, y);
-        } else if (activeCursorToolId) {
-          updateAvatarCursorOverlayPosition(x, y);
-        }
         updateCursorRangeState(x, y);
         setIsCursorOverCompactCursorZone(previousValue => (
           previousValue === isOverCompactCursorZone ? previousValue : isOverCompactCursorZone
@@ -4779,7 +4828,7 @@ function CompactChatApp({
       latestPointerPositionRef.current.x,
       latestPointerPositionRef.current.y,
     );
-  }, [avatarCursorOverlayActive, avatarCursorOverlayImagePath, activeToolItem]);
+  }, [avatarCursorOverlayActive, avatarCursorOverlayImagePath, activeToolItem, avatarCursorOverlayScale]);
 
   useEffect(() => {
     if (!hammerCursorOverlayActive) return;
@@ -4787,7 +4836,7 @@ function CompactChatApp({
       latestPointerPositionRef.current.x,
       latestPointerPositionRef.current.y,
     );
-  }, [hammerCursorOverlayActive, hammerSwingPhase]);
+  }, [hammerCursorOverlayActive, hammerCursorOverlayScale, hammerSwingPhase]);
 
   useEffect(() => {
     if (composerHidden || composerDisabled) {
@@ -4930,6 +4979,9 @@ function CompactChatApp({
       ref={compactInputToolToggleRef}
       type={compactToolToggleActsAsSubmit ? 'submit' : 'button'}
       data-compact-no-drag="true"
+      data-compact-hit-region="true"
+      data-compact-hit-region-id="input:tool-toggle"
+      data-compact-hit-region-kind="input-tool-toggle"
       aria-label={compactToolToggleActsAsSubmit ? sendButtonLabel : overflowMenuAriaLabel}
       aria-haspopup={compactToolToggleActsAsSubmit ? undefined : 'true'}
       aria-expanded={compactToolToggleActsAsSubmit ? undefined : compactInputToolFanOpen}
@@ -4973,6 +5025,9 @@ function CompactChatApp({
       aria-label={i18n('chat.reactWindowMinimize', 'Minimize')}
       title={i18n('chat.reactWindowMinimize', 'Minimize')}
       data-compact-no-drag="true"
+      data-compact-hit-region="true"
+      data-compact-hit-region-id="input:minimize"
+      data-compact-hit-region-kind="input-minimize"
       onPointerDown={beginCompactToolOriginDrag}
       onPointerMove={updateCompactToolOriginDrag}
       onPointerUp={endCompactToolOriginDrag}
@@ -5305,6 +5360,7 @@ function CompactChatApp({
               setIsCursorInsideHostWindow(true);
               setActiveCursorToolId(null);
               setToolMenuOpen(false);
+              closeCompactInputToolFan();
             }}
           >
             <span className="composer-tool-clear-icon" aria-hidden="true" />
@@ -5353,12 +5409,14 @@ function CompactChatApp({
                 if (activeCursorToolId === item.id) {
                   setActiveCursorToolId(null);
                   setToolMenuOpen(false);
+                  closeCompactInputToolFan();
                   return;
                 }
                 setAvatarRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setOutsideRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setActiveCursorToolId(item.id);
                 setToolMenuOpen(false);
+                closeCompactInputToolFan();
               }}
             >
               <img
@@ -5580,7 +5638,7 @@ function CompactChatApp({
       <div
         className="avatar-cursor-overlay-stage"
         style={{
-          transformOrigin: `${activeToolItem.cursorHotspotX ?? 18}px ${activeToolItem.cursorHotspotY ?? 18}px`,
+          transformOrigin: '0 0',
         }}
       >
         <img
@@ -5600,7 +5658,7 @@ function CompactChatApp({
       <div
         className="hammer-cursor-overlay-stage"
         style={{
-          transformOrigin: `${hammerToolItem.cursorHotspotX ?? 18}px ${hammerToolItem.cursorHotspotY ?? 18}px`,
+          transformOrigin: '0 0',
         }}
       >
         {hammerCursorOverlayUsesCompactImage ? (
@@ -5877,6 +5935,7 @@ function CompactChatApp({
                     data-compact-drag-surface="true"
                     data-compact-chat-state={effectiveCompactChatState}
                     data-compact-geometry-part={effectiveCompactChatState === 'input' ? 'inputBody' : 'capsuleBody'}
+                    data-compact-geometry-hit-scope={effectiveCompactChatState === 'input' ? 'children' : undefined}
                     data-compact-tool-toggle-visible={compactToolToggleVisible ? 'true' : 'false'}
                   >
                     {effectiveCompactChatState === 'input' ? (
@@ -5888,6 +5947,9 @@ function CompactChatApp({
                           className="composer-input"
                           ref={compactInputRef}
                           data-compact-no-drag="true"
+                          data-compact-hit-region="true"
+                          data-compact-hit-region-id="input:text"
+                          data-compact-hit-region-kind="input-text"
                           placeholder={inputPlaceholder}
                           aria-label={inputPlaceholder}
                           rows={1}

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -3493,6 +3493,9 @@ function CompactChatApp({
   const closeCompactInputToolFanFromUserClick = useCallback(() => {
     compactInputToolFanSuppressHoverUntilLeaveRef.current = true;
     closeCompactInputToolFan();
+    window.requestAnimationFrame(() => {
+      compactInputToolToggleRef.current?.focus({ preventScroll: true });
+    });
   }, [closeCompactInputToolFan]);
 
   const closeCompactInputToolFanFromDesktopOutside = useCallback(() => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4772,7 +4772,13 @@ function CompactChatApp({
       window.removeEventListener('blur', hideLocalCursorOverlay);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [activeCursorToolId, avatarToolCacheState, setCursorOverAvatarRange]);
+  }, [
+    activeCursorToolId,
+    avatarCursorOverlayScale,
+    avatarToolCacheState,
+    hammerCursorOverlayScale,
+    setCursorOverAvatarRange,
+  ]);
 
   useEffect(() => {
     const root = document.documentElement;

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5366,7 +5366,7 @@ function CompactChatApp({
               setIsCursorInsideHostWindow(true);
               setActiveCursorToolId(null);
               setToolMenuOpen(false);
-              closeCompactInputToolFan();
+              closeCompactInputToolFanFromUserClick();
             }}
           >
             <span className="composer-tool-clear-icon" aria-hidden="true" />
@@ -5415,14 +5415,14 @@ function CompactChatApp({
                 if (activeCursorToolId === item.id) {
                   setActiveCursorToolId(null);
                   setToolMenuOpen(false);
-                  closeCompactInputToolFan();
+                  closeCompactInputToolFanFromUserClick();
                   return;
                 }
                 setAvatarRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setOutsideRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setActiveCursorToolId(item.id);
                 setToolMenuOpen(false);
-                closeCompactInputToolFan();
+                closeCompactInputToolFanFromUserClick();
               }}
             >
               <img

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -905,6 +905,9 @@ export default function CompactExportHistoryPanel({
             className="compact-export-history-scroll"
             role="list"
             aria-label={i18n('chat.messageListAriaLabel', 'Chat messages')}
+            data-compact-hit-region={historyInteractive && !choiceLayerAbove ? 'true' : undefined}
+            data-compact-hit-region-id={historyInteractive && !choiceLayerAbove ? 'history:scroll' : undefined}
+            data-compact-hit-region-kind={historyInteractive && !choiceLayerAbove ? 'scroll' : undefined}
             data-compact-scrollbar-visible={scrollbarVisible ? 'true' : undefined}
             onScroll={handleScroll}
             onWheel={handleWheel}

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -353,6 +353,10 @@ type ToolIconItem = {
   cursorImagePathAlt2?: string;
   cursorHotspotX?: number;
   cursorHotspotY?: number;
+  cursorNaturalWidth?: number;
+  cursorNaturalHeight?: number;
+  cursorDisplayWidth?: number;
+  cursorDisplayHeight?: number;
 };
 
 const toolIconItems: ToolIconItem[] = [
@@ -368,6 +372,10 @@ const toolIconItems: ToolIconItem[] = [
     menuIconScale: 1.18,
     cursorHotspotX: 27,
     cursorHotspotY: 46,
+    cursorNaturalWidth: 55,
+    cursorNaturalHeight: 80,
+    cursorDisplayWidth: 74,
+    cursorDisplayHeight: 108,
   },
   {
     id: 'fist',
@@ -379,6 +387,10 @@ const toolIconItems: ToolIconItem[] = [
     cursorImagePathAlt: '/static/icons/cat_claw2_cursor.png',
     cursorHotspotX: 39,
     cursorHotspotY: 46,
+    cursorNaturalWidth: 78,
+    cursorNaturalHeight: 80,
+    cursorDisplayWidth: 78,
+    cursorDisplayHeight: 80,
   },
   {
     id: 'hammer',
@@ -395,6 +407,10 @@ const toolIconItems: ToolIconItem[] = [
     menuIconOffsetYAlt: -1,
     cursorHotspotX: 50,
     cursorHotspotY: 54,
+    cursorNaturalWidth: 100,
+    cursorNaturalHeight: 96,
+    cursorDisplayWidth: 100,
+    cursorDisplayHeight: 96,
   },
 ];
 
@@ -678,6 +694,38 @@ function resolveCursorValue(item: ToolIconItem, variant: CursorVariant): string 
   const hotspotX = typeof item.cursorHotspotX === 'number' ? item.cursorHotspotX : 18;
   const hotspotY = typeof item.cursorHotspotY === 'number' ? item.cursorHotspotY : 18;
   return `url("${imagePath}") ${hotspotX} ${hotspotY}, auto`;
+}
+
+function getToolCursorOverlayScale(toolId: AvatarInteractionToolId | null, compact: boolean): number {
+  if (!compact) return 1;
+  return toolId === 'hammer' ? 0.52 : 0.56;
+}
+
+function getPositiveCursorMetric(value: number | undefined, fallback: number): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function getScaledToolCursorHotspot(
+  item: Pick<ToolIconItem, 'cursorHotspotX' | 'cursorHotspotY' | 'cursorNaturalWidth' | 'cursorNaturalHeight' | 'cursorDisplayWidth' | 'cursorDisplayHeight'>,
+  scale: number,
+) {
+  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  const naturalWidth = getPositiveCursorMetric(item.cursorNaturalWidth, 0);
+  const naturalHeight = getPositiveCursorMetric(item.cursorNaturalHeight, 0);
+  const displayWidth = getPositiveCursorMetric(item.cursorDisplayWidth, naturalWidth);
+  const displayHeight = getPositiveCursorMetric(item.cursorDisplayHeight, naturalHeight);
+  const displayRatioX = naturalWidth > 0 && displayWidth > 0 ? displayWidth / naturalWidth : 1;
+  const displayRatioY = naturalHeight > 0 && displayHeight > 0 ? displayHeight / naturalHeight : 1;
+  return {
+    x: (item.cursorHotspotX ?? 18) * displayRatioX * safeScale,
+    y: (item.cursorHotspotY ?? 18) * displayRatioY * safeScale,
+  };
+}
+
+function formatCursorOverlayPx(value: number): string {
+  const rounded = Math.round(value * 100) / 100;
+  return `${Object.is(rounded, -0) ? 0 : rounded}px`;
 }
 
 function playAvatarToolSound(soundPath: string) {
@@ -1467,28 +1515,27 @@ export default function FullChatSurface({
     && !isElectronMultiWindow;
   const shouldRenderLocalDesktopCursorOverlay = shouldUseLocalDesktopCursorOverlay
     && isCursorInsideHostWindow;
-  const shouldRenderAvatarRangeOverlay = isCursorOverAvatarRange && !isCursorOverCompactCursorZone;
   const avatarCursorOverlayActive = !!activeToolItem
     && activeCursorToolId !== 'hammer'
     && shouldRenderLocalDesktopCursorOverlay;
-  const avatarCursorOverlayCompact = avatarCursorOverlayActive && !shouldRenderAvatarRangeOverlay;
+  const avatarCursorOverlayCompact = avatarCursorOverlayActive;
   const hammerCursorOverlayActive = activeCursorToolId === 'hammer' && shouldRenderLocalDesktopCursorOverlay;
-  const hammerCursorOverlayCompact = hammerCursorOverlayActive && !shouldRenderAvatarRangeOverlay;
   const hammerCursorOverlayMotionActive = hammerSwingPhase !== 'idle';
+  const hammerCursorOverlayCompact = hammerCursorOverlayActive && !hammerCursorOverlayMotionActive;
   const hammerCompactImagePaths = hammerToolItem
     ? resolveToolImagePaths(hammerToolItem, effectiveCursorVariant)
     : null;
   const hammerCursorOverlayUsesCompactImage = hammerCursorOverlayCompact && !hammerCursorOverlayMotionActive;
   const avatarCursorOverlayImagePath = activeToolItem && activeCursorToolId !== 'hammer'
-    ? (
-      avatarCursorOverlayCompact
-        ? (activeToolImagePaths?.cursorImagePath ?? '')
-        : (activeToolImagePaths?.iconImagePath ?? '')
-    )
+    ? (activeToolImagePaths?.cursorImagePath ?? '')
     : '';
+  const avatarCursorOverlayScale = activeToolItem
+    ? getToolCursorOverlayScale(activeToolItem.id, avatarCursorOverlayCompact)
+    : 1;
   const hammerCursorOverlayCompactImagePath = hammerCursorOverlayUsesCompactImage
     ? (hammerCompactImagePaths?.cursorImagePath ?? '')
     : '';
+  const hammerCursorOverlayScale = getToolCursorOverlayScale('hammer', hammerCursorOverlayCompact);
   const hammerCursorOverlayPrimaryImagePath = hammerToolItem
     ? resolveToolImagePaths(hammerToolItem, 'primary').iconImagePath
     : '';
@@ -2660,6 +2707,10 @@ export default function FullChatSurface({
           cursorImagePathAlt2: activeToolItem.cursorImagePathAlt2,
           cursorHotspotX: activeToolItem.cursorHotspotX,
           cursorHotspotY: activeToolItem.cursorHotspotY,
+          cursorNaturalWidth: activeToolItem.cursorNaturalWidth,
+          cursorNaturalHeight: activeToolItem.cursorNaturalHeight,
+          cursorDisplayWidth: activeToolItem.cursorDisplayWidth,
+          cursorDisplayHeight: activeToolItem.cursorDisplayHeight,
           menuIconScale: activeToolItem.menuIconScale,
         }
         : null,
@@ -2752,18 +2803,16 @@ export default function FullChatSurface({
     latestPointerPositionRef.current = { x: clientX, y: clientY };
     const overlayNode = hammerCursorOverlayRef.current;
     if (!overlayNode || !hammerToolItem) return;
-    const hotspotX = hammerToolItem.cursorHotspotX ?? 18;
-    const hotspotY = hammerToolItem.cursorHotspotY ?? 18;
-    overlayNode.style.transform = `translate3d(${clientX - hotspotX}px, ${clientY - hotspotY}px, 0)`;
+    const hotspot = getScaledToolCursorHotspot(hammerToolItem, hammerCursorOverlayScale);
+    overlayNode.style.transform = `translate3d(${formatCursorOverlayPx(clientX - hotspot.x)}, ${formatCursorOverlayPx(clientY - hotspot.y)}, 0)`;
   }
 
   function updateAvatarCursorOverlayPosition(clientX: number, clientY: number) {
     latestPointerPositionRef.current = { x: clientX, y: clientY };
     const overlayNode = avatarCursorOverlayRef.current;
     if (!overlayNode || !activeToolItem) return;
-    const hotspotX = activeToolItem.cursorHotspotX ?? 18;
-    const hotspotY = activeToolItem.cursorHotspotY ?? 18;
-    overlayNode.style.transform = `translate3d(${clientX - hotspotX}px, ${clientY - hotspotY}px, 0)`;
+    const hotspot = getScaledToolCursorHotspot(activeToolItem, avatarCursorOverlayScale);
+    overlayNode.style.transform = `translate3d(${formatCursorOverlayPx(clientX - hotspot.x)}, ${formatCursorOverlayPx(clientY - hotspot.y)}, 0)`;
   }
 
   function emitAvatarInteraction<T extends AvatarInteractionToolId>(
@@ -3133,17 +3182,17 @@ export default function FullChatSurface({
       setIsCursorInsideHostWindow(true);
       latestPointerPositionRef.current = { x: event.clientX, y: event.clientY };
       latestPointerTargetRef.current = event.target;
+      if (activeCursorToolId === 'hammer') {
+        updateHammerCursorOverlayPosition(event.clientX, event.clientY);
+      } else if (activeCursorToolId) {
+        updateAvatarCursorOverlayPosition(event.clientX, event.clientY);
+      }
       if (frameId) return;
 
       frameId = window.requestAnimationFrame(() => {
         frameId = 0;
         const { x, y } = latestPointerPositionRef.current;
         const isOverCompactCursorZone = isPointerOverCompactCursorZone(latestPointerTargetRef.current);
-        if (activeCursorToolId === 'hammer') {
-          updateHammerCursorOverlayPosition(x, y);
-        } else if (activeCursorToolId) {
-          updateAvatarCursorOverlayPosition(x, y);
-        }
         updateCursorRangeState(x, y);
         setIsCursorOverCompactCursorZone(previousValue => (
           previousValue === isOverCompactCursorZone ? previousValue : isOverCompactCursorZone
@@ -3259,7 +3308,7 @@ export default function FullChatSurface({
       latestPointerPositionRef.current.x,
       latestPointerPositionRef.current.y,
     );
-  }, [avatarCursorOverlayActive, avatarCursorOverlayImagePath, activeToolItem]);
+  }, [avatarCursorOverlayActive, avatarCursorOverlayImagePath, activeToolItem, avatarCursorOverlayScale]);
 
   useEffect(() => {
     if (!hammerCursorOverlayActive) return;
@@ -3267,7 +3316,7 @@ export default function FullChatSurface({
       latestPointerPositionRef.current.x,
       latestPointerPositionRef.current.y,
     );
-  }, [hammerCursorOverlayActive, hammerSwingPhase]);
+  }, [hammerCursorOverlayActive, hammerCursorOverlayScale, hammerSwingPhase]);
 
   useEffect(() => {
     if (composerInteractionsDisabled) {
@@ -3987,7 +4036,7 @@ export default function FullChatSurface({
       <div
         className="avatar-cursor-overlay-stage"
         style={{
-          transformOrigin: `${activeToolItem.cursorHotspotX ?? 18}px ${activeToolItem.cursorHotspotY ?? 18}px`,
+          transformOrigin: '0 0',
         }}
       >
         <img
@@ -4007,7 +4056,7 @@ export default function FullChatSurface({
       <div
         className="hammer-cursor-overlay-stage"
         style={{
-          transformOrigin: `${hammerToolItem.cursorHotspotX ?? 18}px ${hammerToolItem.cursorHotspotY ?? 18}px`,
+          transformOrigin: '0 0',
         }}
       >
         {hammerCursorOverlayUsesCompactImage ? (
@@ -4274,12 +4323,16 @@ export default function FullChatSurface({
                   data-compact-geometry-owner="surface"
                   data-compact-chat-state={effectiveCompactChatState}
                   data-compact-geometry-part={effectiveCompactChatState === 'input' ? 'inputBody' : 'capsuleBody'}
+                  data-compact-geometry-hit-scope={effectiveCompactChatState === 'input' ? 'children' : undefined}
                 >
                   {effectiveCompactChatState === 'input' ? (
                     <>
                       <textarea
                         className="composer-input"
                         ref={compactInputRef}
+                        data-compact-hit-region="true"
+                        data-compact-hit-region-id="input:text"
+                        data-compact-hit-region-kind="input-text"
                         placeholder={inputPlaceholder}
                         aria-label={inputPlaceholder}
                         rows={1}
@@ -4305,6 +4358,9 @@ export default function FullChatSurface({
                         className={`send-button-circle compact-input-tool-toggle${compactInputToolFanOpen ? ' is-open' : ''}`}
                         ref={compactInputToolToggleRef}
                         type={compactInputHasPayload ? 'submit' : 'button'}
+                        data-compact-hit-region="true"
+                        data-compact-hit-region-id="input:tool-toggle"
+                        data-compact-hit-region-kind="input-tool-toggle"
                         aria-label={compactInputHasPayload ? sendButtonLabel : overflowMenuAriaLabel}
                         aria-haspopup={compactInputHasPayload ? undefined : 'true'}
                         aria-expanded={compactInputHasPayload ? undefined : compactInputToolFanOpen}

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -2337,6 +2337,9 @@ export default function FullChatSurface({
   const closeCompactInputToolFanFromUserClick = useCallback(() => {
     compactInputToolFanSuppressHoverUntilLeaveRef.current = true;
     closeCompactInputToolFan();
+    window.requestAnimationFrame(() => {
+      compactInputToolToggleRef.current?.focus({ preventScroll: true });
+    });
   }, [closeCompactInputToolFan]);
 
   const toggleCompactInputToolFanByClick = useCallback(() => {

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -1552,9 +1552,6 @@ export default function FullChatSurface({
   const isCursorWithinAvatarToolRange = isCursorInsideHostWindow
     && isCursorOverAvatarRange
     && !isCursorOverCompactCursorZone;
-  const avatarToolImageKind = activeToolItem
-    ? (isCursorWithinAvatarToolRange ? 'icon' : 'cursor')
-    : 'cursor';
 
   useEffect(() => {
     draftRef.current = draft;
@@ -2694,7 +2691,7 @@ export default function FullChatSurface({
       variant: effectiveCursorVariant,
       avatarRangeVariant: avatarRangeCursorVariant,
       outsideRangeVariant,
-      imageKind: avatarToolImageKind,
+      imageKind: 'cursor',
       withinAvatarRange: isCursorWithinAvatarToolRange,
       overCompactZone: isCursorOverCompactCursorZone,
       insideHostWindow: isCursorInsideHostWindow,
@@ -2726,7 +2723,6 @@ export default function FullChatSurface({
     avatarRangeCursorVariant,
     draft,
     effectiveCursorVariant,
-    avatarToolImageKind,
     isCursorInsideHostWindow,
     isCursorOverCompactCursorZone,
     isCursorWithinAvatarToolRange,

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -3815,7 +3815,7 @@ export default function FullChatSurface({
             }
             if (activeToolItem) {
               clearActiveCursorToolSelection();
-              closeCompactInputToolFan();
+              closeCompactInputToolFanFromUserClick();
               return;
             }
             compactInputToolFanOpenIntentRef.current = 'click';
@@ -3850,7 +3850,7 @@ export default function FullChatSurface({
               setIsCursorInsideHostWindow(true);
               setActiveCursorToolId(null);
               setToolMenuOpen(false);
-              closeCompactInputToolFan();
+              closeCompactInputToolFanFromUserClick();
             }}
           >
             <span aria-hidden="true">×</span>
@@ -3899,14 +3899,14 @@ export default function FullChatSurface({
                 if (activeCursorToolId === item.id) {
                   setActiveCursorToolId(null);
                   setToolMenuOpen(false);
-                  closeCompactInputToolFan();
+                  closeCompactInputToolFanFromUserClick();
                   return;
                 }
                 setAvatarRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setOutsideRangeCursorVariants(prev => ({ ...prev, [item.id]: 'primary' }));
                 setActiveCursorToolId(item.id);
                 setToolMenuOpen(false);
-                closeCompactInputToolFan();
+                closeCompactInputToolFanFromUserClick();
               }}
             >
               <img

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -3252,7 +3252,13 @@ export default function FullChatSurface({
       window.removeEventListener('blur', hideLocalCursorOverlay);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [activeCursorToolId, avatarToolCacheState, setCursorOverAvatarRange]);
+  }, [
+    activeCursorToolId,
+    avatarCursorOverlayScale,
+    avatarToolCacheState,
+    hammerCursorOverlayScale,
+    setCursorOverAvatarRange,
+  ]);
 
   useEffect(() => {
     const root = document.documentElement;

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -132,6 +132,10 @@ const avatarToolDescriptorSchema = z.object({
   cursorImagePathAlt2: z.string().optional(),
   cursorHotspotX: z.number().finite().optional(),
   cursorHotspotY: z.number().finite().optional(),
+  cursorNaturalWidth: z.number().finite().positive().optional(),
+  cursorNaturalHeight: z.number().finite().positive().optional(),
+  cursorDisplayWidth: z.number().finite().positive().optional(),
+  cursorDisplayHeight: z.number().finite().positive().optional(),
   menuIconScale: z.number().finite().positive().optional(),
 }).strict();
 

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -86,11 +86,9 @@ svg {
 
 .avatar-cursor-overlay-stage {
   opacity: 0;
-  transform: scale(calc(var(--avatar-cursor-overlay-scale) * 0.84));
+  transform: scale(var(--avatar-cursor-overlay-scale));
   will-change: transform, opacity;
-  transition:
-    opacity 180ms cubic-bezier(0.22, 0.78, 0.2, 1),
-    transform 180ms cubic-bezier(0.2, 0.82, 0.22, 1);
+  transition: opacity 120ms cubic-bezier(0.22, 0.78, 0.2, 1);
 }
 
 .avatar-cursor-overlay.is-visible .avatar-cursor-overlay-stage {
@@ -112,8 +110,8 @@ svg {
 }
 
 .avatar-cursor-overlay-image-fist {
-  width: 100px;
-  height: 102px;
+  width: 78px;
+  height: 80px;
 }
 
 .fist-floating-drop {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1636,7 +1636,14 @@
                 interactive: false
             });
         }
-        return items.concat(Array.prototype.slice.call(element.querySelectorAll('[data-compact-hit-region="true"]'))
+        var hitRegionElements = [];
+        if (element.getAttribute('data-compact-hit-region') === 'true') {
+            hitRegionElements.push(element);
+        }
+        hitRegionElements = hitRegionElements.concat(
+            Array.prototype.slice.call(element.querySelectorAll('[data-compact-hit-region="true"]'))
+        );
+        return items.concat(hitRegionElements
             .map(function (child, index) {
                 var style = window.getComputedStyle ? window.getComputedStyle(child) : null;
                 if (style && (style.display === 'none' || style.visibility === 'hidden')) return null;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1577,6 +1577,14 @@
         return item;
     }
 
+    function getCompactGeometryItemBoundsRects(item) {
+        if (!item) return [];
+        var rects = [];
+        if (item.visualRect) rects.push(item.visualRect);
+        if (item.nativeRect) rects.push(item.nativeRect);
+        return rects;
+    }
+
     function collectCompactToolFanGeometryItems(element) {
         if (!element || element.getAttribute('data-compact-geometry-item') !== 'toolFan') return [];
         var parentRect = getCompactGeometryElementRect(element);
@@ -1806,8 +1814,12 @@
         var baseSurfaceNativeItems = surfaceItems.filter(function (item) {
             return item && (item.geometryRole === 'baseAnchor' || item.geometryRole === 'baseHit');
         });
-        var surfaceRects = surfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });
-        var baseSurfaceRects = baseSurfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });
+        var surfaceRects = surfaceItems.reduce(function (rects, item) {
+            return rects.concat(getCompactGeometryItemBoundsRects(item));
+        }, []);
+        var baseSurfaceRects = baseSurfaceItems.reduce(function (rects, item) {
+            return rects.concat(getCompactGeometryItemBoundsRects(item));
+        }, []);
         // compact 态不再渲染模型旁的悬浮最小化球，故不再上报其 hit/native 区域，
         // 避免 Electron 桌面壳为一个不可见的球保留点击区域（externalBall 仍走桌面外部球）。
         var ballRect = null;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1632,6 +1632,7 @@
 
     function collectCompactInputSurfaceGeometryItems(element) {
         var parentRect = getCompactGeometryElementRect(element);
+        var inputSurfaceIsDragSurface = element.getAttribute('data-compact-drag-surface') === 'true';
         var items = [];
         if (parentRect) {
             items.push({
@@ -1639,9 +1640,9 @@
                 owner: 'surface',
                 kind: 'input',
                 visualRect: parentRect,
-                hitRect: null,
-                nativeRect: null,
-                interactive: false
+                hitRect: inputSurfaceIsDragSurface ? parentRect : null,
+                nativeRect: inputSurfaceIsDragSurface ? parentRect : null,
+                interactive: inputSurfaceIsDragSurface
             });
         }
         var hitRegionElements = [];

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1561,8 +1561,13 @@
         return kind === 'surfaceShell' || kind === 'capsule' || kind === 'input';
     }
 
+    function isCompactSurfaceBaseHitKind(kind) {
+        return kind === 'inputControl';
+    }
+
     function getCompactSurfaceGeometryRole(kind) {
         if (isCompactSurfaceBaseAnchorKind(kind)) return 'baseAnchor';
+        if (isCompactSurfaceBaseHitKind(kind)) return 'baseHit';
         return 'extraIsland';
     }
 
@@ -1617,6 +1622,44 @@
             .filter(Boolean));
     }
 
+    function collectCompactInputSurfaceGeometryItems(element) {
+        var parentRect = getCompactGeometryElementRect(element);
+        var items = [];
+        if (parentRect) {
+            items.push({
+                id: element.id || 'input:surface',
+                owner: 'surface',
+                kind: 'input',
+                visualRect: parentRect,
+                hitRect: null,
+                nativeRect: null,
+                interactive: false
+            });
+        }
+        return items.concat(Array.prototype.slice.call(element.querySelectorAll('[data-compact-hit-region="true"]'))
+            .map(function (child, index) {
+                var style = window.getComputedStyle ? window.getComputedStyle(child) : null;
+                if (style && (style.display === 'none' || style.visibility === 'hidden')) return null;
+                if (style && Number(style.opacity) <= 0.01) return null;
+                if (style && style.pointerEvents === 'none') return null;
+                var rect = normalizeCompactDomRect(child.getBoundingClientRect());
+                if (!rect) return null;
+                var clippedRect = parentRect ? intersectCompactRects(rect, parentRect) : rect;
+                if (!clippedRect) return null;
+                return {
+                    id: child.getAttribute('data-compact-hit-region-id') || ('input:hit:' + index),
+                    owner: 'surface',
+                    kind: 'inputControl',
+                    visualRect: clippedRect,
+                    hitRect: clippedRect,
+                    nativeRect: clippedRect,
+                    interactive: true,
+                    hitRegionKind: child.getAttribute('data-compact-hit-region-kind') || null
+                };
+            })
+            .filter(Boolean));
+    }
+
     function collectCompactCompositeGeometryItems(element, kind) {
         var parentRect = getCompactGeometryElementRect(element);
         var items = [];
@@ -1627,7 +1670,7 @@
                 kind: kind || 'unknown',
                 visualRect: parentRect,
                 hitRect: null,
-                nativeRect: parentRect,
+                nativeRect: null,
                 interactive: false
             });
             if (kind === 'history') {
@@ -1639,7 +1682,7 @@
                         kind: kind || 'unknown',
                         visualRect: scrollbarRect,
                         hitRect: scrollbarRect,
-                        nativeRect: null,
+                        nativeRect: scrollbarRect,
                         interactive: true,
                         hitRegionKind: 'scrollbar'
                     });
@@ -1666,7 +1709,7 @@
                     kind: kind || 'unknown',
                     visualRect: clippedRect,
                     hitRect: clippedRect,
-                    nativeRect: kind === 'history' ? null : clippedRect,
+                    nativeRect: clippedRect,
                     interactive: true,
                     hitRegionKind: hitRegionKind
                 };
@@ -1690,7 +1733,7 @@
                 kind: 'surfaceShell',
                 visualRect: shellRect,
                 hitRect: null,
-                nativeRect: shellRect,
+                nativeRect: null,
                 interactive: false
             });
         }
@@ -1705,6 +1748,9 @@
             var compactGeometryItem = element.getAttribute('data-compact-geometry-item');
             if (compactGeometryItem === 'toolFan') {
                 return items.concat(collectCompactToolFanGeometryItems(element));
+            }
+            if (compactGeometryItem === 'input') {
+                return items.concat(collectCompactInputSurfaceGeometryItems(element));
             }
             if (compactGeometryItem === 'cat1Mirror') {
                 var mirrorRect = getCompactGeometryElementRect(element);
@@ -1750,8 +1796,11 @@
         var extraIslandItems = surfaceItems.filter(function (item) {
             return item && item.geometryRole === 'extraIsland';
         });
-        var surfaceRects = surfaceItems.map(function (item) { return item.nativeRect; });
-        var baseSurfaceRects = baseSurfaceItems.map(function (item) { return item.nativeRect; });
+        var baseSurfaceNativeItems = surfaceItems.filter(function (item) {
+            return item && (item.geometryRole === 'baseAnchor' || item.geometryRole === 'baseHit');
+        });
+        var surfaceRects = surfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });
+        var baseSurfaceRects = baseSurfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });
         // compact 态不再渲染模型旁的悬浮最小化球，故不再上报其 hit/native 区域，
         // 避免 Electron 桌面壳为一个不可见的球保留点击区域（externalBall 仍走桌面外部球）。
         var ballRect = null;
@@ -1766,9 +1815,8 @@
             surfaceUnion: unionCompactRects(surfaceRects),
             baseSurfaceItems: baseSurfaceItems,
             baseSurfaceRect: unionCompactRects(baseSurfaceRects),
-            baseSurfaceNativeRects: baseSurfaceItems.map(function (item) { return item.nativeRect; }).filter(Boolean),
-            baseSurfaceHitRects: surfaceItems
-                .filter(function (item) { return item && (item.geometryRole === 'baseAnchor' || item.geometryRole === 'baseHit'); })
+            baseSurfaceNativeRects: baseSurfaceNativeItems.map(function (item) { return item.nativeRect; }).filter(Boolean),
+            baseSurfaceHitRects: baseSurfaceNativeItems
                 .map(function (item) { return item.hitRect; })
                 .filter(Boolean),
             extraIslandItems: extraIslandItems,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -765,9 +765,14 @@ def test_desktop_compact_history_hit_regions_are_clipped_to_visible_parent():
     assert "if (!clippedRect) return null;" in composite_block
     assert "visualRect: clippedRect" in composite_block
     assert "hitRect: clippedRect" in composite_block
-    assert "nativeRect: kind === 'history' ? null : clippedRect" in composite_block
+    assert "nativeRect: clippedRect" in composite_block
     assert "id: 'history:scrollbar'" in composite_block
     assert "nativeRect: null" in composite_block
+    parent_native_block = composite_block.split("id: kind + ':native'", 1)[1].split("interactive: false", 1)[0]
+    assert "hitRect: null" in parent_native_block
+    assert "nativeRect: null" in parent_native_block
+    scrollbar_block = composite_block.split("id: 'history:scrollbar'", 1)[1].split("hitRegionKind: 'scrollbar'", 1)[0]
+    assert "nativeRect: scrollbarRect" in scrollbar_block
 
 
 def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
@@ -775,8 +780,11 @@ def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
 
     assert "function isCompactSurfaceBaseAnchorKind(kind)" in script
     assert "return kind === 'surfaceShell' || kind === 'capsule' || kind === 'input';" in script
+    assert "function isCompactSurfaceBaseHitKind(kind)" in script
+    assert "return kind === 'inputControl';" in script
     assert "function getCompactSurfaceGeometryRole(kind)" in script
     assert "if (kind === 'dragHandle') return 'baseHit';" not in script
+    assert "if (isCompactSurfaceBaseHitKind(kind)) return 'baseHit';" in script
     assert "return 'extraIsland';" in script
     assert "item.geometryRole = getCompactSurfaceGeometryRole(item.kind);" in script
 
@@ -789,13 +797,55 @@ def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
     assert "return item && item.geometryRole === 'baseAnchor';" in snapshot_block
     assert "var extraIslandItems = surfaceItems.filter(function (item) {" in snapshot_block
     assert "return item && item.geometryRole === 'extraIsland';" in snapshot_block
+    assert "var baseSurfaceNativeItems = surfaceItems.filter(function (item) {" in snapshot_block
+    assert "item.geometryRole === 'baseAnchor' || item.geometryRole === 'baseHit'" in snapshot_block
+    assert "var surfaceRects = surfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });" in snapshot_block
+    assert "var baseSurfaceRects = baseSurfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });" in snapshot_block
     assert "baseSurfaceItems: baseSurfaceItems" in snapshot_block
     assert "baseSurfaceRect: unionCompactRects(baseSurfaceRects)" in snapshot_block
-    assert "baseSurfaceNativeRects:" in snapshot_block
+    assert "baseSurfaceNativeRects: baseSurfaceNativeItems.map(function (item) { return item.nativeRect; }).filter(Boolean)" in snapshot_block
     assert "baseSurfaceHitRects:" in snapshot_block
     assert "extraIslandItems: extraIslandItems" in snapshot_block
     assert "extraIslandNativeRects:" in snapshot_block
     assert "extraIslandHitRects:" in snapshot_block
+
+
+def test_compact_input_geometry_keeps_transparent_surface_out_of_native_regions():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+    app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
+
+    input_collector = script.split("function collectCompactInputSurfaceGeometryItems(element)", 1)[1].split(
+        "function collectCompactCompositeGeometryItems(element, kind)",
+        1,
+    )[0]
+    surface_collector = script.split("function collectCompactSurfaceGeometryItems()", 1)[1].split(
+        "function getCompactInteractionGeometrySnapshot()",
+        1,
+    )[0]
+
+    assert "id: element.id || 'input:surface'" in input_collector
+    assert "kind: 'input'" in input_collector
+    assert "hitRect: null" in input_collector
+    assert "nativeRect: null" in input_collector
+    assert 'element.querySelectorAll(\'[data-compact-hit-region="true"]\')' in input_collector
+    assert "kind: 'inputControl'" in input_collector
+    assert "hitRect: clippedRect" in input_collector
+    assert "nativeRect: clippedRect" in input_collector
+    assert "hitRegionKind: child.getAttribute('data-compact-hit-region-kind') || null" in input_collector
+    assert "if (compactGeometryItem === 'input')" in surface_collector
+    assert "return items.concat(collectCompactInputSurfaceGeometryItems(element));" in surface_collector
+    assert "id: 'surface:shell'" in surface_collector
+    shell_block = surface_collector.split("id: 'surface:shell'", 1)[1].split("interactive: false", 1)[0]
+    assert "hitRect: null" in shell_block
+    assert "nativeRect: null" in shell_block
+
+    assert "data-compact-geometry-hit-scope={effectiveCompactChatState === 'input' ? 'children' : undefined}" in app_source
+    assert 'data-compact-hit-region-id="input:text"' in app_source
+    assert 'data-compact-hit-region-kind="input-text"' in app_source
+    assert 'data-compact-hit-region-id="input:minimize"' in app_source
+    assert 'data-compact-hit-region-kind="input-minimize"' in app_source
+    assert 'data-compact-hit-region-id="input:tool-toggle"' in app_source
+    assert 'data-compact-hit-region-kind="input-tool-toggle"' in app_source
 
 
 def test_compact_surface_drag_uses_declared_surface_and_no_drag_exclusions():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -814,7 +814,7 @@ def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
     assert "extraIslandHitRects:" in snapshot_block
 
 
-def test_compact_input_geometry_keeps_transparent_surface_out_of_native_regions():
+def test_compact_input_geometry_preserves_drag_surface_native_region():
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
     app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
 
@@ -829,8 +829,10 @@ def test_compact_input_geometry_keeps_transparent_surface_out_of_native_regions(
 
     assert "id: element.id || 'input:surface'" in input_collector
     assert "kind: 'input'" in input_collector
-    assert "hitRect: null" in input_collector
-    assert "nativeRect: null" in input_collector
+    assert "var inputSurfaceIsDragSurface = element.getAttribute('data-compact-drag-surface') === 'true';" in input_collector
+    assert "hitRect: inputSurfaceIsDragSurface ? parentRect : null" in input_collector
+    assert "nativeRect: inputSurfaceIsDragSurface ? parentRect : null" in input_collector
+    assert "interactive: inputSurfaceIsDragSurface" in input_collector
     assert "var hitRegionElements = [];" in input_collector
     assert 'element.getAttribute(\'data-compact-hit-region\') === \'true\'' in input_collector
     assert "hitRegionElements.push(element);" in input_collector

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -827,6 +827,9 @@ def test_compact_input_geometry_keeps_transparent_surface_out_of_native_regions(
     assert "kind: 'input'" in input_collector
     assert "hitRect: null" in input_collector
     assert "nativeRect: null" in input_collector
+    assert "var hitRegionElements = [];" in input_collector
+    assert 'element.getAttribute(\'data-compact-hit-region\') === \'true\'' in input_collector
+    assert "hitRegionElements.push(element);" in input_collector
     assert 'element.querySelectorAll(\'[data-compact-hit-region="true"]\')' in input_collector
     assert "kind: 'inputControl'" in input_collector
     assert "hitRect: clippedRect" in input_collector

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -799,8 +799,12 @@ def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
     assert "return item && item.geometryRole === 'extraIsland';" in snapshot_block
     assert "var baseSurfaceNativeItems = surfaceItems.filter(function (item) {" in snapshot_block
     assert "item.geometryRole === 'baseAnchor' || item.geometryRole === 'baseHit'" in snapshot_block
-    assert "var surfaceRects = surfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });" in snapshot_block
-    assert "var baseSurfaceRects = baseSurfaceItems.map(function (item) { return item.visualRect || item.nativeRect; });" in snapshot_block
+    assert "function getCompactGeometryItemBoundsRects(item)" in script
+    assert "if (item.visualRect) rects.push(item.visualRect);" in script
+    assert "if (item.nativeRect) rects.push(item.nativeRect);" in script
+    assert "var surfaceRects = surfaceItems.reduce(function (rects, item) {" in snapshot_block
+    assert "var baseSurfaceRects = baseSurfaceItems.reduce(function (rects, item) {" in snapshot_block
+    assert "return rects.concat(getCompactGeometryItemBoundsRects(item));" in snapshot_block
     assert "baseSurfaceItems: baseSurfaceItems" in snapshot_block
     assert "baseSurfaceRect: unionCompactRects(baseSurfaceRects)" in snapshot_block
     assert "baseSurfaceNativeRects: baseSurfaceNativeItems.map(function (item) { return item.nativeRect; }).filter(Boolean)" in snapshot_block
@@ -1417,7 +1421,9 @@ def test_compact_history_hit_contract_keeps_transparent_wrappers_out_of_hit_regi
     )[0]
     assert "if (hitStyle && hitStyle.pointerEvents === 'none') return null;" in scrollbar_block
     assert "style.pointerEvents === 'none'" not in scrollbar_block
-    assert "data-compact-hit-region" not in scroll_jsx_block
+    assert "data-compact-hit-region={historyInteractive && !choiceLayerAbove ? 'true' : undefined}" in scroll_jsx_block
+    assert "data-compact-hit-region-id={historyInteractive && !choiceLayerAbove ? 'history:scroll' : undefined}" in scroll_jsx_block
+    assert "data-compact-hit-region-kind={historyInteractive && !choiceLayerAbove ? 'scroll' : undefined}" in scroll_jsx_block
     assert 'className="compact-export-history-scrollbar-hit"' in panel_source
     assert 'data-compact-scrollbar-hit="true"' in panel_source
     assert "hasPointerCapture?.(event.pointerId)" in panel_source


### PR DESCRIPTION
## Summary\n- keep avatar tool cursor overlays anchored with scaled hotspots and stable cursor assets\n- close the compact tool fan after selecting cursor tools\n- mark compact input controls as native hit regions so transparent shell areas stay passthrough\n\n## Tests\n- cd frontend/react-neko-chat && npm test -- src/App.test.tsx\n- cd frontend/react-neko-chat && npm run typecheck\n- uv run pytest tests/unit/test_react_chat_window_static.py\n- cd frontend/react-neko-chat && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 桌面光标叠层尺寸信息增强，改进光标定位精度与缩放显示。
  * 紧凑模式输入区交互标注补齐，优化工具轮盘和输入控制的命中区域识别。

* **问题修复**
  * 调整桌面光标叠层定位逻辑，确保光标热点坐标准确计算。
  * 优化指针移动处理顺序，提升光标响应性能。
  * 改进紧凑模式下工具轮盘关闭与焦点管理流程。

* **测试**
  * 补充光标覆盖层缩放、热点坐标及几何命中区域的验证用例。
  * 强化紧凑输入几何契约和导出历史滚动区域的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->