### PR TITLE
refactor(tts): GPT-SoVITS 启用收口到 ttsModelProvider 下拉单一真相，退役 gptsovitsEnabled

### DIFF
--- a/main_logic/tts_client/workers/gptsovits.py
+++ b/main_logic/tts_client/workers/gptsovits.py
@@ -405,19 +405,12 @@ def gptsovits_tts_worker(request_queue, response_queue, audio_api_key, voice_id)
 
 def _gptsovits_is_selected(ctx) -> bool:
     core_config, cm = ctx.core_config, ctx.cm
-    # 迁移期双信号：新前端把 GPT-SoVITS 迁到 ttsModelProvider 下拉（与 vLLM-Omni 同
-    # 机制），旧前端 / 存量配置仍走 GPTSOVITS_ENABLED 开关。两条选中信号都认，避免
-    # 迁移过程中任一侧漏选。
-    try:
-        raw = cm.load_json_config('core_config.json', {})
-    except Exception:
-        raw = {}
-    if (raw.get('ttsModelProvider') or '').strip() == 'gptsovits':
-        return True
-    # legacy：GPTSOVITS_ENABLED 开关 + tts_custom 槽位的 is_custom。
-    # config_manager 写 snapshot 时已 _as_bool 规整 GPTSOVITS_ENABLED，这里再包一层
-    # 防御性对齐隔壁 ENABLE_CUSTOM_API / core.py，避免直接传入未规整 dict 时字符串
-    # "false"/"0" 被当真值误抢 GPT-SoVITS。
+    # 选中信号收口到 GPTSOVITS_ENABLED 单一真相：config_manager 的 snapshot 已把
+    # ttsModelProvider=='gptsovits' 下拉（与 pre-#1830 存量旧开关）派生进
+    # GPTSOVITS_ENABLED，这里不再自己 raw load core_config.json 读 ttsModelProvider。
+    # snapshot 写 GPTSOVITS_ENABLED 时已 _as_bool 规整，这里再包一层防御性对齐隔壁
+    # ENABLE_CUSTOM_API / core.py，避免直接传入未规整 dict 时字符串 "false"/"0"
+    # 被当真值误抢 GPT-SoVITS。
     if not _as_bool(core_config.get('GPTSOVITS_ENABLED'), False):
         return False
     try:

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -931,6 +931,15 @@ async def update_core_config(request: Request):
                 field = f'{mt}Model{suffix}'
                 if field in data:
                     core_cfg[field] = data[field]
