### PR TITLE
feat(tts): mimo 预制目录迁到 hosted preset_catalog 并从 native 摘除

### DIFF
--- a/main_logic/tts_client/__init__.py
+++ b/main_logic/tts_client/__init__.py
@@ -32,6 +32,7 @@ from functools import partial
 
 from utils.config_manager import get_config_manager
 from utils.native_voice_registry import get_native_tts_worker
+from utils.mimo_tts_voices import MIMO_PRESET_CATALOG
 from utils import tts_provider_registry as _tts_providers
 from utils.logger_config import get_module_logger
 
@@ -461,9 +462,11 @@ _tts_providers.register(_tts_providers.TTSProvider(
 ))
 
 # MiMo：priority 60（clone 之后、native 之前，沿用原 get_tts_worker 顺序）。
-# capabilities 暂只声明 {preset}（现有固定音色目录；该 catalog 暂仍由 native_voice_registry
-# 对外提供，待统一 preset catalog 接管后从 native 摘除）。MiMo 虽有 mimo-v2.5-tts-voiceclone
-# 模型，但克隆 enrollment 尚未实现——「按实际能力注册」，不在 enrollment 落地前把 clone
+# capabilities 声明 {preset}，预制目录由 preset_catalog 提供（MIMO_PRESET_CATALOG，
+# 数据复用 utils.mimo_tts_voices 的固定音色表）——这是 MiMo 预制音色的单一真相，UI
+# /voices 与 validate_voice_id 都查注册表，不再借道 native_voice_registry（MiMo 是
+# hosted SaaS，不是核心自带，见设计文档 §4）。MiMo 虽有 mimo-v2.5-tts-voiceclone 模型，
+# 但克隆 enrollment 尚未实现——「按实际能力注册」，不在 enrollment 落地前把 clone
 # advertise 进 ui_metadata（否则前端 source-first 选声器会渲染一个不能用的 clone tab）；
 # voiceclone enrollment 真实现时再追加 'clone'（见交接 chip）。
 # tts_dropdown_only=False：MiMo 本身是 assist LLM provider，不能被前端从 LLM 下拉隐藏。
@@ -474,5 +477,6 @@ _tts_providers.register(_tts_providers.TTSProvider(
     capabilities=frozenset({'preset'}),
     is_selected=_mimo_is_selected,
     resolve=_mimo_resolve,
+    preset_catalog=MIMO_PRESET_CATALOG,
     tts_dropdown_only=False,
 ))

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -780,6 +780,25 @@ def _get_active_native_preview_provider(config_manager, voice_id: object) -> str
     return None
 
 
+def _is_unpreviewable_selected_preset_voice(config_manager, core_config, voice_id, voice_data) -> bool:
+    """Whether voice_id is a built-in preset of the currently selected hosted/local
+    provider (e.g. MiMo) that has no dedicated preview path yet — and is NOT a user clone.
+
+    A cloned voice whose id collides with a preset name must still preview through its
+    clone path: runtime dispatch selects clone providers (priority 30/40/50) ahead of a
+    static-catalog provider like MiMo (60), so the clone wins. Any id present in a voice
+    storage bucket is therefore never treated as an unpreviewable preset (dual to the
+    native-preview collision guard, which passes voice_id_exists_in_any_storage)."""
+    if voice_data:
+        return False
+    try:
+        if config_manager.voice_id_exists_in_any_storage(voice_id):
+            return False
+    except Exception:
+        pass
+    return tts_provider_registry.is_selected_preset_voice(core_config or {}, config_manager, voice_id)
+
+
 def _read_wav_payload(audio_bytes: bytes) -> tuple[bytes, int, int, int]:
     """Read the WAV returned by upstream; returns PCM plus channel count, sample width and sample rate."""
     with io.BytesIO(audio_bytes) as wav_io:
