### PR TITLE
[codex] Refactor conversation turn fanout

### DIFF
--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -69,15 +69,6 @@ from utils.activity_config import get_activity_preferences
 logger = logging.getLogger(__name__)
 
 
-def _topic_pool_language(language: str | None = None) -> str:
-    try:
-        from utils.language_utils import get_global_language, normalize_language_code
-        source = language if language else get_global_language()
-        return normalize_language_code(source, format='full') or 'en'
-    except Exception:
-        return 'en'
-
-
 # Conversation buffers: small enough to keep prompt sizes tight, large
 # enough to give the emotion-tier LLM real recent context.
 _CONV_BUFFER_MAXLEN = 12
@@ -248,7 +239,6 @@ class UserActivityTracker:
         self._sm = ActivityStateMachine()
         self._collector = collector or get_system_signal_collector()
         self._collector_started = False
-        self._topic_language: str | None = None
 
         # Conversation buffers for emotion-tier LLM enrichment input.
         # Tuples of (timestamp, text). User-side captures whatever the
@@ -355,13 +345,6 @@ class UserActivityTracker:
 
     # ── hooks (called from core.py and friends) ─────────────────
 
-    def set_topic_language(self, language: str | None) -> None:
-        """Update the session language used by background topic hooks."""
-        self._topic_language = _topic_pool_language(language)
-
-    def _topic_pool_language(self) -> str:
-        return self._topic_language or _topic_pool_language()
-
     def on_user_message(self, *, text: str | None = None, now: float | None = None) -> None:
         """Stamp a "user said something" event.
 
@@ -380,11 +363,6 @@ class UserActivityTracker:
         if text and not _privacy_mode_active():
             cleaned = text.strip()[:1000]
             self._user_msg_buffer.append((ts, cleaned))
-            try:
-                from main_logic.topic.pipeline import get_topic_hook_pool
-                get_topic_hook_pool().note_user_message(self.lanlan_name, cleaned, lang=self._topic_pool_language())
-            except Exception:
-                logger.debug('[%s] topic pool user-message note failed', self.lanlan_name, exc_info=True)
 
     def on_ai_message(self, *, text: str | None = None, now: float | None = None) -> None:
         """Stamp an "AI just spoke" event.
@@ -404,11 +382,6 @@ class UserActivityTracker:
         if text and not _privacy_mode_active():
             cleaned = text.strip()[:1000]
             self._ai_msg_buffer.append((ts, cleaned))
-            try:
-                from main_logic.topic.pipeline import get_topic_hook_pool
-                get_topic_hook_pool().note_ai_message(self.lanlan_name, cleaned, lang=self._topic_pool_language())
-            except Exception:
-                logger.debug('[%s] topic pool ai-message note failed', self.lanlan_name, exc_info=True)
             # AI also opens threads (promises, abandoned mid-sentences) →
             # bump _conv_seq so kickoff_open_threads_compute will recompute.
             # Empty / no-text turns (errors / silenced) skip the bump,

