### PR TITLE
[codex] 过滤 free 模型工具调用泄露文本

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -971,6 +971,9 @@ class OmniOfflineClient:
                         log_tool_leak_filtered(event, provider=tool_leak_provider)
                     if tail:
                         streamed_text_buffer += tail
+                        tail_chunk = LLMStreamChunk(content=tail)
+                        setattr(tail_chunk, "_tool_leak_filtered", True)
+                        yield tail_chunk
                     tool_leak_filter.reset()
                 # ChatOpenAI is the right import even though we're outside
                 # ChatOpenAI — `collect_tool_calls` is a staticmethod.
@@ -1257,6 +1260,9 @@ class OmniOfflineClient:
                         log_tool_leak_filtered(event, provider=tool_leak_provider)
                     if tail:
                         streamed_text_buffer += tail
+                        tail_chunk = LLMStreamChunk(content=tail)
+                        setattr(tail_chunk, "_tool_leak_filtered", True)
+                        yield tail_chunk
                     tool_leak_filter.reset()
                 # 把本轮已经流给用户的 text 一起写进历史。Gemini 在同一 turn
                 # 里允许 text part 与 function_call part 并存；如果这里仍写

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -847,24 +847,36 @@ class OmniOfflineClient:
         leak_filter = ToolLeakFilter(tool_names=tool_names)
         provider = getattr(self, "base_url", None) or getattr(self, "model", None)
 
-        async for chunk in self._astream_with_tools(
-            messages, _tool_leak_filter=leak_filter, _tool_leak_provider=provider, **overrides
-        ):
-            if getattr(chunk, "_tool_leak_filtered", False):
-                yield chunk
-                continue
-            content = getattr(chunk, "content", None)
-            if content:
-                chunk.content = self._filter_tool_leak_content(content, leak_filter, provider=provider)
-                setattr(chunk, "_tool_leak_filtered", True)
-            yield chunk
-
-        visible, event = leak_filter.finalize()
-        if event:
-            log_tool_leak_filtered(event, provider=provider)
-        if visible:
+        def _finalize_filter_chunk():
+            visible, event = leak_filter.finalize()
+            if event:
+                log_tool_leak_filtered(event, provider=provider)
+            if not visible:
+                return None
             chunk = LLMStreamChunk(content=visible)
             setattr(chunk, "_tool_leak_filtered", True)
+            return chunk
+
+        try:
+            async for chunk in self._astream_with_tools(
+                messages, _tool_leak_filter=leak_filter, _tool_leak_provider=provider, **overrides
+            ):
+                if getattr(chunk, "_tool_leak_filtered", False):
+                    yield chunk
+                    continue
+                content = getattr(chunk, "content", None)
+                if content:
+                    chunk.content = self._filter_tool_leak_content(content, leak_filter, provider=provider)
+                    setattr(chunk, "_tool_leak_filtered", True)
+                yield chunk
+        except Exception:
+            chunk = _finalize_filter_chunk()
+            if chunk is not None:
+                yield chunk
+            raise
+
+        chunk = _finalize_filter_chunk()
+        if chunk is not None:
             yield chunk
 
     def _filter_tool_leak_content(

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -816,6 +816,8 @@ class OmniOfflineClient:
                     # 让上游 retry 路径基于 attempt+1 重新走（下次会直接
                     # 进 OpenAI-compat，因为 _genai_tools_unsupported=True）。
                     raise
+                if tool_leak_filter is not None:
+                    tool_leak_filter.reset()
             except Exception as e:
                 # Don't break user requests on transient genai SDK errors —
                 # log loudly and fall through. ``_genai_tools_unsupported``
@@ -827,6 +829,8 @@ class OmniOfflineClient:
                     # 流程清空气泡后基于 attempt+1 重试（下一次仍会先尝试
                     # genai，因为 transient 不翻 _genai_tools_unsupported）。
                     raise
+                if tool_leak_filter is not None:
+                    tool_leak_filter.reset()
         async for chunk in self._astream_openai_with_tools(
             messages,
             _tool_leak_filter=tool_leak_filter,

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -5,7 +5,7 @@ import json
 import re
 import time
 from typing import Optional, Callable, Dict, Any, Awaitable, List
-from utils.llm_client import SystemMessage, HumanMessage, AIMessage, create_chat_llm
+from utils.llm_client import SystemMessage, HumanMessage, AIMessage, LLMStreamChunk, create_chat_llm
 from openai import APIConnectionError, AuthenticationError, InternalServerError, RateLimitError
 from utils.frontend_utils import calculate_text_similarity
 from utils.tokenize import count_tokens, truncate_to_tokens
@@ -17,6 +17,7 @@ from main_logic.tool_calling import (
     ToolResult,
     parse_arguments_json,
 )
+from utils.llm_tool_leak_filter import ToolLeakFilter, log_tool_leak_filtered
 
 # google-genai 懒加载。该 SDK import 很重（~0.6s），且在 import 时会捎带 mcp
 # （~0.5s），但 offline 路径只有用户用 native-Gemini 端点时才需要它。改成首次使用
@@ -784,6 +785,8 @@ class OmniOfflineClient:
           documented lanlan.app/free trade-off).
         - Otherwise: ``_astream_openai_with_tools``.
         """
+        tool_leak_filter = overrides.pop("_tool_leak_filter", None)
+        tool_leak_provider = overrides.pop("_tool_leak_provider", None)
         if self._use_genai_sdk and not self._genai_tools_unsupported:
             # 跟踪本轮 Gemini 路径是否已经把 text chunk yield 给上游。如果
             # 已经吐过文本，再 fallback 到 OpenAI-compat 会让用户在同一轮
@@ -792,7 +795,12 @@ class OmniOfflineClient:
             # 触发"清空气泡 + 通知 response_discarded"的标准处理。
             genai_emitted_text = False
             try:
-                async for chunk in self._astream_genai_with_tools(messages, **overrides):
+                async for chunk in self._astream_genai_with_tools(
+                    messages,
+                    _tool_leak_filter=tool_leak_filter,
+                    _tool_leak_provider=tool_leak_provider,
+                    **overrides,
+                ):
                     if getattr(chunk, "content", None):
                         genai_emitted_text = True
                     yield chunk
@@ -819,14 +827,61 @@ class OmniOfflineClient:
                     # 流程清空气泡后基于 attempt+1 重试（下一次仍会先尝试
                     # genai，因为 transient 不翻 _genai_tools_unsupported）。
                     raise
-        async for chunk in self._astream_openai_with_tools(messages, **overrides):
+        async for chunk in self._astream_openai_with_tools(
+            messages,
+            _tool_leak_filter=tool_leak_filter,
+            _tool_leak_provider=tool_leak_provider,
+            **overrides,
+        ):
             yield chunk
+
+    async def _astream_visible_with_tools(self, messages, **overrides):
+        tool_names = {
+            tool.name for tool in getattr(self, "_tool_definitions", [])
+            if getattr(tool, "name", None)
+        }
+        leak_filter = ToolLeakFilter(tool_names=tool_names)
+        provider = getattr(self, "base_url", None) or getattr(self, "model", None)
+
+        async for chunk in self._astream_with_tools(
+            messages, _tool_leak_filter=leak_filter, _tool_leak_provider=provider, **overrides
+        ):
+            if getattr(chunk, "_tool_leak_filtered", False):
+                yield chunk
+                continue
+            content = getattr(chunk, "content", None)
+            if content:
+                chunk.content = self._filter_tool_leak_content(content, leak_filter, provider=provider)
+                setattr(chunk, "_tool_leak_filtered", True)
+            yield chunk
+
+        visible, event = leak_filter.finalize()
+        if event:
+            log_tool_leak_filtered(event, provider=provider)
+        if visible:
+            chunk = LLMStreamChunk(content=visible)
+            setattr(chunk, "_tool_leak_filtered", True)
+            yield chunk
+
+    def _filter_tool_leak_content(
+        self,
+        content: str,
+        leak_filter: ToolLeakFilter,
+        *,
+        provider: str | None = None,
+    ) -> str:
+        visible, event = leak_filter.feed(content)
+        if event:
+            log_tool_leak_filtered(event, provider=provider)
+        return visible
 
     async def _astream_openai_with_tools(self, messages, **overrides):
         """OpenAI Chat Completions tool loop. Streams text chunks; on
         ``finish_reason == "tool_calls"`` runs the tools, appends the
         results to ``messages``, and re-invokes — up to
         ``self.max_tool_iterations`` total LLM calls."""
+        tool_leak_filter = overrides.pop("_tool_leak_filter", None)
+        tool_leak_provider = overrides.pop("_tool_leak_provider", None)
         tools_payload = self._openai_tools_payload()
         if tools_payload:
             overrides.setdefault("tools", tools_payload)
@@ -849,6 +904,11 @@ class OmniOfflineClient:
             streamed_reasoning_buffer = ""
             async for chunk in self.llm.astream(messages, **overrides):
                 if getattr(chunk, "content", None):
+                    if tool_leak_filter is not None:
+                        chunk.content = self._filter_tool_leak_content(
+                            chunk.content, tool_leak_filter, provider=tool_leak_provider
+                        )
+                        setattr(chunk, "_tool_leak_filtered", True)
                     streamed_text_buffer += chunk.content
                 if getattr(chunk, "reasoning_content", None):
                     streamed_reasoning_buffer += chunk.reasoning_content
@@ -905,6 +965,13 @@ class OmniOfflineClient:
                 and tools_payload
                 and self.on_tool_call is not None
             ):
+                if tool_leak_filter is not None:
+                    tail, event = tool_leak_filter.finalize()
+                    if event:
+                        log_tool_leak_filtered(event, provider=tool_leak_provider)
+                    if tail:
+                        streamed_text_buffer += tail
+                    tool_leak_filter.reset()
                 # ChatOpenAI is the right import even though we're outside
                 # ChatOpenAI — `collect_tool_calls` is a staticmethod.
                 from utils.llm_client import ChatOpenAI as _ChatOpenAI
@@ -954,6 +1021,11 @@ class OmniOfflineClient:
                 and not chunk.usage_metadata
             ):
                 continue
+            if getattr(chunk, "content", None) and tool_leak_filter is not None:
+                chunk.content = self._filter_tool_leak_content(
+                    chunk.content, tool_leak_filter, provider=tool_leak_provider
+                )
+                setattr(chunk, "_tool_leak_filtered", True)
             yield chunk
         # prompt_tokens 走局部变量、流结束后无条件回填（与 genai 路径同口径）：这次
         # forced-finalize 没给 usage 时写回 None，而非沿用上一轮 tool-iteration 的旧
@@ -976,7 +1048,8 @@ class OmniOfflineClient:
 
         Raises ``_GenaiToolsUnsupported`` if the SDK or this model
         cannot handle tools — caller falls back to OpenAI-compat."""
-        from utils.llm_client import LLMStreamChunk
+        tool_leak_filter = overrides.pop("_tool_leak_filter", None)
+        tool_leak_provider = overrides.pop("_tool_leak_provider", None)
         if not _ensure_genai():
             raise _GenaiToolsUnsupported("google-genai SDK not importable")
         types = _genai_types
@@ -1101,9 +1174,16 @@ class OmniOfflineClient:
                                 raw_args,
                             ))
                         elif text:
+                            if tool_leak_filter is not None:
+                                text = self._filter_tool_leak_content(
+                                    text, tool_leak_filter, provider=tool_leak_provider,
+                                )
                             had_text = True
                             streamed_text_buffer += text
