### PR TITLE
fix(ui): 修复在暗色模式下记忆整理页面上存储位置的输入框和按钮颜色不正确的问题

### DIFF
--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1412,6 +1412,34 @@ html[data-theme="dark"].subtitle-window-host body.subtitle-window-host {
   border-color: #2a2a2a;
 }
 
+[data-theme="dark"] .storage-location-mini-label,
+[data-theme="dark"] .storage-location-mini-status {
+  color: #4aa3df;
+}
+[data-theme="dark"] .storage-location-mini-value {
+  background: #252525;
+  border-color: #3a5a6e;
+  color: #e0e0e0;
+}
+[data-theme="dark"] .storage-location-open-btn {
+  background: #2d2d2d;
+  border-color: #3a5a6e;
+  color: #4aa3df;
+}
+[data-theme="dark"] .storage-location-open-btn:not(:disabled):hover {
+  background: #383838;
+  border-color: #4aa3df;
+  box-shadow: 0 4px 12px rgba(74, 163, 223, 0.2);
+}
+[data-theme="dark"] .storage-location-open-btn:disabled,
+[data-theme="dark"] .storage-location-manage-btn:disabled {
+  background: #1a1a1a;
+  border-color: #2a2a2a;
+  color: #666;
+  opacity: 0.5;
+  box-shadow: none;
+}
+
 /* ===== 子页面：当前角色栏 ===== */
 [data-theme="dark"] .current-catgirl-bar {
   background: #2a7bc4;


### PR DESCRIPTION
修复在暗色模式下记忆整理页面上存储位置的输入框和按钮颜色不正确的问题（补充暗色模式下的CSS）
> **原样式：**
<img width="269" height="295" alt="PixPin_2026-06-13_11-35-18" src="https://github.com/user-attachments/assets/c5fa21f9-a05e-43fa-823d-e67a8132c249" />

> **修复后：**
<img width="286" height="299" alt="PixPin_2026-06-13_11-35-33" src="https://github.com/user-attachments/assets/dd006bcd-1ee7-4845-86be-f13e3de9ae9c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 为暗色模式下的存储位置界面添加了完整的样式支持，包括标签、状态、数值和按钮等元素。
  * 增强了按钮的交互反馈，包括悬停和禁用状态下的视觉效果。
  * 确保暗色模式下的用户界面配色和交互体验保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->