### PR TITLE
fix(onboarding): 恢复 onboarding 脚本 cache-busting 并加固预览头像长名断行

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -94,6 +94,8 @@ _YUI_GUIDE_ASSET_VERSION_PATHS = (
     _PROJECT_ROOT / "static/assets/neko-idle/cat3-sleep2.mp3",
     _PROJECT_ROOT / "static/css/character_card_manager.css",
     _PROJECT_ROOT / "static/js/character_card_manager.js",
+    _PROJECT_ROOT / "static/css/character_personality_onboarding.css",
+    _PROJECT_ROOT / "static/js/character_personality_onboarding.js",
     _PROJECT_ROOT / "static/css/card_maker.css",
     _PROJECT_ROOT / "static/js/card_maker.js",
     _PROJECT_ROOT / "static/css/model_manager.css",

--- a/static/css/character_personality_onboarding.css
+++ b/static/css/character_personality_onboarding.css
@@ -390,6 +390,8 @@
     font-weight: 900;
     line-height: 1.2;
     text-align: center;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     box-shadow: 0 6px 0 rgba(186, 230, 253, 0.92);
 }
 

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -2,6 +2,21 @@
     'use strict';
 
     const STYLE_ID = 'character-personality-onboarding-style';
+    // 复用本脚本 src 上的 ?v= 版本参数，让动态注入的样式表一起走统一缓存失效。
+    // IIFE 同步执行期间 document.currentScript 即本脚本，querySelector 作为兜底。
+    const ASSET_VERSION_QUERY = (function () {
+        try {
+            let src = document.currentScript && document.currentScript.src;
+            if (!src) {
+                const el = document.querySelector('script[src*="character_personality_onboarding.js"]');
+                src = el ? el.src : '';
+            }
+            const queryIndex = src ? src.indexOf('?') : -1;
+            return queryIndex >= 0 ? src.slice(queryIndex) : '';
+        } catch (err) {
+            return '';
+        }
+    })();
     const TUTORIAL_PROMPT_POLL_INTERVAL_MS = 120;
     const TYPEWRITER_BASE_DELAY_MS = 18;
     const TYPEWRITER_PUNCTUATION_DELAY_MS = 110;
@@ -78,7 +93,7 @@
         const styleLink = document.createElement('link');
         styleLink.id = STYLE_ID;
         styleLink.rel = 'stylesheet';
-        styleLink.href = '/static/css/character_personality_onboarding.css';
+        styleLink.href = '/static/css/character_personality_onboarding.css' + ASSET_VERSION_QUERY;
         document.head.appendChild(styleLink);
     }
 

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -879,7 +879,7 @@
     <script src="/static/live2d-init.js"></script>
     
     <script src="/static/js/reserved_fields_utils.js"></script>
-    <script src="/static/js/character_personality_onboarding.js"></script>
+    <script src="/static/js/character_personality_onboarding.js?v={{ static_asset_version | default('0') }}"></script>
     <script src="/static/js/character_card_manager.js?v={{ static_asset_version | default('0') }}"></script>
 
     <!-- Three.js 核心库和importmap（用于VRM/MMD模型预览）-->


### PR DESCRIPTION
## 改动概述 / Summary

#1811（revert: restore pre-glass UI styling）评审里 Codex / CodeRabbit 提了三条，作者按「严格回退到 #1735 前基线」把它们标为「不在本 PR 内、建议单独 PR」。本 PR 就是那个 follow-up，独立判断后修掉其中两条真问题，并补全评审过程中发现的更深缺口。

**改动文件（4 个，均非测试文件）**

- `templates/character_card_manager.html`：onboarding 脚本补回 `?v={{ static_asset_version | default('0') }}`（恢复与 `index.html` 的对称）。
- `static/css/character_personality_onboarding.css`：`.preview-avatar` 补断行属性。
- `main_routers/pages_router.py`：把 onboarding 的 `.css` + `.js` 加进 `_YUI_GUIDE_ASSET_VERSION_PATHS`。
- `static/js/character_personality_onboarding.js`：动态注入的样式表 `<link>` 复用脚本 `?v=` 版本。

第三条评审（`.character-personality-overlay` 的 `backdrop-filter: blur(12px)`）判定为误判保留：该 blur 是全屏 modal 遮罩的背景虚化（标准 modal 设计），不属于 #1811 回退的卡片玻璃拟态。

## 回归报告 / Regression Report

**改动了什么（`main_routers/pages_router.py`）**
在 `_YUI_GUIDE_ASSET_VERSION_PATHS` 元组里新增两条路径：`static/css/character_personality_onboarding.css` 与 `static/js/character_personality_onboarding.js`。这是个纯数据元组，`_static_assets_ctx()` 遍历它取 `max(mtime)` 拼成 `static_asset_version`，逻辑本身不变。

**理由 / 必要性**
`character_personality_onboarding.js` 此前不在该集合里，但 `index.html`（一直）和 `character_card_manager.html`（本 PR 恢复）都用 `?v={{ static_asset_version }}` 引它——版本值来自集合的聚合 mtime，集合里没有它 ⇒ 只改 onboarding 时版本号不变、`?v=` 不变，旧 bundle 仍命中浏览器缓存（`/static` 不发 no-cache 头）。`onboarding.css` 更彻底地游离在体系外：它从不走模板，是 `onboarding.js` 的 `ensureStyles()` 动态注入的裸路径 `<link>`。Codex 在评审中指出了 js 这一半，css 这一半是核对时发现的。

**改动前后表现对比**
- 改前：改 onboarding js/css → `static_asset_version` 不变 → 用户继续拿旧缓存（正是 cache-busting 想修的场景）；css 完全无缓存失效。
- 改后：改 onboarding js/css → mtime 进入聚合 → 版本号变 → 脚本 url 变 → 重载 → 注入的 css `<link>` 也带新版本，形成闭环。

**潜在回归点与验证**
- 影响范围：`character_card_manager.html` 与 `index.html` 两页的 onboarding 加载；版本号粒度变粗（这两个文件改动现在也会 bump 全页 `static_asset_version`），与集合里其余几十个资源的既有行为一致，属预期。
- `python -m py_compile main_routers/pages_router.py` 通过；新增为纯数据行，文件存在（`OSError` 分支只在缺失时静默跳过）。
- 现有 `test_pages_router_static_asset_version_tracks_tutorial_runtime_modules` 是「`X in source`」包含式断言，加行不影响。

## 不拆分理由 / Why Not Split

不适用：本 PR 改动 4 个非测试文件（≤ 20），且四处改动是同一缓存失效闭环的配套部分，拆开任一处都无法独立生效。

## 测试 / Testing

- `node --check static/js/character_personality_onboarding.js` 通过；`ASSET_VERSION_QUERY` 提取逻辑用 node 验证三种输入（带版本 `?v=...`、裸路径、空串）均符合预期。
- `python -m py_compile main_routers/pages_router.py` 通过。
- 静态确认不破现有测试：`test_initial_personality_onboarding.py` 用 `add_script_tag`/`add_style_tag(path=...)` 直接加载本地资源、绕过模板渲染与 `ensureStyles` 动态注入，无断言依赖版本参数或注入 `<link>` 的 href 形式；`.preview-avatar` 文本断言不受断行属性影响。
- cache-busting 是缓存策略、浏览器无可观察视觉差异；avatar 断行为标准 CSS 属性，仅长无空格角色名触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