-                            yield LLMStreamChunk(content=text)
+                            chunk_out = LLMStreamChunk(content=text)
+                            if tool_leak_filter is not None:
+                                setattr(chunk_out, "_tool_leak_filtered", True)
+                            yield chunk_out
                     # Usage metadata may arrive on the chunk.
                     usage_meta = getattr(chunk, "usage_metadata", None)
                     if usage_meta is not None and not usage_emitted:
@@ -1171,6 +1251,13 @@ class OmniOfflineClient:
                     }
                     for i, (tc_id, tc_name, _args, tc_raw) in enumerate(collected_tool_calls)
                 ]
+                if tool_leak_filter is not None:
+                    tail, event = tool_leak_filter.finalize()
+                    if event:
+                        log_tool_leak_filtered(event, provider=tool_leak_provider)
+                    if tail:
+                        streamed_text_buffer += tail
+                    tool_leak_filter.reset()
                 # 把本轮已经流给用户的 text 一起写进历史。Gemini 在同一 turn
                 # 里允许 text part 与 function_call part 并存；如果这里仍写
                 # ``content=""``，下一轮 LLM 看到的上下文会缺掉前半句，模型
@@ -1266,8 +1353,15 @@ class OmniOfflineClient:
                     continue
                 text = getattr(part, "text", None) or ""
                 if text:
+                    if tool_leak_filter is not None:
+                        text = self._filter_tool_leak_content(
+                            text, tool_leak_filter, provider=tool_leak_provider,
+                        )
                     final_had_text = True
-                    yield LLMStreamChunk(content=text)
+                    chunk_out = LLMStreamChunk(content=text)
+                    if tool_leak_filter is not None:
+                        setattr(chunk_out, "_tool_leak_filtered", True)
+                    yield chunk_out
         # 统一回填本次 forced-finalize 自己的诊断值（含 prompt_tokens）。prompt_tokens
         # 走局部变量、流结束后无条件回填：若这次被挡住/没给 usage，写回 None 而非沿用
         # 上一轮 tool-iteration 的旧值，避免 INFO log / 上层 LLM_NO_RESPONSE 诊断串台。
@@ -1776,7 +1870,7 @@ class OmniOfflineClient:
                         # PLACE). The yielded chunks are exactly the same
                         # shape as raw ``self.llm.astream``, so the existing
                         # prefix/fence/length-guard logic below is untouched.
-                        async for chunk in self._astream_with_tools(self._conversation_history):
+                        async for chunk in self._astream_visible_with_tools(self._conversation_history):
                             if not _ttft_recorded:
                                 _ttft_recorded = True
                                 try:
@@ -2869,7 +2963,7 @@ class OmniOfflineClient:
                 try:
                     # 主动搭话同样走 tool-aware streaming —— agent 注入的 stage
                     # direction 也可能让模型决定调用工具（比如 "讲一下今天天气"）。
-                    async for chunk in self._astream_with_tools(messages_to_send):
+                    async for chunk in self._astream_visible_with_tools(messages_to_send):
                         if hasattr(chunk, 'usage_metadata') and chunk.usage_metadata:
                             logger.debug(f"🔍 [Usage-Proactive] {chunk.usage_metadata}")
                         if hasattr(chunk, 'response_metadata') and chunk.response_metadata:

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -113,6 +113,22 @@ def test_structured_tool_call_ignores_seed_close_text_inside_argument():
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_wins_over_inner_seed_opener():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = (
+        'recall_memory</name><parameter name="query">'
+        "x <seed:tool_call> y</parameter></function></seed:tool_call> after"
+    )
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "recall_memory</name>" not in visible
+    assert "x <seed:tool_call>" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_tool_call_split_close_preserves_following_text():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 
@@ -160,6 +176,27 @@ def test_structured_tool_call_waits_for_seed_close_after_function_boundary():
         [
             "before ",
             'recall_memory</name><parameter name="query">secret</parameter></function>',
+            "</seed:tool_call> after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "</seed:tool_call>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
+def test_structured_tool_call_standalone_function_close_waits_for_seed_close():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">secret</parameter>',
+            "</function>",
             "</seed:tool_call> after",
         ],
     )

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -83,6 +83,38 @@ def test_structured_tool_call_closes_at_function_end_without_seed_close():
     assert events[0].finalized is False
 
 
+def test_structured_tool_call_split_close_preserves_following_text():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">secret</parameter></seed:tool_',
+            "call> after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
+def test_structured_tool_call_strips_function_name_opener():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = '<function><name>recall_memory</name><parameter name="query">secret</parameter></function> after'
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "<function><name>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_seed_marker_across_chunks_is_stripped():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -113,6 +113,21 @@ def test_structured_tool_call_ignores_seed_close_text_inside_argument():
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_ignores_function_close_text_inside_argument():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = (
+        'recall_memory</name><parameter name="query">'
+        "x </function> y</parameter></function> after"
+    )
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "y</parameter>" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_tool_call_keeps_suppressing_when_seed_close_precedes_later_function_close():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -9,10 +9,12 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
+from utils.llm_tool_leak_filter import ToolLeakFilterEvent
 
-def _drain(filter_, chunks: list[str]) -> tuple[str, list[object]]:
+
+def _drain(filter_, chunks: list[str]) -> tuple[str, list[ToolLeakFilterEvent]]:
     output: list[str] = []
-    events: list[object] = []
+    events: list[ToolLeakFilterEvent] = []
     for chunk in chunks:
         visible, event = filter_.feed(chunk)
         output.append(visible)

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -113,6 +113,25 @@ def test_structured_tool_call_ignores_seed_close_text_inside_argument():
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_keeps_suppressing_when_seed_close_precedes_later_function_close():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">x </seed:tool_call> y',
+            "</parameter></function> after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "</parameter></function>" not in visible
+    assert "x </seed:tool_call> y" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_tool_call_wins_over_inner_seed_opener():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 
@@ -177,6 +196,26 @@ def test_structured_tool_call_waits_for_seed_close_after_function_boundary():
             "before ",
             'recall_memory</name><parameter name="query">secret</parameter></function>',
             "</seed:tool_call> after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "</seed:tool_call>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
+def test_structured_tool_call_consumes_formatted_seed_close_after_function():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">secret</parameter></function>',
+            "\n </seed:tool_call> after",
         ],
     )
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -40,6 +40,22 @@ def test_complete_seed_tool_call_is_stripped():
     assert events[0].pattern == "seed_tool_call"
 
 
+def test_seed_tool_call_ignores_seed_close_text_inside_argument():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = (
+        '<seed:tool_call><function><name>recall_memory</name>'
+        '<parameter name="query">x </seed:tool_call> y</parameter>'
+        "</function></seed:tool_call> after"
+    )
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "y</parameter>" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "seed_tool_call"
+
+
 def test_recall_memory_tail_fragment_is_stripped_without_open_seed():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 
@@ -124,6 +140,21 @@ def test_structured_tool_call_ignores_function_close_text_inside_argument():
 
     assert visible == "before  after"
     assert "y</parameter>" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
+def test_structured_tool_call_requires_current_parameter_close_before_function_close():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = (
+        'recall_memory</name><parameter name="scope">recent</parameter>'
+        '<parameter name="query">secret </function> tail</parameter></function> after'
+    )
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "tail</parameter>" not in visible
     assert len(events) == 1
     assert events[0].pattern == "structured_tool_call"
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -159,6 +159,18 @@ def test_structured_tool_call_requires_current_parameter_close_before_function_c
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_treats_self_closing_parameter_as_closed():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = 'recall_memory</name><parameter name="query"/></function> after'
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "<parameter" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_tool_call_keeps_suppressing_when_seed_close_precedes_later_function_close():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -335,6 +335,24 @@ def test_structured_tool_call_opener_prefix_across_chunks_is_stripped():
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_uppercase_tool_name_prefix_across_chunks_is_stripped():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"MyTool"}),
+        [
+            "before <function><name>My",
+            'Tool</name><parameter name="query">secret</parameter></function> after',
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "<function><name>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_zero_arg_tool_split_function_close_is_stripped():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -261,6 +261,22 @@ def test_structured_tool_call_strips_function_name_opener():
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_strips_attributed_function_name_opener():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = (
+        '<function><name type="x">recall_memory</name>'
+        '<parameter name="query">secret</parameter></function> after'
+    )
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert '<function><name type="x">' not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_tool_call_opener_prefix_across_chunks_is_stripped():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -70,6 +70,19 @@ def test_structured_tool_call_variant_across_chunks_is_stripped():
     assert events[0].cross_chunk is True
 
 
+def test_structured_tool_call_closes_at_function_end_without_seed_close():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = 'recall_memory</name><parameter name="query">secret</parameter></function> after'
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
 def test_seed_marker_across_chunks_is_stripped():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+def _drain(filter_, chunks: list[str]) -> tuple[str, list[object]]:
+    output: list[str] = []
+    events: list[object] = []
+    for chunk in chunks:
+        visible, event = filter_.feed(chunk)
+        output.append(visible)
+        if event:
+            events.append(event)
+    visible, event = filter_.finalize()
+    output.append(visible)
+    if event:
+        events.append(event)
+    return "".join(output), events
+
+
+def test_complete_seed_tool_call_is_stripped():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        ["before <seed:tool_call><function><name>recall_memory</name></function></seed:tool_call> after"],
+    )
+
+    assert visible == "before  after"
+    assert len(events) == 1
+    assert events[0].pattern == "seed_tool_call"
+
+
+def test_recall_memory_tail_fragment_is_stripped_without_open_seed():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = 'recall_memory</name><parameter name="query" string="true">secret</parameter></function></seed:tool_call>'
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak, " after"])
+
+    assert visible == "before  after"
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
+def test_seed_marker_across_chunks_is_stripped():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        ["before <seed:tool_", "call>secret</seed:tool_call> after"],
+    )
+
+    assert visible == "before  after"
+    assert len(events) == 1
+    assert events[0].cross_chunk is True
+
+
+def test_suppressed_long_arguments_are_not_output():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    secret = "x" * 5000
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        ["ok ", "<seed:tool_call>", secret, "</seed:tool_call>", " done"],
+    )
+
+    assert visible == "ok  done"
+    assert secret not in visible
+    assert events[0].chars >= len(secret)
+
+
+def test_unclosed_seed_fragment_is_dropped_on_finalize():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        ["before ", "<seed:tool_call>secret"],
+    )
+
+    assert visible == "before "
+    assert len(events) == 1
+    assert events[0].finalized is True
+
+
+def test_normal_xml_html_and_code_examples_are_preserved():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    text = '<div data-x="1">ok</div>\n```xml\n<function><name>demo</name></function>\n```'
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), [text])
+
+    assert visible == text
+    assert events == []
+
+
+def test_tool_call_markup_inside_code_fence_is_replaced_not_revealed():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    text = "```xml\n<seed:tool_call>secret query</seed:tool_call>\n```"
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), [text])
+
+    assert visible == "```xml\n[tool-call markup omitted]\n```"
+    assert "secret query" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "seed_tool_call"
+
+
+def test_structured_tool_call_inside_code_fence_is_replaced_not_revealed():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    text = (
+        "```xml\n"
+        'recall_memory</name><parameter name="query">secret query</parameter></function></seed:tool_call>\n'
+        "```"
+    )
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), [text])
+
+    assert visible == "```xml\n[tool-call markup omitted]\n```"
+    assert "secret query" not in visible
+    assert "recall_memory</name>" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
+def test_lonely_tool_name_close_is_preserved():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    text = "这里是代码示例：recall_memory</name>"
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), [text])
+
+    assert visible == text
+    assert events == []
+
+
+def test_no_seed_requires_registered_tool_and_strong_structure():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = 'unknown_tool</name><parameter name="query">secret</parameter></function></seed:tool_call>'
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), [leak])
+
+    assert "unknown_tool" in visible
+    assert events == []
+
+
+def test_event_metadata_does_not_include_raw_text_or_query():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    query = "secret query"
+    _visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [f'recall_memory</name><parameter name="query">{query}</parameter></function></seed:tool_call>'],
+    )
+
+    event_text = repr(events[0])
+    assert query not in event_text
+    assert "parameter" not in event_text

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -98,6 +98,21 @@ def test_structured_tool_call_closes_at_function_end_without_seed_close():
     assert events[0].finalized is False
 
 
