### PR TITLE
fix(embeddings): E5-2666 v3 加入 CPU 黑名单，onnxruntime SIGILL 前置 disable

### DIFF
--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -480,13 +480,29 @@ def _cpu_is_blocklisted() -> bool:
     the frozen module is baked into the binary, the process environment is
     not. It follows the documented env convention — ``NEKO_`` prefix, with
     the bare name accepted as a fallback, matching config's ``_read_str_env``
-    key order. This is the per-machine escape hatch for a false positive (a
-    listed chip that actually runs fine, or a later microcode fix) and the
-    way to re-try a forced fp32 / int8 load on a blocklisted host.
+    key order: the FIRST env name that is present and non-empty wins, so an
+    explicit ``NEKO_VECTORS_FORCE_ENABLE`` takes precedence over the bare
+    name even when its value is falsey (it does not fall through). This is
+    the per-machine escape hatch for a false positive (a listed chip that
+    actually runs fine, or a later microcode fix) and the way to re-try a
+    forced fp32 / int8 load on a blocklisted host.
     """
     for _key in ("NEKO_VECTORS_FORCE_ENABLE", "VECTORS_FORCE_ENABLE"):
-        if os.getenv(_key, "").strip().lower() in ("1", "true", "yes", "on"):
-            return False
+        _raw = os.getenv(_key)
+        if _raw is None or not _raw.strip():
+            continue
+        # First present-and-non-empty key decides; a later key (the bare
+        # name) never overrides an explicitly-set earlier one, even if that
+        # value is falsey — so NEKO_ precedence holds.
+        if _raw.strip().lower() in ("1", "true", "yes", "on"):
+            return False        # force-enabled → never blocklisted
+        break                   # explicit falsey override → fall to brand check
+    return _brand_blocklisted()
+
+
+def _brand_blocklisted() -> bool:
+    """Pure brand-string side of :func:`_cpu_is_blocklisted` (no env
+    override): True iff the CPU brand matches :data:`_CPU_BRAND_BLOCKLIST`."""
     brand = _read_cpu_brand_string()
     if not brand:
         return False

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -161,6 +161,11 @@ class _DisableReason(enum.Enum):
     # the log separates "no fast path at all" from the now-supported "no VNNI
     # but AVX2 present" case (Haswell 2013+ / Zen+).
     NO_SIMD_INT8_PATH = "no_avx2_or_vnni_for_int8"
+    # CPU brand string is on _CPU_BRAND_BLOCKLIST: it advertises a usable
+    # int8 SIMD path but crashes onnxruntime/MLAS at runtime (illegal
+    # instruction). Disabled *before* the session loads so the crash never
+    # happens; override per machine with XIAO8_VECTORS_FORCE_ENABLE=1.
+    CPU_BLOCKLISTED = "cpu_on_known_bad_blocklist"
     LOW_RAM = "ram_below_threshold"
     LOAD_ERROR = "load_raised"
     INFERENCE_ERROR = "inference_raised"
@@ -326,6 +331,21 @@ _INTEL_VNNI_MIN_MODEL_FAMILY_6 = 0x97  # Alder Lake — also covers Raptor,
                                        # Meteor, Arrow, Lunar, Panther
                                        # Lake; Sapphire/Emerald Rapids.
 
+# CPUs that advertise a usable int8 SIMD path through every numeric signal
+# we trust (family/model, numpy AVX2/VNNI flags) yet still crash
+# onnxruntime/MLAS at runtime with an illegal-instruction fault. Matched as
+# a case-insensitive substring of the CPU *brand string* ("model name" on
+# Linux / ``ProcessorNameString`` on Windows), because family/model can not
+# single out one SKU — e.g. Haswell-EP E5-2666 v3 shares 06_3FH with the
+# entire Haswell-EP cohort, the bulk of which run fine. Brand-string
+# matching is the fragile py-cpuinfo pattern this module otherwise avoids,
+# so keep this list SHORT and evidence-backed (a real SIGILL in
+# onnxruntime's .so, confirmed via ``dmesg``), never a catch-all guess.
+# ``XIAO8_VECTORS_FORCE_ENABLE=1`` overrides it per machine.
+_CPU_BRAND_BLOCKLIST = (
+    "e5-2666 v3",  # AWS-custom Haswell-EP; onnxruntime MLAS int8 SIGILL
+)
+
 # AMD Family 0x19 is shared between Zen 3 (no AVX-VNNI) and Zen 4 (yes), so
 # family alone is not enough — gate on the documented Zen 4 model ranges
 # instead. Zen 5 lives on Family 0x1A and every shipped part has VNNI, so
@@ -413,6 +433,57 @@ def _read_cpu_family_model() -> tuple[str, int, int] | None:
     except Exception:
         return None
     return None
+
+
+def _read_cpu_brand_string() -> str | None:
+    """Return the CPU brand/marketing string (e.g.
+    ``"Intel(R) Xeon(R) CPU E5-2666 v3 @ 2.90GHz"``) from a plain
+    registry / text read, or None when neither source answers.
+
+    The sole consumer is :func:`_cpu_is_blocklisted`. Brand-string parsing
+    is the fragile py-cpuinfo pattern this module avoids everywhere else
+    (numeric family/model is preferred), but it is the *only* signal that
+    pins down one SKU — family/model lumps a whole microarchitecture cohort
+    together — so it is fenced off to this one narrow use.
+    """
+    system = platform.system()
+    try:
+        if system == "Windows":
+            import winreg
+            with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                r"HARDWARE\DESCRIPTION\System\CentralProcessor\0",
+            ) as k:
+                return winreg.QueryValueEx(k, "ProcessorNameString")[0]
+        if system == "Linux":
+            with open("/proc/cpuinfo", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("model name"):
+                        return line.split(":", 1)[1].strip()
+    except Exception:
+        return None
+    return None
+
+
+def _cpu_is_blocklisted() -> bool:
+    """True when the CPU brand string matches :data:`_CPU_BRAND_BLOCKLIST`
+    and the operator has not set ``XIAO8_VECTORS_FORCE_ENABLE``.
+
+    The env override is a runtime ``os.getenv`` read, so it keeps working
+    after the app is Nuitka-compiled: the ``config`` module is frozen into
+    the binary, but the process environment is not. This is the per-machine
+    escape hatch for a false positive (a chip on the list that actually
+    runs fine, or a future microcode fix).
+    """
+    if os.getenv("XIAO8_VECTORS_FORCE_ENABLE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    ):
+        return False
+    brand = _read_cpu_brand_string()
+    if not brand:
+        return False
+    low = brand.lower()
+    return any(bad in low for bad in _CPU_BRAND_BLOCKLIST)
 
 
 def _vnni_via_family_model() -> tuple[bool, bool]:
@@ -1087,7 +1158,13 @@ class EmbeddingService:
         # Decide initial disable conditions (all but model file presence,
         # which we check at load time so a deferred download path can
         # still flip vectors on after first session).
-        if not self._enabled:
+        if _cpu_is_blocklisted():
+            # Highest priority: a known-bad CPU SIGILLs onnxruntime no matter
+            # what the SIMD detection concluded, so this gate sits above the
+            # RAM / quantization checks. Logged (not silent) so the startup
+            # line tells operators why vectors are off and how to override.
+            self._mark_disabled(_DisableReason.CPU_BLOCKLISTED, log=True)
+        elif not self._enabled:
             self._mark_disabled(_DisableReason.USER_DISABLED, log=False)
         elif self._ram_gb is None or self._ram_gb < self._min_ram_gb:
             self._mark_disabled(_DisableReason.LOW_RAM, log=False)

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -164,7 +164,7 @@ class _DisableReason(enum.Enum):
     # CPU brand string is on _CPU_BRAND_BLOCKLIST: it advertises a usable
     # int8 SIMD path but crashes onnxruntime/MLAS at runtime (illegal
     # instruction). Disabled *before* the session loads so the crash never
-    # happens; override per machine with XIAO8_VECTORS_FORCE_ENABLE=1.
+    # happens; override per machine with NEKO_VECTORS_FORCE_ENABLE=1.
     CPU_BLOCKLISTED = "cpu_on_known_bad_blocklist"
     LOW_RAM = "ram_below_threshold"
     LOAD_ERROR = "load_raised"
@@ -333,17 +333,23 @@ _INTEL_VNNI_MIN_MODEL_FAMILY_6 = 0x97  # Alder Lake — also covers Raptor,
 
 # CPUs that advertise a usable int8 SIMD path through every numeric signal
 # we trust (family/model, numpy AVX2/VNNI flags) yet still crash
-# onnxruntime/MLAS at runtime with an illegal-instruction fault. Matched as
-# a case-insensitive substring of the CPU *brand string* ("model name" on
+# onnxruntime at runtime with an illegal-instruction fault. Matched as a
+# case-insensitive substring of the CPU *brand string* ("model name" on
 # Linux / ``ProcessorNameString`` on Windows), because family/model can not
 # single out one SKU — e.g. Haswell-EP E5-2666 v3 shares 06_3FH with the
 # entire Haswell-EP cohort, the bulk of which run fine. Brand-string
 # matching is the fragile py-cpuinfo pattern this module otherwise avoids,
 # so keep this list SHORT and evidence-backed (a real SIGILL in
 # onnxruntime's .so, confirmed via ``dmesg``), never a catch-all guess.
-# ``XIAO8_VECTORS_FORCE_ENABLE=1`` overrides it per machine.
+#
+# A hit disables the WHOLE onnxruntime session — int8 *and* fp32 — not just
+# the int8 kernel. The root cause is not yet pinned to a specific kernel, so
+# we can not assume the fp32 weights (if an operator shipped them) are safe
+# on this silicon; shipping a path we believe still SIGILLs would defeat the
+# guard. The fp32 / forced-load recovery path is not removed, only gated:
+# ``NEKO_VECTORS_FORCE_ENABLE=1`` overrides the blocklist per machine.
 _CPU_BRAND_BLOCKLIST = (
-    "e5-2666 v3",  # AWS-custom Haswell-EP; onnxruntime MLAS int8 SIGILL
+    "e5-2666 v3",  # AWS-custom Haswell-EP; user-reported onnxruntime crash (SIGILL)
 )
 
 # AMD Family 0x19 is shared between Zen 3 (no AVX-VNNI) and Zen 4 (yes), so
@@ -467,18 +473,20 @@ def _read_cpu_brand_string() -> str | None:
 
 def _cpu_is_blocklisted() -> bool:
     """True when the CPU brand string matches :data:`_CPU_BRAND_BLOCKLIST`