--- a/main_logic/conversation_turns.py
+++ b/main_logic/conversation_turns.py
@@ -1,0 +1,147 @@
+"""Fan out user/AI conversation turns to independent runtime consumers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+
+logger = logging.getLogger("N.E.K.O.Main.conversation_turns")
+
+TurnActor = Literal["user", "ai"]
+
+
+def _privacy_mode_active() -> bool:
+    try:
+        from utils.preferences import is_privacy_mode_enabled
+        return is_privacy_mode_enabled()
+    except Exception:
+        return True
+
+
+def normalize_turn_language(language: str | None = None) -> str:
+    try:
+        from utils.language_utils import get_global_language, normalize_language_code
+        source = language if language else get_global_language()
+        return normalize_language_code(source, format='full') or 'en'
+    except Exception:
+        return 'en'
+
+
+@dataclass(frozen=True)
+class ConversationTurnEvent:
+    lanlan_name: str
+    actor: TurnActor
+    text: str | None
+    lang: str
+    timestamp: float
+    text_allowed: bool
+
+
+class ConversationTurnSink(Protocol):
+    def note_turn(self, event: ConversationTurnEvent) -> None:
+        """Consume one conversation turn without blocking the chat path."""
+
+
+class ConversationTurnDispatcher:
+    """Small synchronous fanout for per-turn side consumers.
+
+    The chat path owns turn timing; individual consumers own their storage,
+    scheduling, and async work. Privacy redaction happens before fanout so raw
+    text does not reach topic/memory-like consumers when privacy mode is on.
+    """
+
+    def __init__(
+        self,
+        lanlan_name: str,
+        *,
+        language: str | None = None,
+        privacy_check: Callable[[], bool] = _privacy_mode_active,
+    ) -> None:
+        self.lanlan_name = lanlan_name
+        self._language = normalize_turn_language(language)
+        self._privacy_check = privacy_check
+        self._sinks: list[ConversationTurnSink] = []
+
+    def set_language(self, language: str | None) -> None:
+        self._language = normalize_turn_language(language)
+
+    def current_language(self) -> str:
+        return self._language
+
+    def add_sink(self, sink: ConversationTurnSink) -> None:
+        self._sinks.append(sink)
+
+    def note_user_message(self, *, text: str | None = None, now: float | None = None) -> None:
+        self._emit("user", text=text, now=now)
+
+    def note_ai_message(self, *, text: str | None = None, now: float | None = None) -> None:
+        self._emit("ai", text=text, now=now)
+
+    def _emit(self, actor: TurnActor, *, text: str | None, now: float | None) -> None:
+        ts = now if now is not None else time.time()
+        text_allowed = bool(text) and not self._privacy_check()
+        event = ConversationTurnEvent(
+            lanlan_name=self.lanlan_name,
+            actor=actor,
+            text=text if text_allowed else None,
+            lang=self._language,
+            timestamp=ts,
+            text_allowed=text_allowed,
+        )
+        for sink in list(self._sinks):
+            try:
+                sink.note_turn(event)
+            except Exception:
+                logger.debug(
+                    "[%s] conversation turn sink failed: %s",
+                    self.lanlan_name,
+                    type(sink).__name__,
+                    exc_info=True,
+                )
+
+
+class ActivityTrackerTurnSink:
+    def __init__(self, tracker) -> None:
+        self._tracker = tracker
+
+    def note_turn(self, event: ConversationTurnEvent) -> None:
+        if event.actor == "user":
+            self._tracker.on_user_message(text=event.text, now=event.timestamp)
+        else:
+            self._tracker.on_ai_message(text=event.text, now=event.timestamp)
+
+
+class TopicHookTurnSink:
+    def __init__(self, pool_factory: Callable[[], object] | None = None) -> None:
+        self._pool_factory = pool_factory
+
+    def _pool(self):
+        if self._pool_factory is not None:
+            return self._pool_factory()
+        from main_logic.topic.pipeline import get_topic_hook_pool
+        return get_topic_hook_pool()
+
+    def note_turn(self, event: ConversationTurnEvent) -> None:
+        if not event.text_allowed or not event.text:
+            return
+        pool = self._pool()
+        if event.actor == "user":
+            pool.note_user_message(event.lanlan_name, event.text, lang=event.lang)
+        else:
+            pool.note_ai_message(event.lanlan_name, event.text, lang=event.lang)
+
+
+def create_default_turn_dispatcher(
+    lanlan_name: str,
+    activity_tracker,
+    *,
+    language: str | None = None,
+) -> ConversationTurnDispatcher:
+    dispatcher = ConversationTurnDispatcher(lanlan_name, language=language)
+    dispatcher.add_sink(ActivityTrackerTurnSink(activity_tracker))
+    dispatcher.add_sink(TopicHookTurnSink())
+    return dispatcher

--- a/main_logic/conversation_turns.py
+++ b/main_logic/conversation_turns.py
@@ -83,7 +83,17 @@ class ConversationTurnDispatcher:
 
     def _emit(self, actor: TurnActor, *, text: str | None, now: float | None) -> None:
         ts = now if now is not None else time.time()
-        text_allowed = bool(text) and not self._privacy_check()
+        privacy_on = True
+        if text:
+            try:
+                privacy_on = self._privacy_check()
+            except Exception:
+                logger.debug(
+                    "[%s] privacy check failed; fallback to redacted turn",
+                    self.lanlan_name,
+                    exc_info=True,
+                )
+        text_allowed = bool(text) and not privacy_on
         event = ConversationTurnEvent(
             lanlan_name=self.lanlan_name,
             actor=actor,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1011,6 +1011,7 @@ class LLMSessionManager:
         
         # 用户语言设置（由 start_session 或前端 set_user_language() 设置，初始为 None）
         self.user_language = None
+        self._conversation_turn_language = None
         # 翻译服务（延迟初始化）
         self._translation_service = None
         
@@ -4278,7 +4279,12 @@ class LLMSessionManager:
         if not getattr(self, 'user_language', None):
             topic_language_seed = normalize_language_code(get_global_language_full(), format='full')
             self.user_language = normalize_language_code(topic_language_seed, format='short')
-        self._set_conversation_turn_language(topic_language_seed or self.user_language)
+            self._conversation_turn_language = topic_language_seed
+        self._set_conversation_turn_language(
+            self._conversation_turn_language
+            or topic_language_seed
+            or self.user_language
+        )
         # 重置防刷屏标志
         self.session_closed_by_server = False
         self.last_audio_send_error_time = 0.0
@@ -8226,6 +8232,7 @@ class LLMSessionManager:
         normalized_lang = normalize_language_code(language, format='full')
 
         self.user_language = normalized_lang
+        self._conversation_turn_language = normalized_lang
         self._set_conversation_turn_language(normalized_lang)
         if normalized_lang != language:
             logger.info(f"用户语言已归一化: {language} → {normalized_lang}")

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -951,7 +951,12 @@ class LLMSessionManager:
         # ActivitySnapshot，供 proactive_chat Phase 1/2 决策搭话倾向。
         # 详见 docs/design/user-activity-tracker.md。
         from main_logic.activity import UserActivityTracker
+        from main_logic.conversation_turns import create_default_turn_dispatcher
         self._activity_tracker = UserActivityTracker(lanlan_name)
+        self._turn_dispatcher = create_default_turn_dispatcher(
+            lanlan_name,
+            self._activity_tracker,
+        )
 
         # 进入游戏/娱乐 或 进入专注工作时，给前端推一次性情境信号——前端（仅 A/B
         # 实验组 vision_chat_default_off、每会话每类一次）据此弹窗问要不要开/关主动搭话
@@ -988,8 +993,9 @@ class LLMSessionManager:
         self._activity_tracker.set_context_prompt_callback(_push_activity_context_prompt)
 
         # AI 当前轮文本 buffer：每个 send_lanlan_response chunk 累加，turn end
-        # 时连同 on_ai_message 一起喂给 tracker。后者用末尾文本判断是否问问号
-        # → 触发 unfinished_thread 机制（5 分钟内允许至多 2 次跟进）。
+        # 时作为一个 conversation turn 发给 dispatcher。activity sink 用末尾
+        # 文本判断是否问问号 → 触发 unfinished_thread 机制（5 分钟内允许至多 2
+        # 次跟进）；topic sink 独立消费同一 turn，不和 activity tracker 耦合。
         self._current_ai_turn_text: str = ''
         self._recent_ai_voice_echo_text: str = ''
         self._recent_ai_voice_echo_at: float = 0.0
@@ -1673,21 +1679,45 @@ class LLMSessionManager:
                     if is_first_chunk and self.tts_thread and not self.tts_thread.is_alive():
                         self._respawn_tts_worker()
 
+    def _set_conversation_turn_language(self, language: str | None) -> None:
+        dispatcher = getattr(self, '_turn_dispatcher', None)
+        if dispatcher is not None:
+            dispatcher.set_language(language)
+
+    def _note_user_turn(self, *, text: str | None = None, now: float | None = None) -> None:
+        dispatcher = getattr(self, '_turn_dispatcher', None)
+        if dispatcher is not None:
+            dispatcher.note_user_message(text=text, now=now)
+            return
+        if now is None:
+            self._activity_tracker.on_user_message(text=text)
+        else:
+            self._activity_tracker.on_user_message(text=text, now=now)
+
+    def _note_ai_turn(self, *, text: str | None = None, now: float | None = None) -> None:
+        dispatcher = getattr(self, '_turn_dispatcher', None)
+        if dispatcher is not None:
+            dispatcher.note_ai_message(text=text, now=now)
+            return
+        if now is None:
+            self._activity_tracker.on_ai_message(text=text)
+        else:
+            self._activity_tracker.on_ai_message(text=text, now=now)
+
     def _flush_ai_turn_text_to_tracker(self) -> None:
-        """Flush the per-turn AI text buffer into the activity tracker.
+        """Flush the per-turn AI text buffer into conversation turn sinks.
 
         Called from each AI-turn-end exit point — there are three:
           - ``_emit_turn_end`` for regular replies (and truncate-recovery)
           - ``handle_proactive_complete`` for the agent direct-reply path
           - ``finish_proactive_delivery`` for /api/proactive_chat success
 
-        The tracker runs the question heuristic over the text and (when
-        text is non-empty) bumps ``_conv_seq`` for open_threads cache
-        invalidation. Empty / None text is fine — it just updates the
-        timestamp without opening an unfinished_thread or invalidating
-        the cache.
+        The activity sink runs the question heuristic over the text and
+        (when text is non-empty) bumps ``_conv_seq`` for open_threads cache
+        invalidation. Other sinks, such as background topic collection, see
+        the same turn without living inside ``UserActivityTracker``.
         """
