### PR TITLE
切换角色卡成功后重置模型锁定状态，并退出“请她离开/再见”聊天状态，避免旧角色的 UI 状态泄漏到新角色

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -141,14 +141,60 @@
     function clearGoodbyeStateForCharacterSwitch() {
         const reason = 'character-switch';
 
+        const postFallbackReturnBallHiddenState = () => {
+            const payload = {
+                action: 'idle_return_ball_state',
+                source: 'pet-window',
+                reason: reason,
+                visible: false,
+                tier: 'none',
+                screenRect: null,
+                lanlan_name: (window.lanlan_config && window.lanlan_config.lanlan_name) || '',
+                timestamp: Date.now()
+            };
+            window.dispatchEvent(new CustomEvent('neko:idle-return-ball-state', { detail: payload }));
+            const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
+            if (channel && typeof channel.postMessage === 'function') {
+                try {
+                    channel.postMessage(payload);
+                } catch (_) {}
+            }
+        };
+
+        const hideReturnButtonContainer = (container) => {
+            if (!container) return;
+            if (typeof window.hideNekoReturnBallContainer === 'function') {
+                window.hideNekoReturnBallContainer(container, reason);
+                return;
+            }
+
+            container.removeAttribute('data-neko-return-visible');
+            container.style.display = 'none';
+            container.style.pointerEvents = 'none';
+            container.style.removeProperty('visibility');
+            postFallbackReturnBallHiddenState();
+        };
+
+        const hideAllReturnButtonContainers = () => {
+            if (typeof window.hideAllNekoReturnBallContainers === 'function') {
+                window.hideAllNekoReturnBallContainers(reason);
+                return;
+            }
+            [
+                window.live2dManager && window.live2dManager._returnButtonContainer,
+                window.vrmManager && window.vrmManager._returnButtonContainer,
+                window.mmdManager && window.mmdManager._returnButtonContainer,
+                document.getElementById('live2d-return-button-container'),
+                document.getElementById('vrm-return-button-container'),
+                document.getElementById('mmd-return-button-container')
+            ].forEach(hideReturnButtonContainer);
+        };
+
         const clearManagerReturnState = (manager) => {
             if (!manager) return;
             manager._goodbyeClicked = false;
             if (Object.prototype.hasOwnProperty.call(manager, '_isInReturnState')) {
                 manager._isInReturnState = false;
-            }
-            if (manager._returnButtonContainer && manager._returnButtonContainer.style) {
-                manager._returnButtonContainer.style.display = 'none';
             }
         };
 
@@ -156,6 +202,7 @@
             clearManagerReturnState(window.live2dManager);
             clearManagerReturnState(window.vrmManager);
             clearManagerReturnState(window.mmdManager);
+            hideAllReturnButtonContainers();
 
             window.__nekoGoodbyeSilentState = {
                 active: false,

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -141,10 +141,21 @@
     function clearGoodbyeStateForCharacterSwitch() {
         const reason = 'character-switch';
 
+        const clearManagerReturnState = (manager) => {
+            if (!manager) return;
+            manager._goodbyeClicked = false;
+            if (Object.prototype.hasOwnProperty.call(manager, '_isInReturnState')) {
+                manager._isInReturnState = false;
+            }
+            if (manager._returnButtonContainer && manager._returnButtonContainer.style) {
+                manager._returnButtonContainer.style.display = 'none';
+            }
+        };
+
         try {
-            if (window.live2dManager) window.live2dManager._goodbyeClicked = false;
-            if (window.vrmManager) window.vrmManager._goodbyeClicked = false;
-            if (window.mmdManager) window.mmdManager._goodbyeClicked = false;
+            clearManagerReturnState(window.live2dManager);
+            clearManagerReturnState(window.vrmManager);
+            clearManagerReturnState(window.mmdManager);
 
             window.__nekoGoodbyeSilentState = {
                 active: false,

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -97,6 +97,98 @@
         }
     }
 
+    function resetAvatarLockForCharacterSwitch(modelType) {
+        const hiddenByModelManager = isMainUIHiddenByModelManager();
+
+        try {
+            if (modelType === 'vrm' && window.vrmManager) {
+                if (window.vrmManager.core && typeof window.vrmManager.core.setLocked === 'function') {
+                    window.vrmManager.core.setLocked(false);
+                } else if (window.vrmManager.interaction && typeof window.vrmManager.interaction.setLocked === 'function') {
+                    window.vrmManager.interaction.setLocked(false);
+                } else {
+                    window.vrmManager.isLocked = false;
+                }
+                const lockIcon = document.getElementById('vrm-lock-icon');
+                if (lockIcon) lockIcon.style.backgroundImage = 'url(/static/icons/unlocked_icon.png)';
+            } else if (modelType === 'mmd' && window.mmdManager) {
+                if (window.mmdManager.core && typeof window.mmdManager.core.setLocked === 'function') {
+                    window.mmdManager.core.setLocked(false);
+                } else if (window.mmdManager.interaction && typeof window.mmdManager.interaction.setLocked === 'function') {
+                    window.mmdManager.interaction.setLocked(false);
+                    window.mmdManager.isLocked = false;
+                } else {
+                    window.mmdManager.isLocked = false;
+                }
+                const lockIcon = document.getElementById('mmd-lock-icon');
+                if (lockIcon) lockIcon.style.backgroundImage = 'url(/static/icons/unlocked_icon.png)';
+            } else if (window.live2dManager) {
+                if (typeof window.live2dManager.setLocked === 'function') {
+                    window.live2dManager.setLocked(false, { updateFloatingButtons: !hiddenByModelManager });
+                } else {
+                    window.live2dManager.isLocked = false;
+                }
+            }
+
+            if (hiddenByModelManager) {
+                rehideMainUIIfModelManagerOwnsVisibility('character-switch-lock-reset');
+            }
+        } catch (err) {
+            console.warn('[猫娘切换] 重置模型锁定状态失败:', err);
+        }
+    }
+
+    function clearGoodbyeStateForCharacterSwitch() {
+        const reason = 'character-switch';
+
+        try {
+            if (window.live2dManager) window.live2dManager._goodbyeClicked = false;
+            if (window.vrmManager) window.vrmManager._goodbyeClicked = false;
+            if (window.mmdManager) window.mmdManager._goodbyeClicked = false;
+
+            window.__nekoGoodbyeSilentState = {
+                active: false,
+                reason: reason,
+                pending: true,
+                updatedAt: Date.now()
+            };
+
+            const socket = S && S.socket;
+            if (socket && typeof socket.send === 'function' && socket.readyState === WebSocket.OPEN) {
+                socket.send(JSON.stringify({
+                    action: 'goodbye_state',
+                    active: false,
+                    reason: reason
+                }));
+                window.__nekoGoodbyeSilentState.pending = false;
+                window.__nekoGoodbyeSilentState.updatedAt = Date.now();
+            }
+        } catch (err) {
+            console.warn('[猫娘切换] 清理 goodbye 静默状态失败:', err);
+        }
+
+        try {
+            if (window.appInterpage && typeof window.appInterpage.postGoodbyeChatComposerHiddenState === 'function') {
+                window.appInterpage.postGoodbyeChatComposerHiddenState(false, reason);
+            } else if (typeof window.postGoodbyeChatComposerHiddenState === 'function') {
+                window.postGoodbyeChatComposerHiddenState(false, reason);
+            } else if (window.reactChatWindowHost && typeof window.reactChatWindowHost.setGoodbyeComposerHidden === 'function') {
+                window.reactChatWindowHost.setGoodbyeComposerHidden(false, reason);
+            } else {
+                window.__nekoGoodbyeChatComposerHidden = {
+                    hidden: false,
+                    reason: reason,
+                    timestamp: Date.now()
+                };
+                window.dispatchEvent(new CustomEvent('react-chat-window:set-goodbye-composer-hidden', {
+                    detail: window.__nekoGoodbyeChatComposerHidden
+                }));
+            }
+        } catch (err) {
+            console.warn('[猫娘切换] 清理 goodbye 聊天框状态失败:', err);
+        }
+    }
+
     function supportsLocalModelRuntime() {
         return !/^\/chat(?:_full)?(?:\/|$)/.test(window.location.pathname || '');
     }
@@ -1004,6 +1096,7 @@
                 await window.vrmManager.loadModel(modelUrl);
                 throwIfStale();
                 console.log('[猫娘切换] VRM模型加载完成');
+                resetAvatarLockForCharacterSwitch('vrm');
 
                 // 【关键修复】确保VRM渲染循环已启动（loadModel内部会调用startAnimation，但为了保险再次确认）
                 if (!window.vrmManager._animationFrameId) {
@@ -1341,6 +1434,7 @@
                     await window.mmdManager.loadModel(mmdModelUrl, { loadingSessionId: mmdLoadingSessionId });
                     throwIfStale();
                     console.log('[猫娘切换] MMD 模型加载完成');
+                    resetAvatarLockForCharacterSwitch('mmd');
 
                     // 应用完整设置（光照、渲染、物理、鼠标跟踪）
                     if (savedSettings) {
@@ -1473,6 +1567,7 @@
                             isMobile: typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768)
                         });
                         throwIfStale();
+                        resetAvatarLockForCharacterSwitch('live2d');
 
                         if (window.LanLan1) {
                             window.LanLan1.live2dModel = window.live2dManager.getCurrentModel();
@@ -1514,6 +1609,7 @@
                                     isMobile: typeof window.isMobileWidth === 'function' ? window.isMobileWidth() : (window.innerWidth <= 768)
                                 });
                                 throwIfStale();
+                                resetAvatarLockForCharacterSwitch('live2d');
                                 if (window.LanLan1) {
                                     window.LanLan1.live2dModel = window.live2dManager.getCurrentModel();
                                     window.LanLan1.currentModel = window.live2dManager.getCurrentModel();
@@ -1655,6 +1751,7 @@
             // commit 之后再 dispose 延后保留的旧 MMD 实例（MMD→非 MMD 路径）。
             // commit 前 dispose 会让中途失败的 rollback 没法恢复旧 MMD（容器没渲染 + 实例已销毁）。
             _disposeDeferredMmd();
+            clearGoodbyeStateForCharacterSwitch();
             // 角色卡切换后猫爪必须重新归零并拉取新快照，防止工具服务的旧全局状态污染新角色。
             if (typeof window.resetAgentUiForCharacterSwitch === 'function') {
                 Promise.resolve(window.resetAgentUiForCharacterSwitch(newCatgirl))

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -2179,7 +2179,7 @@
         container.setAttribute('data-dragging', 'false');
     }
 
-    function hideReturnBallContainer(container) {
+    function hideReturnBallContainer(container, reason = 'return-ball-hide') {
         if (!container) return;
         cancelReturnBallReveal(container);
         restoreSavedReturnBallStyle(container);
@@ -2188,8 +2188,10 @@
         container.style.display = 'none';
         container.style.pointerEvents = 'none';
         container.style.removeProperty('visibility');
-        scheduleIdleReturnBallDesktopBridge('return-ball-hide', container);
+        scheduleIdleReturnBallDesktopBridge(reason || 'return-ball-hide', container);
     }
+
+    window.hideNekoReturnBallContainer = hideReturnBallContainer;
 
     function positionReturnBallContainer(container, anchorRect) {
         if (!container) return;
@@ -3130,6 +3132,13 @@
 
         multiWindowReturnBallDragState = state;
     }
+
+    window.hideAllNekoReturnBallContainers = function(reason = 'return-ball-hide') {
+        hideReturnBallContainer(document.getElementById('live2d-return-button-container'), reason);
+        hideReturnBallContainer(document.getElementById('vrm-return-button-container'), reason);
+        hideReturnBallContainer(document.getElementById('mmd-return-button-container'), reason);
+        ensureMultiWindowReturnBallDrag(null);
+    };
 
     /**
      * Wire up floating-button event listeners.

--- a/tests/unit/test_app_character_static.py
+++ b/tests/unit/test_app_character_static.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 APP_CHARACTER_PATH = Path(__file__).resolve().parents[2] / "static" / "app-character.js"
+APP_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "app-ui.js"
 
 
 def test_character_switch_resets_avatar_lock_after_successful_model_load():
@@ -34,9 +35,13 @@ def test_character_switch_clears_goodbye_state_only_after_commit():
     source = APP_CHARACTER_PATH.read_text(encoding="utf-8")
 
     assert "function clearGoodbyeStateForCharacterSwitch()" in source
+    assert "window.hideAllNekoReturnBallContainers(reason)" in source
+    assert "window.hideNekoReturnBallContainer(container, reason)" in source
+    assert "container.removeAttribute('data-neko-return-visible')" in source
+    assert "action: 'idle_return_ball_state'" in source
+    assert "channel.postMessage(payload)" in source
     assert "manager._goodbyeClicked = false" in source
     assert "manager._isInReturnState = false" in source
-    assert "manager._returnButtonContainer.style.display = 'none'" in source
     assert "window.__nekoGoodbyeSilentState = {" in source
     assert "action: 'goodbye_state'" in source
     assert "active: false" in source
@@ -48,3 +53,13 @@ def test_character_switch_clears_goodbye_state_only_after_commit():
     clear = source.index("clearGoodbyeStateForCharacterSwitch();")
     toast = source.index("showStatusToast(window.t ? window.t('app.switchedCatgirl'")
     assert commit < clear < toast
+
+
+def test_app_ui_exposes_shared_return_ball_hide_helper():
+    source = APP_UI_PATH.read_text(encoding="utf-8")
+
+    assert "function hideReturnBallContainer(container, reason = 'return-ball-hide')" in source
+    assert "scheduleIdleReturnBallDesktopBridge(reason || 'return-ball-hide', container)" in source
+    assert "window.hideNekoReturnBallContainer = hideReturnBallContainer" in source
+    assert "window.hideAllNekoReturnBallContainers = function(reason = 'return-ball-hide')" in source
+    assert "ensureMultiWindowReturnBallDrag(null)" in source

--- a/tests/unit/test_app_character_static.py
+++ b/tests/unit/test_app_character_static.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-APP_CHARACTER_PATH = Path("static/app-character.js")
+APP_CHARACTER_PATH = Path(__file__).resolve().parents[2] / "static" / "app-character.js"
 
 
 def test_character_switch_resets_avatar_lock_after_successful_model_load():
@@ -34,6 +34,9 @@ def test_character_switch_clears_goodbye_state_only_after_commit():
     source = APP_CHARACTER_PATH.read_text(encoding="utf-8")
 
     assert "function clearGoodbyeStateForCharacterSwitch()" in source
+    assert "manager._goodbyeClicked = false" in source
+    assert "manager._isInReturnState = false" in source
+    assert "manager._returnButtonContainer.style.display = 'none'" in source
     assert "window.__nekoGoodbyeSilentState = {" in source
     assert "action: 'goodbye_state'" in source
     assert "active: false" in source

--- a/tests/unit/test_app_character_static.py
+++ b/tests/unit/test_app_character_static.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+
+APP_CHARACTER_PATH = Path("static/app-character.js")
+
+
+def test_character_switch_resets_avatar_lock_after_successful_model_load():
+    source = APP_CHARACTER_PATH.read_text(encoding="utf-8")
+
+    assert "function resetAvatarLockForCharacterSwitch(modelType)" in source
+    assert "window.vrmManager.core.setLocked(false)" in source
+    assert "window.mmdManager.core.setLocked(false)" in source
+    assert "window.live2dManager.setLocked(false, { updateFloatingButtons: !hiddenByModelManager })" in source
+    assert "rehideMainUIIfModelManagerOwnsVisibility('character-switch-lock-reset')" in source
+
+    vrm_load = source.index("await window.vrmManager.loadModel(modelUrl);")
+    vrm_reset = source.index("resetAvatarLockForCharacterSwitch('vrm');")
+    assert vrm_load < vrm_reset
+
+    mmd_load = source.index("await window.mmdManager.loadModel(mmdModelUrl, { loadingSessionId: mmdLoadingSessionId });")
+    mmd_reset = source.index("resetAvatarLockForCharacterSwitch('mmd');")
+    assert mmd_load < mmd_reset
+
+    live2d_load = source.index("await window.live2dManager.loadModel(modelConfig, {")
+    live2d_reset = source.index("resetAvatarLockForCharacterSwitch('live2d');", live2d_load)
+    assert live2d_load < live2d_reset
+
+    fallback_load = source.index("await window.live2dManager.loadModel(defaultConfig, {")
+    fallback_reset = source.index("resetAvatarLockForCharacterSwitch('live2d');", fallback_load)
+    assert fallback_load < fallback_reset
+
+
+def test_character_switch_clears_goodbye_state_only_after_commit():
+    source = APP_CHARACTER_PATH.read_text(encoding="utf-8")
+
+    assert "function clearGoodbyeStateForCharacterSwitch()" in source
+    assert "window.__nekoGoodbyeSilentState = {" in source
+    assert "action: 'goodbye_state'" in source
+    assert "active: false" in source
+    assert "window.appInterpage.postGoodbyeChatComposerHiddenState(false, reason)" in source
+    assert "window.reactChatWindowHost.setGoodbyeComposerHidden(false, reason)" in source
+    assert "react-chat-window:set-goodbye-composer-hidden" in source
+
+    commit = source.index("switchHasCommitted = true;")
+    clear = source.index("clearGoodbyeStateForCharacterSwitch();")
+    toast = source.index("showStatusToast(window.t ? window.t('app.switchedCatgirl'")
+    assert commit < clear < toast


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化角色切换：在模型加载与切换提交点自动恢复头像锁定、界面可见性与返回按钮显示，提升切换一致性与流畅性。
  * 新增返回球隐藏接口：支持按原因隐藏单个或全部返回球容器并同步多窗口拖拽状态。

* **测试**
  * 新增静态单元测试，校验模型加载后与切换提交点的状态复位与通知/事件执行顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->