-    and the operator has not set ``XIAO8_VECTORS_FORCE_ENABLE``.
+    and the operator has not set ``NEKO_VECTORS_FORCE_ENABLE``.
 
-    The env override is a runtime ``os.getenv`` read, so it keeps working
-    after the app is Nuitka-compiled: the ``config`` module is frozen into
-    the binary, but the process environment is not. This is the per-machine
-    escape hatch for a false positive (a chip on the list that actually
-    runs fine, or a future microcode fix).
+    The override is read straight from the environment (not via the
+    ``config`` module), so it keeps working after the app is Nuitka-compiled:
+    the frozen module is baked into the binary, the process environment is
+    not. It follows the documented env convention — ``NEKO_`` prefix, with
+    the bare name accepted as a fallback, matching config's ``_read_str_env``
+    key order. This is the per-machine escape hatch for a false positive (a
+    listed chip that actually runs fine, or a later microcode fix) and the
+    way to re-try a forced fp32 / int8 load on a blocklisted host.
     """
-    if os.getenv("XIAO8_VECTORS_FORCE_ENABLE", "").strip().lower() in (
-        "1", "true", "yes", "on",
-    ):
-        return False
+    for _key in ("NEKO_VECTORS_FORCE_ENABLE", "VECTORS_FORCE_ENABLE"):
+        if os.getenv(_key, "").strip().lower() in ("1", "true", "yes", "on"):
+            return False
     brand = _read_cpu_brand_string()
     if not brand:
         return False

--- a/tests/unit/test_embedding_cpu_blocklist.py
+++ b/tests/unit/test_embedding_cpu_blocklist.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the known-bad-CPU brand-string blocklist in
+``memory.embeddings``.
+
+Context: the E5-2666 v3 (AWS-custom Haswell-EP) looks fine through every
+numeric signal we trust (family/model, numpy AVX2/VNNI flags), so ``auto``
+picks int8 and loads onnxruntime as usual — but MLAS then SIGILLs at
+runtime. family/model can not single out this one part (06_3FH is shared by
+the whole Haswell-EP cohort, most of which run fine), so the only way to
+blocklist it is a brand-string substring match. On a hit the service is
+disabled before the session loads, and callers fall back to the pre-vector
+path. ``XIAO8_VECTORS_FORCE_ENABLE=1`` is a runtime ``os.getenv`` escape
+hatch (still effective after Nuitka compilation) for a false positive.
+
+The tests touch no heavy deps: brand reads and the construction path are
+monkeypatched / injected, so they run without onnxruntime/tokenizers/numpy.
+"""
+from __future__ import annotations
+
+import pytest
+
+# 顶层 import 是纯 Python 加载(重依赖都在函数内 lazy import),importorskip
+# 兜底罕见的打包剥离场景。
+embeddings = pytest.importorskip("memory.embeddings")
+
+_E5_2666 = "Intel(R) Xeon(R) CPU E5-2666 v3 @ 2.90GHz"
+_E5_1680 = "Intel(R) Xeon(R) CPU E5-1680 v4 @ 3.40GHz"
+
+
+def test_blocklist_matches_brand_substring_case_insensitive(monkeypatch):
+    """A brand string containing ``E5-2666 v3`` (case-insensitive, as a
+    substring) trips the blocklist."""
+    monkeypatch.delenv("XIAO8_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
+    assert embeddings._cpu_is_blocklisted() is True
+
+
+def test_blocklist_passes_sibling_haswell_cohort_cpu(monkeypatch):
+    """A sibling SKU (e.g. Broadwell E5-1680 v4) must not be caught: the
+    list matches an exact brand substring, never family/model wholesale."""
+    monkeypatch.delenv("XIAO8_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_1680)
+    assert embeddings._cpu_is_blocklisted() is False
+
+
+def test_blocklist_missing_brand_string_does_not_disable(monkeypatch):
+    """When the brand string can not be read (None), treat it as unknown
+    and do not disable — same optimistic stance the module takes for
+    inconclusive CPU detection."""
+    monkeypatch.delenv("XIAO8_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: None)
+    assert embeddings._cpu_is_blocklisted() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_force_enable_env_overrides_blocklist(monkeypatch, val):
+    """A truthy ``XIAO8_VECTORS_FORCE_ENABLE`` forces the CPU through even
+    when the brand matches (per-machine escape hatch, Nuitka-safe)."""
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
+    monkeypatch.setenv("XIAO8_VECTORS_FORCE_ENABLE", val)
+    assert embeddings._cpu_is_blocklisted() is False
+
+
+def test_force_enable_env_falsey_keeps_blocklist(monkeypatch):
+    """A non-truthy value (empty / ``0``) is not the switch; the blocklist
+    still applies."""
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
+    monkeypatch.setenv("XIAO8_VECTORS_FORCE_ENABLE", "0")
+    assert embeddings._cpu_is_blocklisted() is True
+
+
+def test_blocklisted_cpu_disables_service_at_construction(monkeypatch):
+    """A blocklisted CPU drives the service straight to DISABLED at
+    construction with reason ``cpu_on_known_bad_blocklist`` — ahead of the
+    RAM / quantization checks and before any session load, so the SIGILL
+    never happens."""
+    monkeypatch.setattr(embeddings, "_cpu_is_blocklisted", lambda: True)
+    svc = embeddings.EmbeddingService(
+        model_dir="/nonexistent",
+        enabled=True,
+        ram_gb=32.0,            # 足够高,排除 LOW_RAM 干扰
+        has_vnni=False,         # 注入检测结果,构造时不跑真 CPUID
+        vnni_absence_confirmed=True,
+        has_avx2=True,          # 否则 auto 会因无 SIMD 路径 disable,混淆 reason
+        avx2_absence_confirmed=True,
+    )
+    assert svc.is_disabled() is True
+    assert svc.disable_reason() == embeddings._DisableReason.CPU_BLOCKLISTED.value
+    assert svc.disable_reason() == "cpu_on_known_bad_blocklist"
+    # A blocklisted machine must not stamp embedding rows.
+    assert svc.model_id() is None
+
+
+def test_unblocklisted_cpu_constructs_enabled(monkeypatch):
+    """Dual case: with the same injected params but no blocklist hit, this
+    gate does not disable the service (it reaches INIT, loading deferred to
+    request_load) — proving the gate does not catch healthy CPUs."""
+    monkeypatch.setattr(embeddings, "_cpu_is_blocklisted", lambda: False)
+    svc = embeddings.EmbeddingService(
+        model_dir="/nonexistent",
+        enabled=True,
+        ram_gb=32.0,
+        has_vnni=False,
+        vnni_absence_confirmed=True,
+        has_avx2=True,
+        avx2_absence_confirmed=True,
+    )
+    assert svc.is_disabled() is False
+    assert svc.disable_reason() == embeddings._DisableReason.NONE.value

--- a/tests/unit/test_embedding_cpu_blocklist.py
+++ b/tests/unit/test_embedding_cpu_blocklist.py
@@ -9,7 +9,7 @@ runtime. family/model can not single out this one part (06_3FH is shared by
 the whole Haswell-EP cohort, most of which run fine), so the only way to
 blocklist it is a brand-string substring match. On a hit the service is
 disabled before the session loads, and callers fall back to the pre-vector
-path. ``XIAO8_VECTORS_FORCE_ENABLE=1`` is a runtime ``os.getenv`` escape
+path. ``NEKO_VECTORS_FORCE_ENABLE=1`` is a runtime ``os.getenv`` escape
 hatch (still effective after Nuitka compilation) for a false positive.
 
 The tests touch no heavy deps: brand reads and the construction path are
@@ -30,7 +30,8 @@ _E5_1680 = "Intel(R) Xeon(R) CPU E5-1680 v4 @ 3.40GHz"
 def test_blocklist_matches_brand_substring_case_insensitive(monkeypatch):
     """A brand string containing ``E5-2666 v3`` (case-insensitive, as a
     substring) trips the blocklist."""
-    monkeypatch.delenv("XIAO8_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.delenv("NEKO_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.delenv("VECTORS_FORCE_ENABLE", raising=False)
     monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
     assert embeddings._cpu_is_blocklisted() is True
 
@@ -38,7 +39,8 @@ def test_blocklist_matches_brand_substring_case_insensitive(monkeypatch):
 def test_blocklist_passes_sibling_haswell_cohort_cpu(monkeypatch):
     """A sibling SKU (e.g. Broadwell E5-1680 v4) must not be caught: the
     list matches an exact brand substring, never family/model wholesale."""
-    monkeypatch.delenv("XIAO8_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.delenv("NEKO_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.delenv("VECTORS_FORCE_ENABLE", raising=False)
     monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_1680)
     assert embeddings._cpu_is_blocklisted() is False
 
@@ -47,25 +49,37 @@ def test_blocklist_missing_brand_string_does_not_disable(monkeypatch):
     """When the brand string can not be read (None), treat it as unknown
     and do not disable — same optimistic stance the module takes for
     inconclusive CPU detection."""
-    monkeypatch.delenv("XIAO8_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.delenv("NEKO_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.delenv("VECTORS_FORCE_ENABLE", raising=False)
     monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: None)
     assert embeddings._cpu_is_blocklisted() is False
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
 def test_force_enable_env_overrides_blocklist(monkeypatch, val):
-    """A truthy ``XIAO8_VECTORS_FORCE_ENABLE`` forces the CPU through even
+    """A truthy ``NEKO_VECTORS_FORCE_ENABLE`` forces the CPU through even
     when the brand matches (per-machine escape hatch, Nuitka-safe)."""
+    monkeypatch.delenv("VECTORS_FORCE_ENABLE", raising=False)
     monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
-    monkeypatch.setenv("XIAO8_VECTORS_FORCE_ENABLE", val)
+    monkeypatch.setenv("NEKO_VECTORS_FORCE_ENABLE", val)
+    assert embeddings._cpu_is_blocklisted() is False
+
+
+def test_force_enable_bare_name_fallback_overrides_blocklist(monkeypatch):
+    """The bare ``VECTORS_FORCE_ENABLE`` (no NEKO_ prefix) is honored too,
+    matching config's NEKO_<NAME>-first / bare-<NAME>-fallback key order."""
+    monkeypatch.delenv("NEKO_VECTORS_FORCE_ENABLE", raising=False)
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
+    monkeypatch.setenv("VECTORS_FORCE_ENABLE", "1")
     assert embeddings._cpu_is_blocklisted() is False
 
 
 def test_force_enable_env_falsey_keeps_blocklist(monkeypatch):
     """A non-truthy value (empty / ``0``) is not the switch; the blocklist
     still applies."""
+    monkeypatch.delenv("VECTORS_FORCE_ENABLE", raising=False)
     monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
-    monkeypatch.setenv("XIAO8_VECTORS_FORCE_ENABLE", "0")
+    monkeypatch.setenv("NEKO_VECTORS_FORCE_ENABLE", "0")
     assert embeddings._cpu_is_blocklisted() is True
 
 

--- a/tests/unit/test_embedding_cpu_blocklist.py
+++ b/tests/unit/test_embedding_cpu_blocklist.py
@@ -83,6 +83,26 @@ def test_force_enable_env_falsey_keeps_blocklist(monkeypatch):
     assert embeddings._cpu_is_blocklisted() is True
 
 
+def test_explicit_neko_false_beats_bare_true(monkeypatch):
+    """NEKO_ precedence: an explicit falsey ``NEKO_VECTORS_FORCE_ENABLE``
+    wins over a truthy bare ``VECTORS_FORCE_ENABLE`` — the first present,
+    non-empty key decides and we do not fall through to the bare name.
+    Mirrors config's ``_read_str_env`` key order."""
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
+    monkeypatch.setenv("NEKO_VECTORS_FORCE_ENABLE", "0")
+    monkeypatch.setenv("VECTORS_FORCE_ENABLE", "1")
+    assert embeddings._cpu_is_blocklisted() is True
+
+
+def test_empty_neko_falls_through_to_bare(monkeypatch):
+    """An empty ``NEKO_VECTORS_FORCE_ENABLE`` is treated as unset (not a
+    falsey decision), so a truthy bare ``VECTORS_FORCE_ENABLE`` still wins."""
+    monkeypatch.setattr(embeddings, "_read_cpu_brand_string", lambda: _E5_2666)
+    monkeypatch.setenv("NEKO_VECTORS_FORCE_ENABLE", "")
+    monkeypatch.setenv("VECTORS_FORCE_ENABLE", "1")
+    assert embeddings._cpu_is_blocklisted() is False
+
+
 def test_blocklisted_cpu_disables_service_at_construction(monkeypatch):
     """A blocklisted CPU drives the service straight to DISABLED at
     construction with reason ``cpu_on_known_bad_blocklist`` — ahead of the


### PR DESCRIPTION
## 背景

E5-2666 v3（AWS 定制 Haswell-EP）跑本地 embedding 时 onnxruntime **闪退（SIGILL）**，而同 cohort 的 Broadwell **E5-1680 v4 正常**。

排查 `memory/embeddings.py` 的 SIMD 检测：这两颗在 `family/model` 与 numpy 的 `AVX2`/`vnni` flag 上**判定完全一致**——都没有 AVX512/VNNI，但都有 AVX2，`auto` 因此都选 `int8`、加载 onnxruntime，由 MLAS 在运行时自行做 kernel dispatch。也就是说现有检测逻辑区分不出这两颗，崩溃发生在 onnxruntime 那一层。E5-2666 v3 是 AWS 定制 SKU（二手市场常见翻新/ES 片），存在「CPUID 报了某特性但实际执行会 #UD」的情况。

## 改动

`family/model` 无法单独定位这一颗（`06_3FH` 是整个 Haswell-EP cohort 共用，大多数能正常跑），所以**按 CPU brand string 子串匹配**做一个**已知坏芯片黑名单**：

- 新增 `_read_cpu_brand_string()`：Linux 读 `/proc/cpuinfo` 的 `model name`，Windows 读注册表 `ProcessorNameString`（与既有 `_read_cpu_family_model` 同源同风格）。
- 新增 `_cpu_is_blocklisted()` + 模块常量 `_CPU_BRAND_BLOCKLIST = ("e5-2666 v3",)`，大小写无关子串匹配。
- 命中即在构造阶段（**早于 session 加载**）`_mark_disabled(CPU_BLOCKLISTED)`，优先级高于 RAM / 量化判定，崩溃永不发生；`is_available()` 转 False 后 callers 自动回退 pre-vector 检索路径。
- 新增 disable reason `CPU_BLOCKLISTED = "cpu_on_known_bad_blocklist"`，启动日志能明确区分「人为关」「检测失败」「CPU 拉黑」。
- 逃生门 `NEKO_VECTORS_FORCE_ENABLE=1`（兼容裸 `VECTORS_FORCE_ENABLE`，遵循 repo 的 NEKO_ 前缀约定）：运行时 `os.getenv` 读取，**Nuitka 编译后仍可改**（config 模块编进二进制、环境变量没有），用于误杀时单机强开。

### 设计取舍

- brand-string 解析正是本模块其余地方**刻意规避**的 py-cpuinfo 脆弱模式（别处一律用数值 `family/model`）。因此把它**收敛到 `_cpu_is_blocklisted` 这一处**，黑名单保持**短小且有实证**，而不是通用检测，也不用 `family/model` 一刀切误伤整个 Haswell-EP。
- 命中是**有意整体 disable onnxruntime 会话（int8 与 fp32 一并）**，不只 int8 kernel：崩因尚未坐实到具体 kernel，无法假定 fp32 权重在这颗芯片上安全。fp32 恢复路径未被移除，只是改为经 `NEKO_VECTORS_FORCE_ENABLE=1` 开启。

## 测试

`tests/unit/test_embedding_cpu_blocklist.py`（12 个用例，无重依赖，全 monkeypatch / 注入）：

- 子串大小写无关命中；相邻 SKU（E5-1680 v4）不误杀；读不到 brand 不 disable
- `NEKO_VECTORS_FORCE_ENABLE` 真值/假值、裸名 `VECTORS_FORCE_ENABLE` fallback 覆盖
- 命中时构造即 DISABLED + reason 正确 + `model_id()` 为 None；未命中时不被这道闸 disable

本地 `uv` venv 跑：新增 12 + 既有 embedding 套件 41 全绿；ruff 干净；docstring-CJK 守卫（base=Linux）通过。

## 待补（不在本 PR）

仍建议拿 E5-2666 v3 那台的 `echo $?`（确认 132/SIGILL）与 `dmesg`（确认 `invalid opcode in libonnxruntime*.so`）坐实崩点；若后续发现其它同类坏 SKU，往 `_CPU_BRAND_BLOCKLIST` 追加即可。
