### PR TITLE
[codex] Report safety-blocked empty LLM responses

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2885,10 +2885,10 @@ class LLMSessionManager:
                     or 'invalid_api_key' in message_text_lower
                     or ('invalid' in message_text_lower and 'key' in message_text_lower)):
                 await self.send_status(json.dumps({"code": "API_KEY_REJECTED"}))
-            elif '1008' in message_text_lower:
-                await self.send_status(json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": message_text}}))
             elif _is_safety_violation_signal(message_text_lower):
                 await self.send_status(json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": message_text}}))
+            elif '1008' in message_text_lower:
+                await self.send_status(json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": message_text}}))
             else:
                 await self.send_status(json.dumps({"code": "API_UNKNOWN_ERROR", "details": {"msg": message_text}}))
         logger.info("💥 Session closed by API Server.")
@@ -8044,12 +8044,12 @@ class LLMSessionManager:
                             elif '429' in error_msg_lower or 'too many' in error_msg_lower:
                                 user_msg = json.dumps({"code": "API_RATE_LIMIT"})
                                 self._last_tts_error_code = 'API_RATE_LIMIT'
-                            elif '1008' in error_msg_lower:
-                                user_msg = json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": error_msg_text}})
-                                self._last_tts_error_code = 'API_1008_FALLBACK'
                             elif _is_safety_violation_signal(error_msg_lower):
                                 user_msg = json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": error_msg_text}})
                                 self._last_tts_error_code = 'API_POLICY_VIOLATION'
+                            elif '1008' in error_msg_lower:
+                                user_msg = json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": error_msg_text}})
+                                self._last_tts_error_code = 'API_1008_FALLBACK'
                             elif ('401' in error_msg_lower or 'unauthorized' in error_msg_lower
                                     or 'authentication' in error_msg_lower
                                     or 'incorrect api key' in error_msg_lower

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -30,7 +30,7 @@ from utils.frontend_utils import contains_chinese, replace_blank, replace_corner
     is_only_punctuation, TtsStreamNormalizer, TtsBracketStripper, TtsMarkdownStripper
 from utils.screenshot_utils import process_screen_data, overlay_avatar_annotation
 from main_logic.omni_realtime_client import OmniRealtimeClient
-from main_logic.omni_offline_client import OmniOfflineClient
+from main_logic.omni_offline_client import OmniOfflineClient, _is_safety_violation_signal
 from main_logic.tts_client import get_tts_worker, dummy_tts_worker, TTS_PROVIDER_REGISTRY
 from utils.gptsovits_config import is_gsv_disabled_voice_id
 from main_logic.tool_calling import (
@@ -2885,10 +2885,10 @@ class LLMSessionManager:
                     or 'invalid_api_key' in message_text_lower
                     or ('invalid' in message_text_lower and 'key' in message_text_lower)):
                 await self.send_status(json.dumps({"code": "API_KEY_REJECTED"}))
-            elif 'policy violation' in message_text_lower:
-                await self.send_status(json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": message_text}}))
             elif '1008' in message_text_lower:
                 await self.send_status(json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": message_text}}))
+            elif _is_safety_violation_signal(message_text_lower):
+                await self.send_status(json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": message_text}}))
             else:
                 await self.send_status(json.dumps({"code": "API_UNKNOWN_ERROR", "details": {"msg": message_text}}))
         logger.info("💥 Session closed by API Server.")
@@ -8044,12 +8044,12 @@ class LLMSessionManager:
                             elif '429' in error_msg_lower or 'too many' in error_msg_lower:
                                 user_msg = json.dumps({"code": "API_RATE_LIMIT"})
                                 self._last_tts_error_code = 'API_RATE_LIMIT'
-                            elif 'policy violation' in error_msg_lower:
-                                user_msg = json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": error_msg_text}})
-                                self._last_tts_error_code = 'API_POLICY_VIOLATION'
                             elif '1008' in error_msg_lower:
                                 user_msg = json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": error_msg_text}})
                                 self._last_tts_error_code = 'API_1008_FALLBACK'
+                            elif _is_safety_violation_signal(error_msg_lower):
+                                user_msg = json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": error_msg_text}})
+                                self._last_tts_error_code = 'API_POLICY_VIOLATION'
                             elif ('401' in error_msg_lower or 'unauthorized' in error_msg_lower
                                     or 'authentication' in error_msg_lower
                                     or 'incorrect api key' in error_msg_lower

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -132,12 +132,9 @@ _SAFETY_VIOLATION_KEYWORDS = (
     "policy violation",
     "policy_violation",
     "prohibited",
-    "blocked",
-    "block_reason",
     "recitation",
     "responsibleaipolicyviolation",
     "responsible ai policy",
-    "1008",
 )
 
 

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -125,6 +125,20 @@ _API_KEY_REJECTED_KEYWORDS = (
     "invalid key",
     "api key is invalid",
 )
+_SAFETY_VIOLATION_KEYWORDS = (
+    "safety",
+    "content_filter",
+    "content filter",
+    "policy violation",
+    "policy_violation",
+    "prohibited",
+    "blocked",
+    "block_reason",
+    "recitation",
+    "responsibleaipolicyviolation",
+    "responsible ai policy",
+    "1008",
+)
 
 
 def _is_api_key_rejected_error(error: BaseException | str) -> bool:
@@ -146,6 +160,14 @@ def _is_api_key_rejected_error(error: BaseException | str) -> bool:
         ("authenticationerror" in text or "authentication" in text or "unauthorized" in text)
         and "api key" in text
     )
+
+
+def _is_safety_violation_signal(*values: object) -> bool:
+    """Return True when provider diagnostics point to safety/policy blocking."""
+    text = " ".join(str(value) for value in values if value).lower()
+    if not text:
+        return False
+    return any(keyword in text for keyword in _SAFETY_VIOLATION_KEYWORDS)
 
 
 def _truncate_to_last_sentence_end(text: str) -> str:
@@ -2575,7 +2597,23 @@ class OmniOfflineClient:
                     getattr(self, "model", None),
                 )
                 if self.on_status_message:
-                    await self.on_status_message(json.dumps({"code": "LLM_NO_RESPONSE"}))
+                    finish_reason = getattr(self, "_last_finish_reason", None)
+                    block_reason = getattr(self, "_last_block_reason", None)
+                    prompt_tokens = getattr(self, "_last_prompt_tokens", None)
+                    model = getattr(self, "model", None)
+                    if _is_safety_violation_signal(finish_reason, block_reason):
+                        await self.on_status_message(json.dumps({
+                            "code": "API_POLICY_VIOLATION",
+                            "details": {
+                                "msg": "LLM completion was blocked by upstream safety policy.",
+                                "finish_reason": finish_reason,
+                                "block_reason": block_reason,
+                                "prompt_tokens": prompt_tokens,
+                                "model": model,
+                            },
+                        }))
+                    else:
+                        await self.on_status_message(json.dumps({"code": "LLM_NO_RESPONSE"}))
             
             # Call response done callback
             if self.on_response_done:

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -1494,6 +1494,10 @@ def test_safety_violation_helper_detects_provider_block_signals():
     assert _is_safety_violation_signal("content_filter") is True
     assert _is_safety_violation_signal(None, "SAFETY") is True
     assert _is_safety_violation_signal("ResponsibleAIPolicyViolation") is True
+    assert _is_safety_violation_signal("connection blocked by proxy") is False
+    assert _is_safety_violation_signal("BLOCK_REASON_UNSPECIFIED") is False
+    assert _is_safety_violation_signal("1008 connection closed") is False
+    assert _is_safety_violation_signal("1008 policy violation") is True
     assert _is_safety_violation_signal("stop", None) is False
     assert _is_safety_violation_signal(None, None) is False
 
@@ -1541,6 +1545,9 @@ async def test_stream_text_empty_safety_completion_reports_policy_violation(monk
     client.on_response_discarded = None
     client.on_status_message = fake_status
     client.on_repetition_detected = None
+    client._last_finish_reason = None
+    client._last_block_reason = None
+    client._last_prompt_tokens = None
 
     await client.stream_text("hi")
 
@@ -1549,6 +1556,7 @@ async def test_stream_text_empty_safety_completion_reports_policy_violation(monk
     assert status_messages[0]["details"]["finish_reason"] == "content_filter"
     assert status_messages[0]["details"]["block_reason"] == "SAFETY"
     assert status_messages[0]["details"]["prompt_tokens"] == 123
+    assert status_messages[0]["details"]["model"] == "gemini-2.5-flash"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -1488,6 +1488,69 @@ def test_api_key_error_helper_does_not_treat_plain_403_as_invalid_key():
     assert _is_api_key_rejected_error(RuntimeError("AuthenticationError: OAuth token expired")) is False
 
 
+def test_safety_violation_helper_detects_provider_block_signals():
+    from main_logic.omni_offline_client import _is_safety_violation_signal
+
+    assert _is_safety_violation_signal("content_filter") is True
+    assert _is_safety_violation_signal(None, "SAFETY") is True
+    assert _is_safety_violation_signal("ResponsibleAIPolicyViolation") is True
+    assert _is_safety_violation_signal("stop", None) is False
+    assert _is_safety_violation_signal(None, None) is False
+
+
+@pytest.mark.asyncio
+async def test_stream_text_empty_safety_completion_reports_policy_violation(monkeypatch):
+    """Safety-blocked empty completions should not surface as generic no-response."""
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import LLMStreamChunk, SystemMessage
+
+    async def _astream_empty_safety(self, messages, **overrides):
+        self._last_finish_reason = "content_filter"
+        self._last_block_reason = "SAFETY"
+        self._last_prompt_tokens = 123
+        yield LLMStreamChunk(content="", finish_reason="content_filter")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream_empty_safety)
+
+    status_messages: list[dict] = []
+
+    async def fake_status(msg):
+        status_messages.append(json.loads(msg))
+
+    async def fake_done():
+        pass
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.lanlan_name = "Test"
+    client.master_name = "M"
+    client._prefix_buffer_size = 0
+    client._conversation_history = [SystemMessage(content="sys")]
+    client._pending_images = []
+    client._is_responding = False
+    client._recent_responses = []
+    client._repetition_threshold = 0.8
+    client._max_recent_responses = 3
+    client.max_response_length = 300
+    client.max_response_rerolls = 0
+    client.enable_response_guard = False
+    client.vision_model = ""
+    client.model = "gemini-2.5-flash"
+    client.on_text_delta = None
+    client.on_input_transcript = None
+    client.on_response_done = fake_done
+    client.on_response_discarded = None
+    client.on_status_message = fake_status
+    client.on_repetition_detected = None
+
+    await client.stream_text("hi")
+
+    assert len(status_messages) == 1
+    assert status_messages[0]["code"] == "API_POLICY_VIOLATION"
+    assert status_messages[0]["details"]["finish_reason"] == "content_filter"
+    assert status_messages[0]["details"]["block_reason"] == "SAFETY"
+    assert status_messages[0]["details"]["prompt_tokens"] == 123
+
+
 @pytest.mark.asyncio
 async def test_prompt_ephemeral_reports_key_error_from_catch_all(monkeypatch):
     from main_logic.omni_offline_client import OmniOfflineClient


### PR DESCRIPTION
## Summary
- classify safety-blocked empty LLM completions as API_POLICY_VIOLATION instead of generic LLM_NO_RESPONSE
- reuse the safety signal detector for realtime/TTS error string classification
- add regression coverage for content_filter/SAFETY empty completions

## Root cause
Some upstream providers finish a request with safety diagnostics such as content_filter or SAFETY while producing no text. The backend kept those diagnostics only in logs, so the frontend received the generic no-response status.

## Validation
- uv run pytest tests/unit/test_tool_calling.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 统一并改进了安全策略违规信号的识别与分类，API 与 TTS 的安全拦截现在能更准确检测并上报为政策违规；空响应场景下若因安全拦截触发，上报会包含拦截原因、阻断原因、提示tokens与模型信息以便诊断。

* **Tests**
  * 新增单元测试覆盖多种安全拦截信号识别及“空响应且被安全拦截”场景，提升回归保护。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->