### PR TITLE
feat(tts): GPT-SoVITS 选中时显示「教程文档」跳转按钮

### DIFF
--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1469,6 +1469,28 @@ input:checked + .slider:before {
     color: #fff;
 }
 
+/* GPT-SoVITS「教程文档」跳转按钮 */
+.gsv-tutorial-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 14px;
+    border-radius: 6px;
+    border: 1px solid var(--accent-blue);
+    background: #fff;
+    color: var(--text-blue);
+    font-weight: 500;
+    font-size: 0.85em;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: all 0.2s ease;
+}
+
+.gsv-tutorial-link:hover {
+    background: #40C5F1;
+    color: #fff;
+}
+
 /* ============ Key Book Section ============ */
 #key-book-section {
     margin-top: 0;

--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -1487,7 +1487,7 @@ input:checked + .slider:before {
 }
 
 .gsv-tutorial-link:hover {
-    background: #40C5F1;
+    background: var(--accent-blue);
     color: #fff;
 }
 

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1205,6 +1205,18 @@ html[data-theme="dark"].subtitle-window-host body.subtitle-window-host {
   color: #fff !important;
 }
 
+/* GPT-SoVITS 教程文档按钮 */
+[data-theme="dark"] .gsv-tutorial-link {
+  background: #2d2d2d !important;
+  color: #3a9fd8 !important;
+  border-color: #3a9fd8 !important;
+}
+
+[data-theme="dark"] .gsv-tutorial-link:hover {
+  background: #3a9fd8 !important;
+  color: #fff !important;
+}
+
 /* GPT-SoVITS 声音卡片网格 */
 [data-theme="dark"] .gsv-voices-grid {
   background: #1e1e1e;

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -30,7 +30,7 @@
 
     // locale 资源版本（用于 cache-busting，避免客户端长期缓存旧语言包导致新增 key 不生效）
     // 更新语言包内容时可以递增此值
-    const LOCALE_VERSION = '2026-06-13-pr1719-merge';
+    const LOCALE_VERSION = '2026-06-16-pr1852-gsv-tutorial';
 
     function initDecorativeImageDragGuard() {
         const markImage = (img) => {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1242,7 +1242,25 @@ function updateTtsProviderFieldVisibility(provider) {
     const gsvFields = document.getElementById('gptsovits-config-fields');
     if (standardFields) standardFields.style.display = isGsv ? 'none' : '';
     if (gsvFields) gsvFields.style.display = isGsv ? 'block' : 'none';
+    if (isGsv) updateGptSovitsTutorialLink();
 }
+
+/**
+ * 设置 GPT-SoVITS「教程文档」按钮的跳转链接：中文（zh-*）走中文文档，其余语言走通用文档。
+ * 语言可能在打开页面后才切换，故同时在 updateTtsProviderFieldVisibility 与 localechange 时调用。
+ */
+function updateGptSovitsTutorialLink() {
+    const link = document.getElementById('gptsovitsTutorialLink');
+    if (!link) return;
+    const lang = (window.i18n && window.i18n.language) || document.documentElement.lang || 'zh-CN';
+    const isChinese = String(lang).toLowerCase().startsWith('zh');
+    link.href = isChinese
+        ? 'https://docs.qq.com/aio/DQ1dDcU9rdURQTWJE?p=RLq03bnCUOGEIa8YwBS58H&client_hint=0'
+        : 'https://docs.qq.com/aio/DQ1dDcU9rdURQTWJE?p=Z7zYbDaFk1FIrs4EBk7spv&client_hint=0';
+}
+
+// 语言切换时同步更新教程文档链接（中文↔其它语言走不同文档）
+window.addEventListener('localechange', updateGptSovitsTutorialLink);
 
 /**
  * 在 key 输入框旁添加"前往管理簿"快捷按钮（如果还没有）

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- Refresh to fetch voice list --",
         "gptsovitsNoVoices": "-- No configs available --",
         "gptsovitsRefreshVoices": "Refresh List",
+        "gptsovitsTutorialDoc": "Tutorial",
         "gptsovitsVoicesLoaded": "Loaded {{count}} voice config(s)",
         "gptsovitsVoicesLoadFailed": "Failed to fetch voice list",
         "gptsovitsEnabled": "Enable GPT-SoVITS",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- Actualizar para recuperar la lista de voces --",
         "gptsovitsNoVoices": "-- No hay configuraciones disponibles --",
         "gptsovitsRefreshVoices": "Actualizar lista",
+        "gptsovitsTutorialDoc": "Tutorial",
         "gptsovitsVoicesLoaded": "Configuraciones de voz {{count}} cargadas",
         "gptsovitsVoicesLoadFailed": "No se pudo recuperar la lista de voces",
         "gptsovitsEnabled": "Habilitar GPT-SoVITS",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- リストを更新して音声を取得してください --",
         "gptsovitsNoVoices": "-- 利用可能な設定なし --",
         "gptsovitsRefreshVoices": "リスト更新",
+        "gptsovitsTutorialDoc": "チュートリアル",
         "gptsovitsVoicesLoaded": "{{count}}件の音声設定を読み込みました",
         "gptsovitsVoicesLoadFailed": "音声リストの取得に失敗しました",
         "gptsovitsEnabled": "GPT-SoVITS を有効化",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- 목록을 새로고침하여 음성을 가져오세요 --",
         "gptsovitsNoVoices": "-- 사용 가능한 설정 없음 --",
         "gptsovitsRefreshVoices": "목록 새로고침",
+        "gptsovitsTutorialDoc": "튜토리얼",
         "gptsovitsVoicesLoaded": "{{count}}개의 음성 설정을 로드했습니다",
         "gptsovitsVoicesLoadFailed": "음성 목록 가져오기 실패",
         "gptsovitsEnabled": "GPT-SoVITS 활성화",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- Atualize para buscar a lista de vozes --",
         "gptsovitsNoVoices": "-- Nenhuma configuração disponível --",
         "gptsovitsRefreshVoices": "Atualizar lista",
+        "gptsovitsTutorialDoc": "Tutorial",
         "gptsovitsVoicesLoaded": "Configurações de voz {{count}} carregadas",
         "gptsovitsVoicesLoadFailed": "Falha ao buscar a lista de vozes",
         "gptsovitsEnabled": "Habilitar GPT-SoVITS",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- Обновите список, чтобы получить голоса --",
         "gptsovitsNoVoices": "-- Нет доступных конфигураций --",
         "gptsovitsRefreshVoices": "Обновить список",
+        "gptsovitsTutorialDoc": "Руководство",
         "gptsovitsVoicesLoaded": "Загружено {{count}} конфигураций голоса",
         "gptsovitsVoicesLoadFailed": "Не удалось получить список голосов",
         "gptsovitsEnabled": "Включить GPT-SoVITS",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- 请先刷新获取语音列表 --",
         "gptsovitsNoVoices": "-- 无可用配置 --",
         "gptsovitsRefreshVoices": "刷新列表",
+        "gptsovitsTutorialDoc": "教程文档",
         "gptsovitsVoicesLoaded": "已加载 {{count}} 个语音配置",
         "gptsovitsVoicesLoadFailed": "获取语音列表失败",
         "gptsovitsEnabled": "启用 GPT-SoVITS",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1203,6 +1203,7 @@
         "gptsovitsVoiceIdEmpty": "-- 請先刷新獲取語音列表 --",
         "gptsovitsNoVoices": "-- 無可用配置 --",
         "gptsovitsRefreshVoices": "刷新列表",
+        "gptsovitsTutorialDoc": "教程文檔",
         "gptsovitsVoicesLoaded": "已載入 {{count}} 個語音配置",
         "gptsovitsVoicesLoadFailed": "獲取語音列表失敗",
         "gptsovitsEnabled": "啟用 GPT-SoVITS",

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -633,6 +633,17 @@
                                                     文件中管理，此处只需填写声音配置 ID。</span>
                                             </div>
 
+                                            <!-- 教程文档跳转：中文/其它语言走不同文档，href 由
+                                                 updateGptSovitsTutorialLink() 按当前语言设置（默认中文） -->
+                                            <div style="margin: 0 0 12px;">
+                                                <a id="gptsovitsTutorialLink"
+                                                    href="https://docs.qq.com/aio/DQ1dDcU9rdURQTWJE?p=RLq03bnCUOGEIa8YwBS58H&amp;client_hint=0"
+                                                    target="_blank" rel="noopener noreferrer"
+                                                    class="gsv-tutorial-link">
+                                                    📄 <span data-i18n="api.gptsovitsTutorialDoc">教程文档</span>
+                                                </a>
+                                            </div>
+
                                             <!-- API 配置 -->
                                             <div class="field-row">
                                                 <label for="gptsovitsApiUrl">


### PR DESCRIPTION
## 改动

在 API Key 设置页的 **TTS 模型配置（Duplex Streaming）** 中，当服务商选为 **GPT-SoVITS (self-hosted)** 时，在说明框下方显示一个「教程文档」按钮，点击在新标签页打开对应文档。

链接按当前界面语言自动切换，并在切换语言时实时更新：

- 中文（`zh-CN` / `zh-TW`）→ https://docs.qq.com/aio/DQ1dDcU9rdURQTWJE?p=RLq03bnCUOGEIa8YwBS58H&client_hint=0
- 其他语言 → https://docs.qq.com/aio/DQ1dDcU9rdURQTWJE?p=Z7zYbDaFk1FIrs4EBk7spv&client_hint=0

## 实现

- **模板** `templates/api_key_settings.html`：在 `#gptsovits-config-fields`（仅在选中 gptsovits 时显示的容器）说明框下方新增 `<a id="gptsovitsTutorialLink">`，默认 href 为中文文档，文案走 `data-i18n="api.gptsovitsTutorialDoc"`。
- **JS** `static/js/api_key_settings.js`：新增 `updateGptSovitsTutorialLink()`，按 `window.i18n.language`（回退 `document.documentElement.lang`）判断是否 `zh-*` 设置 href；在 `updateTtsProviderFieldVisibility()`（加载与切换 provider 时都会触发）中调用，并监听 `localechange` 事件同步更新。
- **CSS** `static/css/api_key_settings.css` + `dark-mode.css`：新增 `.gsv-tutorial-link` 按钮样式，沿用刷新按钮的蓝色风格，含 dark mode。
- **i18n**：8 个语言包（`zh-CN/zh-TW/en/ja/ko/ru/es/pt`）新增 `api.gptsovitsTutorialDoc` 文案。

## 说明

- 按钮复用了已有的 `#gptsovits-config-fields` 容器显隐逻辑（由 `updateTtsProviderFieldVisibility` 驱动），未选 GPT-SoVITS 时整块隐藏，因此无需额外的显隐判断。
- 8 个 locale JSON 均已通过 `json.load` 校验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为 GPT-SoVITS 配置区域新增“教程文档”快捷链接，点击可在新标签页打开。
  * 链接会随界面语言自动切换：中文环境指向中文教程，其它语言指向通用教程。
* **样式**
  * 为“教程文档”链接提供统一按钮样式，并适配深色主题的悬停效果。
* **本地化**
  * 新增教程文档按钮文案的多语言支持（含中英等多种语言）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->