### PR TITLE
fix(license): 修正 brain/cua 的 Agent-S 帰属与 NOTICE neko 译误（#1723 续）

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,9 +9,22 @@ See the LICENSE file for the full license text.
 
 ------------------------------------------------------------
 
+Third-Party Notices
+
+This product includes software developed by third parties:
+
+- Agent-S, by Simular AI and contributors
+  https://github.com/simular-ai/Agent-S
+  Licensed under the Apache License, Version 2.0.
+  Portions located under brain/cua/ are derived from Agent-S and have been
+  modified by the Project N.E.K.O. Team. See brain/cua/AGENT_LICENSE.txt for
+  the upstream license text.
+
+------------------------------------------------------------
+
 我们种下了人与猫娘幸福共生的种子，我们的征途是星辰大海。
 
-We have planted the seed of a happy symbiosis between humans and catgirls;
+We have planted the seed of a happy symbiosis between humans and nekos;
 our journey is to the sea of stars.
 
         —— Project N.E.K.O. Team

--- a/brain/cua/__init__.py
+++ b/brain/cua/__init__.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/agents/__init__.py
+++ b/brain/cua/agents/__init__.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/agents/agent_s.py
+++ b/brain/cua/agents/agent_s.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/agents/grounding.py
+++ b/brain/cua/agents/grounding.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/agents/worker.py
+++ b/brain/cua/agents/worker.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/core/__init__.py
+++ b/brain/cua/core/__init__.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/core/engine.py
+++ b/brain/cua/core/engine.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/core/mllm.py
+++ b/brain/cua/core/mllm.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/core/module.py
+++ b/brain/cua/core/module.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/memory/__init__.py
+++ b/brain/cua/memory/__init__.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/memory/procedural_memory.py
+++ b/brain/cua/memory/procedural_memory.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/utils/__init__.py
+++ b/brain/cua/utils/__init__.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/brain/cua/utils/common_utils.py
+++ b/brain/cua/utils/common_utils.py
@@ -1,4 +1,8 @@
-# Copyright 2025-2026 Project N.E.K.O. Team
+# Modifications Copyright 2025-2026 Project N.E.K.O. Team
+#
+# This file is derived from simular-ai/Agent-S
+# (https://github.com/simular-ai/Agent-S), licensed under the Apache License,
+# Version 2.0; see brain/cua/AGENT_LICENSE.txt. Modified by the Project N.E.K.O. Team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
@
## 背景

接 #1723（relicense to Apache 2.0）的两个遗留问题。

## 1. brain/cua 的 Agent-S 帰属（核心）

`brain/cua` 的代码 vendored 自 [simular-ai/Agent-S](https://github.com/simular-ai/Agent-S)。先确认事实：**Agent-S 本身就是 Apache 2.0**（`setup.py` classifier `License :: OSI Approved :: Apache Software License`、`LICENSE` 为 Apache 2.0 全文），**不是 MIT**。所以无需 relicense，upstream 与本项目 license 兼容，缺的只是**帰属**。

问题在于 #1723 给这 13 个 vendored 文件刻上了**单独的** `Copyright 2025-2026 Project N.E.K.O. Team` Apache 头（原本无头）。单独署名抹掉了 Apache 2.0 §4(b)/(c) 要求保留的上游帰属。

本 PR：
- `brain/cua/*`（13 文件）：头改为 `Modifications Copyright ... N.E.K.O. Team` + “derived from simular-ai/Agent-S”一行，指向已保留的 `brain/cua/AGENT_LICENSE.txt`（上游 Apache 全文）。
- `NOTICE`：新增 Third-Party Notices 节 credit Agent-S（此前 repo 全局对 Agent-S 零帰属）。

upstream 的 LICENSE 未填 copyright holder、各源文件也无 per-file 头，故未杜撰 Simular 的具体年份/法人著作权行，只做帰属。

## 2. NOTICE 英译修正

`catgirls` → `nekos`（中文「猫娘」不变，仅英文签名）。

## 验证
- `python -m py_compile` 全部 13 文件通过
- 无 license-header 强制 CI 守门脚本，书换不与现有 check 冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新了许可证与著作权声明，添加了第三方软件通知说明
  * 补充了 Apache License 2.0 授权信息与衍生源链接

* **杂务**
  * 完善了多个文件的许可证头部注释，确保完整的法律合规声明

<!-- end of auto-generated comment: release notes by coderabbit.ai -->