### PR TITLE
fix(idle): 根治待机思考气泡 cache-bust 致图像解码缓存泄漏（挂机久了 committed 暴涨 10G+）

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -728,7 +728,11 @@ function _restartNekoIdleThoughtBubbleArt(button, tier) {
     button.classList.remove(_NEKO_IDLE_THOUGHT_BUBBLE_POPPING_CLASS);
     _setNekoIdleThoughtBubbleFocusable(button, false);
     button.classList.toggle(_NEKO_IDLE_THOUGHT_BUBBLE_SLEEPING_CLASS, !!bubbleConfig.sleeping);
-    button.__nekoIdleThoughtBubbleRestartToken = (button.__nekoIdleThoughtBubbleRestartToken || 0) + 1;
+    // cache-bust 用有界的 1/2 交替：相邻两次 URL 不同足以让浏览器重载、重启 GIF 动画从头播，
+    // 同时把唯一 URL 总数钉死在每个 asset 最多 2 个。此前用单调递增 token（…?restart=N，N 永增）
+    // 会让每次待机气泡的图都是全新 URL，Chromium 按 URL 缓存解码位图（~2MB/张，mapped 共享内存、
+    // 不计入进程私有提交），猫咪待机数日后累积到 10G+ committed —— 「挂机久了已提交内存暴涨」的根因。
+    button.__nekoIdleThoughtBubbleRestartToken = ((button.__nekoIdleThoughtBubbleRestartToken || 0) % 2) + 1;
     const bg = button.querySelector('.neko-idle-thought-bubble-bg');
     if (bg) {
         bg.src = _getNekoIdleThoughtBubbleBgAssetUrl(bubbleConfig.assetUrl, button.__nekoIdleThoughtBubbleRestartToken);
@@ -771,7 +775,11 @@ function _popNekoIdleThoughtBubble(button, detail = {}) {
     }
     button.__nekoIdleThoughtBubbleAudio = null;
     button.__nekoIdleThoughtBubbleTimerToken = (button.__nekoIdleThoughtBubbleTimerToken || 0) + 1;
-    button.__nekoIdleThoughtBubbleRestartToken = (button.__nekoIdleThoughtBubbleRestartToken || 0) + 1;
+    // cache-bust 用有界的 1/2 交替：相邻两次 URL 不同足以让浏览器重载、重启 GIF 动画从头播，
+    // 同时把唯一 URL 总数钉死在每个 asset 最多 2 个。此前用单调递增 token（…?restart=N，N 永增）
+    // 会让每次待机气泡的图都是全新 URL，Chromium 按 URL 缓存解码位图（~2MB/张，mapped 共享内存、
+    // 不计入进程私有提交），猫咪待机数日后累积到 10G+ committed —— 「挂机久了已提交内存暴涨」的根因。
+    button.__nekoIdleThoughtBubbleRestartToken = ((button.__nekoIdleThoughtBubbleRestartToken || 0) % 2) + 1;
     const timerToken = button.__nekoIdleThoughtBubbleTimerToken;
 
     button.classList.remove(_NEKO_IDLE_THOUGHT_BUBBLE_SLEEPING_CLASS);


### PR DESCRIPTION
## 问题
N.E.K.O 挂机（切猫咪态 / 「请她离开」）数天后，系统**已提交内存（commit charge）暴涨到 10G+**，但物理内存（working set）只有几百 MB，点托盘「重新加载」能掉好几 G。

棘手之处：常规排查全部失灵 —— 进程私有提交（`PrivatePageCount`）采样、任务管理器「提交大小」列、DevTools heap snapshot **全都看不到**这块内存。

## 根因
`static/avatar-ui-buttons.js` 两处给待机思考气泡的 bg 图做 cache-bust 用的是**单调递增 token**：
- `_restartNekoIdleThoughtBubbleArt`（待机气泡显示，约 5min/次，主累积源）
- `_popNekoIdleThoughtBubble`（气泡被戳破，点击触发）

`_getNekoIdleThoughtBubbleBgAssetUrl(url, token)` 拼成 `url?restart=N`，N 永远递增 → 每次都是**全新 URL**。Chromium 按 URL 缓存解码后的位图（每张 ~2MB），token 无限 → 唯一 URL 无限 → 解码缓存只进不出。

这块缓存是 **`MEM_MAPPED` 共享内存**（pagefile-backed section），不计入进程私有提交 / V8 JS 堆，所以只在系统 commit charge 上可见，常规工具查不到。

实测（`VirtualQueryEx` 遍历 renderer 整个地址空间）：待机数天的 renderer 真实 committed **11G**，其中 mapped **10.3G / 5152 块匿名 section**（多数 ~2MB，正好是解码位图量级），有名文件映射仅 57MB（字体）。reload 销毁 renderer 整片释放 → 对应用户观察到的「掉 7G」。

## 修复
两处 token 改为 `((token || 0) % 2) + 1`，在 1↔2 间交替：
- 相邻两次 bg URL 仍不同 → 保留「重载、重启 GIF 动画从头播」的原意
- 唯一 URL 总数钉死在每个 asset 最多 2 个 → 根除无限累积

## 验证建议
待机态长时间挂机后，renderer 的 mapped committed 不再单调增长（需用 `VirtualQueryEx` 按 `MEM_MAPPED` 口径监控，私有提交 / heap snapshot 口径看不到）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)