@@ -4353,9 +4372,10 @@ async def get_voice_preview(
         # 通道露给前端会渲染试听按钮，但其试听需走该 provider 自己的合成路径（尚未接）。
         # 在此显式拦下返回「暂不支持试听」，避免落到下方 DashScope/CosyVoice 通用分支拿着
         # 该 provider 的 key/voice_id 误合成（PR #1848 Codex review；真试听留作后续）。
+        # 与预制同名的克隆音色不拦（dispatch 克隆 provider 先于 MiMo 命中），仍走克隆试听。
         preview_core_config = await _config_manager.aget_core_config()
-        if tts_provider_registry.is_selected_preset_voice(
-            preview_core_config or {}, _config_manager, voice_id
+        if _is_unpreviewable_selected_preset_voice(
+            _config_manager, preview_core_config, voice_id, voice_data
         ):
             return JSONResponse({
                 'success': False,

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -100,6 +100,7 @@ from utils.native_voice_registry import (
     normalize_native_voice,
     resolve_native_voice_for_routing,
 )
+from utils import tts_provider_registry
 from utils.audio import normalize_voice_clone_api_audio, validate_audio_file
 from utils.character_name import PROFILE_NAME_MAX_UNITS, validate_character_name
 from utils.initial_personality_state import (
@@ -4211,8 +4212,21 @@ async def get_voices():
     result = {"voices": _config_manager.get_voices_for_current_api(for_listing=True)}
 
     core_config = await _config_manager.aget_core_config()
-    active_native_provider = get_active_realtime_native_provider_for_ui(_config_manager)
-    if active_native_provider:
+    # 先看有没有自带静态预制目录的 provider 被选中（如 MiMo，hosted）。与 dispatch
+    # 同一优先级判定：选中的 provider 若有 preset_catalog 就用它，并压过 core-native
+    # （assistApi=mimo 在 dispatch 里 priority 60 也先于 native 命中）；GPT-SoVITS /
+    # vLLM 这类先命中、无静态目录的 provider 则不出目录（preset 为 None）。复用
+    # native_voices 通道——前端 source-first 选声器按 entry 的 provider/provider_label
+    # 自动分组成「<Provider> · 预制」，无需新增来源通道。
+    selected_preset_catalog = tts_provider_registry.selected_preset_catalog_for_ui(
+        core_config or {}, _config_manager
+    )
+    active_native_provider = (
+        None if selected_preset_catalog else get_active_realtime_native_provider_for_ui(_config_manager)
+    )
+    if selected_preset_catalog:
+        result["native_voices"] = selected_preset_catalog
+    elif active_native_provider:
         native_catalog = get_native_voice_catalog_for_ui(active_native_provider) or {}
         if active_native_provider == 'free_intl':
             # 海外免费（lanlan.app/Gemini）：yui + default(=Leda) 两个置顶 pin，

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -795,7 +795,9 @@ def _is_unpreviewable_selected_preset_voice(config_manager, core_config, voice_i
         if config_manager.voice_id_exists_in_any_storage(voice_id):
             return False
     except Exception:
-        pass
+        # 存储桶查询异常（极少见的 IO 错误）：按「无法确认是克隆」继续走下方预制判定，
+        # 不因一次查询失败改变结论；留一条带堆栈的 debug 便于排查（同 _grok 撞名查模式）。
+        logger.debug("voice_id_exists_in_any_storage 查询失败，按非克隆继续判定", exc_info=True)
     return tts_provider_registry.is_selected_preset_voice(core_config or {}, config_manager, voice_id)
 
 

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -4218,14 +4218,25 @@ async def get_voices():
     # vLLM 这类先命中、无静态目录的 provider 则不出目录（preset 为 None）。复用
     # native_voices 通道——前端 source-first 选声器按 entry 的 provider/provider_label
     # 自动分组成「<Provider> · 预制」，无需新增来源通道。
-    # 用 is not None 而非 truthy：preset provider 被选中即应压过 native（dispatch
-    # 会路由到它而非 native），哪怕其目录恰为空字典也不该误回退到 core-native。
-    selected_preset_catalog = tts_provider_registry.selected_preset_catalog_for_ui(
+    # 选声目录与 dispatch 同一优先级：先看哪个注册表 provider 赢得当前配置。
+    #  - 赢家有静态预制目录（如 MiMo）→ 出该目录，压过 core-native（用 is not None，
+    #    空目录也算命中，不误回退）。
+    #  - 赢家无静态目录（vLLM-Omni / GPT-SoVITS，用户自填/自部署音色）→ 既不出目录、
+    #    也不回退 core-native：dispatch 会路由到该赢家，露出 gemini 等原生音色会让用户
+    #    选中后被误传给赢家触发 unsupported-voice（PR #1848 Codex review）。
+    #  - 无注册表 provider 赢 → 回退 core-native（gemini/step/...）。
+    # 复用 native_voices 通道——前端 source-first 选声器按 entry 的 provider/provider_label
+    # 自动分组成「<Provider> · 预制」，无需新增来源通道。
+    winning_provider_key = tts_provider_registry.selected_provider_key(
         core_config or {}, _config_manager
     )
+    selected_preset_catalog = (
+        tts_provider_registry.preset_catalog_for_ui(winning_provider_key)
+        if winning_provider_key else None
+    )
     active_native_provider = (
-        None if selected_preset_catalog is not None
-        else get_active_realtime_native_provider_for_ui(_config_manager)
+        get_active_realtime_native_provider_for_ui(_config_manager)
+        if winning_provider_key is None else None
     )
     if selected_preset_catalog is not None:
         result["native_voices"] = selected_preset_catalog
@@ -4337,6 +4348,20 @@ async def get_voice_preview(
 
         preview_language = _get_voice_preview_language(request, language, i18n_language)
         text = _loc(VOICE_PREVIEW_TEXTS, preview_language)
+
+        # hosted/local provider 的预制音色（如选中 MiMo 时的预制声线）经 native_voices
+        # 通道露给前端会渲染试听按钮，但其试听需走该 provider 自己的合成路径（尚未接）。
+        # 在此显式拦下返回「暂不支持试听」，避免落到下方 DashScope/CosyVoice 通用分支拿着
+        # 该 provider 的 key/voice_id 误合成（PR #1848 Codex review；真试听留作后续）。
+        preview_core_config = await _config_manager.aget_core_config()
+        if tts_provider_registry.is_selected_preset_voice(
+            preview_core_config or {}, _config_manager, voice_id
+        ):
+            return JSONResponse({
+                'success': False,
+                'error': f'当前预制音色暂不支持试听: {voice_id}',
+                'code': 'PRESET_VOICE_PREVIEW_UNSUPPORTED',
+            }, status_code=400)
 
         native_preview_provider = _get_active_native_preview_provider(_config_manager, voice_id)
         if native_preview_provider:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -4218,13 +4218,16 @@ async def get_voices():
     # vLLM 这类先命中、无静态目录的 provider 则不出目录（preset 为 None）。复用
     # native_voices 通道——前端 source-first 选声器按 entry 的 provider/provider_label
     # 自动分组成「<Provider> · 预制」，无需新增来源通道。
+    # 用 is not None 而非 truthy：preset provider 被选中即应压过 native（dispatch
+    # 会路由到它而非 native），哪怕其目录恰为空字典也不该误回退到 core-native。
     selected_preset_catalog = tts_provider_registry.selected_preset_catalog_for_ui(
         core_config or {}, _config_manager
     )
     active_native_provider = (
-        None if selected_preset_catalog else get_active_realtime_native_provider_for_ui(_config_manager)
+        None if selected_preset_catalog is not None
+        else get_active_realtime_native_provider_for_ui(_config_manager)
     )
-    if selected_preset_catalog:
+    if selected_preset_catalog is not None:
         result["native_voices"] = selected_preset_catalog
     elif active_native_provider:
         native_catalog = get_native_voice_catalog_for_ui(active_native_provider) or {}

--- a/tests/unit/test_mimo_tts_voices.py
+++ b/tests/unit/test_mimo_tts_voices.py
@@ -18,13 +18,17 @@ class _CM:
     core_config.json for vLLM/GPT-SoVITS dropdown, the tts_custom slot for the
     GPT-SoVITS legacy gate)."""
 
-    def __init__(self, core_config, tts_custom_config=None, raw_core_config=None):
+    def __init__(self, core_config, tts_custom_config=None, raw_core_config=None, stored_voice_ids=None):
         self._core_config = core_config
         self._tts_custom_config = tts_custom_config or {"is_custom": False}
         self._raw = raw_core_config if raw_core_config is not None else {}
+        self._stored_voice_ids = set(stored_voice_ids or ())
 
     def get_core_config(self):
         return self._core_config
+
+    def voice_id_exists_in_any_storage(self, voice_id):
+        return voice_id in self._stored_voice_ids
 
     def load_json_config(self, filename, default):
         if filename == "core_config.json":
@@ -129,6 +133,22 @@ def test_no_catalog_winner_suppresses_native_voices():
     key = tts_provider_registry.selected_provider_key(core_config, cm)
     assert key == "vllm_omni"
     assert tts_provider_registry.preset_catalog_for_ui(key) is None
+
+
+@pytest.mark.unit
+def test_preview_guard_blocks_mimo_preset_but_lets_same_name_clone_through():
+    from main_routers.characters_router import _is_unpreviewable_selected_preset_voice
+
+    cc = {"CORE_API_TYPE": "qwen", "assistApi": "mimo"}
+    # 纯预制音色（无 voice_data、不在任何存储桶）→ 拦下（暂不支持试听）
+    assert _is_unpreviewable_selected_preset_voice(_CM(cc), cc, "Milo", None) is True
+    # 与预制同名的克隆音色：当前 api 有 voice_data → 放行走克隆试听
+    assert _is_unpreviewable_selected_preset_voice(_CM(cc), cc, "Milo", {"provider": "cosyvoice"}) is False
+    # 跨槽克隆（voice_data 为 None 但存在于任一存储桶）→ 同样放行
+    assert _is_unpreviewable_selected_preset_voice(_CM(cc, stored_voice_ids={"Milo"}), cc, "Milo", None) is False
+    # MiMo 未选中 → 不是预制，放行
+    not_sel = {"CORE_API_TYPE": "qwen", "assistApi": "qwen"}
+    assert _is_unpreviewable_selected_preset_voice(_CM(not_sel), not_sel, "Milo", None) is False
 
 
 @pytest.mark.unit

--- a/tests/unit/test_mimo_tts_voices.py
+++ b/tests/unit/test_mimo_tts_voices.py
@@ -1,36 +1,63 @@
+import json
+
 import pytest
 
-from utils.mimo_tts_voices import normalize_mimo_tts_voice
-from utils.native_voice_registry import (
-    get_active_realtime_native_provider_for_ui,
-    get_provider,
-    is_native_voice,
-    is_saveable_native_voice,
-)
+# Importing the heavy worker package registers the hosted TTS providers
+# (incl. MiMo's TTSProvider + preset_catalog) into tts_provider_registry.
+from main_logic import tts_client  # noqa: F401
+from utils import tts_provider_registry
+from utils.mimo_tts_voices import MIMO_PRESET_CATALOG, normalize_mimo_tts_voice
+from utils.native_voice_registry import get_provider, is_native_voice, list_providers
 
 
 class _CM:
-    def __init__(self, core_config, tts_custom_config=None):
+    """Minimal ConfigManager stub for registry selection queries.
+
+    selected_provider iterates every registered provider's is_selected, so the
+    stub must answer the config reads they do (core_config, the raw
+    core_config.json for vLLM/GPT-SoVITS dropdown, the tts_custom slot for the
+    GPT-SoVITS legacy gate)."""
+
+    def __init__(self, core_config, tts_custom_config=None, raw_core_config=None):
         self._core_config = core_config
         self._tts_custom_config = tts_custom_config or {"is_custom": False}
+        self._raw = raw_core_config if raw_core_config is not None else {}
 
     def get_core_config(self):
         return self._core_config
 
+    def load_json_config(self, filename, default):
+        if filename == "core_config.json":
+            return self._raw
+        return default
+
     def get_model_api_config(self, model_type):
-        if model_type == "realtime":
-            return {"api_type": "qwen", "base_url": ""}
         if model_type == "tts_custom":
             return self._tts_custom_config
-        raise AssertionError(model_type)
+        if model_type == "realtime":
+            return {"api_type": "qwen", "base_url": ""}
+        return {}
+
+    def get_tts_api_key(self, provider):
+        return "test-key"
 
 
 @pytest.mark.unit
-def test_mimo_native_voice_provider_is_registered():
-    provider = get_provider("mimo")
+def test_mimo_registered_as_hosted_with_preset_catalog():
+    provider = tts_provider_registry.get("mimo")
     assert provider is not None
-    assert provider.default_voice == "mimo_default"
-    assert provider.default_male_voice == "Milo"
+    assert provider.kind == "hosted"
+    assert "preset" in provider.capabilities
+    # 预制目录是 MiMo 内置音色的单一真相，挂在统一 provider 上
+    assert provider.preset_catalog is MIMO_PRESET_CATALOG
+
+
+@pytest.mark.unit
+def test_mimo_no_longer_registered_as_native():
+    # mimo 已从 native_voice_registry 摘除（不再 bootstrap、不挂 _PROVIDERS）
+    assert get_provider("mimo") is None
+    assert "mimo" not in list_providers()
+    assert is_native_voice("Milo") is False
 
 
 @pytest.mark.unit
@@ -38,8 +65,20 @@ def test_mimo_voice_aliases_normalize_to_catalog_ids():
     assert normalize_mimo_tts_voice("默认") == ("mimo_default", True)
     assert normalize_mimo_tts_voice("中文女") == ("冰糖", True)
     assert normalize_mimo_tts_voice("english male") == ("Milo", True)
-    assert is_native_voice("冰糖", "mimo") is True
-    assert is_native_voice("not-a-mimo-voice", "mimo") is False
+    assert tts_provider_registry.is_preset_voice("mimo", "冰糖") is True
+    assert tts_provider_registry.is_preset_voice("mimo", "not-a-mimo-voice") is False
+
+
+@pytest.mark.unit
+def test_mimo_preset_catalog_for_ui_shape_matches_native():
+    catalog = tts_provider_registry.preset_catalog_for_ui("mimo")
+    assert catalog
+    milo = catalog["Milo"]
+    # 与 NativeVoiceProvider.voice_catalog_for_ui 同形态：前端按这些字段分组/渲染
+    assert milo["provider"] == "mimo"
+    assert milo["provider_label"] == "MiMo"
+    assert milo["builtin"] is True
+    assert set(milo) == {"prefix", "provider", "provider_label", "gender", "display_name", "builtin"}
 
 
 @pytest.mark.unit
@@ -50,30 +89,64 @@ def test_mimo_voice_aliases_normalize_to_catalog_ids():
         {"CORE_API_TYPE": "qwen", "assistApi": "mimo"},
     ],
 )
-def test_mimo_tts_route_exposes_native_voice_catalog(core_config):
-    assert get_active_realtime_native_provider_for_ui(_CM(core_config)) == "mimo"
+def test_mimo_selected_exposes_preset_catalog_for_ui(core_config):
+    catalog = tts_provider_registry.selected_preset_catalog_for_ui(core_config, _CM(core_config))
+    assert catalog and "Milo" in catalog
 
 
 @pytest.mark.unit
-def test_mimo_assist_api_takes_priority_over_tts_provider_for_voice_catalog():
-    cm = _CM({"CORE_API_TYPE": "qwen", "ttsProvider": "step", "assistApi": "mimo"})
-
-    assert get_active_realtime_native_provider_for_ui(cm) == "mimo"
-
-
-@pytest.mark.unit
-def test_mimo_voice_catalog_is_hidden_when_gptsovits_custom_tts_wins():
-    cm = _CM(
-        {"CORE_API_TYPE": "qwen", "assistApi": "mimo", "GPTSOVITS_ENABLED": True},
-        {"is_custom": True},
-    )
-
-    assert get_active_realtime_native_provider_for_ui(cm) is None
-    assert is_saveable_native_voice(cm, "Milo") is False
+def test_mimo_assist_api_selects_catalog_even_over_core_native():
+    # core=gemini 但 assistApi=mimo：mimo（priority 60）在 dispatch 里先于 native 命中，
+    # UI 目录也应给 mimo（UI/校验与 dispatch 同一优先级判定）。
+    core_config = {"CORE_API_TYPE": "gemini", "ttsProvider": "step", "assistApi": "mimo"}
+    catalog = tts_provider_registry.selected_preset_catalog_for_ui(core_config, _CM(core_config))
+    assert catalog and "Milo" in catalog
 
 
 @pytest.mark.unit
-def test_mimo_tts_route_makes_builtin_voices_saveable():
-    cm = _CM({"CORE_API_TYPE": "qwen", "ttsProvider": "mimo"})
+def test_mimo_catalog_hidden_when_gptsovits_custom_tts_wins():
+    # GPT-SoVITS（priority 10）先命中且无静态预制目录 → 不出 mimo 预制目录，也不算合法预制
+    core_config = {"CORE_API_TYPE": "qwen", "assistApi": "mimo", "GPTSOVITS_ENABLED": True}
+    cm = _CM(core_config, tts_custom_config={"is_custom": True})
+    assert tts_provider_registry.selected_preset_catalog_for_ui(core_config, cm) is None
+    assert tts_provider_registry.is_selected_preset_voice(core_config, cm, "Milo") is False
 
-    assert is_saveable_native_voice(cm, "Milo") is True
+
+@pytest.mark.unit
+def test_mimo_preset_voice_saveable_only_when_selected():
+    selected = {"CORE_API_TYPE": "qwen", "ttsProvider": "mimo"}
+    not_selected = {"CORE_API_TYPE": "qwen", "assistApi": "qwen"}
+    assert tts_provider_registry.is_selected_preset_voice(selected, _CM(selected), "Milo") is True
+    assert tts_provider_registry.is_selected_preset_voice(not_selected, _CM(not_selected), "Milo") is False
+
+
+# ── validate_voice_id 端到端（真 ConfigManager）：cleanup 用它判定有效性，
+#    必须认 mimo 预制 voice 合法（选中时），否则存量 mimo 配置会被清空 ──────────
+
+
+@pytest.fixture()
+def config_manager(clean_user_data_dir):
+    from utils.config_manager import get_config_manager
+    cm = get_config_manager('N.E.K.O')
+    cm.config_dir.mkdir(parents=True, exist_ok=True)
+    yield cm
+
+
+def _write_core_config(cm, data: dict):
+    path = cm.get_config_path('core_config.json')
+    with open(str(path), 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+    cm._core_config_cache = None
+
+
+@pytest.mark.unit
+def test_validate_voice_id_accepts_mimo_preset_when_selected(config_manager):
+    _write_core_config(config_manager, {"coreApi": "qwen", "assistApi": "mimo"})
+    assert config_manager.validate_voice_id("Milo") is True
+    assert config_manager.validate_voice_id("冰糖") is True
+
+
+@pytest.mark.unit
+def test_validate_voice_id_rejects_mimo_preset_when_not_selected(config_manager):
+    _write_core_config(config_manager, {"coreApi": "qwen", "assistApi": "qwen"})
+    assert config_manager.validate_voice_id("Milo") is False

--- a/tests/unit/test_mimo_tts_voices.py
+++ b/tests/unit/test_mimo_tts_voices.py
@@ -82,7 +82,7 @@ def test_mimo_preset_catalog_for_ui_shape_matches_native():
 
 
 def _selected_catalog(core_config, cm):
-    """模拟 /voices 取目录的两步：先拿赢家 key，再按 key 取其静态预制目录。"""
+    # 模拟 /voices 取目录的两步：先拿赢家 key，再按 key 取其静态预制目录
     key = tts_provider_registry.selected_provider_key(core_config, cm)
     return tts_provider_registry.preset_catalog_for_ui(key) if key else None
 

--- a/tests/unit/test_mimo_tts_voices.py
+++ b/tests/unit/test_mimo_tts_voices.py
@@ -81,6 +81,12 @@ def test_mimo_preset_catalog_for_ui_shape_matches_native():
     assert set(milo) == {"prefix", "provider", "provider_label", "gender", "display_name", "builtin"}
 
 
+def _selected_catalog(core_config, cm):
+    """模拟 /voices 取目录的两步：先拿赢家 key，再按 key 取其静态预制目录。"""
+    key = tts_provider_registry.selected_provider_key(core_config, cm)
+    return tts_provider_registry.preset_catalog_for_ui(key) if key else None
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "core_config",
@@ -90,7 +96,7 @@ def test_mimo_preset_catalog_for_ui_shape_matches_native():
     ],
 )
 def test_mimo_selected_exposes_preset_catalog_for_ui(core_config):
-    catalog = tts_provider_registry.selected_preset_catalog_for_ui(core_config, _CM(core_config))
+    catalog = _selected_catalog(core_config, _CM(core_config))
     assert catalog and "Milo" in catalog
 
 
@@ -99,7 +105,7 @@ def test_mimo_assist_api_selects_catalog_even_over_core_native():
     # core=gemini 但 assistApi=mimo：mimo（priority 60）在 dispatch 里先于 native 命中，
     # UI 目录也应给 mimo（UI/校验与 dispatch 同一优先级判定）。
     core_config = {"CORE_API_TYPE": "gemini", "ttsProvider": "step", "assistApi": "mimo"}
-    catalog = tts_provider_registry.selected_preset_catalog_for_ui(core_config, _CM(core_config))
+    catalog = _selected_catalog(core_config, _CM(core_config))
     assert catalog and "Milo" in catalog
 
 
@@ -108,8 +114,21 @@ def test_mimo_catalog_hidden_when_gptsovits_custom_tts_wins():
     # GPT-SoVITS（priority 10）先命中且无静态预制目录 → 不出 mimo 预制目录，也不算合法预制
     core_config = {"CORE_API_TYPE": "qwen", "assistApi": "mimo", "GPTSOVITS_ENABLED": True}
     cm = _CM(core_config, tts_custom_config={"is_custom": True})
-    assert tts_provider_registry.selected_preset_catalog_for_ui(core_config, cm) is None
+    assert _selected_catalog(core_config, cm) is None
     assert tts_provider_registry.is_selected_preset_voice(core_config, cm, "Milo") is False
+    # 赢家是无静态目录的 gptsovits：/voices 也应抑制 core-native（key 非 None 但目录为 None）
+    assert tts_provider_registry.selected_provider_key(core_config, cm) == "gptsovits"
+
+
+@pytest.mark.unit
+def test_no_catalog_winner_suppresses_native_voices():
+    # vLLM-Omni（无静态目录）赢得 dispatch：selected_provider_key 返回 vllm_omni、
+    # 目录为 None → /voices 的三路分支既不出目录、也不回退 core-native。
+    core_config = {"CORE_API_TYPE": "gemini", "ENABLE_CUSTOM_API": True}
+    cm = _CM(core_config, raw_core_config={"ttsModelProvider": "vllm_omni"})
+    key = tts_provider_registry.selected_provider_key(core_config, cm)
+    assert key == "vllm_omni"
+    assert tts_provider_registry.preset_catalog_for_ui(key) is None
 
 
 @pytest.mark.unit

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3143,15 +3143,18 @@ class ConfigManager:
         Dual to :func:`is_saveable_native_voice` but for the unified provider
         registry: a hosted/local provider's presets are only saveable while that
         provider is the one dispatch would route to, so this gates on the same
-        selection the dispatcher uses. The hosted providers are registered by
-        ``main_logic.tts_client`` (the heavy worker module); we force-import it so
-        the registry is populated, mirroring ``config_router``'s ui_metadata site.
-        Any failure (missing optional deps in a stripped env, etc.) degrades to
-        "not a preset voice" rather than breaking validation.
+        selection the dispatcher uses.
+
+        The hosted providers are registered as a side effect of importing
+        ``main_logic.tts_client``. config_manager (utils layer) must NOT import it
+        — that's a CI-enforced layer inversion (utils → main_logic). We rely on the
+        running app having imported tts_client at startup (the TTS pipeline does),
+        so the registry is populated by the time any voice is validated; if it
+        isn't (or the lookup errors), this degrades to "not a preset voice" rather
+        than breaking validation.
         """
         try:
             from utils import tts_provider_registry
-            import main_logic.tts_client  # noqa: F401  确保 hosted provider 已注册
             return tts_provider_registry.is_selected_preset_voice(
                 self.get_core_config() or {}, self, voice_id
             )

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3136,6 +3136,29 @@ class ConfigManager:
             return True
         return False
 
+    def _is_selected_hosted_preset_voice(self, voice_id):
+        """Whether voice_id is a built-in (preset) voice of the currently selected
+        TTS provider in tts_provider_registry (e.g. MiMo, a hosted SaaS).
+
+        Dual to :func:`is_saveable_native_voice` but for the unified provider
+        registry: a hosted/local provider's presets are only saveable while that
+        provider is the one dispatch would route to, so this gates on the same
+        selection the dispatcher uses. The hosted providers are registered by
+        ``main_logic.tts_client`` (the heavy worker module); we force-import it so
+        the registry is populated, mirroring ``config_router``'s ui_metadata site.
+        Any failure (missing optional deps in a stripped env, etc.) degrades to
+        "not a preset voice" rather than breaking validation.
+        """
+        try:
+            from utils import tts_provider_registry
+            import main_logic.tts_client  # noqa: F401  确保 hosted provider 已注册
+            return tts_provider_registry.is_selected_preset_voice(
+                self.get_core_config() or {}, self, voice_id
+            )
+        except Exception:
+            logger.warning("hosted preset voice 校验异常，按非预制处理", exc_info=True)
+            return False
+
     def validate_voice_id(self, voice_id):
         """Validate whether voice_id is valid under the current AUDIO_API_KEY.
         
@@ -3170,6 +3193,11 @@ class ConfigManager:
         if is_saveable_native_voice(self, voice_id):
             return True
 
+        # hosted/local provider 的内置预制音色（如选中 MiMo 时的预制声线），由
+        # tts_provider_registry 收口，仅在该 provider 被选中时算合法
+        if self._is_selected_hosted_preset_voice(voice_id):
+            return True
+
         # 免费预设音色允许豁免保存校验，运行时再由 core.py 按当前线路动态判断可用性
         from utils.api_config_loader import get_free_voices
         free_voices = get_free_voices()
@@ -3197,6 +3225,9 @@ class ConfigManager:
             return True
 
         if is_saveable_native_voice(self, voice_id):
+            return True
+
+        if self._is_selected_hosted_preset_voice(voice_id):
             return True
 
         from utils.api_config_loader import get_free_voices

--- a/utils/mimo_tts_voices.py
+++ b/utils/mimo_tts_voices.py
@@ -6,7 +6,7 @@ published in the MiMo-V2.5-TTS speech synthesis guide.
 """
 
 from utils.api_config_loader import get_native_tts_voice_provider_config
-from utils.native_voice_registry import NativeVoiceProvider, register_provider
+from utils.tts_provider_registry import PresetCatalog
 
 MIMO_TTS_MODEL = "mimo-v2.5-tts"
 # MiMo 的声音克隆模型。当前仅声明为常量占位：MiMo 在 tts_provider_registry 里以
@@ -15,7 +15,6 @@ MIMO_TTS_MODEL = "mimo-v2.5-tts"
 # 接手（见 voice-source-unification 设计文档 / 交接 chip）。
 MIMO_TTS_VOICECLONE_MODEL = "mimo-v2.5-tts-voiceclone"  # TODO: 接 MiMo 克隆 enrollment
 MIMO_TTS_DEFAULT_VOICE = "mimo_default"
-MIMO_TTS_DEFAULT_MALE_VOICE = "Milo"
 MIMO_TTS_BASE_URL = "https://api.xiaomimimo.com/v1"
 
 _FALLBACK_MIMO_TTS_VOICES: dict[str, str] = {
@@ -71,16 +70,12 @@ def _build_aliases(configured: dict[str, str]) -> dict[str, str]:
     }
 
 
-def _create_provider() -> NativeVoiceProvider:
+def _create_preset_catalog() -> PresetCatalog:
     aliases_source = _CFG.get("aliases") or _FALLBACK_MIMO_TTS_ALIASES
-    return NativeVoiceProvider(
-        key="mimo",
+    return PresetCatalog(
         catalog=MIMO_TTS_VOICE_GENDERS,
         aliases=_build_aliases(aliases_source),
         default_voice=_CFG.get("default_voice") or MIMO_TTS_DEFAULT_VOICE,
-        default_male_voice=(
-            _CFG.get("default_male_voice") or MIMO_TTS_DEFAULT_MALE_VOICE
-        ),
         catalog_prefix=_CFG.get("catalog_prefix") or "MiMo",
         catalog_value_is_display_name=bool(
             _CFG.get("catalog_value_is_display_name", False)
@@ -88,9 +83,12 @@ def _create_provider() -> NativeVoiceProvider:
     )
 
 
-MIMO_PROVIDER = _create_provider()
-register_provider(MIMO_PROVIDER)
+# MiMo is a hosted SaaS provider (see design doc §4), so its built-in voice
+# catalog lives on the unified tts_provider_registry.TTSProvider as a
+# preset_catalog, not on native_voice_registry. The TTSProvider entry (in
+# main_logic.tts_client) wires this catalog in via ``preset_catalog=``.
+MIMO_PRESET_CATALOG = _create_preset_catalog()
 
 
 def normalize_mimo_tts_voice(voice_id: str | None) -> tuple[str, bool]:
-    return MIMO_PROVIDER.normalize(voice_id)
+    return MIMO_PRESET_CATALOG.normalize(voice_id)

--- a/utils/native_voice_registry.py
+++ b/utils/native_voice_registry.py
@@ -366,10 +366,9 @@ def _read_tts_native_provider_for_ui(cm: "ConfigManager") -> str | None:
     if _gptsovits_tts_overrides_native_tts_for_ui(cm, core_config):
         return None
 
-    assist_api = str(core_config.get('assistApi') or '').strip().lower()
-    if assist_api == 'mimo' and assist_api in _PROVIDERS:
-        return assist_api
-
+    # MiMo（assistApi=mimo / TTS_PROVIDER=mimo）不再走这里：它是 hosted provider，
+    # 预制目录由 tts_provider_registry 的 preset_catalog 提供，/voices 与校验改查
+    # 注册表（见设计文档 §4，MiMo 归 hosted）。此处只认仍属 native 的 TTS_PROVIDER。
     tts_provider = str(
         core_config.get('TTS_PROVIDER') or core_config.get('ttsProvider') or ''
     ).strip().lower()
@@ -432,7 +431,6 @@ _BUILTIN_PROVIDER_MODULES: tuple[str, ...] = (
     "utils.gemini_tts_voices",
     "utils.stepfun_tts_voices",
     "utils.grok_tts_voices",
-    "utils.mimo_tts_voices",
 )
 
 

--- a/utils/tts_provider_registry.py
+++ b/utils/tts_provider_registry.py
@@ -356,20 +356,20 @@ def is_preset_voice(provider_key: str | None, voice_id: str | None) -> bool:
     return provider.preset_catalog.is_voice(voice_id)
 
 
-def selected_preset_catalog_for_ui(
+def selected_provider_key(
     core_config: Mapping[str, Any],
     cm: "ConfigManager",
-) -> "dict[str, dict[str, str | bool]] | None":
-    """The preset catalog of the provider currently selected for ``core_config`` /
-    ``cm``, or None when the winning provider ships no static catalog.
+) -> str | None:
+    """Key of the provider currently selected for ``core_config`` / ``cm``, or None.
 
-    Used by the ``/voices`` endpoint so e.g. a selected MiMo surfaces its built-in
-    voices, with the same precedence dispatch uses (a GPT-SoVITS / vLLM pick that
-    wins first suppresses the catalog)."""
+    UI precedence helper: the ``/voices`` endpoint reads this to mirror dispatch —
+    if the winner ships a static catalog (``preset_catalog_for_ui(key)`` non-None)
+    show it; if a registry provider wins but ships no catalog (vLLM-Omni /
+    GPT-SoVITS — user-entered or self-hosted voices), core-native voices must be
+    suppressed too, since selecting one would be misrouted to that winner. None
+    means no registry provider won → fall back to core-native voices."""
     provider = selected_provider(DispatchContext(core_config=core_config, cm=cm))
-    if provider is None:
-        return None
-    return preset_catalog_for_ui(provider.key)
+    return provider.key if provider is not None else None
 
 
 def is_selected_preset_voice(

--- a/utils/tts_provider_registry.py
+++ b/utils/tts_provider_registry.py
@@ -184,8 +184,8 @@ class PresetCatalog:
         """Voice list structure for the character UI, keyed by canonical voice name.
 
         ``provider_key`` is the owning :class:`TTSProvider` key, stamped into each
-        entry's ``provider`` field so the source-first picker groups it as
-        "<provider> · 预制".
+        entry's ``provider`` field so the source-first picker groups it under
+        that provider's preset source.
         """
         def format_prefix(group: str, display_name: str) -> str:
             if self.catalog_value_is_display_name:

--- a/utils/tts_provider_registry.py
+++ b/utils/tts_provider_registry.py
@@ -131,6 +131,87 @@ ProbeKind = Literal["ws_handshake", "local_http", "none"]
 
 
 @dataclass(frozen=True)
+class PresetCatalog:
+    """A static, declarative built-in (preset) voice catalog for a provider.
+
+    Dual to :class:`utils.native_voice_registry.NativeVoiceProvider`'s catalog
+    half, but lives on the unified :class:`TTSProvider` so a SaaS provider that
+    ships its own voice set (e.g. MiMo) can advertise its presets without being
+    mis-registered as a core-native provider (see design doc §3/§4: ``mimo`` is
+    ``hosted``, not ``native``). The shape returned by :meth:`catalog_for_ui`
+    intentionally mirrors ``NativeVoiceProvider.voice_catalog_for_ui`` so the
+    ``/voices`` endpoint and the source-first picker consume one structure
+    regardless of whether the catalog came from native or hosted.
+
+    ``catalog`` maps a canonical voice name to a supplementary label (a gender by
+    default, or the display name itself when ``catalog_value_is_display_name``);
+    ``aliases`` maps casefolded user-friendly input back to canonical names. The
+    catalog is static data — dynamic ``/voices``-style fetching (e.g. GPT-SoVITS)
+    is a future variant declared on the same field, not a special-case here.
+    """
+
+    catalog: Mapping[str, str]
+    aliases: Mapping[str, str] = field(default_factory=dict)
+    default_voice: str = ""
+    catalog_prefix: str = ""
+    catalog_value_is_display_name: bool = False
+    _voice_lookup: dict[str, str] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "_voice_lookup",
+            {name.casefold(): name for name in self.catalog},
+        )
+
+    def normalize(self, voice_id: str | None) -> tuple[str, bool]:
+        """Return (canonical voice name, recognized). Empty input is unrecognized."""
+        normalized = (voice_id or "").strip()
+        if not normalized:
+            return self.default_voice, False
+        exact = self._voice_lookup.get(normalized.casefold())
+        if exact:
+            return exact, True
+        alias = self.aliases.get(normalized.casefold())
+        if alias:
+            return alias, True
+        return self.default_voice, False
+
+    def is_voice(self, voice_id: str | None) -> bool:
+        return self.normalize(voice_id)[1]
+
+    def catalog_for_ui(self, provider_key: str) -> dict[str, dict[str, str | bool]]:
+        """Voice list structure for the character UI, keyed by canonical voice name.
+
+        ``provider_key`` is the owning :class:`TTSProvider` key, stamped into each
+        entry's ``provider`` field so the source-first picker groups it as
+        "<provider> · 预制".
+        """
+        def format_prefix(group: str, display_name: str) -> str:
+            if self.catalog_value_is_display_name:
+                return display_name
+            return f"{self.catalog_prefix} {display_name} ({group})"
+
+        def split_value(voice_name: str, value: str) -> tuple[str, str]:
+            if self.catalog_value_is_display_name:
+                return "", value or voice_name
+            return value, voice_name
+
+        catalog_for_ui: dict[str, dict[str, str | bool]] = {}
+        for voice_name, catalog_value in self.catalog.items():
+            gender, display_name = split_value(voice_name, catalog_value)
+            catalog_for_ui[voice_name] = {
+                "prefix": format_prefix(gender, display_name),
+                "provider": provider_key,
+                "provider_label": self.catalog_prefix,
+                "gender": gender,
+                "display_name": display_name,
+                "builtin": True,
+            }
+        return catalog_for_ui
+
+
+@dataclass(frozen=True)
 class TTSProvider:
     """One dispatchable TTS provider, declared in a single place.
 
@@ -153,6 +234,14 @@ class TTSProvider:
     capabilities: frozenset[VoiceSource]
     is_selected: SelectPredicate
     resolve: DispatchResolver
+
+    # Static built-in (preset) voice catalog, when this provider ships one (e.g.
+    # MiMo). None for providers whose presets are user-entered ids against a
+    # configured endpoint (vLLM-Omni) or that have no preset source at all. This
+    # is the single source of truth for the provider's preset voices — the UI
+    # ``/voices`` endpoint and ``validate_voice_id`` query it instead of restating
+    # the catalog elsewhere (see design doc §3 ``preset_catalog``).
+    preset_catalog: "PresetCatalog | None" = None
 
     # ── Declarative UI / probe metadata (single source of truth for frontend) ──
     # Whether this provider appears only in the TTS model dropdown and never
@@ -201,16 +290,14 @@ def all_providers() -> list[TTSProvider]:
     return sorted(_REGISTRY.values(), key=lambda p: p.priority)
 
 
-def resolve_selected(
-    ctx: "DispatchContext",
-) -> "tuple[Callable[..., Any], str | None, str] | None":
-    """Return the dispatch tuple for the first provider selected for ``ctx``, in
-    priority order, or ``None`` when none apply.
+def selected_provider(ctx: "DispatchContext") -> "TTSProvider | None":
+    """Return the first provider selected for ``ctx`` in priority order, or None.
 
-    ``get_tts_worker`` builds ``ctx`` and calls this near the top (after the
-    DISABLE_TTS check) so a user's provider choice — whether an explicit dropdown
-    pick or an implied clone-voice provider — wins over native / core default
-    routing in the original hand-written precedence (priority order).
+    The single place the registry decides "which provider wins for this context".
+    ``resolve_selected`` (dispatch) and the UI / validation preset helpers all go
+    through here so they agree on precedence — e.g. an explicit GPT-SoVITS pick
+    (priority 10) wins over MiMo's preset catalog (priority 60), so the catalog is
+    hidden in exactly the cases dispatch wouldn't route to it.
     """
     for provider in all_providers():
         try:
@@ -224,8 +311,81 @@ def resolve_selected(
             )
             selected = False
         if selected:
-            return provider.resolve(ctx)
+            return provider
     return None
+
+
+def resolve_selected(
+    ctx: "DispatchContext",
+) -> "tuple[Callable[..., Any], str | None, str] | None":
+    """Return the dispatch tuple for the first provider selected for ``ctx``, in
+    priority order, or ``None`` when none apply.
+
+    ``get_tts_worker`` builds ``ctx`` and calls this near the top (after the
+    DISABLE_TTS check) so a user's provider choice — whether an explicit dropdown
+    pick or an implied clone-voice provider — wins over native / core default
+    routing in the original hand-written precedence (priority order).
+    """
+    provider = selected_provider(ctx)
+    return provider.resolve(ctx) if provider is not None else None
+
+
+# ── Preset-catalog queries (single source of truth for built-in voices) ──────
+# Primitives are keyed by provider; the ``selected_*`` variants gate on which
+# provider actually wins for the current config (via ``selected_provider``), so
+# a provider's preset voices only surface / validate when that provider is the
+# one dispatch would route to. The registry must be populated first — callers
+# that run outside the dispatch path ensure ``import main_logic.tts_client``
+# (the heavy worker module that registers the hosted providers), mirroring
+# ``config_router``'s ``ui_metadata`` call site.
+
+
+def preset_catalog_for_ui(provider_key: str | None) -> "dict[str, dict[str, str | bool]] | None":
+    """The UI voice catalog for ``provider_key``'s preset_catalog, or None."""
+    provider = get(provider_key)
+    if provider is None or provider.preset_catalog is None:
+        return None
+    return provider.preset_catalog.catalog_for_ui(provider.key)
+
+
+def is_preset_voice(provider_key: str | None, voice_id: str | None) -> bool:
+    """Whether ``voice_id`` is a built-in voice of ``provider_key``'s catalog."""
+    provider = get(provider_key)
+    if provider is None or provider.preset_catalog is None:
+        return False
+    return provider.preset_catalog.is_voice(voice_id)
+
+
+def selected_preset_catalog_for_ui(
+    core_config: Mapping[str, Any],
+    cm: "ConfigManager",
+) -> "dict[str, dict[str, str | bool]] | None":
+    """The preset catalog of the provider currently selected for ``core_config`` /
+    ``cm``, or None when the winning provider ships no static catalog.
+
+    Used by the ``/voices`` endpoint so e.g. a selected MiMo surfaces its built-in
+    voices, with the same precedence dispatch uses (a GPT-SoVITS / vLLM pick that
+    wins first suppresses the catalog)."""
+    provider = selected_provider(DispatchContext(core_config=core_config, cm=cm))
+    if provider is None:
+        return None
+    return preset_catalog_for_ui(provider.key)
+
+
+def is_selected_preset_voice(
+    core_config: Mapping[str, Any],
+    cm: "ConfigManager",
+    voice_id: str | None,
+) -> bool:
+    """Whether ``voice_id`` is a built-in voice of the currently selected provider
+    (used by ``validate_voice_id`` so a hosted provider's presets are saveable
+    only while that provider is selected — dual to ``is_saveable_native_voice``)."""
+    provider = selected_provider(
+        DispatchContext(core_config=core_config, cm=cm, voice_id=voice_id or "")
+    )
+    if provider is None:
+        return False
+    return is_preset_voice(provider.key, voice_id)
 
 
 def ui_metadata() -> list[dict[str, Any]]:


### PR DESCRIPTION
## 改动概述 / Summary

给统一 TTS 注册表 `TTSProvider` 扩出**预制音色目录能力 `preset_catalog`**（蓝图 §3），把 **MiMo 的预制目录 + 校验**从 `utils/native_voice_registry.py` 搬到 hosted 注册表，并把 **mimo 从 native 摘除**（蓝图 §4：mimo 是 hosted SaaS、不是核心自带，之前错挂 native 只为蹭目录/UI 管线）。`/voices`、`validate_voice_id`、preview 拦截、dispatch 四条路径共用同一选中优先级（`selected_provider`）。

## 回归报告 / Regression Report

**改动了什么**
- `utils/tts_provider_registry.py`：新增 `PresetCatalog`（静态声明式预制目录，`catalog_for_ui()` 与 native `voice_catalog_for_ui()` 逐字段同形态）；`TTSProvider` 加 `preset_catalog` 字段；抽出 `selected_provider(ctx)` 让 dispatch/UI/校验共用同一优先级；加 `is_preset_voice` / `preset_catalog_for_ui` / `selected_provider_key` / `is_selected_preset_voice` helper。
- `utils/mimo_tts_voices.py`：复用同一份固定音色表建 `MIMO_PRESET_CATALOG`，不再经 `NativeVoiceProvider` / 不挂 native registry。
- `main_logic/tts_client/__init__.py`：mimo `TTSProvider` 接 `preset_catalog=MIMO_PRESET_CATALOG`。dispatch 逻辑不变。
- `main_routers/characters_router.py`：`/voices` 三路分支（赢家有静态目录→出目录；赢家无目录如 vllm/gptsovits→既不出目录也不回退 native；无赢家→core-native），复用 `native_voices` 通道；`/voice_preview` 对选中的 hosted preset 显式返回「暂不支持试听」，同名克隆放行走克隆试听。
- `utils/config_manager.py`：`validate_voice_id` / `*_for_api_key` 加 hosted preset 豁免（仅该 provider 选中时合法）；不 import main_logic（守 module-layering），直接查注册表。
- `utils/native_voice_registry.py`：从 `_BUILTIN_PROVIDER_MODULES` 删 `utils.mimo_tts_voices`，删 `_read_tts_native_provider_for_ui` 的 mimo 特判。

**理由 / 必要性**：mimo 同时被注册成 native（蹭目录/UI）和 hosted（dispatch 已走），是设计文档点名要修的「错挂」。预制音色应作为 provider 一等能力声明在统一注册表上、成为单一真相，UI 与校验都查它而非借道 native registry。

**改动前后表现对比**

| 场景 | 改动前 | 改动后 |
|---|---|---|
| dispatch（`get_tts_worker`） | mimo 走 hosted（priority 60） | 不变 |
| `/voices`（mimo 选中） | native 通道吐 mimo 目录 | hosted `preset_catalog` 吐目录，**同 payload 形态**，前端仍归「MiMo · 预制」 |
| `/voices`（vllm/gptsovits 赢且无目录 + 原生 core） | 仍露出 core-native 目录（选中会被误路由） | 抑制 native，不再误露 |
| `validate_voice_id`（mimo 选中 + 预制音色） | `is_saveable_native_voice` 认合法 | hosted preset 分支认合法 |
| `/voice_preview`（mimo 预制） | 走 native 分支返回「不支持预览」（从未真合成） | 显式返回 `PRESET_VOICE_PREVIEW_UNSUPPORTED`；同名克隆仍走克隆试听 |
| `is_native_voice('mimo')` | 含 mimo | 不再含 mimo |

**潜在回归点与验证**
- **掉档**：mimo 无存量用户（dev-only、未上线，维护者确认），单 PR 一步到位，不做双供过渡、不加 cleanup 不掉档回归。
- **校验链路**：hosted preset 分支只对 mimo 选中生效，对其它 provider/voice 零行为变化（唯一带 `preset_catalog` 的是 mimo）；异常降级为「非预制」，不打挂校验/cleanup。
- **前端**：未改任何 JS，`/voices` payload 形态逐字段保持（单测锁定），index 宽/窄 + chat.html Electron 三端渲染与改前一致。
- **module-layering**：config_manager 不 import main_logic，避免 utils→main_logic 倒挂，本地 `check_module_layering.py` 通过。

## 不拆分理由 / Why Not Split

不适用（计入上限的文件 ≤ 20）。

## 测试 / Testing

- 重写 `tests/unit/test_mimo_tts_voices.py`：mimo 注册为 hosted + 带 preset_catalog、已从 native 摘除、目录形态对齐 native、选中出目录、assistApi=mimo 压过 core-native、GPT-SoVITS 占用时隐藏、无目录赢家抑制 native、预览 guard 放行同名克隆、validate 端到端认/拒。
- 既有 dispatch（`test_mimo_tts_worker.py`）+ native/config/connectivity/gptsovits/vllm/voice_id·cleanup·voice_config 子集全绿。
- 本地：`check_docstring_no_cjk.py --base origin/main` EXIT=0、`check_module_layering.py` EXIT=0、ruff 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 引入统一的预设语音目录机制：MiMo 预设音色改由静态预设目录提供，并支持归一化/别名映射。

* **改进**
  * `/voices` 与路由选择联动：按当前实际胜出提供方展示对应 MiMo 预设目录；仅在已选中时允许保存。
  * `/voice_preview` 新增拦截：对不支持的 MiMo 预设试听返回错误；同名克隆在满足条件时可放行。
  * 语音校验（含 API Key）增加“已选预设”豁免规则；原生侧不再预注册 MiMo。

* **测试**
  * 更新并扩展 MiMo 预设目录选择、校验/可用性与预览拦截相关用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->