### PR TITLE
fix: make random jukebox playback use accumulated queue

### DIFF
--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -446,12 +446,14 @@ window.Jukebox = {
     }
   },
 
-  pickRandomSongExcluding: function(excludedId) {
+  pickRandomSongExcluding: function(excludedIds) {
     const songs = Jukebox.State.songs || [];
     if (!songs.length) return null;
-    const candidates = songs.length > 1
-      ? songs.filter(song => song.id !== excludedId)
-      : songs;
+    const excludedSet = new Set((Array.isArray(excludedIds) ? excludedIds : [excludedIds]).filter(Boolean));
+    let candidates = songs.filter(song => !excludedSet.has(song.id));
+    if (!candidates.length && songs.length === 1) {
+      candidates = songs;
+    }
     if (!candidates.length) return null;
     return candidates[Math.floor(Math.random() * candidates.length)];
   },
@@ -492,7 +494,12 @@ window.Jukebox = {
       return Jukebox.findSongById(Jukebox.State.randomQueue[Jukebox.State.randomQueueIndex]);
     }
 
-    const nextRandomSong = Jukebox.pickRandomSongExcluding(currentSongId);
+    const staleCurrentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+    const excludedIds = [currentSongId];
+    if (staleCurrentSongId && staleCurrentSongId !== currentSongId) {
+      excludedIds.push(staleCurrentSongId);
+    }
+    const nextRandomSong = Jukebox.pickRandomSongExcluding(excludedIds);
     if (!nextRandomSong) return null;
     Jukebox.State.randomQueue.push(nextRandomSong.id);
     Jukebox.State.randomQueueIndex = Jukebox.State.randomQueue.length - 1;

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -7065,6 +7065,9 @@ window.Jukebox = {
         return;
       }
       if (Jukebox.State.isPlaying) {
+        if (options.fromQueue === true) {
+          return;
+        }
         console.log('[Jukebox] 停止当前播放的歌曲:', song.name);
         Jukebox.stopPlayback();
         return;

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -231,7 +231,8 @@ window.Jukebox = {
     const previousMode = Jukebox.State.playbackMode;
     Jukebox.State.playbackMode = nextMode;
     if (nextMode === 'random' && previousMode !== 'random') {
-      const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+      const currentSongId = (Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null)
+        || Jukebox.getCurrentRandomQueueSongId();
       if (Jukebox.State.randomQueueExitSongId === currentSongId && Jukebox.State.randomQueue.length) {
         Jukebox.State.randomQueueExitSongId = null;
         Jukebox.ensureRandomQueueAnchor(currentSongId);
@@ -239,9 +240,12 @@ window.Jukebox = {
         Jukebox.resetRandomQueue(currentSongId);
       }
     } else if (previousMode === 'random' && nextMode !== 'random') {
-      const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
-      if (currentSongId && (Jukebox.State.isPlaying || Jukebox.State.isPaused) && Jukebox.State.randomQueue.length) {
-        Jukebox.State.randomQueueExitSongId = currentSongId;
+      const activeSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+      const queuedSongId = !activeSongId ? Jukebox.getCurrentRandomQueueSongId() : null;
+      if (activeSongId && (Jukebox.State.isPlaying || Jukebox.State.isPaused) && Jukebox.State.randomQueue.length) {
+        Jukebox.State.randomQueueExitSongId = activeSongId;
+      } else if (queuedSongId && Jukebox.State.randomQueue.length) {
+        Jukebox.State.randomQueueExitSongId = queuedSongId;
       } else {
         Jukebox.clearRandomQueue();
       }
@@ -355,6 +359,12 @@ window.Jukebox = {
     return (Jukebox.State.songs || []).find(song => song.id === songId) || null;
   },
 
+  getCurrentRandomQueueSongId: function() {
+    const queue = Jukebox.State.randomQueue || [];
+    const queuedSongId = queue[Jukebox.State.randomQueueIndex];
+    return Jukebox.findSongById(queuedSongId) ? queuedSongId : null;
+  },
+
   clearRandomQueue: function() {
     Jukebox.State.randomQueue = [];
     Jukebox.State.randomQueueIndex = -1;
@@ -435,10 +445,8 @@ window.Jukebox = {
       return;
     }
 
-    const queue = Jukebox.State.randomQueue || [];
-    const queuedSongId = queue[Jukebox.State.randomQueueIndex];
     const currentSongId = (Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null)
-      || (Jukebox.findSongById(queuedSongId) ? queuedSongId : null)
+      || Jukebox.getCurrentRandomQueueSongId()
       || null;
     if (!currentSongId || !Jukebox.pruneRandomQueue(currentSongId)) {
       Jukebox.clearRandomQueue();

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -463,9 +463,11 @@ window.Jukebox = {
       return null;
     }
 
+    const queue = Jukebox.State.randomQueue || [];
+    const queuedSongId = queue[Jukebox.State.randomQueueIndex];
     const currentSongId = anchorSongId
+      || (Jukebox.findSongById(queuedSongId) ? queuedSongId : null)
       || (Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null)
-      || (Jukebox.State.randomQueue || [])[Jukebox.State.randomQueueIndex]
       || null;
 
     if (currentSongId) {

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -107,6 +107,9 @@ window.Jukebox = {
     progressTimer: null,
     isSeeking: false,
     playbackMode: 'sequence',
+    randomQueue: [],
+    randomQueueIndex: -1,
+    randomQueueExitSongId: null,
     songSortUnlocked: false,
     draggedSongId: null,
     configRevision: null,
@@ -225,7 +228,24 @@ window.Jukebox = {
 
   setPlaybackMode: function(mode) {
     const nextMode = Jukebox.getPlaybackModeOrder().includes(mode) ? mode : 'sequence';
+    const previousMode = Jukebox.State.playbackMode;
     Jukebox.State.playbackMode = nextMode;
+    if (nextMode === 'random' && previousMode !== 'random') {
+      const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+      if (Jukebox.State.randomQueueExitSongId === currentSongId && Jukebox.State.randomQueue.length) {
+        Jukebox.State.randomQueueExitSongId = null;
+        Jukebox.ensureRandomQueueAnchor(currentSongId);
+      } else {
+        Jukebox.resetRandomQueue(currentSongId);
+      }
+    } else if (previousMode === 'random' && nextMode !== 'random') {
+      const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+      if (currentSongId && (Jukebox.State.isPlaying || Jukebox.State.isPaused) && Jukebox.State.randomQueue.length) {
+        Jukebox.State.randomQueueExitSongId = currentSongId;
+      } else {
+        Jukebox.clearRandomQueue();
+      }
+    }
     Jukebox.setStoredJson('playbackMode', nextMode);
     Jukebox.updatePlaybackModeButtons();
   },
@@ -330,10 +350,127 @@ window.Jukebox = {
     return songs[nextIndex];
   },
 
+  findSongById: function(songId) {
+    if (!songId) return null;
+    return (Jukebox.State.songs || []).find(song => song.id === songId) || null;
+  },
+
+  clearRandomQueue: function() {
+    Jukebox.State.randomQueue = [];
+    Jukebox.State.randomQueueIndex = -1;
+    Jukebox.State.randomQueueExitSongId = null;
+  },
+
+  resetRandomQueue: function(anchorSongId) {
+    const anchorSong = Jukebox.findSongById(anchorSongId);
+    if (anchorSong) {
+      Jukebox.State.randomQueue = [anchorSong.id];
+      Jukebox.State.randomQueueIndex = 0;
+      Jukebox.State.randomQueueExitSongId = null;
+      return;
+    }
+    Jukebox.clearRandomQueue();
+  },
+
+  syncRandomQueueWithSongs: function() {
+    if (Jukebox.State.playbackMode !== 'random') {
+      const pendingSongId = Jukebox.State.randomQueueExitSongId;
+      const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+      if (!pendingSongId || pendingSongId !== currentSongId) {
+        Jukebox.clearRandomQueue();
+      }
+      return;
+    }
+
+    const validIds = new Set((Jukebox.State.songs || []).map(song => song.id));
+    Jukebox.State.randomQueue = (Jukebox.State.randomQueue || []).filter(songId => validIds.has(songId));
+
+    const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+    if (!currentSongId || !validIds.has(currentSongId)) {
+      Jukebox.clearRandomQueue();
+      return;
+    }
+
+    Jukebox.ensureRandomQueueAnchor(currentSongId);
+  },
+
+  ensureRandomQueueAnchor: function(songId) {
+    if (!Jukebox.findSongById(songId)) {
+      Jukebox.clearRandomQueue();
+      return;
+    }
+
+    const queue = Jukebox.State.randomQueue || [];
+    const index = Jukebox.State.randomQueueIndex;
+    if (!queue.length || index < 0 || index >= queue.length || queue[index] !== songId) {
+      Jukebox.resetRandomQueue(songId);
+    }
+  },
+
+  expireRandomQueueIfPendingSongEnded: function(endedSongId) {
+    if (Jukebox.State.playbackMode === 'random') return;
+    if (Jukebox.State.randomQueueExitSongId && Jukebox.State.randomQueueExitSongId === endedSongId) {
+      Jukebox.clearRandomQueue();
+    }
+  },
+
+  pickRandomSongExcluding: function(excludedId) {
+    const songs = Jukebox.State.songs || [];
+    if (!songs.length) return null;
+    const candidates = songs.length > 1
+      ? songs.filter(song => song.id !== excludedId)
+      : songs;
+    if (!candidates.length) return null;
+    return candidates[Math.floor(Math.random() * candidates.length)];
+  },
+
+  getRandomAdjacentSong: function(direction, anchorSongId) {
+    const songs = Jukebox.State.songs || [];
+    if (!songs.length) {
+      Jukebox.clearRandomQueue();
+      return null;
+    }
+
+    const currentSongId = anchorSongId
+      || (Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null)
+      || (Jukebox.State.randomQueue || [])[Jukebox.State.randomQueueIndex]
+      || null;
+
+    if (currentSongId) {
+      Jukebox.ensureRandomQueueAnchor(currentSongId);
+    } else if (!Jukebox.State.randomQueue.length) {
+      if (direction < 0) return null;
+      const firstRandomSong = Jukebox.pickRandomSongExcluding(null);
+      if (!firstRandomSong) return null;
+      Jukebox.State.randomQueue = [firstRandomSong.id];
+      Jukebox.State.randomQueueIndex = 0;
+      return firstRandomSong;
+    }
+
+    if (direction < 0) {
+      if (Jukebox.State.randomQueueIndex <= 0) return null;
+      Jukebox.State.randomQueueIndex -= 1;
+      return Jukebox.findSongById(Jukebox.State.randomQueue[Jukebox.State.randomQueueIndex]);
+    }
+
+    if (Jukebox.State.randomQueueIndex < Jukebox.State.randomQueue.length - 1) {
+      Jukebox.State.randomQueueIndex += 1;
+      return Jukebox.findSongById(Jukebox.State.randomQueue[Jukebox.State.randomQueueIndex]);
+    }
+
+    const nextRandomSong = Jukebox.pickRandomSongExcluding(currentSongId);
+    if (!nextRandomSong) return null;
+    Jukebox.State.randomQueue.push(nextRandomSong.id);
+    Jukebox.State.randomQueueIndex = Jukebox.State.randomQueue.length - 1;
+    return nextRandomSong;
+  },
+
   playAdjacentSong: function(direction) {
-    const nextSong = Jukebox.getManualAdjacentSong(direction);
+    const nextSong = Jukebox.State.playbackMode === 'random'
+      ? Jukebox.getRandomAdjacentSong(direction)
+      : Jukebox.getManualAdjacentSong(direction);
     if (nextSong) {
-      Jukebox.playSong(nextSong.id);
+      Jukebox.playSong(nextSong.id, { fromQueue: Jukebox.State.playbackMode === 'random' });
     }
   },
 
@@ -6645,6 +6782,7 @@ window.Jukebox = {
       
       console.log('[Jukebox]', window.t('Jukebox.songsLoaded', '歌曲列表已加载'), Jukebox.State.songs.length, '首歌曲');
       
+      Jukebox.syncRandomQueueWithSongs();
       Jukebox.renderList();
       
     } catch (error) {
@@ -6824,22 +6962,22 @@ window.Jukebox = {
     if (!endedSong || songs.length === 0) return null;
 
     if (Jukebox.State.playbackMode === 'none') {
+      Jukebox.expireRandomQueueIfPendingSongEnded(endedSong.id);
       return null;
     }
 
     if (Jukebox.State.playbackMode === 'single') {
+      Jukebox.expireRandomQueueIfPendingSongEnded(endedSong.id);
       return songs.find(song => song.id === endedSong.id) || null;
     }
 
     if (Jukebox.State.playbackMode === 'random') {
-      const candidates = songs.length > 1
-        ? songs.filter(song => song.id !== endedSong.id)
-        : songs;
-      if (!candidates.length) return null;
-      return candidates[Math.floor(Math.random() * candidates.length)];
+      Jukebox.ensureRandomQueueAnchor(endedSong.id);
+      return Jukebox.getRandomAdjacentSong(1, endedSong.id);
     }
 
     const currentIndex = songs.findIndex(song => song.id === endedSong.id);
+    Jukebox.expireRandomQueueIfPendingSongEnded(endedSong.id);
     if (currentIndex >= 0 && currentIndex < songs.length - 1) {
       return songs[currentIndex + 1];
     }
@@ -6867,12 +7005,12 @@ window.Jukebox = {
     if (nextSong) {
       setTimeout(() => {
         if (!Jukebox.State.isOpen && !window.__NEKO_JUKEBOX_STANDALONE__) return;
-        Jukebox.playSong(nextSong.id);
+        Jukebox.playSong(nextSong.id, { fromQueue: Jukebox.State.playbackMode === 'random' });
       }, 0);
     }
   },
   
-  playSong: async function(songId) {
+  playSong: async function(songId, options = {}) {
     const song = Jukebox.State.songs.find(s => s.id === songId);
     if (!song) {
       console.error('[Jukebox]', window.t('Jukebox.notFound', '找不到歌曲'), songId);
@@ -6892,6 +7030,16 @@ window.Jukebox = {
       }
     }
     
+    if (Jukebox.State.playbackMode === 'random') {
+      if (options.fromQueue === true) {
+        Jukebox.ensureRandomQueueAnchor(songId);
+      } else {
+        Jukebox.resetRandomQueue(songId);
+      }
+    } else if (Jukebox.State.randomQueueExitSongId && Jukebox.State.randomQueueExitSongId !== songId) {
+      Jukebox.clearRandomQueue();
+    }
+
     console.log('[Jukebox] 播放歌曲:', song.name);
     
     Jukebox.stopPlayback();
@@ -7252,6 +7400,9 @@ window.Jukebox = {
     Jukebox.State.isPlaying = false;
     Jukebox.State.isPaused = false;
     Jukebox.State.isVMDPlaying = false;
+    if (Jukebox.State.playbackMode !== 'random') {
+      Jukebox.clearRandomQueue();
+    }
 
     Jukebox.updateStoppedStatus();
   },

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -436,7 +436,8 @@ window.Jukebox = {
   syncRandomQueueWithSongs: function() {
     if (Jukebox.State.playbackMode !== 'random') {
       const pendingSongId = Jukebox.State.randomQueueExitSongId;
-      const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+      const currentSongId = (Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null)
+        || Jukebox.getCurrentRandomQueueSongId();
       if (!pendingSongId || pendingSongId !== currentSongId) {
         Jukebox.clearRandomQueue();
       } else {

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -7117,9 +7117,11 @@ window.Jukebox = {
 
     console.log('[Jukebox] 播放歌曲:', song.name);
     
-    const preserveRandomQueue = Jukebox.State.playbackMode !== 'random'
-      && Jukebox.State.randomQueueExitSongId
-      && Jukebox.State.randomQueueExitSongId === songId;
+    const preserveRandomQueue = Jukebox.State.playbackMode === 'random'
+      || (
+        Jukebox.State.randomQueueExitSongId
+        && Jukebox.State.randomQueueExitSongId === songId
+      );
     Jukebox.stopPlayback({ preserveRandomQueue });
     
     const requestId = ++Jukebox.State.playRequestId;
@@ -7479,7 +7481,7 @@ window.Jukebox = {
     Jukebox.State.isPlaying = false;
     Jukebox.State.isPaused = false;
     Jukebox.State.isVMDPlaying = false;
-    if (Jukebox.State.playbackMode !== 'random' && !preserveRandomQueue) {
+    if (!preserveRandomQueue) {
       Jukebox.clearRandomQueue();
     }
 

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -379,7 +379,17 @@ window.Jukebox = {
       return false;
     }
 
-    const filteredQueue = (Jukebox.State.randomQueue || []).filter(songId => validIds.has(songId));
+    const queue = Jukebox.State.randomQueue || [];
+    const currentQueueIndex = Jukebox.State.randomQueueIndex;
+    const filteredQueue = [];
+    let retainedQueueIndex = -1;
+    queue.forEach((songId, queueIndex) => {
+      if (!validIds.has(songId)) return;
+      if (queueIndex === currentQueueIndex) {
+        retainedQueueIndex = filteredQueue.length;
+      }
+      filteredQueue.push(songId);
+    });
     Jukebox.State.randomQueue = filteredQueue;
 
     if (!anchorSongId) {
@@ -387,10 +397,18 @@ window.Jukebox = {
         Jukebox.State.randomQueueIndex = -1;
         return false;
       }
-      const index = Jukebox.State.randomQueueIndex;
-      if (index < 0 || index >= filteredQueue.length) {
+      if (retainedQueueIndex !== -1) {
+        Jukebox.State.randomQueueIndex = retainedQueueIndex;
+      } else if (currentQueueIndex < 0 || currentQueueIndex >= filteredQueue.length) {
         Jukebox.State.randomQueueIndex = filteredQueue.length - 1;
+      } else {
+        Jukebox.State.randomQueueIndex = currentQueueIndex;
       }
+      return true;
+    }
+
+    if (retainedQueueIndex !== -1 && filteredQueue[retainedQueueIndex] === anchorSongId) {
+      Jukebox.State.randomQueueIndex = retainedQueueIndex;
       return true;
     }
 

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -372,21 +372,53 @@ window.Jukebox = {
     Jukebox.clearRandomQueue();
   },
 
+  pruneRandomQueue: function(anchorSongId) {
+    const validIds = new Set((Jukebox.State.songs || []).map(song => song.id));
+    if (anchorSongId && !validIds.has(anchorSongId)) {
+      Jukebox.clearRandomQueue();
+      return false;
+    }
+
+    const filteredQueue = (Jukebox.State.randomQueue || []).filter(songId => validIds.has(songId));
+    Jukebox.State.randomQueue = filteredQueue;
+
+    if (!anchorSongId) {
+      if (!filteredQueue.length) {
+        Jukebox.State.randomQueueIndex = -1;
+        return false;
+      }
+      const index = Jukebox.State.randomQueueIndex;
+      if (index < 0 || index >= filteredQueue.length) {
+        Jukebox.State.randomQueueIndex = filteredQueue.length - 1;
+      }
+      return true;
+    }
+
+    const anchorIndex = filteredQueue.lastIndexOf(anchorSongId);
+    if (anchorIndex === -1) {
+      Jukebox.State.randomQueue = [anchorSongId];
+      Jukebox.State.randomQueueIndex = 0;
+      return true;
+    }
+
+    Jukebox.State.randomQueueIndex = anchorIndex;
+    return true;
+  },
+
   syncRandomQueueWithSongs: function() {
     if (Jukebox.State.playbackMode !== 'random') {
       const pendingSongId = Jukebox.State.randomQueueExitSongId;
       const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
       if (!pendingSongId || pendingSongId !== currentSongId) {
         Jukebox.clearRandomQueue();
+      } else {
+        Jukebox.pruneRandomQueue(pendingSongId);
       }
       return;
     }
 
-    const validIds = new Set((Jukebox.State.songs || []).map(song => song.id));
-    Jukebox.State.randomQueue = (Jukebox.State.randomQueue || []).filter(songId => validIds.has(songId));
-
     const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
-    if (!currentSongId || !validIds.has(currentSongId)) {
+    if (!currentSongId || !Jukebox.pruneRandomQueue(currentSongId)) {
       Jukebox.clearRandomQueue();
       return;
     }

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -435,7 +435,11 @@ window.Jukebox = {
       return;
     }
 
-    const currentSongId = Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null;
+    const queue = Jukebox.State.randomQueue || [];
+    const queuedSongId = queue[Jukebox.State.randomQueueIndex];
+    const currentSongId = (Jukebox.State.currentSong ? Jukebox.State.currentSong.id : null)
+      || (Jukebox.findSongById(queuedSongId) ? queuedSongId : null)
+      || null;
     if (!currentSongId || !Jukebox.pruneRandomQueue(currentSongId)) {
       Jukebox.clearRandomQueue();
       return;

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -7117,7 +7117,10 @@ window.Jukebox = {
 
     console.log('[Jukebox] 播放歌曲:', song.name);
     
-    Jukebox.stopPlayback();
+    const preserveRandomQueue = Jukebox.State.playbackMode !== 'random'
+      && Jukebox.State.randomQueueExitSongId
+      && Jukebox.State.randomQueueExitSongId === songId;
+    Jukebox.stopPlayback({ preserveRandomQueue });
     
     const requestId = ++Jukebox.State.playRequestId;
     
@@ -7467,7 +7470,8 @@ window.Jukebox = {
     Jukebox.updateSpeakerIcon(volume === 0);
   },
   
-  stopPlayback: function() {
+  stopPlayback: function(options = {}) {
+    const preserveRandomQueue = options.preserveRandomQueue === true;
     Jukebox.stopAudio();
     Jukebox.stopVMD();
 
@@ -7475,7 +7479,7 @@ window.Jukebox = {
     Jukebox.State.isPlaying = false;
     Jukebox.State.isPaused = false;
     Jukebox.State.isVMDPlaying = false;
-    if (Jukebox.State.playbackMode !== 'random') {
+    if (Jukebox.State.playbackMode !== 'random' && !preserveRandomQueue) {
       Jukebox.clearRandomQueue();
     }
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -578,6 +578,42 @@ def test_jukebox_random_exit_is_delayed_until_current_song_ends(mock_page: Page)
 
 
 @pytest.mark.frontend
+def test_jukebox_random_exit_prunes_removed_songs_while_preserving_anchor(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.State.playbackMode = 'sequence';
+          J.State.currentSong = J.State.songs[1];
+          J.State.randomQueue = ['song1', 'song2', 'song3'];
+          J.State.randomQueueIndex = 1;
+          J.State.randomQueueExitSongId = 'song2';
+
+          J.State.songs = [
+            { id: 'song2', name: 'Song 2', artist: 'B' },
+            { id: 'song4', name: 'Song 4', artist: 'D' }
+          ];
+          J.syncRandomQueueWithSongs();
+
+          return {
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "queue": ["song2"],
+        "index": 0,
+        "pendingExit": "song2",
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_next_appends_only_at_queue_end(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -783,6 +783,91 @@ def test_jukebox_random_exit_pending_song_start_preserves_queue(mock_page: Page)
 
 
 @pytest.mark.frontend
+def test_jukebox_random_explicit_stop_clears_queue(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.stopAudio = () => {};
+          J.stopVMD = () => {};
+          J.updateStoppedStatus = () => {};
+
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[1];
+          J.State.isPlaying = true;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+          J.State.randomQueueExitSongId = null;
+
+          J.stopPlayback();
+
+          return {
+            currentSong: J.State.currentSong && J.State.currentSong.id,
+            isPlaying: J.State.isPlaying,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "currentSong": None,
+        "isPlaying": False,
+        "queue": [],
+        "index": -1,
+        "pendingExit": None,
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_random_song_start_preserves_reset_queue(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const J = window.Jukebox;
+          J.stopAudio = () => {};
+          J.stopVMD = () => {};
+          J.updateStoppedStatus = () => {};
+          J.updatePlayingStatus = () => {};
+          J.updateCalibrationDisplay = () => {};
+          J.playAudio = async () => {};
+          J.getActionForModel = () => null;
+
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[0];
+          J.State.isPlaying = true;
+          J.State.randomQueue = ['song1', 'song3'];
+          J.State.randomQueueIndex = 1;
+
+          await J.playSong('song2');
+
+          return {
+            currentSong: J.State.currentSong && J.State.currentSong.id,
+            isPlaying: J.State.isPlaying,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "currentSong": "song2",
+        "isPlaying": True,
+        "queue": ["song2"],
+        "index": 0,
+        "pendingExit": None,
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_sync_preserves_current_duplicate_queue_entry(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -255,6 +255,8 @@ def test_jukebox_next_song_respects_sequence_single_and_random(mock_page: Page):
           Math.random = () => 0;
           J.State.playbackMode = 'random';
           const randomNext = J.getNextSongToPlay(ended)?.id;
+          const randomQueue = [...J.State.randomQueue];
+          const randomQueueIndex = J.State.randomQueueIndex;
           Math.random = originalRandom;
 
           return {
@@ -263,7 +265,9 @@ def test_jukebox_next_song_respects_sequence_single_and_random(mock_page: Page):
             noneNext,
             singleNext,
             removedSingleNext,
-            randomNext
+            randomNext,
+            randomQueue,
+            randomQueueIndex
           };
         }
         """
@@ -276,6 +280,8 @@ def test_jukebox_next_song_respects_sequence_single_and_random(mock_page: Page):
         "singleNext": "song1",
         "removedSingleNext": None,
         "randomNext": "song2",
+        "randomQueue": ["song1", "song2"],
+        "randomQueueIndex": 1,
     }
 
 
@@ -421,7 +427,7 @@ def test_jukebox_global_transport_controls_follow_sorted_playlist(mock_page: Pag
 
 
 @pytest.mark.frontend
-def test_jukebox_manual_previous_next_ignore_playback_mode(mock_page: Page):
+def test_jukebox_non_random_manual_previous_next_follow_sorted_playlist(mock_page: Page):
     setup_jukebox_page(mock_page)
 
     result = mock_page.evaluate(
@@ -436,7 +442,7 @@ def test_jukebox_manual_previous_next_ignore_playback_mode(mock_page: Page):
 
           J.State.songs = [J.State.songs[2], J.State.songs[0], J.State.songs[1]];
           const song1 = J.State.songs[1];
-          for (const mode of ['random', 'none', 'single']) {
+          for (const mode of ['none', 'single', 'sequence']) {
             J.State.playbackMode = mode;
             J.State.currentSong = song1;
             J.playAdjacentSong(1);
@@ -453,12 +459,311 @@ def test_jukebox_manual_previous_next_ignore_playback_mode(mock_page: Page):
     )
 
     assert result == {
-        "randomNext": "song2",
-        "randomPrevious": "song3",
         "noneNext": "song2",
         "nonePrevious": "song3",
         "singleNext": "song2",
         "singlePrevious": "song3",
+        "sequenceNext": "song2",
+        "sequencePrevious": "song3",
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_random_mode_starts_queue_from_current_song(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.State.currentSong = J.State.songs[1];
+          J.setPlaybackMode('random');
+          const entered = {
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          J.setPlaybackMode('sequence');
+          const exited = {
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          J.State.currentSong = J.State.songs[2];
+          J.setPlaybackMode('random');
+          const reentered = {
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          return { entered, exited, reentered };
+        }
+        """
+    )
+
+    assert result == {
+        "entered": {"queue": ["song2"], "index": 0, "pendingExit": None},
+        "exited": {"queue": [], "index": -1, "pendingExit": None},
+        "reentered": {"queue": ["song3"], "index": 0, "pendingExit": None},
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_random_exit_is_delayed_until_current_song_ends(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[1];
+          J.State.isPlaying = true;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+
+          J.setPlaybackMode('sequence');
+          const afterExit = {
+            mode: J.State.playbackMode,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          J.setPlaybackMode('random');
+          const afterReturn = {
+            mode: J.State.playbackMode,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          J.setPlaybackMode('sequence');
+          const nextSong = J.getNextSongToPlay(J.State.songs[1])?.id;
+          const afterEndedOutsideRandom = {
+            nextSong,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          return { afterExit, afterReturn, afterEndedOutsideRandom };
+        }
+        """
+    )
+
+    assert result == {
+        "afterExit": {
+            "mode": "sequence",
+            "queue": ["song1", "song2"],
+            "index": 1,
+            "pendingExit": "song2",
+        },
+        "afterReturn": {
+            "mode": "random",
+            "queue": ["song1", "song2"],
+            "index": 1,
+            "pendingExit": None,
+        },
+        "afterEndedOutsideRandom": {
+            "nextSong": "song3",
+            "queue": [],
+            "index": -1,
+            "pendingExit": None,
+        },
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_random_next_appends_only_at_queue_end(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          const played = [];
+          let randomCalls = 0;
+          const originalRandom = Math.random;
+          Math.random = () => {
+            randomCalls += 1;
+            return 0;
+          };
+          J.playSong = (songId, options = {}) => {
+            played.push({ songId, fromQueue: options.fromQueue === true });
+            J.State.currentSong = J.State.songs.find((song) => song.id === songId) || null;
+          };
+
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[0];
+          J.State.randomQueue = ['song1'];
+          J.State.randomQueueIndex = 0;
+          J.playAdjacentSong(1);
+          const appended = {
+            played: [...played],
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            randomCalls
+          };
+
+          J.State.currentSong = J.State.songs[1];
+          J.State.randomQueue = ['song1', 'song2', 'song3'];
+          J.State.randomQueueIndex = 1;
+          J.playAdjacentSong(1);
+          Math.random = originalRandom;
+
+          return {
+            appended,
+            finalPlayed: played,
+            finalQueue: J.State.randomQueue,
+            finalIndex: J.State.randomQueueIndex,
+            finalRandomCalls: randomCalls
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "appended": {
+            "played": [{"songId": "song2", "fromQueue": True}],
+            "queue": ["song1", "song2"],
+            "index": 1,
+            "randomCalls": 1,
+        },
+        "finalPlayed": [
+            {"songId": "song2", "fromQueue": True},
+            {"songId": "song3", "fromQueue": True},
+        ],
+        "finalQueue": ["song1", "song2", "song3"],
+        "finalIndex": 2,
+        "finalRandomCalls": 1,
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_random_previous_uses_accumulated_queue(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          const played = [];
+          J.playSong = (songId, options = {}) => {
+            played.push({ songId, fromQueue: options.fromQueue === true });
+            J.State.currentSong = J.State.songs.find((song) => song.id === songId) || null;
+          };
+
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[1];
+          J.State.randomQueue = ['song1', 'song2', 'song3'];
+          J.State.randomQueueIndex = 1;
+          J.playAdjacentSong(-1);
+          J.playAdjacentSong(-1);
+
+          return {
+            played,
+            queue: J.State.randomQueue,
+            index: J.State.randomQueueIndex
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "played": [{"songId": "song1", "fromQueue": True}],
+        "queue": ["song1", "song2", "song3"],
+        "index": 0,
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_random_audio_end_advances_queue_and_skips_idle_restore(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const J = window.Jukebox;
+          const stopArgs = [];
+          const played = [];
+          const originalRandom = Math.random;
+          Math.random = () => 0;
+          J.stopVMD = (skipIdleRestore) => {
+            stopArgs.push(skipIdleRestore);
+          };
+          J.updateStoppedStatus = () => {};
+          J.playSong = async (songId, options = {}) => {
+            played.push({ songId, fromQueue: options.fromQueue === true });
+            J.State.currentSong = J.State.songs.find((song) => song.id === songId) || null;
+          };
+          J.getModelType = () => 'mmd';
+          J.State.isOpen = true;
+          J.State.playbackMode = 'random';
+          J.State.songs[1].boundActions = [{ id: 'action-song2', name: 'Action', format: 'vmd' }];
+          J.State.songs[1].defaultAction = 'action-song2';
+          J.State.currentSong = J.State.songs[0];
+          J.State.randomQueue = ['song1'];
+          J.State.randomQueueIndex = 0;
+
+          J.handleAudioEnded({ options: { loop: 'none' } });
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          Math.random = originalRandom;
+
+          return {
+            stopArgs,
+            played,
+            queue: J.State.randomQueue,
+            index: J.State.randomQueueIndex
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "stopArgs": [True],
+        "played": [{"songId": "song2", "fromQueue": True}],
+        "queue": ["song1", "song2"],
+        "index": 1,
+    }
+
+
+@pytest.mark.frontend
+def test_jukebox_random_user_selected_song_resets_queue_anchor(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const J = window.Jukebox;
+          J.stopPlayback = () => {};
+          J.playAudio = async () => {};
+          J.getActionForModel = () => null;
+          J.updatePlayingStatus = () => {};
+          J.updateCalibrationDisplay = () => {};
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[0];
+          J.State.randomQueue = ['song1', 'song3'];
+          J.State.randomQueueIndex = 1;
+
+          await J.playSong('song2');
+
+          return {
+            currentSong: J.State.currentSong && J.State.currentSong.id,
+            queue: J.State.randomQueue,
+            index: J.State.randomQueueIndex
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "currentSong": "song2",
+        "queue": ["song2"],
+        "index": 0,
     }
 
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -660,6 +660,55 @@ def test_jukebox_random_sync_preserves_current_duplicate_queue_entry(mock_page: 
 
 
 @pytest.mark.frontend
+def test_jukebox_random_sync_preserves_queued_anchor_without_current_song(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.State.playbackMode = 'random';
+          J.State.currentSong = null;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+
+          J.syncRandomQueueWithSongs();
+
+          const retainedQueuedAnchor = {
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex
+          };
+
+          J.State.currentSong = null;
+          J.State.randomQueue = ['missing-song'];
+          J.State.randomQueueIndex = 0;
+
+          J.syncRandomQueueWithSongs();
+
+          return {
+            retainedQueuedAnchor,
+            clearedMissingAnchor: {
+              queue: [...J.State.randomQueue],
+              index: J.State.randomQueueIndex
+            }
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "retainedQueuedAnchor": {
+            "queue": ["song1", "song2"],
+            "index": 1,
+        },
+        "clearedMissingAnchor": {
+            "queue": [],
+            "index": -1,
+        },
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_next_appends_only_at_queue_end(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -614,6 +614,52 @@ def test_jukebox_random_exit_prunes_removed_songs_while_preserving_anchor(mock_p
 
 
 @pytest.mark.frontend
+def test_jukebox_random_sync_preserves_current_duplicate_queue_entry(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[0];
+          J.State.randomQueue = ['song1', 'song2', 'song1', 'song3'];
+          J.State.randomQueueIndex = 0;
+
+          J.syncRandomQueueWithSongs();
+
+          const afterFirstDuplicate = {
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex
+          };
+
+          J.State.randomQueueIndex = 2;
+          J.syncRandomQueueWithSongs();
+
+          return {
+            afterFirstDuplicate,
+            afterSecondDuplicate: {
+              queue: [...J.State.randomQueue],
+              index: J.State.randomQueueIndex
+            }
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "afterFirstDuplicate": {
+            "queue": ["song1", "song2", "song1", "song3"],
+            "index": 0,
+        },
+        "afterSecondDuplicate": {
+            "queue": ["song1", "song2", "song1", "song3"],
+            "index": 2,
+        },
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_next_appends_only_at_queue_end(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -729,6 +729,49 @@ def test_jukebox_random_rapid_next_uses_advanced_queue_anchor(mock_page: Page):
 
 
 @pytest.mark.frontend
+def test_jukebox_random_rapid_previous_does_not_stop_stale_current_song(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          let stopped = false;
+          J.stopPlayback = () => {
+            stopped = true;
+            J.State.isPlaying = false;
+          };
+
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[0];
+          J.State.isPlaying = true;
+          J.State.isPaused = false;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+
+          J.playAdjacentSong(-1);
+
+          return {
+            stopped,
+            currentSong: J.State.currentSong && J.State.currentSong.id,
+            isPlaying: J.State.isPlaying,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "stopped": False,
+        "currentSong": "song1",
+        "isPlaying": True,
+        "queue": ["song1", "song2"],
+        "index": 0,
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_previous_uses_accumulated_queue(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -739,6 +739,50 @@ def test_jukebox_random_exit_sync_preserves_queued_pending_anchor(mock_page: Pag
 
 
 @pytest.mark.frontend
+def test_jukebox_random_exit_pending_song_start_preserves_queue(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+          const J = window.Jukebox;
+          J.stopAudio = () => {};
+          J.stopVMD = () => {};
+          J.updateStoppedStatus = () => {};
+          J.updatePlayingStatus = () => {};
+          J.updateCalibrationDisplay = () => {};
+          J.playAudio = async () => {};
+          J.getActionForModel = () => null;
+
+          J.State.playbackMode = 'sequence';
+          J.State.currentSong = null;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+          J.State.randomQueueExitSongId = 'song2';
+
+          await J.playSong('song2');
+
+          return {
+            currentSong: J.State.currentSong && J.State.currentSong.id,
+            isPlaying: J.State.isPlaying,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "currentSong": "song2",
+        "isPlaying": True,
+        "queue": ["song1", "song2"],
+        "index": 1,
+        "pendingExit": "song2",
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_sync_preserves_current_duplicate_queue_entry(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -684,6 +684,61 @@ def test_jukebox_random_exit_prunes_removed_songs_while_preserving_anchor(mock_p
 
 
 @pytest.mark.frontend
+def test_jukebox_random_exit_sync_preserves_queued_pending_anchor(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.State.playbackMode = 'sequence';
+          J.State.currentSong = null;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+          J.State.randomQueueExitSongId = 'song2';
+
+          J.syncRandomQueueWithSongs();
+
+          const retainedQueuedPending = {
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          J.State.currentSong = null;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+          J.State.randomQueueExitSongId = 'song1';
+
+          J.syncRandomQueueWithSongs();
+
+          return {
+            retainedQueuedPending,
+            clearedMismatchedPending: {
+              queue: [...J.State.randomQueue],
+              index: J.State.randomQueueIndex,
+              pendingExit: J.State.randomQueueExitSongId
+            }
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "retainedQueuedPending": {
+            "queue": ["song1", "song2"],
+            "index": 1,
+            "pendingExit": "song2",
+        },
+        "clearedMismatchedPending": {
+            "queue": [],
+            "index": -1,
+            "pendingExit": None,
+        },
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_sync_preserves_current_duplicate_queue_entry(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -689,7 +689,7 @@ def test_jukebox_random_rapid_next_uses_advanced_queue_anchor(mock_page: Page):
           const J = window.Jukebox;
           const played = [];
           let randomCalls = 0;
-          const randomValues = [0, 0.9];
+          const randomValues = [0, 0];
           const originalRandom = Math.random;
           Math.random = () => randomValues[randomCalls++] || 0;
           J.playSong = (songId, options = {}) => {

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -578,6 +578,76 @@ def test_jukebox_random_exit_is_delayed_until_current_song_ends(mock_page: Page)
 
 
 @pytest.mark.frontend
+def test_jukebox_random_exit_uses_queued_anchor_without_current_song(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          J.State.playbackMode = 'random';
+          J.State.currentSong = null;
+          J.State.isPlaying = false;
+          J.State.isPaused = false;
+          J.State.randomQueue = ['song1', 'song2'];
+          J.State.randomQueueIndex = 1;
+
+          J.setPlaybackMode('sequence');
+          const afterExit = {
+            mode: J.State.playbackMode,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          J.setPlaybackMode('random');
+          const afterReturn = {
+            mode: J.State.playbackMode,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            pendingExit: J.State.randomQueueExitSongId
+          };
+
+          J.State.currentSong = null;
+          J.State.randomQueue = ['missing-song'];
+          J.State.randomQueueIndex = 0;
+          J.setPlaybackMode('sequence');
+
+          return {
+            afterExit,
+            afterReturn,
+            invalidQueuedAnchor: {
+              queue: [...J.State.randomQueue],
+              index: J.State.randomQueueIndex,
+              pendingExit: J.State.randomQueueExitSongId
+            }
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "afterExit": {
+            "mode": "sequence",
+            "queue": ["song1", "song2"],
+            "index": 1,
+            "pendingExit": "song2",
+        },
+        "afterReturn": {
+            "mode": "random",
+            "queue": ["song1", "song2"],
+            "index": 1,
+            "pendingExit": None,
+        },
+        "invalidQueuedAnchor": {
+            "queue": [],
+            "index": -1,
+            "pendingExit": None,
+        },
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_exit_prunes_removed_songs_while_preserving_anchor(mock_page: Page):
     setup_jukebox_page(mock_page)
 

--- a/tests/frontend/test_jukebox_playback_modes.py
+++ b/tests/frontend/test_jukebox_playback_modes.py
@@ -680,6 +680,55 @@ def test_jukebox_random_next_appends_only_at_queue_end(mock_page: Page):
 
 
 @pytest.mark.frontend
+def test_jukebox_random_rapid_next_uses_advanced_queue_anchor(mock_page: Page):
+    setup_jukebox_page(mock_page)
+
+    result = mock_page.evaluate(
+        """
+        () => {
+          const J = window.Jukebox;
+          const played = [];
+          let randomCalls = 0;
+          const randomValues = [0, 0.9];
+          const originalRandom = Math.random;
+          Math.random = () => randomValues[randomCalls++] || 0;
+          J.playSong = (songId, options = {}) => {
+            played.push({ songId, fromQueue: options.fromQueue === true });
+          };
+
+          J.State.playbackMode = 'random';
+          J.State.currentSong = J.State.songs[0];
+          J.State.randomQueue = ['song1'];
+          J.State.randomQueueIndex = 0;
+
+          J.playAdjacentSong(1);
+          J.playAdjacentSong(1);
+          Math.random = originalRandom;
+
+          return {
+            currentSong: J.State.currentSong && J.State.currentSong.id,
+            played,
+            queue: [...J.State.randomQueue],
+            index: J.State.randomQueueIndex,
+            randomCalls
+          };
+        }
+        """
+    )
+
+    assert result == {
+        "currentSong": "song1",
+        "played": [
+            {"songId": "song2", "fromQueue": True},
+            {"songId": "song3", "fromQueue": True},
+        ],
+        "queue": ["song1", "song2", "song3"],
+        "index": 2,
+        "randomCalls": 2,
+    }
+
+
+@pytest.mark.frontend
 def test_jukebox_random_previous_uses_accumulated_queue(mock_page: Page):
     setup_jukebox_page(mock_page)
 


### PR DESCRIPTION
## Summary
- Implement random playback as an accumulated per-session queue.
- Make random previous/next and natural audio end follow the same queue progression.
- Keep the random queue alive when the user briefly switches modes during the current song, and expire it only if that song ends outside random mode.
- Reset the random queue anchor when the user selects a different song in random mode.

## Context
- This PR follows #1782, which has already been merged into `main`.
- The branch was rebased onto the latest `upstream/main`, so the diff is limited to the random queue behavior and its playback mode tests.

## Test plan
- `node --check static/Jukebox.js`
- `node --check static/jukebox-standalone.js`
- `git diff --check`
- `uv run pytest tests/frontend/test_jukebox_standalone_cursor.py tests/frontend/test_jukebox_playback_modes.py tests/frontend/test_jukebox_standalone.py tests/frontend/test_jukebox_manager_standalone.py tests/unit/test_jukebox_batch_delete.py -q`

Result: 67 passed, 1 skipped, 2 warnings. The existing `bilibili_api` atexit warning appears after pytest completion and does not fail the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入可维护的随机播放队列与退出锚点，上一/下一首基于队列邻接并区分来源。

* **改进**
  * 切入/切出随机模式时智能保留或延迟清理队列，播放结束或手动操作时做出相应保留/重置。
  * 随机队列会与已加载曲目同步、去重与修剪，手动选歌会收缩并重置锚点，播放控制更少中断。

* **测试**
  * 增加大量回归用例，涵盖队列初始化、同步、推进、快速跳转/回退、退出延迟与手动选歌行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->