### PR TITLE
fix(activity-signal): 消费心跳 POST 响应体，根治挂机 committed 内存暴涨 10G+

### DIFF
--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -370,6 +370,18 @@
             }
         } finally {
             inFlight = false;
+            // 排空响应体，立即释放 fetch 响应的 Mojo 数据管道共享缓冲（默认容量 ~2MB）。
+            // 成功路径（resp.ok）与多数失败路径都从不读 body，而 isCsrfValidationFailure
+            // 对非 403 直接 return false 也不读 —— 未消费的响应体会让该数据管道一直占着
+            // MEM_MAPPED 直到 GC。每 5s 心跳漏一块 ~2MB，挂机数小时 committed 涨到 10G+
+            // （renderer 私有提交 / 任务管理器「提交大小」/ DevTools heap snapshot 都看
+            // 不到，只在系统 commit charge 上暴涨，需 VirtualQueryEx 按 MEM_MAPPED 口径才
+            // 量得到）。用 body.cancel() 不读内容直接释放管道；bodyUsed 守卫避免重复消费。
+            try {
+                if (typeof resp !== 'undefined' && resp && resp.body && !resp.bodyUsed) {
+                    resp.body.cancel();
+                }
+            } catch (_) { /* 已消费 / 无 body / 环境不支持，忽略 */ }
         }
     }
 


### PR DESCRIPTION
## 问题
N.E.K.O 挂机（尤其切猫咪态 / 长时间 idle）数小时后，系统**已提交内存（commit charge）暴涨到 10GB+**，但物理内存（working set）只有几百 MB。极难排查：进程私有提交、V8 JS 堆、任务管理器「提交大小」列、DevTools heap snapshot **全都看不到**这块内存。

## 根因
`static/app-activity-signal.js` 的活动信号心跳每 5 秒 `fetch('/api/activity_signal', {method:'POST'})`，但**成功路径（`resp.ok`）和多数失败路径都从不读响应体**（`isCsrfValidationFailure` 对非 403 直接 `return false` 也不读 body）。

Chromium 里未消费的 `fetch` 响应体会一直占住它底层的 **Mojo 数据管道共享缓冲（默认容量正好 ~2MB）**，直到 `Response` 对象被 GC。心跳每 5 秒产生一个、累积远快于 GC → 渲染进程的 `MEM_MAPPED` 稳定以 **~24MB/分** 增长 → 挂机一夜系统 committed 涨到 **10GB+**。

这块内存只在系统 commit charge 上可见，需用 `VirtualQueryEx` 按 `MEM_MAPPED`（Type `0x40000`）遍历渲染进程地址空间才量得到。

## 定位过程（逐步二分）
1. 同测所有进程：只有**一个 renderer** 的 mapped 增长，GPU / 主进程 / utility **全平** → 锁定单一渲染进程自己创建的匿名 ~2MB 映射 section。
2. 排除：GIF / canvas / WebGL / createObjectURL（hook 全空）、GPU（`--disable-gpu` 软渲染仍漏）、JS 堆（`performance.memory` GC 健康）、渲染（限帧 60→5fps 无变化）。
3. 掐断 `window.nekoActivitySignal.read` → mapped 增长**当场归零**。
4. hammer 200 次纯 `invoke`（不 POST）→ **不增长**；而空 payload 跳过 POST 后增长**停** → 锁定是**未消费的 POST 响应体**。

## 修复
在 `finally` 里 `resp.body.cancel()` 排空响应体、立即释放数据管道（`bodyUsed` 守卫避免重复消费）。

## 验证
实测修复后渲染进程 mapped 从 **24MB/分 → 0**（3 分钟纹丝不动）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)