### PR TITLE
feat(tts): ElevenLabs voice design + MiMo voiceclone enrollment（统一注册表 Part1+2）

### DIFF
--- a/main_logic/tts_client/__init__.py
+++ b/main_logic/tts_client/__init__.py
@@ -445,7 +445,10 @@ _tts_providers.register(_tts_providers.TTSProvider(
     key='elevenlabs',
     kind='hosted',
     priority=40,
-    capabilities=frozenset({'clone'}),
+    # clone（上传样本）+ design（文字描述生成）。design 经 create-from-preview 落成一个
+    # 普通的 ElevenLabs voice_id（voice_meta.source='design'），dispatch 与 clone 同路
+    # （_elevenlabs_clone_is_selected 按 provider=='elevenlabs' 选中），无需独立 worker。
+    capabilities=frozenset({'clone', 'design'}),
     is_selected=_elevenlabs_clone_is_selected,
     resolve=_elevenlabs_clone_resolve,
     tts_dropdown_only=False,
@@ -462,19 +465,22 @@ _tts_providers.register(_tts_providers.TTSProvider(
 ))
 
 # MiMo：priority 60（clone 之后、native 之前，沿用原 get_tts_worker 顺序）。
-# capabilities 声明 {preset}，预制目录由 preset_catalog 提供（MIMO_PRESET_CATALOG，
-# 数据复用 utils.mimo_tts_voices 的固定音色表）——这是 MiMo 预制音色的单一真相，UI
-# /voices 与 validate_voice_id 都查注册表，不再借道 native_voice_registry（MiMo 是
-# hosted SaaS，不是核心自带，见设计文档 §4）。MiMo 虽有 mimo-v2.5-tts-voiceclone 模型，
-# 但克隆 enrollment 尚未实现——「按实际能力注册」，不在 enrollment 落地前把 clone
-# advertise 进 ui_metadata（否则前端 source-first 选声器会渲染一个不能用的 clone tab）；
-# voiceclone enrollment 真实现时再追加 'clone'（见交接 chip）。
+# capabilities {preset, clone}：
+#   - preset：固定音色目录由 preset_catalog 提供（MIMO_PRESET_CATALOG，数据复用
+#     utils.mimo_tts_voices 的固定音色表）——MiMo 预制音色的单一真相，UI /voices 与
+#     validate_voice_id 都查注册表，不再借道 native_voice_registry（MiMo 是 hosted SaaS，
+#     不是核心自带，见设计文档 §4）。
+#   - clone：voiceclone enrollment（characters_router /voice_clone 的 mimo 分支，对偶
+#     cosyvoice/minimax）。MiMo 克隆没有远端 voice_id——参考音频本地保存、每次合成内联，
+#     dispatch 由 _mimo_resolve 按 voice_meta.provider=='mimo' 选中并读出样本（见 §4/§7）。
+# 同一 provider 条目承载两种选中机制（config-selected preset / voice_meta-selected clone），
+# 见 workers/mimo.py 的 _mimo_is_selected/_mimo_resolve。
 # tts_dropdown_only=False：MiMo 本身是 assist LLM provider，不能被前端从 LLM 下拉隐藏。
 _tts_providers.register(_tts_providers.TTSProvider(
     key='mimo',
     kind='hosted',
     priority=60,
-    capabilities=frozenset({'preset'}),
+    capabilities=frozenset({'preset', 'clone'}),
     is_selected=_mimo_is_selected,
     resolve=_mimo_resolve,
     preset_catalog=MIMO_PRESET_CATALOG,

--- a/main_logic/tts_client/workers/mimo.py
+++ b/main_logic/tts_client/workers/mimo.py
@@ -229,6 +229,14 @@ def _mimo_resolve(ctx):
             "MiMo TTS 已选中但 MiMo API Key 缺失，改用 dummy TTS worker 避免复用主 TTS Key")
         return dummy_tts_worker, None, None
 
+    # base_url 与 api key 必须**同源**地随当前配置解析（不能把克隆时的 base_url 冻进
+    # voice_meta）：get_tts_api_key('mimo') 在 assistApi=mimo+Token Plan 时返回 token-plan
+    # key，而 get_core_config 已把 OPENROUTER_URL 改写成对应的 token-plan 端点
+    # （config_manager:4043）。故 base_url 一律按「assistApi==mimo 时取 OPENROUTER_URL，
+    # 否则默认 xiaomimimo」解析，保证 key 与端点配套（preset/clone 共用此规则）。
+    assist_api_type = str(cc.get('assistApi') or '').strip().lower()
+    mimo_base_url = cc.get('OPENROUTER_URL') if assist_api_type == 'mimo' else None
+
     # 克隆音色优先：用户挑了某个具体的 MiMo 克隆音色（voice_meta.provider=='mimo'），即使
     # 同时把 MiMo 配成了默认 TTS 也应当尊重这个更具体的选择，走 voiceclone 内联参考音频。
     vm = ctx.voice_meta
@@ -238,7 +246,6 @@ def _mimo_resolve(ctx):
             logger.warning(
                 "MiMo 克隆音色 %s 缺少参考音频样本，改用 dummy TTS worker", ctx.voice_id)
             return dummy_tts_worker, None, None
-        mimo_base_url = (vm or {}).get('mimo_base_url') or None
         return (
             partial(mimo_tts_worker, base_url=mimo_base_url, clone_voice=clone_voice),
             mimo_api_key,
@@ -246,8 +253,6 @@ def _mimo_resolve(ctx):
         )
 
     # 配置选中：MiMo 作为默认 TTS，走预制音色目录。
-    assist_api_type = str(cc.get('assistApi') or '').strip().lower()
-    mimo_base_url = cc.get('OPENROUTER_URL') if assist_api_type == 'mimo' else None
     return partial(mimo_tts_worker, base_url=mimo_base_url), mimo_api_key, 'mimo'
 
 def _load_mimo_clone_data_uri(cm, voice_meta) -> str | None:

--- a/main_logic/tts_client/workers/mimo.py
+++ b/main_logic/tts_client/workers/mimo.py
@@ -229,49 +229,44 @@ def _mimo_resolve(ctx):
             "MiMo TTS 已选中但 MiMo API Key 缺失，改用 dummy TTS worker 避免复用主 TTS Key")
         return dummy_tts_worker, None, None
 
-    # base_url 与 api key 必须**同源**地随当前配置解析（不能把克隆时的 base_url 冻进
-    # voice_meta）：get_tts_api_key('mimo') 在 assistApi=mimo+Token Plan 时返回 token-plan
-    # key，而 get_core_config 已把 OPENROUTER_URL 改写成对应的 token-plan 端点
-    # （config_manager:4043）。故 base_url 一律按「assistApi==mimo 时取 OPENROUTER_URL，
-    # 否则默认 xiaomimimo」解析，保证 key 与端点配套（preset/clone 共用此规则）。
     assist_api_type = str(cc.get('assistApi') or '').strip().lower()
-    mimo_base_url = cc.get('OPENROUTER_URL') if assist_api_type == 'mimo' else None
+    # 配置端点：assistApi=mimo 时（Token Plan 的唯一场景）get_core_config 已把 OPENROUTER_URL
+    # 解析成对应端点（普通 / token-plan-*），且 get_tts_api_key('mimo') 返回配套 key——必须用
+    # 它，保证 key 与端点同源；否则用默认 xiaomimimo。
+    config_base_url = cc.get('OPENROUTER_URL') if assist_api_type == 'mimo' else None
 
     # 克隆音色优先：用户挑了某个具体的 MiMo 克隆音色（voice_meta.provider=='mimo'），即使
     # 同时把 MiMo 配成了默认 TTS 也应当尊重这个更具体的选择，走 voiceclone 内联参考音频。
     vm = ctx.voice_meta
     if _mimo_voice_meta_is_clone(vm):
-        clone_voice = _load_mimo_clone_data_uri(ctx.cm, vm)
+        clone_voice = _build_mimo_clone_data_uri(vm)
         if not clone_voice:
             logger.warning(
                 "MiMo 克隆音色 %s 缺少参考音频样本，改用 dummy TTS worker", ctx.voice_id)
             return dummy_tts_worker, None, None
+        # base_url：assistApi=mimo 用配置端点（token-plan 同源）；否则用 voice_meta 里存的
+        # mimo_base_url（对偶 minimax_base_url），缺省回落默认。
+        clone_base_url = config_base_url or (vm or {}).get('mimo_base_url') or None
         return (
-            partial(mimo_tts_worker, base_url=mimo_base_url, clone_voice=clone_voice),
+            partial(mimo_tts_worker, base_url=clone_base_url, clone_voice=clone_voice),
             mimo_api_key,
             'mimo',
         )
 
     # 配置选中：MiMo 作为默认 TTS，走预制音色目录。
-    return partial(mimo_tts_worker, base_url=mimo_base_url), mimo_api_key, 'mimo'
+    return partial(mimo_tts_worker, base_url=config_base_url), mimo_api_key, 'mimo'
 
-def _load_mimo_clone_data_uri(cm, voice_meta) -> str | None:
-    """Read a MiMo clone voice's stored reference sample → a ``data:`` URI for
-    inlining into the voiceclone request, or None when the sample is missing.
+def _build_mimo_clone_data_uri(voice_meta) -> str | None:
+    """Build the ``data:`` reference-audio URI for a MiMo clone from its
+    voice_meta (the clone identity lives entirely in voice_storage.json — the
+    sample base64 is stored inline, dual to MiniMax's remote voice_id), or None
+    when absent.
 
-    Bound into the (same-process) worker thread by ``_mimo_resolve``, so loading
-    the few-hundred-KB sample here once per worker start is cheap.
+    The stored value is already base64, so this only frames it as a data URI —
+    no decode/re-encode. Bound into the (same-process) worker thread.
     """
-    sample_file = str((voice_meta or {}).get('clone_sample_file') or '').strip()
-    if not sample_file:
+    b64 = str((voice_meta or {}).get('clone_sample_b64') or '').strip()
+    if not b64:
         return None
-    try:
-        from utils.mimo_tts_voices import mimo_voice_clone_data_uri
-        audio_bytes = cm.load_voice_clone_sample(sample_file)
-        if not audio_bytes:
-            return None
-        mime_type = str((voice_meta or {}).get('clone_sample_mime') or 'audio/wav')
-        return mimo_voice_clone_data_uri(audio_bytes, mime_type)
-    except Exception:
-        logger.warning("加载 MiMo 克隆参考样本失败 (file=%s)", sample_file, exc_info=True)
-        return None
+    mime = str((voice_meta or {}).get('clone_sample_mime') or '').strip() or 'audio/wav'
+    return f"data:{mime};base64,{b64}"

--- a/main_logic/tts_client/workers/mimo.py
+++ b/main_logic/tts_client/workers/mimo.py
@@ -20,8 +20,12 @@ import json
 import base64
 
 from functools import partial
-from urllib.parse import urlparse, urlunparse
-from utils.mimo_tts_voices import MIMO_TTS_BASE_URL, MIMO_TTS_MODEL, normalize_mimo_tts_voice
+from utils.mimo_tts_voices import (
+    MIMO_TTS_MODEL,
+    MIMO_TTS_VOICECLONE_MODEL,
+    mimo_chat_completions_url,
+    normalize_mimo_tts_voice,
+)
 
 from .._infra import _resample_audio, _enqueue_error, _run_sentence_tts_worker
 from .._telemetry import _record_tts_telemetry
@@ -30,31 +34,10 @@ from utils.logger_config import get_module_logger
 
 logger = get_module_logger(__name__, "Main")
 
-def _get_mimo_chat_completions_url(base_url: str | None = None) -> str:
-    """Normalize a MiMo API base URL to the chat-completions endpoint."""
-    raw_url = (base_url or MIMO_TTS_BASE_URL).strip().rstrip("/")
-    if raw_url.startswith("ws://"):
-        raw_url = "http://" + raw_url[5:]
-    elif raw_url.startswith("wss://"):
-        raw_url = "https://" + raw_url[6:]
-    elif not raw_url.startswith(("http://", "https://")):
-        raw_url = "https://" + raw_url
-
-    parsed = urlparse(raw_url)
-    if not parsed.netloc:
-        raise ValueError(f"无效的 MiMo base_url: {base_url!r}")
-
-    path = parsed.path.rstrip("/")
-    if path.endswith("/chat/completions"):
-        endpoint_path = path
-    else:
-        if not path or path == "/":
-            endpoint_path = "/v1/chat/completions"
-        elif path.endswith("/v1"):
-            endpoint_path = f"{path}/chat/completions"
-        else:
-            endpoint_path = f"{path}/v1/chat/completions"
-    return urlunparse((parsed.scheme, parsed.netloc, endpoint_path, "", "", ""))
+# Backwards-compatible alias — the URL-derivation rule now lives in the utils
+# layer (utils.mimo_tts_voices.mimo_chat_completions_url) so the clone-enrollment
+# client can share it without importing main_logic.
+_get_mimo_chat_completions_url = mimo_chat_completions_url
 
 def _extract_mimo_tts_audio_bytes(payload: dict) -> bytes | None:
     """Extract base64 PCM16 audio from MiMo's chat-completions response."""
@@ -92,18 +75,33 @@ def _extract_mimo_tts_audio_bytes(payload: dict) -> bytes | None:
             return audio_bytes[:usable_len]
     return None
 
-def mimo_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base_url=None):
-    """Xiaomi MiMo-V2.5-TTS worker — chat-completions JSON returns PCM16."""
+def mimo_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base_url=None,
+                    clone_voice=None):
+    """Xiaomi MiMo-V2.5-TTS worker — chat-completions JSON returns PCM16.
+
+    ``clone_voice`` is the cloned-voice variant: when set it is a
+    ``data:audio/...;base64,...`` reference-audio URI (MiMo has no server-side
+    cloned voice id — the sample is inlined per request, see
+    ``utils.mimo_tts_voices.mimo_voice_clone_data_uri``). It is passed as
+    ``audio.voice`` against the ``mimo-v2.5-tts-voiceclone`` model; the catalog
+    ``voice_id`` is ignored in that mode.
+    """
     import httpx
 
-    requested_voice_id = (voice_id or "").strip()
-    voice_id, voice_recognized = normalize_mimo_tts_voice(voice_id)
-    if requested_voice_id and not voice_recognized:
-        logger.warning(
-            "MiMo TTS voice '%s' is not in the supported catalog; falling back to '%s'",
-            requested_voice_id,
-            voice_id,
-        )
+    is_clone = bool(clone_voice)
+    tts_model = MIMO_TTS_VOICECLONE_MODEL if is_clone else MIMO_TTS_MODEL
+    if is_clone:
+        voice_param = clone_voice
+    else:
+        requested_voice_id = (voice_id or "").strip()
+        voice_id, voice_recognized = normalize_mimo_tts_voice(voice_id)
+        if requested_voice_id and not voice_recognized:
+            logger.warning(
+                "MiMo TTS voice '%s' is not in the supported catalog; falling back to '%s'",
+                requested_voice_id,
+                voice_id,
+            )
+        voice_param = voice_id
 
     async def setup(response_queue):
         if not audio_api_key:
@@ -126,13 +124,13 @@ def mimo_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base
 
         async def synthesize(text: str, speech_id: str) -> None:
             payload = {
-                "model": MIMO_TTS_MODEL,
+                "model": tts_model,
                 "messages": [
                     {"role": "assistant", "content": text},
                 ],
                 "audio": {
                     "format": "pcm16",
-                    "voice": voice_id,
+                    "voice": voice_param,
                 },
                 "stream": True,
             }
@@ -157,7 +155,7 @@ def mimo_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base
                         )
                         return
 
-                    _record_tts_telemetry(MIMO_TTS_MODEL, len(text))
+                    _record_tts_telemetry(tts_model, len(text))
                     content_type = resp.headers.get("content-type", "").lower()
                     if "text/event-stream" not in content_type:
                         try:
