### PR TITLE
feat(tts): voice_id 并查集式惰性迁移到结构化 {source,provider,ref}（at-rest）

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -1251,13 +1251,15 @@ async def _init_character_resources(k: str, is_new_character: bool):
                 old_mgr = rs.session_manager
                 # 更新prompt
                 old_mgr.lanlan_prompt = lanlan_prompt[k].replace('{LANLAN_NAME}', k).replace('{MASTER_NAME}', master_name)
-                # 直接读 module global lanlan_basic_config，避免重复 load + deepcopy
-                old_mgr.voice_id = get_reserved(
+                # 直接读 module global lanlan_basic_config，避免重复 load + deepcopy。
+                # 经 read_legacy_voice_id 容忍 voice 的扁平串 / 结构对象两形态（惰性迁移）。
+                from utils.voice_config import read_legacy_voice_id
+                old_mgr.voice_id = read_legacy_voice_id(get_reserved(
                     lanlan_basic_config[k],
                     'voice_id',
                     default='',
                     legacy_keys=('voice_id',),
-                )
+                ))
                 logger.info(f"{k} 有活跃session，只更新配置，不重新创建session_manager")
             except Exception as e:
                 logger.error(f"更新 {k} 的活跃session配置失败: {e}", exc_info=True)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -92,7 +92,10 @@ def get_character_reserved_fields() -> tuple[str, ...]:
 # 角色保留字段 schema（v2）
 # 所有系统保留字段统一收口到 `_reserved`，并按 avatar/live2d/vrm 分层。
 RESERVED_FIELD_SCHEMA = {
-    "voice_id": str,
+    # voice_id 兼容两形态：旧扁平串 + 声音来源统一架构的结构对象 {source,provider,ref}
+    # （并查集式惰性迁移，用户设音色时逐条迁移）。否则已迁移的角色每次 load 都被
+    # validate_reserved_schema 误报 _reserved.voice_id 结构异常。
+    "voice_id": (str, dict),
     "system_prompt": str,
     "field_order": list,
     "persona_override": {

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -4041,9 +4041,12 @@ class LLMSessionManager:
             default='',
             legacy_keys=('voice_id',),
         )
-        # strip 收口在源头：避免 characters.json 里偶发的前后空白让下游 literal
-        # 比较 / route gating / is_free_preset_voice_id 之类的 callee 失配。
-        return (raw or '').strip()
+        # 声音来源统一架构惰性迁移：characters.json 里 voice 可能是旧扁平串，也可能是
+        # 用户设音色后迁成的结构对象 {source,provider,ref}。read_legacy_voice_id 把两形态
+        # 统一读成 dispatch/route gating 一直消费的 legacy 前缀串（顺带 strip 收口空白），
+        # 下游 literal 比较 / is_free_preset_voice_id 等无需感知存储形态。
+        from utils.voice_config import read_legacy_voice_id
+        return read_legacy_voice_id(raw)
 
     def _apply_voice_id_for_route(self) -> None:
         """Resolve the character card's voice_id into self.voice_id /

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -93,6 +93,7 @@ from utils.config_manager import (
     strip_generated_persona_selection_prompt,
 )
 from utils.dashscope_region import DASHSCOPE_GLOBAL_LOCK, configure_dashscope_sdk_urls
+from utils.voice_config import read_legacy_voice_id
 from utils.native_voice_registry import (
     get_active_realtime_native_provider_for_ui,
     get_native_voice_catalog_for_ui,
@@ -2868,12 +2869,12 @@ async def update_catgirl_voice_id(name: str, request: Request):
     if name not in characters.get('猫娘', {}):
         return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
     voice_id = str(data.get('voice_id') or '').strip()
-    old_voice_id = str(get_reserved(
+    old_voice_id = read_legacy_voice_id(get_reserved(
         characters['猫娘'][name],
         'voice_id',
         default='',
         legacy_keys=('voice_id',)
-    ) or '').strip()
+    ))
 
     # 幂等保护：提交同值时直接返回，避免无实际变更触发 reload_page。
     if old_voice_id == voice_id:
@@ -2893,7 +2894,8 @@ async def update_catgirl_voice_id(name: str, request: Request):
             'available_voices': available_voices
         }, status_code=400)
 
-    set_reserved(characters['猫娘'][name], 'voice_id', voice_id)
+    # 用户设音色：惰性迁移这一条到结构对象（用到哪条迁哪条，见 voice_id_to_storage_value）。
+    set_reserved(characters['猫娘'][name], 'voice_id', _config_manager.voice_id_to_storage_value(voice_id))
     await _config_manager.asave_characters(characters)
 
     # 如果是当前活跃的猫娘，需要先通知前端，再关闭session
@@ -3192,7 +3194,7 @@ async def unregister_voice(name: str):
             return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
 
         # 检查是否已有voice_id
-        old_voice_id = get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',))
+        old_voice_id = read_legacy_voice_id(get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',)))
         if not old_voice_id:
             return JSONResponse({'success': False, 'error': 'TTS_VOICE_NOT_REGISTERED', 'code': 'TTS_VOICE_NOT_REGISTERED'}, status_code=400)
 
@@ -3802,9 +3804,9 @@ async def update_catgirl(name: str, request: Request):
         if k != '档案名' and v:
             characters['猫娘'][name][k] = v
 
-    # 兼容旧接口：若请求中带有 voice_id，则同步写入保留字段。
+    # 兼容旧接口：若请求中带有 voice_id，则同步写入保留字段（惰性迁移成结构对象）。
     if voice_id_in_payload:
-        set_reserved(characters['猫娘'][name], 'voice_id', requested_voice_id)
+        set_reserved(characters['猫娘'][name], 'voice_id', _config_manager.voice_id_to_storage_value(requested_voice_id))
 
     # 兼容前端自动修复：若请求中带有 model_type，则同步写入保留字段。
     if model_type_in_payload and requested_model_type:
@@ -3814,7 +3816,7 @@ async def update_catgirl(name: str, request: Request):
 
     await _config_manager.asave_characters(characters)
 
-    new_voice_id = get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',))
+    new_voice_id = read_legacy_voice_id(get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',)))
     voice_id_changed = voice_id_in_payload and old_voice_id != new_voice_id
     prompt_fields_changed = _catgirl_prompt_fields_changed(previous_catgirl_data, characters['猫娘'][name])
 
@@ -4034,7 +4036,7 @@ async def clear_voice_ids():
         # 清除所有猫娘的voice_id
         if '猫娘' in characters:
             for name in characters['猫娘']:
-                if get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',)):
+                if read_legacy_voice_id(get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',))):
                     set_reserved(characters['猫娘'][name], 'voice_id', '')
                     cleared_count += 1
 
@@ -4257,7 +4259,7 @@ async def get_voices():
         if not isinstance(catgirl_config, dict):
             logger.warning(f"角色配置格式异常，已跳过 voice_owners 统计: {catgirl_name}")
             continue
-        vid = get_reserved(catgirl_config, 'voice_id', default='', legacy_keys=('voice_id',))
+        vid = read_legacy_voice_id(get_reserved(catgirl_config, 'voice_id', default='', legacy_keys=('voice_id',)))
         if vid:
             voice_owners.setdefault(vid, []).append(catgirl_name)
     result["voice_owners"] = voice_owners
@@ -4602,7 +4604,7 @@ async def delete_voice(voice_id: str):
 
             if '猫娘' in characters:
                 for name in characters['猫娘']:
-                    if get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',)) == voice_id:
+                    if read_legacy_voice_id(get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',))) == voice_id:
                         set_reserved(characters['猫娘'][name], 'voice_id', '')
                         cleaned_count += 1
 

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -3773,8 +3773,8 @@ async def update_catgirl(name: str, request: Request):
         return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
     previous_catgirl_data = copy.deepcopy(characters['猫娘'][name])
 
-    old_voice_id = get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',))
-    voice_id_will_change = voice_id_in_payload and str(old_voice_id or '').strip() != requested_voice_id
+    old_voice_id = read_legacy_voice_id(get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',)))
+    voice_id_will_change = voice_id_in_payload and old_voice_id != requested_voice_id
     if voice_id_will_change:
         session_manager = get_session_manager()
         if _is_current_catgirl_voice_session_starting(name, characters, session_manager):

--- a/tests/unit/test_voice_config.py
+++ b/tests/unit/test_voice_config.py
@@ -9,6 +9,7 @@ from utils.voice_config import (
     VoiceConfig,
     normalize_voice_id,
     parse_legacy_voice_id,
+    read_legacy_voice_id,
     to_legacy_voice_id,
 )
 
@@ -153,3 +154,39 @@ def test_prefix_roundtrip_via_normalize_and_back():
     for legacy in ("eleven:voiceX", "gsv:my_voice"):
         vc = parse_legacy_voice_id(legacy)
         assert to_legacy_voice_id(vc) == legacy
+
+
+# ── read_legacy_voice_id (lazy-migration read tolerance) ─────────────────────
+
+def test_read_legacy_from_flat_string():
+    assert read_legacy_voice_id("voice-tone-X") == "voice-tone-X"
+    assert read_legacy_voice_id("  spaced  ") == "spaced"
+    assert read_legacy_voice_id("") == ""
+    assert read_legacy_voice_id(None) == ""
+
+
+def test_read_legacy_from_object_clone_restores_prefix():
+    # 对象形态的 clone 读回 legacy 前缀串（与 dispatch/validate 既有契约一致）
+    assert read_legacy_voice_id(
+        {"source": "clone", "provider": "elevenlabs", "ref": "abc"}
+    ) == "eleven:abc"
+    assert read_legacy_voice_id(
+        {"source": "clone", "provider": "gptsovits", "ref": "myv"}
+    ) == "gsv:myv"
+
+
+def test_read_legacy_from_object_preset_is_bare_ref():
+    # preset/native/free 无前缀，对象 round-trip 回裸 ref（与扁平存储零差异）
+    assert read_legacy_voice_id(
+        {"source": "preset", "provider": "gemini", "ref": "Puck"}
+    ) == "Puck"
+    assert read_legacy_voice_id(
+        {"source": "preset", "provider": "free", "ref": "voice-tone-X"}
+    ) == "voice-tone-X"
+
+
+def test_read_legacy_object_str_roundtrip_equivalence():
+    # 关键不变式：扁平串 normalize→to_dict 存对象，再 read 回来 == 原扁平串
+    for legacy in ("eleven:abc", "gsv:myv", "voice-tone-X", "Puck", ""):
+        vc = parse_legacy_voice_id(legacy) or VoiceConfig(ref=legacy)
+        assert read_legacy_voice_id(vc.to_dict()) == legacy

--- a/tests/unit/test_voice_lazy_migration.py
+++ b/tests/unit/test_voice_lazy_migration.py
@@ -1,0 +1,42 @@
+"""voice_id 并查集式惰性迁移的往返不变式测试（声音来源统一架构 §6）。
+
+写侧 ``ConfigManager.voice_id_to_storage_value`` 把用户设的 legacy voice_id 迁成结构对象；
+读侧 ``read_legacy_voice_id`` 把扁平串 / 结构对象两形态统一读回 legacy 串。核心不变式：
+**store → read 往返还原原 legacy 串**，所以迁不迁移对下游 dispatch / validate 透明。
+"""
+
+from utils.config_manager import get_config_manager, get_reserved, set_reserved
+from utils.voice_config import read_legacy_voice_id
+
+
+def test_clone_prefix_storage_roundtrip():
+    """clone 前缀（eleven:/gsv:）写成对象再读回 == 原串（确定性，不依赖运行时上下文）。"""
+    cm = get_config_manager()
+    for vid in ("eleven:abc", "gsv:my_voice"):
+        stored = cm.voice_id_to_storage_value(vid)
+        assert isinstance(stored, dict)  # 用户设音色 → 迁成结构对象
+        assert read_legacy_voice_id(stored) == vid
+
+
+def test_empty_voice_stored_as_empty_string():
+    cm = get_config_manager()
+    assert cm.voice_id_to_storage_value("") == ""
+    assert cm.voice_id_to_storage_value(None) == ""
+    assert read_legacy_voice_id(cm.voice_id_to_storage_value("")) == ""
+
+
+def test_object_form_in_char_config_reads_back_legacy():
+    """模拟运行时读：角色配置里 voice 已迁成对象时，get_reserved + read_legacy_voice_id
+    给出 dispatch 消费的 legacy 串（即 _get_voice_id 的行为）。"""
+    cfg = {}
+    set_reserved(cfg, "voice_id", {"source": "clone", "provider": "elevenlabs", "ref": "abc"})
+    raw = get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",))
+    assert read_legacy_voice_id(raw) == "eleven:abc"
+
+
+def test_legacy_flat_string_still_reads():
+    """未触碰的存量扁平串照常读出（惰性迁移不强制全表迁移）。"""
+    cfg = {}
+    set_reserved(cfg, "voice_id", "gsv:legacy_voice")
+    raw = get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",))
+    assert read_legacy_voice_id(raw) == "gsv:legacy_voice"

--- a/tests/unit/test_voice_lazy_migration.py
+++ b/tests/unit/test_voice_lazy_migration.py
@@ -109,6 +109,16 @@ def test_schema_accepts_structured_voice_object():
     assert not [e for e in validate_reserved_schema({"voice_id": "gsv:x"}) if "voice_id" in e]
 
 
+def test_schema_rejects_malformed_voice_object():
+    """放宽成 (str, dict) 后，结构对象形态仍校验 source/provider/ref 都为 str，
+    挡住 {"foo": 1} 这类坏 dict（CodeRabbit 负例）。"""
+    errors = validate_reserved_schema({"voice_id": {"foo": 1}})
+    assert [e for e in errors if "voice_id" in e], "malformed voice_id dict should be flagged"
+    # provider 类型错也要抓
+    bad = validate_reserved_schema({"voice_id": {"source": "clone", "provider": 1, "ref": "x"}})
+    assert [e for e in bad if "voice_id.provider" in e]
+
+
 def test_storage_guard_keeps_legacy_string_when_roundtrip_would_change_key(monkeypatch):
     """Round-trip guard (Codex P2): if the structured form would read back to a DIFFERENT key
     (provider-tagged but un-prefixed clone), keep the legacy string so the binding's library

--- a/tests/unit/test_voice_lazy_migration.py
+++ b/tests/unit/test_voice_lazy_migration.py
@@ -12,8 +12,9 @@ from utils.config_manager import (
     get_reserved,
     migrate_catgirl_reserved,
     set_reserved,
+    validate_reserved_schema,
 )
-from utils.voice_config import read_legacy_voice_id
+from utils.voice_config import VoiceConfig, read_legacy_voice_id
 
 
 def test_clone_prefix_storage_roundtrip():
@@ -95,3 +96,28 @@ def test_migrate_normalizes_top_level_legacy_string():
     cfg = {"voice_id": "gsv:legacy"}
     migrate_catgirl_reserved(cfg)
     assert get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",)) == "gsv:legacy"
+
+
+def test_schema_accepts_structured_voice_object():
+    """RESERVED_FIELD_SCHEMA accepts the structured object so migrated characters are not
+    flagged malformed on every load (Codex P2)."""
+    errors = validate_reserved_schema(
+        {"voice_id": {"source": "clone", "provider": "elevenlabs", "ref": "abc"}}
+    )
+    assert not [e for e in errors if "voice_id" in e], errors
+    # 旧扁平串仍合法
+    assert not [e for e in validate_reserved_schema({"voice_id": "gsv:x"}) if "voice_id" in e]
+
+
+def test_storage_guard_keeps_legacy_string_when_roundtrip_would_change_key(monkeypatch):
+    """Round-trip guard (Codex P2): if the structured form would read back to a DIFFERENT key
+    (provider-tagged but un-prefixed clone), keep the legacy string so the binding's library
+    key is never rewritten."""
+    cm = get_config_manager()
+    # 模拟 normalize 把裸 key 'xyz' 分类成 elevenlabs（库里以裸 key 存却带 provider 元数据）
+    monkeypatch.setattr(
+        cm, "normalize_voice_id_to_config",
+        lambda v: VoiceConfig(source="clone", provider="elevenlabs", ref="xyz"),
+    )
+    # to_legacy 会还原成 'eleven:xyz' ≠ 'xyz' → 守卫保留原串，不迁移成会改 key 的对象
+    assert cm.voice_id_to_storage_value("xyz") == "xyz"

--- a/tests/unit/test_voice_lazy_migration.py
+++ b/tests/unit/test_voice_lazy_migration.py
@@ -110,8 +110,8 @@ def test_schema_accepts_structured_voice_object():
 
 
 def test_schema_rejects_malformed_voice_object():
-    """放宽成 (str, dict) 后，结构对象形态仍校验 source/provider/ref 都为 str，
-    挡住 {"foo": 1} 这类坏 dict（CodeRabbit 负例）。"""
+    """After widening to (str, dict), the object form still validates source/provider/ref
+    are all str, rejecting malformed dicts like {"foo": 1} (CodeRabbit negative case)."""
     errors = validate_reserved_schema({"voice_id": {"foo": 1}})
     assert [e for e in errors if "voice_id" in e], "malformed voice_id dict should be flagged"
     # provider 类型错也要抓

--- a/tests/unit/test_voice_lazy_migration.py
+++ b/tests/unit/test_voice_lazy_migration.py
@@ -40,3 +40,30 @@ def test_legacy_flat_string_still_reads():
     set_reserved(cfg, "voice_id", "gsv:legacy_voice")
     raw = get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",))
     assert read_legacy_voice_id(raw) == "gsv:legacy_voice"
+
+
+# ── 不变式：characters.json 存的是「指向 voice 库的绑定引用」，不是 voice 本体 ──
+
+def test_binding_is_a_reference_not_an_inlined_voice():
+    """characters.json 里只存绑定引用 {source,provider,ref}，绝不 inline voice 库里的
+    本体字段（audio_md5/file_url/created_at/prefix...）或端点 config。"""
+    cm = get_config_manager()
+    stored = cm.voice_id_to_storage_value("eleven:abc123")
+    assert isinstance(stored, dict)
+    assert set(stored.keys()) <= {"source", "provider", "ref"}
+    # voice 本体只能在 voice_storage.json（库），不能漏进绑定
+    forbidden = {"audio_md5", "file_url", "dashscope_base_url", "elevenlabs_base_url",
+                 "created_at", "name", "prefix", "config"}
+    assert not (set(stored.keys()) & forbidden)
+
+
+def test_binding_roundtrips_to_exact_library_key():
+    """绑定必须能还原成 voice 库里的精确 key（character→库内 voice 的链不断）。
+
+    库 key 形态：elevenlabs/gptsovits 带前缀（voice_storage 就以前缀 key 存）、
+    cosyvoice/minimax/free/native 裸 id。store→read 对每种都还原成同一个 key。
+    """
+    cm = get_config_manager()
+    for library_key in ("eleven:abc123", "gsv:my_voice", "cosyclone-001", "voice-tone-X", "Puck"):
+        stored = cm.voice_id_to_storage_value(library_key)
+        assert read_legacy_voice_id(stored) == library_key, library_key

--- a/tests/unit/test_voice_lazy_migration.py
+++ b/tests/unit/test_voice_lazy_migration.py
@@ -1,16 +1,23 @@
-"""voice_id 并查集式惰性迁移的往返不变式测试（声音来源统一架构 §6）。
+"""Round-trip invariant tests for the union-find-style lazy voice_id migration (voice-source unification §6).
 
-写侧 ``ConfigManager.voice_id_to_storage_value`` 把用户设的 legacy voice_id 迁成结构对象；
-读侧 ``read_legacy_voice_id`` 把扁平串 / 结构对象两形态统一读回 legacy 串。核心不变式：
-**store → read 往返还原原 legacy 串**，所以迁不迁移对下游 dispatch / validate 透明。
+Write side ``ConfigManager.voice_id_to_storage_value`` migrates a user-set legacy
+voice_id into the structured object; read side ``read_legacy_voice_id`` reads both the
+flat-string and structured-object forms back as the legacy string. Core invariant:
+**store → read round-trips back to the original legacy string**, so whether or not an
+entry has migrated is transparent to downstream dispatch / validate.
 """
 
-from utils.config_manager import get_config_manager, get_reserved, set_reserved
+from utils.config_manager import (
+    get_config_manager,
+    get_reserved,
+    migrate_catgirl_reserved,
+    set_reserved,
+)
 from utils.voice_config import read_legacy_voice_id
 
 
 def test_clone_prefix_storage_roundtrip():
-    """clone 前缀（eleven:/gsv:）写成对象再读回 == 原串（确定性，不依赖运行时上下文）。"""
+    """Clone prefixes (eleven:/gsv:) stored as an object read back == the original string (deterministic, no runtime context)."""
     cm = get_config_manager()
     for vid in ("eleven:abc", "gsv:my_voice"):
         stored = cm.voice_id_to_storage_value(vid)
@@ -26,8 +33,8 @@ def test_empty_voice_stored_as_empty_string():
 
 
 def test_object_form_in_char_config_reads_back_legacy():
-    """模拟运行时读：角色配置里 voice 已迁成对象时，get_reserved + read_legacy_voice_id
-    给出 dispatch 消费的 legacy 串（即 _get_voice_id 的行为）。"""
+    """Runtime read: when a character's voice is already an object, get_reserved +
+    read_legacy_voice_id yield the legacy string dispatch consumes (i.e. _get_voice_id's behavior)."""
     cfg = {}
     set_reserved(cfg, "voice_id", {"source": "clone", "provider": "elevenlabs", "ref": "abc"})
     raw = get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",))
@@ -35,7 +42,7 @@ def test_object_form_in_char_config_reads_back_legacy():
 
 
 def test_legacy_flat_string_still_reads():
-    """未触碰的存量扁平串照常读出（惰性迁移不强制全表迁移）。"""
+    """Untouched legacy flat strings still read fine (lazy migration never forces a full-table sweep)."""
     cfg = {}
     set_reserved(cfg, "voice_id", "gsv:legacy_voice")
     raw = get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",))
@@ -45,8 +52,8 @@ def test_legacy_flat_string_still_reads():
 # ── 不变式：characters.json 存的是「指向 voice 库的绑定引用」，不是 voice 本体 ──
 
 def test_binding_is_a_reference_not_an_inlined_voice():
-    """characters.json 里只存绑定引用 {source,provider,ref}，绝不 inline voice 库里的
-    本体字段（audio_md5/file_url/created_at/prefix...）或端点 config。"""
+    """characters.json stores only the binding reference {source,provider,ref}, never inlining the
+    voice library's body fields (audio_md5/file_url/created_at/prefix...) or endpoint config."""
     cm = get_config_manager()
     stored = cm.voice_id_to_storage_value("eleven:abc123")
     assert isinstance(stored, dict)
@@ -58,12 +65,33 @@ def test_binding_is_a_reference_not_an_inlined_voice():
 
 
 def test_binding_roundtrips_to_exact_library_key():
-    """绑定必须能还原成 voice 库里的精确 key（character→库内 voice 的链不断）。
+    """The binding must round-trip to the exact voice-library key (character → library voice link stays intact).
 
-    库 key 形态：elevenlabs/gptsovits 带前缀（voice_storage 就以前缀 key 存）、
-    cosyvoice/minimax/free/native 裸 id。store→read 对每种都还原成同一个 key。
+    Library key shapes: elevenlabs/gptsovits are prefixed (voice_storage keys them with the prefix);
+    cosyvoice/minimax/free/native are bare ids. store→read restores the same key for each.
     """
     cm = get_config_manager()
     for library_key in ("eleven:abc123", "gsv:my_voice", "cosyclone-001", "voice-tone-X", "Puck"):
         stored = cm.voice_id_to_storage_value(library_key)
         assert read_legacy_voice_id(stored) == library_key, library_key
+
+
+def test_migrate_preserves_top_level_structured_voice():
+    """A character card whose **top-level** voice_id is already a structured object must be
+    migrated into _reserved (not skipped), else the later top-level legacy-field cleanup
+    pops it and the binding is silently lost on load (Codex/CodeRabbit P2)."""
+    # 顶层 legacy voice_id 已是对象形态（如旧版导出 / 手改卡），_reserved 里没有
+    cfg = {"voice_id": {"source": "clone", "provider": "elevenlabs", "ref": "abc123"}}
+    migrate_catgirl_reserved(cfg)
+    # 已搬进 _reserved，且能读回库 key
+    assert cfg.get("_reserved", {}).get("voice_id") == {
+        "source": "clone", "provider": "elevenlabs", "ref": "abc123",
+    }
+    assert read_legacy_voice_id(get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",))) == "eleven:abc123"
+
+
+def test_migrate_normalizes_top_level_legacy_string():
+    """Top-level legacy string voice_id is migrated into _reserved as a string (unchanged behavior)."""
+    cfg = {"voice_id": "gsv:legacy"}
+    migrate_catgirl_reserved(cfg)
+    assert get_reserved(cfg, "voice_id", default="", legacy_keys=("voice_id",)) == "gsv:legacy"

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -630,9 +630,13 @@ def migrate_catgirl_reserved(catgirl_data: dict) -> bool:
         changed = True
 
     voice_id = get_reserved(catgirl_data, "voice_id", default="", legacy_keys=("voice_id",))
-    # 旧数据 voice_id 规整成字符串；但结构化对象形态（惰性迁移后）不能被 str(dict) 损坏，
-    # 原样保留。
-    if voice_id is not None and not isinstance(voice_id, dict):
+    # 把 voice_id 收口进 _reserved。结构对象（惰性迁移形态，可能来自顶层 legacy 字段）
+    # 必须原样 set_reserved 搬进来：既不能被 str(dict) 损坏，也不能跳过——否则随后的旧
+    # 顶层字段清理会 pop 掉它，导致绑定在加载时悄悄丢失（Codex/CodeRabbit P2）。
+    # 普通 legacy 值仍规整成字符串。
+    if isinstance(voice_id, dict):
+        changed |= set_reserved(catgirl_data, "voice_id", voice_id)
+    elif voice_id is not None:
         changed |= set_reserved(catgirl_data, "voice_id", str(voice_id))
 
     system_prompt = get_reserved(catgirl_data, "system_prompt", default=None, legacy_keys=("system_prompt",))
@@ -3232,12 +3236,14 @@ class ConfigManager:
         )
 
     def voice_id_to_storage_value(self, voice_id):
-        """用户设音色时，把 legacy voice_id 串转成 at-rest 存储形态。
+        """Convert a user-set legacy ``voice_id`` string into its at-rest storage form.
 
-        声音来源统一架构的「并查集式惰性迁移」写侧：用户每设/换一次音色，就把那一条迁成
-        结构对象 ``{source,provider,ref}``（用到哪条迁哪条，不做全表 sweep）。空值存空串
-        （＝未设音色）。读侧由 :func:`utils.voice_config.read_legacy_voice_id` 容忍两形态，
-        故存量未触碰的扁平串继续可用。
+        Write side of the voice-source-unification "union-find style lazy migration":
+        every time the user sets/changes a voice, that one entry is migrated to the
+        structured object ``{source, provider, ref}`` (migrate-on-touch, never a
+        full-table sweep). Empty value is stored as an empty string (= no voice set).
+        The read side (:func:`utils.voice_config.read_legacy_voice_id`) tolerates both
+        forms, so untouched legacy flat strings keep working.
         """
         s = str(voice_id or '').strip()
         if not s:

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -615,6 +615,16 @@ def validate_reserved_schema(reserved: dict) -> list[str]:
     if reserved is None:
         return errors
     _walk(reserved, RESERVED_FIELD_SCHEMA, "_reserved")
+    # voice_id 是 str | 结构对象的联合类型，schema 的 tuple 分支只做 isinstance，挡不住
+    # {"foo": 1} 这种坏 dict。结构对象形态额外校验 source/provider/ref 都为 str，避免
+    # 放宽 schema 后契约松掉（CodeRabbit）。
+    vid = reserved.get("voice_id")
+    if isinstance(vid, dict):
+        for field in ("source", "provider", "ref"):
+            if not isinstance(vid.get(field), str):
+                errors.append(
+                    f"_reserved.voice_id.{field} 需要 str，实际 {type(vid.get(field)).__name__}"
+                )
     return errors
 
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -50,6 +50,7 @@ from utils.api_config_loader import (
 from utils.custom_tts_adapter import check_custom_tts_voice_allowed
 from utils.file_utils import atomic_write_json
 from utils.gptsovits_config import normalize_gsv_api_url
+from utils.voice_config import read_legacy_voice_id
 from utils.logger_config import get_module_logger
 from utils.native_voice_registry import (
     is_free_lanlan_app_route,
@@ -269,12 +270,12 @@ async def ensure_default_yui_voice_for_free_api(config_manager, core_cfg: dict |
     if not _is_default_yui_character(current_name, current_character):
         return False
 
-    current_voice_id = str(get_reserved(
+    current_voice_id = read_legacy_voice_id(get_reserved(
         current_character,
         "voice_id",
         default="",
         legacy_keys=("voice_id",),
-    ) or "").strip()
+    ))
     if current_voice_id:
         return False
 
@@ -629,7 +630,9 @@ def migrate_catgirl_reserved(catgirl_data: dict) -> bool:
         changed = True
 
     voice_id = get_reserved(catgirl_data, "voice_id", default="", legacy_keys=("voice_id",))
-    if voice_id is not None:
+    # 旧数据 voice_id 规整成字符串；但结构化对象形态（惰性迁移后）不能被 str(dict) 损坏，
+    # 原样保留。
+    if voice_id is not None and not isinstance(voice_id, dict):
         changed |= set_reserved(catgirl_data, "voice_id", str(voice_id))
 
     system_prompt = get_reserved(catgirl_data, "system_prompt", default=None, legacy_keys=("system_prompt",))
@@ -878,7 +881,8 @@ def flatten_reserved(catgirl_data: dict) -> dict:
         return catgirl_data
     result = dict(catgirl_data)
 
-    voice_id = get_reserved(result, "voice_id", default="")
+    # 展平给 legacy 前端/调用方：始终吐 legacy 字符串形态（容忍结构对象）。
+    voice_id = read_legacy_voice_id(get_reserved(result, "voice_id", default=""))
     if voice_id:
         result["voice_id"] = voice_id
     system_prompt = get_reserved(result, "system_prompt", default=None)
@@ -3227,6 +3231,19 @@ class ConfigManager:
             free_voice_ids=set(get_free_voices().values()),
         )
 
+    def voice_id_to_storage_value(self, voice_id):
+        """用户设音色时，把 legacy voice_id 串转成 at-rest 存储形态。
+
+        声音来源统一架构的「并查集式惰性迁移」写侧：用户每设/换一次音色，就把那一条迁成
+        结构对象 ``{source,provider,ref}``（用到哪条迁哪条，不做全表 sweep）。空值存空串
+        （＝未设音色）。读侧由 :func:`utils.voice_config.read_legacy_voice_id` 容忍两形态，
+        故存量未触碰的扁平串继续可用。
+        """
+        s = str(voice_id or '').strip()
+        if not s:
+            return ''
+        return self.normalize_voice_id_to_config(s).to_dict()
+
     def cleanup_invalid_voice_ids(self):
         """Clean up invalid voice_ids in characters.json.
         
@@ -3249,7 +3266,9 @@ class ConfigManager:
 
         catgirls = character_data.get('猫娘', {})
         for name, config in catgirls.items():
-            voice_id = get_reserved(config, 'voice_id', default='', legacy_keys=('voice_id',))
+            # 容忍扁平串 / 结构对象两形态，统一按 legacy 字符串做 remap / validate；
+            # cleanup 不在此把有效条目压成对象（守住「不 bulk sweep」，迁移只在用户设音色时发生）。
+            voice_id = read_legacy_voice_id(get_reserved(config, 'voice_id', default='', legacy_keys=('voice_id',)))
             if not voice_id:
                 continue
             # 已废弃的免费 YUI 预设音色：先平移到现役 yui_cn，再 continue 跳过后续

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3248,7 +3248,16 @@ class ConfigManager:
         s = str(voice_id or '').strip()
         if not s:
             return ''
-        return self.normalize_voice_id_to_config(s).to_dict()
+        from utils.voice_config import to_legacy_voice_id
+        vc = self.normalize_voice_id_to_config(s)
+        # Round-trip guard: only migrate to the structured object when it reads back to
+        # the exact submitted library key. Otherwise (e.g. a provider-tagged but
+        # un-prefixed clone key, where to_legacy_voice_id would re-add a prefix and
+        # change the key) keep the legacy string verbatim — never let migration rewrite
+        # the key a binding points at, or _get_voice_meta would miss and TTS misroute.
+        if to_legacy_voice_id(vc) != s:
+            return s
+        return vc.to_dict()
 
     def cleanup_invalid_voice_ids(self):
         """Clean up invalid voice_ids in characters.json.

--- a/utils/voice_config.py
+++ b/utils/voice_config.py
@@ -221,3 +221,25 @@ def to_legacy_voice_id(vc: "VoiceConfig") -> str:
     if vc.provider == "gptsovits":
         return f"gsv:{vc.ref}"
     return vc.ref
+
+
+def read_legacy_voice_id(raw: Any) -> str:
+    """Read a per-character voice **at rest** (either the legacy flat string or the new
+    structured ``{source, provider, ref}`` object) as the flat, prefixed legacy
+    ``voice_id`` string the runtime / validation chain consumes.
+
+    This is the read-tolerance seam for the union-find-style lazy migration (blueprint
+    §6): some entries are flat strings (untouched), some are objects (migrated on a
+    user voice-set). Every consumer that loads a character's voice as a string funnels
+    through here, so downstream logic (dispatch / validate / free-preset gating) keeps
+    working on strings and never needs to know which form is at rest.
+
+    * ``dict`` → reconstruct the legacy string from the object (``eleven:`` / ``gsv:``
+      prefixes restored from ``provider``; presets/native have no prefix so round-trip
+      to their bare ``ref``).
+    * ``str`` → returned stripped (already the legacy form).
+    * anything else / None → ``""``.
+    """
+    if isinstance(raw, dict):
+        return to_legacy_voice_id(VoiceConfig.from_any(raw))
+    return str(raw or "").strip()


### PR DESCRIPTION
## 背景

#1830（source-first 选声 + 结构化 voice 地基）合并后的 follow-up，落地声音来源统一架构 §6 的 at-rest 存储迁移。base off 含 #1830 的最新 main。

地基已在 #1830：`utils/voice_config.py` 的 `VoiceConfig{source,provider,ref}` + `parse_legacy_voice_id` + `normalize_voice_id` + `to_legacy_voice_id` 反向 shim + `config_manager.normalize_voice_id_to_config`。本 PR 把它接到读写路径上。

## 迁移策略：并查集式惰性，不做 bulk sweep

按维护者要求——**不一次性扫全表迁移**，而是「像并查集一样，用到哪条迁哪条」：

- **写侧（迁移触发点，仅「用户设音色」这一条）**：`config_manager.voice_id_to_storage_value` 把用户经 `PUT /catgirl/voice_id` 设的 legacy 串 normalize 成结构对象 dict 存盘（空值存空串）。内部 preset/free 默认、YUI、清空、cleanup 仍写字符串。
- **读侧（容忍两形态，下游零改）**：`read_legacy_voice_id` 把 at-rest 的 dict / str 统一读回 dispatch/validate 一直消费的 legacy 前缀串。所有 `get_reserved('voice_id')` 读点都经它。
- **绑定不变式**：voice 是库（voice_storage.json），character 绑定库内某 voice、绑定存 characters.json 的 `{source,provider,ref}` 引用（非 voice 本体）。`store → read` 往返还原库的精确 key；加 round-trip 守卫：仅当 `to_legacy(vc)==原串` 才迁对象，否则保留 legacy 串。

## 回归报告

**改动**：把每角色 voice 从扁平 `voice_id` 字符串惰性迁移成结构对象 `{source,provider,ref}`（at-rest，存 characters.json）。触及 `app/main_server.py`（活跃 session voice_id 读）、`main_logic/core.py`（`_get_voice_id` 运行时读）、`main_routers/characters_router.py`（PUT 读旧/写对象等读写）、`utils/config_manager.py`（写转换 + 读容忍 + schema 校验）、`config/__init__.py`（schema 放宽 `voice_id:(str,dict)`）。

**必要性**：声音来源统一架构 §6。#1830 已让 dispatch provider-based、铺好数据模型地基，本 PR 把结构化存储接到读写路径，去掉 voice_id 靠前缀编码 provider 的债，为未来 voice design 预留。按惰性迁移做以避免一次性改写全部用户 characters.json 的高风险。

**前后行为**：
- 改前：characters.json voice 永远是扁平串（含 `gsv:`/`eleven:` 前缀）；读点直接拿字符串。
- 改后：用户设音色的条目写成 `{source,provider,ref}` 对象；未触碰的存量条目仍是扁平串。所有读点经 `read_legacy_voice_id` 统一读回 legacy 串，dispatch/validate/free 判定逻辑零改，运行时行为对「迁没迁移」透明。

**潜在回归与缓解**：
1. 某读点漏接容忍助手 → dict 触发 `dict.strip()` 崩 / 比较恒为「已变」误判。缓解：全量收口所有 `get_reserved('voice_id')` 读点 + 单测（Codex 抓到一处缩进漏网已补）。
2. 顶层 legacy 字段是对象时被清理 pop 丢绑定。缓解：`migrate_catgirl_reserved` 对 dict `set_reserved` 搬进 `_reserved` + 回归测试。
3. 迁移改写绑定 key 致 `_get_voice_meta` miss 走错 worker。缓解：round-trip 守卫 + 5 形态往返不变式测试。
4. schema 把 dict voice_id 误报 malformed。缓解：schema 放宽 `(str,dict)` + 对 dict 补 source/provider/ref 类型校验。

**验证**：voice/迁移/schema/dispatch/yui/config_manager/characters_router 单测全过（约 290+ passed）；真后端 Playwright 选声器 2 passed；docstring-cjk（--base origin/main）/ ruff 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
