### PR TITLE
fix(chat): compact 工具轮盘转角改为会话内记忆+刷新复位

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5026,7 +5026,10 @@ describe('App', () => {
     fireEvent.pointerUp(fan, { pointerId: 7, clientX: 101, clientY: 100, buttons: 0, pointerType: 'mouse' });
   });
 
-  it('reopens compact input tools at the last wheel position', () => {
+  // 折中语义（取舍脉络见 App.tsx openCompactInputToolFan 注释）：
+  // 轮盘转角在「会话内」（组件存活期间）延续上次滚到的位置，关闭再展开不弹回默认；
+  // 但「不」持久化到 localStorage —— 页面刷新/组件重挂后随 useState 初值复位到环位 0。
+  it('keeps the compact input tool wheel position within a session but resets after remount', () => {
     const { unmount } = render(
       <App
         chatSurfaceMode="compact"
@@ -5041,14 +5044,17 @@ describe('App', () => {
 
     fireEvent.wheel(fan, { deltaY: 80 });
     expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-avatar');
-    expect(window.localStorage.getItem(COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY)).toBe('1');
+    // 转角不再写入 localStorage —— 该 key 始终为空。
+    expect(window.localStorage.getItem(COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY)).toBeNull();
 
+    // 会话内关闭再展开：保持上次转出来的位置（avatar 仍在正中槽位 0）。
     fireEvent.click(actionButton);
     expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
     fireEvent.click(actionButton);
     fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
     expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-avatar');
 
+    // 卸载再重挂（模拟页面刷新）：转角复位回默认环位 0（screenshot 居中）。
     unmount();
     render(
       <App
@@ -5058,7 +5064,9 @@ describe('App', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
     fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
-    expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-avatar');
+    expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-screenshot');
+    // 重挂后依然不产生持久化写入。
+    expect(window.localStorage.getItem(COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY)).toBeNull();
   });
 
   it('stops compact input tool wheel motion on pointer release', async () => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -109,7 +109,6 @@ const SPEECH_PLAYBACK_STATE_STORAGE_KEY = 'neko_speech_playback_state';
 const SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';
 const COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY = 'neko.reactChatWindow.compactExportHistoryOpen';
 const COMPACT_HISTORY_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.compactHistorySlotHeight';
-const COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY = 'neko.reactChatWindow.compactInputToolWheelIndex';
 export const COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS = 560;
 const COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT = 7;
 const COMPACT_INPUT_TOOL_WHEEL_DRAG_THRESHOLD = 22;
@@ -377,32 +376,6 @@ function persistCompactHistorySlotHeight(value: number | null) {
   } catch {
     // localStorage can be unavailable in restricted hosts; keep the in-memory state.
   }
-}
-
-function normalizeCompactInputToolWheelIndex(value: unknown): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return 0;
-  const index = Math.trunc(parsed);
-  return ((index % COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT) + COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT) % COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT;
-}
-
-function readPersistedCompactInputToolWheelIndex(): number {
-  if (typeof window === 'undefined') return 0;
-  try {
-    return normalizeCompactInputToolWheelIndex(window.localStorage?.getItem(COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY));
-  } catch {
-    return 0;
-  }
-}
-
-function persistCompactInputToolWheelIndex(index: number) {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage?.setItem(
-      COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY,
-      String(normalizeCompactInputToolWheelIndex(index)),
-    );
-  } catch {}
 }
 
 // 历史区高度上限的基数：Electron 独立窗口用工作区高度（窗口可能只覆盖部分屏，不能用 innerHeight），
@@ -1248,7 +1221,9 @@ function CompactChatApp({
   const [compactInputToolFanOpen, setCompactInputToolFanOpen] = useState(false);
   const [compactInputToolFanInteractive, setCompactInputToolFanInteractive] = useState(false);
   const [compactInputToolWheelLayout, setCompactInputToolWheelLayout] = useState<CompactInputToolWheelLayout>('default');
-  const [compactInputToolWheelIndex, setCompactInputToolWheelIndex] = useState(readPersistedCompactInputToolWheelIndex);
+  // 环位转角是组件级 state：会话内（组件存活期间）一直延续上次滚到的位置，
+  // 但不持久化到 localStorage —— 页面刷新/组件重挂时会随初值复位到环位 0（默认布局）。
+  const [compactInputToolWheelIndex, setCompactInputToolWheelIndex] = useState(0);
   const [compactInputToolWheelFastAnimation, setCompactInputToolWheelFastAnimation] = useState(false);
   const [compactInputToolWheelChargeRatio, setCompactInputToolWheelChargeRatio] = useState(0);
   const [compactInputToolWheelChargeDirection, setCompactInputToolWheelChargeDirection] = useState<1 | -1 | null>(null);
@@ -3440,10 +3415,6 @@ function CompactChatApp({
     toolMenuOpen,
   ]);
 
-  useEffect(() => {
-    persistCompactInputToolWheelIndex(compactInputToolWheelIndex);
-  }, [compactInputToolWheelIndex]);
-
   useLayoutEffect(() => {
     if (!compactInputToolFanOpen) {
       setCompactInputToolWheelLayout('default');
@@ -3473,7 +3444,11 @@ function CompactChatApp({
 
   const openCompactInputToolFan = useCallback((intent: 'click' | 'hover') => {
     if (composerDisabled || compactInputHasPayload) return;
-    // 展开时延续上次轮盘中心索引；hover 抖动重入或重新打开都不应把用户刚滚到的位置弹回默认位。
+    // 展开时延续上次轮盘中心索引（compactInputToolWheelIndex 是组件级 state，会话内常驻）：
+    // hover 抖动重入或重新打开都不主动把用户刚滚到的位置弹回默认位。复位只随页面刷新/组件
+    // 重挂发生（useState 初值为环位 0）。取舍脉络：#1697 曾在此「每次展开复位 index=0」，
+    // #1703 改为 localStorage 持久化记忆，本次去掉持久化、只保留会话内记忆 + 刷新复位。
+    // 因此这里不要再加 setCompactInputToolWheelIndex(0)，也不要重新引入 localStorage 持久化。
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
     compactInputToolFanOpenIntentRef.current = intent;


### PR DESCRIPTION
## 背景 / 根因

`#1697` 曾在 `openCompactInputToolFan` 里实现「每次从关闭态展开都把轮盘转角复位到默认环位 0」。`#1703`（标题：恢复轮盘滚动位置记忆）有意把这段复位删掉，改成 **localStorage 持久化、跨刷新记忆上次停留位置**。所以"复位没生效"并非 bug，而是被后一个 PR 整段替换成了相反行为。

`#1703` 同 commit 的「gal 选项层拦截轮盘点击」修复是**纯 CSS**（`pointer-events`），与转角逻辑解耦，本 PR **未触碰**。

## 改动（折中语义：会话内记忆 + 刷新复位）

- 移除 `#1703` 的持久化全套：`COMPACT_INPUT_TOOL_WHEEL_INDEX_STORAGE_KEY` 常量、`normalize/readPersisted/persist` 三个函数、写回的 `useEffect`。
- `compactInputToolWheelIndex` 改回 `useState(0)`：组件级 state 让转角在**会话内常驻**（关闭再展开不弹回默认），页面刷新/组件重挂时随初值**复位到环位 0**（默认布局）。
- `rotate` 自带取模 wrap，删 `normalize` 无影响。
- 在 `useState` 和 `openCompactInputToolFan` 处补注释，写清 `#1697 → #1703 → 本次` 的取舍脉络，明确「不要再加 setIndex(0)、不要重新引入 localStorage 持久化」。

## 测试

把 `#1703` 的持久化用例重写为折中语义（`keeps the compact input tool wheel position within a session but resets after remount`）：

- 滚一格 → 正中槽位变 avatar，断言 `localStorage` 该 key 为 `null`（不再持久化）。
- 会话内关闭再展开 → 仍 avatar（会话内记忆）。
- `unmount` + 重新 render（模拟刷新）→ 回 screenshot（重挂复位），且仍无持久化写入。

`App.test.tsx` **159/159 通过**，`tsc --noEmit` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了输入工具轮盘位置的会话存储逻辑，现在轮盘位置仅在当前使用会话内保留，刷新页面或重新打开应用后将重置为默认位置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->