### PR TITLE
feat: infer jukebox upload metadata from audio tags

### DIFF
--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -495,7 +495,6 @@ def extract_audio_metadata(file_path: Path) -> dict:
                 merged_metadata,
                 "title",
                 "song",
-                "track",
                 "tracktitle",
                 "track_title",
                 "标题",

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -434,6 +434,89 @@ def calculate_md5(file_path: Path) -> str:
     return md5_hash.hexdigest()
 
 
+def _clean_audio_metadata_value(value) -> str:
+    """Normalize one audio metadata value for jukebox display."""
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple)):
+        value = next((item for item in value if item), "")
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="ignore")
+    value = str(value).replace("\x00", "").strip()
+    value = re.sub(r"\s+", " ", value)
+    if not value:
+        return ""
+    if value.lower() in {
+        "unknown",
+        "unknown artist",
+        "unknown title",
+        "unknown singer",
+        "none",
+        "null",
+        "未知",
+        "未知艺术家",
+        "未知歌手",
+    }:
+        return ""
+    return value[:200]
+
+
+def _pick_audio_metadata_value(metadata: dict, *keys: str) -> str:
+    normalized = {
+        str(key).strip().lower().replace("-", "_").replace(" ", "_"): value
+        for key, value in metadata.items()
+    }
+    for key in keys:
+        value = _clean_audio_metadata_value(
+            normalized.get(key.strip().lower().replace("-", "_").replace(" ", "_"))
+        )
+        if value:
+            return value
+    return ""
+
+
+def extract_audio_metadata(file_path: Path) -> dict:
+    """Best-effort audio tag extraction. Failures must not block upload."""
+    try:
+        import av
+    except Exception:
+        return {}
+
+    try:
+        with av.open(str(file_path)) as container:
+            merged_metadata = dict(getattr(container, "metadata", {}) or {})
+            for stream in getattr(container, "streams", []) or []:
+                if getattr(stream, "type", "") == "audio":
+                    for key, value in (getattr(stream, "metadata", {}) or {}).items():
+                        merged_metadata.setdefault(key, value)
+
+        return {
+            "name": _pick_audio_metadata_value(
+                merged_metadata,
+                "title",
+                "song",
+                "track",
+                "tracktitle",
+                "track_title",
+                "标题",
+            ),
+            "artist": _pick_audio_metadata_value(
+                merged_metadata,
+                "artist",
+                "album_artist",
+                "albumartist",
+                "performer",
+                "author",
+                "composer",
+                "singer",
+                "歌手",
+                "艺术家",
+            ),
+        }
+    except Exception:
+        return {}
+
+
 # ═══════════════════ API 路由 ═══════════════════
 
 @router.get("/config")
