### PR TITLE
为 Qwen realtime TTS 增加抖动缓冲

### DIFF
--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -2052,8 +2052,6 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     session_configured = False
                     pending_text_buffer = ""
                     response_done.clear()
-                    resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
-                    qwen_audio_jitter.reset()
                     if ws:
                         try:
                             await ws.close()
@@ -2065,6 +2063,10 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             await receive_task
                         except asyncio.CancelledError:
                             pass
+                    # 旧接收任务已完全停止后再重置流式状态：await ws.close() 会让出，
+                    # 期间旧 receive_task 可能写入晚到的 audio.delta，若提前重置会被残留污染下一轮
+                    resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
+                    qwen_audio_jitter.reset()
 
                     # 建立新连接（延迟 session.update 至首批文本到达后发送，携带语言提示）
                     try:

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -2133,6 +2133,9 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
 
                 if not ws:
                     # 连接已因空闲超时断开，暂存当前片段并重置 speech_id 以触发重连
+                    # 断线前先冲刷抖动缓冲残留 PCM：重连会走 speech_id 切换分支并 reset()，
+                    # 未达阈值的当前轮尾音否则会被清掉；此处仍是同一 speech_id，顺序连续
+                    qwen_audio_jitter.flush()
                     current_speech_id = None
                     pending = (sid, tts_text)
                     continue

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -7,6 +7,8 @@ import soxr
 import time
 import json
 import re
+import os
+import math
 import base64
 import websockets
 import io
@@ -173,7 +175,21 @@ def _resolve_elevenlabs_api_key(cm) -> str:
     return (cm.get_tts_api_key('elevenlabs') or '').strip()
 
 
