### PR TITLE
fix(idle): 释放 idle 过渡 GIF 解码帧缓存，缓解 live2d 模式 committed 泄漏

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -1441,8 +1441,14 @@ function _cleanupNekoIdleArtTransition(art) {
         clearTimeout(art.__nekoIdleTransitionTimer);
         art.__nekoIdleTransitionTimer = 0;
     }
-    if (art.__nekoIdleTransitionNext && art.__nekoIdleTransitionNext.parentNode) {
-        art.__nekoIdleTransitionNext.parentNode.removeChild(art.__nekoIdleTransitionNext);
+    if (art.__nekoIdleTransitionNext) {
+        // 丢弃过渡临时 <img> 前先清空 src，让 Blink 立即释放该动画 GIF 的解码帧缓存
+        // （MEM_MAPPED 共享内存）。否则每次 idle 美术过渡都 createElement 一个新 <img>
+        // 播 cat-idle GIF，removeChild 后解码缓冲不及时回收，长期累积撑高 committed。
+        try { art.__nekoIdleTransitionNext.removeAttribute('src'); } catch (_) {}
+        if (art.__nekoIdleTransitionNext.parentNode) {
+            art.__nekoIdleTransitionNext.parentNode.removeChild(art.__nekoIdleTransitionNext);
+        }
     }
     art.__nekoIdleTransitionNext = null;
     art.__nekoIdleTransitionTo = '';


### PR DESCRIPTION
承接 #1799。合并后 live2d 模式仍有 committed 单调增长（~2MB/5.5s）。

## 根因
用 `VirtualQueryEx` 按 `MEM_MAPPED` 口径定位（私有提交/任务管理器/heap snapshot 全看不到这块）。逐一排除网络图、canvas/ImageBitmap、createObjectURL、WebGL、截屏帧、5s 心跳——**所有 JS hook 全空**，指纹指向 Blink 原生**动画 GIF 解码帧缓存**：`cat-idle-*.gif` 每播一轮（~5s）累积一块 ~2MB 解码帧不回收。

## 本 PR
`_cleanupNekoIdleArtTransition` 丢弃过渡临时 `<img>` 前先 `removeAttribute('src')`，让 Blink 立即释放其 GIF 解码缓冲（而非等 GC），堵住「每次过渡新建 `<img>` 播 GIF→removeChild 后解码缓冲滞留」这条累积路径。只作用于本就要丢弃的元素，不影响正常显示。

## 边界（诚实标注）
若主 idle GIF（持续循环的 `cat-idle-cat1.gif`）每轮仍累积解码帧，彻底根治需把大动画 GIF 换成 `<video>`(webm/mp4) 或 sprite-sheet——**需要新素材，另开 follow-up PR**。本补丁是不需新素材的针对性缓解。

🤖 Generated with [Claude Code](https://claude.com/claude-code)