@@ -202,21 +200,73 @@ def mimo_tts_worker(request_queue, response_queue, audio_api_key, voice_id, base
 
     _run_sentence_tts_worker(request_queue, response_queue, setup, label="MiMo TTS")
 
-# ── MiMo（hosted SaaS，assistApi=mimo / TTS_PROVIDER=mimo 选中）────────────────
+# ── MiMo（hosted SaaS）────────────────────────────────────────────────────────
+# 两种选中机制（设计文档 §3.1）合并在一个 provider 条目里：
+#   1. 配置选中（preset）——assistApi=mimo / TTS_PROVIDER=mimo 时把 MiMo 当默认 TTS，
+#      走预制音色目录。
+#   2. 音色元数据选中（clone）——用户挑了某个 MiMo 克隆音色（voice_meta.provider=='mimo'），
+#      对偶 cosyvoice/minimax/elevenlabs 的克隆路由。MiMo 克隆没有远端 voice_id：参考音频
+#      存在本地，dispatch 时读出来内联进 voiceclone 请求。
+
+def _mimo_voice_meta_is_clone(vm) -> bool:
+    return bool(vm and vm.get('provider') == 'mimo')
 
 def _mimo_is_selected(ctx) -> bool:
     cc = ctx.core_config
     tts_provider = str(cc.get('TTS_PROVIDER') or cc.get('ttsProvider') or '').strip().lower()
     assist_api_type = str(cc.get('assistApi') or '').strip().lower()
-    return tts_provider == 'mimo' or assist_api_type == 'mimo'
+    if tts_provider == 'mimo' or assist_api_type == 'mimo':
+        return True
+    # 克隆音色选中：按所选音色的 voice_meta.provider 路由（惰性，命中前面 config-selected
+    # provider 时不会触发 voice_meta 加载）。
+    return _mimo_voice_meta_is_clone(ctx.voice_meta)
 
 def _mimo_resolve(ctx):
     cc = ctx.core_config
-    assist_api_type = str(cc.get('assistApi') or '').strip().lower()
-    mimo_base_url = cc.get('OPENROUTER_URL') if assist_api_type == 'mimo' else None
     mimo_api_key = (ctx.cm.get_tts_api_key('mimo') or '').strip()
     if not mimo_api_key:
         logger.warning(
             "MiMo TTS 已选中但 MiMo API Key 缺失，改用 dummy TTS worker 避免复用主 TTS Key")
         return dummy_tts_worker, None, None
+
+    # 克隆音色优先：用户挑了某个具体的 MiMo 克隆音色（voice_meta.provider=='mimo'），即使
+    # 同时把 MiMo 配成了默认 TTS 也应当尊重这个更具体的选择，走 voiceclone 内联参考音频。
+    vm = ctx.voice_meta
+    if _mimo_voice_meta_is_clone(vm):
+        clone_voice = _load_mimo_clone_data_uri(ctx.cm, vm)
+        if not clone_voice:
+            logger.warning(
+                "MiMo 克隆音色 %s 缺少参考音频样本，改用 dummy TTS worker", ctx.voice_id)
+            return dummy_tts_worker, None, None
+        mimo_base_url = (vm or {}).get('mimo_base_url') or None
+        return (
+            partial(mimo_tts_worker, base_url=mimo_base_url, clone_voice=clone_voice),
+            mimo_api_key,
+            'mimo',
+        )
+
+    # 配置选中：MiMo 作为默认 TTS，走预制音色目录。
+    assist_api_type = str(cc.get('assistApi') or '').strip().lower()
+    mimo_base_url = cc.get('OPENROUTER_URL') if assist_api_type == 'mimo' else None
     return partial(mimo_tts_worker, base_url=mimo_base_url), mimo_api_key, 'mimo'
+
+def _load_mimo_clone_data_uri(cm, voice_meta) -> str | None:
+    """Read a MiMo clone voice's stored reference sample → a ``data:`` URI for
+    inlining into the voiceclone request, or None when the sample is missing.
+
+    Bound into the (same-process) worker thread by ``_mimo_resolve``, so loading
+    the few-hundred-KB sample here once per worker start is cheap.
+    """
+    sample_file = str((voice_meta or {}).get('clone_sample_file') or '').strip()
+    if not sample_file:
+        return None
+    try:
+        from utils.mimo_tts_voices import mimo_voice_clone_data_uri
+        audio_bytes = cm.load_voice_clone_sample(sample_file)
+        if not audio_bytes:
+            return None
+        mime_type = str((voice_meta or {}).get('clone_sample_mime') or 'audio/wav')
+        return mimo_voice_clone_data_uri(audio_bytes, mime_type)
+    except Exception:
+        logger.warning("加载 MiMo 克隆参考样本失败 (file=%s)", sample_file, exc_info=True)
+        return None

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1504,6 +1504,15 @@ async def _elevenlabs_clone_voice(
 # so no separate worker is needed (design doc §7).
 ELEVENLABS_VOICE_DESIGN_DESC_MIN = 20
 ELEVENLABS_VOICE_DESIGN_DESC_MAX = 1000
+# ElevenLabs voice-design previews require a ``text`` between 100 and 1000 chars to
+# synthesize audible samples. ``auto_generate_text`` only returns generated voice ids
+# (no audio), which would yield empty/unplayable previews — so we always pass a fixed
+# preview line instead (must stay ≥ 100 chars).
+ELEVENLABS_VOICE_DESIGN_PREVIEW_TEXT = (
+    "Hello! This is a preview of your designed voice. I can read your stories, chat "
+    "with you about your day, and keep you company whenever you would like a friendly "
+    "voice nearby. How do I sound to you so far?"
+)
 
 
 async def _elevenlabs_design_previews(
@@ -1523,7 +1532,8 @@ async def _elevenlabs_design_previews(
     headers = {"xi-api-key": api_key, "Content-Type": "application/json"}
     payload = {
         "voice_description": voice_description,
-        "auto_generate_text": True,
+        # 显式给 text（≥100 chars）而非 auto_generate_text，确保返回可试听的 audio_base_64。
+        "text": ELEVENLABS_VOICE_DESIGN_PREVIEW_TEXT,
     }
     async with httpx.AsyncClient(timeout=60, proxy=None, trust_env=False) as client:
         resp = await client.post(url, headers=headers, json=payload)
@@ -5339,8 +5349,11 @@ async def voice_clone(
             client = MimoVoiceCloneClient(api_key=api_key, base_url=base_url or None)
             sample_bytes = normalized_buffer.getvalue()
             await client.validate_sample(sample_bytes, mime_type='audio/wav')
-            voice_id = f'mimo-clone-{audio_md5[:12]}'
-            sample_filename = f'mimo-{api_key[-8:]}-{voice_id}.wav'
+            # voice_id 含 key 末 8 位，保证「同一参考音频在不同 MiMo key 下克隆」落到不同
+            # voice_id——否则跨 __MIMO__ 桶同名，delete_voice_for_current_api 按 id 扫所有桶
+            # 时可能误删另一个 key 的隐藏条目（Codex review #1851）。
+            voice_id = f'mimo-clone-{api_key[-8:]}-{audio_md5[:12]}'
+            sample_filename = f'{voice_id}.wav'
             sample_filename = await asyncio.to_thread(
                 _config_manager.save_voice_clone_sample, sample_filename, sample_bytes
             )

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -4461,6 +4461,16 @@ async def get_voice_preview(
                 'code': 'PRESET_VOICE_PREVIEW_UNSUPPORTED',
             }, status_code=400)
 
+        # MiMo 克隆音色（provider=='mimo'）的试听暂不支持：与上方 MiMo 预制音色试听同步留作
+        # 后续（见 #1848 注释「真试听留作后续」）。显式拦下，避免落到下方 CosyVoice/DashScope
+        # 通用分支拿着 mimo-clone-* 的 id 误合成（Codex review #1851）。
+        if provider == 'mimo':
+            return JSONResponse({
+                'success': False,
+                'error': f'MiMo 音色暂不支持试听: {voice_id}',
+                'code': 'MIMO_VOICE_PREVIEW_UNSUPPORTED',
+            }, status_code=400)
+
         native_preview_provider = _get_active_native_preview_provider(_config_manager, voice_id)
         if native_preview_provider:
             native_voice_id, _ = normalize_native_voice(native_preview_provider, voice_id)
@@ -5229,7 +5239,13 @@ async def voice_clone(
                 'code': 'MIMO_API_KEY_MISSING',
                 'message': '未配置 MiMo API Key，请先在设置中填写'
             }, status_code=400)
-        base_url = ''  # MiMo 克隆用默认 xiaomimimo 端点（mimo_chat_completions_url 兜底）
+        # base_url 须与 api_key 同源：assistApi=mimo（含 Token Plan）时 get_core_config 已把
+        # OPENROUTER_URL 解析成对应端点（普通 / token-plan-*），get_tts_api_key('mimo') 也据此
+        # 返回配套 key；否则用默认 xiaomimimo 端点。和 _mimo_resolve 的 base_url 规则对偶。
+        if str(core_config.get('assistApi') or '').strip().lower() == 'mimo':
+            base_url = (core_config.get('OPENROUTER_URL') or '').strip()
+        else:
+            base_url = ''
         storage_key = f'{MIMO_VOICE_STORAGE_KEY}{api_key[-8:]}'
         provider_label = 'MiMo'
 
@@ -5337,7 +5353,8 @@ async def voice_clone(
                 'source': 'clone',
                 'clone_sample_file': sample_filename,
                 'clone_sample_mime': 'audio/wav',
-                'mimo_base_url': base_url or '',
+                # 不冻结 base_url：dispatch（_mimo_resolve）按当前配置同源解析端点，
+                # 避免用户切换 Token Plan 后存储的端点与新 key 不匹配。
                 'created_at': datetime.now().isoformat()
             }
 

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -5479,8 +5479,19 @@ async def voice_clone(
         logger.info(f"{provider_label} voice_id 已保存到音色库: {voice_id}")
     except Exception as save_error:
         logger.error(f"保存 {provider_label} voice_id 到音色库失败: {save_error}")
-        # 克隆身份（含 MiMo 的样本 base64）都在 voice_data 里、随这次 save 一起落库，没有
-        # 任何旁路本地文件——save 失败不会留下孤儿，无需额外清理（对偶其它 provider）。
+        # MiMo 与其它家不同：它没有远端音色资源（克隆身份 = voice_meta 里的样本 base64，
+        # save 失败＝什么都没落库，voice_id 是本地生成、此刻指向空）。返回 200+local_save_failed
+        # 会给用户一个根本不存在的 voice_id。而且 MiMo 不存在"重试会重复创建远端资源"的代价
+        # （validate 不创建任何东西），重试是安全的——所以这里返回真失败，让客户端知道并可重试
+        # （Codex review #1851；与 PR #528「远端已创建→200 partial」规则的前提相反）。
+        if provider == 'mimo':
+            return JSONResponse({
+                'error': f'{provider_label}音色保存失败: {str(save_error)}',
+                'code': 'TTS_VOICE_SAVE_FAILED',
+                'provider': provider,
+            }, status_code=500)
+        # 其它 provider（cosyvoice/minimax/elevenlabs）远端音色已创建，本地保存失败仍返回
+        # 200+local_save_failed，避免客户端重试重复创建远端资源、浪费配额（PR #528 既定规则）。
         return JSONResponse({
             'voice_id': voice_id,
             'message': f'{provider_label}音色注册成功，但本地保存失败',

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -4471,15 +4471,61 @@ async def get_voice_preview(
                 'code': 'PRESET_VOICE_PREVIEW_UNSUPPORTED',
             }, status_code=400)
 
-        # MiMo 克隆音色（provider=='mimo'）的试听暂不支持：与上方 MiMo 预制音色试听同步留作
-        # 后续（见 #1848 注释「真试听留作后续」）。显式拦下，避免落到下方 CosyVoice/DashScope
-        # 通用分支拿着 mimo-clone-* 的 id 误合成（Codex review #1851）。
+        # MiMo 克隆音色（provider=='mimo'）试听：读 voice_meta 里的参考样本 base64，用
+        # voiceclone 模型一次性合成预览句（对偶 MiniMax 的克隆试听；避免落到下方
+        # CosyVoice/DashScope 通用分支拿着 mimo-clone-* 的 id 误合成）。
         if provider == 'mimo':
-            return JSONResponse({
-                'success': False,
-                'error': f'MiMo 音色暂不支持试听: {voice_id}',
-                'code': 'MIMO_VOICE_PREVIEW_UNSUPPORTED',
-            }, status_code=400)
+            sample_b64 = (voice_data or {}).get('clone_sample_b64') or ''
+            if not sample_b64:
+                return JSONResponse({
+                    'success': False,
+                    'error': f'MiMo 克隆音色缺少参考样本，无法试听: {voice_id}',
+                    'code': 'MIMO_VOICE_SAMPLE_MISSING',
+                }, status_code=400)
+            mimo_api_key = _config_manager.get_tts_api_key('mimo')
+            if not mimo_api_key:
+                return JSONResponse({
+                    'success': False,
+                    'error': 'MIMO_API_KEY_MISSING',
+                    'code': 'MIMO_API_KEY_MISSING',
+                }, status_code=400)
+            # base_url 与 dispatch 同源：assistApi=mimo（Token Plan 唯一场景）用 OPENROUTER_URL，
+            # 否则用 voice_meta 存的 mimo_base_url，缺省默认端点。
+            if str(preview_core_config.get('assistApi') or '').strip().lower() == 'mimo':
+                mimo_base_url = (preview_core_config.get('OPENROUTER_URL') or '').strip()
+            else:
+                mimo_base_url = str((voice_data or {}).get('mimo_base_url') or '').strip()
+            try:
+                sample_bytes = base64.b64decode(sample_b64)
+            except ValueError:  # binascii.Error 是 ValueError 子类
+                return JSONResponse({
+                    'success': False,
+                    'error': f'MiMo 克隆音色样本损坏，无法试听: {voice_id}',
+                    'code': 'MIMO_VOICE_SAMPLE_CORRUPT',
+                }, status_code=400)
+            try:
+                mimo_client = MimoVoiceCloneClient(api_key=mimo_api_key, base_url=mimo_base_url or None)
+                audio_data = await mimo_client.synthesize_preview(
+                    sample_bytes,
+                    (voice_data or {}).get('clone_sample_mime') or 'audio/wav',
+                    text=text,
+                )
+                audio_base64 = base64.b64encode(audio_data).decode('utf-8')
+                logger.info(f"MiMo 克隆音色 {voice_id} 预览音频生成成功，大小: {len(audio_data)} 字节")
+                return {'success': True, 'audio': audio_base64, 'mime_type': 'audio/wav'}
+            except MimoVoiceCloneError as e:
+                logger.error(f"MiMo 克隆音色 {voice_id} 预览失败: {e}")
+                return JSONResponse({
+                    'success': False,
+                    'error': f'MiMo 预览生成失败: {str(e)}',
+                    'code': 'MIMO_VOICE_PREVIEW_FAILED',
+                }, status_code=502)
+            except Exception as e:
+                logger.error(f"MiMo 克隆音色 {voice_id} 预览异常: {e}")
+                return JSONResponse({
+                    'success': False,
+                    'error': f'MiMo 预览生成失败: {str(e)}',
+                }, status_code=500)
 
         native_preview_provider = _get_active_native_preview_provider(_config_manager, voice_id)
         if native_preview_provider:
@@ -5344,8 +5390,11 @@ async def voice_clone(
             }
 
         elif provider == 'mimo':
-            # MiMo 没有远端注册：校验样本可用后，把参考音频存到本地，克隆身份即这段样本。
-            # voice_id 本地生成（以音频 MD5 为种子，保证唯一且与 MD5 去重一致）。
+            # MiMo 没有远端注册接口（已核实官方文档：voiceclone 只能每次内联参考音频，无
+            # create-voice / 远端 voice_id）。所以严格对偶 MiniMax 的做法是：把克隆身份整段
+            # 落进 voice_storage.json 的 voice_meta——MiniMax 那里存的是远端 voice_id，这里存
+            # 参考音频本身（base64）。不另起本地文件存储，voice_meta 随 voice_storage.json 一起
+            # 云同步（与 MiniMax 同构）。校验样本可用后再落库。
             client = MimoVoiceCloneClient(api_key=api_key, base_url=base_url or None)
             sample_bytes = normalized_buffer.getvalue()
             await client.validate_sample(sample_bytes, mime_type='audio/wav')
@@ -5355,10 +5404,6 @@ async def voice_clone(
             #  - 含 ref_language：去重带 ref_language，若 id 不带则「同音频换语言」绕过去重却又
             #    生成同名 id，覆盖掉前一条 voice_data（CodeRabbit review #1851）。
             voice_id = f'mimo-clone-{api_key[-8:]}-{ref_language}-{audio_md5[:12]}'
-            sample_filename = f'{voice_id}.wav'
-            sample_filename = await asyncio.to_thread(
-                _config_manager.save_voice_clone_sample, sample_filename, sample_bytes
-            )
             voice_data = {
                 'voice_id': voice_id,
                 'prefix': prefix,
@@ -5366,10 +5411,13 @@ async def voice_clone(
                 'ref_language': ref_language,
                 'provider': 'mimo',
                 'source': 'clone',
-                'clone_sample_file': sample_filename,
+                # 克隆身份：参考音频 base64（对偶 MiniMax 的远端 voice_id），dispatch/preview
+                # 读它内联进 voiceclone 请求。存进 voice_meta 即随 voice_storage.json 云同步。
+                'clone_sample_b64': base64.b64encode(sample_bytes).decode('ascii'),
                 'clone_sample_mime': 'audio/wav',
-                # 不冻结 base_url：dispatch（_mimo_resolve）按当前配置同源解析端点，
-                # 避免用户切换 Token Plan 后存储的端点与新 key 不匹配。
+                # base_url 存进 voice_meta（对偶 minimax_base_url）；dispatch 在 assistApi=mimo
+                # （Token Plan 的唯一场景）时仍按当前配置重解析，保证 key/端点配套。
+                'mimo_base_url': base_url or '',
                 'created_at': datetime.now().isoformat()
             }
 
@@ -5431,16 +5479,8 @@ async def voice_clone(
         logger.info(f"{provider_label} voice_id 已保存到音色库: {voice_id}")
     except Exception as save_error:
         logger.error(f"保存 {provider_label} voice_id 到音色库失败: {save_error}")
-        # MiMo 在元数据保存前已把参考样本落盘（其它 provider 无本地文件）；元数据保存失败时
-        # voice_storage.json 不会有指向它的条目，删除流程也找不到它——这里顺手清掉孤儿样本。
-        # 清理是 best-effort：delete_voice_clone_sample 已吞异常返 False，这里再兜一层，确保
-        # 即使清理失败也不会把下方 200 partial-success（local_save_failed）变成 500。
-        orphan_sample = voice_data.get('clone_sample_file') if isinstance(voice_data, dict) else None
-        if orphan_sample:
-            try:
-                _config_manager.delete_voice_clone_sample(orphan_sample)
-            except Exception as cleanup_error:
-                logger.warning("清理 MiMo 孤儿样本失败: file=%s err=%s", orphan_sample, cleanup_error)
+        # 克隆身份（含 MiMo 的样本 base64）都在 voice_data 里、随这次 save 一起落库，没有
+        # 任何旁路本地文件——save 失败不会留下孤儿，无需额外清理（对偶其它 provider）。
         return JSONResponse({
             'voice_id': voice_id,
             'message': f'{provider_label}音色注册成功，但本地保存失败',

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -5399,6 +5399,11 @@ async def voice_clone(
         logger.info(f"{provider_label} voice_id 已保存到音色库: {voice_id}")
     except Exception as save_error:
         logger.error(f"保存 {provider_label} voice_id 到音色库失败: {save_error}")
+        # MiMo 在元数据保存前已把参考样本落盘（其它 provider 无本地文件）；元数据保存失败时
+        # voice_storage.json 不会有指向它的条目，删除流程也找不到它——这里顺手清掉孤儿样本。
+        orphan_sample = voice_data.get('clone_sample_file') if isinstance(voice_data, dict) else None
+        if orphan_sample:
+            _config_manager.delete_voice_clone_sample(orphan_sample)
         return JSONResponse({
             'voice_id': voice_id,
             'message': f'{provider_label}音色注册成功，但本地保存失败',

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -5560,6 +5560,8 @@ async def voice_design_preview(request: Request):
         logger.error(f"ElevenLabs voice design 失败: {e}")
         return JSONResponse({'error': f'语音设计失败: {str(e)}'}, status_code=500)
 
+    # 只保留既有 generated_voice_id 又带 audio_base_64 的可试听项——预览接口的契约是给前端
+    # 可试听的选项。若过滤后为空（上游没回可用音频），按上游异常返回 502，不伪装成 success。
     result_previews = [
         {
             'generated_voice_id': p.get('generated_voice_id', ''),
@@ -5568,8 +5570,13 @@ async def voice_design_preview(request: Request):
             'duration_secs': p.get('duration_secs'),
         }
         for p in previews
-        if isinstance(p, dict) and p.get('generated_voice_id')
+        if isinstance(p, dict) and p.get('generated_voice_id') and p.get('audio_base_64')
     ]
+    if not result_previews:
+        return JSONResponse({
+            'error': 'ElevenLabs 未返回可试听的语音预览',
+            'code': 'ELEVENLABS_PREVIEWS_EMPTY',
+        }, status_code=502)
     return JSONResponse({'success': True, 'previews': result_previews})
 
 

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -119,6 +119,9 @@ from utils.voice_clone import (
     MINIMAX_PREFIX_MAX_LENGTH,
     get_minimax_base_url,
     get_minimax_storage_prefix,
+    MimoVoiceCloneClient,
+    MimoVoiceCloneError,
+    MIMO_VOICE_STORAGE_KEY,
     QwenVoiceCloneClient,
     QwenVoiceCloneError,
     qwen_language_hints,
@@ -1488,6 +1491,79 @@ async def _elevenlabs_clone_voice(
     except Exception as exc:
         raise ElevenLabsUpstreamError(502, "ElevenLabs returned invalid JSON while adding voice") from exc
     raw_voice_id = payload.get("voice_id") or payload.get("voiceId") or ""
+    if not raw_voice_id:
+        raise ElevenLabsUpstreamError(502, "ElevenLabs did not return voice_id")
+    return _prefixed_elevenlabs_voice_id(raw_voice_id)
+
+
+# ── ElevenLabs voice design (text description → generated voice) ──────────────
+# Voice design is the third voice source (besides preset/clone): a text prompt is
+# turned into voice previews, the user picks one, and create-from-preview lands it
+# as a normal ElevenLabs voice_id (stored with source='design'). Dispatch then
+# reuses the existing ElevenLabs clone path (voice_meta.provider=='elevenlabs'),
+# so no separate worker is needed (design doc §7).
+ELEVENLABS_VOICE_DESIGN_DESC_MIN = 20
+ELEVENLABS_VOICE_DESIGN_DESC_MAX = 1000
+
+
+async def _elevenlabs_design_previews(
+    *,
+    api_key: str,
+    base_url: str,
+    voice_description: str,
+) -> list[dict]:
+    """Call POST /v1/text-to-voice/design — returns the list of voice previews.
+
+    Each preview has ``generated_voice_id`` (the handle for create-from-preview)
+    and ``audio_base_64`` (an mp3 sample for the user to audition). We let
+    ElevenLabs auto-generate the preview text so the caller only supplies a
+    description.
+    """
+    url = f"{base_url.rstrip('/')}/v1/text-to-voice/design"
+    headers = {"xi-api-key": api_key, "Content-Type": "application/json"}
+    payload = {
+        "voice_description": voice_description,
+        "auto_generate_text": True,
+    }
+    async with httpx.AsyncClient(timeout=60, proxy=None, trust_env=False) as client:
+        resp = await client.post(url, headers=headers, json=payload)
+    _raise_for_elevenlabs_response(resp, "voice design")
+    try:
+        data = resp.json()
+    except Exception as exc:
+        raise ElevenLabsUpstreamError(502, "ElevenLabs returned invalid JSON while designing voice") from exc
+    previews = data.get("previews") if isinstance(data, dict) else None
+    if not isinstance(previews, list) or not previews:
+        raise ElevenLabsUpstreamError(502, "ElevenLabs did not return voice previews")
+    return previews
+
+
+async def _elevenlabs_create_voice_from_preview(
+    *,
+    api_key: str,
+    base_url: str,
+    voice_name: str,
+    voice_description: str,
+    generated_voice_id: str,
+) -> str:
+    """Call POST /v1/text-to-voice — persist a designed preview into a voice_id."""
+    safe_name = (voice_name or 'NEKO Designed Voice').strip()[:100] or 'NEKO Designed Voice'
+    url = f"{base_url.rstrip('/')}/v1/text-to-voice"
+    headers = {"xi-api-key": api_key, "Content-Type": "application/json"}
+    payload = {
+        "voice_name": safe_name,
+        "voice_description": voice_description,
+        "generated_voice_id": generated_voice_id,
+        "labels": {"source": "NEKO"},
+    }
+    async with httpx.AsyncClient(timeout=60, proxy=None, trust_env=False) as client:
+        resp = await client.post(url, headers=headers, json=payload)
+    _raise_for_elevenlabs_response(resp, "voice design create")
+    try:
+        payload_resp = resp.json()
+    except Exception as exc:
+        raise ElevenLabsUpstreamError(502, "ElevenLabs returned invalid JSON while creating designed voice") from exc
+    raw_voice_id = payload_resp.get("voice_id") or payload_resp.get("voiceId") or ""
     if not raw_voice_id:
         raise ElevenLabsUpstreamError(502, "ElevenLabs did not return voice_id")
     return _prefixed_elevenlabs_voice_id(raw_voice_id)
@@ -5146,6 +5222,17 @@ async def voice_clone(
         storage_key = f'__ELEVENLABS__{api_key[-8:]}'
         provider_label = 'ElevenLabs'
 
+    elif provider == 'mimo':
+        if not api_key:
+            return JSONResponse({
+                'error': 'MIMO_API_KEY_MISSING',
+                'code': 'MIMO_API_KEY_MISSING',
+                'message': '未配置 MiMo API Key，请先在设置中填写'
+            }, status_code=400)
+        base_url = ''  # MiMo 克隆用默认 xiaomimimo 端点（mimo_chat_completions_url 兜底）
+        storage_key = f'{MIMO_VOICE_STORAGE_KEY}{api_key[-8:]}'
+        provider_label = 'MiMo'
+
     else:
         return JSONResponse({'error': f'不支持的 provider: {provider}'}, status_code=400)
 
@@ -5225,7 +5312,32 @@ async def voice_clone(
                 'audio_md5': audio_md5,
                 'ref_language': ref_language,
                 'provider': 'elevenlabs',
+                'source': 'clone',
                 'elevenlabs_base_url': base_url,
+                'created_at': datetime.now().isoformat()
+            }
+
+        elif provider == 'mimo':
+            # MiMo 没有远端注册：校验样本可用后，把参考音频存到本地，克隆身份即这段样本。
+            # voice_id 本地生成（以音频 MD5 为种子，保证唯一且与 MD5 去重一致）。
+            client = MimoVoiceCloneClient(api_key=api_key, base_url=base_url or None)
+            sample_bytes = normalized_buffer.getvalue()
+            await client.validate_sample(sample_bytes, mime_type='audio/wav')
+            voice_id = f'mimo-clone-{audio_md5[:12]}'
+            sample_filename = f'mimo-{api_key[-8:]}-{voice_id}.wav'
+            sample_filename = await asyncio.to_thread(
+                _config_manager.save_voice_clone_sample, sample_filename, sample_bytes
+            )
+            voice_data = {
+                'voice_id': voice_id,
+                'prefix': prefix,
+                'audio_md5': audio_md5,
+                'ref_language': ref_language,
+                'provider': 'mimo',
+                'source': 'clone',
+                'clone_sample_file': sample_filename,
+                'clone_sample_mime': 'audio/wav',
+                'mimo_base_url': base_url or '',
                 'created_at': datetime.now().isoformat()
             }
 
@@ -5267,7 +5379,7 @@ async def voice_clone(
             'code': 'ELEVENLABS_UPSTREAM_ERROR',
             'provider': provider,
         }, status_code=502)
-    except (MinimaxVoiceCloneError, QwenVoiceCloneError) as e:
+    except (MinimaxVoiceCloneError, QwenVoiceCloneError, MimoVoiceCloneError) as e:
         logger.error(f"{provider_label} 音色注册失败: {e}")
         error_detail = str(e)
         if '超时' in error_detail:
@@ -5299,6 +5411,165 @@ async def voice_clone(
         'voice_id': voice_id,
         'message': f'{provider_label}音色注册成功并已保存到音色库',
         'provider': provider,
+    })
+
+
+def _validate_voice_design_description(raw: object) -> tuple[str, JSONResponse | None]:
+    """Validate a voice-design description against ElevenLabs' 20–1000 char window."""
+    description = str(raw or '').strip()
+    if len(description) < ELEVENLABS_VOICE_DESIGN_DESC_MIN:
+        return description, JSONResponse({
+            'error': 'VOICE_DESIGN_DESCRIPTION_TOO_SHORT',
+            'code': 'VOICE_DESIGN_DESCRIPTION_TOO_SHORT',
+            'min': ELEVENLABS_VOICE_DESIGN_DESC_MIN,
+        }, status_code=400)
+    if len(description) > ELEVENLABS_VOICE_DESIGN_DESC_MAX:
+        return description, JSONResponse({
+            'error': 'VOICE_DESIGN_DESCRIPTION_TOO_LONG',
+            'code': 'VOICE_DESIGN_DESCRIPTION_TOO_LONG',
+            'max': ELEVENLABS_VOICE_DESIGN_DESC_MAX,
+        }, status_code=400)
+    return description, None
+
+
+@router.post('/voice_design_preview')
+async def voice_design_preview(request: Request):
+    """Generate ElevenLabs voice-design previews from a text description.
+
+    Returns a list of previews ``[{generated_voice_id, audio (base64 mp3),
+    media_type, duration_secs}]`` for the user to audition; nothing is persisted
+    yet — :func:`voice_design_create` lands the chosen preview as a voice.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return JSONResponse({'error': 'INVALID_JSON', 'code': 'INVALID_JSON'}, status_code=400)
+
+    description, err = _validate_voice_design_description(data.get('description'))
+    if err is not None:
+        return err
+
+    _config_manager = get_config_manager()
+    api_key = _config_manager.get_tts_api_key('elevenlabs')
+    if not api_key:
+        return JSONResponse({
+            'error': 'ELEVENLABS_API_KEY_MISSING',
+            'code': 'ELEVENLABS_API_KEY_MISSING',
+            'message': '未配置 ElevenLabs API Key，请先在设置中填写',
+        }, status_code=400)
+    base_url = await _get_elevenlabs_base_url(_config_manager)
+
+    try:
+        previews = await _elevenlabs_design_previews(
+            api_key=api_key, base_url=base_url, voice_description=description,
+        )
+    except ElevenLabsUpstreamError as e:
+        logger.error(f"ElevenLabs voice design 上游错误 ({e.status_code}): {e}")
+        return JSONResponse({
+            'error': f'ElevenLabs上游服务错误: {str(e)}',
+            'code': 'ELEVENLABS_UPSTREAM_ERROR',
+        }, status_code=502)
+    except ValueError as e:
+        return JSONResponse({'error': str(e)}, status_code=400)
+    except Exception as e:
+        logger.error(f"ElevenLabs voice design 失败: {e}")
+        return JSONResponse({'error': f'语音设计失败: {str(e)}'}, status_code=500)
+
+    result_previews = [
+        {
+            'generated_voice_id': p.get('generated_voice_id', ''),
+            'audio': p.get('audio_base_64', ''),
+            'media_type': p.get('media_type', 'audio/mpeg'),
+            'duration_secs': p.get('duration_secs'),
+        }
+        for p in previews
+        if isinstance(p, dict) and p.get('generated_voice_id')
+    ]
+    return JSONResponse({'success': True, 'previews': result_previews})
+
+
+@router.post('/voice_design_create')
+async def voice_design_create(request: Request):
+    """Persist a chosen ElevenLabs design preview into a reusable voice.
+
+    The voice lands as a normal ElevenLabs voice (``source='design'``) in the
+    ElevenLabs voice_storage bucket, so dispatch reuses the existing ElevenLabs
+    clone path (``voice_meta.provider=='elevenlabs'``).
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return JSONResponse({'error': 'INVALID_JSON', 'code': 'INVALID_JSON'}, status_code=400)
+
+    description, err = _validate_voice_design_description(data.get('description'))
+    if err is not None:
+        return err
+    generated_voice_id = str(data.get('generated_voice_id') or '').strip()
+    if not generated_voice_id:
+        return JSONResponse({
+            'error': 'VOICE_DESIGN_PREVIEW_MISSING',
+            'code': 'VOICE_DESIGN_PREVIEW_MISSING',
+        }, status_code=400)
+    name = str(data.get('name') or data.get('prefix') or '').strip()
+
+    _config_manager = get_config_manager()
+    api_key = _config_manager.get_tts_api_key('elevenlabs')
+    if not api_key:
+        return JSONResponse({
+            'error': 'ELEVENLABS_API_KEY_MISSING',
+            'code': 'ELEVENLABS_API_KEY_MISSING',
+            'message': '未配置 ElevenLabs API Key，请先在设置中填写',
+        }, status_code=400)
+    base_url = await _get_elevenlabs_base_url(_config_manager)
+
+    try:
+        voice_id = await _elevenlabs_create_voice_from_preview(
+            api_key=api_key,
+            base_url=base_url,
+            voice_name=name or 'NEKO Designed Voice',
+            voice_description=description,
+            generated_voice_id=generated_voice_id,
+        )
+    except ElevenLabsUpstreamError as e:
+        logger.error(f"ElevenLabs voice design create 上游错误 ({e.status_code}): {e}")
+        return JSONResponse({
+            'error': f'ElevenLabs上游服务错误: {str(e)}',
+            'code': 'ELEVENLABS_UPSTREAM_ERROR',
+        }, status_code=502)
+    except ValueError as e:
+        return JSONResponse({'error': str(e)}, status_code=400)
+    except Exception as e:
+        logger.error(f"ElevenLabs voice design create 失败: {e}")
+        return JSONResponse({'error': f'语音设计保存失败: {str(e)}'}, status_code=500)
+
+    voice_data = {
+        'voice_id': voice_id,
+        'raw_voice_id': _raw_elevenlabs_voice_id(voice_id),
+        'prefix': name or 'Designed Voice',
+        'provider': 'elevenlabs',
+        'source': 'design',
+        'design_description': description,
+        'elevenlabs_base_url': base_url,
+        'created_at': datetime.now().isoformat(),
+    }
+    storage_key = f'__ELEVENLABS__{api_key[-8:]}'
+    try:
+        _config_manager.save_voice_for_api_key(storage_key, voice_id, voice_data)
+    except Exception as save_error:
+        logger.error(f"保存 ElevenLabs 设计音色到音色库失败: {save_error}")
+        return JSONResponse({
+            'voice_id': voice_id,
+            'message': 'ElevenLabs 设计音色创建成功，但本地保存失败',
+            'local_save_failed': True,
+            'error': str(save_error),
+            'provider': 'elevenlabs',
+        }, status_code=200)
+
+    return JSONResponse({
+        'voice_id': voice_id,
+        'message': 'ElevenLabs 设计音色创建成功并已保存到音色库',
+        'provider': 'elevenlabs',
+        'source': 'design',
     })
 
 

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -5349,10 +5349,12 @@ async def voice_clone(
             client = MimoVoiceCloneClient(api_key=api_key, base_url=base_url or None)
             sample_bytes = normalized_buffer.getvalue()
             await client.validate_sample(sample_bytes, mime_type='audio/wav')
-            # voice_id 含 key 末 8 位，保证「同一参考音频在不同 MiMo key 下克隆」落到不同
-            # voice_id——否则跨 __MIMO__ 桶同名，delete_voice_for_current_api 按 id 扫所有桶
-            # 时可能误删另一个 key 的隐藏条目（Codex review #1851）。
-            voice_id = f'mimo-clone-{api_key[-8:]}-{audio_md5[:12]}'
+            # voice_id 维度必须与 MD5 去重键 (storage_key, audio_md5, ref_language) 一致：
+            #  - 含 key 末 8 位：同一音频在不同 MiMo key 下落不同 voice_id，避免跨 __MIMO__ 桶
+            #    同名被 delete_voice_for_current_api 按 id 扫桶误删（Codex review #1851）。
+            #  - 含 ref_language：去重带 ref_language，若 id 不带则「同音频换语言」绕过去重却又
+            #    生成同名 id，覆盖掉前一条 voice_data（CodeRabbit review #1851）。
+            voice_id = f'mimo-clone-{api_key[-8:]}-{ref_language}-{audio_md5[:12]}'
             sample_filename = f'{voice_id}.wav'
             sample_filename = await asyncio.to_thread(
                 _config_manager.save_voice_clone_sample, sample_filename, sample_bytes
@@ -5431,9 +5433,14 @@ async def voice_clone(
         logger.error(f"保存 {provider_label} voice_id 到音色库失败: {save_error}")
         # MiMo 在元数据保存前已把参考样本落盘（其它 provider 无本地文件）；元数据保存失败时
         # voice_storage.json 不会有指向它的条目，删除流程也找不到它——这里顺手清掉孤儿样本。
+        # 清理是 best-effort：delete_voice_clone_sample 已吞异常返 False，这里再兜一层，确保
+        # 即使清理失败也不会把下方 200 partial-success（local_save_failed）变成 500。
         orphan_sample = voice_data.get('clone_sample_file') if isinstance(voice_data, dict) else None
         if orphan_sample:
-            _config_manager.delete_voice_clone_sample(orphan_sample)
+            try:
+                _config_manager.delete_voice_clone_sample(orphan_sample)
+            except Exception as cleanup_error:
+                logger.warning("清理 MiMo 孤儿样本失败: file=%s err=%s", orphan_sample, cleanup_error)
         return JSONResponse({
             'voice_id': voice_id,
             'message': f'{provider_label}音色注册成功，但本地保存失败',

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -5479,6 +5479,9 @@ async def voice_design_preview(request: Request):
         data = await request.json()
     except Exception:
         return JSONResponse({'error': 'INVALID_JSON', 'code': 'INVALID_JSON'}, status_code=400)
+    # request.json() 也可能返回数组/字符串/null（合法 JSON 但非对象）——直接 .get 会 500。
+    if not isinstance(data, dict):
+        return JSONResponse({'error': 'INVALID_JSON', 'code': 'INVALID_JSON'}, status_code=400)
 
     description, err = _validate_voice_design_description(data.get('description'))
     if err is not None:
@@ -5534,6 +5537,8 @@ async def voice_design_create(request: Request):
     try:
         data = await request.json()
     except Exception:
+        return JSONResponse({'error': 'INVALID_JSON', 'code': 'INVALID_JSON'}, status_code=400)
+    if not isinstance(data, dict):
         return JSONResponse({'error': 'INVALID_JSON', 'code': 'INVALID_JSON'}, status_code=400)
 
     description, err = _validate_voice_design_description(data.get('description'))

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -6490,16 +6490,19 @@ async function _loadPanelVoices(selectEl, currentVoiceId) {
                 });
             }
 
-            // 注册的克隆音色：按 provider 分组成「<Provider> · 克隆」optgroup（source-first，§5）。
-            // 同 provider 复用同一组；provider 缺失时归到「其他 · 克隆」。
+            // 注册的音色：按「provider · 来源」分组成 optgroup（source-first，§5）。来源取
+            // voiceData.source（design=描述生成 / clone=克隆），缺省按 clone（存量克隆音色没有
+            // source 字段）。同 (provider, 来源) 复用同一组；provider 缺失归到「其他 · …」。
             const _cloneGroups = {};
             Object.entries(data.voices).forEach(function ([voiceId, voiceData]) {
                 const provider = (voiceData && voiceData.provider) || '';
-                if (!_cloneGroups[provider]) {
+                const source = (voiceData && voiceData.source === 'design') ? 'design' : 'clone';
+                const groupKey = provider + '|' + source;
+                if (!_cloneGroups[groupKey]) {
                     const grp = document.createElement('optgroup');
-                    grp.label = _panelNormalizeVoiceGroupLabel(_panelVoiceSourceGroupLabel(provider, 'clone'));
-                    grp.dataset.voiceSourceGroup = 'clone';
-                    _cloneGroups[provider] = grp;
+                    grp.label = _panelNormalizeVoiceGroupLabel(_panelVoiceSourceGroupLabel(provider, source));
+                    grp.dataset.voiceSourceGroup = source;
+                    _cloneGroups[groupKey] = grp;
                     selectEl.appendChild(grp);
                 }
                 const option = document.createElement('option');
@@ -6508,7 +6511,7 @@ async function _loadPanelVoices(selectEl, currentVoiceId) {
                 option.textContent = _panelGetRegisteredVoiceDisplayName(voiceId, voiceData);
                 option.title = voiceId;
                 if (voiceId === currentVoiceId) option.selected = true;
-                _cloneGroups[provider].appendChild(option);
+                _cloneGroups[groupKey].appendChild(option);
             });
 
             // 免费预设音色

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -1229,6 +1229,7 @@ document.addEventListener('DOMContentLoaded', function initProviderSwitch() {
         }
         refreshVoiceCloneProviderNotice(providerSelect, noticeDiv);
         normalizePrefixInputForProvider();
+        updateCloneMethodForProvider(providerSelect.value);
     });
     if (prefixInput) {
         prefixInput.addEventListener('input', () => {
@@ -1237,13 +1238,44 @@ document.addEventListener('DOMContentLoaded', function initProviderSwitch() {
     }
     refreshVoiceCloneProviderNotice(providerSelect, noticeDiv);
     normalizePrefixInputForProvider();
+    updateCloneMethodForProvider(providerSelect.value);
 });
 
 // 当前克隆方式
 let currentCloneMethod = 'file';
 
+// MiMo 只支持本地文件克隆：它把参考样本存在本地、不走 /voice_clone_direct（后端
+// valid_providers 不含 mimo，直链会直接 TTS_PROVIDER_INVALID）。选中 MiMo 时禁用直链方式。
+function isDirectLinkUnsupportedProvider(provider) {
+    return provider === 'mimo';
+}
+
+function updateCloneMethodForProvider(provider) {
+    const btnDirectLinkClone = document.getElementById('btnDirectLinkClone');
+    const disabled = isDirectLinkUnsupportedProvider(provider);
+    if (btnDirectLinkClone) {
+        btnDirectLinkClone.disabled = disabled;
+        btnDirectLinkClone.classList.toggle('disabled', disabled);
+        btnDirectLinkClone.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+        btnDirectLinkClone.title = disabled
+            ? (window.t ? window.t('voice.mimoDirectLinkUnsupported') : 'MiMo 暂不支持直链克隆')
+            : '';
+    }
+    // 当前在直链方式但切到了不支持直链的 provider → 强制回退到本地文件
+    if (disabled && currentCloneMethod === 'directlink') {
+        switchCloneMethod('file');
+    }
+}
+
 // 切换克隆方式
 function switchCloneMethod(method) {
+    // 防御：不支持直链的 provider（MiMo）被选中时，无视直链切换请求
+    if (method === 'directlink') {
+        const providerSelect = document.getElementById('voiceProvider');
+        if (providerSelect && isDirectLinkUnsupportedProvider(providerSelect.value)) {
+            method = 'file';
+        }
+    }
     currentCloneMethod = method;
     const btnFileClone = document.getElementById('btnFileClone');
     const btnDirectLinkClone = document.getElementById('btnDirectLinkClone');

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -445,16 +445,26 @@ function getVoiceCloneProviderKeyField(provider) {
     return entry ? entry[1] : '';
 }
 
-// MiMo 的可用凭据可能在普通 key 或 Token Plan key 任一字段——若用户只开了 Token Plan，
-// 凭据只在 assistApiKeyMimoTokenPlan 里，单看 assistApiKeyMimo 会误判 MiMo 无 key 不能克隆。
+// MiMo 的可用凭据在普通 key 或 Token Plan key 两个字段之一——但**不是 OR**：后端
+// get_tts_api_key('mimo') 严格按「assistApi=='mimo' 且 useMimoTokenPlan」二选一取其中一个
+// （token plan 激活取 assistApiKeyMimoTokenPlan，否则取 assistApiKeyMimo）。前端可用性判定必须
+// 镜像同一条规则，否则会出现「OR 判定有 key 但后端取的是另一个空字段 → 上传后 400」的假阳性
+// （Codex review #1851）。
 const VOICE_CLONE_MIMO_TOKEN_PLAN_KEY_FIELD = 'assistApiKeyMimoTokenPlan';
+
+function getActiveMimoKeyField(cfg) {
+    const tokenPlanActive = String((cfg && cfg.assistApi) || '').trim().toLowerCase() === 'mimo'
+        && !!(cfg && cfg.useMimoTokenPlan);
+    return tokenPlanActive ? VOICE_CLONE_MIMO_TOKEN_PLAN_KEY_FIELD : 'assistApiKeyMimo';
+}
 
 function cfgHasCloneProviderKey(cfg, provider) {
     if (!cfg || typeof cfg !== 'object') return false;
+    if (provider === 'mimo') {
+        return !!cfg[getActiveMimoKeyField(cfg)];
+    }
     const fieldName = getVoiceCloneProviderKeyField(provider);
-    if (fieldName && cfg[fieldName]) return true;
-    if (provider === 'mimo' && cfg[VOICE_CLONE_MIMO_TOKEN_PLAN_KEY_FIELD]) return true;
-    return false;
+    return !!(fieldName && cfg[fieldName]);
 }
 
 function getVoiceCloneProviderRegistryKey(provider) {

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -445,6 +445,18 @@ function getVoiceCloneProviderKeyField(provider) {
     return entry ? entry[1] : '';
 }
 
+// MiMo 的可用凭据可能在普通 key 或 Token Plan key 任一字段——若用户只开了 Token Plan，
+// 凭据只在 assistApiKeyMimoTokenPlan 里，单看 assistApiKeyMimo 会误判 MiMo 无 key 不能克隆。
+const VOICE_CLONE_MIMO_TOKEN_PLAN_KEY_FIELD = 'assistApiKeyMimoTokenPlan';
+
+function cfgHasCloneProviderKey(cfg, provider) {
+    if (!cfg || typeof cfg !== 'object') return false;
+    const fieldName = getVoiceCloneProviderKeyField(provider);
+    if (fieldName && cfg[fieldName]) return true;
+    if (provider === 'mimo' && cfg[VOICE_CLONE_MIMO_TOKEN_PLAN_KEY_FIELD]) return true;
+    return false;
+}
+
 function getVoiceCloneProviderRegistryKey(provider) {
     return VOICE_CLONE_PROVIDER_REGISTRY_KEYS[provider] || provider;
 }
@@ -494,9 +506,7 @@ async function ensureVoiceCloneApiConfigState(options = {}) {
 
 function hasVoiceCloneProviderApi(provider) {
     if (voiceCloneApiConfigState.isLocalTts) return true;
-    const cfg = voiceCloneApiConfigState.cfg;
-    const fieldName = getVoiceCloneProviderKeyField(provider);
-    return !!(cfg && fieldName && cfg[fieldName]);
+    return cfgHasCloneProviderKey(voiceCloneApiConfigState.cfg, provider);
 }
 
 async function checkVoiceCloneMainlandChinaUser() {
@@ -843,8 +853,8 @@ async function initVoiceCloneProviderRestrictions() {
 
 function getPreferredCloneProviderFromConfig(cfg) {
     if (!cfg || typeof cfg !== 'object') return '';
-    for (const [provider, fieldName] of VOICE_CLONE_PROVIDER_KEY_FIELDS) {
-        if (cfg[fieldName] && !isVoiceCloneProviderRestricted(provider)) {
+    for (const [provider] of VOICE_CLONE_PROVIDER_KEY_FIELDS) {
+        if (cfgHasCloneProviderKey(cfg, provider) && !isVoiceCloneProviderRestricted(provider)) {
             return provider;
         }
     }
@@ -854,8 +864,8 @@ function getPreferredCloneProviderFromConfig(cfg) {
 function hasUsableCloneApiFromConfig(cfg, isLocalTts) {
     if (isLocalTts) return true;
     if (!cfg || typeof cfg !== 'object') return false;
-    return VOICE_CLONE_PROVIDER_KEY_FIELDS.some(([provider, fieldName]) => (
-        !!cfg[fieldName] && !isVoiceCloneProviderRestricted(provider)
+    return VOICE_CLONE_PROVIDER_KEY_FIELDS.some(([provider]) => (
+        cfgHasCloneProviderKey(cfg, provider) && !isVoiceCloneProviderRestricted(provider)
     ));
 }
 

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -13,6 +13,7 @@ const VOICE_CLONE_PROVIDER_REGISTRY_KEYS = Object.freeze({
     minimax: 'minimax',
     minimax_intl: 'minimax_intl',
     elevenlabs: 'elevenlabs',
+    mimo: 'mimo',
 });
 const VOICE_CLONE_RESTRICTED_REGISTRY_KEYS = new Set([
     'qwen_intl',
@@ -25,6 +26,7 @@ const VOICE_CLONE_PROVIDER_KEY_FIELDS = Object.freeze([
     ['minimax', 'assistApiKeyMinimax'],
     ['minimax_intl', 'assistApiKeyMinimaxIntl'],
     ['elevenlabs', 'assistApiKeyElevenlabs'],
+    ['mimo', 'assistApiKeyMimo'],
 ]);
 const voiceCloneProviderRestrictionState = {
     loaded: false,
@@ -866,10 +868,12 @@ function updateVoiceCloneProviderNoticeText(noticeDiv, provider) {
         'minimax': 'voice.minimaxApiRequired',
         'minimax_intl': 'voice.minimaxIntlApiRequired',
         'elevenlabs': 'voice.elevenlabsApiRequired',
+        'mimo': 'voice.mimoApiRequired',
     };
     const fallbackMap = {
         'cosyvoice_intl': '请先在 API 设置中填写阿里国际版 API Key',
         'elevenlabs': '请先在 API 设置中填写 ElevenLabs API Key',
+        'mimo': '请先在 API 设置中填写 MiMo API Key',
     };
     const i18nKey = keyMap[provider] || 'voice.alibabaApiRequired';
     span.setAttribute('data-i18n', i18nKey);

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -1407,6 +1407,11 @@ function setFormDisabled(disabled) {
             if (btn) btn.disabled = disabled;
         });
     }
+    // 重新启用时恢复「按 provider 的方法可用性」策略：上面的全局启用会把 MiMo 的直链禁用
+    // 状态冲掉，若不重新触发 provider change，MiMo 下直链按钮会变回可点（与策略不一致）。
+    if (!disabled && typeof updateCloneMethodForProvider === 'function') {
+        updateCloneMethodForProvider(voiceProvider ? voiceProvider.value : '');
+    }
 }
 
 async function registerVoice() {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "This feature requires the Alibaba International CosyVoice model. Please save the Alibaba International API Key in API Keys settings (enabling Assist API is not required).",
         "minimaxApiRequired": "This feature requires the MiniMax model (China). Please save the MiniMax API Key in API Keys settings (enabling Assist API is not required).",
         "minimaxIntlApiRequired": "This feature requires the MiniMax model (International). Please save the MiniMax International API Key in API Keys settings (enabling Assist API is not required).",
+        "mimoApiRequired": "This feature requires a MiMo model. Please save your MiMo API Key on the API key settings page.",
         "providerLabel": "Voice Clone Provider",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",
             "cosyvoice_intl": "Alibaba Intl CosyVoice",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Intl)",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo (Xiaomi)"
         },
         "selectFile": "Select local audio file (8 seconds recommended, max 20 seconds, wav/mp3 format)",
         "customPrefix": "Custom Prefix (Required, used to distinguish different voices)",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "This feature requires the MiniMax model (China). Please save the MiniMax API Key in API Keys settings (enabling Assist API is not required).",
         "minimaxIntlApiRequired": "This feature requires the MiniMax model (International). Please save the MiniMax International API Key in API Keys settings (enabling Assist API is not required).",
         "mimoApiRequired": "This feature requires a MiMo model. Please save your MiMo API Key on the API key settings page.",
+        "mimoDirectLinkUnsupported": "MiMo does not support direct-link cloning; please upload a local file instead.",
         "providerLabel": "Voice Clone Provider",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "Esta función requiere el modelo CosyVoice de Alibaba Internacional. Guarde la clave API de Alibaba Internacional en la configuración de claves API (no es necesario habilitar la API auxiliar).",
         "minimaxApiRequired": "Esta característica requiere el modelo MiniMax (China). Guarde la clave API MiniMax en la configuración de claves API (no es necesario habilitar Assist API).",
         "minimaxIntlApiRequired": "Esta característica requiere el modelo MiniMax (Internacional). Guarde la clave API de MiniMax International en la configuración de claves API (no es necesario habilitar Assist API).",
+        "mimoApiRequired": "Esta función requiere un modelo MiMo. Guarde su clave API de MiMo en la página de configuración de claves API.",
         "providerLabel": "Proveedor de clonación de voz",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",
             "cosyvoice_intl": "Alibaba Intl CosyVoice",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Int.)",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo (Xiaomi)"
         },
         "selectFile": "Seleccione el archivo de audio local (se recomiendan 8 segundos, máximo 20 segundos, formato wav/mp3)",
         "customPrefix": "Prefijo personalizado (obligatorio, utilizado para distinguir diferentes voces)",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "Esta característica requiere el modelo MiniMax (China). Guarde la clave API MiniMax en la configuración de claves API (no es necesario habilitar Assist API).",
         "minimaxIntlApiRequired": "Esta característica requiere el modelo MiniMax (Internacional). Guarde la clave API de MiniMax International en la configuración de claves API (no es necesario habilitar Assist API).",
         "mimoApiRequired": "Esta función requiere un modelo MiMo. Guarde su clave API de MiMo en la página de configuración de claves API.",
+        "mimoDirectLinkUnsupported": "MiMo no admite la clonación por enlace directo; suba un archivo local en su lugar.",
         "providerLabel": "Proveedor de clonación de voz",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "この機能にはAlibaba国際版 CosyVoiceモデルが必要です。APIキー設定でAlibaba国際版APIキーを保存してください（Assist APIの有効化は不要）",
         "minimaxApiRequired": "この機能にはMiniMaxモデル（China）が必要です。APIキー設定でMiniMax APIキーを保存してください（Assist APIの有効化は不要）",
         "minimaxIntlApiRequired": "この機能にはMiniMaxモデル（国際版）が必要です。APIキー設定でMiniMax国際版APIキーを保存してください（Assist APIの有効化は不要）",
+        "mimoApiRequired": "この機能には MiMo モデルが必要です。API キー設定ページで MiMo API キーを保存してください",
         "providerLabel": "音声クローンプロバイダー",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",
             "cosyvoice_intl": "Alibaba国際版 CosyVoice",
             "minimax": "MiniMax（中国版）",
             "minimax_intl": "MiniMax（国際版）",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo（小米）"
         },
         "selectFile": "ローカル音声ファイルを選択（8秒推奨、最大20秒、wav/mp3形式）",
         "customPrefix": "カスタムプレフィックス（必須、ボイスの識別用）",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "この機能にはMiniMaxモデル（China）が必要です。APIキー設定でMiniMax APIキーを保存してください（Assist APIの有効化は不要）",
         "minimaxIntlApiRequired": "この機能にはMiniMaxモデル（国際版）が必要です。APIキー設定でMiniMax国際版APIキーを保存してください（Assist APIの有効化は不要）",
         "mimoApiRequired": "この機能には MiMo モデルが必要です。API キー設定ページで MiMo API キーを保存してください",
+        "mimoDirectLinkUnsupported": "MiMo は直リンククローンに未対応です。ローカルファイルのアップロードをご利用ください",
         "providerLabel": "音声クローンプロバイダー",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "이 기능에는 MiniMax 모델 (China)이 필요합니다. API 키 설정에서 MiniMax API 키를 저장하세요 (Assist API 활성화 불필요).",
         "minimaxIntlApiRequired": "이 기능에는 MiniMax 모델(국제판)이 필요합니다. API 키 설정에서 MiniMax 국제판 API 키를 저장하세요 (Assist API 활성화 불필요).",
         "mimoApiRequired": "이 기능은 MiMo 모델이 필요합니다. API 키 설정 페이지에서 MiMo API 키를 저장하세요",
+        "mimoDirectLinkUnsupported": "MiMo는 직접 링크 복제를 지원하지 않습니다. 로컬 파일 업로드를 사용하세요",
         "providerLabel": "음성 복제 제공업체",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "이 기능에는 Alibaba 국제판 CosyVoice 모델이 필요합니다. API 키 설정에서 Alibaba 국제판 API 키를 저장하세요 (Assist API 활성화 불필요).",
         "minimaxApiRequired": "이 기능에는 MiniMax 모델 (China)이 필요합니다. API 키 설정에서 MiniMax API 키를 저장하세요 (Assist API 활성화 불필요).",
         "minimaxIntlApiRequired": "이 기능에는 MiniMax 모델(국제판)이 필요합니다. API 키 설정에서 MiniMax 국제판 API 키를 저장하세요 (Assist API 활성화 불필요).",
+        "mimoApiRequired": "이 기능은 MiMo 모델이 필요합니다. API 키 설정 페이지에서 MiMo API 키를 저장하세요",
         "providerLabel": "음성 복제 제공업체",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",
             "cosyvoice_intl": "Alibaba 국제판 CosyVoice",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (국제판)",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo (샤오미)"
         },
         "selectFile": "로컬 오디오 파일 선택(8초 권장, 최대 20초, wav/mp3 형식)",
         "customPrefix": "사용자 정의 접두사(필수, 다양한 음성을 구별하는 데 사용됨)",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "Este recurso requer o modelo MiniMax (China). Salve a chave de API MiniMax nas configurações de chaves de API (não é necessário ativar a Assist API).",
         "minimaxIntlApiRequired": "Este recurso requer o modelo MiniMax (Internacional). Salve a chave de API internacional MiniMax nas configurações de chaves de API (não é necessário ativar a Assist API).",
         "mimoApiRequired": "Este recurso requer um modelo MiMo. Salve sua chave de API do MiMo na página de configurações de chaves de API.",
+        "mimoDirectLinkUnsupported": "O MiMo não oferece suporte à clonagem por link direto; envie um arquivo local.",
         "providerLabel": "Provedor de clone de voz",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "Este recurso requer o modelo Alibaba International CosyVoice. Salve a chave de API do Alibaba International nas configurações de chaves de API (não é necessário ativar a Assist API).",
         "minimaxApiRequired": "Este recurso requer o modelo MiniMax (China). Salve a chave de API MiniMax nas configurações de chaves de API (não é necessário ativar a Assist API).",
         "minimaxIntlApiRequired": "Este recurso requer o modelo MiniMax (Internacional). Salve a chave de API internacional MiniMax nas configurações de chaves de API (não é necessário ativar a Assist API).",
+        "mimoApiRequired": "Este recurso requer um modelo MiMo. Salve sua chave de API do MiMo na página de configurações de chaves de API.",
         "providerLabel": "Provedor de clone de voz",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",
             "cosyvoice_intl": "Alibaba Intl CosyVoice",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Internacional)",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo (Xiaomi)"
         },
         "selectFile": "Selecione o arquivo de áudio local (8 segundos recomendados, máximo de 20 segundos, formato wav/mp3)",
         "customPrefix": "Prefixo personalizado (obrigatório, usado para distinguir vozes diferentes)",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "Для этой функции необходима модель MiniMax (Китай). Сохраните ключ API MiniMax в настройках API (включение Assist API не требуется).",
         "minimaxIntlApiRequired": "Для этой функции необходима модель MiniMax (Международная). Сохраните ключ API MiniMax (Международная) в настройках API (включение Assist API не требуется).",
         "mimoApiRequired": "Для этой функции требуется модель MiMo. Сохраните ключ MiMo API на странице настроек ключей API.",
+        "mimoDirectLinkUnsupported": "MiMo не поддерживает клонирование по прямой ссылке; загрузите локальный файл.",
         "providerLabel": "Провайдер клонирования голоса",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "Для этой функции нужна модель Alibaba International CosyVoice. Сохраните API-ключ Alibaba International в настройках API (включение Assist API не требуется).",
         "minimaxApiRequired": "Для этой функции необходима модель MiniMax (Китай). Сохраните ключ API MiniMax в настройках API (включение Assist API не требуется).",
         "minimaxIntlApiRequired": "Для этой функции необходима модель MiniMax (Международная). Сохраните ключ API MiniMax (Международная) в настройках API (включение Assist API не требуется).",
+        "mimoApiRequired": "Для этой функции требуется модель MiMo. Сохраните ключ MiMo API на странице настроек ключей API.",
         "providerLabel": "Провайдер клонирования голоса",
         "provider": {
             "cosyvoice": "Alibaba Bailian CosyVoice",
             "cosyvoice_intl": "Alibaba Intl CosyVoice",
             "minimax": "MiniMax (Китай)",
             "minimax_intl": "MiniMax (Международная)",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo (Xiaomi)"
         },
         "selectFile": "Выберите локальный аудиофайл (рекомендуется 15 секунд, макс. 30 секунд, формат wav/mp3)",
         "customPrefix": "Пользовательский префикс (Обязательно, для различения голосов)",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "此功能需要阿里国际版 CosyVoice 模型，请在API密钥设置页中保存阿里国际版API Key（不要求启用辅助API）",
         "minimaxApiRequired": "此功能需要MiniMax模型（国服），请在API密钥设置页中保存MiniMax API Key（不要求启用辅助API）",
         "minimaxIntlApiRequired": "此功能需要MiniMax模型（国际服），请在API密钥设置页中保存MiniMax国际服API Key（不要求启用辅助API）",
+        "mimoApiRequired": "此功能需要 MiMo 模型，请在 API 密钥设置页中保存 MiMo API Key",
         "providerLabel": "语音克隆服务商",
         "provider": {
             "cosyvoice": "阿里百炼 CosyVoice",
             "cosyvoice_intl": "阿里国际版 CosyVoice",
             "minimax": "MiniMax（国服）",
             "minimax_intl": "MiniMax（国际服）",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo（小米）"
         },
         "selectFile": "选择本地音频文件（8秒最佳，请勿超过20秒，wav/mp3格式）",
         "customPrefix": "自定义前缀（必填，用于区分音色）",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "此功能需要MiniMax模型（国服），请在API密钥设置页中保存MiniMax API Key（不要求启用辅助API）",
         "minimaxIntlApiRequired": "此功能需要MiniMax模型（国际服），请在API密钥设置页中保存MiniMax国际服API Key（不要求启用辅助API）",
         "mimoApiRequired": "此功能需要 MiMo 模型，请在 API 密钥设置页中保存 MiMo API Key",
+        "mimoDirectLinkUnsupported": "MiMo 暂不支持直链克隆，请改用本地文件上传",
         "providerLabel": "语音克隆服务商",
         "provider": {
             "cosyvoice": "阿里百炼 CosyVoice",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1534,13 +1534,15 @@
         "alibabaIntlApiRequired": "此功能需要阿里國際版 CosyVoice 模型，請在API密鑰設定頁中保存阿里國際版API Key（不要求啟用輔助API）",
         "minimaxApiRequired": "此功能需要MiniMax模型（中國），請在API密鑰設定頁中保存MiniMax API Key（不要求啟用輔助API）",
         "minimaxIntlApiRequired": "此功能需要MiniMax模型（國際版），請在API密鑰設定頁中保存MiniMax國際版API Key（不要求啟用輔助API）",
+        "mimoApiRequired": "此功能需要 MiMo 模型，請在 API 密鑰設置頁中保存 MiMo API Key",
         "providerLabel": "語音克隆服務商",
         "provider": {
             "cosyvoice": "阿里百煉 CosyVoice",
             "cosyvoice_intl": "阿里國際版 CosyVoice",
             "minimax": "MiniMax（中國）",
             "minimax_intl": "MiniMax（國際版）",
-            "elevenlabs": "ElevenLabs"
+            "elevenlabs": "ElevenLabs",
+            "mimo": "MiMo（小米）"
         },
         "selectFile": "選擇本地音頻文件（8秒最佳，請勿超過20秒，wav/mp3格式）",
         "customPrefix": "自定義前綴（必填，用於區分音色）",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1535,6 +1535,7 @@
         "minimaxApiRequired": "此功能需要MiniMax模型（中國），請在API密鑰設定頁中保存MiniMax API Key（不要求啟用輔助API）",
         "minimaxIntlApiRequired": "此功能需要MiniMax模型（國際版），請在API密鑰設定頁中保存MiniMax國際版API Key（不要求啟用輔助API）",
         "mimoApiRequired": "此功能需要 MiMo 模型，請在 API 密鑰設置頁中保存 MiMo API Key",
+        "mimoDirectLinkUnsupported": "MiMo 暫不支持直鏈克隆，請改用本地文件上傳",
         "providerLabel": "語音克隆服務商",
         "provider": {
             "cosyvoice": "阿里百煉 CosyVoice",

--- a/templates/voice_clone.html
+++ b/templates/voice_clone.html
@@ -44,6 +44,7 @@
                         <option value="minimax" data-i18n="voice.provider.minimax">MiniMax（国服）</option>
                         <option value="minimax_intl" data-i18n="voice.provider.minimax_intl">MiniMax（国际服）</option>
                         <option value="elevenlabs" data-i18n="voice.provider.elevenlabs">ElevenLabs</option>
+                        <option value="mimo" data-i18n="voice.provider.mimo">MiMo（小米）</option>
                     </select>
                 </div>
                 <div id="provider-notice" class="alibaba-api-notice" style="display: none;">

--- a/tests/frontend/test_voice_clone.py
+++ b/tests/frontend/test_voice_clone.py
@@ -12,6 +12,7 @@ VOICE_CLONE_API_PROVIDERS_RESPONSE = {
         "minimax": {"config_field": "assistApiKeyMinimax", "restricted": False},
         "minimax_intl": {"config_field": "assistApiKeyMinimaxIntl", "restricted": True},
         "elevenlabs": {"config_field": "assistApiKeyElevenlabs", "restricted": True},
+        "mimo": {"config_field": "assistApiKeyMimo", "restricted": False},
     },
 }
 
@@ -127,7 +128,7 @@ def test_voice_clone_provider_dropdown_defaults_to_mainland_when_region_indeterm
             const visibleValues = Array.from(select.options)
                 .filter(option => !option.hidden && option.style.display !== 'none')
                 .map(option => option.value);
-            return visibleValues.join(',') === 'cosyvoice,minimax';
+            return visibleValues.join(',') === 'cosyvoice,minimax,mimo';
         }"""
     )
 
@@ -135,7 +136,7 @@ def test_voice_clone_provider_dropdown_defaults_to_mainland_when_region_indeterm
     values = mock_page.locator("#voiceProvider-menu .api-provider-dropdown-option").evaluate_all(
         "(nodes) => nodes.map(node => node.dataset.value)"
     )
-    assert values == ["cosyvoice", "minimax"]
+    assert values == ["cosyvoice", "minimax", "mimo"]
 
 
 @pytest.mark.frontend
@@ -156,6 +157,6 @@ def test_voice_clone_provider_dropdown_defaults_to_mainland_when_region_request_
             const visibleValues = Array.from(select.options)
                 .filter(option => !option.hidden && option.style.display !== 'none')
                 .map(option => option.value);
-            return visibleValues.join(',') === 'cosyvoice,minimax';
+            return visibleValues.join(',') === 'cosyvoice,minimax,mimo';
         }"""
     )

--- a/tests/unit/test_elevenlabs_voice_design.py
+++ b/tests/unit/test_elevenlabs_voice_design.py
@@ -57,16 +57,13 @@ def test_get_tts_worker_routes_design_voice_via_elevenlabs(monkeypatch):
 
 
 @pytest.mark.unit
-def test_registry_declares_design_for_elevenlabs_and_clone_for_mimo():
+def test_registry_declares_design_for_elevenlabs():
     import utils.tts_provider_registry as reg
     el = reg.get("elevenlabs")
-    mimo = reg.get("mimo")
     assert el is not None and "design" in el.capabilities and "clone" in el.capabilities
-    assert mimo is not None and "clone" in mimo.capabilities and "preset" in mimo.capabilities
     # design is advertised in the UI metadata the source-first picker reads
     meta = {m["key"]: m for m in reg.ui_metadata()}
     assert "design" in meta["elevenlabs"]["capabilities"]
-    assert "clone" in meta["mimo"]["capabilities"]
 
 
 # ── router design helpers: design previews → create-from-preview ──────────────

--- a/tests/unit/test_elevenlabs_voice_design.py
+++ b/tests/unit/test_elevenlabs_voice_design.py
@@ -1,0 +1,140 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ElevenLabs voice design (text description → generated voice).
+
+design lands as a normal ElevenLabs voice (source='design') and reuses the
+existing ElevenLabs clone dispatch path, so no separate worker is needed.
+"""
+
+import json
+from functools import partial
+
+import httpx
+import pytest
+
+from main_logic import tts_client
+
+
+# ── dispatch: a design voice routes through the ElevenLabs clone path ─────────
+
+@pytest.mark.unit
+def test_get_tts_worker_routes_design_voice_via_elevenlabs(monkeypatch):
+    class _CM:
+        def get_core_config(self):
+            return {"assistApi": "qwen", "TTS_PROVIDER": "", "GPTSOVITS_ENABLED": False}
+
+        def get_model_api_config(self, model_type):
+            return {"is_custom": False}
+
+        def get_tts_api_key(self, provider):
+            return "el-key" if provider == "elevenlabs" else None
+
+        def get_voices_for_current_api(self, for_listing=False):
+            return {"eleven:designed1": {"provider": "elevenlabs", "source": "design"}}
+
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen", has_custom_voice=True, voice_id="eleven:designed1",
+    )
+
+    assert isinstance(worker, partial)
+    assert worker.func is tts_client.elevenlabs_tts_worker
+    assert provider_key == "elevenlabs"
+    assert api_key == "el-key"
+
+
+@pytest.mark.unit
+def test_registry_declares_design_for_elevenlabs_and_clone_for_mimo():
+    import utils.tts_provider_registry as reg
+    el = reg.get("elevenlabs")
+    mimo = reg.get("mimo")
+    assert el is not None and "design" in el.capabilities and "clone" in el.capabilities
+    assert mimo is not None and "clone" in mimo.capabilities and "preset" in mimo.capabilities
+    # design is advertised in the UI metadata the source-first picker reads
+    meta = {m["key"]: m for m in reg.ui_metadata()}
+    assert "design" in meta["elevenlabs"]["capabilities"]
+    assert "clone" in meta["mimo"]["capabilities"]
+
+
+# ── router design helpers: design previews → create-from-preview ──────────────
+
+class _FakeElevenTransport(httpx.AsyncBaseTransport):
+    def __init__(self):
+        self.requests = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else {}
+        path = request.url.path
+        self.requests.append({"path": path, "body": body, "headers": dict(request.headers)})
+        if path.endswith("/text-to-voice/design"):
+            return httpx.Response(200, json={
+                "previews": [
+                    {"generated_voice_id": "gen-1", "audio_base_64": "QUJD", "media_type": "audio/mpeg", "duration_secs": 1.2},
+                    {"generated_voice_id": "gen-2", "audio_base_64": "REVG", "media_type": "audio/mpeg", "duration_secs": 1.1},
+                ],
+                "text": "hello there",
+            })
+        if path.endswith("/text-to-voice"):
+            return httpx.Response(200, json={"voice_id": "vox123"})
+        return httpx.Response(404, json={"error": "unexpected"})
+
+
+@pytest.mark.unit
+async def test_elevenlabs_design_previews_and_create(monkeypatch):
+    from main_routers import characters_router as cr
+
+    transport = _FakeElevenTransport()
+    original = httpx.AsyncClient
+
+    def patched(*args, **kwargs):
+        kwargs["transport"] = transport
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cr.httpx, "AsyncClient", patched)
+
+    previews = await cr._elevenlabs_design_previews(
+        api_key="el-key", base_url="https://api.elevenlabs.io",
+        voice_description="a warm, gentle young woman with a soft voice",
+    )
+    assert [p["generated_voice_id"] for p in previews] == ["gen-1", "gen-2"]
+    design_req = transport.requests[0]
+    assert design_req["path"].endswith("/v1/text-to-voice/design")
+    assert design_req["body"]["voice_description"].startswith("a warm")
+    assert design_req["body"]["auto_generate_text"] is True
+    assert design_req["headers"]["xi-api-key"] == "el-key"
+
+    voice_id = await cr._elevenlabs_create_voice_from_preview(
+        api_key="el-key", base_url="https://api.elevenlabs.io",
+        voice_name="Aria", voice_description="a warm, gentle young woman",
+        generated_voice_id="gen-1",
+    )
+    # create-from-preview yields a normal (prefixed) ElevenLabs voice id
+    assert voice_id == "eleven:vox123"
+    create_req = transport.requests[1]
+    assert create_req["path"].endswith("/v1/text-to-voice")
+    assert create_req["body"]["generated_voice_id"] == "gen-1"
+    assert create_req["body"]["voice_name"] == "Aria"
+
+
+@pytest.mark.unit
+def test_voice_design_description_validation():
+    from main_routers import characters_router as cr
+    _, too_short = cr._validate_voice_design_description("short")
+    assert too_short is not None and too_short.status_code == 400
+    desc, ok = cr._validate_voice_design_description("a warm gentle young woman voice")
+    assert ok is None and desc.startswith("a warm")
+    _, too_long = cr._validate_voice_design_description("x" * 1001)
+    assert too_long is not None and too_long.status_code == 400

--- a/tests/unit/test_elevenlabs_voice_design.py
+++ b/tests/unit/test_elevenlabs_voice_design.py
@@ -113,7 +113,10 @@ async def test_elevenlabs_design_previews_and_create(monkeypatch):
     design_req = transport.requests[0]
     assert design_req["path"].endswith("/v1/text-to-voice/design")
     assert design_req["body"]["voice_description"].startswith("a warm")
-    assert design_req["body"]["auto_generate_text"] is True
+    # text (≥100 chars) must be sent so previews carry audible audio; auto_generate_text
+    # (ids-only, no audio) must NOT be used.
+    assert "auto_generate_text" not in design_req["body"]
+    assert len(design_req["body"]["text"]) >= 100
     assert design_req["headers"]["xi-api-key"] == "el-key"
 
     voice_id = await cr._elevenlabs_create_voice_from_preview(

--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -133,6 +133,20 @@ def test_mimo_worker_clone_uses_voiceclone_model_and_inlines_sample(monkeypatch)
 
 # ── dispatch: a MiMo clone voice routes to the voiceclone worker ──────────────
 
+def _mimo_clone_meta(sample: bytes, **extra):
+    """A MiMo clone voice_meta with the reference sample stored as base64 (the
+    B-storage model: clone identity lives entirely in voice_storage.json, dual to
+    MiniMax's remote voice_id)."""
+    meta = {
+        "provider": "mimo",
+        "source": "clone",
+        "clone_sample_b64": base64.b64encode(sample).decode("ascii"),
+        "clone_sample_mime": "audio/wav",
+    }
+    meta.update(extra)
+    return meta
+
+
 @pytest.mark.unit
 def test_get_tts_worker_routes_mimo_clone_voice(monkeypatch):
     sample = (np.arange(256, dtype=np.int16)).tobytes()
@@ -149,18 +163,7 @@ def test_get_tts_worker_routes_mimo_clone_voice(monkeypatch):
             return "mimo-key"
 
         def get_voices_for_current_api(self, for_listing=False):
-            return {
-                "mimo-clone-abc": {
-                    "provider": "mimo",
-                    "source": "clone",
-                    "clone_sample_file": "mimo-key-mimo-clone-abc.wav",
-                    "clone_sample_mime": "audio/wav",
-                }
-            }
-
-        def load_voice_clone_sample(self, filename):
-            assert filename == "mimo-key-mimo-clone-abc.wav"
-            return sample
+            return {"mimo-clone-abc": _mimo_clone_meta(sample)}
 
     monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
 
@@ -173,6 +176,7 @@ def test_get_tts_worker_routes_mimo_clone_voice(monkeypatch):
     assert provider_key == "mimo"
     assert api_key == "mimo-key"
     assert worker.keywords["base_url"] is None
+    # the stored value is already base64 → the data URI just frames it (no re-encode)
     expected_uri = "data:audio/wav;base64," + base64.b64encode(sample).decode("ascii")
     assert worker.keywords["clone_voice"] == expected_uri
 
@@ -200,11 +204,8 @@ def test_get_tts_worker_mimo_clone_uses_token_plan_base_url(monkeypatch):
             return "mimo-token-plan-key"
 
         def get_voices_for_current_api(self, for_listing=False):
-            return {"mimo-clone-tp": {"provider": "mimo", "source": "clone",
-                                      "clone_sample_file": "s.wav", "clone_sample_mime": "audio/wav"}}
-
-        def load_voice_clone_sample(self, filename):
-            return sample
+            # stale stored base_url must be ignored in favor of the fresh token-plan endpoint
+            return {"mimo-clone-tp": _mimo_clone_meta(sample, mimo_base_url="https://api.xiaomimimo.com/v1")}
 
     monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
 
@@ -215,6 +216,33 @@ def test_get_tts_worker_mimo_clone_uses_token_plan_base_url(monkeypatch):
     assert api_key == "mimo-token-plan-key"
     assert worker.keywords["base_url"] == "https://token-plan-cn.xiaomimimo.com/v1"
     assert worker.keywords["clone_voice"].startswith("data:audio/wav;base64,")
+
+
+@pytest.mark.unit
+def test_get_tts_worker_mimo_clone_uses_stored_base_url_when_not_assist(monkeypatch):
+    """When MiMo isn't the assist API, the clone path uses the base_url stored in
+    voice_meta (dual to minimax_base_url)."""
+    sample = (np.arange(32, dtype=np.int16)).tobytes()
+
+    class _CM:
+        def get_core_config(self):
+            return {"assistApi": "qwen", "TTS_PROVIDER": "", "GPTSOVITS_ENABLED": False}
+
+        def get_model_api_config(self, model_type):
+            return {"is_custom": False}
+
+        def get_tts_api_key(self, provider):
+            return "mimo-key"
+
+        def get_voices_for_current_api(self, for_listing=False):
+            return {"mimo-clone-s": _mimo_clone_meta(sample, mimo_base_url="https://custom.mimo.example/v1")}
+
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
+    worker, _, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen", has_custom_voice=True, voice_id="mimo-clone-s",
+    )
+    assert provider_key == "mimo"
+    assert worker.keywords["base_url"] == "https://custom.mimo.example/v1"
 
 
 @pytest.mark.unit
@@ -230,10 +258,7 @@ def test_get_tts_worker_mimo_clone_missing_sample_falls_back_to_dummy(monkeypatc
             return "mimo-key"
 
         def get_voices_for_current_api(self, for_listing=False):
-            return {"mimo-clone-x": {"provider": "mimo", "source": "clone", "clone_sample_file": "gone.wav"}}
-
-        def load_voice_clone_sample(self, filename):
-            return None  # sample file missing
+            return {"mimo-clone-x": {"provider": "mimo", "source": "clone"}}  # no sample b64
 
     monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
 
@@ -302,26 +327,62 @@ def test_infer_provider_from_mimo_storage_key():
     assert cm._infer_provider_from_storage_key("__MIMO__abcd1234") == "mimo"
 
 
-# ── config_manager: reference-sample persistence roundtrip ────────────────────
+# ── config_manager: heavy sample base64 is stripped from the /voices listing ──
 
 @pytest.mark.unit
-def test_voice_clone_sample_roundtrip(monkeypatch, tmp_path):
+def test_get_voices_strips_sample_b64_for_listing(monkeypatch):
+    """dispatch (for_listing=False) needs the sample base64; the UI list
+    (for_listing=True) must not ship the MB-sized blob to the frontend."""
     cm = get_config_manager()
-    monkeypatch.setattr(cm, "config_dir", tmp_path)
-    stored = cm.save_voice_clone_sample("mimo-key-voice.wav", b"reference-bytes")
-    assert stored == "mimo-key-voice.wav"
-    assert cm.load_voice_clone_sample(stored) == b"reference-bytes"
-    assert cm.delete_voice_clone_sample(stored) is True
-    assert cm.load_voice_clone_sample(stored) is None
-    # idempotent delete
-    assert cm.delete_voice_clone_sample(stored) is False
+    monkeypatch.setattr(cm, "get_tts_api_key", lambda p: "mimokey12345678" if p == "mimo" else None)
+    monkeypatch.setattr(cm, "load_voice_storage", lambda: {
+        "__MIMO__12345678": {"mimo-clone-x": {"source": "clone", "clone_sample_b64": "QUJDRA==", "clone_sample_mime": "audio/wav"}}
+    })
+    monkeypatch.setattr(cm, "get_model_api_config", lambda t: {})
+    monkeypatch.setattr(cm, "get_core_config", lambda: {})
+    monkeypatch.setattr(cm, "_is_local_tts_storage_active", lambda *a, **k: False)
+    monkeypatch.setattr(cm, "is_free_voice", lambda: False)
+    monkeypatch.setattr(cm, "_get_cosyvoice_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_minimax_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_elevenlabs_storage_keys", lambda: [])
 
+    full = cm.get_voices_for_current_api(for_listing=False)
+    assert full["mimo-clone-x"]["clone_sample_b64"] == "QUJDRA=="
+
+    listing = cm.get_voices_for_current_api(for_listing=True)
+    assert "clone_sample_b64" not in listing["mimo-clone-x"]
+    # other metadata survives
+    assert listing["mimo-clone-x"]["provider"] == "mimo"
+    assert listing["mimo-clone-x"]["clone_sample_mime"] == "audio/wav"
+
+
+# ── MiMo preview client (dual to MiniMax's synthesize_preview) ────────────────
 
 @pytest.mark.unit
-def test_voice_clone_sample_rejects_path_traversal(monkeypatch, tmp_path):
-    cm = get_config_manager()
-    monkeypatch.setattr(cm, "config_dir", tmp_path)
-    # basename strips any directory components, keeping writes inside the sample dir
-    stored = cm.save_voice_clone_sample("../escape.wav", b"x")
-    assert "/" not in stored and "\\" not in stored
-    assert (tmp_path / "voice_clone_samples" / "escape.wav").exists()
+async def test_mimo_synthesize_preview_returns_audio(monkeypatch):
+    from utils.voice_clone import MimoVoiceCloneClient
+
+    pcm = (np.arange(128, dtype=np.int16)).tobytes()
+
+    class _FakeTransport(httpx.AsyncBaseTransport):
+        def __init__(self):
+            self.body = None
+
+        async def handle_async_request(self, request):
+            self.body = json.loads(request.content)
+            return httpx.Response(200, json={
+                "choices": [{"message": {"audio": {"data": base64.b64encode(pcm).decode("ascii")}}}]
+            })
+
+    transport = _FakeTransport()
+    original = httpx.AsyncClient
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: original(*a, **{**k, "transport": transport}))
+
+    client = MimoVoiceCloneClient(api_key="mimo-key")
+    audio = await client.synthesize_preview(b"sample-bytes", "audio/wav", text="测试")
+    assert audio == pcm
+    # preview is a non-stream wav request against the voiceclone model
+    assert transport.body["model"] == "mimo-v2.5-tts-voiceclone"
+    assert transport.body["stream"] is False
+    assert transport.body["audio"]["format"] == "wav"
+    assert transport.body["audio"]["voice"].startswith("data:audio/wav;base64,")

--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -1,0 +1,257 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MiMo voiceclone enrollment + dispatch (dual to cosyvoice/minimax).
+
+MiMo has no remote cloned voice id: the reference sample is persisted locally and
+inlined per synthesis request via ``audio.voice`` against the voiceclone model.
+"""
+
+import base64
+import json
+import queue
+import threading
+import time
+from functools import partial
+
+import httpx
+import numpy as np
+import pytest
+
+from main_logic import tts_client
+from utils.config_manager import get_config_manager
+
+
+class ControlledQueue:
+    def __init__(self):
+        self._queue = queue.Queue()
+        self._stop = object()
+
+    def put(self, item):
+        self._queue.put(item)
+
+    def get(self, timeout=None):
+        item = self._queue.get(timeout=timeout)
+        if item is self._stop:
+            raise EOFError("queue closed")
+        return item
+
+    def close(self):
+        self._queue.put(self._stop)
+
+
+def _wait_for_queue_item(q, predicate, timeout=5.0):
+    deadline = time.time() + timeout
+    seen = []
+    while time.time() < deadline:
+        remaining = max(0.01, deadline - time.time())
+        try:
+            item = q.get(timeout=remaining)
+        except queue.Empty:
+            continue
+        seen.append(item)
+        if predicate(item):
+            return item, seen
+    raise AssertionError(f"Timed out waiting for queue item, seen={seen!r}")
+
+
+class FakeMiMoTransport(httpx.AsyncBaseTransport):
+    def __init__(self, audio_bytes: bytes, status_code: int = 200):
+        self.audio_bytes = audio_bytes
+        self.status_code = status_code
+        self.requests = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else {}
+        self.requests.append({"url": str(request.url), "body": body})
+        if self.status_code != 200:
+            return httpx.Response(self.status_code, json={"error": "bad"})
+        event = {"choices": [{"delta": {"audio": {"data": base64.b64encode(self.audio_bytes).decode("ascii")}}}]}
+        return httpx.Response(
+            200,
+            content=f"data: {json.dumps(event)}\n\ndata: [DONE]\n\n".encode("utf-8"),
+            headers={"content-type": "text/event-stream"},
+        )
+
+
+# ── worker: clone uses the voiceclone model + inlines the reference data URI ──
+
+@pytest.mark.unit
+def test_mimo_worker_clone_uses_voiceclone_model_and_inlines_sample(monkeypatch):
+    pcm_bytes = (np.arange(3000, dtype=np.int16)).tobytes()
+    transport = FakeMiMoTransport(pcm_bytes)
+    original_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    clone_uri = "data:audio/wav;base64,QUJDRA=="
+    request_queue = ControlledQueue()
+    response_queue = queue.Queue()
+    thread = threading.Thread(
+        target=tts_client.mimo_tts_worker,
+        kwargs={
+            "request_queue": request_queue,
+            "response_queue": response_queue,
+            "audio_api_key": "mimo-key",
+            "voice_id": "mimo-clone-abc",  # local id, ignored in clone mode
+            "base_url": None,
+            "clone_voice": clone_uri,
+        },
+        daemon=True,
+    )
+    thread.start()
+
+    _wait_for_queue_item(response_queue, lambda item: item == ("__ready__", True))
+    request_queue.put(("speech-1", "你好"))
+    request_queue.put((None, None))
+    _wait_for_queue_item(response_queue, lambda item: isinstance(item, bytes))
+
+    assert len(transport.requests) == 1
+    body = transport.requests[0]["body"]
+    assert body["model"] == "mimo-v2.5-tts-voiceclone"
+    assert body["audio"] == {"format": "pcm16", "voice": clone_uri}
+
+    request_queue.close()
+    thread.join(timeout=3.0)
+    assert not thread.is_alive()
+
+
+# ── dispatch: a MiMo clone voice routes to the voiceclone worker ──────────────
+
+@pytest.mark.unit
+def test_get_tts_worker_routes_mimo_clone_voice(monkeypatch):
+    sample = (np.arange(256, dtype=np.int16)).tobytes()
+
+    class _CM:
+        def get_core_config(self):
+            return {"assistApi": "qwen", "TTS_PROVIDER": "", "GPTSOVITS_ENABLED": False}
+
+        def get_model_api_config(self, model_type):
+            return {"is_custom": False}
+
+        def get_tts_api_key(self, provider):
+            assert provider == "mimo"
+            return "mimo-key"
+
+        def get_voices_for_current_api(self, for_listing=False):
+            return {
+                "mimo-clone-abc": {
+                    "provider": "mimo",
+                    "source": "clone",
+                    "clone_sample_file": "mimo-key-mimo-clone-abc.wav",
+                    "clone_sample_mime": "audio/wav",
+                }
+            }
+
+        def load_voice_clone_sample(self, filename):
+            assert filename == "mimo-key-mimo-clone-abc.wav"
+            return sample
+
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen", has_custom_voice=True, voice_id="mimo-clone-abc",
+    )
+
+    assert isinstance(worker, partial)
+    assert worker.func is tts_client.mimo_tts_worker
+    assert provider_key == "mimo"
+    assert api_key == "mimo-key"
+    assert worker.keywords["base_url"] is None
+    expected_uri = "data:audio/wav;base64," + base64.b64encode(sample).decode("ascii")
+    assert worker.keywords["clone_voice"] == expected_uri
+
+
+@pytest.mark.unit
+def test_get_tts_worker_mimo_clone_missing_sample_falls_back_to_dummy(monkeypatch):
+    class _CM:
+        def get_core_config(self):
+            return {"assistApi": "qwen", "TTS_PROVIDER": "", "GPTSOVITS_ENABLED": False}
+
+        def get_model_api_config(self, model_type):
+            return {"is_custom": False}
+
+        def get_tts_api_key(self, provider):
+            return "mimo-key"
+
+        def get_voices_for_current_api(self, for_listing=False):
+            return {"mimo-clone-x": {"provider": "mimo", "source": "clone", "clone_sample_file": "gone.wav"}}
+
+        def load_voice_clone_sample(self, filename):
+            return None  # sample file missing
+
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen", has_custom_voice=True, voice_id="mimo-clone-x",
+    )
+    assert worker is tts_client.dummy_tts_worker
+    assert provider_key is None
+
+
+# ── config_manager: __MIMO__ bucket merges into the current-API voice list ────
+
+@pytest.mark.unit
+def test_get_voices_merges_mimo_bucket(monkeypatch):
+    cm = get_config_manager()
+    monkeypatch.setattr(cm, "get_tts_api_key", lambda p: "mimokey12345678" if p == "mimo" else None)
+    monkeypatch.setattr(cm, "load_voice_storage", lambda: {
+        "__MIMO__12345678": {"mimo-clone-x": {"source": "clone"}}  # provider stamped by merge
+    })
+    monkeypatch.setattr(cm, "get_model_api_config", lambda t: {})
+    monkeypatch.setattr(cm, "get_core_config", lambda: {})
+    monkeypatch.setattr(cm, "_is_local_tts_storage_active", lambda *a, **k: False)
+    monkeypatch.setattr(cm, "is_free_voice", lambda: False)
+    monkeypatch.setattr(cm, "_get_cosyvoice_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_minimax_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_elevenlabs_storage_keys", lambda: [])
+
+    voices = cm.get_voices_for_current_api()
+    assert "mimo-clone-x" in voices
+    assert voices["mimo-clone-x"]["provider"] == "mimo"
+
+
+@pytest.mark.unit
+def test_infer_provider_from_mimo_storage_key():
+    cm = get_config_manager()
+    assert cm._infer_provider_from_storage_key("__MIMO__abcd1234") == "mimo"
+
+
+# ── config_manager: reference-sample persistence roundtrip ────────────────────
+
+@pytest.mark.unit
+def test_voice_clone_sample_roundtrip(monkeypatch, tmp_path):
+    cm = get_config_manager()
+    monkeypatch.setattr(cm, "config_dir", tmp_path)
+    stored = cm.save_voice_clone_sample("mimo-key-voice.wav", b"reference-bytes")
+    assert stored == "mimo-key-voice.wav"
+    assert cm.load_voice_clone_sample(stored) == b"reference-bytes"
+    assert cm.delete_voice_clone_sample(stored) is True
+    assert cm.load_voice_clone_sample(stored) is None
+    # idempotent delete
+    assert cm.delete_voice_clone_sample(stored) is False
+
+
+@pytest.mark.unit
+def test_voice_clone_sample_rejects_path_traversal(monkeypatch, tmp_path):
+    cm = get_config_manager()
+    monkeypatch.setattr(cm, "config_dir", tmp_path)
+    # basename strips any directory components, keeping writes inside the sample dir
+    stored = cm.save_voice_clone_sample("../escape.wav", b"x")
+    assert "/" not in stored and "\\" not in stored
+    assert (tmp_path / "voice_clone_samples" / "escape.wav").exists()

--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -178,6 +178,46 @@ def test_get_tts_worker_routes_mimo_clone_voice(monkeypatch):
 
 
 @pytest.mark.unit
+def test_get_tts_worker_mimo_clone_uses_token_plan_base_url(monkeypatch):
+    """When MiMo Token Plan is active (assistApi=mimo), get_core_config resolves
+    OPENROUTER_URL to the token-plan endpoint and get_tts_api_key returns the
+    token-plan key — the clone path must pair the two (not hit the default host)."""
+    sample = (np.arange(64, dtype=np.int16)).tobytes()
+
+    class _CM:
+        def get_core_config(self):
+            return {
+                "assistApi": "mimo",
+                "OPENROUTER_URL": "https://token-plan-cn.xiaomimimo.com/v1",
+                "TTS_PROVIDER": "",
+                "GPTSOVITS_ENABLED": False,
+            }
+
+        def get_model_api_config(self, model_type):
+            return {"is_custom": False}
+
+        def get_tts_api_key(self, provider):
+            return "mimo-token-plan-key"
+
+        def get_voices_for_current_api(self, for_listing=False):
+            return {"mimo-clone-tp": {"provider": "mimo", "source": "clone",
+                                      "clone_sample_file": "s.wav", "clone_sample_mime": "audio/wav"}}
+
+        def load_voice_clone_sample(self, filename):
+            return sample
+
+    monkeypatch.setattr(tts_client, "get_config_manager", lambda: _CM())
+
+    worker, api_key, provider_key = tts_client.get_tts_worker(
+        core_api_type="qwen", has_custom_voice=True, voice_id="mimo-clone-tp",
+    )
+    assert provider_key == "mimo"
+    assert api_key == "mimo-token-plan-key"
+    assert worker.keywords["base_url"] == "https://token-plan-cn.xiaomimimo.com/v1"
+    assert worker.keywords["clone_voice"].startswith("data:audio/wav;base64,")
+
+
+@pytest.mark.unit
 def test_get_tts_worker_mimo_clone_missing_sample_falls_back_to_dummy(monkeypatch):
     class _CM:
         def get_core_config(self):

--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -313,6 +313,41 @@ def test_mimo_chat_completions_url_maps_ws_to_https_not_plaintext():
 
 
 @pytest.mark.unit
+def test_extract_mimo_audio_bytes_tolerates_non_string_audio():
+    from utils.voice_clone import _extract_mimo_audio_bytes
+    # a malformed upstream payload (audio.data is a number/list) must not raise TypeError
+    assert _extract_mimo_audio_bytes({"choices": [{"message": {"audio": {"data": 12345}}}]}) == b""
+    assert _extract_mimo_audio_bytes({"choices": [{"message": {"audio": {"data": ["x"]}}}]}) == b""
+
+
+@pytest.mark.unit
+async def test_mimo_validate_sample_requires_audio(monkeypatch):
+    from utils.voice_clone import MimoVoiceCloneClient, MimoVoiceCloneError
+
+    class _Transport(httpx.AsyncBaseTransport):
+        def __init__(self, with_audio):
+            self.with_audio = with_audio
+
+        async def handle_async_request(self, request):
+            if self.with_audio:
+                return httpx.Response(200, json={
+                    "choices": [{"message": {"audio": {"data": base64.b64encode(b"abc").decode()}}}]
+                })
+            return httpx.Response(200, json={"choices": [{"message": {"content": "no audio here"}}]})
+
+    original = httpx.AsyncClient
+
+    # 200 but no audio → enrollment must fail
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: original(*a, **{**k, "transport": _Transport(False)}))
+    with pytest.raises(MimoVoiceCloneError):
+        await MimoVoiceCloneClient(api_key="k").validate_sample(b"s", "audio/wav")
+
+    # 200 with audio → passes
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: original(*a, **{**k, "transport": _Transport(True)}))
+    await MimoVoiceCloneClient(api_key="k").validate_sample(b"s", "audio/wav")
+
+
+@pytest.mark.unit
 def test_mimo_voice_clone_data_uri_falls_back_on_blank_mime():
     from utils.mimo_tts_voices import mimo_voice_clone_data_uri
     # whitespace-only / empty mime must fall back to audio/wav, never "data:;base64,"

--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -267,6 +267,15 @@ def test_get_voices_merges_mimo_bucket(monkeypatch):
 
 
 @pytest.mark.unit
+def test_mimo_voice_clone_data_uri_falls_back_on_blank_mime():
+    from utils.mimo_tts_voices import mimo_voice_clone_data_uri
+    # whitespace-only / empty mime must fall back to audio/wav, never "data:;base64,"
+    assert mimo_voice_clone_data_uri(b"x", "   ").startswith("data:audio/wav;base64,")
+    assert mimo_voice_clone_data_uri(b"x", "").startswith("data:audio/wav;base64,")
+    assert mimo_voice_clone_data_uri(b"x", "audio/mpeg").startswith("data:audio/mpeg;base64,")
+
+
+@pytest.mark.unit
 def test_infer_provider_from_mimo_storage_key():
     cm = get_config_manager()
     assert cm._infer_provider_from_storage_key("__MIMO__abcd1234") == "mimo"

--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -267,6 +267,27 @@ def test_get_voices_merges_mimo_bucket(monkeypatch):
 
 
 @pytest.mark.unit
+def test_registry_declares_clone_and_preset_for_mimo():
+    import utils.tts_provider_registry as reg
+    mimo = reg.get("mimo")
+    assert mimo is not None and "clone" in mimo.capabilities and "preset" in mimo.capabilities
+    # clone is advertised in the UI metadata the source-first picker reads
+    meta = {m["key"]: m for m in reg.ui_metadata()}
+    assert "clone" in meta["mimo"]["capabilities"]
+
+
+@pytest.mark.unit
+def test_mimo_chat_completions_url_maps_ws_to_https_not_plaintext():
+    from utils.mimo_tts_voices import mimo_chat_completions_url
+    # ws:// must NOT downgrade to plaintext http:// (the api-key header would leak);
+    # it maps to https:// just like wss://.
+    assert mimo_chat_completions_url("ws://api.xiaomimimo.com/v1").startswith("https://")
+    assert mimo_chat_completions_url("wss://api.xiaomimimo.com/v1").startswith("https://")
+    # an explicitly-configured http:// (local proxy) is left as-is
+    assert mimo_chat_completions_url("http://localhost:8000/v1").startswith("http://localhost")
+
+
+@pytest.mark.unit
 def test_mimo_voice_clone_data_uri_falls_back_on_blank_mime():
     from utils.mimo_tts_voices import mimo_voice_clone_data_uri
     # whitespace-only / empty mime must fall back to audio/wav, never "data:;base64,"

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2609,65 +2609,6 @@ class ConfigManager:
             logger.error("保存音色配置失败: %s", e)
             raise
 
-    # ── Voice-clone reference samples (on disk, not in voice_storage.json) ──────
-    # Some clone providers have no server-side cloned voice id and must re-send the
-    # reference audio on every synthesis (MiMo: ``audio.voice`` data URI). The
-    # sample (a few hundred KB) is persisted as a file here, and only its filename
-    # is stored in voice_meta, so voice_storage.json stays small and fast to load
-    # (it is read on every /voices call and the validate/cleanup chain).
-
-    def get_voice_clone_sample_dir(self):
-        """Directory holding persisted voice-clone reference samples (created lazily)."""
-        sample_dir = self.config_dir / "voice_clone_samples"
-        try:
-            sample_dir.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
-            logger.error("创建语音克隆样本目录失败: %s", e)
-        return sample_dir
-
-    def save_voice_clone_sample(self, filename: str, audio_bytes: bytes) -> str:
-        """Persist a reference sample and return the stored filename.
-
-        ``filename`` must be a bare name (no path separators); callers build it
-        from the provider + voice_id. Returns the filename actually stored."""
-        safe_name = os.path.basename(str(filename or '').strip())
-        if not safe_name:
-            raise ValueError("voice clone 样本文件名不能为空")
-        path = self.get_voice_clone_sample_dir() / safe_name
-        with open(path, 'wb') as f:
-            f.write(audio_bytes)
-        return safe_name
-
-    def load_voice_clone_sample(self, filename: str) -> bytes | None:
-        """Read a persisted reference sample by filename, or None when missing."""
-        safe_name = os.path.basename(str(filename or '').strip())
-        if not safe_name:
-            return None
-        path = self.get_voice_clone_sample_dir() / safe_name
-        try:
-            with open(path, 'rb') as f:
-                return f.read()
-        except FileNotFoundError:
-            return None
-        except Exception as e:
-            logger.warning("读取语音克隆样本失败 (%s): %s", safe_name, e)
-            return None
-
-    def delete_voice_clone_sample(self, filename: str) -> bool:
-        """Delete a persisted reference sample by filename. Idempotent."""
-        safe_name = os.path.basename(str(filename or '').strip())
-        if not safe_name:
-            return False
-        path = self.get_voice_clone_sample_dir() / safe_name
-        try:
-            path.unlink()
-            return True
-        except FileNotFoundError:
-            return False
-        except Exception as e:
-            logger.warning("删除语音克隆样本失败 (%s): %s", safe_name, e)
-            return False
-
     @staticmethod
     def is_legacy_cosyvoice_id(voice_id: str) -> bool:
         """CosyVoice v2 / v3 cloned voice IDs became invalid with the CosyVoice 3.5 upgrade."""
@@ -3078,6 +3019,15 @@ class ConfigManager:
                         vdata['provider'] = 'mimo'
                     result[vid] = vdata
 
+        if for_listing:
+            # UI 试听列表不需要 MiMo 克隆的参考样本 base64（可达 MB）——剥掉，避免把大 blob
+            # 推给前端。dispatch / preview 走 for_listing=False，仍拿到完整 voice_meta。
+            result = {
+                vid: ({k: v for k, v in vdata.items() if k != 'clone_sample_b64'}
+                      if isinstance(vdata, dict) and 'clone_sample_b64' in vdata else vdata)
+                for vid, vdata in result.items()
+            }
+
         return result
 
     def save_voice_for_current_api(self, voice_id, voice_data):
@@ -3192,15 +3142,10 @@ class ConfigManager:
                 or storage_key.startswith('__MIMO__')
                 or storage_key.startswith('__COSYVOICE_INTL__')
             ) and voice_id in voice_storage.get(storage_key, {}):
-                removed = voice_storage[storage_key].pop(voice_id, None)
-                # 先持久化元数据删除，再清本地样本——顺序很关键：若 save 抛错（cloudsave
-                # write fence / 磁盘错误），样本仍在，voice_storage.json 也仍指向它，状态一致；
-                # 反序（先删样本再 save）一旦 save 失败就留下指向缺失样本的元数据，合成退化 dummy。
+                # 克隆身份（含 MiMo 的样本 base64）都在 voice_data 里，删除 entry 随之消失，
+                # 无旁路本地文件需清理（对偶 MiniMax/ElevenLabs）。
+                del voice_storage[storage_key][voice_id]
                 self.save_voice_storage(voice_storage)
-                # MiMo 克隆把参考样本存在本地（非 voice_storage.json）；删音色时一并清理，
-                # 避免样本文件孤儿堆积。
-                if isinstance(removed, dict) and removed.get('clone_sample_file'):
-                    self.delete_voice_clone_sample(removed.get('clone_sample_file'))
                 return True
 
         # 再检查当前阿里国内/国际 API Key 的原始分区

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3193,11 +3193,14 @@ class ConfigManager:
                 or storage_key.startswith('__COSYVOICE_INTL__')
             ) and voice_id in voice_storage.get(storage_key, {}):
                 removed = voice_storage[storage_key].pop(voice_id, None)
+                # 先持久化元数据删除，再清本地样本——顺序很关键：若 save 抛错（cloudsave
+                # write fence / 磁盘错误），样本仍在，voice_storage.json 也仍指向它，状态一致；
+                # 反序（先删样本再 save）一旦 save 失败就留下指向缺失样本的元数据，合成退化 dummy。
+                self.save_voice_storage(voice_storage)
                 # MiMo 克隆把参考样本存在本地（非 voice_storage.json）；删音色时一并清理，
                 # 避免样本文件孤儿堆积。
                 if isinstance(removed, dict) and removed.get('clone_sample_file'):
                     self.delete_voice_clone_sample(removed.get('clone_sample_file'))
-                self.save_voice_storage(voice_storage)
                 return True
 
         # 再检查当前阿里国内/国际 API Key 的原始分区

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2609,6 +2609,65 @@ class ConfigManager:
             logger.error("保存音色配置失败: %s", e)
             raise
 
+    # ── Voice-clone reference samples (on disk, not in voice_storage.json) ──────
+    # Some clone providers have no server-side cloned voice id and must re-send the
+    # reference audio on every synthesis (MiMo: ``audio.voice`` data URI). The
+    # sample (a few hundred KB) is persisted as a file here, and only its filename
+    # is stored in voice_meta, so voice_storage.json stays small and fast to load
+    # (it is read on every /voices call and the validate/cleanup chain).
+
+    def get_voice_clone_sample_dir(self):
+        """Directory holding persisted voice-clone reference samples (created lazily)."""
+        sample_dir = self.config_dir / "voice_clone_samples"
+        try:
+            sample_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            logger.error("创建语音克隆样本目录失败: %s", e)
+        return sample_dir
+
+    def save_voice_clone_sample(self, filename: str, audio_bytes: bytes) -> str:
+        """Persist a reference sample and return the stored filename.
+
+        ``filename`` must be a bare name (no path separators); callers build it
+        from the provider + voice_id. Returns the filename actually stored."""
+        safe_name = os.path.basename(str(filename or '').strip())
+        if not safe_name:
+            raise ValueError("voice clone 样本文件名不能为空")
+        path = self.get_voice_clone_sample_dir() / safe_name
+        with open(path, 'wb') as f:
+            f.write(audio_bytes)
+        return safe_name
+
+    def load_voice_clone_sample(self, filename: str) -> bytes | None:
+        """Read a persisted reference sample by filename, or None when missing."""
+        safe_name = os.path.basename(str(filename or '').strip())
+        if not safe_name:
+            return None
+        path = self.get_voice_clone_sample_dir() / safe_name
+        try:
+            with open(path, 'rb') as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            logger.warning("读取语音克隆样本失败 (%s): %s", safe_name, e)
+            return None
+
+    def delete_voice_clone_sample(self, filename: str) -> bool:
+        """Delete a persisted reference sample by filename. Idempotent."""
+        safe_name = os.path.basename(str(filename or '').strip())
+        if not safe_name:
+            return False
+        path = self.get_voice_clone_sample_dir() / safe_name
+        try:
+            path.unlink()
+            return True
+        except FileNotFoundError:
+            return False
+        except Exception as e:
+            logger.warning("删除语音克隆样本失败 (%s): %s", safe_name, e)
+            return False
+
     @staticmethod
     def is_legacy_cosyvoice_id(voice_id: str) -> bool:
         """CosyVoice v2 / v3 cloned voice IDs became invalid with the CosyVoice 3.5 upgrade."""
@@ -2872,11 +2931,31 @@ class ConfigManager:
                 result.append(bucket)
         return result
 
+    def _get_mimo_storage_keys(self) -> list[str]:
+        """Return the list of voice_storage keys for the current MiMo API key.
+
+        Dual to :meth:`_get_elevenlabs_storage_keys`: MiMo cloned voices live in
+        a ``__MIMO__{suffix}`` bucket keyed by the MiMo API key, so they merge
+        into the current-API voice list regardless of which core/TTS provider is
+        otherwise active (a MiMo clone is selected by ``voice_meta.provider`` at
+        dispatch, not by config — see ``workers/mimo.py``)."""
+        voice_storage = self.load_voice_storage()
+        result = []
+        key = self.get_tts_api_key('mimo')
+        if key:
+            suffix = key[-8:] if len(key) >= 8 else key
+            bucket = f'__MIMO__{suffix}'
+            if bucket in voice_storage:
+                result.append(bucket)
+        return result
+
     @staticmethod
     def _infer_provider_from_storage_key(storage_key: str) -> str:
         """Infer the provider from a voice_storage partition key (only for legacy data compatibility)."""
         if storage_key == '__LOCAL_TTS__':
             return 'local'
+        if storage_key.startswith('__MIMO__'):
+            return 'mimo'
         if storage_key.startswith('__ELEVENLABS__'):
             return 'elevenlabs'
         if storage_key.startswith('__MINIMAX_INTL__'):
@@ -2987,6 +3066,16 @@ class ConfigManager:
                 if vid not in result:
                     if isinstance(vdata, dict) and 'provider' not in vdata:
                         vdata['provider'] = 'elevenlabs'
+                    result[vid] = vdata
+
+        # 合并 MiMo 克隆音色，并确保 provider 字段（dual to ElevenLabs/MiniMax；MiMo 克隆走
+        # 独立 __MIMO__ 桶 + voice_meta 选中，与当前 core/TTS provider 无关）
+        for mimo_key in self._get_mimo_storage_keys():
+            mimo_voices = voice_storage.get(mimo_key, {})
+            for vid, vdata in mimo_voices.items():
+                if vid not in result:
+                    if isinstance(vdata, dict) and 'provider' not in vdata:
+                        vdata['provider'] = 'mimo'
                     result[vid] = vdata
 
         return result
@@ -3100,9 +3189,14 @@ class ConfigManager:
                 storage_key.startswith('__MINIMAX__')
                 or storage_key.startswith('__MINIMAX_INTL__')
                 or storage_key.startswith('__ELEVENLABS__')
+                or storage_key.startswith('__MIMO__')
                 or storage_key.startswith('__COSYVOICE_INTL__')
             ) and voice_id in voice_storage.get(storage_key, {}):
-                del voice_storage[storage_key][voice_id]
+                removed = voice_storage[storage_key].pop(voice_id, None)
+                # MiMo 克隆把参考样本存在本地（非 voice_storage.json）；删音色时一并清理，
+                # 避免样本文件孤儿堆积。
+                if isinstance(removed, dict) and removed.get('clone_sample_file'):
+                    self.delete_voice_clone_sample(removed.get('clone_sample_file'))
                 self.save_voice_storage(voice_storage)
                 return True
 

--- a/utils/mimo_tts_voices.py
+++ b/utils/mimo_tts_voices.py
@@ -58,7 +58,10 @@ def mimo_voice_clone_data_uri(audio_bytes: bytes, mime_type: str = "audio/wav") 
     for the ``mimo-v2.5-tts-voiceclone`` model (reference audio is inlined per
     synthesis request — MiMo has no server-side cloned voice id)."""
     b64 = base64.b64encode(audio_bytes).decode("ascii")
-    return f"data:{(mime_type or 'audio/wav').strip()};base64,{b64}"
+    # 先 strip 再回退默认：避免 mime_type="   "（全空白）被 `or` 当真值留下、strip 成空串
+    # 生成非法的 ``data:;base64,...``。
+    safe_mime = (mime_type or "").strip() or "audio/wav"
+    return f"data:{safe_mime};base64,{b64}"
 
 _FALLBACK_MIMO_TTS_VOICES: dict[str, str] = {
     "mimo_default": "Default",

--- a/utils/mimo_tts_voices.py
+++ b/utils/mimo_tts_voices.py
@@ -27,13 +27,20 @@ def mimo_chat_completions_url(base_url: str | None = None) -> str:
 
     Canonical helper shared by the TTS worker and the voice-clone enrollment
     client so the endpoint-derivation rule lives in one place (utils layer).
-    ``ws(s)://`` is coerced to ``http(s)://``; a bare host gets ``https://``.
+    ``ws(s)://`` is coerced to ``https://``; a bare host gets ``https://``.
+
+    Note ``ws://`` maps to ``https://`` (not plaintext ``http://``): MiMo is an
+    HTTP chat-completions API (``ws`` was never a meaningful scheme for it), and
+    requests carry the ``api-key`` header — downgrading to plaintext would leak
+    the credential. An explicit ``http://`` the caller configured is left as-is
+    (local self-hosted proxies); a project-wide "reject remote plaintext for any
+    provider base_url" hardening is tracked separately.
     """
     raw_url = (base_url or MIMO_TTS_BASE_URL).strip().rstrip("/")
-    if raw_url.startswith("ws://"):
-        raw_url = "http://" + raw_url[5:]
-    elif raw_url.startswith("wss://"):
+    if raw_url.startswith("wss://"):
         raw_url = "https://" + raw_url[6:]
+    elif raw_url.startswith("ws://"):
+        raw_url = "https://" + raw_url[5:]
     elif not raw_url.startswith(("http://", "https://")):
         raw_url = "https://" + raw_url
 

--- a/utils/mimo_tts_voices.py
+++ b/utils/mimo_tts_voices.py
@@ -5,17 +5,60 @@ chat-completions with an ``audio.voice`` field. The canonical voice IDs are
 published in the MiMo-V2.5-TTS speech synthesis guide.
 """
 
+import base64
+from urllib.parse import urlparse, urlunparse
+
 from utils.api_config_loader import get_native_tts_voice_provider_config
 from utils.tts_provider_registry import PresetCatalog
 
 MIMO_TTS_MODEL = "mimo-v2.5-tts"
-# MiMo 的声音克隆模型。当前仅声明为常量占位：MiMo 在 tts_provider_registry 里以
-# capabilities={preset, clone} 注册，但克隆 enrollment 流程（上传样本 → 调 MiMo 克隆
-# API → 落 voice_id，对偶 cosyvoice/elevenlabs 的 voice_clone 流程）尚未实现，留待后续
-# 接手（见 voice-source-unification 设计文档 / 交接 chip）。
-MIMO_TTS_VOICECLONE_MODEL = "mimo-v2.5-tts-voiceclone"  # TODO: 接 MiMo 克隆 enrollment
+# MiMo 的声音克隆模型。与 preset 不同，MiMo 克隆没有「注册 → 拿远端 voice_id」这一步：
+# 参考音频每次合成请求内联在 ``audio.voice`` 里（``data:audio/...;base64,...``），克隆身份
+# 即是这段本地保存的样本。enrollment（保存样本 + voice_meta provider=mimo/source=clone）在
+# characters_router 的 /voice_clone mimo 分支，对偶 cosyvoice/minimax 的云端克隆流程；
+# dispatch 由 tts_provider_registry 的 mimo provider 按 voice_meta 选中（见设计文档 §4/§7）。
+MIMO_TTS_VOICECLONE_MODEL = "mimo-v2.5-tts-voiceclone"
 MIMO_TTS_DEFAULT_VOICE = "mimo_default"
 MIMO_TTS_BASE_URL = "https://api.xiaomimimo.com/v1"
+
+
+def mimo_chat_completions_url(base_url: str | None = None) -> str:
+    """Normalize a MiMo API base URL to its chat-completions endpoint.
+
+    Canonical helper shared by the TTS worker and the voice-clone enrollment
+    client so the endpoint-derivation rule lives in one place (utils layer).
+    ``ws(s)://`` is coerced to ``http(s)://``; a bare host gets ``https://``.
+    """
+    raw_url = (base_url or MIMO_TTS_BASE_URL).strip().rstrip("/")
+    if raw_url.startswith("ws://"):
+        raw_url = "http://" + raw_url[5:]
+    elif raw_url.startswith("wss://"):
+        raw_url = "https://" + raw_url[6:]
+    elif not raw_url.startswith(("http://", "https://")):
+        raw_url = "https://" + raw_url
+
+    parsed = urlparse(raw_url)
+    if not parsed.netloc:
+        raise ValueError(f"无效的 MiMo base_url: {base_url!r}")
+
+    path = parsed.path.rstrip("/")
+    if path.endswith("/chat/completions"):
+        endpoint_path = path
+    elif not path or path == "/":
+        endpoint_path = "/v1/chat/completions"
+    elif path.endswith("/v1"):
+        endpoint_path = f"{path}/chat/completions"
+    else:
+        endpoint_path = f"{path}/v1/chat/completions"
+    return urlunparse((parsed.scheme, parsed.netloc, endpoint_path, "", "", ""))
+
+
+def mimo_voice_clone_data_uri(audio_bytes: bytes, mime_type: str = "audio/wav") -> str:
+    """Build the ``data:<mime>;base64,<...>`` URI MiMo expects in ``audio.voice``
+    for the ``mimo-v2.5-tts-voiceclone`` model (reference audio is inlined per
+    synthesis request — MiMo has no server-side cloned voice id)."""
+    b64 = base64.b64encode(audio_bytes).decode("ascii")
+    return f"data:{(mime_type or 'audio/wav').strip()};base64,{b64}"
 
 _FALLBACK_MIMO_TTS_VOICES: dict[str, str] = {
     "mimo_default": "Default",

--- a/utils/voice_clone.py
+++ b/utils/voice_clone.py
@@ -391,7 +391,8 @@ def _extract_mimo_audio_bytes(payload: dict) -> bytes:
             continue
         try:
             return base64.b64decode(b64)
-        except (binascii.Error, ValueError):
+        except (binascii.Error, ValueError, TypeError):
+            # 上游返回了非字符串/非 bytes 的 audio 字段也不应冒泡，按"无音频"继续尝试下一候选。
             continue
     return b''
 
@@ -458,10 +459,17 @@ class MimoVoiceCloneClient:
     ) -> None:
         """Synthesize a short line with the reference sample to confirm it works.
 
+        Confirms the call actually *produced audio* (not just HTTP 200): if the
+        upstream returns success but an empty/missing audio field the sample is
+        unusable, and enrollment must fail here rather than going silent at
+        runtime / preview.
+
         Raises:
-            MimoVoiceCloneError on a non-200 response / network failure.
+            MimoVoiceCloneError on a non-200 response / network failure / no audio.
         """
-        await self._post(self._build_payload(audio_bytes, mime_type, sample_text))
+        data = await self._post(self._build_payload(audio_bytes, mime_type, sample_text))
+        if not _extract_mimo_audio_bytes(data):
+            raise MimoVoiceCloneError("MiMo 校验未产出音频，参考样本可能不可用")
 
     async def synthesize_preview(
         self,

--- a/utils/voice_clone.py
+++ b/utils/voice_clone.py
@@ -344,6 +344,91 @@ class MinimaxVoiceCloneClient:
 
 
 # ============================================================================
+# Xiaomi MiMo 语音克隆
+# ============================================================================
+#
+# 与 MiniMax/CosyVoice/ElevenLabs 的「上传样本 → 远端注册 → 拿 voice_id」不同，MiMo 的
+# voiceclone（mimo-v2.5-tts-voiceclone）没有注册步骤：参考音频每次合成请求内联在
+# OpenAI 兼容 chat-completions 的 ``audio.voice`` 里（``data:audio/...;base64,...``）。
+# 因此「enrollment」= 在本地保存这段参考样本（克隆身份即这段样本），并用 MiMo 做一次
+# 校验性合成确认 key + 样本可用（对偶其它家在 /voice_clone 时真打远端注册接口）。
+# voice_id 由本地生成；dispatch 由 tts_provider_registry 的 mimo provider 按
+# voice_meta.provider 选中后，读出样本内联进 voiceclone 请求。
+
+# voice_storage 中标识 MiMo 克隆音色的前缀（按 MiMo API key 末 8 位分桶）
+MIMO_VOICE_STORAGE_KEY = '__MIMO__'
+
+
+class MimoVoiceCloneError(VoiceCloneError):
+    """MiMo voice-clone related error"""
+
+
+class MimoVoiceCloneClient:
+    """MiMo voice-clone enrollment client.
+
+    MiMo has no remote voice registration; this client validates that the
+    reference sample + API key actually synthesize via the voiceclone model
+    (one short request), so a bad key / unsupported format / oversized sample
+    fails fast at enrollment instead of going silent at runtime.
+    """
+
+    def __init__(self, api_key: str, base_url: Optional[str] = None):
+        self.api_key = api_key
+        self.base_url = base_url or None
+
+    async def validate_sample(
+        self,
+        audio_bytes: bytes,
+        mime_type: str = 'audio/wav',
+        *,
+        sample_text: str = '你好呀，很高兴认识你。',
+    ) -> None:
+        """Synthesize a short line with the reference sample to confirm it works.
+
+        Raises:
+            MimoVoiceCloneError on a non-200 response / network failure.
+        """
+        from utils.mimo_tts_voices import (
+            MIMO_TTS_VOICECLONE_MODEL,
+            mimo_chat_completions_url,
+            mimo_voice_clone_data_uri,
+        )
+
+        url = mimo_chat_completions_url(self.base_url)
+        headers = {'Content-Type': 'application/json', 'api-key': self.api_key}
+        payload = {
+            'model': MIMO_TTS_VOICECLONE_MODEL,
+            'messages': [{'role': 'assistant', 'content': sample_text}],
+            'audio': {
+                'format': 'pcm16',
+                'voice': mimo_voice_clone_data_uri(audio_bytes, mime_type),
+            },
+            'stream': False,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+        except httpx.TimeoutException as e:
+            raise MimoVoiceCloneError("MiMo 克隆校验超时，请稍后重试") from e
+        except Exception as e:
+            raise MimoVoiceCloneError(f"MiMo 克隆校验失败: {e}") from e
+
+        if resp.status_code != 200:
+            raise MimoVoiceCloneError(
+                f"MiMo 克隆校验失败: HTTP {resp.status_code}, {resp.text[:300]}"
+            )
+        # 200 但携带 error 体的兜底（OpenAI 兼容接口偶有 200+error 的情形）
+        try:
+            data = resp.json()
+        except ValueError:
+            return
+        if isinstance(data, dict) and data.get('error'):
+            err = data['error']
+            msg = err.get('message') if isinstance(err, dict) else str(err)
+            raise MimoVoiceCloneError(f"MiMo 克隆校验失败: {msg}")
+
+
+# ============================================================================
 # Qwen / CosyVoice 语音克隆
 # ============================================================================
 

--- a/utils/voice_clone.py
+++ b/utils/voice_clone.py
@@ -30,6 +30,7 @@ Qwen/CosyVoice voice cloning:
 """
 
 import asyncio
+import base64
 import io
 import binascii
 import logging
@@ -348,33 +349,105 @@ class MinimaxVoiceCloneClient:
 # ============================================================================
 #
 # 与 MiniMax/CosyVoice/ElevenLabs 的「上传样本 → 远端注册 → 拿 voice_id」不同，MiMo 的
-# voiceclone（mimo-v2.5-tts-voiceclone）没有注册步骤：参考音频每次合成请求内联在
-# OpenAI 兼容 chat-completions 的 ``audio.voice`` 里（``data:audio/...;base64,...``）。
-# 因此「enrollment」= 在本地保存这段参考样本（克隆身份即这段样本），并用 MiMo 做一次
-# 校验性合成确认 key + 样本可用（对偶其它家在 /voice_clone 时真打远端注册接口）。
-# voice_id 由本地生成；dispatch 由 tts_provider_registry 的 mimo provider 按
-# voice_meta.provider 选中后，读出样本内联进 voiceclone 请求。
+# voiceclone（mimo-v2.5-tts-voiceclone）没有注册步骤（已核实官方文档：无 create-voice /
+# 远端 voice_id）：参考音频每次合成请求内联在 OpenAI 兼容 chat-completions 的 ``audio.voice``
+# 里（``data:audio/...;base64,...``）。
+#
+# **对偶 MiniMax 的存储模型**：MiniMax 在 voice_storage.json 的 voice_meta 里存远端 voice_id
+# 作克隆身份；MiMo 在同一处存**参考音频本身（base64）**作克隆身份——整段落进 voice_meta、
+# 随 voice_storage.json 云同步，不另起本地文件存储。enrollment 时用 MiMo 做一次校验性合成
+# 确认 key + 样本可用（对偶其它家真打远端注册接口）；试听（synthesize_preview）同样内联样本，
+# 对偶 MiniMax 的预览。dispatch 由 mimo provider 按 voice_meta.provider 选中后读出样本内联。
 
 # voice_storage 中标识 MiMo 克隆音色的前缀（按 MiMo API key 末 8 位分桶）
 MIMO_VOICE_STORAGE_KEY = '__MIMO__'
+# MiMo 校验 / 试听用 wav（自包含、非流式一次性返回，便于直接取音频）；运行时 worker 才用
+# pcm16 流式。Codex review #1851：非流式请求不应再要 pcm16 裸流。
+_MIMO_PREVIEW_AUDIO_FORMAT = 'wav'
 
 
 class MimoVoiceCloneError(VoiceCloneError):
     """MiMo voice-clone related error"""
 
 
-class MimoVoiceCloneClient:
-    """MiMo voice-clone enrollment client.
+def _extract_mimo_audio_bytes(payload: dict) -> bytes:
+    """Pull base64 audio out of a MiMo chat-completions (non-stream) response.
 
-    MiMo has no remote voice registration; this client validates that the
-    reference sample + API key actually synthesize via the voiceclone model
-    (one short request), so a bad key / unsupported format / oversized sample
-    fails fast at enrollment instead of going silent at runtime.
+    Mirrors the worker's extractor but lives here so utils stays off main_logic.
+    Returns decoded bytes, or b'' when no audio field is present.
+    """
+    candidates: list = [payload.get('audio')]
+    for choice in payload.get('choices') or []:
+        if isinstance(choice, dict):
+            candidates.append((choice.get('message') or {}).get('audio'))
+            candidates.append(choice.get('audio'))
+    for cand in candidates:
+        b64 = ''
+        if isinstance(cand, str):
+            b64 = cand
+        elif isinstance(cand, dict):
+            b64 = cand.get('data') or cand.get('audio') or cand.get('content') or ''
+        if not b64:
+            continue
+        try:
+            return base64.b64decode(b64)
+        except (binascii.Error, ValueError):
+            continue
+    return b''
+
+
+class MimoVoiceCloneClient:
+    """MiMo voice-clone enrollment + preview client.
+
+    MiMo has no remote voice registration; ``validate_sample`` confirms the
+    reference sample + API key actually synthesize via the voiceclone model (one
+    short non-stream request), so a bad key / unsupported format / oversized
+    sample fails fast at enrollment instead of going silent at runtime.
+    ``synthesize_preview`` returns audible bytes for the voice-list preview
+    button (dual to MiniMax's ``synthesize_preview``).
     """
 
     def __init__(self, api_key: str, base_url: Optional[str] = None):
         self.api_key = api_key
         self.base_url = base_url or None
+
+    def _build_payload(self, audio_bytes: bytes, mime_type: str, text: str) -> dict:
+        from utils.mimo_tts_voices import MIMO_TTS_VOICECLONE_MODEL, mimo_voice_clone_data_uri
+        return {
+            'model': MIMO_TTS_VOICECLONE_MODEL,
+            'messages': [{'role': 'assistant', 'content': text}],
+            'audio': {
+                # 非流式取一次性音频：wav 自包含，不要 pcm16 裸流（Codex review）。
+                'format': _MIMO_PREVIEW_AUDIO_FORMAT,
+                'voice': mimo_voice_clone_data_uri(audio_bytes, mime_type),
+            },
+            'stream': False,
+        }
+
+    async def _post(self, payload: dict) -> dict:
+        from utils.mimo_tts_voices import mimo_chat_completions_url
+        url = mimo_chat_completions_url(self.base_url)
+        headers = {'Content-Type': 'application/json', 'api-key': self.api_key}
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(url, headers=headers, json=payload)
+        except httpx.TimeoutException as e:
+            raise MimoVoiceCloneError("MiMo 请求超时，请稍后重试") from e
+        except Exception as e:
+            raise MimoVoiceCloneError(f"MiMo 请求失败: {e}") from e
+        if resp.status_code != 200:
+            raise MimoVoiceCloneError(
+                f"MiMo 请求失败: HTTP {resp.status_code}, {resp.text[:300]}"
+            )
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise MimoVoiceCloneError("MiMo 返回了无法解析的响应") from e
+        if isinstance(data, dict) and data.get('error'):
+            err = data['error']
+            msg = err.get('message') if isinstance(err, dict) else str(err)
+            raise MimoVoiceCloneError(f"MiMo 请求失败: {msg}")
+        return data if isinstance(data, dict) else {}
 
     async def validate_sample(
         self,
@@ -388,44 +461,25 @@ class MimoVoiceCloneClient:
         Raises:
             MimoVoiceCloneError on a non-200 response / network failure.
         """
-        from utils.mimo_tts_voices import (
-            MIMO_TTS_VOICECLONE_MODEL,
-            mimo_chat_completions_url,
-            mimo_voice_clone_data_uri,
-        )
+        await self._post(self._build_payload(audio_bytes, mime_type, sample_text))
 
-        url = mimo_chat_completions_url(self.base_url)
-        headers = {'Content-Type': 'application/json', 'api-key': self.api_key}
-        payload = {
-            'model': MIMO_TTS_VOICECLONE_MODEL,
-            'messages': [{'role': 'assistant', 'content': sample_text}],
-            'audio': {
-                'format': 'pcm16',
-                'voice': mimo_voice_clone_data_uri(audio_bytes, mime_type),
-            },
-            'stream': False,
-        }
-        try:
-            async with httpx.AsyncClient(timeout=60) as client:
-                resp = await client.post(url, headers=headers, json=payload)
-        except httpx.TimeoutException as e:
-            raise MimoVoiceCloneError("MiMo 克隆校验超时，请稍后重试") from e
-        except Exception as e:
-            raise MimoVoiceCloneError(f"MiMo 克隆校验失败: {e}") from e
+    async def synthesize_preview(
+        self,
+        audio_bytes: bytes,
+        mime_type: str = 'audio/wav',
+        *,
+        text: str = '你好呀，很高兴认识你。',
+    ) -> bytes:
+        """Synthesize a preview line with the reference sample, returning wav bytes.
 
-        if resp.status_code != 200:
-            raise MimoVoiceCloneError(
-                f"MiMo 克隆校验失败: HTTP {resp.status_code}, {resp.text[:300]}"
-            )
-        # 200 但携带 error 体的兜底（OpenAI 兼容接口偶有 200+error 的情形）
-        try:
-            data = resp.json()
-        except ValueError:
-            return
-        if isinstance(data, dict) and data.get('error'):
-            err = data['error']
-            msg = err.get('message') if isinstance(err, dict) else str(err)
-            raise MimoVoiceCloneError(f"MiMo 克隆校验失败: {msg}")
+        Raises:
+            MimoVoiceCloneError on failure / when no audio is returned.
+        """
+        data = await self._post(self._build_payload(audio_bytes, mime_type, text))
+        audio = _extract_mimo_audio_bytes(data)
+        if not audio:
+            raise MimoVoiceCloneError("MiMo 预览成功但未返回音频")
+        return audio
 
 
 # ============================================================================


### PR DESCRIPTION
## 背景

承接声音来源统一架构（`docs/design/tts-voice-source-unification.md` §4/§7），在 #1818（统一注册表）/#1830（source-first 选声器）/#1842（voice_id 惰性迁移）/#1848（mimo catalog → hosted `preset_catalog`，从 native 摘除）地基上，补齐两种声音来源：**ElevenLabs voice design** 与 **MiMo voiceclone**。

原三件套任务里 **Part 3（mimo catalog 从 native 摘除）已由 #1848 落地**，本 PR 做 Part 1 + Part 2。

## Part 1 — ElevenLabs voice design 钩子（design 先行）

- `elevenlabs` capabilities 追加 `'design'`。
- enrollment 两步：
  - `POST /voice_design_preview`：文字描述 → `POST /v1/text-to-voice/design` 拿 previews（`generated_voice_id` + base64 试听音频）。
  - `POST /voice_design_create`：选定 preview → `POST /v1/text-to-voice` create-from-preview，落成一个**普通 ElevenLabs voice_id**，`voice_meta.source='design'`。
- **dispatch 复用现成 ElevenLabs clone 路径**（`voice_meta.provider=='elevenlabs'`），design voice 就是个 elevenlabs voice，无需独立 worker。
- **design 创建 tab UI 留给前端 chip**（任务原文「与前端 chip 协调」）；本 PR 落后端钩子（capability + enrollment endpoint + dispatch）+ 让 source-first picker 按 `voice_meta.source` 分组（design → 「· 描述生成」），chip 拿这些建 tab。

## Part 2 — MiMo voiceclone 真实现（对偶 cosyvoice/minimax）

> ⚠️ 实证（小米官方 [MiMo-Skills](https://github.com/XiaomiMiMo/MiMo-Skills) 仓库）：MiMo 克隆**没有**「上传 → 远端注册 → 拿 voice_id」这一步。`mimo-v2.5-tts-voiceclone` 是**参考音频每次合成请求内联**（`audio.voice="data:audio/...;base64,..."`）。

按拍板「对偶 cosyvoice/minimax」= 同 hosted 云端克隆 UX（voice_clone 页、`voice_meta.provider` 选中、API key gate），只是「远端 voice_id」退化成**本地保存的参考样本**：

- enrollment（`/voice_clone` 的 mimo 分支）：`MimoVoiceCloneClient.validate_sample` 做一次校验合成确认 key + 样本可用 → 样本存**本地文件**（`config_dir/voice_clone_samples/`，**不进 `voice_storage.json`** 避免几百 KB base64 拖慢每次 `/voices` 读）→ `voice_meta{provider:mimo, source:clone, clone_sample_file}` 落 `__MIMO__{key[-8:]}` 桶（dual ElevenLabs）。
- dispatch：`_mimo_is_selected` 追加 `voice_meta.provider=='mimo'`；`_mimo_resolve` clone 分支读样本 → data URI → `partial(mimo_tts_worker, clone_voice=...)`（worker 是 Thread 同进程，绑 URI 不走 pickle）；worker 加 `clone_voice` 参数，set 时 model=voiceclone。`mimo` capabilities 追加 `'clone'`。
- 删音色时一并清本地样本。

## 前端

- `voice_clone.js`/`voice_clone.html`：加 MiMo 克隆 provider（国内服务、不 restricted，mainland 用户可见）。
- `character_card_manager.js`：克隆音色按 `voiceData.source` 分组（design→「· 描述生成」/ clone→「· 克隆」，存量无 source 字段默认 clone）。
- 8 个 locale 加 `voice.provider.mimo` + `voice.mimoApiRequired`（`check_i18n_sync` 绿）。

## 测试

- 新增 `tests/unit/test_mimo_voice_clone.py`（worker clone payload / dispatch / config_manager `__MIMO__` 合并 + 样本 roundtrip + 路径穿越防护）、`tests/unit/test_elevenlabs_voice_design.py`（design helper HTTP 契约 / design voice 经 elevenlabs clone 路由 / capabilities 声明）。
- 相关单测 + 既有 TTS/voice 套件全绿（189 passed）；`check_i18n_sync` 绿；playwright 克隆页下拉断言更新为 `cosyvoice,minimax,mimo` 并通过。
- 既有 flaky 基线（与本 PR 无关，干净 main 同挂）：`test_api_settings::test_api_key_settings`、`test_character_card_manager_regressions::...stale_reload`。
- 未做：实打 MiMo/ElevenLabs 网络流程（需真实 API key，本地不可得）；design 创建 tab UI（chip 负责）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 回归报告

**改了什么**：在统一 TTS provider 注册表上补两种声音来源——ElevenLabs voice design（`main_routers/characters_router.py` 加 `/voice_design_preview`+`/voice_design_create` 两个 endpoint 与 design helper；`main_logic/tts_client/__init__.py` 给 elevenlabs capabilities 加 `design`）+ MiMo voiceclone（`main_logic/tts_client/workers/mimo.py` 给 worker 加 `clone_voice` 参数、`_mimo_is_selected`/`_mimo_resolve` 加 voice_meta 克隆分支；`characters_router.py` 加 `/voice_clone` 的 mimo 分支；`config_manager.py` 加 `__MIMO__` 桶合并 + 本地样本读写删 helper）。

**为什么必要**：设计文档 §4/§7 把 design 列为第三声音来源、mimo 应支持克隆；#1848 已把 mimo 预制目录迁到 hosted preset_catalog，但 clone/design enrollment 一直是占位。

**前后行为对比**：
- 之前：elevenlabs 只能 clone（上传样本）；mimo 只有预制音色；voice design 无入口。
- 之后：elevenlabs 多一条「文字描述→生成→落成普通 voice_id（source=design）」路径，**dispatch 复用现成 elevenlabs clone 路由，无新 worker**；mimo 多一条克隆路径（参考音频本地保存、按 voice_meta 选中时内联进 voiceclone 请求）。两条新路径都只在「用户主动选了对应来源的音色」时触发，preset/已有 clone 路由完全不变。

**潜在回归与缓解**：
- `get_tts_worker` 是高风险 dispatch——改动仅给 mimo 的 `is_selected`/`resolve` **追加** voice_meta 克隆分支（OR 进既有 config-selected 判定），优先级位次不变；既有 mimo dispatch 测试（assist=mimo / TTS_PROVIDER=mimo / 缺 key→dummy / mimo before native / before custom fallback）全部保持通过。
- `config_manager.get_voices_for_current_api` 加 mimo 桶合并，dual 既有 ElevenLabs 合并块，不影响其它 provider 的合并；`delete_voice_for_current_api` 仅多清一个本地样本文件，幂等。
- 元数据保存失败时的孤儿样本已加清理（Greptile P2 已修）。
- 回归覆盖：新增 `tests/unit/test_mimo_voice_clone.py` + `test_elevenlabs_voice_design.py`（worker clone payload / dispatch 路由 / 桶合并 / 样本 roundtrip+路径穿越 / design helper HTTP 契约 / design 经 elevenlabs clone 路由）；相关 TTS/voice 单测 189 passed，`check_i18n_sync` 绿，playwright 克隆页下拉 chromium 实测通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 ElevenLabs「语音设计」：支持文字生成试听预览，并创建可复用语音。
  * 新增 MiMo（小米）语音克隆：支持上传音频样本生成克隆音色，并提供试听预览。
* **改进**
  * 音色下拉按「提供方 + 来源类型（设计/克隆）」分组展示。
  * MiMo 克隆禁用直链模式：改为本地文件上传；并增强克隆/试听失败时的错误提示。
* **本地化**
  * 补充 MiMo 语音克隆相关多语言提示（英文/西班牙文/日文/韩文/葡萄牙文/俄文/中文）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 更新：MiMo 克隆重构为严格对偶 MiniMax（base64 进 voice_meta）

已核实 Xiaomi 官方 MiMo 文档 + MiMo-Skills 仓库：**MiMo voiceclone 没有任何远端注册接口**（无 create-voice、无远端 voice_id），克隆只能每次内联参考音频。因此按 maintainer 要求做严格对偶 MiniMax：

- **存储**：MiniMax 在 voice_meta 存远端 voice_id 作克隆身份；MiMo 在同一处存**参考音频 base64**（`voice_meta.clone_sample_b64`）。**不再有本地文件存储**——克隆身份整段在 voice_storage.json 里，随它自动云同步（顺带消除了之前 reviewer 提的 cross-device / 孤儿文件问题）。移除了 ConfigManager 的 save/load/delete voice-clone-sample 文件 helper。
- `get_voices_for_current_api(for_listing=True)` 剥掉 `clone_sample_b64`，前端音色列表不背 MB blob；dispatch/preview（for_listing=False）仍拿完整 voice_meta。
- **试听**：实现了真正的 MiMo 克隆试听（对偶 MiniMax），替换之前的 suppress——`MimoVoiceCloneClient.synthesize_preview` + `/voice_preview` mimo 分支；校验/试听用非流式 wav。
- **base_url**：存进 voice_meta（对偶 minimax_base_url），dispatch 在 assistApi=mimo（Token Plan）时仍重解析保证 key/端点配套。
- 唯一不可避免的不对偶：voice_id 是本地生成（MiMo 无远端 id），但它只是个存储键，不影响行为。

新增/更新单测覆盖：B-storage dispatch、for_listing 剥离、synthesize_preview、token-plan base_url、stored base_url 回落。
