### PR TITLE
[codex] Add manual UI language override

### DIFF
--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel
 from .shared_state import ensure_steamworks, get_config_manager, get_session_manager, get_initialize_character_data
 from .characters_router import get_current_live2d_model
 from utils.file_utils import atomic_write_json_async, read_json_async
-from utils.preferences import aload_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, aload_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
+from utils.preferences import aload_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, aload_global_conversation_settings, save_global_conversation_settings, aload_ui_language_override, GLOBAL_CONVERSATION_KEY
 from utils.cloudsave_runtime import MaintenanceModeError
 from utils.logger_config import get_module_logger
 from utils.config_manager import ensure_default_yui_voice_for_free_api, get_reserved
@@ -463,6 +463,7 @@ async def get_steam_language():
     
     返回字段：
     - success: 是否成功
+    - uiLanguage: 手工配置的 UI 语言覆盖（无前端生产者）
     - steam_language: Steam 原始语言设置
     - i18n_language: 归一化的 i18n 语言代码
     - ip_country: 用户 IP 所在国家代码（如 "CN"）
@@ -475,7 +476,14 @@ async def get_steam_language():
     """
     from utils.language_utils import normalize_language_code, refresh_global_language, is_supported_language_code
 
+    ui_language = None
     try:
+        try:
+            ui_language = await aload_ui_language_override()
+        except Exception:
+            logger.debug("读取 UI 语言覆盖失败", exc_info=True)
+            ui_language = None
+
         steamworks = ensure_steamworks()
         
         if steamworks is None:
@@ -483,6 +491,7 @@ async def get_steam_language():
             return {
                 "success": False,
                 "error": "Steamworks 未初始化",
+                "uiLanguage": ui_language,
                 "steam_language": None,
                 "i18n_language": None,
                 "ip_country": None,
@@ -549,6 +558,7 @@ async def get_steam_language():
         
         return {
             "success": True,
+            "uiLanguage": ui_language,
             "steam_language": steam_language,
             "i18n_language": i18n_language,
             "ip_country": ip_country,
@@ -560,6 +570,7 @@ async def get_steam_language():
         return {
             "success": False,
             "error": str(e),
+            "uiLanguage": ui_language,
             "steam_language": None,
             "i18n_language": None,
             "ip_country": None,

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -459,20 +459,20 @@ async def save_conversation_settings(request: Request):
 
 @router.get("/steam_language")
 async def get_steam_language():
-    """获取 Steam 客户端的语言设置和 GeoIP 信息，用于前端 i18n 初始化和区域检测
-    
-    返回字段：
-    - success: 是否成功
-    - uiLanguage: 手工配置的 UI 语言覆盖（无前端生产者）
-    - steam_language: Steam 原始语言设置
-    - i18n_language: 归一化的 i18n 语言代码
-    - ip_country: 用户 IP 所在国家代码（如 "CN"）
-    - is_mainland_china: 是否为中国大陆用户（基于语言设置存在 + IP 为 CN）
-    
-    判断逻辑：
-    - 如果存在 Steam 语言设置（即有 Steam 环境），则检查 GeoIP
-    - 如果 IP 国家代码为 "CN"，则标记为中国大陆用户
-    - 如果不存在 Steam 语言设置（无 Steam 环境），默认为非大陆用户
+    """Return Steam language and GeoIP hints for frontend locale setup.
+
+    Response fields:
+    - success: whether the lookup succeeded
+    - uiLanguage: manual UI language override with no frontend producer
+    - steam_language: raw Steam language setting
+    - i18n_language: normalized i18n language code
+    - ip_country: country code from the user's IP, such as "CN"
+    - is_mainland_china: whether the user is in mainland China
+
+    Decision rules:
+    - When a Steam language exists, check GeoIP as well
+    - When the IP country code is "CN", mark the user as mainland China
+    - When no Steam language exists, default to non-mainland behavior
     """
     from utils.language_utils import normalize_language_code, refresh_global_language, is_supported_language_code
 

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -12,7 +12,7 @@
  * 1. 加载本地 i18next 库（从 /static/libs/）
  * 2. 检查依赖加载状态
  * 3. 处理加载失败容错（重新加载或降级方案）
- * 4. 从 Steam API 获取语言设置
+ * 4. 从配置覆盖 / Steam API 获取语言设置
  * 5. 初始化 i18next
  */
 
