### PR TITLE
fix(tts): 标注 hosted preset 音色的 source/provider ownership 元数据

### DIFF
--- a/tests/unit/test_mimo_tts_voices.py
+++ b/tests/unit/test_mimo_tts_voices.py
@@ -8,6 +8,7 @@ from main_logic import tts_client  # noqa: F401
 from utils import tts_provider_registry
 from utils.mimo_tts_voices import MIMO_PRESET_CATALOG, normalize_mimo_tts_voice
 from utils.native_voice_registry import get_provider, is_native_voice, list_providers
+from utils.voice_config import read_legacy_voice_id
 
 
 class _CM:
@@ -189,3 +190,26 @@ def test_validate_voice_id_accepts_mimo_preset_when_selected(config_manager):
 def test_validate_voice_id_rejects_mimo_preset_when_not_selected(config_manager):
     _write_core_config(config_manager, {"coreApi": "qwen", "assistApi": "qwen"})
     assert config_manager.validate_voice_id("Milo") is False
+
+
+# ── normalize/storage 端到端：保存 MiMo 预制音色补全 source=preset/provider=mimo
+#    ownership 元数据（#1842 结构化 schema 缺口，#1848 遗留），并仍 round-trip 回裸 key ──
+
+
+@pytest.mark.unit
+def test_normalize_mimo_preset_marks_source_preset_provider_mimo(config_manager):
+    _write_core_config(config_manager, {"coreApi": "qwen", "assistApi": "mimo"})
+    vc = config_manager.normalize_voice_id_to_config("Milo")
+    assert (vc.source, vc.provider, vc.ref) == ("preset", "mimo", "Milo")
+    # 写入存储：迁成结构对象（非裸串），且 round-trip 回库 key 'Milo'
+    stored = config_manager.voice_id_to_storage_value("Milo")
+    assert stored == {"source": "preset", "provider": "mimo", "ref": "Milo"}
+    assert read_legacy_voice_id(stored) == "Milo"
+
+
+@pytest.mark.unit
+def test_normalize_mimo_preset_unresolved_when_not_selected(config_manager):
+    # 未选中 MiMo → 不认作预制，裸 ref 原样带过（provider/source 空），不误标
+    _write_core_config(config_manager, {"coreApi": "qwen", "assistApi": "qwen"})
+    vc = config_manager.normalize_voice_id_to_config("Milo")
+    assert (vc.source, vc.provider, vc.ref) == ("", "", "Milo")

--- a/tests/unit/test_mimo_tts_voices.py
+++ b/tests/unit/test_mimo_tts_voices.py
@@ -213,3 +213,7 @@ def test_normalize_mimo_preset_unresolved_when_not_selected(config_manager):
     _write_core_config(config_manager, {"coreApi": "qwen", "assistApi": "qwen"})
     vc = config_manager.normalize_voice_id_to_config("Milo")
     assert (vc.source, vc.provider, vc.ref) == ("", "", "Milo")
+    # 落库侧：未解析的裸 ref 存回扁平串（不写成空壳结构对象），守住回归
+    stored = config_manager.voice_id_to_storage_value("Milo")
+    assert stored == "Milo"
+    assert read_legacy_voice_id(stored) == "Milo"

--- a/tests/unit/test_voice_config.py
+++ b/tests/unit/test_voice_config.py
@@ -118,6 +118,38 @@ def test_normalize_free_preset():
     assert vc == VoiceConfig(source=SOURCE_PRESET, provider="free", ref="voice-tone-PGLiTXeJCS")
 
 
