### PR TITLE
revert: restore pre-glass UI styling

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -7511,15 +7511,6 @@ margin-top: 10px;
 /* 入口按钮上方已有 .btn.sm.ai-assist 样式，保留不动 */
 
 .card-companion-panel {
-    --companion-glass-border: rgba(255, 255, 255, 0.62);
-    --companion-glass-highlight: rgba(255, 255, 255, 0.9);
-    --companion-glass-shadow:
-        0 30px 76px rgba(11, 43, 66, 0.22),
-        0 16px 38px rgba(32, 70, 90, 0.08),
-        0 1px 0 rgba(255, 255, 255, 0.62) inset,
-        0 16px 36px rgba(255, 255, 255, 0.14) inset,
-        0 -24px 52px rgba(28, 95, 130, 0.12) inset,
-        0 0 0 1px rgba(255, 255, 255, 0.32) inset;
     position: fixed;
     top: 24px;
     right: 24px;
@@ -7529,18 +7520,10 @@ margin-top: 10px;
     height: min(720px, calc(100vh - 48px));
     min-height: min(360px, calc(100vh - 16px));
     max-height: calc(100vh - 16px);
-    isolation: isolate;
-    background:
-        linear-gradient(116deg, rgba(255, 255, 255, 0.36) 0%, rgba(255, 255, 255, 0.08) 16%, transparent 38%),
-        radial-gradient(circle at 18% 4%, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0.06) 26%, transparent 50%),
-        radial-gradient(circle at 94% 86%, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.02) 28%, transparent 52%),
-        linear-gradient(145deg, rgba(255, 255, 255, 0.2), rgba(245, 248, 250, 0.055) 50%, rgba(255, 255, 255, 0.12)),
-        rgba(255, 255, 255, 0.07);
-    border: 1px solid var(--companion-glass-border);
+    background: linear-gradient(180deg, #ffffff 0%, #f8fcff 100%);
+    border: 2px solid #b3e5fc;
     border-radius: 28px;
-    box-shadow: var(--companion-glass-shadow);
-    backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
-    -webkit-backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);
+    box-shadow: 0 18px 44px rgba(64, 197, 241, 0.24);
     display: flex;
     flex-direction: column;
     z-index: 10100;
@@ -7550,40 +7533,6 @@ margin-top: 10px;
     transition: box-shadow 0.22s ease, background 0.22s ease, opacity 0.22s ease;
     resize: both;
     -webkit-app-region: no-drag;
-}
-
-.card-companion-panel::before,
-.card-companion-panel::after {
-    content: "";
-    position: absolute;
-    pointer-events: none;
-    z-index: 0;
-}
-
-.card-companion-panel::before {
-    inset: 1px;
-    border-radius: 27px;
-    background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.54), rgba(255, 255, 255, 0.1) 16%, rgba(255, 255, 255, 0) 34%),
-        linear-gradient(315deg, rgba(255, 255, 255, 0.26), rgba(255, 255, 255, 0) 32%),
-        linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(245, 248, 250, 0.02) 44%, rgba(255, 255, 255, 0.08) 100%);
-    box-shadow:
-        inset 0 1px 0 var(--companion-glass-highlight),
-        inset 0 0 0 1px rgba(255, 255, 255, 0.36),
-        inset 0 -1px 0 rgba(31, 146, 192, 0.2);
-    opacity: 0.86;
-}
-
-.card-companion-panel::after {
-    top: -42%;
-    left: -30%;
-    width: 70%;
-    height: 86%;
-    border-radius: 999px;
-    background: linear-gradient(118deg, rgba(255, 255, 255, 0.32), rgba(255, 255, 255, 0.05) 46%, transparent 68%);
-    filter: blur(1px);
-    transform: rotate(-18deg);
-    opacity: 0.78;
 }
 
 @keyframes cardCompanionWindowIn {
@@ -7637,12 +7586,6 @@ margin-top: 10px;
 
 .card-companion-panel.card-companion-minimized::before {
     inset: 3px;
-    top: 3px;
-    left: 3px;
-    width: auto;
-    height: auto;
-    transform: none;
-    filter: none;
     z-index: 2;
     background:
         radial-gradient(circle at 32% 22%, rgba(255, 255, 255, 0.7) 0 11%, rgba(255, 255, 255, 0) 30%),
@@ -7652,14 +7595,6 @@ margin-top: 10px;
 
 .card-companion-panel.card-companion-minimized::after {
     inset: 0;
-    top: 0;
-    left: 0;
-    width: auto;
-    height: auto;
-    transform: none;
-    filter: none;
-    background: transparent;
-    opacity: 1;
     z-index: 3;
     border: 1px solid rgba(255, 255, 255, 0.7);
     box-shadow: inset 0 -8px 14px rgba(64, 197, 241, 0.18);
@@ -7688,18 +7623,10 @@ margin-top: 10px;
 .card-companion-panel.card-companion-dragging {
     user-select: none;
     z-index: 100100;
-    box-shadow: 0 18px 42px rgba(11, 43, 66, 0.24);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
+    box-shadow: 0 22px 52px rgba(64, 197, 241, 0.3);
     animation-play-state: paused;
     will-change: left, top;
     transition: none;
-}
-
-.card-companion-panel.card-companion-dragging::before,
-.card-companion-panel.card-companion-dragging::after {
-    filter: none;
-    opacity: 0.38;
 }
 
 .card-companion-panel.card-companion-collapsing {
@@ -7767,33 +7694,18 @@ margin-top: 10px;
 }
 
 .card-companion-header {
-    position: relative;
-    z-index: 1;
     display: flex;
     align-items: center;
     gap: 12px;
     min-height: 76px;
     padding: 12px 18px 11px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.46);
+    border-bottom: 2px solid #d5f2ff;
     background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.32), rgba(245, 251, 255, 0.1) 58%, rgba(255, 255, 255, 0.18)),
-        rgba(255, 255, 255, 0.1);
+        linear-gradient(135deg, rgba(224, 247, 255, 0.96), rgba(255, 255, 255, 0.98) 62%),
+        url('/static/icons/dropdown_item_hover_bg.png') center / cover no-repeat;
     flex-shrink: 0;
     cursor: grab;
     touch-action: none;
-    overflow: hidden;
-}
-
-.card-companion-header::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto;
-    height: 64%;
-    pointer-events: none;
-    background:
-        linear-gradient(112deg, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.08) 42%, transparent 68%),
-        radial-gradient(circle at 12% 0%, rgba(255, 255, 255, 0.42), transparent 34%);
-    opacity: 0.74;
 }
 
 .card-companion-panel.card-companion-dragging .card-companion-header {
@@ -7801,23 +7713,17 @@ margin-top: 10px;
 }
 
 .card-companion-avatar {
-    position: relative;
-    z-index: 1;
     width: 56px;
     height: 56px;
     border-radius: 50%;
     overflow: hidden;
     flex-shrink: 0;
-    background:
-        radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.78), transparent 38%),
-        linear-gradient(135deg, rgba(224, 247, 255, 0.72), rgba(179, 229, 252, 0.38));
+    background: linear-gradient(135deg, #e0f7ff, #b3e5fc);
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid rgba(255, 255, 255, 0.78);
-    box-shadow:
-        0 8px 18px rgba(28, 120, 170, 0.13),
-        inset 0 1px 0 rgba(255, 255, 255, 0.72);
+    border: 2px solid rgba(179, 229, 252, 0.95);
+    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.2);
     cursor: pointer;
     transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
 }