-        self._activity_tracker.on_ai_message(text=self._current_ai_turn_text or None)
+        self._note_ai_turn(text=self._current_ai_turn_text or None)
         self._current_ai_turn_text = ''
 
     async def handle_proactive_complete(self, content_committed: bool = True):
@@ -2357,7 +2387,7 @@ class LLMSessionManager:
             # bump _conv_seq（让 open_threads 缓存失效）、把文本进 buffer 给
             # emotion-tier LLM 用——空 transcript 这些副作用都不该触发。
             if transcript_text:
-                self._activity_tracker.on_user_message(text=transcript)
+                self._note_user_turn(text=transcript)
                 # 真实用户语音消息（已过 echo 抑制 + 非空）才刷「真消息」时间戳，
                 # 给 mini-game 邀请隐式 dismiss 用，避免回声/空噪声误判用户已回应。
                 # 用顶部捕获的到达时刻而非此处 time.time()：takeover dispatcher 的
@@ -4248,8 +4278,7 @@ class LLMSessionManager:
         if not getattr(self, 'user_language', None):
             topic_language_seed = normalize_language_code(get_global_language_full(), format='full')
             self.user_language = normalize_language_code(topic_language_seed, format='short')
-        if hasattr(self._activity_tracker, 'set_topic_language'):
-            self._activity_tracker.set_topic_language(topic_language_seed or self.user_language)
+        self._set_conversation_turn_language(topic_language_seed or self.user_language)
         # 重置防刷屏标志
         self.session_closed_by_server = False
         self.last_audio_send_error_time = 0.0
