### PR TITLE
修复伴学回复渲染与状态回填

### DIFF
--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -122,9 +122,9 @@ def _register_install_routes() -> None:
     )
 
 
-def _plugin_detail_ui_url(*, plugin_id: str, port: str) -> str:
+def _static_plugin_ui_url(*, plugin_id: str, port: str) -> str:
     safe_plugin_id = quote(plugin_id, safe="")
-    return f"http://127.0.0.1:{port}/ui/plugins/{safe_plugin_id}?tab=ui"
+    return f"http://127.0.0.1:{port}/plugin/{safe_plugin_id}/ui/"
 
 
 try:
@@ -380,7 +380,7 @@ class StudyCompanionPlugin(
         if not (1 <= port_num <= 65535):
             port_num = 48916
         port = str(port_num)
-        url = _plugin_detail_ui_url(plugin_id=self.plugin_id, port=port)
+        url = _static_plugin_ui_url(plugin_id=self.plugin_id, port=port)
         try:
             await asyncio.wait_for(
                 asyncio.to_thread(_open_url_in_browser, url),

--- a/plugin/plugins/study_companion/entry_tutor_context_support.py
+++ b/plugin/plugins/study_companion/entry_tutor_context_support.py
@@ -167,8 +167,6 @@ class _TutorContextSupportMixin:
                 self._state.recent_learning_events + [event]
             )[-16:]
             if operation != LLM_OPERATION_KNOWLEDGE_TRACK:
-                self._state.last_reply = summary
-                self._state.last_reply_at = reply.created_at or utc_now_iso()
                 if operation == LLM_OPERATION_QUESTION_GENERATE:
                     if str(payload.get("question") or "").strip():
                         self._state.current_question = dict(payload)

--- a/plugin/plugins/study_companion/models.py
+++ b/plugin/plugins/study_companion/models.py
@@ -53,7 +53,6 @@ class StudyStatusPayload(TypedDict, total=False):
     current_question: dict[str, Any]
     last_answer_evaluation: dict[str, Any]
     screen_classification: dict[str, Any]
-    last_reply: str
     last_error: str
     history: list[dict[str, Any]]
 
@@ -452,8 +451,6 @@ class StudyState:
     last_answer_evaluated_at: str = ""
     last_session_summary: str = ""
     last_session_summary_at: str = ""
-    last_reply: str = ""
-    last_reply_at: str = ""
     checkpoint: dict[str, Any] = field(default_factory=dict)
     dependency_status: dict[str, Any] = field(default_factory=dict)
 

--- a/plugin/plugins/study_companion/service.py
+++ b/plugin/plugins/study_companion/service.py
@@ -42,7 +42,6 @@ def build_status_payload(
         "recent_screen_classifications": copy.deepcopy(
             state.recent_screen_classifications
         ),
-        "current_question": copy.deepcopy(state.current_question),
         "last_answer_evaluation": copy.deepcopy(state.last_answer_evaluation),
         "session_summary_seed": copy.deepcopy(state.session_summary_seed),
         "recent_learning_events": copy.deepcopy(state.recent_learning_events),
@@ -50,8 +49,6 @@ def build_status_payload(
         "last_answer_evaluated_at": state.last_answer_evaluated_at,
         "last_session_summary": state.last_session_summary,
         "last_session_summary_at": state.last_session_summary_at,
-        "last_reply": state.last_reply,
-        "last_reply_at": state.last_reply_at,
         "checkpoint": copy.deepcopy(state.checkpoint),
         "dependencies": copy.deepcopy(state.dependency_status),
         "knowledge_summary": copy.deepcopy(

--- a/plugin/plugins/study_companion/static/index.html
+++ b/plugin/plugins/study_companion/static/index.html
@@ -6,8 +6,8 @@
     <!-- Fallback only for local/Electron loads; meta CSP cannot express dynamic localhost ports or frame-ancestors. -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; style-src-attr 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; object-src 'none'" />
     <title>Study Companion</title>
-    <link rel="stylesheet" href="./katex.min.css" />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="./katex.min.css?v=study-hotfix-20260615v" />
+    <link rel="stylesheet" href="./style.css?v=study-hotfix-20260615v" />
   </head>
   <body>
     <main class="page-shell">
@@ -282,8 +282,8 @@
       </section>
     </main>
     <script src="./i18n.js"></script>
-    <script src="./katex.min.js"></script>
-    <script src="./katex-render.js"></script>
-    <script src="./main.js"></script>
+    <script src="./katex.min.js?v=study-hotfix-20260615v"></script>
+    <script src="./katex-render.js?v=study-hotfix-20260615v"></script>
+    <script src="./main.js?v=study-hotfix-20260615v"></script>
   </body>
 </html>

--- a/plugin/plugins/study_companion/static/katex-render.js
+++ b/plugin/plugins/study_companion/static/katex-render.js
@@ -123,6 +123,9 @@
       value = value.slice(0, -trailing[0].length);
       consumeLength -= trailing[0].length;
     }
+    if (raw.startsWith('$') && isCurrencyProseBeforeBareLatex(value)) {
+      return null;
+    }
     const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*[.,;:!?]*$/);
     if (proseTail) {
       value = value.slice(0, -proseTail[0].length);
@@ -138,6 +141,19 @@
       return null;
     }
     return { value, consumeLength: Math.max(1, consumeLength + (raw.startsWith('$') ? 1 : 0)) };
+  }
+
+  function isCurrencyProseBeforeBareLatex(value) {
+    const amount = String(value || '').match(/^(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?/);
+    if (!amount) {
+      return false;
+    }
+    const command = String(value || '').search(BARE_LATEX_COMMAND_PATTERN);
+    if (command === -1) {
+      return false;
+    }
+    const between = String(value || '').slice(amount[0].length, command);
+    return /[A-Za-z]{2,}/.test(between);
   }
 
   function isLikelyInlineMathValue(raw) {
@@ -171,6 +187,18 @@
       const start = match.index || 0;
       const normalized = normalizeBareLatexMatch(raw);
       if (!normalized) {
+        const recovered = recoverCurrencyProseBareLatexMatch(raw);
+        if (recovered) {
+          const textValue = `${start > last ? source.slice(last, start) : ''}${recovered.textValue}`;
+          if (textValue) {
+            parts.push({ type: 'text', value: textValue });
+          }
+          parts.push({ type: 'math', value: recovered.mathValue, display: false });
+          if (recovered.trailingText) {
+            parts.push({ type: 'text', value: recovered.trailingText });
+          }
+          last = start + recovered.consumeLength;
+        }
         continue;
       }
       if (start > last) {
@@ -182,6 +210,36 @@
     if (last < source.length) {
       parts.push({ type: 'text', value: source.slice(last) });
     }
+  }
+
+  function recoverCurrencyProseBareLatexMatch(raw) {
+    if (!String(raw || '').startsWith('$')) {
+      return null;
+    }
+    const value = String(raw || '').slice(1);
+    if (!isCurrencyProseBeforeBareLatex(value)) {
+      return null;
+    }
+    const command = value.search(BARE_LATEX_COMMAND_PATTERN);
+    if (command <= 0) {
+      return null;
+    }
+    const normalized = normalizeBareLatexMatch(value.slice(command));
+    if (!normalized) {
+      return null;
+    }
+    const trailingPunctuation = normalized.value.match(/[.,;:!?]+$/);
+    const trailingText = trailingPunctuation ? trailingPunctuation[0] : '';
+    const mathValue = trailingText ? normalized.value.slice(0, -trailingText.length) : normalized.value;
+    if (!mathValue) {
+      return null;
+    }
+    return {
+      textValue: `$${value.slice(0, command)}`,
+      mathValue,
+      trailingText,
+      consumeLength: 1 + command + normalized.consumeLength,
+    };
   }
 
   function splitByMath(text) {

--- a/plugin/plugins/study_companion/static/katex-render.js
+++ b/plugin/plugins/study_companion/static/katex-render.js
@@ -1,5 +1,11 @@
 (function () {
   const CURRENCY_START_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?(?=$|[\s)\],.;!?-])/;
+  const CURRENCY_LIKE_LATEX_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?\s*(?:\\(?:times|cdot|frac|sqrt|lt|gt|le|ge|leq|geq)(?![A-Za-z])|[+\-*/=^_<>≤≥])/;
+  const BARE_LATEX_COMMAND_PATTERN = /\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])/;
+  const DOUBLE_ESCAPED_LATEX_COMMAND_PATTERN = /\\\\(?=(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z]))/g;
+  const BARE_LATEX_SPAN_PATTERN = /\$[^\n。；;!?！？]*\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])[^\n。；;!?！？]*|\|?\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])(?:\[[^\]\n]{1,40}\]|\{[^{}\n]{1,120}\}|[A-Za-z0-9\\()+\-*/=.,:_|^\s]){0,180}/g;
+
+  const CJK_TEXT_PATTERN = /[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/;
 
   function escapeHTML(value) {
     const div = document.createElement('div');
@@ -16,7 +22,8 @@
   }
 
   function isLikelyCurrencyStart(source, index) {
-    return CURRENCY_START_PATTERN.test(source.slice(index));
+    const tail = source.slice(index);
+    return CURRENCY_START_PATTERN.test(tail) && !CURRENCY_LIKE_LATEX_PATTERN.test(tail);
   }
 
   function findMathDelimiter(source, start, delimiter) {
@@ -30,13 +37,20 @@
         index = next + delimiter.length;
         continue;
       }
-      if (delimiter === '$' && source[next + 1] === '$') {
-        index = next + 2;
-        continue;
-      }
       return next;
     }
     return -1;
+  }
+
+  function isTrailingPunctuation(value) {
+    return !value || /^[\s.,;:!?，。；：！？)\]}、]/.test(value);
+  }
+
+  function inlineCloseLength(source, closeIndex) {
+    if (source[closeIndex + 1] === '$' && isTrailingPunctuation(source.slice(closeIndex + 2))) {
+      return 2;
+    }
+    return 1;
   }
 
   function findBackslashMathDelimiter(source, start, closeChar) {
@@ -55,9 +69,99 @@
     return -1;
   }
 