@@ -7835,13 +7741,13 @@ margin-top: 10px;
 }
 
 .card-companion-avatar img {
-    width: 148%;
-    height: 148%;
+    width: 130%;
+    height: 130%;
     max-width: none;
     flex-shrink: 0;
     object-fit: cover;
-    object-position: 50% 46%;
-    transform: translateY(5px);
+    object-position: 50% 8%;
+    transform: translateY(3px) scale(1.02);
     transform-origin: center center;
 }
 
@@ -7853,8 +7759,6 @@ margin-top: 10px;
 }
 
 .card-companion-title {
-    position: relative;
-    z-index: 1;
     flex: 1;
     min-width: 0;
 }
@@ -7874,8 +7778,6 @@ margin-top: 10px;
 }
 
 .card-companion-header-paw {
-    position: relative;
-    z-index: 1;
     width: 30px;
     height: 30px;
     object-fit: contain;
@@ -7884,10 +7786,8 @@ margin-top: 10px;
 }
 
 .card-companion-close {
-    position: relative;
-    z-index: 1;
     background: transparent;
-    border: 1px solid transparent;
+    border: none;
     width: 34px;
     height: 34px;
     border-radius: 999px;
@@ -7905,14 +7805,11 @@ margin-top: 10px;
 }
 
 .card-companion-close:hover {
-    background: rgba(255, 255, 255, 0.34);
-    border-color: rgba(255, 255, 255, 0.62);
+    background: rgba(64, 197, 241, 0.16);
     color: #27b8ea;
 }
 
 .card-companion-thread {
-    position: relative;
-    z-index: 1;
     flex: 1 1 auto;
     overflow-y: auto;
     padding: 18px 20px 22px;
@@ -7920,25 +7817,9 @@ margin-top: 10px;
     flex-direction: column;
     gap: 12px;
     background:
-        radial-gradient(circle at 18px 18px, rgba(255, 255, 255, 0.24) 0 2px, transparent 3px) 0 0 / 34px 34px,
-        linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(245, 251, 255, 0.045));
+        radial-gradient(circle at 18px 18px, rgba(179, 229, 252, 0.24) 0 2px, transparent 3px) 0 0 / 34px 34px,
+        linear-gradient(180deg, #ffffff 0%, #f5fcff 100%);
     min-height: 0;
-}
-
-.card-companion-thread::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    background:
-        radial-gradient(circle at 12% 8%, rgba(255, 255, 255, 0.18), transparent 34%),
-        linear-gradient(180deg, rgba(255, 255, 255, 0.16), transparent 28%);
-    opacity: 0.62;
-}
-
-.card-companion-thread > * {
-    position: relative;
-    z-index: 1;
 }
 
 .card-companion-thread::-webkit-scrollbar,
@@ -7974,9 +7855,7 @@ margin-top: 10px;
     line-height: 1.55;
     word-wrap: break-word;
     animation: cardCompanionBubbleIn 0.18s ease-out;