+def test_structured_tool_call_ignores_seed_close_text_inside_argument():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = (
+        'recall_memory</name><parameter name="query">'
+        "x </seed:tool_call> y</parameter></function> after"
+    )
+    visible, events = _drain(ToolLeakFilter(tool_names={"recall_memory"}), ["before ", leak])
+
+    assert visible == "before  after"
+    assert "y</parameter>" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_tool_call_split_close_preserves_following_text():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 
@@ -166,6 +181,38 @@ def test_structured_tool_call_strips_function_name_opener():
     assert visible == "before  after"
     assert "<function><name>" not in visible
     assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
+def test_structured_tool_call_opener_prefix_across_chunks_is_stripped():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before <function><name>rec",
+            'all_memory</name><parameter name="query">secret</parameter></function> after',
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "<function><name>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
+def test_structured_zero_arg_tool_split_function_close_is_stripped():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"sts2_get_status"}),
+        ["before ", "sts2_get_status</name></fun", "ction> after"],
+    )
+
+    assert visible == "before  after"
+    assert "sts2_get_status" not in visible
     assert len(events) == 1
     assert events[0].pattern == "structured_tool_call"
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -64,6 +64,21 @@ def test_seed_marker_across_chunks_is_stripped():
     assert events[0].cross_chunk is True
 
 
+def test_whitespace_tolerant_seed_marker_across_chunks_is_stripped():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        ["before <seed: ", "tool_call>secret</seed:tool_call> after"],
+    )
+
+    assert visible == "before  after"
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "seed_tool_call"
+    assert events[0].cross_chunk is True
+
+
 def test_suppressed_long_arguments_are_not_output():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -227,6 +227,46 @@ def test_structured_tool_call_consumes_formatted_seed_close_after_function():
     assert events[0].finalized is False
 
 
+def test_structured_tool_call_keeps_function_close_pending_after_whitespace():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">secret</parameter></function> ',
+            "after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
+def test_structured_tool_call_tracks_split_parameter_close_before_seed_close():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">secret</p',
+            "arameter></function><",
+            "/seed:tool_call> after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "</seed:tool_call>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
 def test_structured_tool_call_standalone_function_close_waits_for_seed_close():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -102,6 +102,26 @@ def test_structured_tool_call_split_close_preserves_following_text():
     assert events[0].finalized is False
 
 
+def test_structured_tool_call_split_wrapped_close_preserves_following_text():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">secret</parameter></function></seed:tool_',
+            "call> after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "</seed:tool_call>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
 def test_structured_tool_call_strips_function_name_opener():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -51,6 +51,25 @@ def test_recall_memory_tail_fragment_is_stripped_without_open_seed():
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_variant_across_chunks_is_stripped():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</ name><parameter type="x" ',
+            'name="query">secret</parameter></function></seed:tool_call> after',
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].cross_chunk is True
+
+
 def test_seed_marker_across_chunks_is_stripped():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -137,6 +137,26 @@ def test_structured_tool_call_split_wrapped_close_preserves_following_text():
     assert events[0].finalized is False
 
 
+def test_structured_tool_call_waits_for_seed_close_after_function_boundary():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [
+            "before ",
+            'recall_memory</name><parameter name="query">secret</parameter></function>',
+            "</seed:tool_call> after",
+        ],
+    )
+
+    assert visible == "before  after"
+    assert "</seed:tool_call>" not in visible
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+    assert events[0].finalized is False
+
+
 def test_structured_tool_call_strips_function_name_opener():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_call_leak_filter.py
+++ b/tests/unit/test_tool_call_leak_filter.py
@@ -51,6 +51,21 @@ def test_recall_memory_tail_fragment_is_stripped_without_open_seed():
     assert events[0].pattern == "structured_tool_call"
 
 
