### PR TITLE
fix(gemini): resume voice after interruption

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -474,6 +474,7 @@ class OmniRealtimeClient:
         self._gemini_context_manager = None  # For proper cleanup
         self._gemini_current_transcript = ""  # Current response transcript for Gemini
         self._gemini_user_transcript = ""  # Accumulated user input transcript
+        self._gemini_user_transcript_after_interrupt = False
 
         # ── Tool calling state ────────────────────────────────────────
         # ``_tool_definitions`` is the canonical list (ToolDefinition);
@@ -1082,6 +1083,8 @@ class OmniRealtimeClient:
             # 设置 ws 为 session，用于兼容性检查
             self.ws = self._gemini_session
             self._fatal_error_occurred = False
+            self._gemini_user_transcript = ""
+            self._gemini_user_transcript_after_interrupt = False
 
             self._last_speech_time = time.time()
             self.instructions = instructions
@@ -3017,6 +3020,8 @@ class OmniRealtimeClient:
                     input_trans = server_content.input_transcription
                     if hasattr(input_trans, 'text') and input_trans.text:
                         self._gemini_user_transcript += input_trans.text
+                        if self._interrupted:
+                            self._gemini_user_transcript_after_interrupt = True
                 
                 # 检查是否有 AI 内容（model_turn 或 output_transcription）
                 has_ai_content = (
@@ -3044,22 +3049,28 @@ class OmniRealtimeClient:
                         <= self._ai_recent_activity_window
                     )
                     _is_new_turn = _user_spoke_after_ai or not _still_within_ai_window
+                    _can_clear_interrupted = (
+                        not self._interrupted
+                        or self._gemini_user_transcript_after_interrupt
+                        or not _still_within_ai_window
+                    )
                     self._is_responding = True
-                    if _is_new_turn:
+                    if _is_new_turn and _can_clear_interrupted:
                         # Gemini has no response.created event; clear stale interrupt state only
-                        # when we have identified a real new model turn.
+                        # after SDK transcription or a quiet gap proves this is not a canceled tail.
                         self._interrupted = False
                         # 在AI开始响应前，发送累积的用户输入
                         if self._gemini_user_transcript and self.on_input_transcript:
                             await self.on_input_transcript(self._gemini_user_transcript)
                             self._gemini_user_transcript = ""  # 清空累积
+                            self._gemini_user_transcript_after_interrupt = False
                         self._is_first_text_chunk = True  # 重置第一个 chunk 标记
                         self._gemini_current_transcript = ""  # 清空累积
                         if not self._skip_until_next_response and not self._interrupted and self.on_new_message:
                             await self.on_new_message()
                     else:
                         logger.debug(
-                            "Gemini: late content after premature turn_complete (%.2fs ago), treating as continuation",
+                            "Gemini: late content after premature turn_complete/interruption (%.2fs ago), treating as continuation",
                             time.time() - self._ai_recent_activity_time,
                         )
 

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -3046,6 +3046,9 @@ class OmniRealtimeClient:
                     _is_new_turn = _user_spoke_after_ai or not _still_within_ai_window
                     self._is_responding = True
                     if _is_new_turn:
+                        # Gemini has no response.created event; clear stale interrupt state only
+                        # when we have identified a real new model turn.
+                        self._interrupted = False
                         # 在AI开始响应前，发送累积的用户输入
                         if self._gemini_user_transcript and self.on_input_transcript:
                             await self.on_input_transcript(self._gemini_user_transcript)

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -3063,7 +3063,7 @@ class OmniRealtimeClient:
                         if self._gemini_user_transcript and self.on_input_transcript:
                             await self.on_input_transcript(self._gemini_user_transcript)
                             self._gemini_user_transcript = ""  # 清空累积
-                            self._gemini_user_transcript_after_interrupt = False
+                        self._gemini_user_transcript_after_interrupt = False
                         self._is_first_text_chunk = True  # 重置第一个 chunk 标记
                         self._gemini_current_transcript = ""  # 清空累积
                         if not self._skip_until_next_response and not self._interrupted and self.on_new_message:
@@ -3129,8 +3129,10 @@ class OmniRealtimeClient:
                     self._interrupted = True
                     self._is_responding = False
                     # 被中断时也发送已累积的用户输入
