### PR TITLE
修复猫形态在互动动画、坐在紧凑聊天框上、或已贴近毛线球后，聊天框最小化/毛线球移动时只转向不追随的问题，确保状态切换后会重新触发追球同步

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -2210,6 +2210,14 @@ function _isNekoIdleCat1SettledOnCompactTopEdge(state, profile) {
         state.targetKind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE);
 }
 
+function _isNekoIdleCat1SettledOnMinimizedSide(state, profile) {
+    return !!(state &&
+        profile &&
+        state.substate === profile.idleSubstate &&
+        state.actionSettled &&
+        state.targetKind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE);
+}
+
 function _getNekoIdleCat1CompactFollowSpeed(state, surfaceRect, nowMs) {
     const previousRect = state && state.compactFollowLastSurfaceRect;
     const previousAt = state ? Number(state.compactFollowLastAt) || 0 : 0;
@@ -3227,6 +3235,9 @@ function _settleNekoIdleReturnSubactionToIdle(button) {
     const state = _getNekoIdleCat1Journey(button);
     if (!state || state.substate !== state.profile.finishingSubstate || state.paused) return;
     const profile = state.profile;
+    const shouldRecheckTargetAfterSettle = !!(state.target ||
+        state.targetKind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE ||
+        state.targetKind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE);
     _cancelNekoIdleReturnSubactionSettleTimer(state);
     state.substate = profile.idleSubstate;
     state.target = null;
@@ -3243,6 +3254,11 @@ function _settleNekoIdleReturnSubactionToIdle(button) {
             profile.tier,
             { animate: true }
         );
+    }
+
+    if (shouldRecheckTargetAfterSettle &&
+        (_getNekoIdleChatMinimizedRect() || _getNekoIdleChatCompactSurfaceRect())) {
+        _scheduleNekoIdleCat1JourneySync(button);
     }
 
     setTimeout(() => {
@@ -3469,6 +3485,8 @@ function _scheduleNekoIdleCat1WalkStart(button, target) {
     _setNekoIdleCat1Classes(button, state);
     const art = button.querySelector('.neko-idle-return-art');
     if (art && art.__nekoIdleHoverSrc) {
+        state.pendingWalkReady = true;
+        state.pendingWalkDelayMs = 0;
         if (!art.__nekoIdleHoverTimer) {
             _finishNekoIdleHoverArtAfterPlayback(art, profile.tier);
         }
@@ -3754,9 +3772,18 @@ function _syncNekoIdleCat1Journey(button, tier) {
         state.compactTopEdgeDropUntil = 0;
     }
 
+    const previousTargetKind = state.targetKind || '';
     state.target = target;
     state.targetKind = target.kind || '';
     const compactTopEdgeTarget = target.kind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE;
+    const switchingFromCompactTopEdgeToMinimizedSide =
+        previousTargetKind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE &&
+        target.kind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE;
+    const followingMovedMinimizedSideTarget =
+        previousTargetKind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE &&
+        target.kind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE &&
+        state.actionSettled &&
+        target.distance > profile.target.exitDistancePx;
     if (compactTopEdgeTarget) {
         _cancelNekoIdleCat1PairMove(state);
         if (target.distance <= profile.target.exitDistancePx) {
@@ -3774,9 +3801,15 @@ function _syncNekoIdleCat1Journey(button, tier) {
     }
 
     if (target.distance >= profile.target.enterDistancePx ||
-        (compactTopEdgeTarget && target.distance > profile.target.exitDistancePx)) {
+        (compactTopEdgeTarget && target.distance > profile.target.exitDistancePx) ||
+        (switchingFromCompactTopEdgeToMinimizedSide && target.distance > profile.target.exitDistancePx) ||
+        followingMovedMinimizedSideTarget) {
         state.actionSettled = false;
         _cancelNekoIdleCat1PairMove(state);
+        if (switchingFromCompactTopEdgeToMinimizedSide || followingMovedMinimizedSideTarget) {
+            state.pendingWalkReady = true;
+            state.pendingWalkDelayMs = 0;
+        }
         _scheduleNekoIdleCat1WalkStart(button, target);
         return;
     }
@@ -4154,7 +4187,11 @@ function _ensureNekoIdleReturnPresentationBridge() {
                 _scheduleNekoIdleCat1JourneySync(button);
                 return;
             }
-            if (isSmallDesktopChatMove && !_isNekoIdleCat1Walking(button)) return;
+            const settledMinimizedSide = _isNekoIdleCat1SettledOnMinimizedSide(
+                currentState,
+                currentState && currentState.profile
+            );
+            if (isSmallDesktopChatMove && !_isNekoIdleCat1Walking(button) && !settledMinimizedSide) return;
             _scheduleNekoIdleCat1JourneySync(button);
         });
     });

--- a/tests/unit/test_avatar_return_button_cat1_static.py
+++ b/tests/unit/test_avatar_return_button_cat1_static.py
@@ -114,6 +114,87 @@ def test_cat1_walk_uses_resolved_target_facing_instead_of_raw_chat_side():
     assert "state.facingRight = target.facingRight;" not in journey_sync_block
 
 
+def test_cat1_finishing_animation_rechecks_chat_target_after_settle():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    settle_block = source.split("function _settleNekoIdleReturnSubactionToIdle", 1)[1].split(
+        "function _scheduleNekoIdleReturnSubactionSettle",
+        1,
+    )[0]
+    assert "const shouldRecheckTargetAfterSettle = !!(state.target ||" in settle_block
+    assert "state.targetKind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in settle_block
+    assert "state.targetKind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE" in settle_block
+    assert "_getNekoIdleChatMinimizedRect() || _getNekoIdleChatCompactSurfaceRect()" in settle_block
+    assert "_scheduleNekoIdleCat1JourneySync(button);" in settle_block
+    assert settle_block.index("const shouldRecheckTargetAfterSettle") < settle_block.index("state.target = null;")
+    assert settle_block.index("_scheduleNekoIdleCat1JourneySync(button);") < settle_block.index("setTimeout(() => {")
+
+
+def test_cat1_hover_blocked_walk_starts_immediately_after_hover_playback():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    walk_start_block = source.split("function _scheduleNekoIdleCat1WalkStart", 1)[1].split(
+        "function _canScheduleNekoIdleCat1PairMove",
+        1,
+    )[0]
+    hover_block = walk_start_block.split("if (art && art.__nekoIdleHoverSrc) {", 1)[1].split(
+        "if (state.pendingWalkReady)",
+        1,
+    )[0]
+    assert "state.pendingWalkReady = true;" in hover_block
+    assert "state.pendingWalkDelayMs = 0;" in hover_block
+    assert "_finishNekoIdleHoverArtAfterPlayback(art, profile.tier);" in hover_block
+    assert hover_block.index("state.pendingWalkReady = true;") < hover_block.index("return;")
+
+
+def test_cat1_compact_top_edge_to_minimized_side_transition_forces_walk():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    journey_sync_block = source.split("function _syncNekoIdleCat1Journey", 1)[1].split(
+        "function _scheduleNekoIdleCat1JourneySync",
+        1,
+    )[0]
+    assert "const previousTargetKind = state.targetKind || '';" in journey_sync_block
+    assert "const switchingFromCompactTopEdgeToMinimizedSide =" in journey_sync_block
+    assert "previousTargetKind === _NEKO_IDLE_CAT1_TARGET_KIND_COMPACT_TOP_EDGE" in journey_sync_block
+    assert "target.kind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in journey_sync_block
+    assert "switchingFromCompactTopEdgeToMinimizedSide && target.distance > profile.target.exitDistancePx" in journey_sync_block
+    assert journey_sync_block.index("const previousTargetKind = state.targetKind || '';") < journey_sync_block.index("state.targetKind = target.kind || '';")
+    assert journey_sync_block.index("const switchingFromCompactTopEdgeToMinimizedSide =") < journey_sync_block.index("_scheduleNekoIdleCat1WalkStart(button, target);")
+
+
+def test_cat1_settled_minimized_side_retargets_when_ball_moves():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    journey_sync_block = source.split("function _syncNekoIdleCat1Journey", 1)[1].split(
+        "function _scheduleNekoIdleCat1JourneySync",
+        1,
+    )[0]
+    assert "const followingMovedMinimizedSideTarget =" in journey_sync_block
+    assert "previousTargetKind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in journey_sync_block
+    assert "target.kind === _NEKO_IDLE_CAT1_TARGET_KIND_MINIMIZED_SIDE" in journey_sync_block
+    assert "state.actionSettled &&" in journey_sync_block
+    assert "followingMovedMinimizedSideTarget" in journey_sync_block
+    assert "if (switchingFromCompactTopEdgeToMinimizedSide || followingMovedMinimizedSideTarget)" in journey_sync_block
+    assert "state.pendingWalkReady = true;" in journey_sync_block
+    assert "state.pendingWalkDelayMs = 0;" in journey_sync_block
+    assert journey_sync_block.index("const followingMovedMinimizedSideTarget =") < journey_sync_block.index("_scheduleNekoIdleCat1WalkStart(button, target);")
+
+
+def test_cat1_settled_minimized_side_bypasses_small_desktop_move_filter():
+    source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    assert "function _isNekoIdleCat1SettledOnMinimizedSide(state, profile)" in source
+    minimized_state_block = source.split("window.addEventListener('neko:idle-chat-minimized-state'", 1)[1].split(
+        "window.addEventListener('neko:idle-chat-compact-surface-state'",
+        1,
+    )[0]
+    assert "const settledMinimizedSide = _isNekoIdleCat1SettledOnMinimizedSide(" in minimized_state_block
+    assert "currentState && currentState.profile" in minimized_state_block
+    assert "if (isSmallDesktopChatMove && !_isNekoIdleCat1Walking(button) && !settledMinimizedSide) return;" in minimized_state_block
+    assert minimized_state_block.index("const settledMinimizedSide = _isNekoIdleCat1SettledOnMinimizedSide(") < minimized_state_block.index("if (isSmallDesktopChatMove && !_isNekoIdleCat1Walking(button) && !settledMinimizedSide) return;")
+
+
 def test_cat1_external_chat_position_updates_interrupt_pair_move_for_retarget():
     source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -1027,7 +1027,8 @@ def test_cat1_walk_to_minimized_chat_contract_is_present():
     assert '_isNekoIdleCat1Walking' in source
     assert 'movedDistancePx' in source
     assert 'isSmallDesktopChatMove' in source
-    assert 'if (isSmallDesktopChatMove && !_isNekoIdleCat1Walking(button)) return;' in source
+    assert '_isNekoIdleCat1SettledOnMinimizedSide' in source
+    assert 'if (isSmallDesktopChatMove && !_isNekoIdleCat1Walking(button) && !settledMinimizedSide) return;' in source
     assert '_dispatchNekoIdleReturnBallManualMove' in source
     assert '_getNekoIdleDesktopChatMinimizedRect' in source
     assert '_getNekoIdleChatMinimizedRect' in source


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了角色在紧凑和迷你化视图中的状态管理与同步逻辑
  * 优化了角色目标重新评估和动作衔接的流畅性
  * 增强了交互响应的即时性和准确性

* **Tests**
  * 新增5个单元测试以验证状态转换和交互行为
  * 完善现有测试覆盖范围

<!-- end of auto-generated comment: release notes by coderabbit.ai -->