+def test_structured_tool_call_does_not_strip_prior_tool_name_mention():
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    leak = 'recall_memory</name><parameter name="query">secret</parameter></function>'
+    visible, events = _drain(
+        ToolLeakFilter(tool_names={"recall_memory"}),
+        [f"recall_memory is available; {leak} after"],
+    )
+
+    assert visible == "recall_memory is available;  after"
+    assert "secret" not in visible
+    assert len(events) == 1
+    assert events[0].pattern == "structured_tool_call"
+
+
 def test_structured_tool_call_variant_across_chunks_is_stripped():
     from utils.llm_tool_leak_filter import ToolLeakFilter
 

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -2921,7 +2921,7 @@ async def test_stream_text_summary_disabled_keeps_old_truncate_behavior(monkeypa
     assert summarize_calls == []
 
 
-def _minimal_offline_client_for_leak_tests(monkeypatch):
+def _minimal_offline_client_for_leak_tests():
     from main_logic.omni_offline_client import OmniOfflineClient
     from main_logic.tool_calling import ToolDefinition
     from utils.llm_client import SystemMessage
@@ -2970,7 +2970,7 @@ async def test_stream_text_filters_tool_call_leak_before_ui_and_history(monkeypa
     async def noop(*_a, **_kw):
         pass
 
-    client = _minimal_offline_client_for_leak_tests(monkeypatch)
+    client = _minimal_offline_client_for_leak_tests()
     client.on_text_delta = fake_text_delta
     client.on_input_transcript = noop
     client.on_response_done = noop
@@ -3008,7 +3008,7 @@ async def test_prompt_ephemeral_filters_tool_call_leak_before_ui_and_history(mon
     async def noop(*_a, **_kw):
         pass
 
-    client = _minimal_offline_client_for_leak_tests(monkeypatch)
+    client = _minimal_offline_client_for_leak_tests()
     client.on_text_delta = fake_text_delta
     client.on_response_done = noop
     client.on_status_message = noop
@@ -3046,7 +3046,7 @@ async def test_stream_text_only_leak_yields_no_visible_output(monkeypatch):
     async def noop(*_a, **_kw):
         pass
 
-    client = _minimal_offline_client_for_leak_tests(monkeypatch)
+    client = _minimal_offline_client_for_leak_tests()
     client.on_text_delta = fake_text_delta
     client.on_input_transcript = noop
     client.on_response_done = noop
@@ -3058,4 +3058,4 @@ async def test_stream_text_only_leak_yields_no_visible_output(monkeypatch):
 
     assert emitted == []
     assert not any(isinstance(m, AIMessage) for m in client._conversation_history)
-    assert statuses
+    assert [json.loads(message) for message in statuses] == [{"code": "LLM_NO_RESPONSE"}]

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -1848,6 +1848,50 @@ async def test_offline_silent_fallback_when_genai_did_not_emit(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_offline_silent_fallback_resets_unemitted_genai_filter_state(monkeypatch):
+    """genai 路径没 yield 文本但已让 leak filter 持有 pending/suppressing 状态时，
+    静默 fallback 到 OpenAI-compat 前必须清空过滤器状态，避免污染 fallback 文本。"""
+    from main_logic import omni_offline_client as _ofc
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import LLMStreamChunk
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    monkeypatch.setattr(_ofc, "_GENAI_AVAILABLE", True)
+
+    async def _genai_consumes_filter_then_raises(self, messages, **overrides):
+        leak_filter = overrides["_tool_leak_filter"]
+        leak_filter.feed("<seed:tool_call>secret")
+        if False:
+            yield  # make it an async generator
+        raise RuntimeError("HTTP 503 transient before visible output")
+
+    async def _openai_emits(self, messages, **overrides):
+        leak_filter = overrides["_tool_leak_filter"]
+        visible, _event = leak_filter.feed("Hello")
+        yield LLMStreamChunk(content=visible)
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_genai_with_tools", _genai_consumes_filter_then_raises)
+    monkeypatch.setattr(OmniOfflineClient, "_astream_openai_with_tools", _openai_emits)
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client._use_genai_sdk = True
+    client._genai_tools_unsupported = False
+
+    yielded = []
+    leak_filter = ToolLeakFilter(tool_names={"recall_memory"})
+    async for ch in client._astream_with_tools(
+        [{"role": "user", "content": "x"}],
+        _tool_leak_filter=leak_filter,
+        _tool_leak_provider="free",
+    ):
+        yielded.append(ch.content)
+
+    assert yielded == ["Hello"]
+    assert leak_filter.finalize() == ("", None)
+    assert client._genai_tools_unsupported is False
+
+
+@pytest.mark.asyncio
 async def test_offline_genai_tools_unsupported_error_correctly_disables_path(monkeypatch):
     """与上一条对偶：当 genai 真的报"tools not supported"时，必须被包装成
     `_GenaiToolsUnsupported`，让 `_astream_with_tools` 翻 `_genai_tools_unsupported`

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -430,6 +430,32 @@ async def test_offline_openai_path_emits_finalized_pretool_tail():
 
 
 @pytest.mark.asyncio
+async def test_visible_tool_leak_filter_flushes_pending_text_before_stream_error(monkeypatch):
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    async def _astream_with_tools_then_raise(self, messages, **overrides):
+        yield LLMStreamChunk(content="Let")
+        yield LLMStreamChunk(content="s")
+        raise RuntimeError("stream broke")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream_with_tools_then_raise)
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.base_url = "free"
+    client.model = "fake"
+    client._tool_definitions = []
+
+    out_chunks = []
+    with pytest.raises(RuntimeError, match="stream broke"):
+        async for chunk in client._astream_visible_with_tools([{"role": "user", "content": "hi"}]):
+            out_chunks.append(chunk)
+
+    assert "".join(chunk.content for chunk in out_chunks) == "Lets"
+    assert getattr(out_chunks[-1], "_tool_leak_filtered", False) is True
+
+
+@pytest.mark.asyncio
 async def test_offline_openai_path_persists_reasoning_content_with_tool_call():
     """Thinking 模型（DeepSeek-R / Qwen / GLM thinking 等 OpenAI-compat 端点）
     在多轮 tool calling 时，发起 tool_calls 的那条 assistant 消息必须把本轮流出的

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -296,6 +296,76 @@ async def test_offline_openai_path_runs_tool_then_text():
 
 
 @pytest.mark.asyncio
+async def test_offline_openai_path_filters_pretool_leak_before_history():
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    async def recall_handler(args):
+        return {"hits": []}
+
+    tool_def = ToolDefinition(
+        name="recall_memory",
+        description="recall",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=recall_handler,
+    )
+    leak = 'recall_memory</name><parameter name="query">secret</parameter></function></seed:tool_call>'
+    chunks_call_1 = [
+        LLMStreamChunk(content="让我查一下。"),
+        LLMStreamChunk(content=leak),
+        LLMStreamChunk(
+            content="",
+            tool_call_deltas=[{
+                "index": 0,
+                "id": "call_m",
+                "type": "function",
+                "function": {"name": "recall_memory", "arguments": '{"query":"x"}'},
+            }],
+        ),
+        LLMStreamChunk(content="", finish_reason="tool_calls"),
+    ]
+    chunks_call_2 = [LLMStreamChunk(content="没有查到。", finish_reason="stop")]
+    fake_llm = _FakeLLM([chunks_call_1, chunks_call_2])
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.base_url = "free"
+    client.llm = fake_llm
+    client._tool_definitions = [tool_def]
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output=await recall_handler(call.arguments))
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "以前聊过什么？"}]
+    out_chunks = []
+    leak_filter = ToolLeakFilter(tool_names={"recall_memory"})
+    async for ch in client._astream_with_tools(
+        messages,
+        _tool_leak_filter=leak_filter,
+        _tool_leak_provider="free",
+    ):
+        out_chunks.append(ch)
+    tail, _event = leak_filter.finalize()
+    if tail:
+        out_chunks.append(LLMStreamChunk(content=tail))
+
+    visible = "".join(ch.content for ch in out_chunks)
+    assert visible == "让我查一下。没有查到。"
+    assistant_with_tool = next(
+        m for m in messages if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert assistant_with_tool["content"] == "让我查一下。"
+    assert "recall_memory</name>" not in assistant_with_tool["content"]
+    assert "secret" not in assistant_with_tool["content"]
+
+
+@pytest.mark.asyncio
 async def test_offline_openai_path_persists_reasoning_content_with_tool_call():
     """Thinking 模型（DeepSeek-R / Qwen / GLM thinking 等 OpenAI-compat 端点）
     在多轮 tool calling 时，发起 tool_calls 的那条 assistant 消息必须把本轮流出的
@@ -2849,3 +2919,143 @@ async def test_stream_text_summary_disabled_keeps_old_truncate_behavior(monkeypa
         assert c["ui_enabled"] and c["tts_enabled"]
     # 关键回归：禁用模式下小模型摘要器一次都不能被调
     assert summarize_calls == []
+
+
+def _minimal_offline_client_for_leak_tests(monkeypatch):
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from main_logic.tool_calling import ToolDefinition
+    from utils.llm_client import SystemMessage
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.base_url = "free"
+    client.lanlan_name = "T"
+    client.master_name = "M"
+    client._prefix_buffer_size = 0
+    client._conversation_history = [SystemMessage(content="sys")]
+    client._pending_images = []
+    client._is_responding = False
+    client._recent_responses = []
+    client._repetition_threshold = 0.8
+    client._max_recent_responses = 3
+    client.max_response_length = 9999
+    client.max_response_rerolls = 0
+    client.max_tool_iterations = 1
+    client.enable_response_guard = False
+    client.enable_long_response_summary = False
+    client.vision_model = ""
+    client.model = "x"
+    client._tool_definitions = [ToolDefinition(name="recall_memory", description="")]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_stream_text_filters_tool_call_leak_before_ui_and_history(monkeypatch):
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import AIMessage, LLMStreamChunk
+
+    async def _astream(self, messages, **overrides):
+        yield LLMStreamChunk(content="before ")
+        yield LLMStreamChunk(
+            content='recall_memory</name><parameter name="query">secret</parameter></function></seed:tool_call>'
+        )
+        yield LLMStreamChunk(content=" after")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream)
+
+    emitted: list[str] = []
+
+    async def fake_text_delta(text, is_first, **kwargs):
+        emitted.append(text)
+
+    async def noop(*_a, **_kw):
+        pass
+
+    client = _minimal_offline_client_for_leak_tests(monkeypatch)
+    client.on_text_delta = fake_text_delta
+    client.on_input_transcript = noop
+    client.on_response_done = noop
+    client.on_response_discarded = None
+    client.on_status_message = noop
+    client.on_repetition_detected = None
+
+    await client.stream_text("hello")
+
+    visible = "".join(emitted)
+    assert visible == "before  after"
+    assert "recall_memory" not in visible
+    ai_messages = [m for m in client._conversation_history if isinstance(m, AIMessage)]
+    assert ai_messages[-1].content == "before  after"
+    assert "secret" not in ai_messages[-1].content
+
+
+@pytest.mark.asyncio
+async def test_prompt_ephemeral_filters_tool_call_leak_before_ui_and_history(monkeypatch):
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import AIMessage, LLMStreamChunk
+
+    async def _astream(self, messages, **overrides):
+        yield LLMStreamChunk(content="hi ")
+        yield LLMStreamChunk(content="<seed:tool_call>secret</seed:tool_call>")
+        yield LLMStreamChunk(content=" done")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream)
+
+    emitted: list[str] = []
+
+    async def fake_text_delta(text, is_first, **kwargs):
+        emitted.append(text)
+
+    async def noop(*_a, **_kw):
+        pass
+
+    client = _minimal_offline_client_for_leak_tests(monkeypatch)
+    client.on_text_delta = fake_text_delta
+    client.on_response_done = noop
+    client.on_status_message = noop
+    client.on_proactive_done = noop
+
+    assert await client.prompt_ephemeral("nudge", completion_mode="response") is True
+
+    visible = "".join(emitted)
+    assert visible == "hi  done"
+    assert "seed:tool_call" not in visible
+    ai_messages = [m for m in client._conversation_history if isinstance(m, AIMessage)]
+    assert ai_messages[-1].content == "hi  done"
+    assert "secret" not in ai_messages[-1].content
+
+
+@pytest.mark.asyncio
+async def test_stream_text_only_leak_yields_no_visible_output(monkeypatch):
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import AIMessage, LLMStreamChunk
+
+    async def _astream(self, messages, **overrides):
+        yield LLMStreamChunk(content="<seed:tool_call>secret</seed:tool_call>")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream)
+
+    emitted: list[str] = []
+    statuses: list[str] = []
+
+    async def fake_text_delta(text, is_first, **kwargs):
+        emitted.append(text)
+
+    async def fake_status(message):
+        statuses.append(message)
+
+    async def noop(*_a, **_kw):
+        pass
+
+    client = _minimal_offline_client_for_leak_tests(monkeypatch)
+    client.on_text_delta = fake_text_delta
+    client.on_input_transcript = noop
+    client.on_response_done = noop
+    client.on_response_discarded = None
+    client.on_status_message = fake_status
+    client.on_repetition_detected = None
+
+    await client.stream_text("hello")
+
+    assert emitted == []
+    assert not any(isinstance(m, AIMessage) for m in client._conversation_history)
+    assert statuses

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -366,6 +366,70 @@ async def test_offline_openai_path_filters_pretool_leak_before_history():
 
 
 @pytest.mark.asyncio
+async def test_offline_openai_path_emits_finalized_pretool_tail():
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
+    from utils.llm_tool_leak_filter import ToolLeakFilter
+
+    async def recall_handler(args):
+        return {"hits": []}
+
+    tool_def = ToolDefinition(
+        name="recall_memory",
+        description="recall",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=recall_handler,
+    )
+    chunks_call_1 = [
+        LLMStreamChunk(content="Let"),
+        LLMStreamChunk(content="s"),
+        LLMStreamChunk(
+            content="",
+            tool_call_deltas=[{
+                "index": 0,
+                "id": "call_m",
+                "type": "function",
+                "function": {"name": "recall_memory", "arguments": '{"query":"x"}'},
+            }],
+        ),
+        LLMStreamChunk(content="", finish_reason="tool_calls"),
+    ]
+    chunks_call_2 = [LLMStreamChunk(content=" continue.", finish_reason="stop")]
+    fake_llm = _FakeLLM([chunks_call_1, chunks_call_2])
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.base_url = "free"
+    client.llm = fake_llm
+    client._tool_definitions = [tool_def]
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output=await recall_handler(call.arguments))
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "以前聊过什么？"}]
+    out_chunks = []
+    leak_filter = ToolLeakFilter(tool_names={"recall_memory"})
+    async for ch in client._astream_with_tools(
+        messages,
+        _tool_leak_filter=leak_filter,
+        _tool_leak_provider="free",
+    ):
+        out_chunks.append(ch)
+
+    visible = "".join(ch.content for ch in out_chunks)
+    assert visible == "Lets continue."
+    assistant_with_tool = next(
+        m for m in messages if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert assistant_with_tool["content"] == "Lets"
+
+
+@pytest.mark.asyncio
 async def test_offline_openai_path_persists_reasoning_content_with_tool_call():
     """Thinking 模型（DeepSeek-R / Qwen / GLM thinking 等 OpenAI-compat 端点）
     在多轮 tool calling 时，发起 tool_calls 的那条 assistant 消息必须把本轮流出的

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -1849,8 +1849,7 @@ async def test_offline_silent_fallback_when_genai_did_not_emit(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_offline_silent_fallback_resets_unemitted_genai_filter_state(monkeypatch):
-    """genai 路径没 yield 文本但已让 leak filter 持有 pending/suppressing 状态时，
-    静默 fallback 到 OpenAI-compat 前必须清空过滤器状态，避免污染 fallback 文本。"""
+    """Silent fallback must reset leak-filter state that did not emit text."""
     from main_logic import omni_offline_client as _ofc
     from main_logic.omni_offline_client import OmniOfflineClient
     from utils.llm_client import LLMStreamChunk

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -162,18 +162,8 @@ class ToolLeakFilter:
                 self._fence_marker = ""
 
     def _possible_marker_tail_len(self, text: str) -> int:
-        lower = text.lower()
         best = self._seed_marker_tail_len(text)
-        markers = []
-        markers.extend(name.lower() + "</name><parameter name=" for name in self._tool_names)
-        markers.extend(name.lower() + "</name>" for name in self._tool_names)
-        for marker in markers:
-            max_prefix = min(len(marker) - 1, len(lower), self._max_tail)
-            for size in range(max_prefix, 0, -1):
-                if lower.endswith(marker[:size]):
-                    best = max(best, size)
-                    break
-        return best
+        return max(best, self._structured_marker_tail_len(text))
 
     def _seed_marker_tail_len(self, text: str) -> int:
         min_start = max(0, len(text) - self._max_tail)
@@ -265,6 +255,100 @@ class ToolLeakFilter:
 
         ok, _pos, partial = cls._consume_literal_prefix(text, pos, "tool_call")
         return ok and partial
+
+    def _structured_marker_tail_len(self, text: str) -> int:
+        min_start = max(0, len(text) - self._max_tail)
+        tool_names = sorted(self._tool_names, key=len, reverse=True)
+        for start in range(min_start, len(text)):
+            tail = text[start:]
+            if any(self._is_structured_tool_prefix(tail, tool_name) for tool_name in tool_names):
+                return len(tail)
+        return 0
+
+    @classmethod
+    def _is_structured_tool_prefix(cls, text: str, tool_name: str) -> bool:
+        if not text:
+            return False
+
+        ok, pos, partial = cls._consume_literal_prefix(text, 0, tool_name)
+        if not ok:
+            return False
+        if partial or pos == len(text):
+            return True
+
+        ok, pos, partial = cls._consume_name_close_prefix(text, pos)
+        if not ok:
+            return False
+        if partial or pos == len(text):
+            return True
+
+        ok, _pos, partial = cls._consume_parameter_open_prefix(text, pos)
+        return ok and partial
+
+    @classmethod
+    def _consume_name_close_prefix(cls, text: str, pos: int) -> tuple[bool, int, bool]:
+        if pos == len(text):
+            return True, pos, True
+        if text[pos] != "<":
+            return False, pos, False
+
+        pos += 1
+        if pos == len(text):
+            return True, pos, True
+        if text[pos] != "/":
+            return False, pos, False
+
+        pos = cls._consume_whitespace(text, pos + 1)
+        if pos == len(text):
+            return True, pos, True
+
+        ok, pos, partial = cls._consume_literal_prefix(text, pos, "name")
+        if not ok or partial:
+            return ok, pos, partial
+
+        pos = cls._consume_whitespace(text, pos)
+        if pos == len(text):
+            return True, pos, True
+        if text[pos] != ">":
+            return False, pos, False
+        return True, pos + 1, False
+
+    @classmethod
+    def _consume_parameter_open_prefix(cls, text: str, pos: int) -> tuple[bool, int, bool]:
+        if pos == len(text):
+            return True, pos, True
+        if text[pos] != "<":
+            return False, pos, False
+
+        pos = cls._consume_whitespace(text, pos + 1)
+        if pos == len(text):
+            return True, pos, True
+
+        ok, pos, partial = cls._consume_literal_prefix(text, pos, "parameter")
+        if not ok or partial:
+            return ok, pos, partial
+
+        if pos < len(text) and cls._is_word_char(text[pos]):
+            return False, pos, False
+
+        while pos < len(text):
+            if text[pos] == ">":
+                return False, pos, False
+            if text[pos].lower() == "n":
+                ok, name_pos, name_partial = cls._consume_literal_prefix(text, pos, "name")
+                if ok:
+                    if name_partial:
+                        return True, name_pos, True
+                    after_name = cls._consume_whitespace(text, name_pos)
+                    if after_name == len(text):
+                        return True, after_name, True
+                    if text[after_name] == "=":
+                        return True, after_name + 1, False
+                    if not cls._is_word_char(text[after_name]):
+                        return False, after_name, False
+            pos += 1
+
+        return True, pos, True
 
 
 def log_tool_leak_filtered(

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -11,6 +11,7 @@ _DEFAULT_TOOL_NAMES = frozenset({"recall_memory"})
 _SEED_OPEN_RE = re.compile(r"<\s*seed\s*:\s*tool_call\b[^>]*>|(?<!/)\bseed\s*:\s*tool_call\b", re.IGNORECASE)
 _SEED_CLOSE_RE = re.compile(r"<\s*/\s*seed\s*:\s*tool_call\s*>", re.IGNORECASE)
 _PARAMETER_RE = re.compile(r"<\s*parameter\b[^>]*\bname\s*=", re.IGNORECASE)
+_PARAMETER_CLOSE_RE = re.compile(r"<\s*/\s*parameter\s*>", re.IGNORECASE)
 _FUNCTION_CLOSE_RE = re.compile(r"<\s*/\s*function\s*>", re.IGNORECASE)
 _FUNCTION_NAME_OPEN_TAIL_RE = re.compile(r"<\s*function\b[^>]*>\s*<\s*name\s*>\s*$", re.IGNORECASE)
 _NAME_CLOSE_RE = re.compile(r"</\s*name\s*>", re.IGNORECASE)
@@ -35,6 +36,7 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
+        self._structured_parameter_closed = False
         self._in_code_fence = False
         self._fence_marker = ""
         self._fence_line_buffer = ""
@@ -53,15 +55,19 @@ class ToolLeakFilter:
             if self._suppressing:
                 close_match = self._suppression_close_match(text)
                 if close_match:
+                    self._track_suppressed_structure(text[: close_match.end()])
                     self._suppressed_chars += close_match.end()
                     text = text[close_match.end():]
                     event = self._finish_event()
                     continue
                 keep_tail = self._suppression_close_tail_len(text)
                 if keep_tail > 0:
-                    self._suppressed_chars += len(text) - keep_tail
+                    consumed = text[:-keep_tail]
+                    self._track_suppressed_structure(consumed)
+                    self._suppressed_chars += len(consumed)
                     self._pending = text[-keep_tail:]
                 else:
+                    self._track_suppressed_structure(text)
                     self._suppressed_chars += len(text)
                 text = ""
                 break
@@ -83,6 +89,7 @@ class ToolLeakFilter:
             self._suppressed_chars = 0
             self._suppression_pattern = pattern
             self._cross_chunk = had_pending
+            self._structured_parameter_closed = False
 
         return "".join(output), event
 
@@ -102,6 +109,7 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
+        self._structured_parameter_closed = False
         self._in_code_fence = False
         self._fence_marker = ""
         self._fence_line_buffer = ""
@@ -117,6 +125,7 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
+        self._structured_parameter_closed = False
         return event
 
     def _suppression_close_match(self, text: str) -> re.Match[str] | None:
@@ -126,19 +135,34 @@ class ToolLeakFilter:
         seed_close = _SEED_CLOSE_RE.search(text)
         function_close = _FUNCTION_CLOSE_RE.search(text)
         if function_close is None:
-            return seed_close
+            if seed_close is not None and self._structured_seed_close_can_finish(text, seed_close):
+                return seed_close
+            return None
 
-        trailing_seed_close = _SEED_CLOSE_RE.match(text, function_close.end())
+        after_function = self._consume_whitespace(text, function_close.end())
+        trailing_seed_close = _SEED_CLOSE_RE.match(text, after_function)
         if trailing_seed_close is not None:
             return trailing_seed_close
 
-        trailing = text[function_close.end():]
+        trailing = text[after_function:]
         if not trailing:
             return None
-        if trailing and self._is_seed_close_prefix(trailing):
+        if self._is_seed_close_prefix(trailing):
             return None
 
         return function_close
+
+    def _track_suppressed_structure(self, text: str) -> None:
+        if self._suppression_pattern != "structured_tool_call" or self._structured_parameter_closed:
+            return
+        if _PARAMETER_CLOSE_RE.search(text):
+            self._structured_parameter_closed = True
+
+    def _structured_seed_close_can_finish(self, text: str, seed_close: re.Match[str]) -> bool:
+        return (
+            self._structured_parameter_closed
+            or _PARAMETER_CLOSE_RE.search(text[: seed_close.start()]) is not None
+        )
 
     def _suppression_close_tail_len(self, text: str) -> int:
         min_start = max(0, len(text) - self._max_tail)

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -133,7 +133,7 @@ class ToolLeakFilter:
             return trailing_seed_close
 
         trailing = text[function_close.end():]
-        if not trailing and function_close.start() > 0:
+        if not trailing:
             return None
         if trailing and self._is_seed_close_prefix(trailing):
             return None
@@ -154,8 +154,9 @@ class ToolLeakFilter:
 
     def _find_leak_start(self, text: str) -> Optional[tuple[int, int, str]]:
         seed = _SEED_OPEN_RE.search(text)
+        best: Optional[tuple[int, int, str]] = None
         if seed:
-            return seed.start(), seed.end(), "seed_tool_call"
+            best = (seed.start(), seed.end(), "seed_tool_call")
 
         if self._tool_names:
             lower_text = text.lower()
@@ -172,9 +173,13 @@ class ToolLeakFilter:
                         structured_suffix = suffix[name_close.end():]
                         if _PARAMETER_RE.search(structured_suffix) or _FUNCTION_CLOSE_RE.search(structured_suffix):
                             start = self._structured_tool_start(text, idx)
-                            return start, idx + len(tool_name), "structured_tool_call"
+                            candidate = (start, idx + len(tool_name), "structured_tool_call")
+                            if best is None or candidate[0] < best[0]:
+                                best = candidate
+                                if best[0] == 0:
+                                    return best
                     search_from = idx + len(tool_name)
-        return None
+        return best
 
     @staticmethod
     def _structured_tool_start(text: str, tool_name_start: int) -> int:

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -12,6 +12,10 @@ _SEED_OPEN_RE = re.compile(r"<\s*seed\s*:\s*tool_call\b[^>]*>|(?<!/)\bseed\s*:\s
 _SEED_CLOSE_RE = re.compile(r"<\s*/\s*seed\s*:\s*tool_call\s*>", re.IGNORECASE)
 _PARAMETER_RE = re.compile(r"<\s*parameter\b[^>]*\bname\s*=", re.IGNORECASE)
 _PARAMETER_CLOSE_RE = re.compile(r"<\s*/\s*parameter\s*>", re.IGNORECASE)
+_PARAMETER_BOUNDARY_RE = re.compile(
+    r"<\s*parameter\b[^>]*\bname\s*=|<\s*/\s*parameter\s*>",
+    re.IGNORECASE,
+)
 _FUNCTION_CLOSE_RE = re.compile(r"<\s*/\s*function\s*>", re.IGNORECASE)
 _FUNCTION_NAME_OPEN_TAIL_RE = re.compile(r"<\s*function\b[^>]*>\s*<\s*name\b[^>]*>\s*$", re.IGNORECASE)
 _NAME_CLOSE_RE = re.compile(r"</\s*name\s*>", re.IGNORECASE)
@@ -36,9 +40,8 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
-        self._structured_parameter_opened = False
-        self._structured_parameter_closed = False
         self._structured_tail = ""
+        self._structured_tail_depth = 0
         self._in_code_fence = False
         self._fence_marker = ""
         self._fence_line_buffer = ""
@@ -91,9 +94,8 @@ class ToolLeakFilter:
             self._suppressed_chars = 0
             self._suppression_pattern = pattern
             self._cross_chunk = had_pending
-            self._structured_parameter_opened = False
-            self._structured_parameter_closed = False
             self._structured_tail = ""
+            self._structured_tail_depth = 0
 
         return "".join(output), event
 
@@ -113,9 +115,8 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
-        self._structured_parameter_opened = False
-        self._structured_parameter_closed = False
         self._structured_tail = ""
+        self._structured_tail_depth = 0
         self._in_code_fence = False
         self._fence_marker = ""
         self._fence_line_buffer = ""
@@ -131,14 +132,13 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
-        self._structured_parameter_opened = False
-        self._structured_parameter_closed = False
         self._structured_tail = ""
+        self._structured_tail_depth = 0
         return event
 
     def _suppression_close_match(self, text: str) -> re.Match[str] | None:
         if self._suppression_pattern != "structured_tool_call":
-            return _SEED_CLOSE_RE.search(text)
+            return self._seed_close_match(text)
 
         seed_close = _SEED_CLOSE_RE.search(text)
         function_close = self._structured_function_close_match(text)
@@ -161,21 +161,23 @@ class ToolLeakFilter:
         return function_close
 
     def _track_suppressed_structure(self, text: str) -> None:
-        if self._suppression_pattern != "structured_tool_call" or not text:
+        if not text:
             return
 
+        base_depth = self._structured_tail_depth
         tracked = self._structured_tail + text
-        if not self._structured_parameter_opened and _PARAMETER_RE.search(tracked):
-            self._structured_parameter_opened = True
-        if not self._structured_parameter_closed and _PARAMETER_CLOSE_RE.search(tracked):
-            self._structured_parameter_closed = True
+        trim = max(0, len(tracked) - self._max_tail)
+        self._structured_tail_depth = self._parameter_depth_after(tracked[:trim], base_depth)
         self._structured_tail = tracked[-self._max_tail:]
 
     def _structured_seed_close_can_finish(self, text: str, seed_close: re.Match[str]) -> bool:
-        return (
-            self._structured_parameter_closed
-            or _PARAMETER_CLOSE_RE.search(text[: seed_close.start()]) is not None
-        )
+        return self._suppressed_parameter_depth_after(text[: seed_close.start()]) == 0
+
+    def _seed_close_match(self, text: str) -> re.Match[str] | None:
+        for seed_close in _SEED_CLOSE_RE.finditer(text):
+            if self._suppressed_parameter_depth_after(text[: seed_close.start()]) == 0:
+                return seed_close
+        return None
 
     def _structured_function_close_match(self, text: str) -> re.Match[str] | None:
         for function_close in _FUNCTION_CLOSE_RE.finditer(text):
@@ -184,14 +186,19 @@ class ToolLeakFilter:
         return None
 
     def _structured_function_close_can_finish(self, text: str, function_close: re.Match[str]) -> bool:
-        prefix = text[: function_close.start()]
-        parameter_opened = self._structured_parameter_opened or _PARAMETER_RE.search(prefix) is not None
-        if not parameter_opened:
-            return True
-        return (
-            self._structured_parameter_closed
-            or _PARAMETER_CLOSE_RE.search(prefix) is not None
-        )
+        return self._suppressed_parameter_depth_after(text[: function_close.start()]) == 0
+
+    def _suppressed_parameter_depth_after(self, text: str) -> int:
+        return self._parameter_depth_after(self._structured_tail + text, self._structured_tail_depth)
+
+    @staticmethod
+    def _parameter_depth_after(text: str, depth: int = 0) -> int:
+        for match in _PARAMETER_BOUNDARY_RE.finditer(text):
+            if re.match(r"<\s*/", match.group(0)):
+                depth = max(0, depth - 1)
+            else:
+                depth += 1
+        return depth
 
     def _suppression_close_tail_len(self, text: str) -> int:
         if self._suppression_pattern == "structured_tool_call":

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -127,8 +127,6 @@ class ToolLeakFilter:
         function_close = _FUNCTION_CLOSE_RE.search(text)
         if function_close is None:
             return seed_close
-        if seed_close is not None and seed_close.start() < function_close.start():
-            return seed_close
 
         trailing_seed_close = _SEED_CLOSE_RE.match(text, function_close.end())
         if trailing_seed_close is not None:
@@ -382,7 +380,14 @@ class ToolLeakFilter:
         if not text:
             return False
 
-        ok, pos, partial = cls._consume_literal_prefix(text, 0, tool_name)
+        ok, pos, partial = cls._consume_function_name_open_prefix(text, 0)
+        if ok:
+            if partial or pos == len(text):
+                return True
+        else:
+            pos = 0
+
+        ok, pos, partial = cls._consume_literal_prefix(text, pos, tool_name)
         if not ok:
             return False
         if partial or pos == len(text):
@@ -395,7 +400,44 @@ class ToolLeakFilter:
             return True
 
         ok, _pos, partial = cls._consume_parameter_open_prefix(text, pos)
-        return ok and partial
+        if ok and partial:
+            return True
+        return cls._is_function_close_prefix(text[pos:])
+
+    @classmethod
+    def _consume_function_name_open_prefix(cls, text: str, pos: int) -> tuple[bool, int, bool]:
+        ok, pos, partial = cls._consume_xml_open_prefix(text, pos, "function")
+        if not ok or partial:
+            return ok, pos, partial
+
+        pos = cls._consume_whitespace(text, pos)
+        if pos == len(text):
+            return True, pos, True
+        return cls._consume_xml_open_prefix(text, pos, "name")
+
+    @classmethod
+    def _consume_xml_open_prefix(cls, text: str, pos: int, literal: str) -> tuple[bool, int, bool]:
+        if pos == len(text):
+            return True, pos, True
+        if text[pos] != "<":
+            return False, pos, False
+
+        pos = cls._consume_whitespace(text, pos + 1)
+        if pos == len(text):
+            return True, pos, True
+
+        ok, pos, partial = cls._consume_literal_prefix(text, pos, literal)
+        if not ok or partial:
+            return ok, pos, partial
+
+        if pos < len(text) and cls._is_word_char(text[pos]):
+            return False, pos, False
+
+        while pos < len(text):
+            if text[pos] == ">":
+                return True, pos + 1, False
+            pos += 1
+        return True, pos, True
 
     @classmethod
     def _consume_name_close_prefix(cls, text: str, pos: int) -> tuple[bool, int, bool]:

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -12,6 +12,7 @@ _SEED_OPEN_RE = re.compile(r"<\s*seed\s*:\s*tool_call\b[^>]*>|(?<!/)\bseed\s*:\s
 _SEED_CLOSE_RE = re.compile(r"<\s*/\s*seed\s*:\s*tool_call\s*>", re.IGNORECASE)
 _PARAMETER_RE = re.compile(r"<\s*parameter\b[^>]*\bname\s*=", re.IGNORECASE)
 _FUNCTION_CLOSE_RE = re.compile(r"<\s*/\s*function\s*>", re.IGNORECASE)
+_FUNCTION_NAME_OPEN_TAIL_RE = re.compile(r"<\s*function\b[^>]*>\s*<\s*name\s*>\s*$", re.IGNORECASE)
 _NAME_CLOSE_RE = re.compile(r"</\s*name\s*>", re.IGNORECASE)
 
 
@@ -56,7 +57,12 @@ class ToolLeakFilter:
                     text = text[close_match.end():]
                     event = self._finish_event()
                     continue
-                self._suppressed_chars += len(text)
+                keep_tail = self._suppression_close_tail_len(text)
+                if keep_tail > 0:
+                    self._suppressed_chars += len(text) - keep_tail
+                    self._pending = text[-keep_tail:]
+                else:
+                    self._suppressed_chars += len(text)
                 text = ""
                 break
 
@@ -127,6 +133,16 @@ class ToolLeakFilter:
         trailing_seed_close = _SEED_CLOSE_RE.match(text, function_close.end())
         return trailing_seed_close or function_close
 
+    def _suppression_close_tail_len(self, text: str) -> int:
+        min_start = max(0, len(text) - self._max_tail)
+        for start in range(min_start, len(text)):
+            tail = text[start:]
+            if self._is_seed_close_prefix(tail):
+                return len(tail)
+            if self._suppression_pattern == "structured_tool_call" and self._is_function_close_prefix(tail):
+                return len(tail)
+        return 0
+
     def _find_leak_start(self, text: str) -> Optional[tuple[int, int, str]]:
         seed = _SEED_OPEN_RE.search(text)
         if seed:
@@ -142,8 +158,16 @@ class ToolLeakFilter:
                 if _NAME_CLOSE_RE.search(suffix) and (
                     _PARAMETER_RE.search(suffix) or _FUNCTION_CLOSE_RE.search(suffix)
                 ):
-                    return idx, idx + len(tool_name), "structured_tool_call"
+                    start = self._structured_tool_start(text, idx)
+                    return start, idx + len(tool_name), "structured_tool_call"
         return None
+
+    @staticmethod
+    def _structured_tool_start(text: str, tool_name_start: int) -> int:
+        opener = _FUNCTION_NAME_OPEN_TAIL_RE.search(text[:tool_name_start])
+        if opener:
+            return opener.start()
+        return tool_name_start
 
     def _split_safe_tail(self, text: str) -> tuple[str, str]:
         keep_tail = self._possible_marker_tail_len(text)
@@ -269,6 +293,64 @@ class ToolLeakFilter:
 
         ok, _pos, partial = cls._consume_literal_prefix(text, pos, "tool_call")
         return ok and partial
+
+    @classmethod
+    def _is_seed_close_prefix(cls, text: str) -> bool:
+        return cls._is_xml_close_prefix(text, "seed", ":", "tool_call")
+
+    @classmethod
+    def _is_function_close_prefix(cls, text: str) -> bool:
+        return cls._is_xml_close_prefix(text, "function")
+
+    @classmethod
+    def _is_xml_close_prefix(
+        cls,
+        text: str,
+        first_literal: str,
+        separator: str | None = None,
+        second_literal: str | None = None,
+    ) -> bool:
+        if not text or text[0] != "<":
+            return False
+
+        pos = cls._consume_whitespace(text, 1)
+        if pos == len(text):
+            return True
+        if text[pos] != "/":
+            return False
+
+        pos = cls._consume_whitespace(text, pos + 1)
+        if pos == len(text):
+            return True
+
+        ok, pos, partial = cls._consume_literal_prefix(text, pos, first_literal)
+        if not ok:
+            return False
+        if partial:
+            return True
+
+        if separator is not None:
+            pos = cls._consume_whitespace(text, pos)
+            if pos == len(text):
+                return True
+            if text[pos] != separator:
+                return False
+
+            pos = cls._consume_whitespace(text, pos + 1)
+            if pos == len(text):
+                return True
+
+            assert second_literal is not None
+            ok, pos, partial = cls._consume_literal_prefix(text, pos, second_literal)
+            if not ok:
+                return False
+            if partial:
+                return True
+
+        pos = cls._consume_whitespace(text, pos)
+        if pos == len(text):
+            return True
+        return text[pos] == ">" and pos == len(text) - 1
 
     def _structured_marker_tail_len(self, text: str) -> int:
         min_start = max(0, len(text) - self._max_tail)

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -285,11 +285,12 @@ class ToolLeakFilter:
     @staticmethod
     def _consume_literal_prefix(text: str, pos: int, literal: str) -> tuple[bool, int, bool]:
         fragment = text[pos : pos + len(literal)].lower()
-        if not literal.startswith(fragment):
+        literal_lower = literal.lower()
+        if not literal_lower.startswith(fragment):
             return False, pos, False
-        if len(fragment) < len(literal):
+        if len(fragment) < len(literal_lower):
             return True, len(text), True
-        return True, pos + len(literal), False
+        return True, pos + len(literal_lower), False
 
     @staticmethod
     def _consume_whitespace(text: str, pos: int) -> int:

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -13,7 +13,7 @@ _SEED_CLOSE_RE = re.compile(r"<\s*/\s*seed\s*:\s*tool_call\s*>", re.IGNORECASE)
 _PARAMETER_RE = re.compile(r"<\s*parameter\b[^>]*\bname\s*=", re.IGNORECASE)
 _PARAMETER_CLOSE_RE = re.compile(r"<\s*/\s*parameter\s*>", re.IGNORECASE)
 _PARAMETER_BOUNDARY_RE = re.compile(
-    r"<\s*parameter\b[^>]*\bname\s*=|<\s*/\s*parameter\s*>",
+    r"<\s*parameter\b[^>]*\bname\s*=[^>]*>|<\s*/\s*parameter\s*>",
     re.IGNORECASE,
 )
 _FUNCTION_CLOSE_RE = re.compile(r"<\s*/\s*function\s*>", re.IGNORECASE)
@@ -194,9 +194,10 @@ class ToolLeakFilter:
     @staticmethod
     def _parameter_depth_after(text: str, depth: int = 0) -> int:
         for match in _PARAMETER_BOUNDARY_RE.finditer(text):
-            if re.match(r"<\s*/", match.group(0)):
+            tag = match.group(0)
+            if re.match(r"<\s*/", tag):
                 depth = max(0, depth - 1)
-            else:
+            elif not re.search(r"/\s*>$", tag):
                 depth += 1
         return depth
 

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -163,10 +163,10 @@ class ToolLeakFilter:
 
     def _possible_marker_tail_len(self, text: str) -> int:
         lower = text.lower()
-        markers = ["<seed:tool_call", "seed:tool_call"]
+        best = self._seed_marker_tail_len(text)
+        markers = []
         markers.extend(name.lower() + "</name><parameter name=" for name in self._tool_names)
         markers.extend(name.lower() + "</name>" for name in self._tool_names)
-        best = 0
         for marker in markers:
             max_prefix = min(len(marker) - 1, len(lower), self._max_tail)
             for size in range(max_prefix, 0, -1):
@@ -174,6 +174,97 @@ class ToolLeakFilter:
                     best = max(best, size)
                     break
         return best
+
+    def _seed_marker_tail_len(self, text: str) -> int:
+        min_start = max(0, len(text) - self._max_tail)
+        for start in range(min_start, len(text)):
+            first = text[start]
+            if first != "<" and first.lower() != "s":
+                continue
+            tail = text[start:]
+            if self._is_seed_opener_prefix(tail):
+                return len(tail)
+        return 0
+
+    @classmethod
+    def _is_seed_opener_prefix(cls, text: str) -> bool:
+        return cls._is_bracketed_seed_opener_prefix(text) or cls._is_bare_seed_opener_prefix(text)
+
+    @staticmethod
+    def _consume_literal_prefix(text: str, pos: int, literal: str) -> tuple[bool, int, bool]:
+        fragment = text[pos : pos + len(literal)].lower()
+        if not literal.startswith(fragment):
+            return False, pos, False
+        if len(fragment) < len(literal):
+            return True, len(text), True
+        return True, pos + len(literal), False
+
+    @staticmethod
+    def _consume_whitespace(text: str, pos: int) -> int:
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        return pos
+
+    @staticmethod
+    def _is_word_char(char: str) -> bool:
+        return char == "_" or char.isalnum()
+
+    @classmethod
+    def _is_bracketed_seed_opener_prefix(cls, text: str) -> bool:
+        if not text or text[0] != "<":
+            return False
+
+        pos = cls._consume_whitespace(text, 1)
+        if pos == len(text):
+            return True
+
+        ok, pos, partial = cls._consume_literal_prefix(text, pos, "seed")
+        if not ok:
+            return False
+        if partial:
+            return True
+
+        pos = cls._consume_whitespace(text, pos)
+        if pos == len(text):
+            return True
+        if text[pos] != ":":
+            return False
+
+        pos = cls._consume_whitespace(text, pos + 1)
+        if pos == len(text):
+            return True
+
+        ok, pos, partial = cls._consume_literal_prefix(text, pos, "tool_call")
+        if not ok:
+            return False
+        if partial or pos == len(text):
+            return True
+
+        return not cls._is_word_char(text[pos]) and ">" not in text[pos:]
+
+    @classmethod
+    def _is_bare_seed_opener_prefix(cls, text: str) -> bool:
+        if not text or text[0].lower() != "s":
+            return False
+
+        ok, pos, partial = cls._consume_literal_prefix(text, 0, "seed")
+        if not ok:
+            return False
+        if partial:
+            return True
+
+        pos = cls._consume_whitespace(text, pos)
+        if pos == len(text):
+            return True
+        if text[pos] != ":":
+            return False
+
+        pos = cls._consume_whitespace(text, pos + 1)
+        if pos == len(text):
+            return True
+
+        ok, _pos, partial = cls._consume_literal_prefix(text, pos, "tool_call")
+        return ok and partial
 
 
 def log_tool_leak_filtered(

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -13,7 +13,7 @@ _SEED_CLOSE_RE = re.compile(r"<\s*/\s*seed\s*:\s*tool_call\s*>", re.IGNORECASE)
 _PARAMETER_RE = re.compile(r"<\s*parameter\b[^>]*\bname\s*=", re.IGNORECASE)
 _PARAMETER_CLOSE_RE = re.compile(r"<\s*/\s*parameter\s*>", re.IGNORECASE)
 _FUNCTION_CLOSE_RE = re.compile(r"<\s*/\s*function\s*>", re.IGNORECASE)
-_FUNCTION_NAME_OPEN_TAIL_RE = re.compile(r"<\s*function\b[^>]*>\s*<\s*name\s*>\s*$", re.IGNORECASE)
+_FUNCTION_NAME_OPEN_TAIL_RE = re.compile(r"<\s*function\b[^>]*>\s*<\s*name\b[^>]*>\s*$", re.IGNORECASE)
 _NAME_CLOSE_RE = re.compile(r"</\s*name\s*>", re.IGNORECASE)
 
 

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -37,6 +37,7 @@ class ToolLeakFilter:
         self._suppression_pattern = ""
         self._cross_chunk = False
         self._structured_parameter_closed = False
+        self._structured_tail = ""
         self._in_code_fence = False
         self._fence_marker = ""
         self._fence_line_buffer = ""
@@ -90,6 +91,7 @@ class ToolLeakFilter:
             self._suppression_pattern = pattern
             self._cross_chunk = had_pending
             self._structured_parameter_closed = False
+            self._structured_tail = ""
 
         return "".join(output), event
 
@@ -110,6 +112,7 @@ class ToolLeakFilter:
         self._suppression_pattern = ""
         self._cross_chunk = False
         self._structured_parameter_closed = False
+        self._structured_tail = ""
         self._in_code_fence = False
         self._fence_marker = ""
         self._fence_line_buffer = ""
@@ -126,6 +129,7 @@ class ToolLeakFilter:
         self._suppression_pattern = ""
         self._cross_chunk = False
         self._structured_parameter_closed = False
+        self._structured_tail = ""
         return event
 
     def _suppression_close_match(self, text: str) -> re.Match[str] | None:
@@ -153,10 +157,13 @@ class ToolLeakFilter:
         return function_close
 
     def _track_suppressed_structure(self, text: str) -> None:
-        if self._suppression_pattern != "structured_tool_call" or self._structured_parameter_closed:
+        if self._suppression_pattern != "structured_tool_call" or not text:
             return
-        if _PARAMETER_CLOSE_RE.search(text):
+
+        tracked = self._structured_tail + text
+        if not self._structured_parameter_closed and _PARAMETER_CLOSE_RE.search(tracked):
             self._structured_parameter_closed = True
+        self._structured_tail = tracked[-self._max_tail:]
 
     def _structured_seed_close_can_finish(self, text: str, seed_close: re.Match[str]) -> bool:
         return (
@@ -165,6 +172,11 @@ class ToolLeakFilter:
         )
 
     def _suppression_close_tail_len(self, text: str) -> int:
+        if self._suppression_pattern == "structured_tool_call":
+            function_tail = self._pending_function_close_tail_len(text)
+            if function_tail > 0:
+                return function_tail
+
         min_start = max(0, len(text) - self._max_tail)
         for start in range(min_start, len(text)):
             tail = text[start:]
@@ -175,6 +187,15 @@ class ToolLeakFilter:
             if self._suppression_pattern == "structured_tool_call" and _FUNCTION_CLOSE_RE.fullmatch(tail):
                 return len(tail)
         return 0
+
+    def _pending_function_close_tail_len(self, text: str) -> int:
+        tail_len = 0
+        for match in _FUNCTION_CLOSE_RE.finditer(text):
+            after_function = self._consume_whitespace(text, match.end())
+            trailing = text[after_function:]
+            if not trailing or self._is_seed_close_prefix(trailing):
+                tail_len = len(text) - match.start()
+        return tail_len
 
     def _find_leak_start(self, text: str) -> Optional[tuple[int, int, str]]:
         seed = _SEED_OPEN_RE.search(text)

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -158,15 +158,20 @@ class ToolLeakFilter:
         if self._tool_names:
             lower_text = text.lower()
             for tool_name in sorted(self._tool_names, key=len, reverse=True):
-                idx = lower_text.find(tool_name.lower())
-                if idx < 0:
-                    continue
-                suffix = text[idx:]
-                if _NAME_CLOSE_RE.search(suffix) and (
-                    _PARAMETER_RE.search(suffix) or _FUNCTION_CLOSE_RE.search(suffix)
-                ):
-                    start = self._structured_tool_start(text, idx)
-                    return start, idx + len(tool_name), "structured_tool_call"
+                search_from = 0
+                lower_tool_name = tool_name.lower()
+                while True:
+                    idx = lower_text.find(lower_tool_name, search_from)
+                    if idx < 0:
+                        break
+                    suffix = text[idx + len(tool_name):]
+                    name_close = _NAME_CLOSE_RE.match(suffix)
+                    if name_close is not None:
+                        structured_suffix = suffix[name_close.end():]
+                        if _PARAMETER_RE.search(structured_suffix) or _FUNCTION_CLOSE_RE.search(structured_suffix):
+                            start = self._structured_tool_start(text, idx)
+                            return start, idx + len(tool_name), "structured_tool_call"
+                    search_from = idx + len(tool_name)
         return None
 
     @staticmethod

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -131,7 +131,14 @@ class ToolLeakFilter:
             return seed_close
 
         trailing_seed_close = _SEED_CLOSE_RE.match(text, function_close.end())
-        return trailing_seed_close or function_close
+        if trailing_seed_close is not None:
+            return trailing_seed_close
+
+        trailing = text[function_close.end():]
+        if trailing and self._is_seed_close_prefix(trailing):
+            return None
+
+        return function_close
 
     def _suppression_close_tail_len(self, text: str) -> int:
         min_start = max(0, len(text) - self._max_tail)

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -36,6 +36,7 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
+        self._structured_parameter_opened = False
         self._structured_parameter_closed = False
         self._structured_tail = ""
         self._in_code_fence = False
@@ -90,6 +91,7 @@ class ToolLeakFilter:
             self._suppressed_chars = 0
             self._suppression_pattern = pattern
             self._cross_chunk = had_pending
+            self._structured_parameter_opened = False
             self._structured_parameter_closed = False
             self._structured_tail = ""
 
@@ -111,6 +113,7 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
+        self._structured_parameter_opened = False
         self._structured_parameter_closed = False
         self._structured_tail = ""
         self._in_code_fence = False
@@ -128,6 +131,7 @@ class ToolLeakFilter:
         self._suppressed_chars = 0
         self._suppression_pattern = ""
         self._cross_chunk = False
+        self._structured_parameter_opened = False
         self._structured_parameter_closed = False
         self._structured_tail = ""
         return event
@@ -137,7 +141,7 @@ class ToolLeakFilter:
             return _SEED_CLOSE_RE.search(text)
 
         seed_close = _SEED_CLOSE_RE.search(text)
-        function_close = _FUNCTION_CLOSE_RE.search(text)
+        function_close = self._structured_function_close_match(text)
         if function_close is None:
             if seed_close is not None and self._structured_seed_close_can_finish(text, seed_close):
                 return seed_close
@@ -161,6 +165,8 @@ class ToolLeakFilter:
             return
 
         tracked = self._structured_tail + text
+        if not self._structured_parameter_opened and _PARAMETER_RE.search(tracked):
+            self._structured_parameter_opened = True
         if not self._structured_parameter_closed and _PARAMETER_CLOSE_RE.search(tracked):
             self._structured_parameter_closed = True
         self._structured_tail = tracked[-self._max_tail:]
@@ -169,6 +175,22 @@ class ToolLeakFilter:
         return (
             self._structured_parameter_closed
             or _PARAMETER_CLOSE_RE.search(text[: seed_close.start()]) is not None
+        )
+
+    def _structured_function_close_match(self, text: str) -> re.Match[str] | None:
+        for function_close in _FUNCTION_CLOSE_RE.finditer(text):
+            if self._structured_function_close_can_finish(text, function_close):
+                return function_close
+        return None
+
+    def _structured_function_close_can_finish(self, text: str, function_close: re.Match[str]) -> bool:
+        prefix = text[: function_close.start()]
+        parameter_opened = self._structured_parameter_opened or _PARAMETER_RE.search(prefix) is not None
+        if not parameter_opened:
+            return True
+        return (
+            self._structured_parameter_closed
+            or _PARAMETER_CLOSE_RE.search(prefix) is not None
         )
 
     def _suppression_close_tail_len(self, text: str) -> int:

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -135,6 +135,8 @@ class ToolLeakFilter:
             return trailing_seed_close
 
         trailing = text[function_close.end():]
+        if not trailing and function_close.start() > 0:
+            return None
         if trailing and self._is_seed_close_prefix(trailing):
             return None
 
@@ -147,6 +149,8 @@ class ToolLeakFilter:
             if self._is_seed_close_prefix(tail):
                 return len(tail)
             if self._suppression_pattern == "structured_tool_call" and self._is_function_close_prefix(tail):
+                return len(tail)
+            if self._suppression_pattern == "structured_tool_call" and _FUNCTION_CLOSE_RE.fullmatch(tail):
                 return len(tail)
         return 0
 

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -1,0 +1,194 @@
+# -- coding: utf-8 --
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Optional
+
+
+_DEFAULT_TOOL_NAMES = frozenset({"recall_memory"})
+_SEED_OPEN_RE = re.compile(r"<\s*seed\s*:\s*tool_call\b[^>]*>|(?<!/)\bseed\s*:\s*tool_call\b", re.IGNORECASE)
+_SEED_CLOSE_RE = re.compile(r"<\s*/\s*seed\s*:\s*tool_call\s*>", re.IGNORECASE)
+_PARAMETER_RE = re.compile(r"<\s*parameter\b[^>]*\bname\s*=", re.IGNORECASE)
+_FUNCTION_CLOSE_RE = re.compile(r"<\s*/\s*function\s*>", re.IGNORECASE)
+_NAME_CLOSE_RE = re.compile(r"</\s*name\s*>", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ToolLeakFilterEvent:
+    pattern: str
+    chars: int
+    cross_chunk: bool = False
+    finalized: bool = False
+
+
+class ToolLeakFilter:
+    """Streaming filter for provider-emitted tool-call markup in assistant text."""
+
+    def __init__(self, *, tool_names: set[str] | None = None, max_tail: int = 2048):
+        self._tool_names = {name for name in (tool_names or _DEFAULT_TOOL_NAMES) if name}
+        self._max_tail = max(128, int(max_tail))
+        self._pending = ""
+        self._suppressing = False
+        self._suppressed_chars = 0
+        self._suppression_pattern = ""
+        self._cross_chunk = False
+        self._in_code_fence = False
+        self._fence_marker = ""
+        self._fence_line_buffer = ""
+
+    def feed(self, chunk: str) -> tuple[str, ToolLeakFilterEvent | None]:
+        if not chunk:
+            return "", None
+
+        text = self._pending + str(chunk)
+        had_pending = bool(self._pending)
+        self._pending = ""
+        output: list[str] = []
+        event: ToolLeakFilterEvent | None = None
+
+        while text:
+            if self._suppressing:
+                close_match = _SEED_CLOSE_RE.search(text)
+                if close_match:
+                    self._suppressed_chars += close_match.end()
+                    text = text[close_match.end():]
+                    event = self._finish_event()
+                    continue
+                self._suppressed_chars += len(text)
+                text = ""
+                break
+
+            match = self._find_leak_start(text)
+            if not match:
+                keep, self._pending = self._split_safe_tail(text)
+                if keep:
+                    self._append_visible(output, keep)
+                break
+
+            start, _end, pattern = match
+            if start:
+                self._append_visible(output, text[:start])
+            text = text[start:]
+            if self._in_code_fence:
+                self._append_visible(output, "[tool-call markup omitted]")
+            self._suppressing = True
+            self._suppressed_chars = 0
+            self._suppression_pattern = pattern
+            self._cross_chunk = had_pending
+
+        return "".join(output), event
+
+    def finalize(self) -> tuple[str, ToolLeakFilterEvent | None]:
+        if self._suppressing:
+            self._suppressed_chars += len(self._pending)
+            self._pending = ""
+            return "", self._finish_event(finalized=True)
+
+        visible = self._pending
+        self._pending = ""
+        return visible, None
+
+    def reset(self) -> None:
+        self._pending = ""
+        self._suppressing = False
+        self._suppressed_chars = 0
+        self._suppression_pattern = ""
+        self._cross_chunk = False
+        self._in_code_fence = False
+        self._fence_marker = ""
+        self._fence_line_buffer = ""
+
+    def _finish_event(self, *, finalized: bool = False) -> ToolLeakFilterEvent:
+        event = ToolLeakFilterEvent(
+            pattern=self._suppression_pattern or "tool_call_markup",
+            chars=self._suppressed_chars,
+            cross_chunk=self._cross_chunk,
+            finalized=finalized,
+        )
+        self._suppressing = False
+        self._suppressed_chars = 0
+        self._suppression_pattern = ""
+        self._cross_chunk = False
+        return event
+
+    def _find_leak_start(self, text: str) -> Optional[tuple[int, int, str]]:
+        seed = _SEED_OPEN_RE.search(text)
+        if seed:
+            return seed.start(), seed.end(), "seed_tool_call"
+
+        if self._tool_names:
+            lower_text = text.lower()
+            for tool_name in sorted(self._tool_names, key=len, reverse=True):
+                idx = lower_text.find(tool_name.lower())
+                if idx < 0:
+                    continue
+                suffix = text[idx:]
+                if _NAME_CLOSE_RE.search(suffix) and (
+                    _PARAMETER_RE.search(suffix) or _FUNCTION_CLOSE_RE.search(suffix)
+                ):
+                    return idx, idx + len(tool_name), "structured_tool_call"
+        return None
+
+    def _split_safe_tail(self, text: str) -> tuple[str, str]:
+        keep_tail = self._possible_marker_tail_len(text)
+        if keep_tail <= 0:
+            return text, ""
+        return text[:-keep_tail], text[-keep_tail:]
+
+    def _append_visible(self, output: list[str], text: str) -> None:
+        output.append(text)
+        self._track_code_fences(text)
+
+    def _track_code_fences(self, text: str) -> None:
+        if not text:
+            return
+
+        self._fence_line_buffer += text
+        while "\n" in self._fence_line_buffer:
+            line, self._fence_line_buffer = self._fence_line_buffer.split("\n", 1)
+            self._apply_fence_line(line)
+
+    def _apply_fence_line(self, line: str) -> None:
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            marker = stripped[:3]
+            if not self._in_code_fence:
+                self._in_code_fence = True
+                self._fence_marker = marker
+            elif marker == self._fence_marker:
+                self._in_code_fence = False
+                self._fence_marker = ""
+
+    def _possible_marker_tail_len(self, text: str) -> int:
+        lower = text.lower()
+        markers = ["<seed:tool_call", "seed:tool_call"]
+        markers.extend(name.lower() + "</name><parameter name=" for name in self._tool_names)
+        markers.extend(name.lower() + "</name>" for name in self._tool_names)
+        best = 0
+        for marker in markers:
+            max_prefix = min(len(marker) - 1, len(lower), self._max_tail)
+            for size in range(max_prefix, 0, -1):
+                if lower.endswith(marker[:size]):
+                    best = max(best, size)
+                    break
+        return best
+
+
+def log_tool_leak_filtered(
+    event: ToolLeakFilterEvent,
+    *,
+    provider: str | None = None,
+    session: str = "OmniOfflineClient",
+) -> None:
+    parts = [
+        "[tool-leak-filter] stripped",
+        f"provider={provider or 'unknown'}",
+        f"session={session}",
+        f"pattern={event.pattern}",
+        f"chars={event.chars}",
+        f"cross_chunk={str(event.cross_chunk).lower()}",
+        f"finalized={str(event.finalized).lower()}",
+    ]
+    print(" ".join(parts))

--- a/utils/llm_tool_leak_filter.py
+++ b/utils/llm_tool_leak_filter.py
@@ -50,7 +50,7 @@ class ToolLeakFilter:
 
         while text:
             if self._suppressing:
-                close_match = _SEED_CLOSE_RE.search(text)
+                close_match = self._suppression_close_match(text)
                 if close_match:
                     self._suppressed_chars += close_match.end()
                     text = text[close_match.end():]
@@ -112,6 +112,20 @@ class ToolLeakFilter:
         self._suppression_pattern = ""
         self._cross_chunk = False
         return event
+
+    def _suppression_close_match(self, text: str) -> re.Match[str] | None:
+        if self._suppression_pattern != "structured_tool_call":
+            return _SEED_CLOSE_RE.search(text)
+
+        seed_close = _SEED_CLOSE_RE.search(text)
+        function_close = _FUNCTION_CLOSE_RE.search(text)
+        if function_close is None:
+            return seed_close
+        if seed_close is not None and seed_close.start() < function_close.start():
+            return seed_close
+
+        trailing_seed_close = _SEED_CLOSE_RE.match(text, function_close.end())
+        return trailing_seed_close or function_close
 
     def _find_leak_start(self, text: str) -> Optional[tuple[int, int, str]]:
         seed = _SEED_OPEN_RE.search(text)


### PR DESCRIPTION
## 改动概述 / Summary

过滤 free/free-model 偶发把内部工具调用 XML/seed 片段当作普通 assistant 正文输出的问题，避免污染 UI、TTS、对话历史和记忆链路。

## 回归报告 / Regression Report

- 改动：新增 `ToolLeakFilter`，并接入 `OmniOfflineClient.stream_text` / `prompt_ephemeral` 及 OpenAI-compat / GenAI tool loop 的 pre-tool 文本累积路径。
- 必要性：事故轮次没有真实工具调用，但 provider 文本仍泄露内部工具调用结构，后端需要在可见输出和 history 写入前止血。
- 前后对比：改动前泄露片段可能进入前端、TTS、history、memory；改动后普通正文泄露片段会被丢弃，Markdown 代码块里的精确工具调用结构改为 `[tool-call markup omitted]`。
- 潜在回归：可能误伤精确复刻当前注册工具名和强结构工具调用片段的正常说明；新增独立流式出口时需要复用同一过滤器。

## 风险与边界

不禁用 free tools，不改 provider、前端、Electron 或配置链路；不把普通 assistant XML 解析成工具调用；只过滤 assistant 输出，不处理用户输入、工具返回或 system prompt，也不记录原始泄露文本和工具参数。

## 不拆分理由 / Why Not Split

不适用。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明
* **新功能**
  * 在流式输出与临时提示中启用工具调用泄露过滤，自动剔除工具标记及敏感参数；围栏内以占位文本替代，并在可见尾部补齐后再输出。
  * 统一适配 OpenAI-compat 与 Gemini 的脱敏效果，并记录脱敏事件。
* **修复**
  * 异常、回退与静默分支下，确保已积压文本与过滤尾部按一致规则刷新，避免影响后续 UI 与历史展示。
* **测试**
  * 新增回归用例覆盖跨分块、未闭合丢弃、事件脱敏，以及 `stream_text`/`prompt_ephemeral` 一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->