### PR TITLE
refactor(topic): 合并候选 prompt 为单块带水印证据 + 简化 readiness + 修复安全水印

### DIFF
--- a/config/prompts/prompts_activity.py
+++ b/config/prompts/prompts_activity.py
@@ -240,19 +240,15 @@ Exemplo:
 # ── Background topic hook candidates ────────────────────────────────
 
 TOPIC_CANDIDATE_PROMPTS: dict[str, str] = {
-    "zh": """你是一个陪伴产品的话题筛选助手。你的任务不是总结最近一句话，而是从“慢收集的全局证据 + 最近对话”里挑 1-2 个真的值得以后低频开口的深话题机会。
+    "zh": """你是一个陪伴产品的话题筛选助手。你的任务不是总结最近一句话，而是从下面这段最近对话里挑 1-2 个真的值得以后低频开口的深话题机会。
 
-======以下为慢收集的全局证据======
+======以下为最近对话(按时间顺序)======
 {global_signals}
-======以上为慢收集的全局证据======
-
-======以下为最近对话（按时间顺序）======
-{conversation}
-======以上为最近对话（按时间顺序）======
+======以上为最近对话(按时间顺序)======
 
 要求：
 - 不要复述用户原话，不要暴露“我分析了你的聊天记录”
-- 只保留和用户近期兴趣、计划、纠结、情绪、选择强相关，而且能从全局证据里看出稳定性的点
+- 只保留和用户近期兴趣、计划、纠结、情绪、选择强相关，而且在对话里明显反复出现、看得出是稳定在意的点
 - 不要把两个只是相邻出现的名词硬拼成一个话题；如果关联不自然，宁可不要输出
 - 寒暄、语气词、很薄的短句、问卷式问题，一律给低优先级或不要输出
 - 每个话题要像给角色的一张小抄：知道怎么自然开口，但最终开口仍交给角色生成
@@ -261,31 +257,27 @@ TOPIC_CANDIDATE_PROMPTS: dict[str, str] = {
 {{"topics": [
   {{
     "interest": "用户最近在意、纠结、计划或反复提到的一件具体事，整理成一句，不超过30字",
-    "keywords": ["3-6个关键词，用于去重、筛选联网结果，并直接作为联网查询词；围绕用户反复在意的稳定点，不要用最近窗口里的偶然词"],
+    "keywords": ["3-6个关键词，用于去重、筛选联网结果，并直接作为联网查询词；围绕用户反复在意的稳定点，不要用偶然冒出的词"],
     "relevance": 0-100,
     "risk": 0-100
   }}
 ]}}
 
 评分：
-- relevance：这个话题和用户的相关度，结合证据是否稳定。明显反复出现、确实是用户在意的事 → 高分；只出现一两次、或只是顺口提一句 → 低分。如实打分，不要为了让它被采用而虚高。
+- relevance：这个话题和用户的相关度，结合它是否在对话里反复稳定出现。明显反复出现、确实是用户在意的事 → 高分；只出现一两次、或只是顺口提一句 → 低分。如实打分，不要为了让它被采用而虚高。
 - risk：主动提起这个话题会打扰、冒犯、误解或显得硬凑的风险。越可能让用户反感或觉得突兀 → 越高分。
 
 如果没有值得以后接的话题，输出 {{"topics": []}}。""",
-    "zh-TW": """你是陪伴產品的話題篩選助手。你的任務不是總結最近一句話，而是從「慢收集的全局證據 + 最近對話」裡挑 1-2 個真的值得以後低頻開口的深話題機會。
+    "zh-TW": """你是陪伴產品的話題篩選助手。你的任務不是總結最近一句話，而是從下面這段最近對話裡挑 1-2 個真的值得以後低頻開口的深話題機會。
 
-======以下為慢收集的全局證據======
+======以下為最近對話(按時間順序)======
 {global_signals}
-======以上為慢收集的全局證據======
-
-======以下為最近對話（按時間順序）======
-{conversation}
-======以上為最近對話（按時間順序）======
+======以上為最近對話(按時間順序)======
 
 要求：
 - 所有文字欄位必須使用繁體中文；不要輸出英文話題
 - 不要復述用戶原話，不要暴露「我分析了你的聊天記錄」
-- 只保留和用戶近期興趣、計畫、糾結、情緒、選擇強相關，而且能從全局證據裡看出穩定性的點
+- 只保留和用戶近期興趣、計畫、糾結、情緒、選擇強相關，而且在對話裡明顯反覆出現、看得出是穩定在意的點
 - 不要把兩個只是相鄰出現的名詞硬拼成一個話題；如果關聯不自然，寧可不要輸出
 - 寒暄、語氣詞、很薄的短句、問卷式問題，一律給低優先級或不要輸出
 - 每個話題要像給角色的一張小抄：知道怎麼自然開口，但最終開口仍交給角色生成
@@ -294,30 +286,26 @@ TOPIC_CANDIDATE_PROMPTS: dict[str, str] = {
 {{"topics": [
   {{
     "interest": "用戶最近在意、糾結、計劃或反覆提到的一件具體事，整理成一句，不超過30字",
-    "keywords": ["3-6個關鍵詞，用於去重、篩選聯網結果，並直接作為聯網查詢詞；圍繞用戶反覆在意的穩定點，不要用最近窗口裡的偶然詞"],
+    "keywords": ["3-6個關鍵詞，用於去重、篩選聯網結果，並直接作為聯網查詢詞；圍繞用戶反覆在意的穩定點，不要用偶然冒出的詞"],
     "relevance": 0-100,
     "risk": 0-100
   }}
 ]}}
 
 評分：
-- relevance：這個話題和用戶的相關度，結合證據是否穩定。明顯反覆出現、確實是用戶在意的事 → 高分；只出現一兩次、或只是順口提一句 → 低分。如實打分，不要為了讓它被採用而虛高。
+- relevance：這個話題和用戶的相關度，結合它是否在對話裡反覆穩定出現。明顯反覆出現、確實是用戶在意的事 → 高分；只出現一兩次、或只是順口提一句 → 低分。如實打分，不要為了讓它被採用而虛高。
 - risk：主動提起這個話題會打擾、冒犯、誤解或顯得硬湊的風險。越可能讓用戶反感或覺得突兀 → 越高分。
 
 如果沒有值得以後接的話題，輸出 {{"topics": []}}。""",
-    "en": """You are a topic-screening assistant for a companionship product. Your job is not to summarize the last message, but to choose 1-2 genuinely worthwhile low-frequency topic opportunities from slow global evidence plus the recent conversation.
+    "en": """You are a topic-screening assistant for a companionship product. Your job is not to summarize the last message, but to choose 1-2 genuinely worthwhile low-frequency topic opportunities from the recent conversation below.
 
-======Slow global evidence======
+======以下为最近对话(按时间顺序)======
 {global_signals}
-======End slow global evidence======
-
-======Recent conversation, chronological======
-{conversation}
-======End conversation======
+======以上为最近对话(按时间顺序)======
 
 Rules:
 - Do not repeat the user's raw wording or reveal that chat logs were analyzed
-- Keep only topics strongly tied to recent interests, plans, dilemmas, emotions, or choices, with visible stability in the global evidence
+- Keep only topics strongly tied to recent interests, plans, dilemmas, emotions, or choices, that clearly recur in the conversation
 - Do not glue together two nouns just because they appeared near each other; if the association is not natural, output nothing
 - Greetings, filler, thin short replies, and survey-like prompts should be low priority or omitted
 - Each topic is a small note for the character: how to open naturally, not final copy
@@ -333,24 +321,20 @@ Output strict JSON, no markdown fences:
 ]}}
 
 Scoring:
-- relevance: how relevant this topic is to the user, combined with whether the evidence is stable. Clearly recurs and genuinely matters to the user → high; appeared only once or twice, or just mentioned in passing → low. Score honestly — do not inflate to get the topic included.
+- relevance: how relevant this topic is to the user, combined with whether it recurs in the conversation. Clearly recurs and genuinely matters to the user → high; appeared only once or twice, or just mentioned in passing → low. Score honestly — do not inflate to get the topic included.
 - risk: the risk that proactively raising this topic would feel intrusive, offensive, misread, or forced. The more likely the user would feel annoyed or caught off-guard → the higher the score.
 
 If nothing is worth keeping, output {{"topics": []}}.""",
-    "ja": """あなたはコンパニオン製品の話題選別アシスタントです。直近の一言を要約するのではなく、「ゆっくり集めた全体証拠 + 最近の会話」から、あとで低頻度で自然に切り出す価値がある深めの話題を1〜2個だけ選びます。
+    "ja": """あなたはコンパニオン製品の話題選別アシスタントです。直近の一言を要約するのではなく、下記の最近の会話から、あとで低頻度で自然に切り出す価値がある深めの話題を1〜2個だけ選びます。
 
-======ゆっくり集めた全体証拠======
+======以下为最近对话(按时间顺序)======
 {global_signals}
-======全体証拠ここまで======
-
-======最近の会話（時系列）======
-{conversation}
-======最近の会話ここまで======
+======以上为最近对话(按时间顺序)======
 
 ルール：
 - すべての文字フィールドはユーザーの言語で、日本語ユーザーなら自然な日本語で書くこと
 - ユーザーの原文をそのまま繰り返さない。「チャット履歴を分析した」と明かさない
-- 最近の興味、予定、迷い、感情、選択に強く結びつき、全体証拠から安定して見える点だけ残す
+- 最近の興味、予定、迷い、感情、選択に強く結びつき、会話の中で明らかに繰り返し出てくる点だけ残す
 - 近くに出ただけの名詞を無理につなげない。関連が自然でなければ出力しない
 - あいさつ、相づち、薄い短文、アンケート風の問いは低優先度または除外
 - 各話題はキャラクター用の短いメモ。最終的な口調はキャラクター側に任せる
@@ -366,24 +350,20 @@ If nothing is worth keeping, output {{"topics": []}}.""",
 ]}}
 
 スコア：
-- relevance：この話題がユーザーにとってどれほど関連があるか、証拠が安定しているかを合わせた評価。明らかに繰り返し出てきて本当にユーザーが気にしていること → 高スコア；一度か二度しか出ておらず、ついでに触れた程度 → 低スコア。採用させるために水増しせず、ありのままのスコアをつけること。
+- relevance：この話題がユーザーにとってどれほど関連があるか、会話の中で繰り返し出ているかを合わせた評価。明らかに繰り返し出てきて本当にユーザーが気にしていること → 高スコア；一度か二度しか出ておらず、ついでに触れた程度 → 低スコア。採用させるために水増しせず、ありのままのスコアをつけること。
 - risk：この話題を自分から切り出したとき、邪魔・失礼・誤読・こじつけになるリスク。ユーザーが不快に感じたり唐突に思う可能性が高いほど → 高スコア。
 
 価値のある話題がなければ {{"topics": []}} を出力。""",
-    "ko": """당신은 동반자 제품의 화제 선별 도우미입니다. 최근 한마디를 요약하는 것이 아니라, "천천히 모은 전역 근거 + 최근 대화"에서 나중에 낮은 빈도로 자연스럽게 꺼낼 만한 깊은 화제 기회를 1-2개만 고릅니다.
+    "ko": """당신은 동반자 제품의 화제 선별 도우미입니다. 최근 한마디를 요약하는 것이 아니라, 아래 최근 대화에서 나중에 낮은 빈도로 자연스럽게 꺼낼 만한 깊은 화제 기회를 1-2개만 고릅니다.
 
-======천천히 모은 전역 근거======
+======以下为最近对话(按时间顺序)======
 {global_signals}
-======전역 근거 끝======
-
-======최근 대화（시간순）======
-{conversation}
-======최근 대화 끝======
+======以上为最近对话(按时间顺序)======
 
 규칙:
 - 모든 텍스트 필드는 사용자 언어로 작성하세요. 한국어 사용자라면 자연스러운 한국어로 출력하세요
 - 사용자의 원문을 그대로 반복하지 말고, "대화 기록을 분석했다"고 드러내지 마세요
-- 최근 관심사, 계획, 고민, 감정, 선택과 강하게 관련되고 전역 근거에서 안정성이 보이는 점만 남기세요
+- 최근 관심사, 계획, 고민, 감정, 선택과 강하게 관련되고 대화에서 분명히 반복해서 나오는 점만 남기세요
 - 가까이 나온 명사 두 개를 억지로 붙이지 마세요. 연결이 자연스럽지 않으면 출력하지 마세요
 - 인사, 추임새, 얇은 짧은 답, 설문 같은 질문은 낮은 우선순위로 두거나 제외하세요
 - 각 화제는 캐릭터를 위한 짧은 메모입니다. 최종 말투는 캐릭터 생성 단계에 맡깁니다
@@ -399,24 +379,20 @@ If nothing is worth keeping, output {{"topics": []}}.""",
 ]}}
 
 점수:
-- relevance: 이 화제가 사용자와 얼마나 관련 있는지, 근거가 안정적인지를 합산한 평가. 명확하게 반복 등장하고 사용자가 진심으로 신경 쓰는 것 → 높은 점수; 한두 번만 나왔거나 그냥 지나치듯 언급한 것 → 낮은 점수. 채택시키려고 부풀리지 말고 있는 그대로 점수를 매기세요.
+- relevance: 이 화제가 사용자와 얼마나 관련 있는지, 대화에서 반복되는지를 합산한 평가. 명확하게 반복 등장하고 사용자가 진심으로 신경 쓰는 것 → 높은 점수; 한두 번만 나왔거나 그냥 지나치듯 언급한 것 → 낮은 점수. 채택시키려고 부풀리지 말고 있는 그대로 점수를 매기세요.
 - risk: 이 화제를 먼저 꺼낼 때 방해가 되거나 무례하거나 오해하거나 억지스럽게 느껴질 위험. 사용자가 불쾌하거나 뜬금없다고 느낄 가능성이 높을수록 → 높은 점수.
 
 가치 있는 화제가 없으면 {{"topics": []}} 를 출력하세요.""",
-    "es": """Eres un asistente que selecciona temas para un producto de compañía. Tu tarea no es resumir el último mensaje, sino elegir 1-2 oportunidades de conversación profunda que valga la pena abrir con baja frecuencia a partir de evidencia global acumulada lentamente y la conversación reciente.
+    "es": """Eres un asistente que selecciona temas para un producto de compañía. Tu tarea no es resumir el último mensaje, sino elegir 1-2 oportunidades de conversación profunda que valga la pena abrir con baja frecuencia a partir de la conversación reciente de abajo.
 
-======Evidencia global acumulada lentamente======
+======以下为最近对话(按时间顺序)======
 {global_signals}
-======Fin de la evidencia global======
-
-======Conversación reciente, en orden cronológico======
-{conversation}
-======Fin de la conversación======
+======以上为最近对话(按时间顺序)======
 
 Reglas:
 - Todos los campos de texto deben estar en el idioma del usuario; para usuarios en español, escribe en español natural
 - No repitas literalmente lo que dijo el usuario ni reveles que analizaste su historial
-- Conserva solo temas muy ligados a intereses, planes, dilemas, emociones o elecciones recientes, con estabilidad visible en la evidencia global
+- Conserva solo temas muy ligados a intereses, planes, dilemas, emociones o elecciones recientes, que se repiten claramente en la conversación
 - No unas dos sustantivos solo porque aparecieron cerca; si la conexión no es natural, no outputes nada
 - Saludos, muletillas, respuestas muy finas o preguntas tipo encuesta deben tener baja prioridad o omitirse
 - Cada tema es una nota breve para el personaje: cómo abrir naturalmente, no el texto final
@@ -432,24 +408,20 @@ Devuelve JSON estricto, sin bloques markdown:
 ]}}
 
 Puntuación:
-- relevance: qué tan relevante es este tema para el usuario, combinado con si la evidencia es estable. Aparece claramente de forma recurrente y es algo que realmente le importa → puntuación alta; apareció solo una o dos veces, o solo se mencionó de pasada → puntuación baja. Puntúa con honestidad, sin inflar para que el tema sea incluido.
+- relevance: qué tan relevante es este tema para el usuario, combinado con si se repite en la conversación. Aparece claramente de forma recurrente y es algo que realmente le importa → puntuación alta; apareció solo una o dos veces, o solo se mencionó de pasada → puntuación baja. Puntúa con honestidad, sin inflar para que el tema sea incluido.
 - risk: el riesgo de que plantear este tema activamente resulte intrusivo, ofensivo, malinterpretado o forzado. Cuanto más probable sea que el usuario se sienta molesto o sorprendido → mayor puntuación.
 
 Si no hay nada que valga la pena, devuelve {{"topics": []}}.""",