+        # gptsovitsEnabled 退役后的惰性迁移（save choke point，对偶 #1842 voice_id 思路）：
+        # GSV 启用已收口到 ttsModelProvider=='gptsovits' 单一真相，旧 gptsovitsEnabled 仅作
+        # pre-#1830 存量兜底。前端加载会把启用中的 GSV 下拉钉到 'gptsovits'，故任何提交了
+        # 非 'gptsovits' 的 ttsModelProvider 都是用户显式切走 → 顺手把残留旧 flag 落 False，
+        # 否则 get_core_config 的 follow_* 回落分支会把旧 true 兜回来（切到 follow_assist 也
+        # 关不掉 GSV）。未提交 ttsModelProvider 的局部更新不碰旧 flag，保住从不重存的存量。
+        _incoming_tts_provider = str(data.get('ttsModelProvider', '') or '').strip()
+        if _incoming_tts_provider and _incoming_tts_provider != 'gptsovits':
+            core_cfg['gptsovitsEnabled'] = False
         if 'ttsVoiceId' in data:
             core_cfg['ttsVoiceId'] = data['ttsVoiceId']
 

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1626,13 +1626,15 @@ async function loadCurrentApiKey() {
             setInputValue('ttsModelApiKey', data.ttsModelApiKey);
             setInputValue('ttsVoiceId', data.ttsVoiceId);
 
-            // 加载 GPT-SoVITS 配置（优先使用显式启用状态，兼容旧配置）
+            // 加载 GPT-SoVITS 配置：启用状态以 ttsModelProvider 下拉为准，
+            // 无下拉时回落旧 gptsovitsEnabled / localhost 启发式（兼容存量）
             loadGptSovitsConfig(
                 data.ttsModelUrl,
                 data.ttsVoiceId,
                 data.ttsModelId,
                 data.ttsModelApiKey,
                 data.gptsovitsEnabled,
+                data.ttsModelProvider,
             );
 
             // 加载MCPR_TOKEN
@@ -1709,9 +1711,9 @@ let pendingApiKey = null;
 
 /**
  * 从保存的 TTS 字段解析并加载 GPT-SoVITS v3 配置
- * 优先使用显式 gptsovitsEnabled，旧配置再做有限兼容判断
+ * 启用状态以 ttsModelProvider 下拉为准；无下拉时回落旧 gptsovitsEnabled / localhost 启发式（兼容存量）
  */
-function loadGptSovitsConfig(ttsModelUrl, ttsVoiceId, ttsModelId = '', ttsModelApiKey = '', gptsovitsEnabled = null) {
+function loadGptSovitsConfig(ttsModelUrl, ttsVoiceId, ttsModelId = '', ttsModelApiKey = '', gptsovitsEnabled = null, ttsModelProvider = '') {
     // 检查是否是禁用但保存了配置的情况
     let isDisabledWithConfig = false;
     let savedUrl = '';
@@ -1724,11 +1726,24 @@ function loadGptSovitsConfig(ttsModelUrl, ttsVoiceId, ttsModelId = '', ttsModelA
         if (parts.length >= 2) savedVoiceId = parts[1];
     }
 
+    // 启用判定与后端 snapshot 派生对偶（见 utils/config_manager.py）：ttsModelProvider
+    // 一旦写出（非空）即唯一真相——选中 gptsovits 才启用，选别家就关，旧 gptsovitsEnabled
+    // 不再参与；仅 provider 缺失/空串（pre-#1830 存量）时才回落显式旧 flag / localhost 启发式。
+    // 这保证远程 GSV 的 dropdown-only 用户（startup heuristic 不认远程 URL）reload 时仍回填
+    // 配置，且切走下拉后残留旧 flag 不会把 GSV 兜回来。
+    const provider = (ttsModelProvider || '').trim();
     const hasExplicitEnabledFlag = typeof gptsovitsEnabled === 'boolean';
     const isLegacyEnabled = !hasExplicitEnabledFlag
         && !isDisabledWithConfig
         && looksLikeLegacyGptSovitsConfig(ttsModelUrl, ttsModelId, ttsModelApiKey);
-    const isEnabled = !isDisabledWithConfig && (hasExplicitEnabledFlag ? gptsovitsEnabled : isLegacyEnabled);
+    let isEnabled;
+    if (isDisabledWithConfig) {
+        isEnabled = false;
+    } else if (provider) {
+        isEnabled = (provider === 'gptsovits');
+    } else {
+        isEnabled = hasExplicitEnabledFlag ? gptsovitsEnabled : isLegacyEnabled;
+    }
 
     _loadedGptSovitsState = isDisabledWithConfig ? 'disabled' : (isEnabled ? 'enabled' : 'none');
 
@@ -2256,9 +2271,11 @@ async function save_button_down(e) {
     let ttsVoiceId = getVal('ttsVoiceId');
 
     // 检查 GPT-SoVITS v3 配置
-    // GSV「是否启用」迁到 ttsModelProvider 下拉：选中 gptsovits 即启用，取代旧的独立
-    // 启用开关。迁移期仍把 gptsovitsEnabled=true 写进 payload（后端整条 GSV 链路 key off
-    // GPTSOVITS_ENABLED），与 ttsModelProvider='gptsovits' 双信号并存。
+    // GSV「是否启用」收口到 ttsModelProvider 下拉单一真相：选中 gptsovits 即启用。
+    // gptsovitsEnabled 已退役，保存时不再写进 payload——后端 snapshot 直接从
+    // ttsModelProvider 派生 GPTSOVITS_ENABLED（见 utils/config_manager.py）。这里的
+    // 局部 gptsovitsEnabled 只是本函数内据下拉算出的本地标志，仅供 URL 校验 /
+    // ttsModelUrl·ttsVoiceId 赋值 / ttsProvider 复用，不外发。
     const gptsovitsEnabled = (document.getElementById('ttsModelProvider')?.value || '').trim() === 'gptsovits';
     const gptsovitsConfigForSave = getGptSovitsConfigForSave();
 
@@ -2331,7 +2348,7 @@ async function save_button_down(e) {
         agentModelUrl, agentModelId, agentModelApiKey,
         omniModelUrl, omniModelId, omniModelApiKey,
         ttsModelUrl, ttsModelId, ttsModelApiKey, ttsVoiceId,
-        mcpToken, enableCustomApi, gptsovitsEnabled,
+        mcpToken, enableCustomApi,
         useMimoTokenPlan,
         assistApiKeyMimoTokenPlan: mimoTokenPlanKey,
         resolvedProviderUrls: _resolvedProviderUrls,
@@ -2429,7 +2446,9 @@ function refreshAutoResolvedModelUrlsForSave(params) {
     };
 
     MODEL_TYPES.forEach(modelType => {
-        if (modelType === 'tts' && params.gptsovitsEnabled) return;
+        // GSV 选中时 tts URL 由 GSV 专属字段提供，跳过自动解析。启用信号收口到
+        // ttsModelProvider 下拉（gptsovitsEnabled 已不再外发）。
+        if (modelType === 'tts' && (params.ttsModelProvider || '').trim() === 'gptsovits') return;
 
         const providerField = `${modelType}ModelProvider`;
         const urlField = `${modelType}ModelUrl`;

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1727,25 +1727,35 @@ function loadGptSovitsConfig(ttsModelUrl, ttsVoiceId, ttsModelId = '', ttsModelA
     }
 
     // 启用判定与后端 snapshot 派生对偶（见 utils/config_manager.py）：ttsModelProvider
-    // 一旦写出（非空）即唯一真相——选中 gptsovits 才启用，选别家就关，旧 gptsovitsEnabled
-    // 不再参与；仅 provider 缺失/空串（pre-#1830 存量）时才回落显式旧 flag / localhost 启发式。
-    // 这保证远程 GSV 的 dropdown-only 用户（startup heuristic 不认远程 URL）reload 时仍回填
-    // 配置，且切走下拉后残留旧 flag 不会把 GSV 兜回来。
+    // 一旦「显式选了某个 TTS provider」即唯一真相——选中 gptsovits 才启用、选别家就关，
+    // 旧 gptsovitsEnabled / disabled sentinel 不参与。仅当未显式选择时（provider 缺失/空串，
+    // 或 follow_assist/follow_core 这两个「跟随 assist/core」默认哨兵）才回落 legacy 路径：
+    // 先认 __gptsovits_disabled__| sentinel，再回落显式旧 flag / localhost 启发式。
+    // ⚠️ follow_* 必须当「未显式选」而非显式 provider，否则存量 GSV 用户（gptsovitsEnabled=true
+    // + ttsModelProvider='follow_assist' 默认值）会被前端判成关、与后端分叉（Codex PR#1850 P1）。
+    // 显式 provider 压过 sentinel：provider=gptsovits 共存旧 sentinel 时仍判启用，URL/voice
+    // 从 sentinel 解出做迁移（CodeRabbit/Greptile PR#1850）。这也保证远程 GSV 的 dropdown-only
+    // 用户（启发式不认远程 URL）reload 仍回填，且显式切走后残留旧 flag 不会把 GSV 兜回来。
     const provider = (ttsModelProvider || '').trim();
+    const isFollowOrUnset = (provider === '' || provider === 'follow_assist' || provider === 'follow_core');
     const hasExplicitEnabledFlag = typeof gptsovitsEnabled === 'boolean';
     const isLegacyEnabled = !hasExplicitEnabledFlag
         && !isDisabledWithConfig
         && looksLikeLegacyGptSovitsConfig(ttsModelUrl, ttsModelId, ttsModelApiKey);
     let isEnabled;
-    if (isDisabledWithConfig) {
-        isEnabled = false;
-    } else if (provider) {
+    if (!isFollowOrUnset) {
         isEnabled = (provider === 'gptsovits');
+    } else if (isDisabledWithConfig) {
+        isEnabled = false;
     } else {
         isEnabled = hasExplicitEnabledFlag ? gptsovitsEnabled : isLegacyEnabled;
     }
 
-    _loadedGptSovitsState = isDisabledWithConfig ? 'disabled' : (isEnabled ? 'enabled' : 'none');
+    // disabled 态仅在「未显式选 + 存量 sentinel」时成立；显式选了 provider（含 gptsovits）
+    // 以下拉为准，不被 sentinel 拉回 disabled。
+    _loadedGptSovitsState = (isFollowOrUnset && isDisabledWithConfig)
+        ? 'disabled'
+        : (isEnabled ? 'enabled' : 'none');
 
     // GSV 迁到 ttsModelProvider 下拉后，启用状态由下拉表达（这里不再操作已删除的
     // gptsovitsEnabled 开关）。下拉值与字段可见性由随后的 provider 还原循环统一处理

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -707,6 +707,51 @@ def test_load_gptsovits_enabled_by_dropdown_with_remote_url(mock_page: Page, run
 
 
 @pytest.mark.frontend
+def test_load_gptsovits_legacy_follow_default_and_sentinel(mock_page: Page, running_server: str):
+    """⚠️ Codex/CodeRabbit PR#1850 regressions on the load path:
+
+    1. A pre-#1830 GSV user has gptsovitsEnabled=true with the TTS dropdown left at its
+       default 'follow_assist' (the old save path submitted every provider dropdown).
+       follow_* is a 'follow assist/core' sentinel — NOT an explicit provider — so the
+       frontend must fall back to the legacy flag and load GSV as enabled, matching the
+       backend snapshot (otherwise the frontend mirror loads it off and diverges).
+    2. The legacy `__gptsovits_disabled__|` sentinel must NOT force 'disabled' when the
+       dropdown explicitly selects gptsovits — the explicit provider wins, and the
+       URL/voice are recovered from the sentinel for migration.
+    """
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_selector("#ttsModelProvider option[value='gptsovits']", state="attached", timeout=10000)
+
+    result = mock_page.evaluate("""
+        () => {
+            // 1) 存量：gptsovitsEnabled=true + 默认 follow_assist 哨兵 + 远程 URL → 回落旧 flag 启用
+            document.getElementById('gptsovitsApiUrl').value = '';
+            loadGptSovitsConfig('http://192.168.1.50:9881', 'gsv:legacy_voice', '', '', true, 'follow_assist');
+            const legacyFollow = {
+                state: _loadedGptSovitsState,
+                url: document.getElementById('gptsovitsApiUrl').value,
+            };
+            // 2) disabled sentinel（在 ttsVoiceId 位）+ 显式 provider=gptsovits → 显式胜出，
+            //    从 sentinel 解 URL/voice
+            document.getElementById('gptsovitsApiUrl').value = '';
+            loadGptSovitsConfig('', '__gptsovits_disabled__|http://10.0.0.9:9881|gsv:kept', '', '', null, 'gptsovits');
+            const sentinelButSelected = {
+                state: _loadedGptSovitsState,
+                url: document.getElementById('gptsovitsApiUrl').value,
+            };
+            return { legacyFollow, sentinelButSelected };
+        }
+    """)
+
+    assert result["legacyFollow"]["state"] == "enabled"
+    assert result["legacyFollow"]["url"] == "http://192.168.1.50:9881"
+    assert result["sentinelButSelected"]["state"] == "enabled"
+    assert result["sentinelButSelected"]["url"] == "http://10.0.0.9:9881"
+
+
+@pytest.mark.frontend
 def test_switching_tts_provider_to_vllm_resets_stale_model(mock_page: Page, running_server: str):
     """Switching from another TTS provider to vLLM should not keep stale model IDs."""
     mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -111,7 +111,9 @@ def test_tts_voice_id_not_rewritten_when_gptsovits_disabled(mock_page: Page, run
     """)
 
     assert payload["enableCustomApi"] is True
-    assert payload["gptsovitsEnabled"] is False
+    # gptsovitsEnabled 已退役，保存不再外发；启用状态由 ttsModelProvider 表达（这里 custom，未选 GSV）。
+    assert "gptsovitsEnabled" not in payload
+    assert payload["ttsModelProvider"] == "custom"
     assert payload["ttsModelUrl"] == "https://example.com/v1/audio/speech"
     assert payload["ttsModelId"] == "tts-1"
     assert payload["ttsVoiceId"] == "alloy"
@@ -599,9 +601,10 @@ def test_gptsovits_dropdown_shows_gsv_fields_and_saves_enabled(mock_page: Page, 
     - the registry-only provider 'gptsovits' shows up in the TTS dropdown (Codex #3);
     - selecting it shows the GSV-specific fields (URL + voice grid) and hides the
       standard url/model/key/voice fields;
-    - on save ttsModelProvider/ttsProvider=='gptsovits', gptsovitsEnabled is true
-      (dual migration signal), ttsModelUrl is the GSV URL, ttsVoiceId is the GSV
-      voice, and no __gptsovits_disabled__| placeholder is written.
+    - on save ttsModelProvider/ttsProvider=='gptsovits' and gptsovitsEnabled is no
+      longer emitted (retired single source of truth — backend derives
+      GPTSOVITS_ENABLED from ttsModelProvider), ttsModelUrl is the GSV URL,
+      ttsVoiceId is the GSV voice, and no __gptsovits_disabled__| placeholder is written.
     """
     mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
     mock_page.goto(f"{running_server}/api_key")
@@ -654,10 +657,53 @@ def test_gptsovits_dropdown_shows_gsv_fields_and_saves_enabled(mock_page: Page, 
 
     assert payload["ttsModelProvider"] == "gptsovits"
     assert payload["ttsProvider"] == "gptsovits"
-    assert payload["gptsovitsEnabled"] is True
+    # gptsovitsEnabled 已退役，保存不再外发；启用收口到 ttsModelProvider=='gptsovits' 单一真相，
+    # 后端 snapshot 据此派生 GPTSOVITS_ENABLED（见 utils/config_manager.py）。
+    assert "gptsovitsEnabled" not in payload
     assert payload["ttsModelUrl"] == "http://127.0.0.1:9881"
     assert payload["ttsVoiceId"] == "my_voice"
     assert not payload["ttsVoiceId"].startswith("__gptsovits_disabled__|")
+
+
+@pytest.mark.frontend
+def test_load_gptsovits_enabled_by_dropdown_with_remote_url(mock_page: Page, running_server: str):
+    """Reload path after gptsovitsEnabled was retired: a dropdown-only user with a
+    REMOTE GSV URL (which the localhost legacy heuristic does not recognize) and no
+    stored gptsovitsEnabled (response returns null) must still load as enabled — the
+    GSV URL/voice fields are repopulated, mirroring the backend snapshot derivation.
+    The negative case (provider switched away while a stale URL lingers) must NOT
+    re-enable GSV.
+    """
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_selector("#ttsModelProvider option[value='gptsovits']", state="attached", timeout=10000)
+
+    result = mock_page.evaluate("""
+        () => {
+            const remoteUrl = 'http://192.168.1.50:9881';
+            // 下拉为准：provider=gptsovits + gptsovitsEnabled=null（未存）+ 远程 URL
+            document.getElementById('gptsovitsApiUrl').value = '';
+            loadGptSovitsConfig(remoteUrl, 'gsv:remote_voice', '', '', null, 'gptsovits');
+            const enabled = {
+                state: _loadedGptSovitsState,
+                url: document.getElementById('gptsovitsApiUrl').value,
+            };
+            // 切走下拉：provider=vllm_omni + 残留 gptsovitsEnabled=true 不得把 GSV 兜回来
+            document.getElementById('gptsovitsApiUrl').value = '';
+            loadGptSovitsConfig(remoteUrl, 'gsv:remote_voice', '', '', true, 'vllm_omni');
+            const switchedAway = {
+                state: _loadedGptSovitsState,
+                url: document.getElementById('gptsovitsApiUrl').value,
+            };
+            return { enabled, switchedAway };
+        }
+    """)
+
+    assert result["enabled"]["state"] == "enabled"
+    assert result["enabled"]["url"] == "http://192.168.1.50:9881"
+    assert result["switchedAway"]["state"] == "none"
+    assert result["switchedAway"]["url"] == ""
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -728,18 +728,22 @@ def test_load_gptsovits_legacy_follow_default_and_sentinel(mock_page: Page, runn
         () => {
             // 1) 存量：gptsovitsEnabled=true + 默认 follow_assist 哨兵 + 远程 URL → 回落旧 flag 启用
             document.getElementById('gptsovitsApiUrl').value = '';
+            document.getElementById('gptsovitsVoiceId').value = '';
             loadGptSovitsConfig('http://192.168.1.50:9881', 'gsv:legacy_voice', '', '', true, 'follow_assist');
             const legacyFollow = {
                 state: _loadedGptSovitsState,
                 url: document.getElementById('gptsovitsApiUrl').value,
+                voice: document.getElementById('gptsovitsVoiceId').value,
             };
             // 2) disabled sentinel（在 ttsVoiceId 位）+ 显式 provider=gptsovits → 显式胜出，
             //    从 sentinel 解 URL/voice
             document.getElementById('gptsovitsApiUrl').value = '';
+            document.getElementById('gptsovitsVoiceId').value = '';
             loadGptSovitsConfig('', '__gptsovits_disabled__|http://10.0.0.9:9881|gsv:kept', '', '', null, 'gptsovits');
             const sentinelButSelected = {
                 state: _loadedGptSovitsState,
                 url: document.getElementById('gptsovitsApiUrl').value,
+                voice: document.getElementById('gptsovitsVoiceId').value,
             };
             return { legacyFollow, sentinelButSelected };
         }
@@ -747,8 +751,10 @@ def test_load_gptsovits_legacy_follow_default_and_sentinel(mock_page: Page, runn
 
     assert result["legacyFollow"]["state"] == "enabled"
     assert result["legacyFollow"]["url"] == "http://192.168.1.50:9881"
+    assert result["legacyFollow"]["voice"] == "gsv:legacy_voice"
     assert result["sentinelButSelected"]["state"] == "enabled"
     assert result["sentinelButSelected"]["url"] == "http://10.0.0.9:9881"
+    assert result["sentinelButSelected"]["voice"] == "gsv:kept"
 
 
 @pytest.mark.frontend

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -1417,13 +1417,13 @@ class TestGptsovitsEnabledDerivation:
         assert cfg['GPTSOVITS_ENABLED'] is False
 
     @pytest.mark.unit
-    def test_provider_authoritative_over_stale_legacy_flag(self, config_manager):
-        """Dropdown wins over a stale legacy flag. After a user switches the
-        dropdown away from gptsovits, the file may still carry gptsovitsEnabled=true
-        (the frontend retired that field and the backend merges partially). A
-        non-empty ttsModelProvider is the single source of truth and must derive
-        False here — a naive OR would let the stale true stick and leave GSV stuck on."""
-        # 这就是不用纯 OR 的原因：旧 flag 在增量合并下会粘住，下拉切走也切不掉。
+    def test_explicit_provider_authoritative_over_stale_legacy_flag(self, config_manager):
+        """An explicit (non-follow) provider wins over a stale legacy flag. After a
+        user switches the dropdown to e.g. vllm_omni, the file may still carry
+        gptsovitsEnabled=true (the frontend retired that field and the backend merges
+        partially). An explicit provider is the single source of truth and must derive
+        False — a naive OR would let the stale true stick and leave GSV stuck on."""
+        # 这就是不用纯 OR 的原因：旧 flag 在增量合并下会粘住，显式选别家也切不掉。
         _write_core_config(config_manager, {
             'coreApi': 'qwen',
             'assistApi': 'qwen',
@@ -1432,6 +1432,24 @@ class TestGptsovitsEnabledDerivation:
         })
         cfg = config_manager.get_core_config()
         assert cfg['GPTSOVITS_ENABLED'] is False
+
+    @pytest.mark.unit
+    def test_follow_default_provider_falls_back_to_legacy_flag(self, config_manager):
+        """⚠️ Codex PR#1850 P1 regression: a pre-#1830 user who enabled GSV via the
+        old checkbox has gptsovitsEnabled=true AND the TTS dropdown left at its default
+        'follow_assist'/'follow_core' (the older save path submitted every provider
+        dropdown). follow_* is a 'follow assist/core' sentinel — NOT an explicit
+        provider — so it must fall back to the legacy flag and keep GSV enabled, not
+        be misread as 'switched to another provider' and disabled."""
+        for follow in ('follow_assist', 'follow_core'):
+            _write_core_config(config_manager, {
+                'coreApi': 'qwen',
+                'assistApi': 'qwen',
+                'gptsovitsEnabled': True,
+                'ttsModelProvider': follow,
+            })
+            cfg = config_manager.get_core_config()
+            assert cfg['GPTSOVITS_ENABLED'] is True, f"{follow} 应回落旧 flag 保住存量 GSV"
 
     @pytest.mark.unit
     def test_empty_provider_falls_back_to_legacy_flag(self, config_manager):
@@ -1462,6 +1480,82 @@ class TestGptsovitsEnabledDerivation:
         assert cfg['GPTSOVITS_ENABLED'] is True
         tts_cfg = config_manager.get_model_api_config('tts_custom')
         assert tts_cfg['is_custom'] is True
+
+
+# ---------------------------------------------------------------------------
+# save choke point 惰性迁移：gptsovitsEnabled 退役后，用户经下拉显式切到非 gptsovits
+# provider（含 follow_*）保存时，把残留旧 flag 落 False——否则 get_core_config 的
+# follow_* 回落分支会把旧 true 兜回来，导致切到 follow_assist 也关不掉 GSV。对偶 #1842
+# voice_id 的 access-choke-point 惰性迁移思路。
+# ---------------------------------------------------------------------------
+class TestGptsovitsEnabledSaveMigration:
+
+    @staticmethod
+    def _neutralize_side_effects(monkeypatch):
+        """Stub out the heavy post-save side effects of update_core_config so the
+        test exercises only the persisted-config logic."""
+        import asyncio
+        from main_routers import config_router
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(config_router, 'get_session_manager', lambda: {})
+        monkeypatch.setattr(config_router, 'get_initialize_character_data', lambda: _noop)
+        monkeypatch.setattr(config_router, 'ensure_default_yui_voice_for_free_api', _noop)
+        monkeypatch.setattr(config_router, '_auto_resolve_provider_urls_for_save', _noop)
+        return config_router, asyncio
+
+    class _FakeRequest:
+        def __init__(self, payload):
+            self._payload = payload
+
+        async def json(self):
+            return self._payload
+
+    @pytest.mark.unit
+    def test_save_non_gptsovits_provider_clears_stale_flag(self, config_manager, monkeypatch):
+        """存量 gptsovitsEnabled=true，用户经下拉显式切到 follow_assist 保存 → 旧 flag 落
+        False，派生 GPTSOVITS_ENABLED=False（GSV 真正关掉）。"""
+        config_router, asyncio = self._neutralize_side_effects(monkeypatch)
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen', 'assistApi': 'qwen', 'enableCustomApi': True,
+            'gptsovitsEnabled': True, 'ttsModelProvider': 'gptsovits',
+            'ttsModelUrl': 'http://127.0.0.1:9881', 'ttsVoiceId': 'gsv:v',
+        })
+
+        resp = asyncio.run(config_router.update_core_config(self._FakeRequest({
+            'enableCustomApi': True, 'coreApi': 'qwen', 'assistApi': 'qwen',
+            'ttsModelProvider': 'follow_assist',
+        })))
+        assert resp.get('success') is True
+
+        saved = config_manager.load_json_config('core_config.json', {})
+        assert saved.get('gptsovitsEnabled') is False
+        config_manager._core_config_cache = None
+        assert config_manager.get_core_config()['GPTSOVITS_ENABLED'] is False
+
+    @pytest.mark.unit
+    def test_save_gptsovits_provider_keeps_flag_enabled(self, config_manager, monkeypatch):
+        """保持/切到 gptsovits 保存时不清旧 flag，GSV 仍启用。"""
+        config_router, asyncio = self._neutralize_side_effects(monkeypatch)
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen', 'assistApi': 'qwen', 'enableCustomApi': True,
+            'gptsovitsEnabled': True, 'ttsModelProvider': 'gptsovits',
+            'ttsModelUrl': 'http://127.0.0.1:9881', 'ttsVoiceId': 'gsv:v',
+        })
+
+        resp = asyncio.run(config_router.update_core_config(self._FakeRequest({
+            'enableCustomApi': True, 'coreApi': 'qwen', 'assistApi': 'qwen',
+            'ttsModelProvider': 'gptsovits',
+            'ttsModelUrl': 'http://127.0.0.1:9881', 'ttsVoiceId': 'gsv:v',
+        })))
+        assert resp.get('success') is True
+
+        saved = config_manager.load_json_config('core_config.json', {})
+        assert saved.get('gptsovitsEnabled') is not False
+        config_manager._core_config_cache = None
+        assert config_manager.get_core_config()['GPTSOVITS_ENABLED'] is True
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -1555,7 +1555,8 @@ class TestGptsovitsEnabledSaveMigration:
         assert resp.get('success') is True
 
         saved = config_manager.load_json_config('core_config.json', {})
-        assert saved.get('gptsovitsEnabled') is not False
+        # 切到/保持 gptsovits 不触发惰性清理，存量 true 原样保留。
+        assert saved.get('gptsovitsEnabled') is True
         config_manager._core_config_cache = None
         assert config_manager.get_core_config()['GPTSOVITS_ENABLED'] is True
 

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -1515,8 +1515,9 @@ class TestGptsovitsEnabledSaveMigration:
 
     @pytest.mark.unit
     def test_save_non_gptsovits_provider_clears_stale_flag(self, config_manager, monkeypatch):
-        """存量 gptsovitsEnabled=true，用户经下拉显式切到 follow_assist 保存 → 旧 flag 落
-        False，派生 GPTSOVITS_ENABLED=False（GSV 真正关掉）。"""
+        """Stored gptsovitsEnabled=true; the user explicitly switches the dropdown to
+        follow_assist and saves -> the stale flag is set to False, and the derived
+        GPTSOVITS_ENABLED becomes False (GSV is actually turned off)."""
         config_router, asyncio = self._neutralize_side_effects(monkeypatch)
         _write_core_config(config_manager, {
             'coreApi': 'qwen', 'assistApi': 'qwen', 'enableCustomApi': True,
@@ -1537,7 +1538,8 @@ class TestGptsovitsEnabledSaveMigration:
 
     @pytest.mark.unit
     def test_save_gptsovits_provider_keeps_flag_enabled(self, config_manager, monkeypatch):
-        """保持/切到 gptsovits 保存时不清旧 flag，GSV 仍启用。"""
+        """Saving while the dropdown stays on/returns to gptsovits does not clear the
+        legacy flag; GSV remains enabled."""
         config_router, asyncio = self._neutralize_side_effects(monkeypatch)
         _write_core_config(config_manager, {
             'coreApi': 'qwen', 'assistApi': 'qwen', 'enableCustomApi': True,

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -1363,5 +1363,106 @@ class TestVllmOmniRawKeyPassthrough:
         assert config_manager.get_tts_api_key('cosyvoice') is None
 
 
+# ---------------------------------------------------------------------------
+# GPT-SoVITS「是否启用」收口到 ttsModelProvider 下拉单一真相：snapshot 在
+# get_core_config() 这一处把下拉（与 pre-#1830 存量旧 gptsovitsEnabled 开关）派生进
+# GPTSOVITS_ENABLED，13 个下游读点全部不动。派生语义：ttsModelProvider 非空即唯一
+# 真相，仅缺失/空串时才回落旧开关——不用纯 OR，避免存量切走下拉后旧 true 粘住。
+# ---------------------------------------------------------------------------
+class TestGptsovitsEnabledDerivation:
+
+    @pytest.mark.unit
+    def test_dropdown_provider_only_enables(self, config_manager):
+        """Dropdown only: ttsModelProvider=gptsovits (no legacy flag) -> GPTSOVITS_ENABLED=True."""
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'ttsModelProvider': 'gptsovits',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['GPTSOVITS_ENABLED'] is True
+
+    @pytest.mark.unit
+    def test_legacy_flag_only_enables(self, config_manager):
+        """Legacy flag only: a pre-#1830 stored config (gptsovitsEnabled=true, no
+        ttsModelProvider) still derives GPTSOVITS_ENABLED=True, so existing GSV
+        users are not silently dropped."""
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'gptsovitsEnabled': True,
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['GPTSOVITS_ENABLED'] is True
+
+    @pytest.mark.unit
+    def test_neither_signal_disabled(self, config_manager):
+        """Neither signal: no dropdown and no legacy flag -> GPTSOVITS_ENABLED=False."""
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['GPTSOVITS_ENABLED'] is False
+
+    @pytest.mark.unit
+    def test_dropdown_other_provider_disabled(self, config_manager):
+        """Dropdown picked another provider: ttsModelProvider=vllm_omni -> GPTSOVITS_ENABLED=False."""
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'ttsModelProvider': 'vllm_omni',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['GPTSOVITS_ENABLED'] is False
+
+    @pytest.mark.unit
+    def test_provider_authoritative_over_stale_legacy_flag(self, config_manager):
+        """Dropdown wins over a stale legacy flag. After a user switches the
+        dropdown away from gptsovits, the file may still carry gptsovitsEnabled=true
+        (the frontend retired that field and the backend merges partially). A
+        non-empty ttsModelProvider is the single source of truth and must derive
+        False here — a naive OR would let the stale true stick and leave GSV stuck on."""
+        # 这就是不用纯 OR 的原因：旧 flag 在增量合并下会粘住，下拉切走也切不掉。
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'gptsovitsEnabled': True,
+            'ttsModelProvider': 'vllm_omni',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['GPTSOVITS_ENABLED'] is False
+
+    @pytest.mark.unit
+    def test_empty_provider_falls_back_to_legacy_flag(self, config_manager):
+        """An empty ttsModelProvider (treated as unselected) falls back to the
+        legacy flag, preserving existing configs."""
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'gptsovitsEnabled': True,
+            'ttsModelProvider': '',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['GPTSOVITS_ENABLED'] is True
+
+    @pytest.mark.unit
+    def test_enabled_snapshot_self_heals_is_custom(self, config_manager):
+        """End-to-end: dropdown=gptsovits + a GSV URL -> snapshot GPTSOVITS_ENABLED=True,
+        and get_model_api_config('tts_custom') self-heals is_custom=True (no separate
+        enableCustomApi needed), which is what dispatch's _gptsovits_is_selected requires."""
+        _write_core_config(config_manager, {
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'ttsModelProvider': 'gptsovits',
+            'ttsModelUrl': 'http://127.0.0.1:9881',
+            'ttsVoiceId': 'gsv:my_voice',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg['GPTSOVITS_ENABLED'] is True
+        tts_cfg = config_manager.get_model_api_config('tts_custom')
+        assert tts_cfg['is_custom'] is True
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/unit/test_gptsovits_dropdown_routing.py
+++ b/tests/unit/test_gptsovits_dropdown_routing.py
@@ -1,25 +1,32 @@
-"""Dispatch-selection regression tests for GPT-SoVITS moved to the ttsModelProvider dropdown.
+"""Dispatch-selection regression tests for GPT-SoVITS after the enabled signal
+collapsed onto a single source of truth.
 
-During migration ``_gptsovits_is_selected`` honors two signals: the new
-``ttsModelProvider == 'gptsovits'`` (same mechanism as vLLM-Omni) and the legacy
-``GPTSOVITS_ENABLED`` switch path.
+The enabled signal is now ttsModelProvider=='gptsovits'. The config_manager
+snapshot derives GPTSOVITS_ENABLED from the dropdown (plus the pre-#1830 legacy
+gptsovitsEnabled switch as a backfill), and dispatch's ``_gptsovits_is_selected``
+reads only GPTSOVITS_ENABLED plus the tts_custom slot's is_custom — it no longer
+raw-loads core_config.json to read ttsModelProvider itself.
+
+The snapshot derivation itself (legacy-flag-only / dropdown-only / neither /
+switch-away-does-not-stick) is covered by
+tests/unit/test_api_config_manager.py::TestGptsovitsEnabledDerivation; this file
+only checks the dispatch selection once GPTSOVITS_ENABLED is already derived.
 """
 
 from main_logic import tts_client
 
 
 class _FakeConfigManager:
-    def __init__(self, core_config, raw_json, *, is_custom=False):
+    def __init__(self, core_config, *, is_custom=False):
         self._core_config = core_config
-        self._raw_json = raw_json
         self._is_custom = is_custom
 
     def get_core_config(self):
         return self._core_config
 
     def load_json_config(self, name, default=None):
-        if name == "core_config.json":
-            return self._raw_json
+        # gptsovits 选中已不再 raw load core_config.json；保留此方法只为别的
+        # provider（vllm_omni 等）共用 ctx 时不抛属性错。
         return default if default is not None else {}
 
     def get_model_api_config(self, model_type):
@@ -40,11 +47,12 @@ def _base_core_config(**overrides):
     return cfg
 
 
-def test_dropdown_provider_selects_gptsovits(monkeypatch):
-    """ttsModelProvider=='gptsovits' (the new dropdown signal) selects GPT-SoVITS on its own, no legacy switch needed."""
+def test_enabled_snapshot_selects_gptsovits(monkeypatch):
+    """With GPTSOVITS_ENABLED=True (derived from the dropdown or the legacy flag)
+    and tts_custom.is_custom, dispatch selects GPT-SoVITS."""
     cm = _FakeConfigManager(
-        core_config=_base_core_config(),
-        raw_json={"ttsModelProvider": "gptsovits"},
+        core_config=_base_core_config(GPTSOVITS_ENABLED=True),
+        is_custom=True,
     )
     monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
 
@@ -57,28 +65,47 @@ def test_dropdown_provider_selects_gptsovits(monkeypatch):
     assert provider_key == "gptsovits"
 
 
-def test_legacy_enabled_flag_still_selects_gptsovits(monkeypatch):
-    """The legacy GPTSOVITS_ENABLED switch + tts_custom.is_custom path is still honored during migration."""
+def test_enabled_but_not_custom_does_not_select_gptsovits(monkeypatch):
+    """GPTSOVITS_ENABLED=True but the tts_custom slot is unconfigured
+    (is_custom=False, e.g. dropdown picked gptsovits but no URL was filled): do
+    not select — fall through gracefully instead of grabbing a worker that would
+    immediately report an invalid URL."""
     cm = _FakeConfigManager(
         core_config=_base_core_config(GPTSOVITS_ENABLED=True),
-        raw_json={},  # 无 ttsModelProvider，走 legacy 分支
+        is_custom=False,
+    )
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
+
+    _, _, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen", has_custom_voice=False, voice_id="",
+    )
+
+    assert provider_key != "gptsovits"
+
+
+def test_disabled_snapshot_does_not_select_gptsovits(monkeypatch):
+    """With GPTSOVITS_ENABLED=False (dropdown picked another provider, or neither
+    dropdown nor legacy flag is set), GPT-SoVITS must not be selected even when
+    tts_custom.is_custom=True."""
+    cm = _FakeConfigManager(
+        core_config=_base_core_config(GPTSOVITS_ENABLED=False),
         is_custom=True,
     )
     monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
 
-    worker, api_key_override, provider_key = tts_client.get_tts_worker(
+    _, _, provider_key = tts_client.get_tts_worker(
         core_api_type="qwen", has_custom_voice=False, voice_id="",
     )
 
-    assert worker is tts_client.gptsovits_tts_worker
-    assert provider_key == "gptsovits"
+    assert provider_key != "gptsovits"
 
 
-def test_no_signal_does_not_select_gptsovits(monkeypatch):
-    """With neither the dropdown signal nor the legacy switch, GPT-SoVITS must not be wrongly selected."""
+def test_string_falsey_enabled_not_misread_as_truthy(monkeypatch):
+    """A raw, un-normalized string "false" must not be treated as truthy
+    (defensive _as_bool alignment)."""
     cm = _FakeConfigManager(
-        core_config=_base_core_config(),
-        raw_json={"ttsModelProvider": ""},
+        core_config=_base_core_config(GPTSOVITS_ENABLED="false"),
+        is_custom=True,
     )
     monkeypatch.setattr(tts_client, "get_config_manager", lambda: cm)
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3943,8 +3943,21 @@ class ConfigManager:
         enable_custom_api = core_cfg.get('enableCustomApi', False)
         config['ENABLE_CUSTOM_API'] = enable_custom_api
 
-        # GPT-SoVITS 配置映射
-        config['GPTSOVITS_ENABLED'] = _as_bool(core_cfg.get('gptsovitsEnabled', False))
+        # GPT-SoVITS「是否启用」收口到 ttsModelProvider 下拉这单一真相（见
+        # docs/design/tts-voice-source-unification.md §3/§4）。choke-point 在此派生，
+        # 13 个下游读点（core.py 路由 / 本文件 URL 解析与 TTS_VOICE_ID override /
+        # get_model_api_config 的 is_custom 自愈 / 各 router）以及 worker 的
+        # _gptsovits_is_selected 全部沿用 GPTSOVITS_ENABLED 不变。
+        # 派生语义：ttsModelProvider 一旦写出（非空）即唯一真相——选中 gptsovits 才启用，
+        # 选别家就关；旧 gptsovitsEnabled 开关仅作 pre-#1830 存量（只有旧 flag、无
+        # ttsModelProvider）的兜底。刻意不用 `旧flag OR 下拉` 的纯 OR：前端已退役
+        # gptsovitsEnabled 写路径（保存不再写），而旧 flag 在增量合并下会粘住；若纯 OR，
+        # 存量用户把下拉切走后旧 true 仍会兜出 GSV，切不掉。
+        _tts_model_provider = str(core_cfg.get('ttsModelProvider', '') or '').strip()
+        if _tts_model_provider:
+            config['GPTSOVITS_ENABLED'] = (_tts_model_provider == 'gptsovits')
+        else:
+            config['GPTSOVITS_ENABLED'] = _as_bool(core_cfg.get('gptsovitsEnabled', False))
 
         config['ELEVENLABS_API_KEY'] = core_cfg.get('assistApiKeyElevenlabs', '')
         config['TTS_PROVIDER'] = core_cfg.get('ttsProvider', '')

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3948,16 +3948,21 @@ class ConfigManager:
         # 13 个下游读点（core.py 路由 / 本文件 URL 解析与 TTS_VOICE_ID override /
         # get_model_api_config 的 is_custom 自愈 / 各 router）以及 worker 的
         # _gptsovits_is_selected 全部沿用 GPTSOVITS_ENABLED 不变。
-        # 派生语义：ttsModelProvider 一旦写出（非空）即唯一真相——选中 gptsovits 才启用，
-        # 选别家就关；旧 gptsovitsEnabled 开关仅作 pre-#1830 存量（只有旧 flag、无
-        # ttsModelProvider）的兜底。刻意不用 `旧flag OR 下拉` 的纯 OR：前端已退役
-        # gptsovitsEnabled 写路径（保存不再写），而旧 flag 在增量合并下会粘住；若纯 OR，
-        # 存量用户把下拉切走后旧 true 仍会兜出 GSV，切不掉。
+        # 派生语义：ttsModelProvider 一旦「显式选了某个 TTS provider」即唯一真相——选中
+        # gptsovits 才启用、选别家（vllm_omni/mimo/custom…）就关，旧 gptsovitsEnabled 不参与。
+        # 仅当未显式选择时（provider 缺失/空串，或 follow_assist/follow_core 这两个「跟随
+        # assist/core」哨兵——它们是各 model provider 下拉的默认值，等同未选）才回落旧开关，
+        # 兜住 pre-#1830 存量（用 checkbox 开 GSV、下拉仍停在默认 follow_* 的用户）。
+        # ⚠️ 不能把 follow_* 当显式 provider，否则存量 GSV 用户（gptsovitsEnabled=true +
+        # ttsModelProvider='follow_assist'）会被误判为关 → 升级后 GSV 失效（Codex PR#1850 P1）。
+        # 刻意不用 `旧flag OR 下拉` 的纯 OR：前端已退役 gptsovitsEnabled 写路径，旧 flag 在
+        # 增量合并下会粘住；显式切走由「下拉为准」关掉，follow_* 切走由 config_router 的
+        # save choke point 惰性落 False 清掉（见该处注释）。
         _tts_model_provider = str(core_cfg.get('ttsModelProvider', '') or '').strip()
-        if _tts_model_provider:
-            config['GPTSOVITS_ENABLED'] = (_tts_model_provider == 'gptsovits')
-        else:
+        if _tts_model_provider in ('', 'follow_assist', 'follow_core'):
             config['GPTSOVITS_ENABLED'] = _as_bool(core_cfg.get('gptsovitsEnabled', False))
+        else:
+            config['GPTSOVITS_ENABLED'] = (_tts_model_provider == 'gptsovits')
 
         config['ELEVENLABS_API_KEY'] = core_cfg.get('assistApiKeyElevenlabs', '')
         config['TTS_PROVIDER'] = core_cfg.get('ttsProvider', '')


### PR DESCRIPTION
## 改了什么

把 GPT-SoVITS 的「是否启用」从 `GPTSOVITS_ENABLED` 旧开关收口到 `ttsModelProvider=='gptsovits'` 单一真相，退役 `gptsovitsEnabled`。延续 TTS 重构蓝图 `docs/design/tts-voice-source-unification.md` §3/§4（#1818 / #1824 / #1830 / #1842 之后）。

choke-point 在 `config_manager.get_core_config` 的 snapshot 派生 `GPTSOVITS_ENABLED`，13 个下游读点 + worker `_gptsovits_is_selected` 全部沿用该值不变。

- **`utils/config_manager.py`**：派生语义「显式选了某个 TTS provider 即唯一真相（gptsovits 才启用、别家就关）；未显式选（provider 缺失/空串，或 `follow_assist`/`follow_core` 这两个跟随哨兵）才回落旧 `gptsovitsEnabled`」。
- **`main_logic/tts_client/workers/gptsovits.py`**：`_gptsovits_is_selected` 删自己 raw load 读 ttsModelProvider 那段，回到只读派生后的 `GPTSOVITS_ENABLED` + `tts_custom.is_custom`（pre-#1830 原版）。
- **`static/js/api_key_settings.js`**：save 不再外发 `gptsovitsEnabled`；load 启用判定与后端派生对偶（显式 provider 为准、follow_*/空 回落 legacy、显式 provider 压过 disabled sentinel）。
- **`main_routers/config_router.py`**：save choke point 惰性迁移——用户显式切到非 gptsovits provider（含 follow_*）时把残留旧 flag 落 False（对偶 #1842 voice_id 惰性迁移）。

## 回归报告 / Regression Report

### 为什么这么改（及为什么不用纯 OR）

方案初稿 `旧flag OR 下拉=='gptsovits'` 与「前端停写 gptsovitsEnabled」凑一起会反向坏：后端 save 增量合并（`core_cfg=dict(existing)`），残留 `gptsovitsEnabled=true` 会粘住，纯 OR 让切走下拉的用户切不掉 GSV。改成「下拉为准、无显式选择才回落旧 flag」（维护者拍板）。

### ⚠️ follow_* 哨兵（Codex P1 修正）

TTS provider 下拉 #1830 前就存在、默认值 `follow_assist`（`MODEL_TYPES` 早含 `'tts'`、模板早有 `#ttsModelProvider`）。pre-#1830 用 checkbox 开 GSV 的用户配置 = `{gptsovitsEnabled:true, ttsModelProvider:'follow_assist'}`。所以 `follow_assist`/`follow_core` 必须当「未显式选」回落旧 flag，否则被误判为「选了别家」→存量 GSV 升级后失效。后端 snapshot + 前端 load 同步按此处理。

### 改动前后行为

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 仅旧 flag（pre-#1830，无 ttsModelProvider） | 选中 GSV | 选中（回落旧 flag） |
| 旧 flag + 默认 `follow_assist`（典型存量 GSV 用户） | 选中 GSV | 选中（follow_* 回落旧 flag）✅ Codex P1 |
| 仅下拉 `gptsovits` | 选中（worker raw load） | 选中（snapshot 派生） |
| 旧 flag + 显式切到 `vllm_omni` | 旧逻辑→误选 GSV | 下拉为准→关闭 ✅ |
| 旧 flag + 切到 `follow_assist` 并保存 | （#1830 写 false）关闭 | save 惰性清旧 flag→关闭 ✅ |
| 远程 GSV、dropdown-only reload | 依赖 #1830 双写 flag | 下拉为准回填 ✅ |
| disabled sentinel + 显式 `gptsovits` | sentinel 压过→判 disabled | 显式 provider 胜出→enabled，URL/voice 从 sentinel 迁移 ✅ Greptile/CodeRabbit |

### 潜在回归与缓解

- **存量选不到 GSV / follow_* 误关**（最严重）：`test_follow_default_provider_falls_back_to_legacy_flag`（snapshot）+ `test_load_gptsovits_legacy_follow_default_and_sentinel`（前端）。
- **切走下拉旧 flag 粘住**：显式 provider→`test_explicit_provider_authoritative_over_stale_legacy_flag`；follow_* 切走→save 惰性清理 `test_save_non_gptsovits_provider_clears_stale_flag`。
- **远程 GSV reload 不回填**：`test_load_gptsovits_enabled_by_dropdown_with_remote_url`。
- **dropdown 无 URL 不误抢**：`is_custom` gate，`test_enabled_but_not_custom_does_not_select_gptsovits`。

## 后置清理（不在本 PR）

- `config_router` 的 `gptsovitsEnabled` 响应(~760) 过渡保留；惰性迁移会随用户重存逐步清掉旧 flag，全清后可删字段。
- locales 里 `gptsovitsEnabled`/`gptsovitsEnabledHint` 是 #1830 已删旧开关孤儿 key，清理需 i18n lockstep + 管理员批准。

## 验证

- `pytest`（主仓 venv，cwd=worktree）：config / tts routing / save migration / follow_urls 等 —— 全绿（含新增 snapshot 派生·follow 回落·save 迁移单测）。
- 前端 playwright `test_api_settings.py`：16 passed（`test_api_key_settings` 在 origin/main 基线即红，既有 flaky，非本 PR）。
- docstring 禁 CJK：`check_docstring_no_cjk.py --base origin/main` EXIT=0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改进
* 统一 GPT-SoVITS 启用判定：以 TTS 模型提供商下拉为单一真相，前端加载/回填逻辑同步调整。
* 核心启用状态改为基于快照派生（GPTSOVITS_ENABLED），并对布尔值做防御性处理。

## 修复
* 修正旧配置兼容与冲突消解：legacy 标记与新下拉冲突时按新选择器优先，避免误启用/误保留。
* 保存时不再携带 `gptsovitsEnabled`，并在切换到非 GPT-SoVITS 时清理残留。

## 测试
* 更新并补充前后端与路由相关用例，覆盖新判定与迁移场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->