### PR TITLE
fix(ui): trigger avatar drag hint on switch miss

### DIFF
--- a/static/avatar-multiscreen-drag-hint.js
+++ b/static/avatar-multiscreen-drag-hint.js
@@ -54,6 +54,18 @@
         return Number(state.snoozeUntil) > now();
     }
 
+    async function hasMultipleDisplays() {
+        try {
+            if (!window.electronScreen || typeof window.electronScreen.getAllDisplays !== 'function') {
+                return false;
+            }
+            const displays = await window.electronScreen.getAllDisplays();
+            return Array.isArray(displays) && displays.length > 1;
+        } catch (_) {
+            return false;
+        }
+    }
+
     function ensureStyles() {
         if (document.getElementById('avatar-multiscreen-drag-hint-style')) return;
 
@@ -264,9 +276,10 @@
         return nextRecord;
     }
 
-    function recordDisplaySwitchMissNow(source) {
+    async function recordDisplaySwitchMissNow(source) {
         const state = readState();
         if (isSuppressed(state) || isPromptVisible) return false;
+        if (!(await hasMultipleDisplays())) return false;
 
         const currentTime = now();
         const lastMissAt = Number(state.lastMissAt) || 0;

--- a/static/avatar-multiscreen-drag-hint.js
+++ b/static/avatar-multiscreen-drag-hint.js
@@ -54,11 +54,17 @@
         return Number(state.snoozeUntil) > now();
     }
 
+    function hasDisplaySwitchBridge() {
+        return Boolean(
+            window.electronScreen &&
+            typeof window.electronScreen.getAllDisplays === 'function' &&
+            typeof window.electronScreen.moveWindowToDisplay === 'function'
+        );
+    }
+
     async function hasMultipleDisplays() {
         try {
-            if (!window.electronScreen || typeof window.electronScreen.getAllDisplays !== 'function') {
-                return false;
-            }
+            if (!hasDisplaySwitchBridge()) return false;
             const displays = await window.electronScreen.getAllDisplays();
             return Array.isArray(displays) && displays.length > 1;
         } catch (_) {
@@ -322,7 +328,7 @@
         const originalCheckAndSwitchDisplay = proto._checkAndSwitchDisplay;
         const wrappedCheckAndSwitchDisplay = async function (model) {
             const displaySwitched = await originalCheckAndSwitchDisplay.apply(this, arguments);
-            if (!displaySwitched && isModelCenterOutsideCurrentWindow(model)) {
+            if (hasDisplaySwitchBridge() && !displaySwitched && isModelCenterOutsideCurrentWindow(model)) {
                 recordDisplaySwitchMiss('live2d');
             }
             return displaySwitched;

--- a/static/avatar-multiscreen-drag-hint.js
+++ b/static/avatar-multiscreen-drag-hint.js
@@ -3,8 +3,8 @@
 
     const STORAGE_KEY = 'neko:avatar-multiscreen-drag-hint:v1';
     const SNOOZE_MS = 3 * 24 * 60 * 60 * 1000;
-    const BOUNCE_WINDOW_MS = 30 * 1000;
-    const REQUIRED_BOUNCES = 2;
+    const MISS_WINDOW_MS = 30 * 1000;
+    const REQUIRED_MISSES = 2;
 
     const FALLBACK_TEXT = {
         title: 'Move YUI to another screen',
@@ -14,7 +14,7 @@
     };
 
     let isPromptVisible = false;
-    let bounceRecordQueue = Promise.resolve();
+    let missRecordQueue = Promise.resolve();
 
     function now() {
         return Date.now();
@@ -52,21 +52,6 @@
         if (!state || typeof state !== 'object') return false;
         if (state.never === true) return true;
         return Number(state.snoozeUntil) > now();
-    }
-
-    async function hasMultipleDisplays() {
-        try {
-            if (!window.electronScreen || typeof window.electronScreen.getAllDisplays !== 'function') {
-                return false;
-            }
-            const displays = await window.electronScreen.getAllDisplays();
-            if (!Array.isArray(displays) || displays.length <= 1) {
-                return false;
-            }
-            return true;
-        } catch (_) {
-            return false;
-        }
     }
 
     function ensureStyles() {
@@ -207,8 +192,8 @@
     function ackPrompt() {
         const state = readState();
         state.snoozeUntil = now() + SNOOZE_MS;
-        state.recentBounceCount = 0;
-        state.lastBounceAt = 0;
+        state.recentMissCount = 0;
+        state.lastMissAt = 0;
         writeState(state);
         removePrompt();
     }
@@ -216,8 +201,8 @@
     function dismissForever() {
         const state = readState();
         state.never = true;
-        state.recentBounceCount = 0;
-        state.lastBounceAt = 0;
+        state.recentMissCount = 0;
+        state.lastMissAt = 0;
         writeState(state);
         removePrompt();
     }
@@ -271,55 +256,94 @@
         isPromptVisible = true;
     }
 
-    function recordEdgeBounce(source) {
-        const nextRecord = bounceRecordQueue.then(function () {
-            return recordEdgeBounceNow(source);
+    function recordDisplaySwitchMiss(source) {
+        const nextRecord = missRecordQueue.then(function () {
+            return recordDisplaySwitchMissNow(source);
         });
-        bounceRecordQueue = nextRecord.catch(function () {});
+        missRecordQueue = nextRecord.catch(function () {});
         return nextRecord;
     }
 
-    async function recordEdgeBounceNow(source) {
+    function recordDisplaySwitchMissNow(source) {
         const state = readState();
         if (isSuppressed(state) || isPromptVisible) return false;
 
-        const multiDisplay = await hasMultipleDisplays();
-        if (!multiDisplay) return false;
-
         const currentTime = now();
-        const lastBounceAt = Number(state.lastBounceAt) || 0;
-        const recentCount = currentTime - lastBounceAt <= BOUNCE_WINDOW_MS
-            ? (Number(state.recentBounceCount) || 0) + 1
+        const lastMissAt = Number(state.lastMissAt) || 0;
+        const recentCount = currentTime - lastMissAt <= MISS_WINDOW_MS
+            ? (Number(state.recentMissCount) || 0) + 1
             : 1;
 
-        state.lastBounceAt = currentTime;
-        state.recentBounceCount = recentCount;
+        state.lastMissAt = currentTime;
+        state.recentMissCount = recentCount;
         state.lastSource = source || 'avatar';
         writeState(state);
 
-        if (state.recentBounceCount >= REQUIRED_BOUNCES) {
+        if (state.recentMissCount >= REQUIRED_MISSES) {
             showPrompt();
             return true;
         }
         return false;
     }
 
+    function isModelCenterOutsideCurrentWindow(model) {
+        try {
+            if (!model || typeof model.getBounds !== 'function') return false;
+            const bounds = model.getBounds();
+            if (!bounds) return false;
+            const centerX = (Number(bounds.left) + Number(bounds.right)) / 2;
+            const centerY = (Number(bounds.top) + Number(bounds.bottom)) / 2;
+            if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) return false;
+            return centerX < 0 || centerX >= window.innerWidth || centerY < 0 || centerY >= window.innerHeight;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function installLive2DDisplaySwitchMissHook() {
+        const Manager = window.Live2DManager;
+        const proto = Manager && Manager.prototype;
+        if (!proto || typeof proto._checkAndSwitchDisplay !== 'function') return false;
+        if (proto._checkAndSwitchDisplay.__nekoDisplaySwitchMissHooked) return true;
+
+        const originalCheckAndSwitchDisplay = proto._checkAndSwitchDisplay;
+        const wrappedCheckAndSwitchDisplay = async function (model) {
+            const displaySwitched = await originalCheckAndSwitchDisplay.apply(this, arguments);
+            if (!displaySwitched && isModelCenterOutsideCurrentWindow(model)) {
+                recordDisplaySwitchMiss('live2d');
+            }
+            return displaySwitched;
+        };
+        wrappedCheckAndSwitchDisplay.__nekoDisplaySwitchMissHooked = true;
+        wrappedCheckAndSwitchDisplay.__nekoOriginalCheckAndSwitchDisplay = originalCheckAndSwitchDisplay;
+        proto._checkAndSwitchDisplay = wrappedCheckAndSwitchDisplay;
+        return true;
+    }
+
+    function scheduleLive2DDisplaySwitchMissHook() {
+        [0, 50, 250, 1000, 3000, 6000].forEach(function (delay) {
+            setTimeout(installLive2DDisplaySwitchMissHook, delay);
+        });
+    }
+
     function markDisplaySwitchSuccess(source) {
         const state = readState();
         state.successAt = now();
         state.successSource = source || 'avatar';
-        state.recentBounceCount = 0;
-        state.lastBounceAt = 0;
+        state.recentMissCount = 0;
+        state.lastMissAt = 0;
         writeState(state);
         removePrompt();
         return true;
     }
 
     window.NekoAvatarMultiScreenDragHint = {
-        recordEdgeBounce,
+        recordDisplaySwitchMiss,
         markDisplaySwitchSuccess,
         ackPrompt,
         dismissForever,
         _readState: readState
     };
+
+    scheduleLive2DDisplaySwitchMissHook();
 })();

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -454,14 +454,15 @@ class MMDInteraction {
         const renderer = this.manager.renderer;
         if (!mesh || !camera || !renderer) return false;
 
-        try {
-            const recordDisplaySwitchMiss = () => {
-                if (window.NekoAvatarMultiScreenDragHint &&
-                    typeof window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss === 'function') {
-                    window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss('mmd');
-                }
-            };
+        const recordDisplaySwitchMiss = () => {
+            if (window.NekoAvatarMultiScreenDragHint &&
+                typeof window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss === 'function') {
+                window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss('mmd');
+            }
+        };
+        let displaySwitchAttempted = false;
 
+        try {
             // 1. 计算模型在当前窗口中的屏幕空间中心点（像素）
             mesh.updateMatrixWorld(true);
             const box = new THREE.Box3().setFromObject(mesh);
@@ -510,6 +511,7 @@ class MMDInteraction {
 
             // 2. 多屏幕检查。第一版提示机制不以多屏数量为前置条件：
             // 只要用户把模型中心拖出当前窗口但未完成切屏，就记一次 miss。
+            displaySwitchAttempted = true;
             const displays = await window.electronScreen.getAllDisplays();
             if (!displays || displays.length <= 1) {
                 recordDisplaySwitchMiss();
@@ -609,6 +611,7 @@ class MMDInteraction {
             return true;
         } catch (error) {
             console.error('[MMD] 检测/切换屏幕时出错:', error);
+            if (displaySwitchAttempted) recordDisplaySwitchMiss();
             return false;
         }
     }

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -335,9 +335,6 @@ class MMDInteraction {
                     const snapped = await this._snapModelIntoScreen({ animate: true });
                     if (!snapped) {
                         this._savePositionAfterInteraction();
-                    } else if (window.NekoAvatarMultiScreenDragHint &&
-                        typeof window.NekoAvatarMultiScreenDragHint.recordEdgeBounce === 'function') {
-                        window.NekoAvatarMultiScreenDragHint.recordEdgeBounce('mmd');
                     }
                 }
             }
@@ -458,6 +455,13 @@ class MMDInteraction {
         if (!mesh || !camera || !renderer) return false;
 
         try {
+            const recordDisplaySwitchMiss = () => {
+                if (window.NekoAvatarMultiScreenDragHint &&
+                    typeof window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss === 'function') {
+                    window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss('mmd');
+                }
+            };
+
             // 1. 计算模型在当前窗口中的屏幕空间中心点（像素）
             mesh.updateMatrixWorld(true);
             const box = new THREE.Box3().setFromObject(mesh);
@@ -497,10 +501,6 @@ class MMDInteraction {
             const modelCenterX = (modelMinX + modelMaxX) / 2 + canvasRect.left;
             const modelCenterY = (modelMinY + modelMaxY) / 2 + canvasRect.top;
 
-            // 2. 多屏幕检查
-            const displays = await window.electronScreen.getAllDisplays();
-            if (!displays || displays.length <= 1) return false;
-
             const windowWidth = window.innerWidth;
             const windowHeight = window.innerHeight;
             if (modelCenterX >= 0 && modelCenterX < windowWidth &&
@@ -508,10 +508,19 @@ class MMDInteraction {
                 return false;
             }
 
+            // 2. 多屏幕检查。第一版提示机制不以多屏数量为前置条件：
+            // 只要用户把模型中心拖出当前窗口但未完成切屏，就记一次 miss。
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!displays || displays.length <= 1) {
+                recordDisplaySwitchMiss();
+                return false;
+            }
+
             // 3. 计算模型中心在整个桌面上的绝对坐标
             const currentDisplay = await window.electronScreen.getCurrentDisplay();
             if (!currentDisplay) {
                 console.warn('[MMD] 无法获取当前显示器信息');
+                recordDisplaySwitchMiss();
                 return false;
             }
             let currentScreenX = currentDisplay.screenX;
@@ -523,6 +532,7 @@ class MMDInteraction {
                     currentScreenX = currentDisplay.bounds.x;
                     currentScreenY = currentDisplay.bounds.y;
                 } else {
+                    recordDisplaySwitchMiss();
                     return false;
                 }
             }
@@ -549,13 +559,17 @@ class MMDInteraction {
                     break;
                 }
             }
-            if (!targetDisplay) return false;
+            if (!targetDisplay) {
+                recordDisplaySwitchMiss();
+                return false;
+            }
 
             console.log('[MMD] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
 
             const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
 
             if (!(result && result.success && !result.sameDisplay)) {
+                recordDisplaySwitchMiss();
                 return false;
             }
             console.log('[MMD] 屏幕切换成功:', result);

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -340,11 +340,7 @@ class VRMInteraction {
 
                 if (!displaySwitched) {
                     // 拖拽结束后：若超出屏幕范围，执行回弹
-                    const snapped = await this._snapModelIntoScreen({ animate: true });
-                    if (snapped && window.NekoAvatarMultiScreenDragHint &&
-                        typeof window.NekoAvatarMultiScreenDragHint.recordEdgeBounce === 'function') {
-                        window.NekoAvatarMultiScreenDragHint.recordEdgeBounce('vrm');
-                    }
+                    await this._snapModelIntoScreen({ animate: true });
 
                     // 拖动结束后保存位置（包含回弹后的位置）
                     await this._savePositionAfterInteraction();
@@ -883,6 +879,13 @@ class VRMInteraction {
         if (!scene || !vrm || !camera || !renderer) return false;
 
         try {
+            const recordDisplaySwitchMiss = () => {
+                if (window.NekoAvatarMultiScreenDragHint &&
+                    typeof window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss === 'function') {
+                    window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss('vrm');
+                }
+            };
+
             // 1. 计算模型在当前窗口中的屏幕空间中心点（像素）
             vrm.scene.updateMatrixWorld(true);
             const box = new THREE.Box3().setFromObject(vrm.scene);
@@ -922,10 +925,6 @@ class VRMInteraction {
             const modelCenterX = (modelMinX + modelMaxX) / 2 + canvasRect.left;
             const modelCenterY = (modelMinY + modelMaxY) / 2 + canvasRect.top;
 
-            // 2. 多屏幕检查
-            const displays = await window.electronScreen.getAllDisplays();
-            if (!displays || displays.length <= 1) return false;
-
             const windowWidth = window.innerWidth;
             const windowHeight = window.innerHeight;
             // 如果模型中心仍在当前窗口内，不切屏
@@ -934,10 +933,19 @@ class VRMInteraction {
                 return false;
             }
 
+            // 2. 多屏幕检查。第一版提示机制不以多屏数量为前置条件：
+            // 只要用户把模型中心拖出当前窗口但未完成切屏，就记一次 miss。
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!displays || displays.length <= 1) {
+                recordDisplaySwitchMiss();
+                return false;
+            }
+
             // 3. 计算模型中心在整个桌面（screen）上的绝对坐标
             const currentDisplay = await window.electronScreen.getCurrentDisplay();
             if (!currentDisplay) {
                 console.warn('[VRM] 无法获取当前显示器信息');
+                recordDisplaySwitchMiss();
                 return false;
             }
             let currentScreenX = currentDisplay.screenX;
@@ -949,6 +957,7 @@ class VRMInteraction {
                     currentScreenX = currentDisplay.bounds.x;
                     currentScreenY = currentDisplay.bounds.y;
                 } else {
+                    recordDisplaySwitchMiss();
                     return false;
                 }
             }
@@ -975,13 +984,17 @@ class VRMInteraction {
                     break;
                 }
             }
-            if (!targetDisplay) return false;
+            if (!targetDisplay) {
+                recordDisplaySwitchMiss();
+                return false;
+            }
 
             console.log('[VRM] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
 
             const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
 
             if (!(result && result.success && !result.sameDisplay)) {
+                recordDisplaySwitchMiss();
                 return false;
             }
             console.log('[VRM] 屏幕切换成功:', result);

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -878,14 +878,15 @@ class VRMInteraction {
         const renderer = this.manager.renderer;
         if (!scene || !vrm || !camera || !renderer) return false;
 
-        try {
-            const recordDisplaySwitchMiss = () => {
-                if (window.NekoAvatarMultiScreenDragHint &&
-                    typeof window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss === 'function') {
-                    window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss('vrm');
-                }
-            };
+        const recordDisplaySwitchMiss = () => {
+            if (window.NekoAvatarMultiScreenDragHint &&
+                typeof window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss === 'function') {
+                window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss('vrm');
+            }
+        };
+        let displaySwitchAttempted = false;
 
+        try {
             // 1. 计算模型在当前窗口中的屏幕空间中心点（像素）
             vrm.scene.updateMatrixWorld(true);
             const box = new THREE.Box3().setFromObject(vrm.scene);
@@ -935,6 +936,7 @@ class VRMInteraction {
 
             // 2. 多屏幕检查。第一版提示机制不以多屏数量为前置条件：
             // 只要用户把模型中心拖出当前窗口但未完成切屏，就记一次 miss。
+            displaySwitchAttempted = true;
             const displays = await window.electronScreen.getAllDisplays();
             if (!displays || displays.length <= 1) {
                 recordDisplaySwitchMiss();
@@ -1037,6 +1039,7 @@ class VRMInteraction {
             return true;
         } catch (error) {
             console.error('[VRM] 检测/切换屏幕时出错:', error);
+            if (displaySwitchAttempted) recordDisplaySwitchMiss();
             return false;
         }
     }

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -16,15 +16,17 @@ def test_multiscreen_drag_hint_ack_snoozes_for_three_days():
     assert "neko:avatar-multiscreen-drag-hint:v1" in source
 
 
-def test_multiscreen_drag_hint_counts_display_switch_misses_without_multi_display_gate():
+def test_multiscreen_drag_hint_counts_display_switch_misses_only_on_multiple_displays():
     source = _source("static/avatar-multiscreen-drag-hint.js")
 
     assert "const REQUIRED_MISSES = 2;" in source
     assert "const MISS_WINDOW_MS = 30 * 1000;" in source
+    assert "async function hasMultipleDisplays()" in source
+    assert "window.electronScreen.getAllDisplays" in source
+    assert "return Array.isArray(displays) && displays.length > 1;" in source
     assert "function recordDisplaySwitchMiss(source)" in source
+    assert "if (!(await hasMultipleDisplays())) return false;" in source
     assert "state.recentMissCount >= REQUIRED_MISSES" in source
-    assert "window.electronScreen.getAllDisplays" not in source
-    assert "displays.length <= 1" not in source
     assert "moveWindowToDisplay" not in source
 
 

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -21,13 +21,16 @@ def test_multiscreen_drag_hint_counts_display_switch_misses_only_on_multiple_dis
 
     assert "const REQUIRED_MISSES = 2;" in source
     assert "const MISS_WINDOW_MS = 30 * 1000;" in source
+    assert "function hasDisplaySwitchBridge()" in source
+    assert "typeof window.electronScreen.moveWindowToDisplay === 'function'" in source
     assert "async function hasMultipleDisplays()" in source
     assert "window.electronScreen.getAllDisplays" in source
+    assert "if (!hasDisplaySwitchBridge()) return false;" in source
     assert "return Array.isArray(displays) && displays.length > 1;" in source
     assert "function recordDisplaySwitchMiss(source)" in source
     assert "if (!(await hasMultipleDisplays())) return false;" in source
     assert "state.recentMissCount >= REQUIRED_MISSES" in source
-    assert "moveWindowToDisplay" not in source
+    assert "hasDisplaySwitchBridge() && !displaySwitched && isModelCenterOutsideCurrentWindow(model)" in source
 
 
 def test_multiscreen_drag_hint_serializes_display_switch_miss_updates():

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -16,26 +16,27 @@ def test_multiscreen_drag_hint_ack_snoozes_for_three_days():
     assert "neko:avatar-multiscreen-drag-hint:v1" in source
 
 
-def test_multiscreen_drag_hint_only_observes_multi_display_edge_bounces():
+def test_multiscreen_drag_hint_counts_display_switch_misses_without_multi_display_gate():
     source = _source("static/avatar-multiscreen-drag-hint.js")
 
-    assert "const REQUIRED_BOUNCES = 2;" in source
-    assert "const BOUNCE_WINDOW_MS = 30 * 1000;" in source
-    assert "window.electronScreen.getAllDisplays" in source
-    assert "displays.length <= 1" in source
-    assert "state.recentBounceCount >= REQUIRED_BOUNCES" in source
+    assert "const REQUIRED_MISSES = 2;" in source
+    assert "const MISS_WINDOW_MS = 30 * 1000;" in source
+    assert "function recordDisplaySwitchMiss(source)" in source
+    assert "state.recentMissCount >= REQUIRED_MISSES" in source
+    assert "window.electronScreen.getAllDisplays" not in source
+    assert "displays.length <= 1" not in source
     assert "moveWindowToDisplay" not in source
 
 
-def test_multiscreen_drag_hint_serializes_edge_bounce_counter_updates():
+def test_multiscreen_drag_hint_serializes_display_switch_miss_updates():
     source = _source("static/avatar-multiscreen-drag-hint.js")
 
-    assert "let bounceRecordQueue = Promise.resolve();" in source
-    assert "function recordEdgeBounce(source) {" in source
-    assert "const nextRecord = bounceRecordQueue.then(function () {" in source
-    assert "return recordEdgeBounceNow(source);" in source
-    assert "bounceRecordQueue = nextRecord.catch(function () {});" in source
-    assert "async function recordEdgeBounceNow(source)" in source
+    assert "let missRecordQueue = Promise.resolve();" in source
+    assert "function recordDisplaySwitchMiss(source) {" in source
+    assert "const nextRecord = missRecordQueue.then(function () {" in source
+    assert "return recordDisplaySwitchMissNow(source);" in source
+    assert "missRecordQueue = nextRecord.catch(function () {});" in source
+    assert "function recordDisplaySwitchMissNow(source)" in source
 
 
 def test_multiscreen_drag_hint_can_be_disabled_or_suppressed_after_success():
@@ -44,6 +45,8 @@ def test_multiscreen_drag_hint_can_be_disabled_or_suppressed_after_success():
     assert "state.never = true;" in source
     assert "state.successAt = now();" in source
     assert "window.NekoAvatarMultiScreenDragHint" in source
+    assert "state.recentMissCount = 0;" in source
+    assert "state.lastMissAt = 0;" in source
     assert "if (Number(state.successAt) > 0) return true;" not in source
 
 
@@ -65,16 +68,23 @@ def test_multiscreen_drag_hint_uses_top_center_project_popup_style():
     assert ".avatar-multiscreen-drag-hint-visible" in source
 
 
-def test_model_interactions_report_supported_bounces_and_display_switch_success():
+def test_model_interactions_report_display_switch_misses_and_success():
+    helper = _source("static/avatar-multiscreen-drag-hint.js")
     live2d = _source("static/live2d-interaction.js")
     mmd = _source("static/mmd-interaction.js")
     vrm = _source("static/vrm-interaction.js")
 
-    assert "recordEdgeBounce('live2d')" in live2d
+    assert "installLive2DDisplaySwitchMissHook" in helper
+    assert "window.Live2DManager" in helper
+    assert "_checkAndSwitchDisplay" in helper
+    assert "recordDisplaySwitchMiss('live2d')" in helper
+    assert "recordDisplaySwitchMiss('live2d')" not in live2d
     assert "markDisplaySwitchSuccess('live2d')" in live2d
-    assert "recordEdgeBounce('mmd')" in mmd
+    assert "recordDisplaySwitchMiss('mmd')" in mmd
+    assert "recordEdgeBounce('mmd')" not in mmd
     assert "markDisplaySwitchSuccess('mmd')" in mmd
-    assert "recordEdgeBounce('vrm')" in vrm
+    assert "recordDisplaySwitchMiss('vrm')" in vrm
+    assert "recordEdgeBounce('vrm')" not in vrm
     assert "markDisplaySwitchSuccess('vrm')" in vrm
 
 

--- a/tests/unit/test_mmd_interaction_static_contracts.py
+++ b/tests/unit/test_mmd_interaction_static_contracts.py
@@ -27,3 +27,13 @@ def test_mmd_display_switch_snaps_to_target_screen_before_saving_position():
     display_switch_section = source.split("console.log('[MMD] 屏幕切换成功:', result);", 1)[1]
     assert "const snapped = await this._snapModelIntoScreen({ animate: true });" in display_switch_section
     assert "if (!snapped) {\n                await this._savePositionAfterInteraction();" in display_switch_section
+
+
+def test_mmd_display_switch_miss_records_bridge_errors_after_model_leaves_window():
+    source = _mmd_source()
+    method_section = source.split("async _checkAndSwitchDisplay() {", 1)[1].split("\n    /**\n     * 基于可见像素限制", 1)[0]
+
+    assert method_section.index("const recordDisplaySwitchMiss = () => {") < method_section.index("try {")
+    assert "let displaySwitchAttempted = false;" in method_section
+    assert method_section.index("displaySwitchAttempted = true;") < method_section.index("window.electronScreen.getAllDisplays()")
+    assert "if (displaySwitchAttempted) recordDisplaySwitchMiss();" in method_section

--- a/tests/unit/test_mmd_interaction_static_contracts.py
+++ b/tests/unit/test_mmd_interaction_static_contracts.py
@@ -18,7 +18,6 @@ def test_mmd_pan_drag_snaps_on_all_platforms_before_saving_position():
     assert "if (!snapped) {" in pan_drag_section
     assert "this._savePositionAfterInteraction();" in pan_drag_section
     assert "recordEdgeBounce('mmd')" not in pan_drag_section
-    assert "recordDisplaySwitchMiss('mmd')" in source
 
 
 def test_mmd_display_switch_snaps_to_target_screen_before_saving_position():
@@ -34,6 +33,7 @@ def test_mmd_display_switch_miss_records_bridge_errors_after_model_leaves_window
     method_section = source.split("async _checkAndSwitchDisplay() {", 1)[1].split("\n    /**\n     * 基于可见像素限制", 1)[0]
 
     assert method_section.index("const recordDisplaySwitchMiss = () => {") < method_section.index("try {")
+    assert "recordDisplaySwitchMiss('mmd')" in method_section
     assert "let displaySwitchAttempted = false;" in method_section
     assert method_section.index("displaySwitchAttempted = true;") < method_section.index("window.electronScreen.getAllDisplays()")
     assert "if (displaySwitchAttempted) recordDisplaySwitchMiss();" in method_section

--- a/tests/unit/test_mmd_interaction_static_contracts.py
+++ b/tests/unit/test_mmd_interaction_static_contracts.py
@@ -17,7 +17,8 @@ def test_mmd_pan_drag_snaps_on_all_platforms_before_saving_position():
     assert "const snapped = await this._snapModelIntoScreen({ animate: true });" in pan_drag_section
     assert "if (!snapped) {" in pan_drag_section
     assert "this._savePositionAfterInteraction();" in pan_drag_section
-    assert "recordEdgeBounce('mmd')" in pan_drag_section
+    assert "recordEdgeBounce('mmd')" not in pan_drag_section
+    assert "recordDisplaySwitchMiss('mmd')" in source
 
 
 def test_mmd_display_switch_snaps_to_target_screen_before_saving_position():

--- a/tests/unit/test_vrm_interaction_static_contracts.py
+++ b/tests/unit/test_vrm_interaction_static_contracts.py
@@ -11,3 +11,13 @@ def test_vrm_initial_visibility_fence_uses_runtime_threshold():
     assert "clampModelPosition(position, { minVisiblePixels = 200 } = {})" in interaction_source
     assert "clampModelPosition(currentPos, { minVisiblePixels: 300 })" not in manager_source
     assert "const correctedPos = this.interaction.clampModelPosition(currentPos);" in manager_source
+
+
+def test_vrm_display_switch_miss_records_bridge_errors_after_model_leaves_window():
+    source = (PROJECT_ROOT / "static/vrm-interaction.js").read_text(encoding="utf-8")
+    method_section = source.split("async _checkAndSwitchDisplay() {", 1)[1].split("\n\n    /**\n     * 兼容旧接口", 1)[0]
+
+    assert method_section.index("const recordDisplaySwitchMiss = () => {") < method_section.index("try {")
+    assert "let displaySwitchAttempted = false;" in method_section
+    assert method_section.index("displaySwitchAttempted = true;") < method_section.index("window.electronScreen.getAllDisplays()")
+    assert "if (displaySwitchAttempted) recordDisplaySwitchMiss();" in method_section


### PR DESCRIPTION
## Summary
- 将副屏拖拽提示从“边缘回弹计数”改为“跨屏拖拽未完成计数”
- 暂不增加多屏数量前置判断，方便先验证触发机制
- Live2D 侧不改 `static/live2d-interaction.js`，由提示脚本轻量 hook 记录 miss；VRM/MMD 保持各自交互文件内记录
- 更新静态契约测试，覆盖新触发机制和不再依赖回弹判断

## Test Plan
- [x] uv run pytest tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
- [x] node --check static/avatar-multiscreen-drag-hint.js
- [x] node --check static/vrm-interaction.js
- [x] node --check static/mmd-interaction.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 多屏拖拽提示由“边缘回弹”改为基于“显示切换未命中（miss）”的检测，提示触发、抑制与重置更准确，确认或永久忽略后关闭并清空相关计数。
  * 模型集成（Live2D/MMD/VRM）上报增强，更可靠地记录显示切换未命中与成功，减少误报。

* **测试**
  * 单元测试已更新以覆盖未命中计数、串行化行为及模型交互的契约断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->