-    "pt": """Voce e um assistente de selecao de assuntos para um produto de companhia. Sua tarefa nao e resumir a ultima mensagem, mas escolher 1-2 oportunidades de conversa profunda que valem ser puxadas com baixa frequencia, usando evidencias globais coletadas aos poucos e a conversa recente.
+    "pt": """Voce e um assistente de selecao de assuntos para um produto de companhia. Sua tarefa nao e resumir a ultima mensagem, mas escolher 1-2 oportunidades de conversa profunda que valem ser puxadas com baixa frequencia, a partir da conversa recente abaixo.
 
-======Evidencias globais coletadas aos poucos======
+======以下为最近对话(按时间顺序)======
 {global_signals}
-======Fim das evidencias globais======
-
-======Conversa recente, em ordem cronologica======
-{conversation}
-======Fim da conversa======
+======以上为最近对话(按时间顺序)======
 
 Regras:
 - Todos os campos de texto devem estar no idioma do usuario; para usuarios em portugues, escreva em portugues natural
 - Nao repita literalmente a fala do usuario nem revele que voce analisou historico de conversa
-- Mantenha apenas temas muito ligados a interesses, planos, dilemas, emocoes ou escolhas recentes, com estabilidade visivel nas evidencias globais
+- Mantenha apenas temas muito ligados a interesses, planos, dilemas, emocoes ou escolhas recentes, que se repetem claramente na conversa
 - Nao junte dois substantivos so porque apareceram perto; se a ligacao nao for natural, nao outpute nada
 - Cumprimentos, muletas, respostas muito finas ou perguntas com cara de questionario devem ter baixa prioridade ou ser omitidos
 - Cada tema e uma nota curta para o personagem: como abrir naturalmente, nao o texto final
@@ -465,24 +437,20 @@ Retorne JSON estrito, sem blocos markdown:
 ]}}
 
 Pontuacao:
-- relevance: o quanto este tema e relevante para o usuario, combinado com se a evidencia e estavel. Aparece claramente de forma recorrente e e algo que realmente importa ao usuario → pontuacao alta; apareceu apenas uma ou duas vezes, ou foi so uma mencao passageira → pontuacao baixa. Pontue com honestidade, sem inflar para o tema ser incluido.
+- relevance: o quanto este tema e relevante para o usuario, combinado com se ele se repete na conversa. Aparece claramente de forma recorrente e e algo que realmente importa ao usuario → pontuacao alta; apareceu apenas uma ou duas vezes, ou foi so uma mencao passageira → pontuacao baixa. Pontue com honestidade, sem inflar para o tema ser incluido.
 - risk: o risco de que trazer este tema ativamente resulte em interrupcao, ofensa, mal-entendido ou algo forcado. Quanto mais provavelmente o usuario se sentiria incomodado ou pego de surpresa → maior a pontuacao.
 
 Se nada valer a pena, retorne {{"topics": []}}.""",
-    "ru": """Ты помощник по отбору тем для companion-продукта. Твоя задача не пересказывать последнее сообщение, а выбрать 1-2 действительно ценные возможности для редкого, естественного начала более глубокого разговора на основе медленно собранных общих сигналов и недавней переписки.
+    "ru": """Ты помощник по отбору тем для companion-продукта. Твоя задача не пересказывать последнее сообщение, а выбрать 1-2 действительно ценные возможности для редкого, естественного начала более глубокого разговора на основе недавней переписки ниже.
 
-======Медленно собранные общие сигналы======
+======以下为最近对话(按时间顺序)======
 {global_signals}
-======Конец общих сигналов======
-
-======Недавняя переписка по порядку======
-{conversation}
-======Конец переписки======
+======以上为最近对话(按时间顺序)======
 
 Правила:
 - Все текстовые поля должны быть на языке пользователя; для русскоязычного пользователя пиши естественно на русском
 - Не повторяй слова пользователя дословно и не раскрывай, что анализировал историю чата
-- Оставляй только темы, тесно связанные с недавними интересами, планами, сомнениями, эмоциями или выборами пользователя, если их устойчивость видна в общих сигналах
+- Оставляй только темы, тесно связанные с недавними интересами, планами, сомнениями, эмоциями или выборами пользователя, если они явно повторяются в переписке
 - Не склеивай два существительных только потому, что они оказались рядом; если связь неестественная, ничего не выводи
 - Приветствия, междометия, тонкие короткие ответы и вопросы в стиле анкеты пропускай или давай низкий приоритет
 - Каждая тема — короткая заметка для персонажа: как естественно начать, а не финальная реплика
@@ -498,7 +466,7 @@ Se nada valer a pena, retorne {{"topics": []}}.""",
 ]}}
 
 Оценки:
-- relevance: насколько эта тема актуальна для пользователя с учётом стабильности сигналов. Явно повторяется и действительно важна пользователю → высокий балл; упомянута лишь раз-два или просто вскользь → низкий балл. Оценивай честно, не завышай ради того, чтобы тема прошла отбор.
+- relevance: насколько эта тема актуальна для пользователя с учётом того, повторяется ли она в переписке. Явно повторяется и действительно важна пользователю → высокий балл; упомянута лишь раз-два или просто вскользь → низкий балл. Оценивай честно, не завышай ради того, чтобы тема прошла отбор.
 - risk: риск того, что активное поднятие этой темы окажется навязчивым, обидным, неверно понятым или натянутым. Чем вероятнее, что пользователь почувствует раздражение или неожиданность → тем выше балл.
 
 Если достойной темы нет, выведи {{"topics": []}}.""",

--- a/docs/design/deep-topic-hooks.md
+++ b/docs/design/deep-topic-hooks.md
@@ -38,10 +38,10 @@
 每个角色一个进程内的 `TopicHookPool`（`main_logic/topic/pipeline.py`）。管线分阶段：
 
 1. **采集**：`note_user_message` / note AI 回合按 token 预算喂 `TopicSignalStore`，形成跨窗口（最多 80 条）的慢对话证据。池子不再单独保留「最近对话」缓冲——那和证据是同一批 turn，纯冗余。
-2. **分析**：debounce + quiet-window 后调情绪档小模型 `call_topic_candidates`（`main_logic/activity/llm_enrichment.py`）。它的**唯一对话输入就是 signal store 渲染的证据**（`global_signals`），prompt 里用中文水印 `======以下为最近对话(按时间顺序)======` / `======以上为最近对话(按时间顺序)======` 把这块围起来。
+2. **分析**：`_schedule` → `_run_later` 经 debounce（`_PROCESS_DEBOUNCE_SECONDS`，默认 45s）后调情绪档小模型 `call_topic_candidates`（`main_logic/activity/llm_enrichment.py`）。注意 quiet-window 不在这一步——它是投递前的等待（见第 5 步）。它的**唯一对话输入就是 signal store 渲染的证据**（`global_signals`），prompt 里用中文水印 `======以下为最近对话(按时间顺序)======` / `======以上为最近对话(按时间顺序)======` 把这块围起来。
 3. **打分 / 门控**：后端代码按 `relevance ≥ 70 且 risk ≤ 65` 过滤（`_material_is_ready`），不是 prompt 自己判阈值。
 4. **联网增强（可选）**：`enrich_topic_materials_online`（`main_logic/topic/materials.py`）拿物料的检索词做一次轻量联网，把现实细节烘进 `material_hint`。
-5. **投递**：到达触发条件后 `trigger_topic_hook_once`（`main_logic/topic/delivery.py`）把物料包成 callback，经 `ProactiveDeliveryManager` 一次性投给角色，命中日配额、一次性 used 记账。
+5. **投递**：材料就绪后 `_schedule_trigger` → `_run_trigger` 经 quiet-window（`_TRIGGER_AFTER_QUIET_SECONDS`，默认 60s 静默等待）+ gap/quota 才调 `trigger_topic_hook_once`（`main_logic/topic/delivery.py`），把物料包成 callback、经 `ProactiveDeliveryManager` 一次性投给角色，命中日配额、一次性 used 记账。
 
 ### 物料契约
 

--- a/docs/design/deep-topic-hooks.md
+++ b/docs/design/deep-topic-hooks.md
@@ -21,7 +21,7 @@
 
 深话题 hook 是「10% 神明降临」那一侧的能力：低频地、像随口想起来一样，主动接住用户最近真正在意的一件事，而不是高频寒暄。
 
-1. 从「慢收集的全局证据 + 最近对话」里挑 1-2 个值得以后低频开口的深话题，**而不是**总结最近一句话。
+1. 从慢收集的对话证据里挑 1-2 个值得以后低频开口的深话题，**而不是**总结最近一句话。
 2. 物料只是给角色的**信号**，不是开口台词；最终怎么开口由 Phase-2 角色模型决定。
 3. 后台预先把话题备好（含可选的联网现实细节），让 proactive chat 投递时不必同步拉取原始对话。
 4. 全程尊重活动倾向门（propensity）与隐私模式，宁可不开口也不硬凑。
@@ -37,8 +37,8 @@
 
 每个角色一个进程内的 `TopicHookPool`（`main_logic/topic/pipeline.py`）。管线分阶段：
 
-1. **采集**：`note_user_message` / note AI 回合把最近对话按 token 预算存进池子；同时喂 `TopicSignalStore` 形成慢全局证据。
-2. **分析**：debounce + quiet-window 后调情绪档小模型 `call_topic_candidates`（`main_logic/activity/llm_enrichment.py`），从「全局证据 + 最近对话」产出候选物料。
+1. **采集**：`note_user_message` / note AI 回合按 token 预算喂 `TopicSignalStore`，形成跨窗口（最多 80 条）的慢对话证据。池子不再单独保留「最近对话」缓冲——那和证据是同一批 turn，纯冗余。
+2. **分析**：debounce + quiet-window 后调情绪档小模型 `call_topic_candidates`（`main_logic/activity/llm_enrichment.py`）。它的**唯一对话输入就是 signal store 渲染的证据**（`global_signals`），prompt 里用中文水印 `======以下为最近对话(按时间顺序)======` / `======以上为最近对话(按时间顺序)======` 把这块围起来。
 3. **打分 / 门控**：后端代码按 `relevance ≥ 70 且 risk ≤ 65` 过滤（`_material_is_ready`），不是 prompt 自己判阈值。
 4. **联网增强（可选）**：`enrich_topic_materials_online`（`main_logic/topic/materials.py`）拿物料的检索词做一次轻量联网，把现实细节烘进 `material_hint`。
 5. **投递**：到达触发条件后 `trigger_topic_hook_once`（`main_logic/topic/delivery.py`）把物料包成 callback，经 `ProactiveDeliveryManager` 一次性投给角色，命中日配额、一次性 used 记账。
@@ -51,7 +51,7 @@
 |---|---|
 | `interest` | 一句话描述用户最近在意/纠结/计划/反复提的一件具体事（≤90 字符存储，prompt 要求 ≤30 字） |
 | `keywords` | 3-6 个关键词；用于去重、筛选联网结果，并直接作为联网查询词；锚定用户反复在意的稳定点 |
-| `relevance` | 0-100，话题与用户的相关度 × 证据稳定度 |
+| `relevance` | 0-100，话题与用户的相关度 × 它是否在对话里反复出现 |
 | `risk` | 0-100，主动提起的打扰/冒犯/硬凑风险 |
 
 ## 设计决策（review 敲定，含理由）
@@ -97,7 +97,11 @@ prompt 只给「明显反复出现 → 高分，顺口一提 → 低分；如实
 
 ### 输入预算按 token
 
-对话与全局证据都按 token 截断（`utils/tokenize.py`），不按字数。对话路单条上限与全局证据统一。
+慢对话证据按 token 截断（`utils/tokenize.py`，每条 300 token），不按字数。
+
+### is_ready 门：数有信息量的发言，不做魔法打分
+
+分析器只在 `TopicSignalStore.is_ready` 通过后才跑：攒够 `min_user_turns_for_topic` 条**有信息量的用户发言**（`_is_meaningful_turn`：非寒暄填充词、且有 ≥3 个信息字符）才算 ready。早期版本用 signal_len / 信息密度 / 稳定度 一堆魔法数凑到 ≥80，对 AI 无 grounding、对维护是负担，已删；门本身（攒够信号再分析、防刚说一句就开聊）保留。`readiness_percent` 仅供日志。
 
 ### 联网与 i18n
 

--- a/main_logic/activity/llm_enrichment.py
+++ b/main_logic/activity/llm_enrichment.py
@@ -298,28 +298,25 @@ async def call_open_threads(
 
 async def call_topic_candidates(
     *,
-    user_msgs: list[tuple[float, str]],
-    ai_msgs: list[tuple[float, str]],
     lang: str,
     global_signals: str = "",
     timeout: float = 8.0,
 ) -> list[dict[str, Any]] | None:
     """Extract low-frequency deeper topic hooks for the background pool.
 