-    box-shadow:
-        0 10px 22px rgba(28, 120, 170, 0.09),
-        inset 0 1px 0 rgba(255, 255, 255, 0.56);
+    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.09);
 }
 
 @keyframes cardCompanionBubbleIn {
@@ -7986,27 +7865,19 @@ margin-top: 10px;
 
 .card-companion-bubble-assistant {
     align-self: flex-start;
-    background:
-        linear-gradient(145deg, rgba(255, 255, 255, 0.48), rgba(255, 255, 255, 0.18)),
-        rgba(255, 255, 255, 0.22);
+    background: #fff;
     color: #263241;
-    border: 1px solid rgba(255, 255, 255, 0.62);
+    border: 2px solid #d5f2ff;
     border-bottom-left-radius: 8px;
-    backdrop-filter: blur(4px) saturate(1.08);
-    -webkit-backdrop-filter: blur(4px) saturate(1.08);
 }
 
 .card-companion-bubble-user {
     align-self: flex-end;
-    background:
-        linear-gradient(135deg, rgba(64, 197, 241, 0.86), rgba(107, 220, 255, 0.72)),
-        rgba(255, 255, 255, 0.12);
+    background: linear-gradient(135deg, #40C5F1, #6bdcff);
     color: #fff;
-    border: 1px solid rgba(255, 255, 255, 0.78);
+    border: 2px solid rgba(255, 255, 255, 0.75);
     border-bottom-right-radius: 8px;
-    box-shadow:
-        0 12px 24px rgba(64, 197, 241, 0.2),
-        inset 0 1px 0 rgba(255, 255, 255, 0.56);
+    box-shadow: 0 8px 18px rgba(64, 197, 241, 0.18);
 }
 
 .card-companion-bubble-system {
@@ -8050,9 +7921,9 @@ margin-top: 10px;
 }
 
 .card-companion-chip {
-    background: rgba(255, 255, 255, 0.3);
+    background: #f0fbff;
     color: #257da5;
-    border: 1px solid rgba(255, 255, 255, 0.62);
+    border: 2px solid #b3e5fc;
     border-radius: 999px;
     padding: 4px 12px;
     font-size: 11.5px;
@@ -8080,12 +7951,12 @@ margin-top: 10px;
 .card-companion-bubble-custom-input {
     width: 100%;
     padding: 6px 12px;
-    border: 1px solid rgba(255, 255, 255, 0.62);
+    border: 2px solid #b3e5fc;
     border-radius: 999px;
     font-size: 12px;
     box-sizing: border-box;
     font-family: inherit;
-    background: rgba(255, 255, 255, 0.36);
+    background: #fff;
     color: #257da5;
 }
 
@@ -8115,61 +7986,16 @@ margin-top: 10px;
 }
 
 .card-companion-input-bar {
-    position: relative;
-    z-index: 1;
-    border-top: 1px solid rgba(255, 255, 255, 0.46);
+    border-top: 2px solid #d5f2ff;
     padding: 16px 18px 18px;
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.24)),
-        rgba(245, 251, 255, 0.06);
+    background: linear-gradient(180deg, #f8fcff 0%, #ffffff 100%);
     flex-shrink: 0;
-    overflow: hidden;
-}
-
-.card-companion-input-bar::before {
-    content: "";
-    position: absolute;
-    inset: 0 0 auto;
-    height: 54%;
-    pointer-events: none;
-    background: linear-gradient(112deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.05) 50%, transparent 76%);
-    opacity: 0.7;
-}
-
-.card-companion-input-bar::after {
-    content: "";
-    position: absolute;
-    left: 24px;
-    right: 24px;
-    bottom: 12px;
-    height: 38px;
-    pointer-events: none;
-    border-radius: 999px;
-    background: radial-gradient(ellipse at center, rgba(64, 197, 241, 0.24), rgba(64, 197, 241, 0) 68%);
-    filter: blur(10px);
-    opacity: 0.78;
 }
 
 .card-companion-input-row {
-    position: relative;
-    z-index: 1;
     display: flex;
     gap: 12px;
     align-items: flex-end;
-}
-
-.card-companion-input-row::before {
-    content: "";
-    position: absolute;
-    inset: -6px -7px;
-    pointer-events: none;
-    border-radius: 999px;
-    border: 1px solid rgba(125, 211, 252, 0.52);
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(64, 197, 241, 0.08));
-    box-shadow:
-        0 0 0 2px rgba(64, 197, 241, 0.18),
-        0 10px 26px rgba(28, 120, 170, 0.12),
-        inset 0 1px 0 rgba(255, 255, 255, 0.58);
 }
 
 .card-companion-input {
@@ -8177,7 +8003,7 @@ margin-top: 10px;
     min-height: 46px;
     max-height: 120px;
     padding: 11px 16px;
-    border: 1px solid rgba(125, 211, 252, 0.72);
+    border: 2px solid #b3e5fc;
     border-radius: 999px;
     font-size: 15px;
     box-sizing: border-box;
@@ -8186,24 +8012,13 @@ margin-top: 10px;
     line-height: 1.5;
     overflow-y: auto;
     color: #257da5;
-    background: rgba(255, 255, 255, 0.46);
-    box-shadow:
-        0 0 0 2px rgba(64, 197, 241, 0.12),
-        0 10px 24px rgba(28, 120, 170, 0.12),
-        inset 0 1px 0 rgba(255, 255, 255, 0.76);
-    backdrop-filter: blur(3px) saturate(1.08);
-    -webkit-backdrop-filter: blur(3px) saturate(1.08);
+    background: #fff;
 }
 
 .card-companion-input:focus {
     outline: none;
     border-color: #40C5F1;
-    background: rgba(255, 255, 255, 0.7);
-    box-shadow:
-        0 0 0 3px rgba(64, 197, 241, 0.2),
-        0 0 22px rgba(64, 197, 241, 0.32),
-        0 12px 28px rgba(28, 120, 170, 0.14),
-        inset 0 1px 0 rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 0 3px rgba(64, 197, 241, 0.16);
 }
 
 .card-companion-input::placeholder {
@@ -8238,8 +8053,6 @@ margin-top: 10px;
 }
 
 .card-companion-quick-row {
-    position: relative;
-    z-index: 1;
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
@@ -8247,9 +8060,9 @@ margin-top: 10px;
 }
 
 .card-companion-quick-chip {
-    background: rgba(255, 255, 255, 0.34);
+    background: #f0fbff;
     color: #1686c2;
-    border: 1px solid rgba(255, 255, 255, 0.62);
+    border: 2px solid #d5f2ff;
     border-radius: 999px;
     padding: 5px 12px;
     font-size: 12px;
@@ -8279,22 +8092,7 @@ margin-top: 10px;
 }
 
 [data-theme="dark"] .card-companion-panel.card-companion-dragging {
-    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.58);
-}
-
-[data-theme="dark"] .card-companion-panel::before {
-    background:
-        linear-gradient(135deg, rgba(125, 211, 252, 0.12), rgba(15, 23, 42, 0.08) 22%, rgba(15, 23, 42, 0) 42%),
-        linear-gradient(315deg, rgba(125, 211, 252, 0.07), rgba(15, 23, 42, 0) 38%);
-    box-shadow:
-        inset 0 1px 0 rgba(148, 197, 223, 0.24),
-        inset 0 0 0 1px rgba(125, 211, 252, 0.12);
-    opacity: 0.56;
-}
-
-[data-theme="dark"] .card-companion-panel::after {
-    background: linear-gradient(118deg, rgba(125, 211, 252, 0.12), rgba(125, 211, 252, 0.03) 46%, transparent 68%);
-    opacity: 0.42;
+    box-shadow: 0 22px 56px rgba(0, 0, 0, 0.62);
 }
 
 [data-theme="dark"] .card-companion-header {
@@ -8302,13 +8100,6 @@ margin-top: 10px;
         linear-gradient(135deg, rgba(14, 116, 144, 0.24), rgba(15, 23, 42, 0.98) 62%),
         url('/static/icons/dropdown_item_hover_bg.png') center / cover no-repeat;
     border-bottom-color: rgba(125, 211, 252, 0.2);
-}
-
-[data-theme="dark"] .card-companion-header::before {
-    background:
-        linear-gradient(112deg, rgba(125, 211, 252, 0.12), rgba(15, 23, 42, 0.04) 44%, transparent 70%),
-        radial-gradient(circle at 12% 0%, rgba(125, 211, 252, 0.1), transparent 36%);
-    opacity: 0.48;
 }
 
 [data-theme="dark"] .card-companion-name { color: #e5e7eb; }
@@ -8336,13 +8127,6 @@ margin-top: 10px;
     background:
         radial-gradient(circle at 18px 18px, rgba(56, 189, 248, 0.08) 0 2px, transparent 3px) 0 0 / 34px 34px,
         linear-gradient(180deg, #111827 0%, #101d2a 100%);
-}
-
-[data-theme="dark"] .card-companion-thread::before {
-    background:
-        radial-gradient(circle at 12% 8%, rgba(125, 211, 252, 0.08), transparent 34%),
-        linear-gradient(180deg, rgba(125, 211, 252, 0.05), transparent 30%);
-    opacity: 0.42;
 }
 
 [data-theme="dark"] .card-companion-bubble-assistant {
@@ -8393,25 +8177,6 @@ margin-top: 10px;
 [data-theme="dark"] .card-companion-input-bar {
     background: linear-gradient(180deg, #101d2a 0%, #0f172a 100%);
     border-top-color: rgba(125, 211, 252, 0.2);
-}
-
-[data-theme="dark"] .card-companion-input-bar::before {
-    background: linear-gradient(112deg, rgba(125, 211, 252, 0.08), rgba(15, 23, 42, 0.04) 52%, transparent 78%);
-    opacity: 0.42;
-}
-
-[data-theme="dark"] .card-companion-input-bar::after {
-    background: radial-gradient(ellipse at center, rgba(56, 189, 248, 0.14), rgba(56, 189, 248, 0) 68%);
-    opacity: 0.52;
-}
-
-[data-theme="dark"] .card-companion-input-row::before {
-    border-color: rgba(125, 211, 252, 0.28);
-    background: linear-gradient(135deg, rgba(125, 211, 252, 0.08), rgba(15, 23, 42, 0.14));
-    box-shadow:
-        0 0 0 2px rgba(56, 189, 248, 0.1),
-        0 10px 24px rgba(0, 0, 0, 0.28),
-        inset 0 1px 0 rgba(125, 211, 252, 0.18);
 }
 
 [data-theme="dark"] .card-companion-input {

--- a/static/css/character_personality_onboarding.css
+++ b/static/css/character_personality_onboarding.css
@@ -5,43 +5,28 @@
 }
 
 .character-personality-overlay {
-    --jelly-blue-50: #f4fbff;
-    --jelly-blue-100: #d8f2ff;
-    --jelly-blue-200: #aee5ff;
-    --jelly-blue-300: #7bd9ff;
-    --jelly-blue-400: #40c5f1;
-    --jelly-blue-500: #25afe2;
-    --jelly-blue-600: #1689bd;
+    --jelly-blue-50: #f0f9ff;
+    --jelly-blue-100: #e0f2fe;
+    --jelly-blue-200: #bae6fd;
+    --jelly-blue-300: #7dd3fc;
+    --jelly-blue-400: #38bdf8;
+    --jelly-blue-500: #0ea5e9;
+    --jelly-blue-600: #0284c7;
     --text-main: #334155;
     --text-sub: #64748b;
-    --surface: rgba(245, 251, 255, 0.24);
-    --surface-solid: #ffffff;
-    --surface-soft: rgba(248, 253, 255, 0.2);
+    --surface: #ffffff;
+    --surface-soft: #f8fbff;
     --danger-bg: #fff1f2;
     --danger-border: #fecdd3;
     --danger-text: #e11d48;
     --radius-pill: 999px;
     --radius-sm: 12px;
-    --radius-md: 18px;
-    --radius-lg: 30px;
-    --glass-border: rgba(255, 255, 255, 0.62);
-    --glass-highlight: rgba(255, 255, 255, 0.9);
-    --shadow-shell:
-        0 30px 76px rgba(11, 43, 66, 0.24),
-        0 16px 38px rgba(32, 70, 90, 0.08),
-        0 1px 0 rgba(255, 255, 255, 0.62) inset,
-        0 16px 36px rgba(255, 255, 255, 0.14) inset,
-        0 -24px 52px rgba(28, 95, 130, 0.12) inset,
-        0 0 0 1px rgba(255, 255, 255, 0.32) inset;
-    --shadow-card:
-        0 14px 30px rgba(16, 70, 100, 0.16),
-        inset 0 1px 0 rgba(255, 255, 255, 0.72),
-        inset 0 -14px 26px rgba(28, 95, 130, 0.08);
-    --shadow-card-hover:
-        0 18px 36px rgba(28, 120, 170, 0.22),
-        inset 0 1px 0 rgba(255, 255, 255, 0.86),
-        inset 0 -12px 26px rgba(32, 70, 90, 0.05);
-    --shadow-button: 0 8px 18px rgba(64, 197, 241, 0.24);
+    --radius-md: 20px;
+    --radius-lg: 28px;
+    --shadow-shell: 0 24px 48px -12px rgba(14, 165, 233, 0.22);
+    --shadow-card: 0 10px 0 rgba(186, 230, 253, 0.9);
+    --shadow-card-hover: 0 16px 0 rgba(125, 211, 252, 0.95);
+    --shadow-button: 0 6px 0 rgba(2, 132, 199, 0.95);
     position: fixed;
     inset: 0;
     z-index: 2147483000;
@@ -49,9 +34,8 @@
     align-items: center;
     justify-content: center;
     padding: 24px;
-    background: rgba(18, 42, 58, 0.34);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
+    background: rgba(240, 249, 255, 0.7);
+    backdrop-filter: blur(12px);
     pointer-events: auto;
 }
 
@@ -60,75 +44,33 @@
 }
 
 .character-personality-shell {
-    position: relative;
-    width: min(900px, 100%);
+    width: min(920px, 100%);
     max-height: min(860px, calc(100vh - 48px));
     overflow: auto;
-    scrollbar-width: none;
-    isolation: isolate;
-    border: 1px solid rgba(255, 255, 255, 0.68);
-    border-radius: 32px;
-    background:
-        linear-gradient(116deg, rgba(255, 255, 255, 0.34) 0%, rgba(255, 255, 255, 0.08) 15%, transparent 36%),
-        radial-gradient(circle at 18% 6%, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.05) 24%, transparent 48%),
-        radial-gradient(circle at 94% 84%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02) 28%, transparent 50%),
-        linear-gradient(145deg, rgba(255, 255, 255, 0.48), rgba(245, 248, 250, 0.34) 48%, rgba(255, 255, 255, 0.42)),
-        rgba(255, 255, 255, 0.58);
-    backdrop-filter: blur(30px) saturate(1.28) contrast(1.08) brightness(1.1);
-    -webkit-backdrop-filter: blur(30px) saturate(1.28) contrast(1.08) brightness(1.1);
+    border: 4px solid rgba(255, 255, 255, 0.96);
+    border-radius: 36px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.99), rgba(244, 251, 255, 0.98));
     box-shadow: var(--shadow-shell);
     color: var(--text-main);
 }
 