+def test_normalize_hosted_preset_marks_selected_provider():
+    # 选中的 hosted/local provider 的预制音色（如 MiMo 的 Milo）→ source=preset/provider=<key>
+    vc = normalize_voice_id(
+        "Milo",
+        hosted_preset_provider=lambda r: "mimo" if r == "Milo" else None,
+    )
+    assert vc == VoiceConfig(source=SOURCE_PRESET, provider="mimo", ref="Milo")
+
+
+def test_normalize_hosted_preset_after_native_before_free():
+    # 解析顺序与 validate_voice_id 一致：native 命中先于 hosted preset，hosted preset 先于 free
+    native_first = normalize_voice_id(
+        "Milo",
+        is_native=lambda r: True,
+        native_provider="step",
+        hosted_preset_provider=lambda r: "mimo",
+    )
+    assert native_first.provider == "step"
+    hosted_before_free = normalize_voice_id(
+        "Milo",
+        hosted_preset_provider=lambda r: "mimo",
+        free_voice_ids={"Milo"},
+    )
+    assert hosted_before_free.provider == "mimo"
+
+
+def test_normalize_hosted_preset_miss_carries_ref():
+    # lookup 返回 None（未选中该 provider / 非预制）→ 不误标，裸 ref 原样带过
+    vc = normalize_voice_id("Milo", hosted_preset_provider=lambda r: None)
+    assert vc == VoiceConfig(ref="Milo")
+
+
 def test_normalize_unresolved_carries_ref():
     vc = normalize_voice_id("totally-unknown")
     assert vc == VoiceConfig(ref="totally-unknown")

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3312,12 +3312,34 @@ class ConfigManager:
                 return str(vdata.get('provider') or '')
             return None
 
+        def _hosted_preset_provider(ref):
+            """Selected hosted/local provider key when ``ref`` is one of its preset
+            voices (e.g. MiMo's "Milo"), else None — so the structured object keeps
+            the ``source=preset / provider=<key>`` ownership the flat string drops.
+
+            Dual to :meth:`_is_selected_hosted_preset_voice` (used by validate); both
+            gate on tts_provider_registry's selection so a hosted preset is only
+            recognized while that provider is the one dispatch would route to. Same
+            layer rule: config_manager (utils) must NOT import main_logic, so we only
+            query the same-layer registry, which the running app populates by
+            importing main_logic.tts_client at startup. Degrades to None on error.
+            """
+            try:
+                from utils import tts_provider_registry
+                core = self.get_core_config() or {}
+                if tts_provider_registry.is_selected_preset_voice(core, self, ref):
+                    return tts_provider_registry.selected_provider_key(core, self)
+            except Exception:
+                logger.warning("hosted preset voice 归一化异常，按非预制处理", exc_info=True)
+            return None
+
         return normalize_voice_id(
             voice_id,
             vllm_selected=self._is_vllm_omni_tts_selected(self.get_core_config()),
             clone_provider_lookup=_clone_lookup,
             is_native=lambda ref: is_saveable_native_voice(self, ref),
             native_provider=get_active_realtime_native_provider(self) or '',
+            hosted_preset_provider=_hosted_preset_provider,
             free_voice_ids=set(get_free_voices().values()),
         )
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3319,19 +3319,21 @@ class ConfigManager:
 
             Dual to :meth:`_is_selected_hosted_preset_voice` (used by validate); both
             gate on tts_provider_registry's selection so a hosted preset is only