+  function hasMathSyntax(source) {
+    return (
+      source.includes('$')
+      || source.includes('\\(')
+      || source.includes('\\[')
+      || BARE_LATEX_COMMAND_PATTERN.test(source)
+    );
+  }
+
+  function normalizeBareLatexMatch(raw) {
+    let value = String(raw || '');
+    let consumeLength = value.length;
+    if (value.startsWith('$')) {
+      if (value.slice(1).includes('$')) {
+        return null;
+      }
+      value = value.slice(1);
+      consumeLength -= 1;
+    }
+    const leading = value.match(/^\s+/);
+    if (leading) {
+      value = value.slice(leading[0].length);
+      consumeLength -= leading[0].length;
+    }
+    const trailing = value.match(/\s+$/);
+    if (trailing) {
+      value = value.slice(0, -trailing[0].length);
+      consumeLength -= trailing[0].length;
+    }
+    const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*$/);
+    if (proseTail) {
+      value = value.slice(0, -proseTail[0].length);
+      consumeLength -= proseTail[0].length;
+    }
+    if (
+      !value
+      || value.includes('$$')
+      || value.includes('**')
+      || /[\n#]/.test(value)
+      || !BARE_LATEX_COMMAND_PATTERN.test(value)
+    ) {
+      return null;
+    }
+    return { value, consumeLength: Math.max(1, consumeLength + (raw.startsWith('$') ? 1 : 0)) };
+  }
+
+  function isLikelyInlineMathValue(raw) {
+    const value = String(raw || '').trim();
+    if (
+      !value
+      || value.includes('$$')
+      || value.includes('**')
+      || /[\n#]/.test(value)
+    ) {
+      return false;
+    }
+    if (CJK_TEXT_PATTERN.test(value) && !/\\(?:text|mathrm|operatorname)(?![A-Za-z])/.test(value)) {
+      return false;
+    }
+    return (
+      BARE_LATEX_COMMAND_PATTERN.test(value)
+      || /[A-Za-z0-9]/.test(value)
+      || /[=+\-*/^_|()[\]{},.]/.test(value)
+    );
+  }
+
+  function pushTextParts(parts, value) {
+    const source = String(value || '');
+    if (!source) {
+      return;
+    }
+    let last = 0;
+    for (const match of source.matchAll(BARE_LATEX_SPAN_PATTERN)) {
+      const raw = match[0] || '';
+      const start = match.index || 0;
+      const normalized = normalizeBareLatexMatch(raw);
+      if (!normalized) {
+        continue;
+      }
+      if (start > last) {
+        parts.push({ type: 'text', value: source.slice(last, start) });
+      }
+      parts.push({ type: 'math', value: normalized.value, display: false });
+      last = start + normalized.consumeLength;
+    }
+    if (last < source.length) {
+      parts.push({ type: 'text', value: source.slice(last) });
+    }
+  }
+
   function splitByMath(text) {
     const parts = [];
-    const source = String(text || '');
+    const source = String(text || '').replace(/\\\$\\\$/g, () => '$$').replace(/\\\$\$/g, () => '$$');
     let last = 0;
     let index = 0;
     while (index < source.length) {
@@ -73,7 +177,7 @@
             continue;
           }
           if (index > last) {
-            parts.push({ type: 'text', value: source.slice(last, index) });
+            pushTextParts(parts, source.slice(last, index));
           }
           const mathValue = source.slice(index + 2, closer).trim();
           if (mathValue) {
@@ -99,7 +203,7 @@
           continue;
         }
         if (index > last) {
-          parts.push({ type: 'text', value: source.slice(last, index) });
+          pushTextParts(parts, source.slice(last, index));
         }
         parts.push({
           type: 'math',
@@ -121,25 +225,30 @@
         continue;
       }
       if (index > last) {
-        parts.push({ type: 'text', value: source.slice(last, index) });
+        pushTextParts(parts, source.slice(last, index));
       }
       const mathValue = source.slice(index + 1, inlineCloser).trim();
-      if (mathValue) {
+      if (mathValue && isLikelyInlineMathValue(mathValue)) {
         parts.push({ type: 'math', value: mathValue, display: false });
+        const closeLength = inlineCloseLength(source, inlineCloser);
+        index = inlineCloser + closeLength;
       } else {
         parts.push({ type: 'text', value: source.slice(index, inlineCloser + 1) });
+        index = inlineCloser + 1;
       }
-      index = inlineCloser + 1;
       last = index;
     }
     if (last < source.length) {
-      parts.push({ type: 'text', value: source.slice(last) });
+      pushTextParts(parts, source.slice(last));
     }
     return parts;
   }
 
   function normalizeLatexForKatex(value) {
-    return String(value || '').replace(/</g, '\\lt ').replace(/>/g, '\\gt ');
+    return String(value || '')
+      .replace(DOUBLE_ESCAPED_LATEX_COMMAND_PATTERN, '\\')
+      .replace(/</g, '\\lt ')
+      .replace(/>/g, '\\gt ');
   }
 
   function renderMathPart(part) {
@@ -149,28 +258,171 @@
     }
     const latex = normalizeLatexForKatex(part.value);
     try {
-      return window.katex.renderToString(latex, {
+      const rendered = window.katex.renderToString(latex, {
         displayMode: part.display,
         throwOnError: false,
         trust: false,
       });
+      if (rendered.includes('katex-error')) {
+        return `<code>${wrapper}${escapeHTML(part.value)}${wrapper}</code>`;
+      }
+      return rendered;
     } catch (_error) {
       return `<code>${wrapper}${escapeHTML(part.value)}${wrapper}</code>`;
     }
   }
 
+  function renderInlineMarkdown(escaped) {
+    return String(escaped || '')
+      .replace(/`([^`\n]{1,180})`/g, '<code>$1</code>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*\*/g, '');
+  }
+
+  function renderEscapedInlineMarkdown(value) {
+    return renderInlineMarkdown(escapeHTML(value));
+  }
+
+  function renderMathAndInlineMarkdown(value) {
+    const renderedMath = [];
+    const html = splitByMath(value).map((part) => {
+      if (part.type !== 'math') {
+        return escapeHTML(part.value);
+      }
+      const token = `@@STUDY_MATH_${renderedMath.length}@@`;
+      renderedMath.push(renderMathPart(part));
+      return token;
+    }).join('');
+    return renderInlineMarkdown(html).replace(/@@STUDY_MATH_(\d+)@@/g, (_match, index) => (
+      renderedMath[Number(index)] || ''
+    ));
+  }
+
+  function studySectionMeta(value) {
+    const normalized = String(value || '')
+      .replace(/^#{1,4}\s+/, '')
+      .replace(/^\*\*(.+?)\*\*$/, '$1')
+      .replace(/[：:]\s*$/, '')
+      .trim()
+      .toLowerCase();
+    const variants = {
+      '解析': ['analysis', '解析'],
+      '题目解析': ['analysis', '题目解析'],
+      '題目解析': ['analysis', '題目解析'],
+      'problem analysis': ['analysis', 'Problem Analysis'],
+      '解题过程': ['process', '解题过程'],
+      '解題過程': ['process', '解題過程'],
+      'solution process': ['process', 'Solution Process'],
+      '答案': ['answer', '答案'],
+      'final answer': ['answer', 'Final Answer'],
+      '举一反三': ['transfer', '举一反三'],
+      '舉一反三': ['transfer', '舉一反三'],
+      'transfer practice': ['transfer', 'Transfer Practice'],
+    };
+    const match = variants[normalized];
+    if (!match) {
+      return null;
+    }
+    return { variant: match[0], title: match[1] };
+  }
+
+  function renderMarkdownBlocks(text, inlineRenderer) {
+    const renderInline = typeof inlineRenderer === 'function' ? inlineRenderer : renderInlineMarkdown;
+    const lines = String(text || '').split(/\r?\n/);
+    const blocks = [];
+    let inList = false;
+    let inStudySection = false;
+    const closeList = () => {
+      if (inList) {
+        blocks.push('</ul>');
+        inList = false;
+      }
+    };
+    const closeStudySection = () => {
+      closeList();
+      if (inStudySection) {
+        blocks.push('</section>');
+        inStudySection = false;
+      }
+    };
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      const trimmed = line.trim();
+      if (!trimmed) {
+        closeList();
+        continue;
+      }
+      const displayMath = trimmed.match(/^\$\$\s*(.+?)\s*\$\$$/);
+      if (displayMath) {
+        closeList();
+        blocks.push(renderMathPart({ type: 'math', value: displayMath[1], display: true }));
+        continue;
+      }
+      if (trimmed === '$$') {
+        const mathLines = [];
+        let closer = -1;
+        for (let scan = index + 1; scan < lines.length; scan += 1) {
+          if (lines[scan].trim() === '$$') {
+            closer = scan;
+            break;
+          }
+          mathLines.push(lines[scan]);
+        }
+        if (closer !== -1) {
+          closeList();
+          blocks.push(renderMathPart({ type: 'math', value: mathLines.join('\n').trim(), display: true }));
+          index = closer;
+          continue;
+        }
+      }
+      const heading = trimmed.match(/^(#{1,4})\s+(.+)$/);
+      if (heading) {
+        const studySection = studySectionMeta(heading[2]);
+        if (studySection) {
+          closeStudySection();
+          blocks.push(`<section class="study-reply-section study-reply-section--${studySection.variant}">`);
+          blocks.push(`<h3 class="study-reply-section__title">${renderInline(studySection.title)}</h3>`);
+          inStudySection = true;
+          continue;
+        }
+        closeStudySection();
+        const level = Math.min(4, heading[1].length);
+        blocks.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
+        continue;
+      }
+      const studySection = studySectionMeta(trimmed);
+      if (studySection) {
+        closeStudySection();
+        blocks.push(`<section class="study-reply-section study-reply-section--${studySection.variant}">`);
+        blocks.push(`<h3 class="study-reply-section__title">${renderInline(studySection.title)}</h3>`);
+        inStudySection = true;
+        continue;
+      }
+      const bullet = trimmed.match(/^(?:[-*+])\s+(.+)$/);
+      if (bullet) {
+        closeList();
+        blocks.push(`<p class="study-reply-bullet">&bull; ${renderInline(bullet[1])}</p>`);
+        continue;
+      }
+      closeList();
+      blocks.push(`<p>${renderInline(trimmed)}</p>`);
+    }
+    closeStudySection();
+    return blocks.join('\n');
+  }
+
   function renderMathInText(text) {
-    const source = String(text || '');
-    const hasMathDelimiter = source.includes('$') || source.includes('\\(') || source.includes('\\[');
-    if (!source || !hasMathDelimiter || !window.katex || typeof window.katex.renderToString !== 'function') {
-      return escapeHTML(source);
+    const source = String(text || '').replace(/\\\$\\\$/g, () => '$$').replace(/\\\$\$/g, () => '$$');
+    if (!source) {
+      return '';
+    }
+    if (!hasMathSyntax(source) || !window.katex || typeof window.katex.renderToString !== 'function') {
+      return renderMarkdownBlocks(source, renderEscapedInlineMarkdown);
     }
     try {
-      return splitByMath(source).map((part) => (
-        part.type === 'math' ? renderMathPart(part) : escapeHTML(part.value)
-      )).join('');
+      return renderMarkdownBlocks(source, renderMathAndInlineMarkdown);
     } catch (_error) {
-      return escapeHTML(source);
+      return renderMarkdownBlocks(source, renderEscapedInlineMarkdown);
     }
   }
 
@@ -181,8 +433,12 @@
     isLikelyCurrencyStart,
     findMathDelimiter,
     findBackslashMathDelimiter,
+    hasMathSyntax,
+    isLikelyInlineMathValue,
     normalizeLatexForKatex,
     splitByMath,
+    studySectionMeta,
+    renderMarkdownBlocks,
     renderMathInText,
   };
 })();

--- a/plugin/plugins/study_companion/static/katex-render.js
+++ b/plugin/plugins/study_companion/static/katex-render.js
@@ -1,6 +1,6 @@
 (function () {
-  const CURRENCY_START_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?(?=$|[\s)\],.;!?-])/;
-  const CURRENCY_LIKE_LATEX_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?\s*(?:\\(?:times|cdot|frac|sqrt|lt|gt|le|ge|leq|geq)(?![A-Za-z])|[+\-*/=^_<>≤≥])/;
+  const CURRENCY_START_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?(?=$|[\s)\],.;!?+\-])/;
+  const CURRENCY_AMOUNT_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?/;
   const BARE_LATEX_COMMAND_PATTERN = /\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])/;
   const DOUBLE_ESCAPED_LATEX_COMMAND_PATTERN = /\\\\(?=(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z]))/g;
   const BARE_LATEX_SPAN_PATTERN = /\$[^\n。；;!?！？]*\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])[^\n。；;!?！？]*|\|?\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])(?:\[[^\]\n]{1,40}\]|\{[^{}\n]{1,120}\}|[A-Za-z0-9\\()+\-*/=.,:_|^\s]){0,180}/g;
@@ -23,7 +23,32 @@
 
   function isLikelyCurrencyStart(source, index) {
     const tail = source.slice(index);
-    return CURRENCY_START_PATTERN.test(tail) && !CURRENCY_LIKE_LATEX_PATTERN.test(tail);
+    return CURRENCY_START_PATTERN.test(tail) && !isCurrencyLikeLatexStart(tail);
+  }
+
+  function isCurrencyLikeLatexStart(tail) {
+    const amount = tail.match(CURRENCY_AMOUNT_PATTERN);
+    if (!amount) {
+      return false;
+    }
+    const closer = findMathDelimiter(tail, 1, '$');
+    if (closer === -1) {
+      return false;
+    }
+    const expression = tail.slice(amount[0].length, closer);
+    if (/^\s*\\(?:times|cdot|frac|sqrt|lt|gt|le|ge|leq|geq)(?![A-Za-z])/.test(expression)) {
+      return true;
+    }
+    if (!/^\s*[+\-*/=^_<>≤≥]/.test(expression)) {
+      return false;
+    }
+    if (/[A-Za-z]{2,}/.test(expression.replace(/\\[A-Za-z]+/g, ''))) {
+      return false;
+    }
+    return (
+      /[=+\-*/^_<>≤≥\\]/.test(expression)
+      && /[A-Za-z0-9\\{}()[\]^_<>≤≥]/.test(expression)
+    );
   }
 
   function findMathDelimiter(source, start, delimiter) {

--- a/plugin/plugins/study_companion/static/katex-render.js
+++ b/plugin/plugins/study_companion/static/katex-render.js
@@ -98,7 +98,7 @@
       value = value.slice(0, -trailing[0].length);
       consumeLength -= trailing[0].length;
     }
-    const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*$/);
+    const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*[.,;:!?]*$/);
     if (proseTail) {
       value = value.slice(0, -proseTail[0].length);
       consumeLength -= proseTail[0].length;
@@ -330,14 +330,8 @@
     const renderInline = typeof inlineRenderer === 'function' ? inlineRenderer : renderInlineMarkdown;
     const lines = String(text || '').split(/\r?\n/);
     const blocks = [];
-    let inList = false;
     let inStudySection = false;
-    const closeList = () => {
-      if (inList) {
-        blocks.push('</ul>');
-        inList = false;
-      }
-    };
+    const closeList = () => {};
     const closeStudySection = () => {
       closeList();
       if (inStudySection) {
@@ -358,11 +352,20 @@
         blocks.push(renderMathPart({ type: 'math', value: displayMath[1], display: true }));
         continue;
       }
-      if (trimmed === '$$') {
+      const displayMathBlock = trimmed.match(/^\$\$\s*(.*)$/);
+      if (displayMathBlock) {
         const mathLines = [];
+        if (displayMathBlock[1]) {
+          mathLines.push(displayMathBlock[1]);
+        }
         let closer = -1;
         for (let scan = index + 1; scan < lines.length; scan += 1) {
-          if (lines[scan].trim() === '$$') {
+          const closeAt = lines[scan].indexOf('$$');
+          if (closeAt !== -1) {
+            const beforeClose = lines[scan].slice(0, closeAt).trim();
+            if (beforeClose) {
+              mathLines.push(beforeClose);
+            }
             closer = scan;
             break;
           }

--- a/plugin/plugins/study_companion/static/katex-render.js
+++ b/plugin/plugins/study_companion/static/katex-render.js
@@ -356,10 +356,17 @@
   }
 
   function renderInlineMarkdown(escaped) {
-    return String(escaped || '')
-      .replace(/`([^`\n]{1,180})`/g, '<code>$1</code>')
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*\*/g, '');
+    const codeSpans = [];
+    const html = String(escaped || '')
+      .replace(/`([^`\n]{1,180})`/g, (_match, code) => {
+        const token = `@@STUDY_CODE_${codeSpans.length}@@`;
+        codeSpans.push(`<code>${code}</code>`);
+        return token;
+      })
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    return html.replace(/@@STUDY_CODE_(\d+)@@/g, (_match, index) => (
+      codeSpans[Number(index)] || ''
+    ));
   }
 
   function renderEscapedInlineMarkdown(value) {

--- a/plugin/plugins/study_companion/static/katex-render.js
+++ b/plugin/plugins/study_companion/static/katex-render.js
@@ -375,7 +375,13 @@
 
   function renderMathAndInlineMarkdown(value) {
     const renderedMath = [];
-    const html = splitByMath(value).map((part) => {
+    const protectedCodeSpans = [];
+    const source = String(value || '').replace(/`([^`\n]{1,180})`/g, (_match, code) => {
+      const token = `@@STUDY_PROTECTED_CODE_${protectedCodeSpans.length}@@`;
+      protectedCodeSpans.push(`<code>${escapeHTML(code)}</code>`);
+      return token;
+    });
+    const html = splitByMath(source).map((part) => {
       if (part.type !== 'math') {
         return escapeHTML(part.value);
       }
@@ -383,8 +389,11 @@
       renderedMath.push(renderMathPart(part));
       return token;
     }).join('');
-    return renderInlineMarkdown(html).replace(/@@STUDY_MATH_(\d+)@@/g, (_match, index) => (
+    const withMath = renderInlineMarkdown(html).replace(/@@STUDY_MATH_(\d+)@@/g, (_match, index) => (
       renderedMath[Number(index)] || ''
+    ));
+    return withMath.replace(/@@STUDY_PROTECTED_CODE_(\d+)@@/g, (_match, index) => (
+      protectedCodeSpans[Number(index)] || ''
     ));
   }
 
@@ -442,16 +451,21 @@
         blocks.push(renderMathPart({ type: 'math', value: displayMath[1], display: true }));
         continue;
       }
-      const displayMathBlock = trimmed.match(/^\$\$\s*(.*)$/);
-      if (displayMathBlock) {
+      const openerAt = findMathDelimiter(line, 0, '$$');
+      const closesOnOpeningLine = openerAt !== -1
+        ? findMathDelimiter(line, openerAt + 2, '$$') !== -1
+        : false;
+      if (openerAt !== -1 && !closesOnOpeningLine) {
+        const beforeOpen = line.slice(0, openerAt).trim();
+        const afterOpen = line.slice(openerAt + 2).trim();
         const mathLines = [];
-        if (displayMathBlock[1]) {
-          mathLines.push(displayMathBlock[1]);
+        if (afterOpen) {
+          mathLines.push(afterOpen);
         }
         let closer = -1;
         let trailingCloseText = '';
         for (let scan = index + 1; scan < lines.length; scan += 1) {
-          const closeAt = lines[scan].indexOf('$$');
+          const closeAt = findMathDelimiter(lines[scan], 0, '$$');
           if (closeAt !== -1) {
             const beforeClose = lines[scan].slice(0, closeAt).trim();
             if (beforeClose) {
@@ -465,6 +479,9 @@
         }
         if (closer !== -1) {
           closeList();
+          if (beforeOpen) {
+            blocks.push(`<p>${renderInline(beforeOpen)}</p>`);
+          }
           blocks.push(renderMathPart({ type: 'math', value: mathLines.join('\n').trim(), display: true }));
           if (trailingCloseText) {
             blocks.push(`<p>${renderInline(trailingCloseText)}</p>`);

--- a/plugin/plugins/study_companion/static/katex-render.js
+++ b/plugin/plugins/study_companion/static/katex-render.js
@@ -359,6 +359,7 @@
           mathLines.push(displayMathBlock[1]);
         }
         let closer = -1;
+        let trailingCloseText = '';
         for (let scan = index + 1; scan < lines.length; scan += 1) {
           const closeAt = lines[scan].indexOf('$$');
           if (closeAt !== -1) {
@@ -366,6 +367,7 @@
             if (beforeClose) {
               mathLines.push(beforeClose);
             }
+            trailingCloseText = lines[scan].slice(closeAt + 2).trim();
             closer = scan;
             break;
           }
@@ -374,6 +376,9 @@
         if (closer !== -1) {
           closeList();
           blocks.push(renderMathPart({ type: 'math', value: mathLines.join('\n').trim(), display: true }));
+          if (trailingCloseText) {
+            blocks.push(`<p>${renderInline(trailingCloseText)}</p>`);
+          }
           index = closer;
           continue;
         }

--- a/plugin/plugins/study_companion/static/main.js
+++ b/plugin/plugins/study_companion/static/main.js
@@ -89,6 +89,7 @@ let firstRunDismissed = false;
 let advancedSettingsOpen = false;
 let modeChangeInFlight = false;
 let refreshPending = false;
+let lastReplyValue = '';
 
 function t(key, fallback) {
   return window.I18n && typeof window.I18n.t === 'function'
@@ -113,8 +114,22 @@ function setStatus(text) {
 // a code path that skips escapeHTML().
 function setReply(text) {
   const value = text || '';
+  lastReplyValue = value;
   if (window.renderMathInText && typeof window.renderMathInText === 'function') {
     replyText.innerHTML = window.renderMathInText(value);
+    if (!window.katex || typeof window.katex.renderToString !== 'function') {
+      window.setTimeout(() => {
+        if (
+          lastReplyValue === value
+          && window.katex
+          && typeof window.katex.renderToString === 'function'
+          && window.renderMathInText
+          && typeof window.renderMathInText === 'function'
+        ) {
+          replyText.innerHTML = window.renderMathInText(value);
+        }
+      }, 100);
+    }
   } else {
     replyText.textContent = value;
   }
@@ -412,13 +427,6 @@ function setStudyState(data = {}) {
     if (classification.reason) {
       screenType.title = classification.reason;
     }
-  }
-  const currentQuestion = data.current_question || {};
-  if (questionStatus) {
-    questionStatus.textContent = compactText(currentQuestion.question);
-  }
-  if (questionText) {
-    questionText.textContent = currentQuestion.question || '';
   }
   const evaluation = data.last_answer_evaluation || {};
   if (evaluationStatus) {
@@ -810,17 +818,10 @@ async function callPlugin(entryId, args = {}) {
   throw new Error(t('ui.error.plugin_call_timeout', 'Plugin call timed out'));
 }
 
-async function refreshStatus(options = {}) {
-  const updateReply = options.updateReply !== false;
+async function refreshStatus(_options = {}) {
   setStatus(t('ui.status.refreshing', 'Refreshing...'));
   const data = await callPlugin('study_status');
   setStatusLine(data);
-  if (updateReply && data.last_reply) {
-    setReply(data.last_reply);
-  }
-  if (data.last_ocr_text && !studyInput.value.trim()) {
-    studyInput.value = data.last_ocr_text;
-  }
 }
 
 async function runOcr() {

--- a/plugin/plugins/study_companion/static/math-parser.js
+++ b/plugin/plugins/study_companion/static/math-parser.js
@@ -117,6 +117,9 @@
       value = value.slice(0, -trailing[0].length);
       consumeLength -= trailing[0].length;
     }
+    if (raw.startsWith('$') && isCurrencyProseBeforeBareLatex(value)) {
+      return null;
+    }
     const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*[.,;:!?]*$/);
     if (proseTail) {
       value = value.slice(0, -proseTail[0].length);
@@ -132,6 +135,19 @@
       return null;
     }
     return { value, consumeLength: Math.max(1, consumeLength + (raw.startsWith('$') ? 1 : 0)) };
+  }
+
+  function isCurrencyProseBeforeBareLatex(value) {
+    const amount = String(value || '').match(/^(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?/);
+    if (!amount) {
+      return false;
+    }
+    const command = String(value || '').search(BARE_LATEX_COMMAND_PATTERN);
+    if (command === -1) {
+      return false;
+    }
+    const between = String(value || '').slice(amount[0].length, command);
+    return /[A-Za-z]{2,}/.test(between);
   }
 
   function isLikelyInlineMathValue(raw) {
@@ -165,6 +181,18 @@
       const start = match.index || 0;
       const normalized = normalizeBareLatexMatch(raw);
       if (!normalized) {
+        const recovered = recoverCurrencyProseBareLatexMatch(raw);
+        if (recovered) {
+          const textValue = `${start > last ? source.slice(last, start) : ''}${recovered.textValue}`;
+          if (textValue) {
+            parts.push({ type: 'text', value: textValue });
+          }
+          parts.push({ type: 'math', value: recovered.mathValue, display: false });
+          if (recovered.trailingText) {
+            parts.push({ type: 'text', value: recovered.trailingText });
+          }
+          last = start + recovered.consumeLength;
+        }
         continue;
       }
       if (start > last) {
@@ -176,6 +204,36 @@
     if (last < source.length) {
       parts.push({ type: 'text', value: source.slice(last) });
     }
+  }
+
+  function recoverCurrencyProseBareLatexMatch(raw) {
+    if (!String(raw || '').startsWith('$')) {
+      return null;
+    }
+    const value = String(raw || '').slice(1);
+    if (!isCurrencyProseBeforeBareLatex(value)) {
+      return null;
+    }
+    const command = value.search(BARE_LATEX_COMMAND_PATTERN);
+    if (command <= 0) {
+      return null;
+    }
+    const normalized = normalizeBareLatexMatch(value.slice(command));
+    if (!normalized) {
+      return null;
+    }
+    const trailingPunctuation = normalized.value.match(/[.,;:!?]+$/);
+    const trailingText = trailingPunctuation ? trailingPunctuation[0] : '';
+    const mathValue = trailingText ? normalized.value.slice(0, -trailingText.length) : normalized.value;
+    if (!mathValue) {
+      return null;
+    }
+    return {
+      textValue: `$${value.slice(0, command)}`,
+      mathValue,
+      trailingText,
+      consumeLength: 1 + command + normalized.consumeLength,
+    };
   }
 
   function splitByMath(text) {

--- a/plugin/plugins/study_companion/static/math-parser.js
+++ b/plugin/plugins/study_companion/static/math-parser.js
@@ -1,5 +1,11 @@
 (function () {
   const CURRENCY_START_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?(?=$|[\s)\],.;!?-])/;
+  const CURRENCY_LIKE_LATEX_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?\s*(?:\\(?:times|cdot|frac|sqrt|lt|gt|le|ge|leq|geq)(?![A-Za-z])|[+\-*/=^_<>≤≥])/;
+  const BARE_LATEX_COMMAND_PATTERN = /\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])/;
+  const DOUBLE_ESCAPED_LATEX_COMMAND_PATTERN = /\\\\(?=(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z]))/g;
+  const BARE_LATEX_SPAN_PATTERN = /\$[^\n。；;!?！？]*\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])[^\n。；;!?！？]*|\|?\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])(?:\[[^\]\n]{1,40}\]|\{[^{}\n]{1,120}\}|[A-Za-z0-9\\()+\-*/=.,:_|^\s]){0,180}/g;
+
+  const CJK_TEXT_PATTERN = /[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/;
 
   function hasEscapedDelimiter(source, index) {
     let slashes = 0;
@@ -10,7 +16,8 @@
   }
 
   function isLikelyCurrencyStart(source, index) {
-    return CURRENCY_START_PATTERN.test(source.slice(index));
+    const tail = source.slice(index);
+    return CURRENCY_START_PATTERN.test(tail) && !CURRENCY_LIKE_LATEX_PATTERN.test(tail);
   }
 
   function findMathDelimiter(source, start, delimiter) {
@@ -24,13 +31,20 @@
         index = next + delimiter.length;
         continue;
       }
-      if (delimiter === '$' && source[next + 1] === '$') {
-        index = next + 2;
-        continue;
-      }
       return next;
     }
     return -1;
+  }
+
+  function isTrailingPunctuation(value) {
+    return !value || /^[\s.,;:!?，。；：！？)\]}、]/.test(value);
+  }
+
+  function inlineCloseLength(source, closeIndex) {
+    if (source[closeIndex + 1] === '$' && isTrailingPunctuation(source.slice(closeIndex + 2))) {
+      return 2;
+    }
+    return 1;
   }
 
   function findBackslashMathDelimiter(source, start, closeChar) {
@@ -49,9 +63,99 @@
     return -1;
   }
 
+  function hasMathSyntax(source) {
+    return (
+      source.includes('$')
+      || source.includes('\\(')
+      || source.includes('\\[')
+      || BARE_LATEX_COMMAND_PATTERN.test(source)
+    );
+  }
+
+  function normalizeBareLatexMatch(raw) {
+    let value = String(raw || '');
+    let consumeLength = value.length;
+    if (value.startsWith('$')) {
+      if (value.slice(1).includes('$')) {
+        return null;
+      }
+      value = value.slice(1);
+      consumeLength -= 1;
+    }
+    const leading = value.match(/^\s+/);
+    if (leading) {
+      value = value.slice(leading[0].length);
+      consumeLength -= leading[0].length;
+    }
+    const trailing = value.match(/\s+$/);
+    if (trailing) {
+      value = value.slice(0, -trailing[0].length);
+      consumeLength -= trailing[0].length;
+    }
+    const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*$/);
+    if (proseTail) {
+      value = value.slice(0, -proseTail[0].length);
+      consumeLength -= proseTail[0].length;
+    }
+    if (
+      !value
+      || value.includes('$$')
+      || value.includes('**')
+      || /[\n#]/.test(value)
+      || !BARE_LATEX_COMMAND_PATTERN.test(value)
+    ) {
+      return null;
+    }
+    return { value, consumeLength: Math.max(1, consumeLength + (raw.startsWith('$') ? 1 : 0)) };
+  }
+
+  function isLikelyInlineMathValue(raw) {
+    const value = String(raw || '').trim();
+    if (
+      !value
+      || value.includes('$$')
+      || value.includes('**')
+      || /[\n#]/.test(value)
+    ) {
+      return false;
+    }
+    if (CJK_TEXT_PATTERN.test(value) && !/\\(?:text|mathrm|operatorname)(?![A-Za-z])/.test(value)) {
+      return false;
+    }
+    return (
+      BARE_LATEX_COMMAND_PATTERN.test(value)
+      || /[A-Za-z0-9]/.test(value)
+      || /[=+\-*/^_|()[\]{},.]/.test(value)
+    );
+  }
+
+  function pushTextParts(parts, value) {
+    const source = String(value || '');
+    if (!source) {
+      return;
+    }
+    let last = 0;
+    for (const match of source.matchAll(BARE_LATEX_SPAN_PATTERN)) {
+      const raw = match[0] || '';
+      const start = match.index || 0;
+      const normalized = normalizeBareLatexMatch(raw);
+      if (!normalized) {
+        continue;
+      }
+      if (start > last) {
+        parts.push({ type: 'text', value: source.slice(last, start) });
+      }
+      parts.push({ type: 'math', value: normalized.value, display: false });
+      last = start + normalized.consumeLength;
+    }
+    if (last < source.length) {
+      parts.push({ type: 'text', value: source.slice(last) });
+    }
+  }
+
   function splitByMath(text) {
     const parts = [];
-    const source = String(text || '');
+    const source = String(text || '').replace(/\\\$\\\$/g, () => '$$').replace(/\\\$\$/g, () => '$$');
     let last = 0;
     let index = 0;
     while (index < source.length) {
@@ -67,7 +171,7 @@
             continue;
           }
           if (index > last) {
-            parts.push({ type: 'text', value: source.slice(last, index) });
+            pushTextParts(parts, source.slice(last, index));
           }
           const mathValue = source.slice(index + 2, closer).trim();
           if (mathValue) {
@@ -93,7 +197,7 @@
           continue;
         }
         if (index > last) {
-          parts.push({ type: 'text', value: source.slice(last, index) });
+          pushTextParts(parts, source.slice(last, index));
         }
         parts.push({
           type: 'math',
@@ -115,25 +219,30 @@
         continue;
       }
       if (index > last) {
-        parts.push({ type: 'text', value: source.slice(last, index) });
+        pushTextParts(parts, source.slice(last, index));
       }
       const mathValue = source.slice(index + 1, inlineCloser).trim();
-      if (mathValue) {
+      if (mathValue && isLikelyInlineMathValue(mathValue)) {
         parts.push({ type: 'math', value: mathValue, display: false });
+        const closeLength = inlineCloseLength(source, inlineCloser);
+        index = inlineCloser + closeLength;
       } else {
         parts.push({ type: 'text', value: source.slice(index, inlineCloser + 1) });
+        index = inlineCloser + 1;
       }
-      index = inlineCloser + 1;
       last = index;
     }
     if (last < source.length) {
-      parts.push({ type: 'text', value: source.slice(last) });
+      pushTextParts(parts, source.slice(last));
     }
     return parts;
   }
 
   function normalizeLatexForKatex(value) {
-    return String(value || '').replace(/</g, '\\lt ').replace(/>/g, '\\gt ');
+    return String(value || '')
+      .replace(DOUBLE_ESCAPED_LATEX_COMMAND_PATTERN, '\\')
+      .replace(/</g, '\\lt ')
+      .replace(/>/g, '\\gt ');
   }
 
   window.__studyCompanionMathParser = {
@@ -142,7 +251,9 @@
     isLikelyCurrencyStart,
     findMathDelimiter,
     findBackslashMathDelimiter,
+    hasMathSyntax,
     splitByMath,
+    isLikelyInlineMathValue,
     normalizeLatexForKatex,
   };
 })();

--- a/plugin/plugins/study_companion/static/math-parser.js
+++ b/plugin/plugins/study_companion/static/math-parser.js
@@ -1,6 +1,6 @@
 (function () {
-  const CURRENCY_START_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?(?=$|[\s)\],.;!?-])/;
-  const CURRENCY_LIKE_LATEX_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?\s*(?:\\(?:times|cdot|frac|sqrt|lt|gt|le|ge|leq|geq)(?![A-Za-z])|[+\-*/=^_<>≤≥])/;
+  const CURRENCY_START_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?(?=$|[\s)\],.;!?+\-])/;
+  const CURRENCY_AMOUNT_PATTERN = /^\$(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?(?:[A-Z]{2,4}|%)?/;
   const BARE_LATEX_COMMAND_PATTERN = /\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])/;
   const DOUBLE_ESCAPED_LATEX_COMMAND_PATTERN = /\\\\(?=(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z]))/g;
   const BARE_LATEX_SPAN_PATTERN = /\$[^\n。；;!?！？]*\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])[^\n。；;!?！？]*|\|?\\(?:vec|overrightarrow|overline|bar|hat|frac|sqrt|sum|prod|int|lim|cdot|times|angle|sin|cos|tan|log|ln|infty|to|left|right|mathbf|mathbb|mathrm)(?![A-Za-z])(?:\[[^\]\n]{1,40}\]|\{[^{}\n]{1,120}\}|[A-Za-z0-9\\()+\-*/=.,:_|^\s]){0,180}/g;