-    This is intentionally a background-only helper. It summarizes raw recent
-    turns into short topic materials, so proactive chat never needs to pull raw
-    conversation text synchronously.
+    Background-only helper. Its only conversation input is the slow
+    cross-window evidence the signal store keeps (``global_signals``); it
+    distils that into short topic materials, so proactive chat never needs to
+    pull raw conversation text synchronously.
     """
     lang_key = _normalize_lang(lang)
     template = _select_lang_template(TOPIC_CANDIDATE_PROMPTS, lang_key)
 
-    if not user_msgs and not ai_msgs:
+    evidence = (global_signals or "").strip()
+    if not evidence:
         return []
 
-    prompt = template.format(
-        conversation=_format_conversation(user_msgs, ai_msgs),
-        global_signals=(global_signals or "(no global signals yet)").strip(),
-    )
+    prompt = template.format(global_signals=evidence)
 
     raw = await _invoke_emotion_tier(prompt, timeout=timeout, label='topic_candidates')
     if raw is None:

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections import defaultdict, deque
+from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from copy import deepcopy
 from datetime import date, datetime
@@ -32,7 +32,6 @@ TopicTrigger = Callable[
     Awaitable[bool],
 ]
 
-_MAX_TURNS_PER_SIDE = 8
 _MAX_TEXT_CHARS = 1000
 _PROCESS_DEBOUNCE_SECONDS = 45.0
 _TRIGGER_AFTER_QUIET_SECONDS = 60.0
@@ -171,22 +170,10 @@ def _material_bigram_units(material: Mapping[str, Any]) -> set[str]:
     return {unit for unit in _material_topic_units(material) if len(unit) >= 2}
 
 
-async def _default_analyzer(
-    *,
-    user_msgs: list[str],
-    ai_msgs: list[str],
-    lang: str,
-    global_signals: str = "",
-):
+async def _default_analyzer(*, lang: str, global_signals: str = ""):
     from main_logic.activity.llm_enrichment import call_topic_candidates
 
-    now = time.time()
-    return await call_topic_candidates(
-        user_msgs=[(now + idx * 0.001, text) for idx, text in enumerate(user_msgs)],
-        ai_msgs=[(now + idx * 0.001, text) for idx, text in enumerate(ai_msgs)],
-        lang=lang,
-        global_signals=global_signals,
-    )
+    return await call_topic_candidates(lang=lang, global_signals=global_signals)
 
 
 def _privacy_mode_active() -> bool:
@@ -226,8 +213,6 @@ class TopicHookPool:
         self._signal_store = TopicSignalStore(
             min_user_turns_for_topic=min_user_turns_for_topic,
         )
-        self._user_turns: dict[str, deque[str]] = defaultdict(lambda: deque(maxlen=_MAX_TURNS_PER_SIDE))
-        self._ai_turns: dict[str, deque[str]] = defaultdict(lambda: deque(maxlen=_MAX_TURNS_PER_SIDE))
         self._langs: dict[str, str] = {}
         self._materials: dict[str, list[dict[str, Any]]] = {}
         self._tasks: dict[str, asyncio.Task] = {}
@@ -238,8 +223,6 @@ class TopicHookPool:
 
     def _purge_character_state(self, name: str) -> None:
         """Drop all accumulated topic state for a character (privacy wipe)."""
-        self._user_turns.pop(name, None)
-        self._ai_turns.pop(name, None)
         self._signal_store.clear(name)
         self._materials.pop(name, None)
         self._dirty.discard(name)
@@ -250,8 +233,7 @@ class TopicHookPool:
             return
         name = str(lanlan_name or "default")
         self._seq[name] += 1
-        self._user_turns[name].append(cleaned)
-        self._signal_store.note_turn(name, actor="user", text=cleaned, lang=lang)
+        self._signal_store.note_turn(name, actor="user", text=cleaned)
         self._langs[name] = lang or self._langs.get(name, "zh")
         self._dirty.add(name)
         self._cancel_trigger(name)
@@ -263,8 +245,7 @@ class TopicHookPool:
             return
         name = str(lanlan_name or "default")
         self._seq[name] += 1
-        self._ai_turns[name].append(cleaned)
-        self._signal_store.note_turn(name, actor="ai", text=cleaned, lang=lang)
+        self._signal_store.note_turn(name, actor="ai", text=cleaned)
         self._langs[name] = lang or self._langs.get(name, "zh")
         self._dirty.add(name)
         self._cancel_trigger(name)
@@ -295,11 +276,6 @@ class TopicHookPool:
             self._purge_character_state(name)
             return
         seen_seq = self._seq.get(name, 0)
-        user_msgs = list(self._user_turns.get(name, ()))
-        ai_msgs = list(self._ai_turns.get(name, ()))
-        if not user_msgs and not ai_msgs:
-            self._dirty.discard(name)
-            return
         if self._daily_quota_reached(name):
             logger.info("[%s] topic collection paused: daily topic quota reached", name)
             self._materials.pop(name, None)
@@ -317,8 +293,6 @@ class TopicHookPool:
         topic_lang = lang or self._langs.get(name, "zh")
         global_signals = self._signal_store.format_global_signals(name, lang=topic_lang)
         raw_materials = await self._analyzer(
-            user_msgs=user_msgs,
-            ai_msgs=ai_msgs,
             lang=topic_lang,
             global_signals=global_signals,
         )

--- a/main_logic/topic/signals.py
+++ b/main_logic/topic/signals.py
@@ -13,17 +13,15 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
-from main_logic.topic.common import ZH_TOPIC_STOP_CHARS, clean_text, topic_units
+from main_logic.topic.common import clean_text
 from utils.tokenize import truncate_to_tokens
 
 
 _MAX_SIGNAL_TEXT_CHARS = 500
-# Per-turn evidence cap in tokens, unified with the recent-conversation
-# per-turn budget (llm_enrichment._MAX_CONV_TOKENS_PER_TURN) so both inputs
-# to the emotion-tier topic call share one budget unit.
+# Per-turn evidence cap in tokens. The topic candidate prompt feeds this slow
+# evidence as its only conversation input, so the per-turn budget lives here.
 _MAX_SIGNAL_TOKENS_PER_TURN = 300
 _MAX_GLOBAL_TURNS = 80
-_READY_SCORE = 80
 _FILLER_TEXTS = {
     "你好",
     "啊",
@@ -44,7 +42,6 @@ _FILLER_TEXTS = {
 
 _GLOBAL_SIGNAL_LABELS = {
     "zh": {
-        "evidence": "全局证据",
         "user": "用户",
         "ai": "AI",
         "seconds_ago": "{value}s前",
@@ -52,7 +49,6 @@ _GLOBAL_SIGNAL_LABELS = {
         "hours_ago": "{value}h前",
     },
     "zh-TW": {
-        "evidence": "全域證據",
         "user": "使用者",
         "ai": "AI",
         "seconds_ago": "{value}s前",
@@ -60,7 +56,6 @@ _GLOBAL_SIGNAL_LABELS = {
         "hours_ago": "{value}h前",
     },
     "en": {
-        "evidence": "Global evidence",
         "user": "User",
         "ai": "AI",
         "seconds_ago": "{value}s ago",
@@ -68,7 +63,6 @@ _GLOBAL_SIGNAL_LABELS = {
         "hours_ago": "{value}h ago",
     },
     "ja": {
-        "evidence": "全体証拠",
         "user": "ユーザー",
         "ai": "AI",
         "seconds_ago": "{value}秒前",
@@ -76,7 +70,6 @@ _GLOBAL_SIGNAL_LABELS = {
         "hours_ago": "{value}時間前",
     },
     "ko": {
-        "evidence": "전역 증거",
         "user": "사용자",
         "ai": "AI",
         "seconds_ago": "{value}초 전",
@@ -84,7 +77,6 @@ _GLOBAL_SIGNAL_LABELS = {
         "hours_ago": "{value}시간 전",
     },
     "es": {
-        "evidence": "Evidencia global",
         "user": "Usuario",
         "ai": "IA",
         "seconds_ago": "hace {value}s",
@@ -92,7 +84,6 @@ _GLOBAL_SIGNAL_LABELS = {
         "hours_ago": "hace {value}h",
     },
     "pt": {
-        "evidence": "Evidência global",
         "user": "Usuário",
         "ai": "IA",
         "seconds_ago": "há {value}s",
@@ -100,7 +91,6 @@ _GLOBAL_SIGNAL_LABELS = {
         "hours_ago": "há {value}h",
     },
     "ru": {
-        "evidence": "Глобальные сигналы",
         "user": "Пользователь",
         "ai": "AI",
         "seconds_ago": "{value}с назад",
@@ -142,7 +132,6 @@ class TopicTurnSignal:
     actor: str
     text: str
     timestamp: float
-    lang: str
 
 
 class TopicSignalStore:
@@ -165,7 +154,6 @@ class TopicSignalStore:
         *,
         actor: str,
         text: Any,
-        lang: str = "zh",
         now: float | None = None,
     ) -> None:
         cleaned = truncate_to_tokens(_clean_text(text), _MAX_SIGNAL_TOKENS_PER_TURN)
@@ -178,7 +166,6 @@ class TopicSignalStore:
                 actor=safe_actor,
                 text=cleaned,
                 timestamp=float(now if now is not None else time.time()),
-                lang=lang or "zh",
             )
         )
 
@@ -186,37 +173,22 @@ class TopicSignalStore:
         self._turns.pop(str(lanlan_name or "default"), None)
 
     def readiness_percent(self, lanlan_name: str) -> int:
-        user_turns = self._user_turns(lanlan_name)
-        if not user_turns:
-            return 0
-        meaningful = [turn for turn in user_turns if _turn_information_score(turn.text) >= 20]
-        if not meaningful:
-            return 0
-
-        sample_score = min(
-            40,
-            int(len(meaningful) * 40 / self._min_user_turns_for_topic),
-        )
-        density_score = int(
-            sum(_turn_information_score(turn.text) for turn in meaningful)
-            / len(meaningful)
-            * 0.5
-        )
-        stability_score = _stability_score(meaningful)
-        return max(0, min(100, sample_score + density_score + stability_score))
+        # Coarse "have we heard enough to bother analysing" estimate, for logs.
+        count = len(self._meaningful_user_turns(lanlan_name))
+        return min(100, int(count * 100 / self._min_user_turns_for_topic))
 
     def is_ready(self, lanlan_name: str) -> bool:
-        return self.readiness_percent(lanlan_name) >= _READY_SCORE
+        return (
+            len(self._meaningful_user_turns(lanlan_name))
+            >= self._min_user_turns_for_topic
+        )
 
     def format_global_signals(self, lanlan_name: str, *, max_lines: int = 40, lang: str | None = None) -> str:
-        """Render the slow-evidence turns as prompt context.
+        """Render the slow-evidence turns as the topic prompt's only context.
 
-        Only the raw evidence list is emitted. The local heuristic stats
-        (readiness / density / stability / counts) are deliberately NOT
-        injected — they have no grounding or scale the LLM can use, and the
-        model can read stability straight off the evidence. Those scores
-        stay backend-only, feeding the ``is_ready`` gate (see
-        ``readiness_percent``), not the prompt.
+        Just the turn list — the readiness count gate (see ``is_ready`` /
+        ``readiness_percent``) stays backend-only and never reaches the prompt.
+        The caller fences this block with the conversation-history watermark.
         """
         name = str(lanlan_name or "default")
         labels = _GLOBAL_SIGNAL_LABELS[_label_key_for_lang(lang)]