-            recognized while that provider is the one dispatch would route to. Same
-            layer rule: config_manager (utils) must NOT import main_logic, so we only
-            query the same-layer registry, which the running app populates by
-            importing main_logic.tts_client at startup. Degrades to None on error.
+            recognized while that provider is the one dispatch would route to. A
+            single ``selected_preset_provider_key`` dispatch resolves both membership
+            and key together, so the two can never disagree. Same layer rule:
+            config_manager (utils) must NOT import main_logic, so we only query the
+            same-layer registry, which the running app populates by importing
+            main_logic.tts_client at startup. Degrades to None on error.
             """
             try:
                 from utils import tts_provider_registry
-                core = self.get_core_config() or {}
-                if tts_provider_registry.is_selected_preset_voice(core, self, ref):
-                    return tts_provider_registry.selected_provider_key(core, self)
+                return tts_provider_registry.selected_preset_provider_key(
+                    self.get_core_config() or {}, self, ref
+                )
             except Exception:
                 logger.warning("hosted preset voice 归一化异常，按非预制处理", exc_info=True)
-            return None
+                return None
 
         return normalize_voice_id(
             voice_id,
@@ -3364,6 +3366,14 @@ class ConfigManager:
         # change the key) keep the legacy string verbatim — never let migration rewrite
         # the key a binding points at, or _get_voice_meta would miss and TTS misroute.
         if to_legacy_voice_id(vc) != s:
+            return s
+        # Ownership guard: a bare id we could NOT resolve (no source/provider tagged)
+        # carries zero information beyond the flat string. Storing it as
+        # ``{source:"", provider:"", ref}`` is a half-migrated shell that only bloats
+        # storage and disguises "ownership unknown" as "migrated" — keep the legacy
+        # string until we can actually tag its ownership. (Only resolved bindings,
+        # incl. hosted presets like MiMo's, become structured objects.)
+        if not vc.source and not vc.provider:
             return s
         return vc.to_dict()
 

--- a/utils/tts_provider_registry.py
+++ b/utils/tts_provider_registry.py
@@ -372,6 +372,30 @@ def selected_provider_key(
     return provider.key if provider is not None else None
 
 
+def selected_preset_provider_key(
+    core_config: Mapping[str, Any],
+    cm: "ConfigManager",
+    voice_id: str | None,
+) -> str | None:
+    """Key of the currently selected provider **iff** ``voice_id`` is one of its
+    preset_catalog voices, else None — resolved in a single ``selected_provider``
+    dispatch.
+
+    Write-side dual of :func:`is_selected_preset_voice`: the normalizer
+    (``ConfigManager.normalize_voice_id_to_config``) needs both "is this a selected
+    preset" and "whose preset" together to tag ``{source:preset, provider:<key>}``.
+    Folding the two into one dispatch (instead of ``is_selected_preset_voice`` +
+    ``selected_provider_key``) closes the window where a future provider whose
+    ``is_selected`` depends on ``ctx.voice_id`` could answer the membership and the
+    key queries with different winners."""
+    provider = selected_provider(
+        DispatchContext(core_config=core_config, cm=cm, voice_id=voice_id or "")
+    )
+    if provider is None or not is_preset_voice(provider.key, voice_id):
+        return None
+    return provider.key
+
+
 def is_selected_preset_voice(
     core_config: Mapping[str, Any],
     cm: "ConfigManager",
@@ -380,12 +404,7 @@ def is_selected_preset_voice(
     """Whether ``voice_id`` is a built-in voice of the currently selected provider
     (used by ``validate_voice_id`` so a hosted provider's presets are saveable
     only while that provider is selected — dual to ``is_saveable_native_voice``)."""
-    provider = selected_provider(
-        DispatchContext(core_config=core_config, cm=cm, voice_id=voice_id or "")
-    )
-    if provider is None:
-        return False
-    return is_preset_voice(provider.key, voice_id)
+    return selected_preset_provider_key(core_config, cm, voice_id) is not None
 
 
 def ui_metadata() -> list[dict[str, Any]]:

--- a/utils/voice_config.py
+++ b/utils/voice_config.py
@@ -157,6 +157,7 @@ def normalize_voice_id(
     clone_provider_lookup: "Any" = None,
     is_native: "Any" = None,
     native_provider: str = "",
+    hosted_preset_provider: "Any" = None,
     free_voice_ids: "Any" = (),
 ) -> "VoiceConfig":
     """Resolve a legacy ``voice_id`` (prefixed *or* bare) to a structured VoiceConfig.