-.character-personality-shell::-webkit-scrollbar {
-    display: none;
-}
-
-.character-personality-shell::before {
-    content: "";
-    position: absolute;
-    inset: 1px;
-    border-radius: 31px;
-    pointer-events: none;
-    background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.1) 16%, rgba(255, 255, 255, 0) 34%),
-        linear-gradient(315deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0) 30%),
-        linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(245, 248, 250, 0.02) 44%, rgba(255, 255, 255, 0.06) 100%);
-    box-shadow:
-        inset 0 1px 0 var(--glass-highlight),
-        inset 0 0 0 1px rgba(255, 255, 255, 0.36),
-        inset 0 -1px 0 rgba(31, 146, 192, 0.22);
-    opacity: 0.86;
-}
-
-.character-personality-shell::after {
-    display: none;
-}
-
 .shell-deco-bar {
-    height: 0;
+    height: 12px;
     width: 100%;
-    border: 0;
-    background: none;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
+    background: linear-gradient(
+        90deg,
+        var(--jelly-blue-300),
+        var(--jelly-blue-400)
+    );
 }
 
 .character-personality-body {
-    position: relative;
-    z-index: 1;
     min-height: 480px;
-}
-
-.character-personality-body::before {
-    display: none;
 }
 
 .character-personality-stage {
-    position: relative;
-    z-index: 1;
     min-height: 480px;
-    padding: 36px 48px 30px;
+    padding: 40px 48px 32px;
 }
 
 .character-personality-stage-two {
@@ -152,12 +94,11 @@
 .character-personality-eyebrow {
     display: inline-flex;
     align-items: center;
-    min-height: 30px;
-    padding: 0 13px;
-    border: 1px solid rgba(255, 255, 255, 0.72);
+    min-height: 32px;
+    padding: 0 14px;
+    border: 2px solid var(--jelly-blue-100);
     border-radius: var(--radius-pill);
-    background: rgba(244, 251, 255, 0.42);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+    background: var(--jelly-blue-50);
     color: var(--jelly-blue-500);
     font-size: 13px;
     font-weight: 800;
@@ -170,15 +111,13 @@
     justify-content: center;
     min-height: 34px;
     padding: 0 16px;
-    border: 1px solid rgba(255, 255, 255, 0.72);
+    border: 2px solid var(--jelly-blue-100);
     border-radius: var(--radius-pill);
-    background: rgba(255, 255, 255, 0.42);
+    background: var(--surface);
     color: var(--jelly-blue-600);
     font-size: 14px;
     font-weight: 800;
-    box-shadow:
-        0 8px 18px rgba(28, 120, 170, 0.1),
-        inset 0 1px 0 rgba(255, 255, 255, 0.48);
+    box-shadow: 0 4px 0 rgba(186, 230, 253, 0.92);
 }
 
 .cph-title,
@@ -188,45 +127,34 @@
     font-size: 28px;
     font-weight: 800;
     line-height: 1.2;
-    text-shadow:
-        0 1px 2px rgba(255, 255, 255, 0.78),
-        0 0 14px rgba(244, 251, 255, 0.48);
 }
 
 .character-personality-hint {
     margin: 12px 0 0;
-    color: #334e68;
+    color: var(--text-sub);
     font-size: 14px;
     line-height: 1.7;
-    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.68);
 }
 
 .character-personality-intro {
-    margin-bottom: 20px;
-    color: #334e68;
+    margin-bottom: 24px;
+    color: var(--text-sub);
     font-size: 15px;
     line-height: 1.7;
-    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.68);
 }
 
 .character-personality-warning {
     display: block;
     margin: 18px 0 20px;
     padding: 14px 16px;
-    border: 1px solid rgba(255, 255, 255, 0.72);
-    border-radius: 16px;
-    background:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.38), rgba(245, 248, 250, 0.16)),
-        rgba(245, 251, 255, 0.48);
-    backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
-    -webkit-backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
+    border: 2px solid var(--jelly-blue-200);
+    border-radius: 18px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(224, 242, 254, 0.92));
     color: var(--text-main);
     font-size: 14px;
     font-weight: 700;
     line-height: 1.7;