-                    if self._gemini_user_transcript and self.on_input_transcript:
-                        await self.on_input_transcript(self._gemini_user_transcript)
+                    if self._gemini_user_transcript:
+                        self._gemini_user_transcript_after_interrupt = True
+                        if self.on_input_transcript:
+                            await self.on_input_transcript(self._gemini_user_transcript)
                         self._gemini_user_transcript = ""
                     logger.info("Gemini response was interrupted by user")
         

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -1,6 +1,8 @@
 import pytest
 import json
 import base64
+import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Adjust path to import project modules
@@ -822,6 +824,98 @@ def _make_server_vad_client(model: str, api_type: str = "", base_url: str = "wss
         turn_detection_mode=TurnDetectionMode.SERVER_VAD,
         api_type=api_type,
     )
+
+
+def _gemini_response(**server_fields):
+    defaults = {
+        "input_transcription": None,
+        "output_transcription": None,
+        "model_turn": None,
+        "turn_complete": False,
+        "interrupted": False,
+    }
+    defaults.update(server_fields)
+    return SimpleNamespace(
+        tool_call=None,
+        server_content=SimpleNamespace(**defaults),
+    )
+
+
+def _gemini_output_text(text: str):
+    return SimpleNamespace(text=text)
+
+
+def _gemini_model_turn_audio(data: bytes = b"audio"):
+    return SimpleNamespace(
+        parts=[
+            SimpleNamespace(
+                inline_data=SimpleNamespace(data=data),
+                thought=False,
+            )
+        ]
+    )
+
+
+@pytest.mark.unit
+async def test_gemini_interruption_clears_on_true_new_turn():
+    client = _make_server_vad_client(
+        model="gemini-2.0-flash-exp",
+        api_type="gemini",
+        base_url="https://generativelanguage.googleapis.com",
+    )
+    client.on_input_transcript = AsyncMock()
+    client.on_new_message = AsyncMock()
+    client.on_text_delta = AsyncMock()
+    client.on_audio_delta = AsyncMock()
+
+    client._gemini_user_transcript = "hello"
+    await client._process_gemini_response(_gemini_response(interrupted=True))
+
+    assert client._interrupted is True
+    client.on_input_transcript.assert_awaited_once_with("hello")
+
+    client._ai_recent_activity_time = 0.0
+    client._user_recent_activity_time = time.time()
+    await client._process_gemini_response(
+        _gemini_response(
+            output_transcription=_gemini_output_text("hi"),
+            model_turn=_gemini_model_turn_audio(b"pcm"),
+        )
+    )
+
+    assert client._interrupted is False
+    client.on_new_message.assert_awaited_once()
+    client.on_text_delta.assert_awaited_once_with("hi", True)
+    client.on_audio_delta.assert_awaited_once_with(b"pcm")
+
+
+@pytest.mark.unit
+async def test_gemini_interrupted_late_continuation_stays_suppressed():
+    client = _make_server_vad_client(
+        model="gemini-2.0-flash-exp",
+        api_type="gemini",
+        base_url="https://generativelanguage.googleapis.com",
+    )
+    client.on_new_message = AsyncMock()
+    client.on_text_delta = AsyncMock()
+    client.on_audio_delta = AsyncMock()
+
+    client._interrupted = True
+    client._is_responding = False
+    client._ai_recent_activity_time = time.time()
+    client._user_recent_activity_time = client._ai_recent_activity_time - 1
+
+    await client._process_gemini_response(
+        _gemini_response(
+            output_transcription=_gemini_output_text("late"),
+            model_turn=_gemini_model_turn_audio(b"late-audio"),
+        )
+    )
+
+    assert client._interrupted is True
+    client.on_new_message.assert_not_awaited()
+    client.on_text_delta.assert_not_awaited()
+    client.on_audio_delta.assert_not_awaited()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -958,6 +958,45 @@ async def test_gemini_interrupted_user_audio_without_transcript_stays_suppressed
 
 
 @pytest.mark.unit
