### PR TITLE
修复紧凑聊天框轮盘中头像道具按钮的取消逻辑

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5056,7 +5056,9 @@ describe('App', () => {
       expect(avatarTool).toHaveAttribute('data-compact-tool-active', 'true');
       expect(emojiButton).toHaveClass('is-active');
 
-      fireEvent.click(screen.getByRole('button', { name: '棒棒糖' }));
+      const firstQuickToolButton = fan.querySelector<HTMLButtonElement>('#composer-avatar-tool-quickbar .avatar-tool-quickbar-button');
+      expect(firstQuickToolButton).not.toBeNull();
+      fireEvent.click(firstQuickToolButton!);
 
       expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
       expect(fan.querySelector('#composer-tool-popover-compact')).toBeNull();
@@ -5069,7 +5071,12 @@ describe('App', () => {
       expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
       expect(avatarTool).toHaveAttribute('data-compact-tool-active', 'true');
       expect(avatarTool.querySelector('.composer-emoji-btn')).toHaveClass('is-active');
-      expect(fan.querySelector('#composer-avatar-tool-quickbar')).not.toBeNull();
+      expect(fan.querySelector('#composer-avatar-tool-quickbar')).toBeNull();
+
+      fireEvent.click(emojiButton);
+
+      expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
+      expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
     } finally {
       vi.useRealTimers();
     }
@@ -7186,20 +7193,20 @@ describe('App', () => {
 
     expect(screen.getByRole('group', { name: 'Avatar quick tools' })).toBeInTheDocument();
 
-    const lollipopButton = screen.getByRole('button', { name: '棒棒糖' });
-    expect(lollipopButton).toHaveAttribute('aria-pressed', 'false');
+    const firstQuickToolButton = document.body.querySelector<HTMLButtonElement>('.avatar-tool-quickbar-button');
+    expect(firstQuickToolButton).not.toBeNull();
+    expect(firstQuickToolButton).toHaveAttribute('aria-pressed', 'false');
 
-    fireEvent.click(lollipopButton);
+    fireEvent.click(firstQuickToolButton!);
 
-    expect(lollipopButton).toHaveClass('is-active');
-    expect(lollipopButton).toHaveAttribute('aria-pressed', 'true');
+    expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
+    expect(screen.queryByRole('group', { name: 'Avatar quick tools' })).toBeNull();
 
-    fireEvent.click(lollipopButton);
+    await openCompactInputTools();
+    fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
 
-    expect(screen.getByRole('button', { name: 'Avatar tools' })).toBeInTheDocument();
-    expect(screen.getByRole('group', { name: 'Avatar quick tools' })).toBeInTheDocument();
-    expect(lollipopButton).not.toHaveClass('is-active');
-    expect(lollipopButton).toHaveAttribute('aria-pressed', 'false');
+    expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
+    expect(screen.queryByRole('group', { name: 'Avatar quick tools' })).toBeNull();
   });
 
   it('closes the transparent compact tool fan after selecting an avatar cursor tool', async () => {
@@ -7216,18 +7223,42 @@ describe('App', () => {
     expect(queryAvatarCursorOverlay()).not.toBeNull();
   });
 
+  it('clears the selected compact avatar tool from the avatar wheel button', async () => {
+    renderInputApp();
+
+    await openCompactInputTools();
+    fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
+    const firstQuickToolButton = document.body.querySelector<HTMLButtonElement>('.avatar-tool-quickbar-button');
+    expect(firstQuickToolButton).not.toBeNull();
+    fireEvent.click(firstQuickToolButton!);
+
+    expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
+    expect(screen.queryByRole('group', { name: 'Avatar quick tools' })).toBeNull();
+
+    await openCompactInputTools();
+    const fan = document.body.querySelector<HTMLElement>('.compact-input-tool-fan');
+    const avatarTool = fan?.querySelector<HTMLElement>('.compact-input-tool-item-avatar');
+    expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'true');
+    expect(avatarTool).toHaveAttribute('data-compact-tool-active', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
+
+    expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
+    expect(queryAvatarCursorOverlay()).toBeNull();
+    expect(screen.queryByRole('group', { name: 'Avatar quick tools' })).toBeNull();
+    expect(fan).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
+  });
+
   it('disables avatar sub-actions when the avatar wheel slot is not actionable', async () => {
     const { container } = renderInputApp();
 
     await openCompactInputTools();
     const fan = document.body.querySelector('.compact-input-tool-fan') as HTMLDivElement;
     fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
-    const lollipopButton = screen.getByRole('button', { name: '棒棒糖' }) as HTMLButtonElement;
-    fireEvent.click(lollipopButton);
 
-    const clearButton = screen.getByRole('button', { name: '恢复鼠标' }) as HTMLButtonElement;
+    const lollipopButton = document.body.querySelector<HTMLButtonElement>('.avatar-tool-quickbar-button');
     const editButton = container.querySelector('.avatar-tool-quickbar-edit') as HTMLButtonElement;
-    expect(clearButton).not.toBeDisabled();
+    expect(lollipopButton).not.toBeNull();
     expect(lollipopButton).not.toBeDisabled();
     expect(editButton).not.toBeDisabled();
 
@@ -7236,8 +7267,6 @@ describe('App', () => {
     fireEvent.wheel(fan, { deltaY: 80 });
 
     expect(fan.querySelector('.compact-input-tool-item-avatar')).toHaveAttribute('data-compact-tool-wheel-slot', '-2');
-    expect(clearButton).toBeDisabled();
-    expect(clearButton).toHaveAttribute('tabindex', '-1');
     expect(lollipopButton).toBeDisabled();
     expect(editButton).toBeDisabled();
   });
@@ -7247,15 +7276,18 @@ describe('App', () => {
 
     await openCompactInputTools();
     fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
-    const fistButton = screen.getByRole('button', { name: '猫爪' });
-    fireEvent.click(fistButton);
+    const quickToolButtons = document.body.querySelectorAll<HTMLButtonElement>('.avatar-tool-quickbar-button');
+    const fistButton = quickToolButtons[1];
+    expect(fistButton).not.toBeUndefined();
+    fireEvent.click(fistButton!);
 
-    expect(fistButton).toHaveAttribute('aria-pressed', 'true');
+    expect(document.documentElement).toHaveClass('neko-tool-cursor-active');
 
-    fireEvent.click(fistButton);
+    await openCompactInputTools();
+    fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
 
-    expect(screen.getByRole('button', { name: 'Avatar tools' })).toBeInTheDocument();
-    expect(fistButton).toHaveAttribute('aria-pressed', 'false');
+    expect(document.documentElement).not.toHaveClass('neko-tool-cursor-active');
+    expect(document.body.querySelector('.compact-input-tool-fan')).toHaveAttribute('data-compact-input-tool-fan-open', 'false');
   });
 
   it('emits avatar tool state changes for desktop hosts', async () => {
@@ -7310,7 +7342,7 @@ describe('App', () => {
     renderInputApp();
 
     await openCompactInputTools();
-    fireEvent.click(screen.getByRole('button', { name: 'Emoji' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
     fireEvent.click(screen.getByRole('button', { name: '猫爪' }), {
       clientX: 240,
       clientY: 320,
@@ -7398,8 +7430,9 @@ describe('App', () => {
 
     fireEvent.blur(window);
 
+    await openCompactInputTools();
     onAvatarToolStateChange.mockClear();
-    fireEvent.click(screen.getByRole('button', { name: '恢复鼠标' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Avatar tools' }));
 
     expect(onAvatarToolStateChange).toHaveBeenCalledWith(expect.objectContaining({
       active: false,

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -3859,6 +3859,12 @@ function CompactChatApp({
     });
   }, [closeCompactInputToolFan]);
 
+  const clearActiveCursorToolAndCloseCompactFan = useCallback(() => {
+    setIsCursorInsideHostWindow(true);
+    clearActiveCursorToolSelection();
+    closeCompactInputToolFanFromUserClick();
+  }, [clearActiveCursorToolSelection, closeCompactInputToolFanFromUserClick]);
+
   const closeCompactInputToolFanFromDesktopOutside = useCallback(() => {
     resetCompactInputToolFanHoverBlock();
     scheduleCompactInputToolFanTransientClose({
@@ -5836,9 +5842,7 @@ function CompactChatApp({
             }
             if (activeToolItem) {
               event.stopPropagation();
-              setIsCursorInsideHostWindow(true);
-              clearActiveCursorToolSelection();
-              closeCompactInputToolFanFromUserClick();
+              clearActiveCursorToolAndCloseCompactFan();
               return;
             }
             compactInputToolFanOpenIntentRef.current = 'click';
@@ -5868,9 +5872,7 @@ function CompactChatApp({
                 return;
               }
               event.stopPropagation();
-              setIsCursorInsideHostWindow(true);
-              clearActiveCursorToolSelection();
-              closeCompactInputToolFanFromUserClick();
+              clearActiveCursorToolAndCloseCompactFan();
             }}
           >
             <span className="composer-tool-clear-icon" aria-hidden="true" />

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -5834,6 +5834,13 @@ function CompactChatApp({
               event.stopPropagation();
               return;
             }
+            if (activeToolItem) {
+              event.stopPropagation();
+              setIsCursorInsideHostWindow(true);
+              clearActiveCursorToolSelection();
+              closeCompactInputToolFanFromUserClick();
+              return;
+            }
             compactInputToolFanOpenIntentRef.current = 'click';
             clearCompactInputToolFanCloseTimer();
             setToolMenuOpen(open => !open);


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

已选中头像道具时再次点击主按钮会清除当前选择并关闭轮盘，而不是反复开关道具列表

## 测试 / Testing

手动使用道具功能测试

## 修复前后对比

修复前:

https://github.com/user-attachments/assets/497d2261-2250-4138-9c8e-4657d7bc9315

修复后:


https://github.com/user-attachments/assets/a0281d82-40ac-4863-807d-ccf03f5511a3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 优化紧凑输入态的头像工具交互：当已有光标工具处于激活状态时，点击头像工具将优先清除当前选择并关闭工具扇区，同时正确维护光标激活状态。

* **测试**
  * 更新并扩展紧凑头像工具相关用例：加强对 quickbar 流程、光标激活与分组关闭/扇区展开状态的断言，并调整部分交互触发顺序以匹配实际行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->