-    box-shadow:
-        0 10px 24px rgba(28, 120, 170, 0.08),
-        inset 0 1px 0 rgba(255, 255, 255, 0.72);
+    box-shadow: 0 8px 20px rgba(14, 165, 233, 0.08);
 }
 
 .character-personality-warning-stage-two {
@@ -236,7 +164,7 @@
 .character-personality-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 20px;
+    gap: 24px;
 }
 
 .character-personality-card {
@@ -244,15 +172,11 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    min-height: 238px;
-    padding: 24px 20px 22px;
-    border: 1px solid rgba(255, 255, 255, 0.72);
+    min-height: 264px;
+    padding: 28px 20px 24px;
+    border: 3px solid var(--jelly-blue-100);
     border-radius: var(--radius-lg);
-    background:
-        linear-gradient(145deg, rgba(255, 255, 255, 0.42), rgba(245, 248, 250, 0.18) 54%, rgba(255, 255, 255, 0.3)),
-        rgba(255, 255, 255, 0.46);
-    backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
-    -webkit-backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
+    background: linear-gradient(180deg, var(--surface), var(--jelly-blue-50));
     box-shadow: var(--shadow-card);
     color: inherit;
     text-align: left;
@@ -270,52 +194,26 @@
     position: absolute;
     top: 0;
     left: 50%;
-    width: 58px;
-    height: 7px;
+    width: 44px;
+    height: 6px;
     transform: translateX(-50%);
-    border: 1px solid rgba(255, 255, 255, 0.34);
-    border-top: 0;
-    border-radius: 0 0 10px 10px;
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.44), rgba(255, 255, 255, 0.08)),
-        rgba(245, 251, 255, 0.12);
-    box-shadow:
-        0 8px 18px rgba(32, 70, 90, 0.08),
-        inset 0 1px 0 rgba(255, 255, 255, 0.58);
-    opacity: 0.78;
-}
-
-.character-personality-card::after {
-    content: "";
-    position: absolute;
-    inset: 1px;
-    border-radius: 29px;
-    pointer-events: none;
-    background:
-        linear-gradient(118deg, rgba(255, 255, 255, 0.46), rgba(255, 255, 255, 0.1) 18%, rgba(255, 255, 255, 0) 38%),
-        radial-gradient(circle at 92% 18%, rgba(255, 255, 255, 0.3), transparent 28%),
-        linear-gradient(315deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 32%);
-    opacity: 0.66;
+    border-radius: 0 0 8px 8px;
+    background: var(--jelly-blue-200);
 }
 
 .character-personality-card:hover,
 .character-personality-card:focus-visible {
-    transform: translateY(-3px);
-    border-color: rgba(255, 255, 255, 0.88);
+    transform: translateY(-8px);
+    border-color: var(--jelly-blue-400);
     box-shadow:
         var(--shadow-card-hover),
-        inset 0 1px 0 rgba(255, 255, 255, 0.96);
-    background:
-        linear-gradient(145deg, rgba(255, 255, 255, 0.34), rgba(245, 248, 250, 0.06) 54%, rgba(255, 255, 255, 0.12)),
-        rgba(255, 255, 255, 0.13);
+        0 20px 30px rgba(14, 165, 233, 0.1);
     outline: none;
 }
 
 .character-personality-card:active {
-    transform: translateY(1px);
-    box-shadow:
-        0 6px 16px rgba(28, 120, 170, 0.12),
-        inset 0 1px 0 rgba(255, 255, 255, 0.72);
+    transform: translateY(3px);
+    box-shadow: 0 0 0 rgba(186, 230, 253, 0);
 }
 
 .card-watermark {
@@ -325,23 +223,9 @@
     color: var(--jelly-blue-400);
     font-size: 48px;
     font-weight: 900;
-    opacity: 0.06;
+    opacity: 0.08;
     transform: rotate(10deg);
     pointer-events: none;
-    transition:
-        opacity 180ms ease,
-        text-shadow 180ms ease,
-        transform 180ms ease;
-}
-
-.character-personality-card:hover .card-watermark,
-.character-personality-card:focus-visible .card-watermark {
-    opacity: 0.22;
-    text-shadow:
-        0 0 12px rgba(255, 255, 255, 0.7),
-        0 0 22px rgba(64, 197, 241, 0.48),
-        0 0 34px rgba(64, 197, 241, 0.3);
-    transform: rotate(8deg) scale(1.04);
 }
 
 .cpc-pill {
@@ -351,10 +235,9 @@
     align-items: center;
     min-height: 32px;
     padding: 0 12px;
-    border: 1px solid var(--jelly-blue-100);
-    border-radius: 999px;
-    background: rgba(244, 251, 255, 0.34);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+    border: 2px solid var(--jelly-blue-100);
+    border-radius: 10px;
+    background: var(--surface);
     color: var(--jelly-blue-500);
     font-size: 13px;
     font-weight: 800;
@@ -364,14 +247,11 @@
 .character-personality-card-name {
     position: relative;
     z-index: 1;
-    margin: 15px 0 0;
+    margin: 16px 0 0;
     color: var(--text-main);
     font-size: 20px;
     font-weight: 800;
     line-height: 1.3;
-    text-shadow:
-        0 1px 2px rgba(255, 255, 255, 0.74),
-        0 0 10px rgba(244, 251, 255, 0.42);
 }
 
 .cpc-desc,
@@ -383,7 +263,6 @@
     font-size: 14px;
     font-weight: 600;
     line-height: 1.6;
-    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.64);
 }
 
 .cpc-quote,
@@ -392,11 +271,9 @@
     z-index: 1;
     margin-top: auto;
     padding: 14px 16px;
-    border: 1px solid var(--jelly-blue-100);
-    border-radius: 16px;
-    background: rgba(244, 251, 255, 0.32);
-    backdrop-filter: blur(10px) saturate(1.3);
-    -webkit-backdrop-filter: blur(10px) saturate(1.3);
+    border: 2px solid var(--jelly-blue-100);
+    border-radius: 12px 12px 12px 4px;
+    background: rgba(255, 255, 255, 0.96);
     color: var(--jelly-blue-600);
     font-size: 13px;
     font-weight: 700;
@@ -416,11 +293,11 @@
     justify-content: center;
     width: 44px;
     height: 44px;
-    border: 2px solid var(--jelly-blue-100);
+    border: 3px solid var(--jelly-blue-100);
     border-radius: 14px;
     background: var(--surface);
     color: var(--text-sub);
-    box-shadow: 0 6px 14px rgba(64, 197, 241, 0.14);
+    box-shadow: 0 4px 0 rgba(186, 230, 253, 0.92);
     cursor: pointer;
     transition:
         transform 160ms ease,