@@ -17,7 +17,32 @@
 
   function isLikelyCurrencyStart(source, index) {
     const tail = source.slice(index);
-    return CURRENCY_START_PATTERN.test(tail) && !CURRENCY_LIKE_LATEX_PATTERN.test(tail);
+    return CURRENCY_START_PATTERN.test(tail) && !isCurrencyLikeLatexStart(tail);
+  }
+
+  function isCurrencyLikeLatexStart(tail) {
+    const amount = tail.match(CURRENCY_AMOUNT_PATTERN);
+    if (!amount) {
+      return false;
+    }
+    const closer = findMathDelimiter(tail, 1, '$');
+    if (closer === -1) {
+      return false;
+    }
+    const expression = tail.slice(amount[0].length, closer);
+    if (/^\s*\\(?:times|cdot|frac|sqrt|lt|gt|le|ge|leq|geq)(?![A-Za-z])/.test(expression)) {
+      return true;
+    }
+    if (!/^\s*[+\-*/=^_<>≤≥]/.test(expression)) {
+      return false;
+    }
+    if (/[A-Za-z]{2,}/.test(expression.replace(/\\[A-Za-z]+/g, ''))) {
+      return false;
+    }
+    return (
+      /[=+\-*/^_<>≤≥\\]/.test(expression)
+      && /[A-Za-z0-9\\{}()[\]^_<>≤≥]/.test(expression)
+    );
   }
 
   function findMathDelimiter(source, start, delimiter) {

--- a/plugin/plugins/study_companion/static/math-parser.js
+++ b/plugin/plugins/study_companion/static/math-parser.js
@@ -92,7 +92,7 @@
       value = value.slice(0, -trailing[0].length);
       consumeLength -= trailing[0].length;
     }