@@ -6897,10 +6926,10 @@ class LLMSessionManager:
         with no new chat turn to reschedule the trigger), that captured value
         goes stale. Topic delivery re-resolves from here so the hook renders in
         the current locale (preserving zh-TW etc.). Returns None when no
-        tracker is available so the caller keeps the captured language.
+        dispatcher is available so the caller keeps the captured language.
         """
-        tracker = getattr(self, '_activity_tracker', None)
-        getter = getattr(tracker, '_topic_pool_language', None)
+        dispatcher = getattr(self, '_turn_dispatcher', None)
+        getter = getattr(dispatcher, 'current_language', None)
         if not callable(getter):
             return None
         try:
@@ -7717,7 +7746,7 @@ class LLMSessionManager:
                     # 里挂——后者也被 proactive abort 流程调用做清理（见
                     # main_routers/system_router.py），那不算用户活动。
                     # text 进 buffer 给 emotion-tier 用。
-                    self._activity_tracker.on_user_message(text=data if isinstance(data, str) else None)
+                    self._note_user_turn(text=data if isinstance(data, str) else None)
                     # Telemetry：D1 漏斗——本进程首条用户消息（lazy import 防循环）。
                     try:
                         from utils.token_tracker import TokenTracker as _TT
@@ -8197,8 +8226,7 @@ class LLMSessionManager:
         normalized_lang = normalize_language_code(language, format='full')
 
         self.user_language = normalized_lang
-        if hasattr(self._activity_tracker, 'set_topic_language'):
-            self._activity_tracker.set_topic_language(normalized_lang)
+        self._set_conversation_turn_language(normalized_lang)
         if normalized_lang != language:
             logger.info(f"用户语言已归一化: {language} → {normalized_lang}")
         else:

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -681,10 +681,8 @@ def test_loader_returns_defaults_when_no_activity_section(tmp_path):
     assert p.user_app_overrides == {}
 
 
-def test_activity_tracker_sends_messages_to_background_topic_pool(monkeypatch):
-    from main_logic.activity.tracker import UserActivityTracker
-    from main_logic.topic import pipeline as topic_pipeline
-    from utils import language_utils
+def test_conversation_turn_dispatcher_sends_messages_to_background_topic_pool():
+    from main_logic.conversation_turns import ConversationTurnDispatcher, TopicHookTurnSink
 
     calls = []
 
@@ -695,12 +693,15 @@ def test_activity_tracker_sends_messages_to_background_topic_pool(monkeypatch):
         def note_ai_message(self, lanlan_name, text, *, lang='zh'):
             calls.append(('ai', lanlan_name, text, lang))
 
-    monkeypatch.setattr(topic_pipeline, 'get_topic_hook_pool', lambda: FakeTopicPool())
-    monkeypatch.setattr(language_utils, 'get_global_language', lambda: 'zh-CN')
+    dispatcher = ConversationTurnDispatcher(
+        'test_lanlan',
+        language='zh-CN',
+        privacy_check=lambda: False,
+    )
+    dispatcher.add_sink(TopicHookTurnSink(pool_factory=lambda: FakeTopicPool()))
 
-    tracker = UserActivityTracker('test_lanlan')
-    tracker.on_user_message(text='我想买凯迪拉克，但预算有点顶不住', now=1.0)
-    tracker.on_ai_message(text='别急着破釜沉舟，先看看预算。', now=2.0)
+    dispatcher.note_user_message(text='我想买凯迪拉克，但预算有点顶不住', now=1.0)
+    dispatcher.note_ai_message(text='别急着破釜沉舟，先看看预算。', now=2.0)
 
     assert calls == [
         ('user', 'test_lanlan', '我想买凯迪拉克，但预算有点顶不住', 'zh-CN'),
@@ -708,9 +709,8 @@ def test_activity_tracker_sends_messages_to_background_topic_pool(monkeypatch):
     ]
 
 
-def test_activity_tracker_uses_global_language_for_background_topic_pool(monkeypatch):
-    from main_logic.activity.tracker import UserActivityTracker
-    from main_logic.topic import pipeline as topic_pipeline
+def test_conversation_turn_dispatcher_uses_global_language_for_background_topic_pool(monkeypatch):
+    from main_logic.conversation_turns import ConversationTurnDispatcher, TopicHookTurnSink
     from utils import language_utils
 
     calls = []
@@ -722,12 +722,12 @@ def test_activity_tracker_uses_global_language_for_background_topic_pool(monkeyp
         def note_ai_message(self, lanlan_name, text, *, lang='zh'):
             calls.append(('ai', lanlan_name, text, lang))
 
-    monkeypatch.setattr(topic_pipeline, 'get_topic_hook_pool', lambda: FakeTopicPool())
     monkeypatch.setattr(language_utils, 'get_global_language', lambda: 'en-US')
 
-    tracker = UserActivityTracker('test_lanlan')
-    tracker.on_user_message(text='I want a new phone but I am not sure about the price.', now=1.0)
-    tracker.on_ai_message(text='Fair, let us slow down before your wallet files a complaint.', now=2.0)
+    dispatcher = ConversationTurnDispatcher('test_lanlan', privacy_check=lambda: False)
+    dispatcher.add_sink(TopicHookTurnSink(pool_factory=lambda: FakeTopicPool()))
+    dispatcher.note_user_message(text='I want a new phone but I am not sure about the price.', now=1.0)
+    dispatcher.note_ai_message(text='Fair, let us slow down before your wallet files a complaint.', now=2.0)
 
     assert calls == [
         ('user', 'test_lanlan', 'I want a new phone but I am not sure about the price.', 'en'),
@@ -735,9 +735,8 @@ def test_activity_tracker_uses_global_language_for_background_topic_pool(monkeyp
     ]
 
 
-def test_activity_tracker_uses_session_language_for_background_topic_pool(monkeypatch):
-    from main_logic.activity.tracker import UserActivityTracker
-    from main_logic.topic import pipeline as topic_pipeline
+def test_conversation_turn_dispatcher_uses_session_language_for_background_topic_pool(monkeypatch):
+    from main_logic.conversation_turns import ConversationTurnDispatcher, TopicHookTurnSink
     from utils import language_utils
 
     calls = []
@@ -749,13 +748,13 @@ def test_activity_tracker_uses_session_language_for_background_topic_pool(monkey
         def note_ai_message(self, lanlan_name, text, *, lang='zh'):
             calls.append(('ai', lanlan_name, text, lang))
 
-    monkeypatch.setattr(topic_pipeline, 'get_topic_hook_pool', lambda: FakeTopicPool())
     monkeypatch.setattr(language_utils, 'get_global_language', lambda: 'en-US')
 
-    tracker = UserActivityTracker('test_lanlan')
-    tracker.set_topic_language('ja-JP')
-    tracker.on_user_message(text='転職について少し迷っています。', now=1.0)
-    tracker.on_ai_message(text='焦らず、次の条件を一緒に整理しよう。', now=2.0)
+    dispatcher = ConversationTurnDispatcher('test_lanlan', privacy_check=lambda: False)
+    dispatcher.add_sink(TopicHookTurnSink(pool_factory=lambda: FakeTopicPool()))
+    dispatcher.set_language('ja-JP')
+    dispatcher.note_user_message(text='転職について少し迷っています。', now=1.0)
+    dispatcher.note_ai_message(text='焦らず、次の条件を一緒に整理しよう。', now=2.0)
 
     assert calls == [
         ('user', 'test_lanlan', '転職について少し迷っています。', 'ja'),
@@ -763,9 +762,8 @@ def test_activity_tracker_uses_session_language_for_background_topic_pool(monkey
     ]
 
 
-def test_activity_tracker_preserves_traditional_chinese_topic_locale(monkeypatch):
-    from main_logic.activity.tracker import UserActivityTracker
-    from main_logic.topic import pipeline as topic_pipeline
+def test_conversation_turn_dispatcher_preserves_traditional_chinese_topic_locale():
+    from main_logic.conversation_turns import ConversationTurnDispatcher, TopicHookTurnSink
 
     calls = []
 
@@ -773,13 +771,54 @@ def test_activity_tracker_preserves_traditional_chinese_topic_locale(monkeypatch
         def note_user_message(self, lanlan_name, text, *, lang='zh'):
             calls.append((lanlan_name, text, lang))
 
-    monkeypatch.setattr(topic_pipeline, 'get_topic_hook_pool', lambda: FakeTopicPool())
-
-    tracker = UserActivityTracker('test_lanlan')
-    tracker.set_topic_language('zh-TW')
-    tracker.on_user_message(text='我想用繁體中文聊最近的生活選擇', now=1.0)
+    dispatcher = ConversationTurnDispatcher('test_lanlan', privacy_check=lambda: False)
+    dispatcher.add_sink(TopicHookTurnSink(pool_factory=lambda: FakeTopicPool()))
+    dispatcher.set_language('zh-TW')
+    dispatcher.note_user_message(text='我想用繁體中文聊最近的生活選擇', now=1.0)
 
     assert calls == [('test_lanlan', '我想用繁體中文聊最近的生活選擇', 'zh-TW')]
+
+
+def test_conversation_turn_dispatcher_redacts_topic_text_in_privacy_mode():
+    from main_logic.conversation_turns import (
+        ActivityTrackerTurnSink,
+        ConversationTurnDispatcher,
+        TopicHookTurnSink,
+    )
+
+    activity_calls = []
+    topic_calls = []
+
+    class FakeActivityTracker:
+        def on_user_message(self, *, text=None, now=None):
+            activity_calls.append(('user', text, now))
+
+        def on_ai_message(self, *, text=None, now=None):
+            activity_calls.append(('ai', text, now))
+
+    class FakeTopicPool:
+        def note_user_message(self, lanlan_name, text, *, lang='zh'):
+            topic_calls.append(('user', lanlan_name, text, lang))
+
+        def note_ai_message(self, lanlan_name, text, *, lang='zh'):
+            topic_calls.append(('ai', lanlan_name, text, lang))
+
+    dispatcher = ConversationTurnDispatcher(
+        'test_lanlan',
+        language='zh-CN',
+        privacy_check=lambda: True,
+    )
+    dispatcher.add_sink(ActivityTrackerTurnSink(FakeActivityTracker()))
+    dispatcher.add_sink(TopicHookTurnSink(pool_factory=lambda: FakeTopicPool()))
+
+    dispatcher.note_user_message(text='secret user turn', now=1.0)
+    dispatcher.note_ai_message(text='secret ai turn?', now=2.0)
+
+    assert activity_calls == [
+        ('user', None, 1.0),
+        ('ai', None, 2.0),
+    ]
+    assert topic_calls == []
 
 
 # ── Hot-reload (Codex P2) ───────────────────────────────────────────

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -821,6 +821,47 @@ def test_conversation_turn_dispatcher_redacts_topic_text_in_privacy_mode():
     assert topic_calls == []
 
 
+def test_conversation_turn_dispatcher_redacts_when_privacy_check_fails():
+    from main_logic.conversation_turns import (
+        ActivityTrackerTurnSink,
+        ConversationTurnDispatcher,
+        TopicHookTurnSink,
+    )
+
+    activity_calls = []
+    topic_calls = []
+
+    class FakeActivityTracker:
+        def on_user_message(self, *, text=None, now=None):
+            activity_calls.append(('user', text, now))
+
+        def on_ai_message(self, *, text=None, now=None):
+            activity_calls.append(('ai', text, now))
+
+    class FakeTopicPool:
+        def note_user_message(self, lanlan_name, text, *, lang='zh'):
+            topic_calls.append(('user', lanlan_name, text, lang))
+
+        def note_ai_message(self, lanlan_name, text, *, lang='zh'):
+            topic_calls.append(('ai', lanlan_name, text, lang))
+
+    def broken_privacy_check():
+        raise RuntimeError("preference store unavailable")
+
+    dispatcher = ConversationTurnDispatcher(
+        'test_lanlan',
+        language='zh-CN',
+        privacy_check=broken_privacy_check,
+    )
+    dispatcher.add_sink(ActivityTrackerTurnSink(FakeActivityTracker()))
+    dispatcher.add_sink(TopicHookTurnSink(pool_factory=lambda: FakeTopicPool()))
+
+    dispatcher.note_user_message(text='secret user turn', now=1.0)
+
+    assert activity_calls == [('user', None, 1.0)]
+    assert topic_calls == []
+
+
 # ── Hot-reload (Codex P2) ───────────────────────────────────────────
 
 

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1042,7 +1042,9 @@ def test_start_session_seeds_topic_hooks_with_full_global_locale():
 
     assert "topic_language_seed = normalize_language_code(get_global_language_full(), format='full')" in normalized_source
     assert "self.user_language = normalize_language_code(topic_language_seed, format='short')" in normalized_source
-    assert "self._set_conversation_turn_language(topic_language_seed or self.user_language)" in normalized_source
+    assert "self._conversation_turn_language = topic_language_seed" in normalized_source
+    assert "self._conversation_turn_language or topic_language_seed or self.user_language" in normalized_source
+    assert "self._conversation_turn_language = normalized_lang" in normalized_source
 
 
 async def test_submit_proactive_callback_does_not_fail_ack_when_goodbye_silent():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1042,7 +1042,7 @@ def test_start_session_seeds_topic_hooks_with_full_global_locale():
 
     assert "topic_language_seed = normalize_language_code(get_global_language_full(), format='full')" in normalized_source
     assert "self.user_language = normalize_language_code(topic_language_seed, format='short')" in normalized_source
-    assert "self._activity_tracker.set_topic_language(topic_language_seed or self.user_language)" in normalized_source
+    assert "self._set_conversation_turn_language(topic_language_seed or self.user_language)" in normalized_source
 
 
 async def test_submit_proactive_callback_does_not_fail_ack_when_goodbye_silent():


### PR DESCRIPTION
## 改动概述 / Summary

- Add a lightweight conversation turn dispatcher with independent activity and topic hook sinks.
- Route `LLMSessionManager` user/AI turn entrypoints through the dispatcher.
- Remove direct topic hook coupling and language state from `UserActivityTracker`.
- Update focused tests for topic fanout, locale preservation, and privacy redaction.

## 回归报告 / Regression Report

- 改动了什么：新增 `main_logic/conversation_turns.py` 作为 user/AI turn fanout 层；`core.py` 统一通过 dispatcher 发送 turn；`activity/tracker.py` 不再直接导入或调用 topic hook pool；topic hook 作为独立 sink 消费同一 turn event。
- 理由 / 必要性：#1651 合并后，background topic hooks 临时挂在 activity tracker 的 user/AI message hook 上，导致 topic 功能寄生在 activity 模块里。dispatcher 将“消息产生点”和“消息消费者”拆开，避免后续新增 message tracker 时继续污染 activity tracker 或 core 的散点逻辑。
- 改动前后的表现对比：改动前，`UserActivityTracker.on_user_message()` / `on_ai_message()` 同时更新 activity 状态和转发 topic pool；改动后，core 发出一次 conversation turn，activity sink 负责原有状态/buffer/open-thread 行为，topic sink 负责 background topic collection。用户可见行为应保持一致。
- 潜在回归点：文本/语音用户消息、AI turn end、topic hook 语言保持、隐私模式文本脱敏、老测试替身缺少 dispatcher 时的 fallback。已用 focused tests 覆盖 dispatcher fanout、topic locale、privacy redaction、core game-route 合约和 topic hook delivery gate。

## 不拆分理由 / Why Not Split

不适用。计入上限的文件数 ≤ 20。

## 测试 / Testing

- `uv run pytest tests/test_activity_tracker_followup.py -k "conversation_turn_dispatcher"`
- `uv run pytest tests/unit/test_proactive_sm_integration.py -k "topic_hooks"`
- `uv run pytest tests/unit/test_core_game_route_memory_contract.py -q`
- `uv run pytest tests/unit/test_system_router_topic_hooks.py -q`
- `uv run ruff check main_logic/conversation_turns.py main_logic/activity/tracker.py main_logic/core.py tests/test_activity_tracker_followup.py tests/unit/test_proactive_sm_integration.py`
- `uv run python scripts/check_docstring_no_cjk.py --base origin/main`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了对话事件和语言设置的内部处理机制，使消息分发流程更加清晰独立。
  * 增强了隐私模式下的消息脱敏机制，确保敏感内容在隐私保护模式下得到正确处理。
  * 改进了多语言支持的语言标准化逻辑。

* **测试**
  * 更新了相关测试用例以验证新的消息分发和隐私保护机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->