@@ -431,16 +308,16 @@
 
 .btn-back-icon:hover,
 .btn-back-icon:focus-visible {
-    transform: translateY(-2px);
+    transform: translateY(-3px);
     border-color: var(--jelly-blue-300);
-    box-shadow: 0 10px 20px rgba(64, 197, 241, 0.2);
+    box-shadow: 0 8px 0 rgba(125, 211, 252, 0.92);
     color: var(--jelly-blue-600);
     outline: none;
 }
 
 .btn-back-icon:active {
-    transform: translateY(1px);
-    box-shadow: 0 3px 8px rgba(64, 197, 241, 0.16);
+    transform: translateY(2px);
+    box-shadow: 0 0 0 rgba(125, 211, 252, 0);
 }
 
 .stage-two-title {
@@ -448,9 +325,6 @@
     color: var(--text-main);
     font-size: 24px;
     font-weight: 800;
-    text-shadow:
-        0 1px 2px rgba(255, 255, 255, 0.74),
-        0 0 12px rgba(244, 251, 255, 0.44);
 }
 
 .stage-two-subtitle {
@@ -461,7 +335,7 @@
     padding: 0 16px;
     border: 2px solid var(--jelly-blue-200);
     border-radius: var(--radius-pill);
-    background: rgba(244, 251, 255, 0.34);
+    background: var(--jelly-blue-50);
     color: var(--jelly-blue-600);
     font-size: 14px;
     font-weight: 800;
@@ -475,32 +349,10 @@
 }
 
 .preview-section {
-    position: relative;
-    overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.58);
-    border-radius: 22px;
-    background:
-        linear-gradient(145deg, rgba(255, 255, 255, 0.42), rgba(245, 248, 250, 0.18)),
-        rgba(255, 255, 255, 0.46);
+    border: 3px solid var(--jelly-blue-100);
+    border-radius: 24px;
+    background: var(--surface);
     padding: 24px;
-    backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
-    -webkit-backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
-    box-shadow:
-        0 8px 20px rgba(32, 70, 90, 0.07),
-        inset 0 1px 0 rgba(255, 255, 255, 0.52);
-}
-
-.preview-section::before,
-.detail-group::before {
-    content: "";
-    position: absolute;
-    inset: 1px;
-    border-radius: inherit;
-    pointer-events: none;
-    background:
-        linear-gradient(125deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.08) 20%, rgba(255, 255, 255, 0) 42%),
-        linear-gradient(315deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0) 32%);
-    opacity: 0.64;
 }
 
 .preview-label,
@@ -510,7 +362,7 @@
     min-height: 32px;
     padding: 0 12px;
     border-radius: 10px;
-    background: rgba(244, 251, 255, 0.3);
+    background: var(--jelly-blue-50);
     color: var(--jelly-blue-600);
     font-size: 14px;
     font-weight: 800;
@@ -528,48 +380,26 @@
     align-items: center;
     justify-content: center;
     width: 64px;
-    height: 64px;
-    flex: 0 0 64px;
-    padding: 3px;
-    border: 1px solid rgba(255, 255, 255, 0.78);
-    border-radius: 50%;
-    background:
-        linear-gradient(145deg, rgba(255, 255, 255, 0.58), rgba(244, 251, 255, 0.16)),
-        rgba(245, 251, 255, 0.22);
-    box-shadow:
-        0 10px 22px rgba(28, 120, 170, 0.18),
-        inset 0 1px 0 rgba(255, 255, 255, 0.82),
-        inset 0 -10px 18px rgba(32, 70, 90, 0.05);
-    overflow: hidden;
-}
-
-.preview-avatar-img {
-    display: block;
-    width: 118%;
-    height: 118%;
-    border-radius: 50%;
-    object-fit: cover;
-    object-position: 50% 18%;
-}
-
-.preview-avatar.is-empty::before {
-    content: "";
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    background: rgba(64, 197, 241, 0.32);
-    box-shadow: 0 0 18px rgba(64, 197, 241, 0.28);
+    min-height: 64px;
+    padding: 8px;
+    border: 3px solid #ffffff;
+    border-radius: 18px;
+    background: linear-gradient(180deg, var(--jelly-blue-300), var(--jelly-blue-500));
+    color: #ffffff;
+    font-size: 15px;
+    font-weight: 900;
+    line-height: 1.2;
+    text-align: center;
+    box-shadow: 0 6px 0 rgba(186, 230, 253, 0.92);
 }
 
 .preview-bubble {
     flex: 1;
     min-height: 180px;
     padding: 20px;
-    border: 2px solid var(--jelly-blue-200);
-    border-radius: 18px 18px 18px 6px;
-    background: rgba(244, 251, 255, 0.46);
-    backdrop-filter: blur(10px) saturate(1.14);
-    -webkit-backdrop-filter: blur(10px) saturate(1.14);
+    border: 3px solid var(--jelly-blue-200);
+    border-radius: 20px 20px 20px 4px;
+    background: var(--jelly-blue-50);
 }
 
 .character-personality-preview-stream {
@@ -580,7 +410,6 @@
     line-height: 1.8;
     white-space: pre-wrap;
     word-break: break-word;
-    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.68);
 }
 
 .character-personality-preview-stream[data-typing="active"]::after {
@@ -602,22 +431,15 @@
 .details-section {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 24px;
     padding-top: 4px;
 }
 
 .detail-group {
-    position: relative;
-    overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.58);
-    border-radius: 20px;
-    background:
-        linear-gradient(145deg, rgba(255, 255, 255, 0.42), rgba(245, 248, 250, 0.18)),
-        rgba(255, 255, 255, 0.46);
+    border: 2px solid rgba(186, 230, 253, 0.9);
+    border-radius: 22px;
+    background: rgba(255, 255, 255, 0.94);
     padding: 18px 18px 16px;
-    backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
-    -webkit-backdrop-filter: blur(10px) saturate(1.14) contrast(1.04) brightness(1.05);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.52);
 }
 
 .detail-group-title {
@@ -626,7 +448,6 @@
     font-size: 15px;
     font-weight: 800;
     line-height: 1.4;
-    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.68);
 }
 
 .detail-pills {
@@ -642,16 +463,16 @@
     padding: 0 14px;
     border: 2px solid var(--jelly-blue-100);
     border-radius: var(--radius-pill);
-    background: rgba(255, 255, 255, 0.3);
+    background: var(--surface);
     color: var(--text-sub);
     font-size: 13px;
     font-weight: 700;
-    box-shadow: 0 4px 10px rgba(64, 197, 241, 0.08);
+    box-shadow: 0 3px 0 rgba(240, 249, 255, 0.96);
 }
 
 .detail-group.danger {
     border-color: rgba(254, 205, 211, 0.96);
-    background: rgba(255, 250, 251, 0.38);
+    background: rgba(255, 250, 251, 0.96);
 }
 
 .detail-group.danger .detail-pill {
@@ -666,7 +487,7 @@
     justify-content: center;
     align-items: center;
     gap: 20px;
-    margin-top: 26px;
+    margin-top: 28px;
 }
 
 .character-personality-button {
@@ -674,7 +495,7 @@
     align-items: center;
     justify-content: center;
     min-width: 140px;
-    min-height: 46px;
+    min-height: 48px;
     padding: 0 28px;
     border: 0;
     border-radius: var(--radius-pill);
@@ -690,46 +511,44 @@
 
 .character-personality-button:hover,
 .character-personality-button:focus-visible {
-    transform: translateY(-2px);
+    transform: translateY(-3px);
     outline: none;
 }
 
 .character-personality-button:active {
-    transform: translateY(1px);
+    transform: translateY(2px);
 }
 
 .btn-ghost-jelly {
-    border: 2px solid var(--jelly-blue-100);
+    border: 3px solid var(--jelly-blue-100);
     background: var(--surface);
     color: var(--text-sub);
-    box-shadow: 0 6px 14px rgba(64, 197, 241, 0.12);
+    box-shadow: 0 6px 0 rgba(224, 242, 254, 0.96);
 }
 
 .btn-ghost-jelly:hover,
 .btn-ghost-jelly:focus-visible {
-    box-shadow: 0 10px 20px rgba(64, 197, 241, 0.18);
+    box-shadow: 0 10px 0 rgba(186, 230, 253, 0.96);
     color: var(--text-main);
 }
 
 .btn-ghost-jelly:active {
-    box-shadow: 0 3px 8px rgba(64, 197, 241, 0.12);
+    box-shadow: 0 0 0 rgba(224, 242, 254, 0);
 }
 
 .btn-primary-jelly {
     color: #ffffff;
-    background: var(--jelly-blue-400);
-    box-shadow: var(--shadow-button);
+    background: linear-gradient(180deg, var(--jelly-blue-400), var(--jelly-blue-500));
+    box-shadow: var(--shadow-button), 0 14px 20px rgba(14, 165, 233, 0.18);
 }
 
 .btn-primary-jelly:hover,
 .btn-primary-jelly:focus-visible {
-    background: #3ab8e0;
-    box-shadow: 0 10px 22px rgba(64, 197, 241, 0.3);
+    box-shadow: 0 10px 0 rgba(2, 132, 199, 0.95), 0 18px 24px rgba(14, 165, 233, 0.2);
 }
 
 .btn-primary-jelly:active {
-    background: #2fa8d0;
-    box-shadow: 0 3px 8px rgba(64, 197, 241, 0.2);
+    box-shadow: 0 0 0 rgba(2, 132, 199, 0);
 }
 
 .btn-primary-jelly.success,

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -100,43 +100,6 @@
         return element;
     }
 