+async def test_gemini_interrupted_same_event_transcript_allows_next_turn():
+    client = _make_server_vad_client(
+        model="gemini-2.0-flash-exp",
+        api_type="gemini",
+        base_url="https://generativelanguage.googleapis.com",
+    )
+    client.on_input_transcript = AsyncMock()
+    client.on_new_message = AsyncMock()
+    client.on_text_delta = AsyncMock()
+    client.on_audio_delta = AsyncMock()
+
+    await client._process_gemini_response(
+        _gemini_response(
+            input_transcription=_gemini_input_text("barge in"),
+            interrupted=True,
+        )
+    )
+
+    assert client._interrupted is True
+    assert client._gemini_user_transcript_after_interrupt is True
+    client.on_input_transcript.assert_awaited_once_with("barge in")
+
+    client._ai_recent_activity_time = time.time() - 0.5
+    client._user_recent_activity_time = time.time()
+    await client._process_gemini_response(
+        _gemini_response(
+            output_transcription=_gemini_output_text("next"),
+            model_turn=_gemini_model_turn_audio(b"next-audio"),
+        )
+    )
+
+    assert client._interrupted is False
+    assert client._gemini_user_transcript_after_interrupt is False
+    client.on_new_message.assert_awaited_once()
+    client.on_text_delta.assert_awaited_once_with("next", True)
+    client.on_audio_delta.assert_awaited_once_with(b"next-audio")
+
+
+@pytest.mark.unit
 def test_uplink_rate_gpt_is_24k_with_resampler():
     """gpt models must target a 24kHz uplink and own a stream resampler."""
     client = _make_server_vad_client(model="gpt-realtime", api_type="openai")

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -845,6 +845,10 @@ def _gemini_output_text(text: str):
     return SimpleNamespace(text=text)
 
 
+def _gemini_input_text(text: str):
+    return SimpleNamespace(text=text)
+
+
 def _gemini_model_turn_audio(data: bytes = b"audio"):
     return SimpleNamespace(
         parts=[
@@ -874,7 +878,11 @@ async def test_gemini_interruption_clears_on_true_new_turn():
     assert client._interrupted is True
     client.on_input_transcript.assert_awaited_once_with("hello")
 
-    client._ai_recent_activity_time = 0.0
+    await client._process_gemini_response(
+        _gemini_response(input_transcription=_gemini_input_text("next question"))
+    )
+
+    client._ai_recent_activity_time = time.time() - 0.5
     client._user_recent_activity_time = time.time()
     await client._process_gemini_response(
         _gemini_response(
@@ -884,6 +892,8 @@ async def test_gemini_interruption_clears_on_true_new_turn():
     )
 
     assert client._interrupted is False
+    assert client.on_input_transcript.await_count == 2
+    client.on_input_transcript.assert_awaited_with("next question")
     client.on_new_message.assert_awaited_once()
     client.on_text_delta.assert_awaited_once_with("hi", True)
     client.on_audio_delta.assert_awaited_once_with(b"pcm")
@@ -909,6 +919,35 @@ async def test_gemini_interrupted_late_continuation_stays_suppressed():
         _gemini_response(
             output_transcription=_gemini_output_text("late"),
             model_turn=_gemini_model_turn_audio(b"late-audio"),
+        )
+    )
+
+    assert client._interrupted is True
+    client.on_new_message.assert_not_awaited()
+    client.on_text_delta.assert_not_awaited()
+    client.on_audio_delta.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_gemini_interrupted_user_audio_without_transcript_stays_suppressed():
+    client = _make_server_vad_client(
+        model="gemini-2.0-flash-exp",
+        api_type="gemini",
+        base_url="https://generativelanguage.googleapis.com",
+    )
+    client.on_new_message = AsyncMock()
+    client.on_text_delta = AsyncMock()
+    client.on_audio_delta = AsyncMock()
+
+    client._interrupted = True
+    client._is_responding = False
+    client._ai_recent_activity_time = time.time() - 0.5
+    client._user_recent_activity_time = time.time()
+
+    await client._process_gemini_response(
+        _gemini_response(
+            output_transcription=_gemini_output_text("canceled tail"),
+            model_turn=_gemini_model_turn_audio(b"canceled-tail-audio"),
         )
     )
 


### PR DESCRIPTION
## Summary
- clear stale Gemini interruption state when a real new model turn starts
- keep interrupted late-continuation Gemini chunks suppressed
- add regression coverage for both paths

## Root cause
The Gemini SDK path does not emit the OpenAI-compatible `response.created` event that normally clears `_interrupted`. After a Gemini `server_content.interrupted` event, `_interrupted` could stay true and suppress later `on_new_message`, text delta, and audio delta callbacks until the call was restarted.

## Tests
- `uv run pytest tests/unit/test_voice_session.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 精化语音中断与“新回合”判定：在会话建立/进入时重置中断追踪；仅在满足更严格条件（含中断后已收到用户转录及时间窗等）时清除中断并触发后续回调，避免被迟到续写误判。
  * 在检测到中断且已累计用户转录时，立即发送转录回调以保障后续判定正确。

* **Tests**
  * 新增单元测试覆盖中断清理、延迟续写抑制及缺失转录场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->