@@ -226,7 +198,7 @@ class TopicSignalStore:
 
         selected = _select_turns_for_prompt(turns, max_lines=max_lines)
         base_ts = turns[-1].timestamp
-        lines = [f"{labels['evidence']}:"]
+        lines: list[str] = []
         for turn in selected:
             age_s = max(0.0, base_ts - turn.timestamp)
             age = _format_age(age_s, labels)
@@ -237,6 +209,12 @@ class TopicSignalStore:
     def _user_turns(self, lanlan_name: str) -> list[TopicTurnSignal]:
         name = str(lanlan_name or "default")
         return [turn for turn in self._turns.get(name, ()) if turn.actor == "user"]
+
+    def _meaningful_user_turns(self, lanlan_name: str) -> list[TopicTurnSignal]:
+        return [
+            turn for turn in self._user_turns(lanlan_name)
+            if _is_meaningful_turn(turn.text)
+        ]
 
 
 def _select_turns_for_prompt(
@@ -258,51 +236,18 @@ def _select_turns_for_prompt(
     return all_turns[:head_count] + all_turns[-tail_count:]
 
 
-def _turn_information_score(text: str) -> int:
+def _is_meaningful_turn(text: str) -> bool:
+    """Whether a user turn carries enough signal to count toward readiness.
+
+    Filler words and near-empty turns don't count; anything with a few real
+    information characters does. Coarse "have we heard enough to bother
+    analysing" gate, not a quality score.
+    """
     cleaned = _clean_text(text, limit=120)
-    if not cleaned:
-        return 0
-    normalized = cleaned.lower()
-    if normalized in _FILLER_TEXTS:
-        return 0
-    cjk_count = sum(1 for char in cleaned if "\u4e00" <= char <= "\u9fff")
-    ascii_count = sum(1 for char in cleaned if char.isalnum() and not ("\u4e00" <= char <= "\u9fff"))
-    signal_len = cjk_count + ascii_count
-    if signal_len <= 2:
-        return 0
-    if signal_len <= 4:
-        return 12
-
-    score = min(60, int(signal_len * 2.5))
-    unique_units = _topic_units(cleaned)
-    score += min(20, int(len(unique_units) * 2.5))
-    if any(mark in cleaned for mark in "，。！？,.!?"):
-        score += 5
-    if len(cleaned) >= 18:
-        score += 8
-    if len(cleaned) >= 30:
-        score += 7
-    return max(0, min(100, score))
-
-
-def _topic_units(text: str) -> set[str]:
-    return topic_units(text, limit=120, stop_chars=ZH_TOPIC_STOP_CHARS)
-
-
-def _stability_score(turns: Iterable[TopicTurnSignal]) -> int:
-    unit_counts: dict[str, int] = defaultdict(int)
-    valid_turns = 0
-    for turn in turns:
-        units = _topic_units(turn.text)
-        if not units:
-            continue
-        valid_turns += 1
-        for unit in units:
-            unit_counts[unit] += 1
-    if valid_turns < 2:
-        return 0
-    repeated_units = [
-        unit for unit, count in unit_counts.items()
-        if count >= 2 and (len(unit) >= 2 or "\u4e00" <= unit <= "\u9fff")
-    ]
-    return min(30, len(repeated_units) * 5)
+    if not cleaned or cleaned.lower() in _FILLER_TEXTS:
+        return False
+    signal_len = sum(
+        1 for char in cleaned
+        if ("一" <= char <= "鿿") or char.isalnum()
+    )
+    return signal_len >= 3

--- a/tests/unit/test_topic_llm_enrichment.py
+++ b/tests/unit/test_topic_llm_enrichment.py
@@ -77,7 +77,7 @@ async def test_call_topic_candidates_parses_model_output(monkeypatch):
 
     topics = await llm_enrichment.call_topic_candidates(
         lang="zh-CN",
-        global_signals="全局证据: 用户多次提到想买凯迪拉克但预算紧张",
+        global_signals="- [3min前] 用户: 我想买凯迪拉克，但根本买不起\n- [0s前] 用户: 毕业一年才攒了4600",
     )
 
     assert topics == [
@@ -120,10 +120,10 @@ async def test_call_topic_candidates_passes_global_signals_and_keeps_keywords(mo
 
     topics = await llm_enrichment.call_topic_candidates(
         lang="zh-CN",
-        global_signals="全局信号：用户三次提到买车和自由感",
+        global_signals="- [5min前] 用户: 又聊到买车\n- [1min前] 用户: 买车让我觉得能自由点",
     )
 
-    assert "全局信号：用户三次提到买车和自由感" in captured["prompt"]
+    assert "买车让我觉得能自由点" in captured["prompt"]
     assert topics == [
         {
             "interest": "用户把买车和生活自由感联系在一起",
@@ -156,7 +156,7 @@ async def test_call_topic_candidates_skips_low_relevance(monkeypatch):
 
     topics = await llm_enrichment.call_topic_candidates(
         lang="zh-CN",
-        global_signals="收集进度: 60%",
+        global_signals="- [2min前] 用户: 还没聊开，就随口提了句",
     )
 
     assert topics == []
@@ -183,7 +183,7 @@ async def test_call_topic_candidates_skips_high_risk(monkeypatch):
 
     topics = await llm_enrichment.call_topic_candidates(
         lang="zh-CN",
-        global_signals="全局证据: 用户顺口提了一句不太想被追问的事",
+        global_signals="- [1min前] 用户: 顺口提了一句不太想被追问的事",
     )
 
     # relevance clears the bar but risk > 65 must still reject — guards the
@@ -213,7 +213,7 @@ async def test_call_topic_candidates_keeps_short_cjk_interests(monkeypatch):
 
     topics = await llm_enrichment.call_topic_candidates(
         lang="zh-CN",
-        global_signals="收集进度: 100%",
+        global_signals="- [4min前] 用户: 我最近一直在想转职\n- [0s前] 用户: 越来越认真在考虑",
     )
 
     assert topics and topics[0]["interest"] == "转职"
@@ -248,7 +248,7 @@ async def test_call_topic_candidates_uses_localized_prompt_for_supported_languag
 
     topics = await llm_enrichment.call_topic_candidates(
         lang=lang,
-        global_signals="collection: enough evidence",
+        global_signals="- [2min ago] User: I keep thinking about wanting a new phone",
     )
 
     assert topics == []

--- a/tests/unit/test_topic_llm_enrichment.py
+++ b/tests/unit/test_topic_llm_enrichment.py
@@ -76,9 +76,8 @@ async def test_call_topic_candidates_parses_model_output(monkeypatch):
     monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
 
     topics = await llm_enrichment.call_topic_candidates(
-        user_msgs=[(1.0, "我想买凯迪拉克，但我根本买不起，毕业一年才攒了4600")],
-        ai_msgs=[],
         lang="zh-CN",
+        global_signals="全局证据: 用户多次提到想买凯迪拉克但预算紧张",
     )
 
     assert topics == [
@@ -120,8 +119,6 @@ async def test_call_topic_candidates_passes_global_signals_and_keeps_keywords(mo
     monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
 
     topics = await llm_enrichment.call_topic_candidates(
-        user_msgs=[(1.0, "刚才又聊到买车")],
-        ai_msgs=[],
         lang="zh-CN",
         global_signals="全局信号：用户三次提到买车和自由感",
     )
@@ -158,8 +155,6 @@ async def test_call_topic_candidates_skips_low_relevance(monkeypatch):
     monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
 
     topics = await llm_enrichment.call_topic_candidates(
-        user_msgs=[(1.0, "还没聊开")],
-        ai_msgs=[],
         lang="zh-CN",
         global_signals="收集进度: 60%",
     )
@@ -187,9 +182,8 @@ async def test_call_topic_candidates_skips_high_risk(monkeypatch):
     monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
 
     topics = await llm_enrichment.call_topic_candidates(
-        user_msgs=[(1.0, "顺口提了一句不太想被追问的事")],
-        ai_msgs=[],
         lang="zh-CN",
+        global_signals="全局证据: 用户顺口提了一句不太想被追问的事",
     )
 
     # relevance clears the bar but risk > 65 must still reject — guards the
@@ -218,8 +212,6 @@ async def test_call_topic_candidates_keeps_short_cjk_interests(monkeypatch):
     monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
 
     topics = await llm_enrichment.call_topic_candidates(
-        user_msgs=[(1.0, "我最近一直在想转职")],
-        ai_msgs=[],
         lang="zh-CN",
         global_signals="收集进度: 100%",
     )
@@ -255,8 +247,6 @@ async def test_call_topic_candidates_uses_localized_prompt_for_supported_languag
     monkeypatch.setattr(llm_enrichment, "_invoke_emotion_tier", fake_invoke)
 
     topics = await llm_enrichment.call_topic_candidates(
-        user_msgs=[(1.0, "I mentioned wanting a new phone.")],
-        ai_msgs=[],
         lang=lang,
         global_signals="collection: enough evidence",
     )

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -44,7 +44,7 @@ def test_clean_material_normalizes_media_intent_string_and_bad_created_at():
 async def test_topic_pool_waits_for_slow_global_collection_before_analysis():
     calls = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, global_signals):
+    async def fake_analyzer(*, lang, global_signals):
         calls.append(global_signals)
         return [
             {
@@ -75,17 +75,16 @@ async def test_topic_pool_waits_for_slow_global_collection_before_analysis():
     await pool.process_now("妮可")
 
     assert len(calls) == 1
-    assert "全局证据:" in calls[0]
+    assert "- [" in calls[0]  # rendered evidence lines, no inner header
     assert "第一句只是随口聊聊" in calls[0]
     assert pool.get_ready_materials("妮可")[0]["interest"] == "慢慢形成的长期兴趣"
 
 
 @pytest.mark.asyncio
-async def test_topic_pool_global_signals_keep_more_than_recent_window():
+async def test_topic_pool_passes_full_global_signals_to_analyzer():
     captured = {}
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, global_signals):
-        captured["recent"] = list(user_msgs)
+    async def fake_analyzer(*, lang, global_signals):
         captured["global"] = global_signals
         return [
             {
@@ -108,16 +107,16 @@ async def test_topic_pool_global_signals_keep_more_than_recent_window():
 
     await pool.process_now("妮可")
 
-    assert "第0次聊换车和预算" not in captured["recent"]
     assert "第0次聊换车和预算" in captured["global"]
+    assert "第9次聊换车和预算" in captured["global"]
 
 
 @pytest.mark.asyncio
 async def test_topic_pool_collects_silently_until_background_processing():
     calls = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
-        calls.append((list(user_msgs), list(ai_msgs), lang))
+    async def fake_analyzer(*, lang, **kwargs):
+        calls.append(lang)
         return [
             {
                 "interest": "想买凯迪拉克但预算压力很大",
@@ -154,9 +153,11 @@ async def test_topic_pool_collects_silently_until_background_processing():
 
 @pytest.mark.asyncio
 async def test_topic_pool_uses_ai_context_without_blocking_collection():
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
-        assert user_msgs == ["我想换工作，但是怕踩坑，最近每天都在想是不是该换个方向"]
-        assert ai_msgs == ["换工作这事可以慢慢拆，别上来就破釜沉舟。"]
+    async def fake_analyzer(*, lang, global_signals=None, **kwargs):
+        # both the user turn and the AI turn reach the analyzer via the
+        # rendered slow evidence (no separate recent-conversation input)
+        assert "我想换工作" in (global_signals or "")
+        assert "换工作这事可以慢慢拆" in (global_signals or "")
         return [
             {
                 "interest": "想换工作但担心选错",
@@ -187,7 +188,7 @@ async def test_topic_pool_uses_ai_context_without_blocking_collection():
 async def test_topic_pool_passes_chat_language_to_online_enrichment(monkeypatch):
     langs = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "看平民代步车的小改件",
@@ -221,8 +222,8 @@ async def test_topic_pool_discards_stale_analysis_when_new_turn_arrives():
     release = asyncio.Event()
     calls = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
-        calls.append(list(user_msgs))
+    async def fake_analyzer(*, lang, **kwargs):
+        calls.append(lang)
         await release.wait()
         return [
             {
@@ -245,7 +246,7 @@ async def test_topic_pool_discards_stale_analysis_when_new_turn_arrives():
     release.set()
     assert await task is None
 
-    assert calls == [["第一句认真说一下我最近一直在纠结要不要换工作"]]
+    assert len(calls) == 1  # analyzer ran once; its stale result was discarded
     assert pool.get_ready_materials("妮可") == []
 
 
@@ -254,7 +255,7 @@ async def test_topic_pool_discards_stale_analysis_when_new_turn_arrives_during_e
     entered_enrich = asyncio.Event()
     release_enrich = asyncio.Event()
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "旧话题",
@@ -294,7 +295,7 @@ async def test_topic_pool_debounce_retries_after_background_analyzer_failure():
     calls = 0
     retried = asyncio.Event()
 
-    async def flaky_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def flaky_analyzer(*, lang, **kwargs):
         nonlocal calls
         calls += 1
         if calls == 1:
@@ -346,7 +347,7 @@ async def test_topic_pool_keeps_dirty_when_analyzer_returns_none():
     calls = 0
     retried = asyncio.Event()
 
-    async def flaky_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def flaky_analyzer(*, lang, **kwargs):
         nonlocal calls
         calls += 1
         if calls == 1:
@@ -395,7 +396,7 @@ async def test_topic_pool_keeps_dirty_when_analyzer_returns_none():
 async def test_topic_pool_triggers_ready_hook_after_quiet_window():
     delivered = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "买车像进入新生活阶段",
@@ -433,7 +434,7 @@ async def test_topic_pool_clears_pending_trigger_when_privacy_turns_on(monkeypat
     delivered = []
     privacy_enabled = False
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "买车像进入新生活阶段",
@@ -474,7 +475,7 @@ async def test_topic_pool_clears_pending_trigger_when_privacy_turns_on(monkeypat
 async def test_topic_pool_triggers_highest_relevance_material_first():
     delivered = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "低优先级话题",
@@ -516,7 +517,7 @@ async def test_topic_pool_keeps_material_pending_when_delivery_defers():
     first_attempt = asyncio.Event()
     attempts = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "买车像进入新生活阶段",
@@ -553,7 +554,7 @@ async def test_topic_pool_retries_pending_material_after_delivery_defers():
     attempts = []
     retried = asyncio.Event()
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "买车像进入新生活阶段",
@@ -595,7 +596,7 @@ async def test_topic_pool_retries_pending_material_after_trigger_exception():
     attempts = []
     retried = asyncio.Event()
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "买车像进入新生活阶段",
@@ -636,7 +637,7 @@ async def test_topic_pool_retries_pending_material_after_trigger_exception():
 async def test_topic_pool_does_not_cancel_current_trigger_when_ai_turn_is_recorded():
     triggered = asyncio.Event()
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "买车像进入新生活阶段",
@@ -674,10 +675,14 @@ async def test_topic_pool_does_not_cancel_current_trigger_when_ai_turn_is_record
 async def test_topic_pool_resets_trigger_wait_when_chat_continues():
     delivered = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, global_signals=None, **kwargs):
+        # newest evidence line is the latest turn; echo it as the interest so
+        # the test can prove the post-continue analysis (not the stale one) won
+        last_line = (global_signals or "").strip().splitlines()[-1]
+        interest = last_line.split(": ", 1)[-1] if ": " in last_line else last_line
         return [
             {
-                "interest": user_msgs[-1],
+                "interest": interest,
                 "hook": "接住最新话题",
                 "relevance": 90,
             }
@@ -713,7 +718,7 @@ async def test_topic_pool_limits_daily_topic_triggers_to_two():
     delivered = []
     analyzer_calls = 0
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         nonlocal analyzer_calls
         interests = [
             "凯迪拉克预算压力",
@@ -793,7 +798,7 @@ async def test_topic_pool_does_not_trigger_second_topic_immediately_after_first(
     delivered = []
     analyzer_calls = 0
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         nonlocal analyzer_calls
         analyzer_calls += 1
         interest = "凯迪拉克预算压力" if analyzer_calls == 1 else "海边旅行计划"
@@ -837,7 +842,7 @@ async def test_topic_pool_does_not_trigger_second_topic_immediately_after_first(
 async def test_topic_pool_suppresses_same_topic_after_it_was_used_today():
     delivered = []
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, **kwargs):
+    async def fake_analyzer(*, lang, **kwargs):
         return [
             {
                 "interest": "文本世界模型的无撤回机制与幻觉问题",
@@ -882,7 +887,7 @@ async def test_enrich_pool_discards_material_when_privacy_toggles_on_mid_analysi
     privacy = {"on": False}
     monkeypatch.setattr(topic_pipeline, "_privacy_mode_active", lambda: privacy["on"])
 
-    async def fake_analyzer(*, user_msgs, ai_msgs, lang, global_signals):
+    async def fake_analyzer(*, lang, global_signals):
         privacy["on"] = True  # user enables privacy while we're "analyzing"
         return [
             {

--- a/tests/unit/test_topic_signals.py
+++ b/tests/unit/test_topic_signals.py
@@ -7,64 +7,70 @@ def test_topic_signal_store_keeps_filler_chat_below_ready_even_after_many_turns(
     for text in ["嗯", "哈哈", "好", "可以", "啊", "行", "哦", "没事", "对", "不知道"]:
         store.note_turn("妮可", actor="user", text=text, now=1.0)
 
-    assert store.readiness_percent("妮可") < 80
+    # All filler → no meaningful turns → never ready, however many arrive.
+    assert store.readiness_percent("妮可") == 0
     assert store.is_ready("妮可") is False
     formatted = store.format_global_signals("妮可")
-    # stats head (readiness/density/stability) is no longer injected into the
-    # prompt — only the raw evidence list remains. readiness stays a backend gate.
+    # Only the raw evidence list is emitted — no stats head, no inner header.
     assert "收集进度:" not in formatted
-    assert "信息密度:" not in formatted
-    assert "全局证据:" in formatted
+    assert "全局证据:" not in formatted
+    assert "- [" in formatted  # turn lines still render
 
 
-def test_topic_signal_store_allows_dense_short_collection_to_be_analyzed():
+def test_topic_signal_store_ready_after_enough_meaningful_user_turns():
     store = TopicSignalStore(min_user_turns_for_topic=4)
 
     store.note_turn("妮可", actor="user", text="我最近一直在纠结要不要换工作，怕换了之后更坑", now=1.0)
     store.note_turn("妮可", actor="ai", text="你像是在怕失去可控感。", now=2.0)
     store.note_turn("妮可", actor="user", text="对，我不是怕累，是怕选错了以后回不了头", now=3.0)
     store.note_turn("妮可", actor="user", text="但现在这个工作又真的让我每天都很烦", now=4.0)
+    store.note_turn("妮可", actor="user", text="要不要干脆换个城市重新开始", now=5.0)
 
-    assert store.readiness_percent("妮可") >= 80
+    # 4 meaningful user turns reach the gate (the AI turn does not count).
     assert store.is_ready("妮可") is True
+    assert store.readiness_percent("妮可") >= 80
     formatted = store.format_global_signals("妮可")
     assert "稳定度:" not in formatted
     assert "换工作" in formatted
 
 
-def test_topic_signal_store_localizes_global_signal_labels():
+def test_topic_signal_store_localizes_evidence_lines():
     store = TopicSignalStore(min_user_turns_for_topic=1)
-    store.note_turn("neko", actor="user", text="I keep thinking about moving to a quieter city", lang="en", now=1.0)
-    store.note_turn("neko", actor="ai", text="That sounds like a need for more control.", lang="en", now=2.0)
+    store.note_turn("neko", actor="user", text="I keep thinking about moving to a quieter city", now=1.0)
+    store.note_turn("neko", actor="ai", text="That sounds like a need for more control.", now=2.0)
 
     formatted = store.format_global_signals("neko", lang="en")
 
-    # stats head dropped; the evidence-list label still localizes by lang
-    assert "Global evidence:" in formatted
+    # No stats head / inner header; the per-line actor + age label localizes.
     assert "moving to a quieter city" in formatted
-    assert "Collection progress:" not in formatted
-    assert "User evidence count:" not in formatted
+    assert "User:" in formatted
+    assert "Global evidence:" not in formatted
     assert "收集进度:" not in formatted
 
 
-def test_topic_signal_store_scores_repeated_theme_higher_than_unrelated_thin_turns():
-    repeated = TopicSignalStore(min_user_turns_for_topic=4)
-    repeated.note_turn("妮可", actor="user", text="我最近一直在看赛博朋克2077的夜之城细节", now=1.0)
-    repeated.note_turn("妮可", actor="user", text="夜之城那些路边小故事特别戳我", now=2.0)
-    repeated.note_turn("妮可", actor="user", text="我喜欢这种不直接讲但能让人懂的游戏细节", now=3.0)
+def test_filler_turns_do_not_count_toward_readiness():
+    substantive = TopicSignalStore(min_user_turns_for_topic=4)
+    for text in [
+        "我在纠结要不要换工作",
+        "怕选错了以后回不了头",
+        "现在的工作让我每天都很烦",
+        "想去个安静点的城市重新开始",
+    ]:
+        substantive.note_turn("妮可", actor="user", text=text, now=1.0)
 
-    scattered = TopicSignalStore(min_user_turns_for_topic=4)
-    scattered.note_turn("妮可", actor="user", text="今天还行", now=1.0)
-    scattered.note_turn("妮可", actor="user", text="这个按钮在哪", now=2.0)
-    scattered.note_turn("妮可", actor="user", text="哈哈确实", now=3.0)
+    filler = TopicSignalStore(min_user_turns_for_topic=4)
+    for text in ["嗯", "哈哈", "好", "可以"]:
+        filler.note_turn("妮可", actor="user", text=text, now=1.0)
 
-    assert repeated.readiness_percent("妮可") > scattered.readiness_percent("妮可")
+    assert substantive.is_ready("妮可") is True
+    assert filler.is_ready("妮可") is False
+    assert substantive.readiness_percent("妮可") > filler.readiness_percent("妮可")
 
 
 def test_select_turns_for_prompt_clamps_negative_max_lines():
     turns = [
-        TopicTurnSignal(actor="user", text="第一句", timestamp=1.0, lang="zh-CN"),
-        TopicTurnSignal(actor="user", text="第二句", timestamp=2.0, lang="zh-CN"),
+        TopicTurnSignal(actor="user", text="第一句", timestamp=1.0),
+        TopicTurnSignal(actor="user", text="第二句", timestamp=2.0),
     ]
 
     assert _select_turns_for_prompt(turns, max_lines=-1) == []


### PR DESCRIPTION
#1651 深话题候选链路的「上下游清理」跟进。核心是把喂给筛选小模型的输入从两块冗余收成一块，并修复 6 个 locale 漏掉的对话历史安全水印。

## 回归报告

### 改动
1. **prompt 合并 + 水印修复**（`config/prompts/prompts_activity.py`，8 locale）：原来喂两块——「慢收集的全局证据」+「最近对话」——其实是同一批 turn 渲染两遍（而且「最近对话」那路的时间戳在生产里是 `_default_analyzer` 造的假值，全 `[0s ago]`）。合成一块，用中文对话历史安全水印 `======以下为最近对话(按时间顺序)======` / `======以上为最近对话(按时间顺序)======` 围起来（zh-TW 用繁体 為，其余 locale 沿用简体水印，和兄弟 prompt `ACTIVITY_GUESS_PROMPTS` 一致）。原本 en/ja/ko/es/pt/ru 6 个 locale 把对话块 fence 翻译成本地语言 + start/end 风格（End conversation / ここまで / 끝 / Fin / Конец），**丢掉了中文 `以下为/以上为` 水印**，本 PR 补回。顺带 de-jargon「慢收集 / 全局证据 / 稳定性」为模型能直接判的「最近对话 / 是否反复出现」。
2. **`call_topic_candidates`**（`main_logic/activity/llm_enrichment.py`）：去掉 `user_msgs/ai_msgs` 入参，唯一对话输入就是 signal store 渲染的证据 `global_signals`。
3. **pipeline**（`main_logic/topic/pipeline.py`）：删掉和 signal store 重复的 `_user_turns/_ai_turns` deque + `_MAX_TURNS_PER_SIDE`；`_default_analyzer` / `enrich_topic_pool` 不再传原始 turn。
4. **signals**（`main_logic/topic/signals.py`）：`is_ready` 改为「数有信息量的用户发言 ≥ `min_user_turns_for_topic`」（`_is_meaningful_turn`：非寒暄 + ≥3 信息字符），删掉 signal_len / 信息密度 / 稳定度 一堆魔法数打分（`_turn_information_score` / `_stability_score` / `_topic_units` / `_READY_SCORE`）；删死字段 `TopicTurnSignal.lang`；删 `format_global_signals` 内部冗余的 `全局证据:` 小标题 + 对应 label。门本身（攒够信号再分析）保留。

### 必要性
#1651 review 暴露的链路冗余 + 安全水印缺陷。两块同源 turn 重复进 prompt（还带假时间戳），是误导小模型的噪声；6 个 locale 漏水印是真实安全回归（对话历史注入面没被中文水印围栏标记）。

### 前后行为
- prompt 从两块变一块，内容去重；小模型现在只看一份带真实时间戳的证据。功能语义不变（仍是「从最近对话里挑深话题」）。
- `is_ready` 门的**意图不变**（攒够有效发言才分析），只是判据从魔法数打分换成可读的计数；阈值仍是 `min_user_turns_for_topic`。
- signal store 的语言渲染、token 截断、80 条窗口、head/tail 采样均不变。

### 潜在回归
中低。signal store 全套单测重写并覆盖（filler 不计入 readiness、攒够才 ready、证据渲染无内部标题、locale 化）；pipeline 19 个 fake_analyzer 迁到 `global_signals`-only 契约；llm_enrichment 6 个调用点迁移。topic 全套本地 180 passed，`check_i18n_sync` / `check_i18n` / `check_docstring_no_cjk` 三守门 0 退出。水印形态与兄弟 prompt `ACTIVITY_GUESS_PROMPTS` 对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 话题识别机制优化

* **Bug Fixes**
  * 优化就绪度判定：更严格过滤填充对话与无信息回合，减少误触发
  * 调整候选评分口径：更强调话题在对话中的反复出现，并统一相关性/风险评估说明

* **Refactor**
  * 话题候选生成与触发时机：改为基于全局证据进行分析，收紧数据流与触发门控逻辑

* **Documentation**
  * 更新深话题机制设计文档与评估口径

* **Tests**
  * 更新并强化单元测试，覆盖新的证据渲染与触发/候选生成流程
<!-- end of auto-generated comment: release notes by coderabbit.ai -->