-    function findLoadedCharacterAvatarSrc(characterName) {
-        const targetName = String(characterName || '').trim();
-        if (!targetName || typeof document === 'undefined') {
-            return '';
-        }
-        const imageSrc = (image) => {
-            const src = image && image.getAttribute && image.getAttribute('src');
-            if (!src) {
-                return '';
-            }
-            if (/default_character_card\.png|sidebar_logo|paw_ui\.png/i.test(src)) {
-                return '';
-            }
-            return image.src || src;
-        };
-
-        const panelImg = Array.from(document.querySelectorAll('.catgirl-panel-wrapper')).find((wrapper) => {
-            return String(wrapper && wrapper.dataset && wrapper.dataset.catgirlName || '').trim() === targetName;
-        })?.querySelector('.catgirl-panel-card-image img.card-face-img');
-        const panelSrc = imageSrc(panelImg);
-        if (panelSrc) {
-            return panelSrc;
-        }
-
-        const gridCard = Array.from(document.querySelectorAll('.chara-card-item')).find((card) => {
-            const nameEl = card.querySelector('.card-name');
-            return String(nameEl && nameEl.textContent || '').trim() === targetName;
-        });
-        const gridImg = gridCard ? gridCard.querySelector('.card-avatar img.card-face-img') : null;
-        const gridSrc = imageSrc(gridImg);
-        if (gridSrc) {
-            return gridSrc;
-        }
-
-        return '';
-    }
-
     class CharacterPersonalityOnboardingManager {
         constructor() {
             this.overlay = null;
@@ -1080,33 +1043,11 @@
             previewSection.appendChild(previewLabel);
 
             const bubbleWrapper = createElement('div', 'preview-bubble-wrapper');
-            const avatar = createElement('div', 'preview-avatar');
-            const avatarLabel = this.currentCharacterName
-                ? translate(
-                    'memory.characterSelection.currentCharacterAvatarAlt',
-                    '{{characterName}} 的头像',
-                    { characterName: this.currentCharacterName }
-                )
-                : translate('memory.characterSelection.currentCharacterEmpty', '当前角色');
-            avatar.setAttribute('aria-label', avatarLabel);
-            avatar.title = avatarLabel;
-            if (this.currentCharacterName) {
-                const avatarImg = document.createElement('img');
-                avatarImg.className = 'preview-avatar-img';
-                avatarImg.alt = avatarLabel;
-                avatarImg.draggable = false;
-                avatarImg.src = (
-                    findLoadedCharacterAvatarSrc(this.currentCharacterName)
-                    || `/api/characters/catgirl/${encodeURIComponent(this.currentCharacterName)}/card-face`
-                );
-                avatarImg.addEventListener('error', () => {
-                    avatarImg.remove();
-                    avatar.classList.add('is-empty');
-                }, { once: true });
-                avatar.appendChild(avatarImg);
-            } else {
-                avatar.classList.add('is-empty');
-            }
+            const avatar = createElement(
+                'div',
+                'preview-avatar',
+                this.currentCharacterName || translate('memory.characterSelection.currentCharacterEmpty', '当前角色')
+            );
             bubbleWrapper.appendChild(avatar);
 
             const bubble = createElement('div', 'preview-bubble');

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -879,7 +879,7 @@
     <script src="/static/live2d-init.js"></script>
     
     <script src="/static/js/reserved_fields_utils.js"></script>
-    <script src="/static/js/character_personality_onboarding.js?v={{ static_asset_version | default('0') }}"></script>
+    <script src="/static/js/character_personality_onboarding.js"></script>
     <script src="/static/js/character_card_manager.js?v={{ static_asset_version | default('0') }}"></script>
 
     <!-- Three.js 核心库和importmap（用于VRM/MMD模型预览）-->

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -1611,8 +1611,8 @@ def test_character_card_manager_card_assist_avatar_toggles_companion(
     assert state["titleDisplayWhenMinimized"] == "none"
     assert state["closeDisplayWhenMinimized"] == "none"
     assert state["avatarSrc"].endswith("/api/characters/catgirl/YUI/card-face")
-    assert state["avatarImgObjectPosition"] == "50% 46%"
-    assert state["avatarImgTransform"] == "matrix(1, 0, 0, 1, 0, 5)"
+    assert state["avatarImgObjectPosition"] == "50% 8%"
+    assert state["avatarImgTransform"] == "matrix(1.02, 0, 0, 1.02, 0, 3)"
     assert state["avatarRole"] == "button"
     assert state["avatarTabIndex"] == "0"
     assert state["ariaAfterFirstClick"] == "false"

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -1071,55 +1070,6 @@ def test_onboarding_marks_overlay_controls_as_no_drag_for_desktop_clicks(mock_pa
 
 
 @pytest.mark.frontend
-def test_onboarding_overlay_uses_non_blurred_scrim_for_readability(mock_page: Page):
-    _bootstrap_page(mock_page)
-    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static" / "css" / "character_personality_onboarding.css"))
-    mock_page.evaluate("() => { window.universalTutorialManager.isTutorialRunning = false; }")
-    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
-
-    mock_page.evaluate(
-        """
-        () => {
-            window.CharacterPersonalityOnboarding.bootstrap();
-        }
-        """
-    )
-
-    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
-    overlay_style = mock_page.evaluate(
-        """
-        () => {
-            const overlay = document.querySelector("[data-testid='character-personality-overlay']");
-            const shell = document.querySelector(".character-personality-shell");
-            const style = getComputedStyle(overlay);
-            const shellStyle = getComputedStyle(shell);
-            return {
-                backgroundColor: style.backgroundColor,
-                backdropFilter: style.backdropFilter,
-                webkitBackdropFilter: style.webkitBackdropFilter,
-                shellBackgroundColor: shellStyle.backgroundColor,
-                shellBackdropFilter: shellStyle.backdropFilter,
-                shellScrollbarWidth: shellStyle.scrollbarWidth,
-                titleTextShadow: getComputedStyle(document.querySelector(".character-personality-title")).textShadow,
-                cardBackdropFilter: getComputedStyle(document.querySelector(".character-personality-card")).backdropFilter,
-            };
-        }
-        """
-    )
-
-    assert re.match(r"rgba?\(18, 42, 58(?:,|\s*/)", overlay_style["backgroundColor"]) is not None
-    assert "0.34" in overlay_style["backgroundColor"]
-    assert "blur(" not in (
-        overlay_style["backdropFilter"] or overlay_style["webkitBackdropFilter"] or ""
-    )
-    assert "0.58" in overlay_style["shellBackgroundColor"]
-    assert "blur(30px)" in overlay_style["shellBackdropFilter"]
-    assert overlay_style["shellScrollbarWidth"] == "none"
-    assert overlay_style["titleTextShadow"] != "none"
-    assert "blur(10px)" in overlay_style["cardBackdropFilter"]
-
-
-@pytest.mark.frontend
 def test_manual_character_personality_reselect_opens_directly_on_home_refresh(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(
@@ -1829,33 +1779,11 @@ def test_onboarding_uses_dynamic_character_name_and_split_detail_pills(mock_page
     )
 
     expect(mock_page.locator(".cph-badge")).to_have_text("小天")
-    mock_page.evaluate(
-        """
-        () => {
-            const card = document.createElement('div');
-            card.className = 'chara-card-item active';
-            const avatar = document.createElement('div');
-            avatar.className = 'card-avatar';
-            const img = document.createElement('img');
-            img.className = 'card-face-img';
-            img.src = '/mock-current-avatar.png';
-            avatar.appendChild(img);
-            const name = document.createElement('div');
-            name.className = 'card-name';
-            name.textContent = '小天';
-            card.appendChild(avatar);
-            card.appendChild(name);
-            document.body.appendChild(card);
-        }
-        """
-    )
 
     mock_page.locator("[data-testid='character-personality-preset-classic_genki']").click()
 
     expect(mock_page.locator("#previewTitleBadge")).to_have_text("经典元气猫娘")
-    expect(mock_page.locator(".preview-avatar")).to_have_text("")
-    avatar_img = mock_page.locator(".preview-avatar-img")
-    expect(avatar_img).to_have_attribute("src", re.compile(r"/mock-current-avatar\.png$"))
+    expect(mock_page.locator(".preview-avatar")).to_have_text("小天")
 
     speech_pills = mock_page.locator("#detailCatchphrases .detail-pill")
     expect(speech_pills).to_have_count(2)
@@ -1866,56 +1794,6 @@ def test_onboarding_uses_dynamic_character_name_and_split_detail_pills(mock_page
     expect(hobby_pills).to_have_count(2)
     expect(hobby_pills.nth(0)).to_have_text("陪伴")
     expect(hobby_pills.nth(1)).to_have_text("温暖")
-
-
-@pytest.mark.frontend
-def test_onboarding_avatar_ignores_other_character_images_when_card_face_img_is_missing(mock_page: Page):
-    _bootstrap_page(mock_page)
-    mock_page.evaluate("() => { window.universalTutorialManager.isTutorialRunning = false; }")
-    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
-
-    mock_page.evaluate(
-        """
-        () => {
-            window.CharacterPersonalityOnboarding.bootstrap();
-        }
-        """
-    )
-
-    expect(mock_page.locator(".cph-badge")).to_have_text("小天")
-    mock_page.evaluate(
-        """
-        () => {
-            const otherCard = document.createElement('div');
-            otherCard.className = 'chara-card-item active';
-            const otherAvatar = document.createElement('div');
-            otherAvatar.className = 'card-avatar';
-            const otherImg = document.createElement('img');
-            otherImg.className = 'card-face-img';
-            otherImg.src = '/other-character-avatar.png';
-            otherAvatar.appendChild(otherImg);
-            const otherName = document.createElement('div');
-            otherName.className = 'card-name';
-            otherName.textContent = '其他角色';
-            otherCard.appendChild(otherAvatar);
-            otherCard.appendChild(otherName);
-            document.body.appendChild(otherCard);
-
-            const cover = document.createElement('img');
-            cover.id = 'character-card-cover-img';
-            cover.src = '/visible-cover-avatar.png';
-            document.body.appendChild(cover);
-        }
-        """
-    )
-
-    mock_page.locator("[data-testid='character-personality-preset-classic_genki']").click()
-
-    expect(mock_page.locator(".preview-avatar")).to_have_text("")
-    expect(mock_page.locator(".preview-avatar-img")).to_have_attribute(
-        "src",
-        re.compile(r"/api/characters/catgirl/%E5%B0%8F%E5%A4%A9/card-face$"),
-    )
 
 
 @pytest.mark.frontend

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1250,35 +1250,6 @@ def test_character_card_manager_cloudsave_button_uses_icon_badge():
         assert expected in css_source
 
 
-def test_character_card_companion_uses_liquid_glass_surface():
-    css_source = Path("static/css/character_card_manager.css").read_text(encoding="utf-8")
-
-    for expected in (
-        "--companion-glass-border",
-        "--companion-glass-highlight",
-        ".card-companion-panel::before",
-        ".card-companion-panel::after",
-        "backdrop-filter: blur(7px) saturate(1.18) contrast(1.04) brightness(1.05);",
-        "inset 0 1px 0 var(--companion-glass-highlight)",
-        ".card-companion-header::before",
-        ".card-companion-thread::before",
-        ".card-companion-input-bar::before",
-        ".card-companion-input-row::before",
-        "0 0 0 2px rgba(64, 197, 241, 0.18)",
-        ".card-companion-panel.card-companion-dragging::before",
-        ".card-companion-panel.card-companion-dragging::after",
-        "backdrop-filter: none;",
-        "[data-theme=\"dark\"] .card-companion-panel::before",
-        "[data-theme=\"dark\"] .card-companion-panel::after",
-        "[data-theme=\"dark\"] .card-companion-header::before",
-        "[data-theme=\"dark\"] .card-companion-thread::before",
-        "[data-theme=\"dark\"] .card-companion-input-bar::before",
-        "[data-theme=\"dark\"] .card-companion-input-bar::after",
-        "[data-theme=\"dark\"] .card-companion-input-row::before",
-    ):
-        assert expected in css_source
-
-
 def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
     avatar_reload_source = Path("static/tutorial-avatar-reload-controller.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Revert the glass/readability UI polish for initial personality onboarding and the character card personality modal
- Restore the related onboarding and regression tests to the pre-glass behavior

## Verification
- `git diff --cached --check` before commit
- `uv run pytest tests/frontend/test_initial_personality_onboarding.py tests/frontend/test_character_card_manager_regressions.py tests/test_agent_rewrite_regression.py -q` -> 196 passed, 2 failed

## Notes
- The two failures are expected fallout from reverting the newer behavior/tests back to the old version: one stale-reopen regression assertion from the reverted card-manager changes, and one unrelated agent rewrite assertion expecting `create_task` while the current code uses `_create_tracked_task`.
- Preview was launched on `http://127.0.0.1:48931/` for manual visual confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **样式和视觉更新**
  * 更新了伴侣侧边面板、聊天气泡和输入区域的外观，采用更直接的渐变背景和边框设计
  * 优化了角色性格引导界面的主题配色和视觉参数，统一了设计系统变量的使用

* **功能优化**
  * 简化了头像显示逻辑，移除了动态图片加载和失败处理机制

* **测试更新**
  * 更新了回归测试断言以符合新的视觉设计

<!-- end of auto-generated comment: release notes by coderabbit.ai -->