### PR TITLE
修复辅助 API 服务商选择框宽度随 MiMo Token Plan 开关变化的问题，使其与核心 API 选择框宽度一致，并让 MiMo …

### DIFF
--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -963,14 +963,18 @@ opacity: 0.95 !important;
 
 .mimo-assist-select-row {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    flex-wrap: wrap;
     gap: 12px;
-    max-width: 760px;
+    width: 100%;
+    max-width: 600px;
 }
 
 .mimo-assist-select-row .api-provider-dropdown,
 .mimo-assist-select-row select {
-    flex: 1 1 420px;
+    flex: 0 0 100%;
+    width: 100%;
+    max-width: 600px;
 }
 
 .mimo-token-plan-toggle {

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -375,6 +375,45 @@ def test_mimo_token_plan_locks_regular_mimo_key(mock_page: Page, running_server:
 
 
 @pytest.mark.frontend
+def test_mimo_token_plan_toggle_wraps_below_assist_provider(mock_page: Page, running_server: str):
+    """The Assist API provider dropdown should keep the Core API width when MiMo controls appear."""
+    mock_page.set_viewport_size({"width": 1280, "height": 900})
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='mimo']", state="attached", timeout=10000)
+
+    mock_page.select_option("#assistApiSelect", "mimo")
+    expect(mock_page.locator("#mimoTokenPlanToggleRow")).to_be_visible(timeout=5000)
+
+    metrics = mock_page.evaluate("""
+        () => {
+            const getRect = (selector) => {
+                const el = document.querySelector(selector);
+                const rect = el.getBoundingClientRect();
+                return {
+                    top: rect.top,
+                    bottom: rect.bottom,
+                    width: rect.width,
+                };
+            };
+
+            return {
+                core: getRect("#coreApiSelect-dropdown-trigger"),
+                assist: getRect("#assistApiSelect-dropdown-trigger"),
+                row: getRect(".mimo-assist-select-row"),
+                toggle: getRect("#mimoTokenPlanToggleRow"),
+            };
+        }
+    """)
+
+    assert abs(metrics["assist"]["width"] - metrics["core"]["width"]) <= 1
+    assert metrics["assist"]["width"] <= 600
+    assert metrics["row"]["width"] <= metrics["core"]["width"] + 1
+    assert metrics["toggle"]["top"] >= metrics["assist"]["bottom"] - 1
+
+
+@pytest.mark.frontend
 def test_mimo_token_plan_connectivity_tries_endpoint_candidates(mock_page: Page, running_server: str):
     """Token Plan connectivity should try regional MiMo endpoints until one succeeds."""
     mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")


### PR DESCRIPTION
…开关换行显示

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

让辅助API的服务商选择与核心API表现一致，而不是跟随其中的文字内容变换横向长度

## 测试 / Testing

手动进入API设置页切换辅助API测试

## UI修改对比

修改前:
<img width="1036" height="548" alt="image" src="https://github.com/user-attachments/assets/65d15bdb-1053-4dc8-a128-4a87c5a91c4a" />
<img width="979" height="551" alt="image" src="https://github.com/user-attachments/assets/521670b3-430e-43f7-b0bf-be33809a1523" />

修改后:
<img width="984" height="540" alt="image" src="https://github.com/user-attachments/assets/4fe8b8e6-6769-4715-adce-7df2b76d110e" />
<img width="978" height="584" alt="image" src="https://github.com/user-attachments/assets/804c5815-d39e-40ec-ae44-4b524810d20b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 样式调整

* **Style**
  * MiMo Token Plan 控件布局已调整，现支持多行折行显示
  * 下拉选择器和选择控件采用堆叠排列方式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->