-    const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*$/);
+    const proseTail = value.match(/\s+[A-Za-z]{2,}(?:\s+[A-Za-z]{2,})*[.,;:!?]*$/);
     if (proseTail) {
       value = value.slice(0, -proseTail[0].length);
       consumeLength -= proseTail[0].length;

--- a/plugin/plugins/study_companion/static/style.css
+++ b/plugin/plugins/study_companion/static/style.css
@@ -864,6 +864,104 @@ pre,
   overflow-y: hidden;
 }
 
+#replyText p,
+#replyText h1,
+#replyText h2,
+#replyText h3,
+#replyText h4,
+#replyText ul {
+  margin: 0 0 0.7rem;
+}
+
+#replyText h1,
+#replyText h2,
+#replyText h3,
+#replyText h4 {
+  color: var(--ink);
+  line-height: 1.25;
+}
+
+#replyText h3 {
+  font-size: 17px;
+}
+
+#replyText h4 {
+  font-size: 15px;
+}
+
+#replyText ul {
+  padding-left: 1.3rem;
+}
+
+#replyText li {
+  margin: 0.25rem 0;
+}
+
+#replyText .study-reply-bullet {
+  padding-left: 1.1rem;
+  text-indent: -1.1rem;
+}
+
+#replyText .study-reply-section,
+.study-panel__math-reply .study-reply-section {
+  margin: 0 0 0.85rem;
+  border: 1px solid rgba(31, 35, 41, 0.10);
+  border-left: 4px solid var(--study-section-accent, rgba(47, 125, 87, 0.42));
+  border-radius: var(--radius-sm);
+  background: var(--study-section-bg, rgba(255, 255, 255, 0.72));
+  padding: 10px 12px 11px;
+  white-space: normal;
+}
+
+#replyText .study-reply-section--analysis,
+.study-panel__math-reply .study-reply-section--analysis {
+  --study-section-accent: #2f7d57;
+  --study-section-bg: rgba(47, 125, 87, 0.08);
+}
+
+#replyText .study-reply-section--process,
+.study-panel__math-reply .study-reply-section--process {
+  --study-section-accent: #2f6fbb;
+  --study-section-bg: rgba(47, 111, 187, 0.08);
+}
+
+#replyText .study-reply-section--answer,
+.study-panel__math-reply .study-reply-section--answer {
+  --study-section-accent: #9b6a16;
+  --study-section-bg: rgba(155, 106, 22, 0.09);
+}
+
+#replyText .study-reply-section--transfer,
+.study-panel__math-reply .study-reply-section--transfer {
+  --study-section-accent: #7a4aa0;
+  --study-section-bg: rgba(122, 74, 160, 0.08);
+}
+
+#replyText .study-reply-section__title,
+.study-panel__math-reply .study-reply-section__title {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  margin: 0 0 0.45rem;
+  border-radius: 4px;
+  background: var(--study-section-accent, #2f7d57);
+  color: #fff;
+  padding: 2px 8px;
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+#replyText .study-reply-section__body,
+.study-panel__math-reply .study-reply-section__body {
+  white-space: pre-wrap;
+}
+
+#replyText .study-reply-section > :last-child,
+.study-panel__math-reply .study-reply-section > :last-child {
+  margin-bottom: 0;
+}
+
 #replyText code,
 .study-panel__math-reply code {
   border-radius: 5px;

--- a/plugin/plugins/study_companion/surfaces/study_panel.tsx
+++ b/plugin/plugins/study_companion/surfaces/study_panel.tsx
@@ -6,20 +6,12 @@ type StudyStatus = {
   status?: string;
   active_mode?: string;
   mode?: string;
-  last_reply?: string;
   last_ocr_text?: string;
   last_error?: string;
   screen_classification?: {
     screen_type?: string;
     confidence?: number;
     reason?: string;
-  };
-  current_question?: {
-    question?: string;
-    answer?: string;
-    hint?: string;
-    topic?: string;
-    difficulty?: number;
   };
   last_answer_evaluation?: {
     verdict?: string;
@@ -47,15 +39,29 @@ const MODE_ORDER: Array<{ id: StudyMode; labelKey: string; fallback: string }> =
   { id: 'interactive', labelKey: 'status.mode.interactive', fallback: 'Interactive' },
   { id: 'teaching', labelKey: 'status.mode.teaching', fallback: 'Teaching' },
 ];
-const KATEX_CSS_URL = '/plugin/study_companion/ui/katex.min.css';
-const KATEX_SCRIPT_URL = '/plugin/study_companion/ui/katex.min.js';
-const KATEX_RENDER_SCRIPT_URL = '/plugin/study_companion/ui/katex-render.js';
+const KATEX_ASSET_VERSION = 'study-hotfix-20260615v';
+const KATEX_CSS_URL = `/plugin/study_companion/ui/katex.min.css?v=${KATEX_ASSET_VERSION}`;
+const KATEX_SCRIPT_URL = `/plugin/study_companion/ui/katex.min.js?v=${KATEX_ASSET_VERSION}`;
+const KATEX_RENDER_SCRIPT_URL = `/plugin/study_companion/ui/katex-render.js?v=${KATEX_ASSET_VERSION}`;
 let katexLoadPromise: Promise<void> | null = null;
 
 type MathTextPart = {
   type: 'text' | 'math';
   value: string;
   display?: boolean;
+};
+
+type StudyReplySectionVariant = 'analysis' | 'process' | 'answer' | 'transfer';
+
+type StudyReplyBlock =
+  | { type: 'text'; value: string }
+  | { type: 'section'; variant: StudyReplySectionVariant; title: string; value: string };
+
+const STUDY_REPLY_SECTION_CLASS_BY_VARIANT: Record<StudyReplySectionVariant, string> = {
+  analysis: 'study-reply-section--analysis',
+  process: 'study-reply-section--process',
+  answer: 'study-reply-section--answer',
+  transfer: 'study-reply-section--transfer',
 };
 
 type StudyMathTools = {
@@ -98,11 +104,12 @@ function ensureHostedScript(id: string, src: string) {
     };
     const existing = document.getElementById(id) as HTMLScriptElement | null;
     if (existing) {
-      if (existing.dataset.studyKatexLoaded === 'true') {
+      if (existing.getAttribute('src') !== src) {
+        existing.remove();
+      } else if (existing.dataset.studyKatexLoaded === 'true') {
         resolve();
         return;
-      }
-      if (existing.dataset.studyKatexFailed === 'true') {
+      } else if (existing.dataset.studyKatexFailed === 'true') {
         existing.remove();
       } else {
         existing.addEventListener('load', () => resolveLoad(existing), { once: true });
@@ -128,7 +135,11 @@ function ensureHostedKatex() {
     return katexLoadPromise;
   }
   katexLoadPromise = new Promise((resolve) => {
-    if (!document.getElementById('study-companion-katex-css')) {
+    const existingCss = document.getElementById('study-companion-katex-css') as HTMLLinkElement | null;
+    if (existingCss && existingCss.getAttribute('href') !== KATEX_CSS_URL) {
+      existingCss.href = KATEX_CSS_URL;
+    }
+    if (!existingCss) {
       const link = document.createElement('link');
       link.id = 'study-companion-katex-css';
       link.rel = 'stylesheet';
@@ -165,14 +176,79 @@ function renderMathSpans(root: HTMLElement | null) {
   });
 }
 
+function studyReplySectionMeta(value: string): { variant: StudyReplySectionVariant; title: string } | null {
+  const normalized = String(value || '')
+    .replace(/^#{1,4}\s+/, '')
+    .replace(/^\*\*(.+?)\*\*$/, '$1')
+    .replace(/[：:]\s*$/, '')
+    .trim()
+    .toLowerCase();
+  const variants: Record<string, { variant: StudyReplySectionVariant; title: string }> = {
+    解析: { variant: 'analysis', title: '解析' },
+    题目解析: { variant: 'analysis', title: '题目解析' },
+    題目解析: { variant: 'analysis', title: '題目解析' },
+    'problem analysis': { variant: 'analysis', title: 'Problem Analysis' },
+    解题过程: { variant: 'process', title: '解题过程' },
+    解題過程: { variant: 'process', title: '解題過程' },
+    'solution process': { variant: 'process', title: 'Solution Process' },
+    答案: { variant: 'answer', title: '答案' },
+    'final answer': { variant: 'answer', title: 'Final Answer' },
+    举一反三: { variant: 'transfer', title: '举一反三' },
+    舉一反三: { variant: 'transfer', title: '舉一反三' },
+    'transfer practice': { variant: 'transfer', title: 'Transfer Practice' },
+  };
+  return variants[normalized] || null;
+}
+
+function buildStudyReplyBlocks(text: string): StudyReplyBlock[] {
+  const lines = String(text || '').split(/\r?\n/);
+  const blocks: StudyReplyBlock[] = [];
+  let textLines: string[] = [];
+  let section: Extract<StudyReplyBlock, { type: 'section' }> | null = null;
+  const flushText = () => {
+    if (textLines.length > 0) {
+      blocks.push({ type: 'text', value: textLines.join('\n') });
+      textLines = [];
+    }
+  };
+  const flushSection = () => {
+    if (section) {
+      blocks.push(section);
+      section = null;
+    }
+  };
+  for (const line of lines) {
+    const meta = studyReplySectionMeta(line.trim());
+    if (meta) {
+      flushText();
+      flushSection();
+      section = { type: 'section', variant: meta.variant, title: meta.title, value: '' };
+      continue;
+    }
+    if (section) {
+      section.value = section.value ? `${section.value}\n${line}` : line;
+    } else {
+      textLines.push(line);
+    }
+  }
+  flushText();
+  flushSection();
+  return blocks.length > 0 ? blocks : [{ type: 'text', value: text }];
+}
+
 function MathReply({ text, label }: { text: string; label: string }) {
   const containerRef = useRef<HTMLElement | null>(null);
   const [mathReady, setMathReady] = useState(() => Boolean(getStudyMathTools()));
+  const [mathRenderTick, setMathRenderTick] = useState(0);
   useEffect(() => {
     let active = true;
     ensureHostedKatex().then(() => {
       if (active) {
-        setMathReady(Boolean(getStudyMathTools()));
+        const ready = Boolean(getStudyMathTools());
+        setMathReady(ready);
+        if (ready && hasHostedKatex()) {
+          setMathRenderTick((tick) => tick + 1);
+        }
       }
     });
     return () => {
@@ -183,9 +259,27 @@ function MathReply({ text, label }: { text: string; label: string }) {
     if (mathReady) {
       renderMathSpans(containerRef.current);
     }
-  }, [mathReady, text]);
+  }, [mathReady, mathRenderTick, text]);
   const mathTools = mathReady ? getStudyMathTools() : null;
   const parts: MathTextPart[] = mathTools ? mathTools.splitByMath(text) : [{ type: 'text', value: text }];
+  const renderParts = (items: MathTextPart[], keyPrefix: string) => items.map((part, index) => {
+    if (part.type === 'math') {
+      const wrapper = part.display ? '$$' : '$';
+      return (
+        <span
+          key={`${keyPrefix}-math-${index}`}
+          data-study-math="true"
+          data-display={part.display ? 'true' : 'false'}
+          data-math={part.value}
+        >
+          {wrapper}{part.value}{wrapper}
+        </span>
+      );
+    }
+    return <span key={`${keyPrefix}-text-${index}`}>{part.value}</span>;
+  });
+  const blocks = buildStudyReplyBlocks(text);
+  const hasStudySections = blocks.some((block) => block.type === 'section');
   return (
     <div
       ref={containerRef}
@@ -194,22 +288,26 @@ function MathReply({ text, label }: { text: string; label: string }) {
       aria-live="polite"
       aria-label={label}
     >
-      {parts.map((part, index) => {
-        if (part.type === 'math') {
-          const wrapper = part.display ? '$$' : '$';
-          return (
-            <span
-              key={`math-${index}`}
-              data-study-math="true"
-              data-display={part.display ? 'true' : 'false'}
-              data-math={part.value}
-            >
-              {wrapper}{part.value}{wrapper}
-            </span>
-          );
-        }
-        return <span key={`text-${index}`}>{part.value}</span>;
-      })}
+      {hasStudySections
+        ? blocks.map((block, index) => {
+          if (block.type === 'section') {
+            const sectionParts = mathTools ? mathTools.splitByMath(block.value) : [{ type: 'text' as const, value: block.value }];
+            return (
+              <section
+                key={`section-${index}`}
+                className={`study-reply-section ${STUDY_REPLY_SECTION_CLASS_BY_VARIANT[block.variant]}`}
+              >
+                <h3 className="study-reply-section__title">{block.title}</h3>
+                <div className="study-reply-section__body">
+                  {renderParts(sectionParts, `section-${index}`)}
+                </div>
+              </section>
+            );
+          }
+          const textParts = mathTools ? mathTools.splitByMath(block.value) : [{ type: 'text' as const, value: block.value }];
+          return <span key={`text-block-${index}`}>{renderParts(textParts, `text-block-${index}`)}</span>;
+        })
+        : renderParts(parts, 'reply')}
     </div>
   );
 }
@@ -485,7 +583,6 @@ export default function StudyPanel(props: PluginSurfaceProps) {
   const explainControllerRef = useRef<AbortController | null>(null);
   const pasteControllerRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(false);
-  const textAutoFilledFromOcrRef = useRef(false);
   const textImageRef = useRef('');
   const pastePendingRef = useRef(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -543,9 +640,6 @@ export default function StudyPanel(props: PluginSurfaceProps) {
     const screen = data.screen_classification && typeof data.screen_classification === 'object'
       ? data.screen_classification as Record<string, unknown>
       : undefined;
-    const question = data.current_question && typeof data.current_question === 'object'
-      ? data.current_question as Record<string, unknown>
-      : undefined;
     const evaluation = data.last_answer_evaluation && typeof data.last_answer_evaluation === 'object'
       ? data.last_answer_evaluation as Record<string, unknown>
       : undefined;
@@ -553,20 +647,12 @@ export default function StudyPanel(props: PluginSurfaceProps) {
       status: typeof data.status === 'string' ? data.status : undefined,
       active_mode: typeof data.active_mode === 'string' ? data.active_mode : undefined,
       mode: typeof data.mode === 'string' ? data.mode : undefined,
-      last_reply: typeof data.last_reply === 'string' ? data.last_reply : undefined,
       last_ocr_text: typeof data.last_ocr_text === 'string' ? data.last_ocr_text : undefined,
       last_error: typeof data.last_error === 'string' ? data.last_error : undefined,
       screen_classification: screen ? {
         screen_type: typeof screen.screen_type === 'string' ? screen.screen_type : undefined,
         confidence: typeof screen.confidence === 'number' ? screen.confidence : undefined,
         reason: typeof screen.reason === 'string' ? screen.reason : undefined,
-      } : undefined,
-      current_question: question ? {
-        question: typeof question.question === 'string' ? question.question : undefined,
-        answer: typeof question.answer === 'string' ? question.answer : undefined,
-        hint: typeof question.hint === 'string' ? question.hint : undefined,
-        topic: typeof question.topic === 'string' ? question.topic : undefined,
-        difficulty: typeof question.difficulty === 'number' ? question.difficulty : undefined,
       } : undefined,
       last_answer_evaluation: evaluation ? {
         verdict: typeof evaluation.verdict === 'string' ? evaluation.verdict : undefined,
@@ -600,12 +686,6 @@ export default function StudyPanel(props: PluginSurfaceProps) {
 
   function setStatusLine(data: StudyStatus) {
     setStatus({ ...data, active_mode: String(data.active_mode || data.mode || 'companion') });
-    setQuestion(data.current_question?.question || '');
-  }
-
-  function setManualText(value: string) {
-    textAutoFilledFromOcrRef.current = false;
-    setText(value);
   }
 
   function setTextImageValue(value: string) {
@@ -613,31 +693,12 @@ export default function StudyPanel(props: PluginSurfaceProps) {
     setTextImage(value);
   }
 
-  function clearAutoFilledTextOnImagePaste() {
-    if (!textAutoFilledFromOcrRef.current) {
-      return;
-    }
-    textAutoFilledFromOcrRef.current = false;
-    setText('');
-  }
-
-  async function refresh(signal?: AbortSignal, options: { updateReply?: boolean } = {}) {
-    const updateReply = options.updateReply !== false;
+  async function refresh(signal?: AbortSignal, _options: { updateReply?: boolean } = {}) {
     const data = normalizeStudyStatus(await callStudyPlugin(props.api, 'study_status', {}, signal));
     if (signal?.aborted) {
       return;
     }
     setStatusLine(data);
-    if (updateReply) {
-      setReply(data.last_reply || '');
-    }
-    setText((prev) => {
-      if (textImageRef.current || prev.trim() || !data.last_ocr_text) {
-        return prev;
-      }
-      textAutoFilledFromOcrRef.current = true;
-      return data.last_ocr_text;
-    });
   }
 
   async function setMode(mode: StudyMode) {
@@ -890,10 +951,9 @@ export default function StudyPanel(props: PluginSurfaceProps) {
   const handleTextPaste = createPasteHandler(
     {
       setImage: setTextImageValue,
-      setTextValue: setManualText,
+      setTextValue: setText,
       setPasteError: setTextPasteError,
       setPastePending: setPastePendingState,
-      onImageAccepted: clearAutoFilledTextOnImagePaste,
       pasteErrorMessage: t('ui.error.image_paste_failed', 'Image paste failed. Please try a smaller JPEG or PNG image.'),
       unsupportedTypeMessage: t('ui.error.image_paste_unsupported', 'Only JPEG and PNG images can be pasted here.'),
     },
@@ -959,7 +1019,7 @@ export default function StudyPanel(props: PluginSurfaceProps) {
         </div>
         <div>
           <span>{t('ui.label.question', 'Question')}</span>
-          <strong>{compactText(question || status.current_question?.question)}</strong>
+          <strong>{compactText(question)}</strong>
         </div>
         <div>
           <span>{t('ui.label.answer', 'Answer')}</span>
@@ -971,7 +1031,7 @@ export default function StudyPanel(props: PluginSurfaceProps) {
         placeholder={t('ui.placeholder.input', 'Paste a concept, problem statement, or OCR text here.')}
         value={text}
         readOnly={interactionBusy}
-        onChange={(event) => setManualText(event.target.value)}
+        onChange={(event) => setText(event.target.value)}
         onPaste={handleTextPaste}
       />
       {textImage ? (

--- a/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
+++ b/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
@@ -270,6 +270,54 @@ export const BRAND_CSS = `
     color: var(--ink);
   }
 
+  .study-panel__math-reply .study-reply-section {
+    margin: 0 0 0.85rem;
+    border: 1px solid rgba(31, 35, 41, 0.10);
+    border-left: 4px solid var(--study-section-accent, rgba(47, 125, 87, 0.42));
+    border-radius: var(--radius-sm);
+    background: var(--study-section-bg, rgba(255, 255, 255, 0.72));
+    padding: 10px 12px 11px;
+    white-space: normal;
+  }
+
+  .study-panel__math-reply .study-reply-section--analysis {
+    --study-section-accent: #2f7d57;
+    --study-section-bg: rgba(47, 125, 87, 0.08);
+  }
+
+  .study-panel__math-reply .study-reply-section--process {
+    --study-section-accent: #2f6fbb;
+    --study-section-bg: rgba(47, 111, 187, 0.08);
+  }
+
+  .study-panel__math-reply .study-reply-section--answer {
+    --study-section-accent: #9b6a16;
+    --study-section-bg: rgba(155, 106, 22, 0.09);
+  }
+
+  .study-panel__math-reply .study-reply-section--transfer {
+    --study-section-accent: #7a4aa0;
+    --study-section-bg: rgba(122, 74, 160, 0.08);
+  }
+
+  .study-panel__math-reply .study-reply-section__title {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    margin: 0 0 0.45rem;
+    border-radius: 4px;
+    background: var(--study-section-accent, #2f7d57);
+    color: #fff;
+    padding: 2px 8px;
+    font-size: 13px;
+    font-weight: 800;
+    line-height: 1.35;
+  }
+
+  .study-panel__math-reply .study-reply-section__body {
+    white-space: pre-wrap;
+  }
+
   .study-panel textarea {
     resize: vertical;
     background-image:

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -313,7 +313,7 @@ async def test_study_plugin_startup_auto_opens_static_ui(
 
     try:
         assert isinstance(result, Ok)
-        assert opened == ["http://127.0.0.1:49888/ui/plugins/study_companion?tab=ui"]
+        assert opened == ["http://127.0.0.1:49888/plugin/study_companion/ui/"]
     finally:
         await plugin.shutdown()
 
@@ -339,7 +339,7 @@ async def test_study_plugin_startup_auto_open_falls_back_for_invalid_port(
 
     try:
         assert isinstance(result, Ok)
-        assert opened == ["http://127.0.0.1:48916/ui/plugins/study_companion?tab=ui"]
+        assert opened == ["http://127.0.0.1:48916/plugin/study_companion/ui/"]
     finally:
         await plugin.shutdown()
 
@@ -2458,7 +2458,7 @@ def test_study_companion_hosted_panel_uses_long_running_entry_poll_budget() -> N
     assert "fetch(`/runs/" not in source
     assert "for (let i = 0; i < 40; i += 1)" not in source
     assert (
-        "async function refresh(signal?: AbortSignal, options: { updateReply?: boolean } = {})"
+        "async function refresh(signal?: AbortSignal, _options: { updateReply?: boolean } = {})"
         in source
     )
     assert "await refresh(controller.signal, { updateReply: false });" in source
@@ -2544,13 +2544,16 @@ def test_study_companion_hosted_panel_supports_image_paste_contract() -> None:
     assert "if (textImage) genArgs.vision_image_base64 = textImage;" in source
     assert "if (!answer.trim() && !answerImage)" in source
     assert "if (answerImage) evalArgs.vision_image_base64 = answerImage;" in source
-    assert "const textAutoFilledFromOcrRef = useRef(false);" in source
     assert "const textImageRef = useRef('');" in source
-    assert "textAutoFilledFromOcrRef.current = true;" in source
     assert "textImageRef.current = value;" in source
-    assert "if (textImageRef.current || prev.trim() || !data.last_ocr_text)" in source
+    assert "textAutoFilledFromOcrRef" not in source
+    assert "data.last_ocr_text" in source
+    assert "return data.last_ocr_text;" not in source
+    assert "data.current_question" not in source
+    assert "setQuestion(data.current_question?.question || '')" not in source
+    assert "status.current_question?.question" not in source
     assert "setPastePending: setPastePendingState," in source
-    assert "onImageAccepted: clearAutoFilledTextOnImagePaste," in source
+    assert "onImageAccepted: clearAutoFilledTextOnImagePaste," not in source
     assert "setTextImageValue('');" in source
     assert "setAnswerImage('');" in source
     assert 'data-busy={interactionBusy ? "true" : "false"}' in source

--- a/plugin/tests/unit/plugins/test_study_companion_integration_mode_flow.py
+++ b/plugin/tests/unit/plugins/test_study_companion_integration_mode_flow.py
@@ -49,7 +49,8 @@ def test_integration_mode_switch_persists_context_and_status_payload(tmp_path: P
 
         assert switched["changed"] is True
         assert payload["active_mode"] == MODE_TEACHING
-        assert payload["current_question"]["topic"] == "calculus"
+        assert loaded.current_question["topic"] == "calculus"
+        assert "current_question" not in payload
         assert payload["recent_learning_events"][0]["kind"] == "question_generate"
     finally:
         store.close()

--- a/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
@@ -293,6 +293,25 @@ def test_phase9_reply_renderer_keeps_currency_ranges_as_text() -> None:
     assert 'class="katex"' not in html
 
 
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_keeps_currency_prose_before_bare_latex_as_text(asset_name: str) -> None:
+    parts = _split_math_with_node(asset_name, "Price is $20 and formula \\frac{1}{2}.")
+
+    assert parts == [
+        {"type": "text", "value": "Price is $20 and formula "},
+        {"type": "math", "value": "\\frac{1}{2}", "display": False},
+        {"type": "text", "value": "."},
+    ]
+
+
+def test_phase9_reply_renderer_keeps_currency_prose_before_bare_latex_as_text() -> None:
+    html = _render_reply_with_node("Price is $20 and formula \\frac{1}{2}.")
+
+    assert "Price is $20 and formula " in html
+    assert '<span class="katex" data-display="false">\\frac{1}{2}</span>' in html
+    assert "20 and formula \\frac" not in html
+
+
 def test_phase9_reply_renderer_does_not_swallow_markdown_after_bare_latex() -> None:
     html = _render_reply_with_node(
         "*   $8 \\\\times 1 = 8。\n"

--- a/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import re
+import shutil
+import subprocess
 
 import pytest
 
@@ -20,9 +22,12 @@ def test_phase9_static_math_assets_are_local_and_registered() -> None:
     assert (PLUGIN_DIR / "static" / "katex.min.js").is_file()
     assert (PLUGIN_DIR / "static" / "katex.min.css").is_file()
     assert len(list((PLUGIN_DIR / "static" / "fonts").glob("KaTeX_*"))) >= 20
-    assert '<link rel="stylesheet" href="./katex.min.css" />' in index
-    assert '<script src="./katex.min.js"></script>' in index
-    assert '<script src="./katex-render.js"></script>' in index
+    css = (PLUGIN_DIR / "static" / "style.css").read_text(encoding="utf-8")
+
+    assert '<link rel="stylesheet" href="./katex.min.css?v=study-hotfix-20260615v" />' in index
+    assert '<script src="./katex.min.js?v=study-hotfix-20260615v"></script>' in index
+    assert '<script src="./katex-render.js?v=study-hotfix-20260615v"></script>' in index
+    assert '<script src="./main.js?v=study-hotfix-20260615v"></script>' in index
     assert "window.renderMathInText" in renderer
     assert "window.__studyCompanionMath" in renderer
     assert "normalizeLatexForKatex" in renderer
@@ -33,10 +38,317 @@ def test_phase9_static_math_assets_are_local_and_registered() -> None:
     assert "function isLikelyCurrencyStart" in renderer
     assert "function findMathDelimiter" in renderer
     assert "function findBackslashMathDelimiter" in renderer
+    assert "function hasMathSyntax" in renderer
+    assert "BARE_LATEX_SPAN_PATTERN" in renderer
     assert "source.includes('\\\\(')" in renderer
     assert "source.includes('\\\\[')" in renderer
     assert "trust: false" in renderer
     assert "replyText.innerHTML = window.renderMathInText(value)" in main_js
+    assert "let lastReplyValue = ''" in main_js
+    assert "window.setTimeout(() => {" in main_js
+
+
+def _split_math_with_node(asset_name: str, text: str) -> list[dict[str, object]]:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    source = (PLUGIN_DIR / "static" / asset_name).read_text(encoding="utf-8")
+    script = f"""
+global.window = {{}};
+global.document = {{
+  createElement() {{
+    return {{
+      appendChild() {{}},
+      get innerHTML() {{ return ''; }},
+    }};
+  }},
+  createTextNode() {{ return {{}}; }},
+}};
+{source}
+const tools = window.__studyCompanionMath || window.__studyCompanionMathParser;
+console.log(JSON.stringify(tools.splitByMath({json.dumps(text)})));
+"""
+    result = subprocess.run(
+        [node, "-e", script],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    return json.loads(result.stdout)
+
+
+def _render_reply_with_node(text: str) -> str:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    source = (PLUGIN_DIR / "static" / "katex-render.js").read_text(encoding="utf-8")
+    script = f"""
+global.window = {{
+  katex: {{
+    renderToString(latex, options) {{
+      return `<span class="katex" data-display="${{options.displayMode ? 'true' : 'false'}}">${{latex}}</span>`;
+    }},
+  }},
+}};
+global.document = {{
+  createElement() {{
+    return {{
+      _text: '',
+      appendChild(node) {{ this._text += node.text || ''; }},
+      get innerHTML() {{
+        return this._text
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;');
+      }},
+    }};
+  }},
+  createTextNode(text) {{ return {{ text: String(text || '') }}; }},
+}};
+{source}
+console.log(window.renderMathInText({json.dumps(text)}));
+"""
+    result = subprocess.run(
+        [node, "-e", script],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    return result.stdout.strip()
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_recognizes_bare_vector_norm(asset_name: str) -> None:
+    parts = _split_math_with_node(
+        asset_name,
+        "$8 \\times 1 = 8。∗。∗\\sum_{i=1}^8 \\vec{OA_i} = \\vec{0}",
+    )
+
+    assert parts == [
+        {"type": "math", "value": "8 \\times 1 = 8", "display": False},
+        {"type": "text", "value": "。∗。∗"},
+        {
+            "type": "math",
+            "value": "\\sum_{i=1}^8 \\vec{OA_i} = \\vec{0}",
+            "display": False,
+        },
+    ]
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_keeps_display_vector_norm(asset_name: str) -> None:
+    parts = _split_math_with_node(
+        asset_name,
+        "$$ S = 8|\\vec{PO}|^2 + 8 $$",
+    )
+
+    assert parts == [
+        {"type": "math", "value": "S = 8|\\vec{PO}|^2 + 8", "display": True},
+    ]
+
+
+def test_phase9_reply_renderer_normalizes_double_escaped_latex() -> None:
+    html = _render_reply_with_node("$$ S = 8|\\\\vec{PO}|^2 + 8 $$")
+
+    assert '<span class="katex" data-display="true">S = 8|\\vec{PO}|^2 + 8</span>' in html
+    assert "\\\\vec" not in html
+    assert "$$" not in html
+
+
+def test_phase9_reply_renderer_accepts_escaped_display_delimiters() -> None:
+    html = _render_reply_with_node("\\$\\$ S = 8|\\\\vec{PO}|^2 + 8 \\$\\$")
+
+    assert '<span class="katex" data-display="true">S = 8|\\vec{PO}|^2 + 8</span>' in html
+    assert "\\$\\$" not in html
+
+
+def test_phase9_reply_renderer_accepts_multiline_display_cases_block() -> None:
+    html = _render_reply_with_node(
+        "$$\n\n"
+        "\\begin{cases}\n\n"
+        "2 - x = 0 \\\\\n\n"
+        "y + 3 = 0\n\n"
+        "\\end{cases}\n\n"
+        "$$"
+    )
+
+    assert '<span class="katex" data-display="true">' in html
+    assert "\\begin{cases}\n\n2 - x = 0 \\\\\n\ny + 3 = 0\n\n\\end{cases}" in html
+    assert "<p>$$</p>" not in html
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_tolerates_duplicate_inline_closing_dollar(asset_name: str) -> None:
+    parts = _split_math_with_node(asset_name, "即 $8 \\times 1 = 8$$。")
+
+    assert parts == [
+        {"type": "text", "value": "即 "},
+        {"type": "math", "value": "8 \\times 1 = 8", "display": False},
+        {"type": "text", "value": "。"},
+    ]
+
+
+def test_phase9_reply_renderer_tolerates_duplicate_inline_closing_dollar() -> None:
+    html = _render_reply_with_node("即 $8 \\times 1 = 8$$。")
+
+    assert '<span class="katex" data-display="false">8 \\times 1 = 8</span>。' in html
+    assert "$$。" not in html
+    assert "$8 \\times 1 = 8" not in html
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_accepts_set_definition_inequality(asset_name: str) -> None:
+    parts = _split_math_with_node(
+        asset_name,
+        "$D(x_0) = \\{d \\in \\mathbb{R} \\mid f(x_0 + d) > f(x_0)\\}$\u3002",
+    )
+
+    assert parts == [
+        {
+            "type": "math",
+            "value": "D(x_0) = \\{d \\in \\mathbb{R} \\mid f(x_0 + d) > f(x_0)\\}",
+            "display": False,
+        },
+        {"type": "text", "value": "\u3002"},
+    ]
+
+
+def test_phase9_reply_renderer_accepts_set_definition_inequality() -> None:
+    html = _render_reply_with_node(
+        "$D(x_0) = \\{d \\in \\mathbb{R} \\mid f(x_0 + d) > f(x_0)\\}$\u3002"
+    )
+
+    assert (
+        '<span class="katex" data-display="false">'
+        "D(x_0) = \\{d \\in \\mathbb{R} \\mid f(x_0 + d) \\gt  f(x_0)\\}"
+        "</span>\u3002"
+    ) in html
+    assert "$D(" not in html
+    assert "&gt;" not in html
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_treats_zero_started_inequality_as_math_not_currency(
+    asset_name: str,
+) -> None:
+    parts = _split_math_with_node(
+        asset_name,
+        "Proof: assume $0 < a < b$ but $f(a) > f(b)$.",
+    )
+
+    assert parts == [
+        {"type": "text", "value": "Proof: assume "},
+        {"type": "math", "value": "0 < a < b", "display": False},
+        {"type": "text", "value": " but "},
+        {"type": "math", "value": "f(a) > f(b)", "display": False},
+        {"type": "text", "value": "."},
+    ]
+
+
+def test_phase9_reply_renderer_treats_zero_started_inequality_as_math_not_currency() -> None:
+    html = _render_reply_with_node(
+        "Proof: assume $0 < a < b$ but $f(a) > f(b)$."
+    )
+
+    assert '<span class="katex" data-display="false">0 \\lt  a \\lt  b</span>' in html
+    assert '<span class="katex" data-display="false">f(a) \\gt  f(b)</span>' in html
+    assert "$0 < a < b$" not in html
+    assert "$f(a) > f(b)$" not in html
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_keeps_plain_currency_as_text(asset_name: str) -> None:
+    parts = _split_math_with_node(asset_name, "Cost is $20, then compare $x > 1$.")
+
+    assert parts == [
+        {"type": "text", "value": "Cost is $20, then compare "},
+        {"type": "math", "value": "x > 1", "display": False},
+        {"type": "text", "value": "."},
+    ]
+
+
+def test_phase9_reply_renderer_does_not_swallow_markdown_after_bare_latex() -> None:
+    html = _render_reply_with_node(
+        "*   $8 \\\\times 1 = 8。\n"
+        "**第三步：得到简化表达式**\n"
+        "$$ S = 8|\\\\vec{PO}|^2 + 8 $$"
+    )
+
+    assert 'class="study-reply-bullet"' in html
+    assert "<li>" not in html
+    assert "<strong>第三步：得到简化表达式</strong>" in html
+    assert '<span class="katex" data-display="true">S = 8|\\vec{PO}|^2 + 8</span>' in html
+    assert "$$" not in html
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_keeps_bare_latex_on_one_line(asset_name: str) -> None:
+    parts = _split_math_with_node(
+        asset_name,
+        "*。∗\\sum_{i=1}^8 \\vec{OA_i} = \\vec{0}（正多边形顶点向量和为零向量）\n"
+        "**第三步：得到简化表达式**\n"
+        "$$ S = 8|\\\\vec{PO}|^2 + 8 $$",
+    )
+
+    math_values = [str(part["value"]) for part in parts if part["type"] == "math"]
+
+    assert any(value == "S = 8|\\\\vec{PO}|^2 + 8" for value in math_values)
+    assert all("$$" not in value for value in math_values)
+    assert all("**" not in value for value in math_values)
+    assert all("\n" not in value for value in math_values)
+
+
+def test_phase9_reply_renderer_handles_markdown_without_raw_html() -> None:
+    html = _render_reply_with_node(
+        "### 步骤\n**重点**：向量\n*   第一项 $x^2$\n<script>alert(1)</script>"
+    )
+
+    assert "<h3>步骤</h3>" in html
+    assert "<strong>重点</strong>" in html
+    assert 'class="study-reply-bullet"' in html
+    assert "&bull; 第一项 " in html
+    assert '<span class="katex" data-display="false">x^2</span>' in html
+    assert "<script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
+def test_phase9_reply_renderer_highlights_study_answer_sections() -> None:
+    html = _render_reply_with_node(
+        "解析\n先看条件。\n\n"
+        "解题过程\n计算 $x^2$。\n\n"
+        "答案\nA\n\n"
+        "举一反三\n换成同类条件。"
+    )
+
+    assert 'class="study-reply-section study-reply-section--analysis"' in html
+    assert 'class="study-reply-section study-reply-section--process"' in html
+    assert 'class="study-reply-section study-reply-section--answer"' in html
+    assert 'class="study-reply-section study-reply-section--transfer"' in html
+    assert '<h3 class="study-reply-section__title">解析</h3>' in html
+    assert '<span class="katex" data-display="false">x^2</span>' in html
+    assert html.index("study-reply-section--analysis") < html.index("study-reply-section--process")
+    assert html.index("study-reply-section--process") < html.index("study-reply-section--answer")
+    assert html.index("study-reply-section--answer") < html.index("study-reply-section--transfer")
+
+
+def test_phase9_reply_renderer_keeps_step_five_markdown_out_of_math() -> None:
+    html = _render_reply_with_node(
+        "**第四步：分析点$P$的位置**\n"
+        "$|PO|_{max} = |OA_1| = 1$。\n"
+        "**第五步：计算数值范围**\n"
+        "$|PO|^2$的范围是$[\\cos^2(22.5^\\circ), 1]$。**利用半角公式：**"
+    )
+
+    assert "<strong>第四步：分析点" in html
+    assert "<strong>第五步：计算数值范围</strong>" in html
+    assert "<strong>利用半角公式：</strong>" in html
+    assert 'data-display="false">|PO|_{max} = |OA_1| = 1</span>' in html
+    assert 'data-display="false">|PO|^2</span>的范围是' in html
+    assert 'data-display="false">[\\cos^2(22.5^\\circ), 1]</span>' in html
+    assert "∗∗第五步" not in html
+    assert "第五步：计算数值范围∗" not in html
+    assert 'data-display="false">的范围是</span>' not in html
 
 
 def test_phase9_hosted_study_panel_uses_span_based_katex_rendering() -> None:
@@ -46,12 +358,20 @@ def test_phase9_hosted_study_panel_uses_span_based_katex_rendering() -> None:
     assert "dangerouslySetInnerHTML" not in source
     assert "/plugin/study_companion/ui/katex.min.js" in source
     assert "/plugin/study_companion/ui/katex-render.js" in source
+    assert "KATEX_ASSET_VERSION = 'study-hotfix-20260615v'" in source
+    assert "existing.getAttribute('src') !== src" in source
     assert "window as any).__studyCompanionMath" in source
     assert "function getStudyMathTools" in source
     assert "function normalizeLatexForKatex" not in source
+    assert "const [mathRenderTick, setMathRenderTick] = useState(0)" in source
+    assert "setMathRenderTick((tick) => tick + 1)" in source
+    assert "[mathReady, mathRenderTick, text]" in source
     assert "katexLoadPromise = null" in source
     assert "dataset.studyKatexFailed" in source
     assert "data-study-math" in source
+    assert "study-reply-section--analysis" in source
+    assert "study-reply-section--process" in source
+    assert "study-reply-section--transfer" in source
     assert "function hasEscapedDelimiter" not in source
     assert "function isLikelyCurrencyStart" not in source
     assert "function findMathDelimiter" not in source

--- a/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
@@ -357,6 +357,14 @@ def test_phase9_reply_renderer_handles_markdown_without_raw_html() -> None:
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
 
 
+def test_phase9_reply_renderer_preserves_asterisks_inside_code_spans() -> None:
+    html = _render_reply_with_node("Use `x**2` in Python, not 2 ** 3.")
+
+    assert "<code>x**2</code>" in html
+    assert "not 2 ** 3" in html
+    assert "<code>x2</code>" not in html
+
+
 @pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
 def test_phase9_math_parser_keeps_punctuated_english_after_bare_latex_as_text(
     asset_name: str,

--- a/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
@@ -187,6 +187,16 @@ def test_phase9_reply_renderer_preserves_text_after_display_math_closer() -> Non
     assert "therefore x=1" in html
 
 
+def test_phase9_reply_renderer_preserves_prose_before_multiline_display_math() -> None:
+    html = _render_reply_with_node("Here is $$\nx=1\n$$ done")
+
+    assert "<p>Here is</p>" in html
+    assert '<span class="katex" data-display="true">x=1</span>' in html
+    assert "<p>done</p>" in html
+    assert "<p>Here is $$</p>" not in html
+    assert "<p>$$ done</p>" not in html
+
+
 @pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
 def test_phase9_math_parser_tolerates_duplicate_inline_closing_dollar(asset_name: str) -> None:
     parts = _split_math_with_node(asset_name, "即 $8 \\times 1 = 8$$。")
@@ -363,6 +373,14 @@ def test_phase9_reply_renderer_preserves_asterisks_inside_code_spans() -> None:
     assert "<code>x**2</code>" in html
     assert "not 2 ** 3" in html
     assert "<code>x2</code>" not in html
+
+
+def test_phase9_reply_renderer_keeps_latex_literal_inside_code_spans() -> None:
+    html = _render_reply_with_node("Use `\\frac{1}{2}` literally, then $x^2$.")
+
+    assert "<code>\\frac{1}{2}</code>" in html
+    assert '<span class="katex" data-display="false">x^2</span>' in html
+    assert '<span class="katex" data-display="false">\\frac{1}{2}</span>' not in html
 
 
 @pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])

--- a/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
@@ -22,7 +22,6 @@ def test_phase9_static_math_assets_are_local_and_registered() -> None:
     assert (PLUGIN_DIR / "static" / "katex.min.js").is_file()
     assert (PLUGIN_DIR / "static" / "katex.min.css").is_file()
     assert len(list((PLUGIN_DIR / "static" / "fonts").glob("KaTeX_*"))) >= 20
-    css = (PLUGIN_DIR / "static" / "style.css").read_text(encoding="utf-8")
 
     assert '<link rel="stylesheet" href="./katex.min.css?v=study-hotfix-20260615v" />' in index
     assert '<script src="./katex.min.js?v=study-hotfix-20260615v"></script>' in index
@@ -73,6 +72,7 @@ console.log(JSON.stringify(tools.splitByMath({json.dumps(text)})));
         check=True,
         capture_output=True,
         encoding="utf-8",
+        timeout=10,
     )
     return json.loads(result.stdout)
 
@@ -114,6 +114,7 @@ console.log(window.renderMathInText({json.dumps(text)}));
         check=True,
         capture_output=True,
         encoding="utf-8",
+        timeout=10,
     )
     return result.stdout.strip()
 
@@ -311,6 +312,28 @@ def test_phase9_reply_renderer_handles_markdown_without_raw_html() -> None:
     assert '<span class="katex" data-display="false">x^2</span>' in html
     assert "<script>" not in html
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_keeps_punctuated_english_after_bare_latex_as_text(
+    asset_name: str,
+) -> None:
+    parts = _split_math_with_node(asset_name, "Use \\frac{1}{2} as the coefficient.")
+
+    assert parts == [
+        {"type": "text", "value": "Use "},
+        {"type": "math", "value": "\\frac{1}{2}", "display": False},
+        {"type": "text", "value": " as the coefficient."},
+    ]
+
+
+def test_phase9_reply_renderer_accepts_display_block_with_opening_content() -> None:
+    html = _render_reply_with_node("Start\n$$ S = 1 +\n2 $$\nEnd")
+
+    assert '<span class="katex" data-display="true">S = 1 +\n2</span>' in html
+    assert "<p>$$" not in html
+    assert "<p>Start</p>" in html
+    assert "<p>End</p>" in html
 
 
 def test_phase9_reply_renderer_highlights_study_answer_sections() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
@@ -179,6 +179,14 @@ def test_phase9_reply_renderer_accepts_multiline_display_cases_block() -> None:
     assert "<p>$$</p>" not in html
 
 
+def test_phase9_reply_renderer_preserves_text_after_display_math_closer() -> None:
+    html = _render_reply_with_node("$$\nx=1\n$$ therefore x=1")
+
+    assert '<span class="katex" data-display="true">x=1</span>' in html
+    assert "<p>therefore x=1</p>" in html
+    assert "therefore x=1" in html
+
+
 @pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
 def test_phase9_math_parser_tolerates_duplicate_inline_closing_dollar(asset_name: str) -> None:
     parts = _split_math_with_node(asset_name, "即 $8 \\times 1 = 8$$。")

--- a/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase9_ux.py
@@ -277,6 +277,22 @@ def test_phase9_math_parser_keeps_plain_currency_as_text(asset_name: str) -> Non
     ]
 
 
+@pytest.mark.parametrize("asset_name", ["katex-render.js", "math-parser.js"])
+def test_phase9_math_parser_keeps_currency_ranges_as_text(asset_name: str) -> None:
+    parts = _split_math_with_node(asset_name, "Cost is $20 - $30, or $20 + tax and $30 max.")
+
+    assert parts == [
+        {"type": "text", "value": "Cost is $20 - $30, or $20 + tax and $30 max."},
+    ]
+
+
+def test_phase9_reply_renderer_keeps_currency_ranges_as_text() -> None:
+    html = _render_reply_with_node("Cost is $20 - $30, or $20 + tax and $30 max.")
+
+    assert "<p>Cost is $20 - $30, or $20 + tax and $30 max.</p>" in html
+    assert 'class="katex"' not in html
+
+
 def test_phase9_reply_renderer_does_not_swallow_markdown_after_bare_latex() -> None:
     html = _render_reply_with_node(
         "*   $8 \\\\times 1 = 8。\n"

--- a/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
+++ b/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
@@ -55,6 +55,7 @@ def test_service_payload_builders_preserve_nested_state_and_reply_payloads() -> 
     assert status["is_first_run"] is True
     assert status["history"] == [{"role": "user"}]
     assert status["weak_topics"] == [{"topic_id": "t"}]
+    assert "current_question" not in status
     assert build_tutor_payload(reply)["summary"] == "structured"
     assert build_explain_payload(reply)["extra"] == {"nested": True}
     assert build_ocr_payload(snapshot)["summary"] == "ocr text"

--- a/plugin/tests/unit/plugins/test_study_companion_ui_render.py
+++ b/plugin/tests/unit/plugins/test_study_companion_ui_render.py
@@ -447,12 +447,23 @@ def test_study_companion_math_and_mastery_colors_meet_contrast_contract() -> Non
 
     assert "#replyText .katex" in style_css
     assert ".study-panel__math-reply .katex" in style_css
+    assert "#replyText .study-reply-section" in style_css
+    assert ".study-panel__math-reply .study-reply-section" in style_css
+    assert ".study-reply-section--analysis" in style_css
+    assert ".study-reply-section--process" in style_css
+    assert ".study-reply-section--answer" in style_css
+    assert ".study-reply-section--transfer" in style_css
+    assert ".study-reply-section__title" in style_css
     assert re.search(
         r"#replyText \.katex,\s*\.study-panel__math-reply \.katex \{[^}]*color: var\(--ink\);",
         style_css,
         flags=re.DOTALL,
     )
     assert ".study-panel__math-reply .katex" in surface_utils
+    assert ".study-panel__math-reply .study-reply-section" in surface_utils
+    assert ".study-panel__math-reply .study-reply-section--analysis" in surface_utils
+    assert ".study-panel__math-reply .study-reply-section--process" in surface_utils
+    assert ".study-panel__math-reply .study-reply-section--transfer" in surface_utils
     assert re.search(
         r"\.study-panel__math-reply \.katex \{[^}]*color: var\(--ink\);",
         surface_utils,

--- a/plugin/tests/unit/plugins/test_study_companion_ui_render.py
+++ b/plugin/tests/unit/plugins/test_study_companion_ui_render.py
@@ -463,6 +463,7 @@ def test_study_companion_math_and_mastery_colors_meet_contrast_contract() -> Non
     assert ".study-panel__math-reply .study-reply-section" in surface_utils
     assert ".study-panel__math-reply .study-reply-section--analysis" in surface_utils
     assert ".study-panel__math-reply .study-reply-section--process" in surface_utils
+    assert ".study-panel__math-reply .study-reply-section--answer" in surface_utils
     assert ".study-panel__math-reply .study-reply-section--transfer" in surface_utils
     assert re.search(
         r"\.study-panel__math-reply \.katex \{[^}]*color: var\(--ink\);",


### PR DESCRIPTION
﻿## 为什么改
伴学回复区在包含复杂 LaTeX、Markdown 强调和分段解答时会出现渲染残留或原始公式外露，刷新状态时还会把上一次回复、旧题目或旧 OCR 文本重新灌回界面，导致用户看到的内容和当前操作不一致。

## 怎么改
收紧回复区渲染链路：增强 KaTeX 分隔符识别、裸 LaTeX 片段识别、转义 display math 处理和 Markdown 安全渲染；对“题目解析 / 解题过程 / 答案 / 举一反三”做统一分段展示。状态 payload 和 hosted/static UI 刷新逻辑不再恢复 last_reply、current_question 或旧 OCR 文本，同时自动打开插件时直接进入静态伴学 UI。

## 前后变化截图区域（修改前）
<img width="968" height="483" alt="image" src="https://github.com/user-attachments/assets/a2d1032b-3e69-426f-9868-1c5e8ffc2a8b" />



## 前后变化截图区域（修改后）
<img width="1104" height="1430" alt="3b77f234865b79c5de02188f3408319c" src="https://github.com/user-attachments/assets/e1284757-101a-491e-a4a2-8d2e86f9d893" />

## 风险与边界
本 PR 只处理伴学插件 UI 渲染和状态回填，不改变图片题视觉调用链路和模型请求时长。运行时代码仍限制在 `plugin/plugins/study_companion/**`；测试变更覆盖静态 UI、hosted surface 和 service payload。文件数为 15，低于备忘录 20 文件提醒线。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 回复渲染升级：更智能的 LaTeX/数学识别与解析分段，支持解析/过程/答案/举一反三分区与 Markdown 协同渲染；异常回退显示更可靠
* **Improvements**
  * 学习面板与数学资源改为热修复版本化加载，提升加载一致性
  * 自动打开静态插件 UI 的页面路径已更新
  * 状态刷新与回复渲染联动逻辑简化，增加异步公式重渲染校验
* **Bug Fixes**
  * 状态负载精简：移除旧的“回复/当前题目”等字段；知识追踪场景下状态落库行为已调整
* **Tests**
  * 同步更新渲染、资源与状态字段断言用例
<!-- end of auto-generated comment: release notes by coderabbit.ai -->