@@ -477,6 +560,9 @@ async def upload_songs(
     results = []
     for i, (file, meta) in enumerate(zip(files, meta_list)):
         try:
+            if not isinstance(meta, dict):
+                meta = {}
+
             # 检查文件大小
             check_file_size(file, MAX_FILE_SIZE)
 
@@ -518,10 +604,23 @@ async def upload_songs(
                 results.append({"success": False, "error": f"歌曲已存在: {existing_song_id}"})
                 continue
 
-            # 使用提供的值或文件名作为默认显示名称
+            try:
+                audio_metadata = await asyncio.to_thread(extract_audio_metadata, target_path)
+            except Exception:
+                audio_metadata = {}
+
+            # 使用提供的值、音频元信息或文件名作为默认显示名称
             # 如果文件名有数字后缀（如"歌曲(1).mp3"），默认显示名称也保留这个后缀
-            song_name = meta.get("name") or Path(target_filename).stem
-            song_artist = meta.get("artist") or "未知"
+            song_name = (
+                _clean_audio_metadata_value(meta.get("name"))
+                or audio_metadata.get("name")
+                or Path(target_filename).stem
+            )
+            song_artist = (
+                _clean_audio_metadata_value(meta.get("artist"))
+                or audio_metadata.get("artist")
+                or "未知"
+            )
 
             # 创建歌曲记录
             song = Song(

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3008,10 +3008,7 @@ window.Jukebox = {
 
     async uploadSongs(files) {
       try {
-        const metadata = files.map(f => ({
-          name: f.name.replace(/\.[^/.]+$/, ''),
-          artist: '未知'
-        }));
+        const metadata = files.map(() => ({}));
         const result = await this.api.uploadSongs(files, metadata);
         console.log('[SongActionManager] 上传歌曲成功:', result);
         await this.load();

--- a/tests/unit/test_jukebox_batch_delete.py
+++ b/tests/unit/test_jukebox_batch_delete.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from starlette.datastructures import UploadFile
 
 from main_routers import jukebox_router
 
@@ -170,6 +171,168 @@ def test_save_builtin_overrides_persists_changed_fields(tmp_path):
                 "name": "Renamed Action",
             }
         },
+    }
+
+
+@pytest.mark.asyncio
+async def test_upload_song_uses_audio_metadata_title_and_artist_when_form_metadata_empty(
+    monkeypatch, tmp_path
+):
+    jukebox_dir = tmp_path / "jukebox"
+    fake = _FakeJukeboxConfig(
+        {
+            "songs": {},
+            "actions": {},
+            "bindings": {},
+            "md5Index": {"songs": {}, "actions": {}},
+        },
+        jukebox_dir,
+    )
+    fake.songs_dir.mkdir(parents=True)
+    _install_fake_config(monkeypatch, fake)
+    monkeypatch.setattr(
+        jukebox_router,
+        "extract_audio_metadata",
+        lambda _path: {"name": "Metadata Title", "artist": "Metadata Artist"},
+    )
+
+    result = await jukebox_router.upload_songs(
+        [UploadFile(filename="uploaded.mp3", file=io.BytesIO(b"audio-bytes"))],
+        metadata=json.dumps([{}], ensure_ascii=False),
+    )
+
+    assert result["success"] is True
+    assert result["song"]["name"] == "Metadata Title"
+    assert result["song"]["artist"] == "Metadata Artist"
+    assert fake.data["songs"][result["song"]["id"]]["name"] == "Metadata Title"
+    assert fake.data["songs"][result["song"]["id"]]["artist"] == "Metadata Artist"
+    assert (fake.songs_dir / "uploaded.mp3").exists()
+    assert fake.saved is True
+
+
+@pytest.mark.asyncio
+async def test_upload_song_uses_audio_metadata_artist_when_form_artist_missing(monkeypatch, tmp_path):
+    jukebox_dir = tmp_path / "jukebox"
+    fake = _FakeJukeboxConfig(
+        {
+            "songs": {},
+            "actions": {},
+            "bindings": {},
+            "md5Index": {"songs": {}, "actions": {}},
+        },
+        jukebox_dir,
+    )
+    fake.songs_dir.mkdir(parents=True)
+    _install_fake_config(monkeypatch, fake)
+    monkeypatch.setattr(
+        jukebox_router,
+        "extract_audio_metadata",
+        lambda _path: {"name": "Metadata Title", "artist": "Metadata Artist"},
+    )
+
+    result = await jukebox_router.upload_songs(
+        [UploadFile(filename="uploaded.mp3", file=io.BytesIO(b"audio-bytes"))],
+        metadata=json.dumps([{"name": "Manual Title"}], ensure_ascii=False),
+    )
+
+    assert result["success"] is True
+    assert result["song"]["name"] == "Manual Title"
+    assert result["song"]["artist"] == "Metadata Artist"
+    assert fake.data["songs"][result["song"]["id"]]["artist"] == "Metadata Artist"
+    assert (fake.songs_dir / "uploaded.mp3").exists()
+    assert fake.saved is True
+
+
+@pytest.mark.asyncio
+async def test_upload_song_treats_unknown_form_artist_as_missing(monkeypatch, tmp_path):
+    jukebox_dir = tmp_path / "jukebox"
+    fake = _FakeJukeboxConfig(
+        {
+            "songs": {},
+            "actions": {},
+            "bindings": {},
+            "md5Index": {"songs": {}, "actions": {}},
+        },
+        jukebox_dir,
+    )
+    fake.songs_dir.mkdir(parents=True)
+    _install_fake_config(monkeypatch, fake)
+    monkeypatch.setattr(
+        jukebox_router,
+        "extract_audio_metadata",
+        lambda _path: {"name": "Metadata Title", "artist": "Metadata Artist"},
+    )
+
+    result = await jukebox_router.upload_songs(
+        [UploadFile(filename="uploaded.mp3", file=io.BytesIO(b"audio-bytes"))],
+        metadata=json.dumps([{"name": "Manual Title", "artist": "未知"}], ensure_ascii=False),
+    )
+
+    assert result["success"] is True
+    assert result["song"]["artist"] == "Metadata Artist"
+
+
+@pytest.mark.asyncio
+async def test_upload_song_falls_back_when_audio_metadata_extraction_fails(
+    monkeypatch, tmp_path
+):
+    jukebox_dir = tmp_path / "jukebox"
+    fake = _FakeJukeboxConfig(
+        {
+            "songs": {},
+            "actions": {},
+            "bindings": {},
+            "md5Index": {"songs": {}, "actions": {}},
+        },
+        jukebox_dir,
+    )
+    fake.songs_dir.mkdir(parents=True)
+    _install_fake_config(monkeypatch, fake)
+
+    def _raise_metadata_error(_path):
+        raise RuntimeError("tag read failed")
+
+    monkeypatch.setattr(jukebox_router, "extract_audio_metadata", _raise_metadata_error)
+
+    result = await jukebox_router.upload_songs(
+        [UploadFile(filename="fallback-title.mp3", file=io.BytesIO(b"audio-bytes"))],
+        metadata=json.dumps([{}], ensure_ascii=False),
+    )
+
+    assert result["success"] is True
+    assert result["song"]["name"] == "fallback-title"
+    assert result["song"]["artist"] == "未知"
+    assert fake.saved is True
+
+
+def test_extract_audio_metadata_picks_common_artist_tags(monkeypatch, tmp_path):
+    audio_path = tmp_path / "tagged.mp3"
+    audio_path.write_bytes(b"not-real-audio")
+
+    class _FakeStream:
+        type = "audio"
+        metadata = {"PERFORMER": " Stream Artist "}
+
+    class _FakeContainer:
+        metadata = {"title": " Meta Title "}
+        streams = [_FakeStream()]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    class _FakeAv:
+        @staticmethod
+        def open(_path):
+            return _FakeContainer()
+
+    monkeypatch.setitem(__import__("sys").modules, "av", _FakeAv)
+
+    assert jukebox_router.extract_audio_metadata(audio_path) == {
+        "name": "Meta Title",
+        "artist": "Stream Artist",
     }
 
 

--- a/tests/unit/test_jukebox_batch_delete.py
+++ b/tests/unit/test_jukebox_batch_delete.py
@@ -305,6 +305,38 @@ async def test_upload_song_falls_back_when_audio_metadata_extraction_fails(
     assert fake.saved is True
 
 
+@pytest.mark.asyncio
+async def test_upload_song_uses_filename_when_audio_metadata_title_is_missing(
+    monkeypatch, tmp_path
+):
+    jukebox_dir = tmp_path / "jukebox"
+    fake = _FakeJukeboxConfig(
+        {
+            "songs": {},
+            "actions": {},
+            "bindings": {},
+            "md5Index": {"songs": {}, "actions": {}},
+        },
+        jukebox_dir,
+    )
+    fake.songs_dir.mkdir(parents=True)
+    _install_fake_config(monkeypatch, fake)
+    monkeypatch.setattr(
+        jukebox_router,
+        "extract_audio_metadata",
+        lambda _path: {"name": "", "artist": "Metadata Artist"},
+    )
+
+    result = await jukebox_router.upload_songs(
+        [UploadFile(filename="fallback-title.mp3", file=io.BytesIO(b"audio-bytes"))],
+        metadata=json.dumps([{}], ensure_ascii=False),
+    )
+
+    assert result["success"] is True
+    assert result["song"]["name"] == "fallback-title"
+    assert result["song"]["artist"] == "Metadata Artist"
+
+
 def test_extract_audio_metadata_picks_common_artist_tags(monkeypatch, tmp_path):
     audio_path = tmp_path / "tagged.mp3"
     audio_path.write_bytes(b"not-real-audio")
@@ -333,6 +365,33 @@ def test_extract_audio_metadata_picks_common_artist_tags(monkeypatch, tmp_path):
     assert jukebox_router.extract_audio_metadata(audio_path) == {
         "name": "Meta Title",
         "artist": "Stream Artist",
+    }
+
+
+def test_extract_audio_metadata_ignores_track_number_as_title(monkeypatch, tmp_path):
+    audio_path = tmp_path / "track-only.mp3"
+    audio_path.write_bytes(b"not-real-audio")
+
+    class _FakeContainer:
+        metadata = {"track": "03/12", "artist": "Metadata Artist"}
+        streams = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    class _FakeAv:
+        @staticmethod
+        def open(_path):
+            return _FakeContainer()
+
+    monkeypatch.setitem(__import__("sys").modules, "av", _FakeAv)
+
+    assert jukebox_router.extract_audio_metadata(audio_path) == {
+        "name": "",
+        "artist": "Metadata Artist",
     }
 
 


### PR DESCRIPTION
## Summary
- Infer jukebox upload title and artist from audio metadata when explicit upload metadata is missing.
- Stop sending frontend placeholder artist metadata so the backend can use audio tag fallbacks.
- Keep upload best-effort when metadata extraction fails.

## Notes
- Follows #1782, which has been merged.

## Test plan
- node --check static/Jukebox.js
- uv run python -m py_compile main_routers/jukebox_router.py
- uv run ruff check main_routers/jukebox_router.py tests/unit/test_jukebox_batch_delete.py
- PYTHONUTF8=1 uv run python scripts/check_docstring_no_cjk.py --base upstream/main
- git diff --check upstream/main...HEAD
- uv run pytest tests/unit/test_jukebox_batch_delete.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 上传音频时尽力从文件容器/流元数据提取歌曲名与艺术家，用作元数据回退来源，优先级为：用户输入 > 音频标签 > 文件名/未知。
* **修复**
  * 上传时若表单 metadata 非对象则兜底为空对象，避免后续异常；上传客户端默认发送空 metadata 以允许音频提取生效。
* **测试**
  * 为音频元数据提取与上传回退逻辑新增单元测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->