@@ -171,13 +172,19 @@ def normalize_voice_id(
     3. ``clone_provider_lookup(ref)`` returns a provider (the ref is a cloned voice
        in the current API's voice_storage) → ``{clone, <provider>, ref}``.
     4. ``is_native(ref)`` → ``{preset, <native_provider>, ref}``.
-    5. ``ref in free_voice_ids`` → ``{preset, free, ref}``.
-    6. otherwise unresolved → ``{ref}`` only (provider/source unknown; carried through
+    5. ``hosted_preset_provider(ref)`` returns a provider key (the ref is a built-in
+       preset of the currently selected hosted/local provider, e.g. MiMo's "Milo")
+       → ``{preset, <provider key>, ref}``.
+    6. ``ref in free_voice_ids`` → ``{preset, free, ref}``.
+    7. otherwise unresolved → ``{ref}`` only (provider/source unknown; carried through
        so nothing is lost — callers treat an unresolved ref as "leave as-is").
 
     Args:
         clone_provider_lookup: ``ref -> provider|None`` (None = not a known clone).
         is_native: ``ref -> bool``.
+        hosted_preset_provider: ``ref -> provider key|None`` — the selected
+            hosted/local provider's key when ``ref`` is one of its preset voices,
+            else None (mirrors ``tts_provider_registry.is_selected_preset_voice``).
         free_voice_ids: container of free preset voice ids.
     """
     parsed = parse_legacy_voice_id(voice_id)
@@ -198,6 +205,11 @@ def normalize_voice_id(
 
     if is_native is not None and is_native(ref):
         return VoiceConfig(source=SOURCE_PRESET, provider=str(native_provider or ""), ref=ref)
+
+    if hosted_preset_provider is not None:
+        provider = hosted_preset_provider(ref)
+        if provider:
+            return VoiceConfig(source=SOURCE_PRESET, provider=str(provider), ref=ref)
 
     if ref in free_voice_ids:
         return VoiceConfig(source=SOURCE_PRESET, provider="free", ref=ref)


### PR DESCRIPTION
@
## 背景

#1848 把 MiMo 预制音色从 `native_voice_registry` 迁到 hosted `tts_provider_registry` 的 `TTSProvider.preset_catalog`，并让 `validate_voice_id` 经 `is_selected_preset_voice` 认其合法。但 Codex review 指出保存侧有遗留缺口（#1848 未在本 PR 修）：

`voice_id_to_storage_value → normalize_voice_id_to_config → normalize_voice_id` 只认 vllm/clone/native/free 四类，不认 hosted preset。选中 MiMo 时保存预制音色（如 `"Milo"`）会落到「unresolved」分支，存成 `{source:"", provider:"", ref:"Milo"}`，丢了 `{source:preset, provider:mimo}` 这层 ownership 元数据（#1842 引入的结构化 schema 对 hosted preset 标注不完整）。

当前无功能损害（ref 原样保留、读路径/validate/dispatch 都仍正确），但将来 source-first 选声/迁移依赖该字段时会读到空 provider。

## 改动

- `utils/voice_config.py`：纯函数 `normalize_voice_id` 新增 `hosted_preset_provider` 注入点（`ref -> provider key|None`），解析顺序与 `validate_voice_id` 严格对齐——native 之后、free 之前。命中则标 `source=preset / provider=<选中 key>`。保持纯函数、可脱离 ConfigManager 测试。
- `utils/config_manager.py`：`normalize_voice_id_to_config` 新增 `_hosted_preset_provider`，经同层的 `tts_provider_registry.is_selected_preset_voice` + `selected_provider_key` 查「当前选中 provider 的 preset_catalog 命中」。和已有的 `_is_selected_hosted_preset_voice`（validate 侧）对偶，异常降级为「非预制」。**不 import main_logic**，守住 utils 层规则。

`voice_id_to_storage_value` 的 round-trip 守卫对 `provider=mimo` 的 preset 天然放行（`to_legacy_voice_id` 还原回裸 `ref="Milo"` == 原串），所以现在会正确迁成结构对象。

## 验证

- 新增 pure 函数测试（命中 / native 优先 / hosted 先于 free / miss 不误标）+ MiMo 端到端存储 round-trip 测试（选中 → `{source:preset, provider:mimo, ref:Milo}`、读回裸 key；未选中 → 裸 ref 原样带过）。
- 不影响 vllm/clone/native/free 既有标注。MiMo 无存量用户，无需迁移。
- 已 rebase 到含 #1850/#1851 的最新 main，相关测试合并后 72 passed 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **测试**
  * 新增语音ID规范化单元测试，覆盖预制音色选择、解析优先级与未命中回退语义
  * 新增 MiMo 音色处理端到端测试，验证语音配置补全及存储恢复行为

* **改进**
  * 增强语音ID解析对预制音色来源归属的判断
  * 优化存储逻辑：避免写入不完整的结构化语音配置，确保读取结果一致
<!-- end of auto-generated comment: release notes by coderabbit.ai -->