### PR TITLE
fix(hosted-ui): bundle sibling modules for hosted-tsx surfaces

### DIFF
--- a/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
+++ b/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
@@ -187,7 +187,10 @@ function hasDefaultExport(source) {
 function createCheckFile(entryPath, tempDir, index, surface, tomlPath) {
   const source = readFileSync(entryPath, 'utf8')
   const stripped = source
-    .replace(/^\s*import[\s\S]*?from\s+['"](?:@neko\/plugin-ui|neko:ui)['"]\s*;?\s*/gm, '')
+    // The `(?:(?!\bfrom\b)[\s\S])*?` guard lets a multi-line UI-kit import match
+    // without spanning past an adjacent sibling import's `from` (which a plain
+    // `[\s\S]*?` would swallow when semicolons are omitted, dropping the sibling).
+    .replace(/^\s*import\s+(?:(?!\bfrom\b)[\s\S])*?from\s+['"](?:@neko\/plugin-ui|neko:ui)['"]\s*;?\s*/gm, '')
     .replace(/^\s*import\s+['"](?:@neko\/plugin-ui|neko:ui)['"]\s*;?\s*/gm, '')
   // Mirror the entry's repo-relative layout into the temp dir (forcing a .tsx
   // suffix so .jsx surfaces still parse as TS) so sibling imports like

--- a/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
+++ b/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
@@ -1,6 +1,6 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
 import ts from 'typescript'
@@ -189,8 +189,15 @@ function createCheckFile(entryPath, tempDir, index, surface, tomlPath) {
   const stripped = source
     .replace(/^\s*import[\s\S]*?from\s+['"](?:@neko\/plugin-ui|neko:ui)['"]\s*;?\s*/gm, '')
     .replace(/^\s*import\s+['"](?:@neko\/plugin-ui|neko:ui)['"]\s*;?\s*/gm, '')
-  const checkPath = join(tempDir, `surface-${index}.tsx`)
+  // Mirror the entry's repo-relative layout into the temp dir (forcing a .tsx
+  // suffix so .jsx surfaces still parse as TS) so sibling imports like
+  // `./study_surface_utils` resolve against the real repo via `rootDirs`.
+  const relativeEntryPath = relative(repoRoot, entryPath)
+  const checkPath = relativeEntryPath.startsWith('..') || isAbsolute(relativeEntryPath)
+    ? join(tempDir, `surface-${index}.tsx`)
+    : join(tempDir, relativeEntryPath.replace(/\.[jt]sx?$/, '.tsx'))
   const prefixLines = 6
+  mkdirSync(dirname(checkPath), { recursive: true })
   writeFileSync(
     checkPath,
     `/// <reference path="${hostedUiGlobalsPath}" />\nimport * as NekoUi from "@neko/plugin-ui";\nimport type { PluginSurfaceProps, HostedAction, JsonSchema, HostedApi } from "@neko/plugin-ui";\nconst { ${[
@@ -276,6 +283,7 @@ function main() {
       target: ts.ScriptTarget.ES2020,
       moduleResolution: ts.ModuleResolutionKind.Bundler,
       baseUrl: repoRoot,
+      rootDirs: [tempDir, repoRoot],
       paths: {
         '@neko/plugin-ui': ['plugin/sdk/hosted-ui'],
       },

--- a/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
+++ b/frontend/plugin-manager/scripts/check-hosted-tsx.mjs
@@ -285,13 +285,19 @@ function main() {
       baseUrl: repoRoot,
       rootDirs: [tempDir, repoRoot],
       paths: {
+        // The runtime maps both specifiers to the UI-kit global; mirror both so
+        // a real sibling helper importing either form resolves under rootDirs.
         '@neko/plugin-ui': ['plugin/sdk/hosted-ui'],
+        'neko:ui': ['plugin/sdk/hosted-ui'],
       },
       noEmit: true,
       strict: false,
       skipLibCheck: true,
       esModuleInterop: true,
       allowSyntheticDefaultImports: true,
+      // rootDirs now follows sibling imports into the real repo, which may
+      // include .js helpers; allow them so the program loads instead of erroring.
+      allowJs: true,
     })
     const diagnostics = ts.getPreEmitDiagnostics(program)
     if (warnings.length > 0) {

--- a/frontend/plugin-manager/src/api/plugins.ts
+++ b/frontend/plugin-manager/src/api/plugins.ts
@@ -224,6 +224,8 @@ export function getPluginHostedSurfaceSource(pluginId: string, params: {
   mode: string
   entry: string
   source: string
+  entry_module?: string
+  modules?: Array<{ path: string; source: string }>
   source_locale?: string
   translations?: Record<string, Record<string, string>>
   warnings?: PluginUiWarning[]

--- a/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
+++ b/frontend/plugin-manager/src/components/plugin/HostedSurfaceFrame.vue
@@ -410,6 +410,8 @@ async function loadHostedTsx() {
         surface: props.surface,
         context,
         locale: String(locale.value),
+        modules: response.modules,
+        entryModule: response.entry_module,
       })
     }
     iframeKey.value += 1

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
@@ -267,6 +267,53 @@ describe('hosted TSX document runtime', () => {
     expect(root.querySelector('.badge')?.textContent).toBe('OK')
   })
 
+  it('resolves directory-barrel imports via the index fallback', () => {
+    const { root } = executeHostedDocument(
+      `
+        import { Page } from "@neko/plugin-ui"
+        import { label } from "./widgets"
+        export default function Panel() { return <Page title={label} /> }
+      `,
+      baseContext(),
+      baseContext(),
+      {
+        entryModule: 'surfaces/main',
+        // backend ships a directory barrel under its `index` key
+        modules: [{ path: 'surfaces/widgets/index', source: `export const label = "Barrel"` }],
+      },
+    )
+
+    expect(root.textContent).toContain('Barrel')
+  })
+
+  it('supports ESM cycles where a sibling imports back from the entry', () => {
+    const { root } = executeHostedDocument(
+      `
+        import { Page, Text } from "@neko/plugin-ui"
+        import { decorate } from "./helper"
+        export const PREFIX = ">> "
+        export default function Panel() { return <Page><Text>{decorate("hi")}</Text></Page> }
+      `,
+      baseContext(),
+      baseContext(),
+      {
+        entryModule: 'surfaces/main',
+        modules: [
+          {
+            path: 'surfaces/helper',
+            // imports back into the entry module — a valid cycle
+            source: `
+              import { PREFIX } from "./main"
+              export function decorate(s) { return PREFIX + s.toUpperCase() }
+            `,
+          },
+        ],
+      },
+    )
+
+    expect(root.textContent).toContain('>> HI')
+  })
+
   it('bridges api.call and api.refresh through parent postMessage', async () => {
     const { root, messages } = executeHostedDocument(`
       export default function Panel(props) {

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
@@ -314,6 +314,35 @@ describe('hosted TSX document runtime', () => {
     expect(root.textContent).toContain('>> HI')
   })
 
+  it('keeps aliased and namespaced UI-kit imports working in bundled modules', () => {
+    const { root } = executeHostedDocument(
+      `
+        import { Page as UiPage } from "@neko/plugin-ui"
+        import { shout } from "./helper"
+        export default function Panel() { return <UiPage title={shout("ok")} /> }
+      `,
+      baseContext(),
+      baseContext(),
+      {
+        entryModule: 'surfaces/main',
+        modules: [
+          {
+            path: 'surfaces/helper',
+            // sibling import sits next to an aliased UI-kit import with no semicolons
+            source: `
+              import { text } from "./strings"
+              import * as Ui from "@neko/plugin-ui"
+              export function shout(s) { return Ui.h ? text(s).toUpperCase() : s }
+            `,
+          },
+          { path: 'surfaces/strings', source: `export function text(s) { return ">> " + s }` },
+        ],
+      },
+    )
+
+    expect(root.textContent).toContain('>> OK')
+  })
+
   it('bridges api.call and api.refresh through parent postMessage', async () => {
     const { root, messages } = executeHostedDocument(`
       export default function Panel(props) {

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.test.ts
@@ -130,7 +130,12 @@ function mcpContext(): PluginUiContext {
   }
 }
 
-function executeHostedDocument(source: string, context: PluginUiContext = baseContext(), refreshContext: PluginUiContext = context) {
+function executeHostedDocument(
+  source: string,
+  context: PluginUiContext = baseContext(),
+  refreshContext: PluginUiContext = context,
+  extra: { modules?: Array<{ path: string; source: string }>; entryModule?: string } = {},
+) {
   const messages: any[] = []
   document.documentElement.innerHTML = '<head></head><body><main id="root"></main></body>'
   window.confirm = vi.fn(() => true)
@@ -159,6 +164,8 @@ function executeHostedDocument(source: string, context: PluginUiContext = baseCo
     surface: baseSurface(),
     context,
     locale: 'en',
+    modules: extra.modules,
+    entryModule: extra.entryModule,
   })
 
   new Function(extractScript(html)).call(window)
@@ -213,6 +220,51 @@ describe('hosted TSX document runtime', () => {
 
     expect(root.textContent).toContain('Imported')
     expect(root.textContent).toContain('ok')
+  })
+
+  it('bundles sibling modules (named, default, transitive, type-only imports)', () => {
+    const { root } = executeHostedDocument(
+      `
+        import { Page, Text } from "@neko/plugin-ui"
+        import { greeting, shout } from "./utils"
+        import Badge from "./badge"
+        import type { Unused } from "./utils"
+
+        export default function Panel() {
+          const _typecheck: Unused | null = null
+          return <Page title={greeting("Neko")}><Text>{shout("hi")}</Text><Badge label="ok" /></Page>
+        }
+      `,
+      baseContext(),
+      baseContext(),
+      {
+        entryModule: 'surfaces/main',
+        modules: [
+          {
+            path: 'surfaces/utils',
+            source: `
+              export type Unused = string
+              export function greeting(name: string) { return "Hello " + name }
+              export function shout(text: string) { return text.toUpperCase() }
+            `,
+          },
+          {
+            path: 'surfaces/badge',
+            // default export plus a transitive sibling import
+            source: `
+              import { shout } from "./utils"
+              export default function Badge(props) {
+                return <span class="badge">{shout(props.label)}</span>
+              }
+            `,
+          },
+        ],
+      },
+    )
+
+    expect(root.textContent).toContain('Hello Neko')
+    expect(root.textContent).toContain('HI')
+    expect(root.querySelector('.badge')?.textContent).toBe('OK')
   })
 
   it('bridges api.call and api.refresh through parent postMessage', async () => {

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
@@ -112,13 +112,17 @@ function jsStringLiteral(value: string) {
 // specifiers against the importer and maps `@neko/plugin-ui` to the UI kit.
 function buildHostedModuleBody(options: BuildHostedTsxDocumentOptions) {
   const entryKey = options.entryModule || 'entry'
-  const defines = (options.modules || [])
+  // The entry is registered alongside its siblings so a sibling importing back
+  // into it (a valid ESM cycle) resolves to the same module record.
+  const defines = [
+    ...(options.modules || []),
+    { path: entryKey, source: options.source },
+  ]
     .map((module) => {
       const compiled = compileHostedTsxModule(module.source)
       return `__defineHostedModule(${jsStringLiteral(module.path)}, function(module, exports, require) {\n${compiled}\n});`
     })
     .join('\n')
-  const entryCompiled = compileHostedTsxModule(options.source)
 
   return `
     const __hostedModules = Object.create(null);
@@ -135,23 +139,26 @@ function buildHostedModuleBody(options: BuildHostedTsxDocumentOptions) {
       }
       return parts.join('/').replace(/\\.(tsx?|jsx?|mjs)$/, '');
     }
-    function __hostedRequire(importer, spec) {
-      if (spec === '@neko/plugin-ui' || spec === 'neko:ui') return window.NekoUiKit;
-      const key = __resolveHostedModule(importer, spec);
+    function __loadHostedModule(key) {
       const record = __hostedModules[key];
-      if (!record) throw new Error('Hosted module not found: ' + spec + ' (imported from ' + importer + ')');
+      if (!record) return null;
       if (!record.loaded) {
         record.loaded = true;
         record.factory(record.module, record.module.exports, function(s) { return __hostedRequire(key, s); });
       }
       return record.module.exports;
     }
+    function __hostedRequire(importer, spec) {
+      if (spec === '@neko/plugin-ui' || spec === 'neko:ui') return window.NekoUiKit;
+      const key = __resolveHostedModule(importer, spec);
+      // Mirror the backend's index.* fallback for directory-barrel imports.
+      if (key in __hostedModules) return __loadHostedModule(key);
+      if ((key + '/index') in __hostedModules) return __loadHostedModule(key + '/index');
+      throw new Error('Hosted module not found: ' + spec + ' (imported from ' + importer + ')');
+    }
 ${defines}
-    const __entryModule = { exports: {} };
-    (function(module, exports, require) {
-${entryCompiled}
-    })(__entryModule, __entryModule.exports, function(s) { return __hostedRequire(${jsStringLiteral(entryKey)}, s); });
-    const __Panel = (__entryModule.exports && (__entryModule.exports.default || __entryModule.exports.Panel)) || null;
+    const __entryExports = __loadHostedModule(${jsStringLiteral(entryKey)}) || {};
+    const __Panel = (__entryExports.default || __entryExports.Panel) || null;
 `
 }
 

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
@@ -2,12 +2,25 @@ import { transform } from 'sucrase'
 import type { PluginUiContext, PluginUiSurface } from '@/types/api'
 import { buildUiKitBundle } from './uiKitBundle'
 
+type HostedModule = {
+  path: string
+  source: string
+}
+
 type BuildHostedTsxDocumentOptions = {
   source: string
   pluginId: string
   surface: PluginUiSurface
   context?: PluginUiContext | null
   locale: string
+  /**
+   * Sibling modules reachable from the entry through relative imports, shipped
+   * by the backend so the bundler-less runtime can assemble them. When empty,
+   * the single-file fast path is used (unchanged behaviour).
+   */
+  modules?: HostedModule[] | null
+  /** Root-relative, extension-less key of the entry, used for import resolution. */
+  entryModule?: string | null
 }
 
 function escapeScriptContent(value: string) {
@@ -76,8 +89,76 @@ function buildPayload(options: BuildHostedTsxDocumentOptions) {
   }
 }
 
+// Module-mode compile: keep the plugin-ui imports stripped (those symbols are
+// runtime globals) and let Sucrase's `imports` transform rewrite the remaining
+// relative ESM imports/exports into CommonJS so a tiny require registry can wire
+// the sibling modules together.
+function compileHostedTsxModule(source: string) {
+  return transform(normalizeSource(source), {
+    transforms: ['typescript', 'jsx', 'imports'],
+    jsxPragma: 'h',
+    jsxFragmentPragma: 'Fragment',
+    production: true,
+  }).code
+}
+
+function jsStringLiteral(value: string) {
+  return JSON.stringify(value)
+}
+
+// Assemble the entry plus its sibling modules into one classic-script body that
+// ends with `const __Panel = ...`, matching the single-file contract. Each
+// module runs in its own CommonJS-style scope; `require` resolves relative
+// specifiers against the importer and maps `@neko/plugin-ui` to the UI kit.
+function buildHostedModuleBody(options: BuildHostedTsxDocumentOptions) {
+  const entryKey = options.entryModule || 'entry'
+  const defines = (options.modules || [])
+    .map((module) => {
+      const compiled = compileHostedTsxModule(module.source)
+      return `__defineHostedModule(${jsStringLiteral(module.path)}, function(module, exports, require) {\n${compiled}\n});`
+    })
+    .join('\n')
+  const entryCompiled = compileHostedTsxModule(options.source)
+
+  return `
+    const __hostedModules = Object.create(null);
+    function __defineHostedModule(key, factory) {
+      __hostedModules[key] = { factory: factory, module: { exports: {} }, loaded: false };
+    }
+    function __resolveHostedModule(importer, spec) {
+      const parts = importer.split('/');
+      parts.pop();
+      for (const segment of spec.split('/')) {
+        if (segment === '' || segment === '.') continue;
+        if (segment === '..') parts.pop();
+        else parts.push(segment);
+      }
+      return parts.join('/').replace(/\\.(tsx?|jsx?|mjs)$/, '');
+    }
+    function __hostedRequire(importer, spec) {
+      if (spec === '@neko/plugin-ui' || spec === 'neko:ui') return window.NekoUiKit;
+      const key = __resolveHostedModule(importer, spec);
+      const record = __hostedModules[key];
+      if (!record) throw new Error('Hosted module not found: ' + spec + ' (imported from ' + importer + ')');
+      if (!record.loaded) {
+        record.loaded = true;
+        record.factory(record.module, record.module.exports, function(s) { return __hostedRequire(key, s); });
+      }
+      return record.module.exports;
+    }
+${defines}
+    const __entryModule = { exports: {} };
+    (function(module, exports, require) {
+${entryCompiled}
+    })(__entryModule, __entryModule.exports, function(s) { return __hostedRequire(${jsStringLiteral(entryKey)}, s); });
+    const __Panel = (__entryModule.exports && (__entryModule.exports.default || __entryModule.exports.Panel)) || null;
+`
+}
+
 export function buildHostedTsxDocument(options: BuildHostedTsxDocumentOptions) {
-  const compiled = compileHostedTsx(options.source)
+  const compiled = (options.modules && options.modules.length > 0)
+    ? buildHostedModuleBody(options)
+    : compileHostedTsx(options.source)
   const payload = escapeScriptContent(JSON.stringify(buildPayload(options)))
   const locale = escapeHtmlAttribute(options.locale)
   const uiKit = buildUiKitBundle()

--- a/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
+++ b/frontend/plugin-manager/src/components/plugin/hosted/tsxRuntime.ts
@@ -89,12 +89,15 @@ function buildPayload(options: BuildHostedTsxDocumentOptions) {
   }
 }
 
-// Module-mode compile: keep the plugin-ui imports stripped (those symbols are
-// runtime globals) and let Sucrase's `imports` transform rewrite the remaining
-// relative ESM imports/exports into CommonJS so a tiny require registry can wire
-// the sibling modules together.
+// Module-mode compile: let Sucrase's `imports` transform rewrite every ESM
+// import/export (relative siblings AND `@neko/plugin-ui`) into CommonJS so the
+// require registry can wire them. We do NOT pre-strip the UI-kit import here:
+// `__hostedRequire` maps `@neko/plugin-ui` to the global UI kit, which preserves
+// aliased (`import { Text as UiText }`) and namespace (`import * as Ui`) imports
+// that a regex strip would silently drop. Regex stripping could also span a
+// semicolon-less newline and eat an adjacent sibling import.
 function compileHostedTsxModule(source: string) {
-  return transform(normalizeSource(source), {
+  return transform(source, {
     transforms: ['typescript', 'jsx', 'imports'],
     jsxPragma: 'h',
     jsxFragmentPragma: 'Fragment',

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -109,46 +109,49 @@ def _hosted_plugin_not_running_message(locale: str | None) -> str:
 _HOSTED_MODULE_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".mjs")
 _HOSTED_MODULE_MAX_COUNT = 64
 _HOSTED_MODULE_MAX_TOTAL_BYTES = 512 * 1024
-_HOSTED_COMMENT_RE = None
-# The specifier is the first quoted string on an import/export statement line
-# (`import './x'`, `import X from './x'`, `export {y} from './x'`, or a
-# multi-line import's closing `} from './x'`).
-_HOSTED_SPEC_IN_LINE_RE = None
+_HOSTED_SCAN_RES = None
 
 
 def _hosted_scan_regexes():
-    global _HOSTED_COMMENT_RE, _HOSTED_SPEC_IN_LINE_RE
-    if _HOSTED_COMMENT_RE is None:
+    global _HOSTED_SCAN_RES
+    if _HOSTED_SCAN_RES is None:
         import re
 
-        _HOSTED_COMMENT_RE = re.compile(r"/\*.*?\*/|//[^\n]*", re.DOTALL)
-        _HOSTED_SPEC_IN_LINE_RE = re.compile(r"""['"]([^'"]+)['"]""")
-    return _HOSTED_COMMENT_RE, _HOSTED_SPEC_IN_LINE_RE
+        _HOSTED_SCAN_RES = {
+            "comment": re.compile(r"/\*.*?\*/|//[^\n]*", re.DOTALL),
+            # First quoted string on a statement line is the module specifier.
+            "spec": re.compile(r"""['"]([^'"]+)['"]"""),
+            # `import` not followed by an identifier char also matches the
+            # whitespace-less compact forms `import{x}from` / `import*as x`.
+            "import": re.compile(r"^import(?![\w$])"),
+            # Re-export (`export ... from` / `} from`) — a plain value export
+            # such as `export const x = "./y"` has no `from` and is skipped.
+            "reexport": re.compile(r"""^(?:export\b|\})[^'"]*\bfrom\b"""),
+            # Type-only edges are erased by Sucrase — not runtime dependencies.
+            "type_only": re.compile(r"^(?:import|export)\s+type\b"),
+        }
+    return _HOSTED_SCAN_RES
 
 
 def _iter_hosted_import_specs(text: str):
-    """Yield the module specifier of each import/export statement in *text*.
+    """Yield the module specifier of each runtime import/export statement.
 
     Line-anchored on purpose: only lines that begin with ``import``/``export``
     (or a multi-line import's closing ``} from``) are treated as statements, so
     an import-looking fragment inside a comment or string literal (e.g.
     ``const s = "import x from './scratch'"``) is not mistaken for a real
-    dependency. Comments are stripped first. The original source is still
-    shipped verbatim; this scan only drives dependency discovery.
+    dependency. ``import type`` / ``export type`` edges are skipped because the
+    runtime (Sucrase) erases them. Comments are stripped first; the original
+    source is still shipped verbatim — this scan only drives discovery.
     """
-    comment_re, spec_re = _hosted_scan_regexes()
-    for raw_line in comment_re.sub("", text).split("\n"):
+    res = _hosted_scan_regexes()
+    for raw_line in res["comment"].sub("", text).split("\n"):
         line = raw_line.strip()
-        # `import ...` (side-effect or `from`) is always a dependency; `export`
-        # and a multi-line continuation are only dependencies when they re-export
-        # `from '...'` — a plain `export const x = "./y"` is not an import.
-        is_import = line.startswith(("import ", "import'", 'import"'))
-        is_reexport_from = (
-            line.startswith(("export ", "export{", "export*", "} ", "}")) and " from " in line
-        )
-        if not (is_import or is_reexport_from):
+        if res["type_only"].match(line):
             continue
-        match = spec_re.search(line)
+        if not (res["import"].match(line) or res["reexport"].match(line)):
+            continue
+        match = res["spec"].search(line)
         if match:
             yield match.group(1)
 
@@ -167,12 +170,13 @@ def _resolve_hosted_module_path(spec: str, importer_dir: Path, root: Path) -> Pa
 
     candidates: list[Path] = []
     if base.suffix:
-        candidates.append(base)
         # TS authors commonly write the ESM `./helper.js` form while the real
-        # source is `helper.ts`/`.tsx`; try the TS equivalents before giving up.
+        # source is `helper.ts`/`.tsx`; prefer the TS sources (matching the
+        # checker's Bundler resolution) and fall back to the literal path.
         if base.suffix in {".js", ".jsx", ".mjs"}:
             candidates.append(base.with_suffix(".ts"))
             candidates.append(base.with_suffix(".tsx"))
+        candidates.append(base)
     else:
         candidates.extend(base.with_suffix(suffix) for suffix in _HOSTED_MODULE_SUFFIXES)
         candidates.extend(base / f"index{suffix}" for suffix in _HOSTED_MODULE_SUFFIXES)
@@ -222,8 +226,16 @@ def _collect_hosted_tsx_modules_sync(entry_path: Path, root: Path) -> list[dict[
             seen.add(resolved)
             try:
                 module_text = resolved.read_text(encoding="utf-8")
-            except (OSError, UnicodeError):
-                continue
+            except (OSError, UnicodeError) as exc:
+                # A resolved helper that exists but can't be read/decoded would
+                # otherwise be silently omitted, surfacing as a runtime "Hosted
+                # module not found"; fail closed with a deterministic error.
+                raise ServerDomainError(
+                    code="PLUGIN_UI_MODULE_UNREADABLE",
+                    message=f"hosted-tsx helper module could not be read: {spec}",
+                    status_code=500,
+                    details={"error_type": type(exc).__name__},
+                ) from exc
             total_bytes += len(module_text.encode("utf-8"))
             if len(modules) >= _HOSTED_MODULE_MAX_COUNT or total_bytes > _HOSTED_MODULE_MAX_TOTAL_BYTES:
                 # Fail closed: a truncated graph would silently omit modules and

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -140,6 +140,11 @@ def _resolve_hosted_module_path(spec: str, importer_dir: Path, root: Path) -> Pa
     candidates: list[Path] = []
     if base.suffix:
         candidates.append(base)
+        # TS authors commonly write the ESM `./helper.js` form while the real
+        # source is `helper.ts`/`.tsx`; try the TS equivalents before giving up.
+        if base.suffix in {".js", ".jsx", ".mjs"}:
+            candidates.append(base.with_suffix(".ts"))
+            candidates.append(base.with_suffix(".tsx"))
     else:
         candidates.extend(base.with_suffix(suffix) for suffix in _HOSTED_MODULE_SUFFIXES)
         candidates.extend(base / f"index{suffix}" for suffix in _HOSTED_MODULE_SUFFIXES)

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -109,20 +109,41 @@ def _hosted_plugin_not_running_message(locale: str | None) -> str:
 _HOSTED_MODULE_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".mjs")
 _HOSTED_MODULE_MAX_COUNT = 64
 _HOSTED_MODULE_MAX_TOTAL_BYTES = 512 * 1024
-# Captures the specifier of `from '...'`, side-effect `import '...'`, and
-# `export ... from '...'`. Relative specifiers (starting with `.`) are followed.
-_HOSTED_IMPORT_SPEC_RE = None
+_HOSTED_COMMENT_RE = None
+# The specifier is the first quoted string on an import/export statement line
+# (`import './x'`, `import X from './x'`, `export {y} from './x'`, or a
+# multi-line import's closing `} from './x'`).
+_HOSTED_SPEC_IN_LINE_RE = None
 
 
-def _hosted_import_spec_re():
-    global _HOSTED_IMPORT_SPEC_RE
-    if _HOSTED_IMPORT_SPEC_RE is None:
+def _hosted_scan_regexes():
+    global _HOSTED_COMMENT_RE, _HOSTED_SPEC_IN_LINE_RE
+    if _HOSTED_COMMENT_RE is None:
         import re
 
-        _HOSTED_IMPORT_SPEC_RE = re.compile(
-            r"""(?:\bfrom|\bimport)\s+['"]([^'"]+)['"]""",
-        )
-    return _HOSTED_IMPORT_SPEC_RE
+        _HOSTED_COMMENT_RE = re.compile(r"/\*.*?\*/|//[^\n]*", re.DOTALL)
+        _HOSTED_SPEC_IN_LINE_RE = re.compile(r"""['"]([^'"]+)['"]""")
+    return _HOSTED_COMMENT_RE, _HOSTED_SPEC_IN_LINE_RE
+
+
+def _iter_hosted_import_specs(text: str):
+    """Yield the module specifier of each import/export statement in *text*.
+
+    Line-anchored on purpose: only lines that begin with ``import``/``export``
+    (or a multi-line import's closing ``} from``) are treated as statements, so
+    an import-looking fragment inside a comment or string literal (e.g.
+    ``const s = "import x from './scratch'"``) is not mistaken for a real
+    dependency. Comments are stripped first. The original source is still
+    shipped verbatim; this scan only drives dependency discovery.
+    """
+    comment_re, spec_re = _hosted_scan_regexes()
+    for raw_line in comment_re.sub("", text).split("\n"):
+        line = raw_line.strip()
+        if not (line.startswith(("import ", "import'", 'import"', "export ", "} from", "}from"))):
+            continue
+        match = spec_re.search(line)
+        if match:
+            yield match.group(1)
 
 
 def _resolve_hosted_module_path(spec: str, importer_dir: Path, root: Path) -> Path | None:
@@ -174,7 +195,6 @@ def _collect_hosted_tsx_modules_sync(entry_path: Path, root: Path) -> list[dict[
     path and bounded by count/byte caps. The entry itself is not included —
     the runtime already has its source.
     """
-    spec_re = _hosted_import_spec_re()
     seen: set[Path] = {entry_path.resolve()}
     queue: list[Path] = [entry_path.resolve()]
     modules: list[dict[str, str]] = []
@@ -186,7 +206,7 @@ def _collect_hosted_tsx_modules_sync(entry_path: Path, root: Path) -> list[dict[
             text = current.read_text(encoding="utf-8")
         except (OSError, UnicodeError):
             continue
-        for spec in spec_re.findall(text):
+        for spec in _iter_hosted_import_specs(text):
             if not spec.startswith("."):
                 continue
             resolved = _resolve_hosted_module_path(spec, current.parent, root)
@@ -199,13 +219,19 @@ def _collect_hosted_tsx_modules_sync(entry_path: Path, root: Path) -> list[dict[
                 continue
             total_bytes += len(module_text.encode("utf-8"))
             if len(modules) >= _HOSTED_MODULE_MAX_COUNT or total_bytes > _HOSTED_MODULE_MAX_TOTAL_BYTES:
-                logger.warning(
-                    "hosted-tsx module graph exceeded limits: entry=%s count=%d bytes=%d",
-                    entry_path,
-                    len(modules),
-                    total_bytes,
+                # Fail closed: a truncated graph would silently omit modules and
+                # surface as a runtime "Hosted module not found" with a green
+                # check, so reject the whole request with a deterministic error.
+                raise ServerDomainError(
+                    code="PLUGIN_UI_MODULE_GRAPH_TOO_LARGE",
+                    message=(
+                        "hosted-tsx surface imports too many sibling modules "
+                        f"(limit {_HOSTED_MODULE_MAX_COUNT} modules / "
+                        f"{_HOSTED_MODULE_MAX_TOTAL_BYTES} bytes)"
+                    ),
+                    status_code=400,
+                    details={"count": len(modules) + 1, "bytes": total_bytes},
                 )
-                return modules
             modules.append({"path": _module_key(resolved, root), "source": module_text})
             queue.append(resolved)
 

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -100,6 +100,113 @@ def _hosted_plugin_not_running_message(locale: str | None) -> str:
     return _PLUGIN_NOT_RUNNING_MESSAGES[key]
 
 
+# hosted-tsx surfaces may import sibling helper modules (e.g. `./memory_shared`).
+# The browser runtime fetches a single entry source and compiles it without a
+# bundler, so any such relative import would survive as a bare ESM `import` and
+# throw at render time. We resolve the relative-import graph here, inside the
+# plugin root, and ship every reachable module alongside the entry so the
+# runtime can assemble them into one document.
+_HOSTED_MODULE_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".mjs")
+_HOSTED_MODULE_MAX_COUNT = 64
+_HOSTED_MODULE_MAX_TOTAL_BYTES = 512 * 1024
+# Captures the specifier of `from '...'`, side-effect `import '...'`, and
+# `export ... from '...'`. Relative specifiers (starting with `.`) are followed.
+_HOSTED_IMPORT_SPEC_RE = None
+
+
+def _hosted_import_spec_re():
+    global _HOSTED_IMPORT_SPEC_RE
+    if _HOSTED_IMPORT_SPEC_RE is None:
+        import re
+
+        _HOSTED_IMPORT_SPEC_RE = re.compile(
+            r"""(?:\bfrom|\bimport)\s+['"]([^'"]+)['"]""",
+        )
+    return _HOSTED_IMPORT_SPEC_RE
+
+
+def _resolve_hosted_module_path(spec: str, importer_dir: Path, root: Path) -> Path | None:
+    """Resolve a relative import *spec* to a file inside the plugin *root*.
+
+    Tries the literal target, then the known source suffixes, then an
+    ``index.*`` barrel. Returns ``None`` for anything that escapes ``root``
+    or does not resolve to a regular file.
+    """
+    try:
+        base = (importer_dir / spec).resolve()
+    except OSError:
+        return None
+
+    candidates: list[Path] = []
+    if base.suffix:
+        candidates.append(base)
+    else:
+        candidates.extend(base.with_suffix(suffix) for suffix in _HOSTED_MODULE_SUFFIXES)
+        candidates.extend(base / f"index{suffix}" for suffix in _HOSTED_MODULE_SUFFIXES)
+
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(root)
+        except (OSError, ValueError):
+            continue
+        if resolved.is_file():
+            return resolved
+    return None
+
+
+def _module_key(path: Path, root: Path) -> str:
+    """Root-relative, POSIX, extension-stripped key used to address a module."""
+    rel = path.resolve().relative_to(root)
+    return rel.with_suffix("").as_posix()
+
+
+def _collect_hosted_tsx_modules_sync(entry_path: Path, root: Path) -> list[dict[str, str]]:
+    """Walk the relative-import graph from *entry_path* (exclusive).
+
+    Returns ``[{"path": <module key>, "source": <text>}, ...]`` for every
+    sibling module reachable through relative imports, deduped by resolved
+    path and bounded by count/byte caps. The entry itself is not included —
+    the runtime already has its source.
+    """
+    spec_re = _hosted_import_spec_re()
+    seen: set[Path] = {entry_path.resolve()}
+    queue: list[Path] = [entry_path.resolve()]
+    modules: list[dict[str, str]] = []
+    total_bytes = 0
+
+    while queue:
+        current = queue.pop(0)
+        try:
+            text = current.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        for spec in spec_re.findall(text):
+            if not spec.startswith("."):
+                continue
+            resolved = _resolve_hosted_module_path(spec, current.parent, root)
+            if resolved is None or resolved in seen:
+                continue
+            seen.add(resolved)
+            try:
+                module_text = resolved.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            total_bytes += len(module_text.encode("utf-8"))
+            if len(modules) >= _HOSTED_MODULE_MAX_COUNT or total_bytes > _HOSTED_MODULE_MAX_TOTAL_BYTES:
+                logger.warning(
+                    "hosted-tsx module graph exceeded limits: entry=%s count=%d bytes=%d",
+                    entry_path,
+                    len(modules),
+                    total_bytes,
+                )
+                return modules
+            modules.append({"path": _module_key(resolved, root), "source": module_text})
+            queue.append(resolved)
+
+    return modules
+
+
 def _get_plugin_meta_sync(plugin_id: str) -> dict[str, object] | None:
     with state.acquire_plugins_read_lock():
         plugin_meta_obj = state.plugins.get(plugin_id)
@@ -674,6 +781,30 @@ class PluginUiQueryService:
 
             source = await asyncio.to_thread(entry_path.read_text, encoding="utf-8")
             translations_payload = await asyncio.to_thread(_load_surface_translations_sync, entry_path)
+
+            # hosted-tsx surfaces may import sibling modules; ship the resolved
+            # relative-import graph so the bundler-less browser runtime can
+            # assemble them. markdown surfaces never import anything.
+            modules: list[dict[str, str]] = []
+            entry_module = ""
+            config_path_obj = plugin_meta.get("config_path")
+            if mode == "hosted-tsx" and isinstance(config_path_obj, str) and config_path_obj:
+                root = Path(config_path_obj).parent.resolve()
+                try:
+                    entry_module = _module_key(entry_path, root)
+                    modules = await asyncio.to_thread(
+                        _collect_hosted_tsx_modules_sync, entry_path, root
+                    )
+                except (OSError, ValueError) as exc:
+                    logger.warning(
+                        "hosted-tsx module collection failed: plugin_id=%s entry=%s err=%s",
+                        plugin_id,
+                        entry_obj,
+                        str(exc),
+                    )
+                    modules = []
+                    entry_module = ""
+
             return {
                 "plugin_id": plugin_id,
                 "kind": kind,
@@ -681,6 +812,8 @@ class PluginUiQueryService:
                 "mode": mode,
                 "entry": entry_obj,
                 "source": source,
+                "entry_module": entry_module,
+                "modules": modules,
                 "source_locale": hit_locale or translations_payload["source_locale"],
                 "translations": translations_payload["translations"],
                 "warnings": warnings,

--- a/plugin/server/application/plugins/ui_query_service.py
+++ b/plugin/server/application/plugins/ui_query_service.py
@@ -139,7 +139,14 @@ def _iter_hosted_import_specs(text: str):
     comment_re, spec_re = _hosted_scan_regexes()
     for raw_line in comment_re.sub("", text).split("\n"):
         line = raw_line.strip()
-        if not (line.startswith(("import ", "import'", 'import"', "export ", "} from", "}from"))):
+        # `import ...` (side-effect or `from`) is always a dependency; `export`
+        # and a multi-line continuation are only dependencies when they re-export
+        # `from '...'` — a plain `export const x = "./y"` is not an import.
+        is_import = line.startswith(("import ", "import'", 'import"'))
+        is_reexport_from = (
+            line.startswith(("export ", "export{", "export*", "} ", "}")) and " from " in line
+        )
+        if not (is_import or is_reexport_from):
             continue
         match = spec_re.search(line)
         if match:

--- a/plugin/tests/unit/server/test_plugin_ui_query_service.py
+++ b/plugin/tests/unit/server/test_plugin_ui_query_service.py
@@ -368,5 +368,10 @@ def test_resolve_hosted_module_path_tries_suffixes_and_index(tmp_path) -> None:
     barrel = _resolve_hosted_module_path("./widgets", surfaces, root)
     assert barrel is not None and barrel.name == "index.tsx"
 
+    # A `./helper.js` ESM specifier resolves to the real `.ts`/`.tsx` source.
+    (surfaces / "helper.ts").write_text("export const y = 2\n", encoding="utf-8")
+    js_spec = _resolve_hosted_module_path("./helper.js", surfaces, root)
+    assert js_spec is not None and js_spec.name == "helper.ts"
+
     # Escaping the plugin root is rejected.
     assert _resolve_hosted_module_path("../../secret", surfaces, root) is None

--- a/plugin/tests/unit/server/test_plugin_ui_query_service.py
+++ b/plugin/tests/unit/server/test_plugin_ui_query_service.py
@@ -355,6 +355,54 @@ def test_collect_hosted_modules_ignores_commented_and_quoted_imports(tmp_path) -
     assert modules == []
 
 
+def test_collect_hosted_modules_skips_type_only_follows_compact(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    (surfaces / "types.ts").write_text("export type Schema = string\n", encoding="utf-8")
+    (surfaces / "compact.ts").write_text("export const v = 1\n", encoding="utf-8")
+    entry = surfaces / "panel.tsx"
+    entry.write_text(
+        "import type { Schema } from './types'\n"  # type-only — erased at runtime
+        "import{v}from './compact'\n"  # whitespace-less compact import — a real dep
+        "export default function Panel() { return null }\n",
+        encoding="utf-8",
+    )
+
+    modules = _collect_hosted_tsx_modules_sync(entry, root)
+
+    assert {m["path"] for m in modules} == {"surfaces/compact"}
+
+
+def test_resolve_hosted_module_prefers_ts_over_literal_js(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    (surfaces / "helper.ts").write_text("export const x = 1\n", encoding="utf-8")
+    (surfaces / "helper.js").write_text("module.exports = {}\n", encoding="utf-8")
+
+    resolved = _resolve_hosted_module_path("./helper.js", surfaces, root)
+    assert resolved is not None and resolved.name == "helper.ts"
+
+
+def test_collect_hosted_modules_fails_closed_on_unreadable_helper(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    # invalid UTF-8 helper — readable bytes but not decodable as the source
+    (surfaces / "broken.ts").write_bytes(b"\xff\xfe export const x = 1\n")
+    entry = surfaces / "panel.tsx"
+    entry.write_text(
+        "import { x } from './broken'\n"
+        "export default function Panel() { return null }\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ServerDomainError) as exc_info:
+        _collect_hosted_tsx_modules_sync(entry, root)
+    assert exc_info.value.code == "PLUGIN_UI_MODULE_UNREADABLE"
+
+
 def test_collect_hosted_modules_follows_reexports_not_value_exports(tmp_path) -> None:
     root = (tmp_path / "demo_plugin").resolve()
     surfaces = root / "surfaces"

--- a/plugin/tests/unit/server/test_plugin_ui_query_service.py
+++ b/plugin/tests/unit/server/test_plugin_ui_query_service.py
@@ -355,6 +355,27 @@ def test_collect_hosted_modules_ignores_commented_and_quoted_imports(tmp_path) -
     assert modules == []
 
 
+def test_collect_hosted_modules_follows_reexports_not_value_exports(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    (surfaces / "scratch.ts").write_text("export const junk = 1\n", encoding="utf-8")
+    (surfaces / "real.ts").write_text("export const value = 2\n", encoding="utf-8")
+    entry = surfaces / "panel.tsx"
+    entry.write_text(
+        # value export that merely contains a path-like string — NOT a dependency
+        "export const SCRATCH_PATH = './scratch'\n"
+        # genuine re-export — IS a dependency
+        "export { value } from './real'\n"
+        "export default function Panel() { return null }\n",
+        encoding="utf-8",
+    )
+
+    modules = _collect_hosted_tsx_modules_sync(entry, root)
+
+    assert {m["path"] for m in modules} == {"surfaces/real"}
+
+
 def test_collect_hosted_modules_fails_closed_when_graph_too_large(tmp_path) -> None:
     root = (tmp_path / "demo_plugin").resolve()
     surfaces = root / "surfaces"

--- a/plugin/tests/unit/server/test_plugin_ui_query_service.py
+++ b/plugin/tests/unit/server/test_plugin_ui_query_service.py
@@ -11,9 +11,12 @@ from plugin.server.application import config as config_application
 from plugin.server.domain.errors import ServerDomainError
 from plugin.server.application.plugins.ui_query_service import (
     _build_plugin_list_actions_from_meta,
+    _collect_hosted_tsx_modules_sync,
     _get_static_ui_config_from_meta,
     _hosted_plugin_not_running_message,
+    _module_key,
     _PLUGIN_NOT_RUNNING_MESSAGES,
+    _resolve_hosted_module_path,
     PluginUiQueryService,
 )
 
@@ -288,3 +291,82 @@ def test_call_surface_action_localizes_plugin_not_running(tmp_path) -> None:
 )
 def test_hosted_plugin_not_running_message_locale_mapping(locale, expected_key) -> None:
     assert _hosted_plugin_not_running_message(locale) == _PLUGIN_NOT_RUNNING_MESSAGES[expected_key]
+
+
+def _write_hosted_surface_tree(root):
+    """Build a plugin surface tree with named/default/transitive/type imports."""
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    (surfaces / "panel.tsx").write_text(
+        "import { useState } from '@neko/plugin-ui'\n"
+        "import { callPlugin, text } from './shared'\n"
+        "import NoteCard from './note_card'\n"
+        "import type { NoteItem } from './note_card'\n"
+        "export default function Panel() { return null }\n",
+        encoding="utf-8",
+    )
+    (surfaces / "shared.ts").write_text(
+        "import type { PluginSurfaceProps } from '@neko/plugin-ui'\n"
+        "export function callPlugin() { return {} }\n"
+        "export function text() { return '' }\n",
+        encoding="utf-8",
+    )
+    # note_card depends transitively on shared and lives as a .tsx default export.
+    (surfaces / "note_card.tsx").write_text(
+        "import { text } from './shared'\n"
+        "export default function NoteCard() { return null }\n",
+        encoding="utf-8",
+    )
+    return surfaces / "panel.tsx"
+
+
+def test_collect_hosted_modules_follows_relative_import_graph(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    entry = _write_hosted_surface_tree(root)
+
+    modules = _collect_hosted_tsx_modules_sync(entry, root)
+
+    keys = {module["path"] for module in modules}
+    # shared is reachable directly and transitively but appears exactly once.
+    assert keys == {"surfaces/shared", "surfaces/note_card"}
+    assert len(modules) == 2
+    assert _module_key(entry, root) == "surfaces/panel"
+    shared = next(m for m in modules if m["path"] == "surfaces/shared")
+    assert "export function callPlugin" in shared["source"]
+
+
+def test_collect_hosted_modules_ignores_bare_and_escaping_specifiers(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    # A secret file outside the plugin root must never be collected.
+    (tmp_path / "secret.ts").write_text("export const token = 'leak'\n", encoding="utf-8")
+    entry = surfaces / "panel.tsx"
+    entry.write_text(
+        "import { useState } from '@neko/plugin-ui'\n"
+        "import { token } from '../../secret'\n"
+        "export default function Panel() { return null }\n",
+        encoding="utf-8",
+    )
+
+    modules = _collect_hosted_tsx_modules_sync(entry, root)
+
+    assert modules == []
+
+
+def test_resolve_hosted_module_path_tries_suffixes_and_index(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    nested = surfaces / "widgets"
+    nested.mkdir(parents=True)
+    (surfaces / "shared.ts").write_text("export const x = 1\n", encoding="utf-8")
+    (nested / "index.tsx").write_text("export default function W() { return null }\n", encoding="utf-8")
+
+    shared = _resolve_hosted_module_path("./shared", surfaces, root)
+    assert shared is not None and shared.name == "shared.ts"
+
+    barrel = _resolve_hosted_module_path("./widgets", surfaces, root)
+    assert barrel is not None and barrel.name == "index.tsx"
+
+    # Escaping the plugin root is rejected.
+    assert _resolve_hosted_module_path("../../secret", surfaces, root) is None

--- a/plugin/tests/unit/server/test_plugin_ui_query_service.py
+++ b/plugin/tests/unit/server/test_plugin_ui_query_service.py
@@ -335,6 +335,47 @@ def test_collect_hosted_modules_follows_relative_import_graph(tmp_path) -> None:
     assert "export function callPlugin" in shared["source"]
 
 
+def test_collect_hosted_modules_ignores_commented_and_quoted_imports(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    # A real file that must NOT be pulled in just because it is named in a comment.
+    (surfaces / "scratch.ts").write_text("export const junk = 1\n", encoding="utf-8")
+    entry = surfaces / "panel.tsx"
+    entry.write_text(
+        "// import { junk } from './scratch'\n"
+        "const example = \"import { x } from './scratch'\"\n"
+        "/* import './scratch' */\n"
+        "export default function Panel() { return null }\n",
+        encoding="utf-8",
+    )
+
+    modules = _collect_hosted_tsx_modules_sync(entry, root)
+
+    assert modules == []
+
+
+def test_collect_hosted_modules_fails_closed_when_graph_too_large(tmp_path) -> None:
+    root = (tmp_path / "demo_plugin").resolve()
+    surfaces = root / "surfaces"
+    surfaces.mkdir(parents=True)
+    # A single helper larger than the byte cap must reject the whole request
+    # rather than silently shipping a truncated graph.
+    (surfaces / "huge.ts").write_text(
+        "export const blob = '" + ("x" * (600 * 1024)) + "'\n", encoding="utf-8"
+    )
+    entry = surfaces / "panel.tsx"
+    entry.write_text(
+        "import { blob } from './huge'\n"
+        "export default function Panel() { return null }\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ServerDomainError) as exc_info:
+        _collect_hosted_tsx_modules_sync(entry, root)
+    assert exc_info.value.code == "PLUGIN_UI_MODULE_GRAPH_TOO_LARGE"
+
+
 def test_collect_hosted_modules_ignores_bare_and_escaping_specifiers(tmp_path) -> None:
     root = (tmp_path / "demo_plugin").resolve()
     surfaces = root / "surfaces"


### PR DESCRIPTION
## 问题（live on main）

main 上的 study_companion hosted-tsx 面板（`daily_goal_editor`、`due_review_panel`、`notebook_panel` 等 17 个 surface）按值导入兄弟模块，例如：

```ts
import { callPlugin, errorMessage, text } from './memory_shared';
```

但 hosted 运行时 `compileHostedTsx()` 只对**单个入口文件**跑 Sucrase（`typescript`+`jsx`，无打包），把输出塞进一个普通 `<script>`。这些相对 import 因此原样残留为裸 ESM `import`，在面板渲染前就抛 `SyntaxError`。

与此同时 `check-hosted-tsx` 会**通过**，因为它能把这些 import 解析到真实仓库——形成 **check 绿 / 运行时红** 的缺口。这是当前 main 上的真实缺陷。

## 修复

解析入口的相对 import 图并整体装配，让 check 与运行时对齐：

- **后端 `get_surface_source`**：在插件根目录内遍历入口的相对 import 图（后缀/`index` 解析、越界路径拒绝、数量/字节上限），把每个可达模块连同 `entry_module` key 一起作为 `modules` 下发。
- **运行时 `tsxRuntime`**：有 modules 时用 Sucrase 的 `imports` transform 编译各模块，挂到一个极简 CommonJS 风格 `require` 注册表（相对 importer 解析；`@neko/plugin-ui` 映射到 UI-kit 全局）。单文件面板保持原 fast path 不变。
- **`check-hosted-tsx`**：把入口的仓库相对目录布局镜像进临时目录（强制 `.tsx` 后缀，使 `.jsx` surface 仍按 TS 解析）并加 `rootDirs`，让兄弟 import 解析到真实仓库。

## 测试

- 运行时：命名 / 默认 / 传递 / 仅类型 import 的装配（`tsxRuntime.test.ts`）
- 后端：import 图遍历去重 + 后缀/`index` 解析 + 越界拒绝（`test_plugin_ui_query_service.py`）
- 本地验证：`test:hosted` 36/36、`check-hosted-tsx` 17 面板全过、`vue-tsc` 通过、后端 pytest 26/26 + study_companion 105/105

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 托管 TSX 支持上传并传递模块清单与入口标识，运行时可装配同级模块、目录 barrel 并处理循环依赖，确保导入/导出在渲染中正确解析；运行时在未导出组件时会报明确错误提示。

* **Backend**
  * 后端新增模块图采集并在响应中返回模块列表与入口标识；当模块图超出限制时会以错误终止请求（不会静默截断）。

* **Tests**
  * 新增单元测试覆盖模块收集、路径解析、大小限制与多模块运行时交互场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->