@@ -92,6 +92,31 @@
         return '';
     }
 
+    function normalizeSupportedLanguageCode(rawLanguage) {
+        const value = String(rawLanguage || '').trim();
+        if (!value) {
+            return '';
+        }
+        if (SUPPORTED_LANGUAGES.includes(value)) {
+            return value;
+        }
+        const lower = value.toLowerCase();
+        const langCode = lower.split('-')[0];
+        if (langCode === 'en') return 'en';
+        if (langCode === 'ja') return 'ja';
+        if (langCode === 'ko') return 'ko';
+        if (langCode === 'ru') return 'ru';
+        if (langCode === 'es') return 'es';
+        if (langCode === 'pt') return 'pt';
+        if (langCode === 'zh') {
+            if (/(tw|hk|hant)/i.test(value)) {
+                return 'zh-TW';
+            }
+            return 'zh-CN';
+        }
+        return '';
+    }
+
     // 获取浏览器语言（同步，作为 fallback）
     function getBrowserLanguage() {
         const queryLanguage = getLanguageFromQuery();
@@ -108,25 +133,9 @@
         // 2. 检查浏览器语言设置
         const browserLanguage = navigator.language || navigator.userLanguage;
         if (browserLanguage) {
-            // 完全匹配
-            if (SUPPORTED_LANGUAGES.includes(browserLanguage)) {
-                return browserLanguage;
-            }
-            // 部分匹配（例如 'en-US' 匹配 'en'）
-            const langCode = browserLanguage.split('-')[0].toLowerCase();
-            if (langCode === 'en') return 'en';
-            if (langCode === 'ja') return 'ja';
-            if (langCode === 'ko') return 'ko';
-            if (langCode === 'ru') return 'ru';
-            if (langCode === 'es') return 'es';
-            if (langCode === 'pt') return 'pt';
-            if (langCode === 'zh') {
-                // 根据地区/脚本区分简繁（如 zh-TW / zh-HK / zh-Hant）
-                const upper = browserLanguage.toUpperCase();
-                if (upper.includes('TW') || upper.includes('HK') || upper.includes('HANT')) {
-                    return 'zh-TW';
-                }
-                return 'zh-CN';
+            const normalized = normalizeSupportedLanguageCode(browserLanguage);
+            if (normalized) {
+                return normalized;
             }
         }
 
@@ -134,39 +143,53 @@
         return 'zh-CN';
     }
 
-    // 从 Steam API 获取语言设置（异步）
-    async function getSteamLanguage() {
+    // 从后端获取语言设置（异步）：同一请求携带手工 UI 覆盖和 Steam 语言
+    async function getServerLanguagePreferences() {
         try {
             const response = await fetch('/api/config/steam_language', {
                 method: 'GET',
                 headers: { 'Content-Type': 'application/json' },
+                cache: 'no-store',
                 // 设置超时，避免阻塞太久
                 signal: AbortSignal.timeout(2000)
             });
 
             if (!response.ok) {
                 console.log('[i18n] Steam 语言 API 响应异常:', response.status);
-                return null;
+                return { uiLanguage: null, steamLanguage: null };
             }
 
             const data = await response.json();
             console.log('[i18n] Steam API 返回语言设置:', data);
 
-            if (data.success && data.i18n_language && SUPPORTED_LANGUAGES.includes(data.i18n_language)) {
-                return data.i18n_language;
+            const uiLanguage = normalizeSupportedLanguageCode(data && data.uiLanguage);
+            if (uiLanguage) {
+                console.log('[i18n] 使用 uiLanguage 覆盖语言:', uiLanguage);
             }
 
-            console.log('[i18n] Steam 语言 API 返回无效数据，回退到浏览器设置');
-            return null;
+            let steamLanguage = null;
+            if (data.success && data.i18n_language && SUPPORTED_LANGUAGES.includes(data.i18n_language)) {
+                steamLanguage = data.i18n_language;
+            }
+
+            if (!steamLanguage) {
+                console.log('[i18n] Steam 语言 API 返回无效数据，回退到浏览器设置');
+            }
+            return { uiLanguage, steamLanguage };
         } catch (error) {
             // 可能是超时或网络错误，静默处理
             console.log('[i18n] 无法从 Steam 获取语言设置，使用浏览器设置:', error.message);
-            return null;
+            return { uiLanguage: null, steamLanguage: null };
         }
     }
 
-    // 获取初始语言：优先 Steam 设置，然后 localStorage，然后浏览器设置，最后默认中文
+    // 获取初始语言：uiLanguage 强制覆盖 > URL 参数 > Steam 设置 > localStorage / 浏览器设置 > 默认中文
     async function getInitialLanguage() {
+        const serverLanguages = await getServerLanguagePreferences();
+        if (serverLanguages.uiLanguage) {
+            return serverLanguages.uiLanguage;
+        }
+
         const queryLanguage = getLanguageFromQuery();
         if (queryLanguage) {
             localStorage.setItem('i18nextLng', queryLanguage);
@@ -174,11 +197,10 @@
         }
 
         // 1. 尝试从 Steam API 获取语言
-        const steamLanguage = await getSteamLanguage();
-        if (steamLanguage) {
+        if (serverLanguages.steamLanguage) {
             // 保存到 localStorage，下次可以直接使用
-            localStorage.setItem('i18nextLng', steamLanguage);
-            return steamLanguage;
+            localStorage.setItem('i18nextLng', serverLanguages.steamLanguage);
+            return serverLanguages.steamLanguage;
         }
 
         // 2. 回退到浏览器语言

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -82,8 +82,8 @@
     function getLanguageFromQuery() {
         try {
             const params = new URLSearchParams(window.location.search || '');
-            const queryLanguage = String(params.get('ui_lang') || params.get('lang') || '').trim();
-            if (queryLanguage && SUPPORTED_LANGUAGES.includes(queryLanguage)) {
+            const queryLanguage = normalizeSupportedLanguageCode(params.get('ui_lang') || params.get('lang'));
+            if (queryLanguage) {
                 return queryLanguage;
             }
         } catch (error) {

--- a/tests/unit/test_cloudsave_i18n.py
+++ b/tests/unit/test_cloudsave_i18n.py
@@ -13,6 +13,7 @@ CLOUDSAVE_TEMPLATE = PROJECT_ROOT / "templates" / "cloudsave_manager.html"
 CHARA_TEMPLATE = PROJECT_ROOT / "templates" / "character_card_manager.html"
 CHARA_MANAGER_JS = PROJECT_ROOT / "static" / "js" / "character_card_manager.js"
 I18N_JS = PROJECT_ROOT / "static" / "i18n-i18next.js"
+APP_SETTINGS_JS = PROJECT_ROOT / "static" / "app-settings.js"
 
 
 def _get_nested_value(payload: dict, dotted_key: str):
@@ -506,6 +507,32 @@ def test_i18n_script_supports_explicit_popup_language_query():
 
     assert "function getLanguageFromQuery()" in script
     assert "params.get('ui_lang')" in script
+
+
+@pytest.mark.unit
+def test_i18n_script_prefers_manual_ui_language_override_without_persisting_it():
+    script = I18N_JS.read_text(encoding="utf-8")
+
+    assert "function getServerLanguagePreferences()" in script
+    assert "fetch('/api/config/steam_language'" in script
+    assert "fetch('/api/config/ui_language'" not in script
+    assert "const uiLanguage = normalizeSupportedLanguageCode(data && data.uiLanguage);" in script
+    assert "const serverLanguages = await getServerLanguagePreferences();" in script
+    assert re.search(
+        r"async function getInitialLanguage\(\) \{\s*"
+        r"const serverLanguages = await getServerLanguagePreferences\(\);[\s\S]*?"
+        r"if \(serverLanguages\.uiLanguage\) \{[\s\S]*?"
+        r"const queryLanguage = getLanguageFromQuery\(\);",
+        script,
+    )
+    assert "localStorage.setItem('i18nextLng', serverLanguages.uiLanguage)" not in script
+
+
+@pytest.mark.unit
+def test_app_settings_does_not_produce_manual_ui_language_override():
+    script = APP_SETTINGS_JS.read_text(encoding="utf-8")
+
+    assert "uiLanguage" not in script
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cloudsave_i18n.py
+++ b/tests/unit/test_cloudsave_i18n.py
@@ -507,6 +507,8 @@ def test_i18n_script_supports_explicit_popup_language_query():
 
     assert "function getLanguageFromQuery()" in script
     assert "params.get('ui_lang')" in script
+    assert "normalizeSupportedLanguageCode(params.get('ui_lang') || params.get('lang'))" in script
+    assert "SUPPORTED_LANGUAGES.includes(queryLanguage)" not in script
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cloudsave_lifecycle_flow.py
+++ b/tests/unit/test_cloudsave_lifecycle_flow.py
@@ -570,6 +570,7 @@ def test_main_server_limited_mode_middleware_blocks_runtime_routes():
     assert payload["limited_mode"] is True
     assert health_response.status_code == 200
     assert steam_language_response.status_code == 200
+    assert "uiLanguage" in steam_language_response.json()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -96,6 +96,30 @@ def _write_runtime_state(cm, *, character_name="小满"):
 
 
 @pytest.mark.unit
+def test_ui_language_override_uses_raw_global_preference_only(tmp_path):
+    cm = _make_config_manager(tmp_path)
+    cm.ensure_config_directory()
+    atomic_write_json(
+        cm.get_runtime_config_path("user_preferences.json"),
+        [
+            {
+                "model_path": "__global_conversation__",
+                "userLanguage": "en",
+                "uiLanguage": "zh-TW",
+            }
+        ],
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    import utils.preferences as preferences
+
+    with patch.object(preferences, "_config_manager", cm):
+        assert preferences.load_ui_language_override() == "zh-TW"
+        assert "uiLanguage" not in preferences.load_global_conversation_settings()
+
+
+@pytest.mark.unit
 def test_resolve_managed_target_path_rejects_traversal(tmp_path):
     from utils.cloudsave_runtime import _resolve_managed_target_path
 

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -347,6 +347,31 @@ async def aload_global_conversation_settings() -> Dict[str, Any]:
     return await asyncio.to_thread(load_global_conversation_settings)
 
 
+def load_ui_language_override() -> Optional[str]:
+    """Load the optional UI language override from the raw global settings entry."""
+    try:
+        global PREFERENCES_FILE
+        PREFERENCES_FILE = _get_active_preferences_path()
+        if os.path.exists(PREFERENCES_FILE):
+            with open(PREFERENCES_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                for pref in data:
+                    if pref.get('model_path') == GLOBAL_CONVERSATION_KEY:
+                        value = pref.get('uiLanguage')
+                        if isinstance(value, str):
+                            value = value.strip()
+                            return value or None
+    except Exception as e:
+        print(f"加载 UI 语言覆盖失败: {e}")
+    return None
+
+
+async def aload_ui_language_override() -> Optional[str]:
+    """Async wrapper for ``load_ui_language_override``."""
+    return await asyncio.to_thread(load_ui_language_override)
+
+
 def is_privacy_mode_enabled() -> bool:
     """前端"隐私模式"开关是否开启。
 


### PR DESCRIPTION
## Summary

- Add a read-only `uiLanguage` preference override for forcing the UI locale for specific users.
- Include the override in the existing `/api/config/steam_language` response so the frontend does not need an extra local TCP request.
- Make frontend language selection prefer `uiLanguage`, then URL override, then Steam language, then stored/browser fallback.

## Root cause

Some environments could briefly initialize with the expected Chinese locale, then switch to English once the asynchronous language probe completed. `user_preferences.json` already had `userLanguage: zh`, but that field is produced by normal preference flows and is not a dedicated high-priority UI override.

## Validation

- `node --check static\i18n-i18next.js`
- `uv run pytest tests\unit\test_cloudsave_i18n.py -q`
- `uv run pytest tests\unit\test_cloudsave_runtime.py -q -k ui_language_override`
- `uv run pytest tests\unit\test_cloudsave_lifecycle_flow.py -q -k limited_mode_middleware`
- `uv run python scripts\check_docstring_no_cjk.py --base origin/main`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持“手动 UI 语言覆盖”并可由服务器强制覆盖客户端显示语言；服务端返回包含 uiLanguage 的响应。
  * 语言初始化改进：统一语言码、区分繁/简体、URL 参数经归一化处理，优先级为：服务器覆盖 > URL 参数（可写入存储） > Steam/服务器语言 > 浏览器回退；手动 UI 覆盖不再持久化到本地存储。
* **测试**
  * 增补单元测试，覆盖语言归一、优先级、受限模式下返回字段及不持久化 UI 覆盖的行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->