-def _resample_audio(audio_int16: np.ndarray, src_rate: int, dst_rate: int, 
+def _parse_env_float(env_name: str, default: float, min_value: float) -> float:
+    raw = os.getenv(env_name)
+    if raw is None or raw == "":
+        value = default
+    else:
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = default
+    if not math.isfinite(value):
+        value = default
+    return max(value, min_value)
+
+
+def _resample_audio(audio_int16: np.ndarray, src_rate: int, dst_rate: int,
                     resampler: 'soxr.ResampleStream | None' = None) -> bytes:
     """使用 soxr 进行高质量音频重采样
     
@@ -1775,6 +1791,44 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
         pending_text_buffer = ""  # 延迟发送的文本缓冲，用于首 N 字语言检测
         # 流式重采样器（24kHz→48kHz）- 维护 chunk 边界状态
         resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
+        # Qwen realtime can produce 1-2s inter-chunk gaps. A small jitter buffer
+        # gives the client enough queued PCM to ride over short upstream stalls.
+        qwen_audio_bytes_per_second = 48000 * 2
+        qwen_initial_buffer_bytes = int(_parse_env_float("NEKO_QWEN_TTS_INITIAL_BUFFER_MS", 800, 0) / 1000 * qwen_audio_bytes_per_second)
+        qwen_steady_buffer_bytes = int(_parse_env_float("NEKO_QWEN_TTS_STEADY_BUFFER_MS", 200, 0) / 1000 * qwen_audio_bytes_per_second)
+
+        class QwenAudioJitterBuffer:
+            def __init__(self):
+                self.buffer = bytearray()
+                self.started = False
+
+            def reset(self):
+                self.buffer.clear()
+                self.started = False
+
+            def append(self, audio_bytes):
+                if not audio_bytes:
+                    return
+                self.buffer.extend(audio_bytes)
+                if not self.started:
+                    if len(self.buffer) < qwen_initial_buffer_bytes:
+                        return
+                    self._flush()
+                    self.started = True
+                    return
+                if len(self.buffer) >= qwen_steady_buffer_bytes:
+                    self._flush()
+
+            def flush(self):
+                self._flush()
+
+            def _flush(self):
+                if not self.buffer:
+                    return
+                response_queue.put(bytes(self.buffer))
+                self.buffer.clear()
+
+        qwen_audio_jitter = QwenAudioJitterBuffer()
 
         def build_config_message(lang_hint=None):
             """构造 session.update 消息；lang_hint='ja' 时指定 Japanese，其他走服务端 Auto。"""
@@ -1901,12 +1955,13 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                                 audio_bytes = base64.b64decode(event.get("delta", ""))
                                 audio_array = np.frombuffer(audio_bytes, dtype=np.int16)
                                 # 使用流式重采样器 24000Hz -> 48000Hz
-                                response_queue.put(_resample_audio(audio_array, 24000, 48000, resampler))
+                                qwen_audio_jitter.append(_resample_audio(audio_array, 24000, 48000, resampler))
                             except Exception as e:
                                 logger.error(f"处理音频数据时出错: {e}")
                         elif event_type in ["response.done", "response.audio.done", "output.done"]:
                             # 服务器明确表示音频生成完成，设置完成标志
                             logger.debug(f"收到响应完成事件: {event_type}")
+                            qwen_audio_jitter.flush()
                             response_done.set()
                 except websockets.exceptions.ConnectionClosed:
                     pass
@@ -1961,6 +2016,7 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     buffer_committed = False
                     session_configured = False
                     pending_text_buffer = ""
+                    qwen_audio_jitter.reset()
                     continue
 
                 if sid is None:
@@ -1997,6 +2053,7 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     pending_text_buffer = ""
                     response_done.clear()
                     resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
+                    qwen_audio_jitter.reset()
                     if ws:
                         try:
                             await ws.close()
@@ -2036,12 +2093,13 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                                             audio_bytes = base64.b64decode(event.get("delta", ""))
                                             audio_array = np.frombuffer(audio_bytes, dtype=np.int16)
                                             # 使用流式重采样器 24000Hz -> 48000Hz
-                                            response_queue.put(_resample_audio(audio_array, 24000, 48000, resampler))
+                                            qwen_audio_jitter.append(_resample_audio(audio_array, 24000, 48000, resampler))
                                         except Exception as e:
                                             logger.error(f"处理音频数据时出错: {e}")
                                     elif event_type in ["response.done", "response.audio.done", "output.done"]:
                                         # 服务器明确表示音频生成完成，设置完成标志
                                         logger.debug(f"收到响应完成事件: {event_type}")
+                                        qwen_audio_jitter.flush()
                                         response_done.set()
                             except websockets.exceptions.ConnectionClosed:
                                 pass


### PR DESCRIPTION
- 为 `qwen_realtime_tts_worker` 增加抖动缓冲 `QwenAudioJitterBuffer`：用初始/稳态两级缓冲累积重采样后的 PCM，吸收 Qwen realtime 上游约 1-2s 的 chunk 间隔，避免客户端音频断续
- 通过 `NEKO_QWEN_TTS_INITIAL_BUFFER_MS`（默认 800）和 `NEKO_QWEN_TTS_STEADY_BUFFER_MS`（默认 200）配置缓冲阈值
- 打断、轮次切换、关闭连接时重置缓冲；`response.done` 时 flush 残留 PCM
- 新增 `_parse_env_float` 辅助函数（环境变量解析，带默认值兜底与下限约束）

注：本 PR 已从原「按句并行合成」方案收敛为**仅保留抖动缓冲**，移除了并行 worker、`qwen_parallel` provider 及 `NEKO_QWEN_TTS_PARALLEL_SENTENCES` 开关。

验证：`python -m py_compile main_logic/tts_client.py` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改进实时音频抖动缓冲机制：稳态阈值下自动输出，断线/中断时提前刷新并重置，避免旧流尾部音频污染新轮次，提升音频输出稳定性与切换可靠性。
* **新功能**
  * 增强环境变量浮点解析：更好处理缺失/空值、解析异常与非有限值，并支持下限剪裁，便于参数调优。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->