### PR TITLE
feat(topic): add deep research skeleton

### DIFF
--- a/main_logic/topic/deep_research.py
+++ b/main_logic/topic/deep_research.py
@@ -97,13 +97,20 @@ async def run_deep_research(
         updates: dict[str, Any] = {"deep_query": query}
 
         try:
-            enriched = await enrich([probe], lang=lang, max_materials=1)
-        except Exception:
+            enriched = await enrich(
+                [probe],
+                lang=lang,
+                max_materials=1,
+                timeout_s=normalized_budget.per_call_timeout,
+            )
+        except Exception as exc:
             if floor_hint is not None:
                 updates["material_hint"] = floor_hint
             return DeepResearchResult(
                 material_updates=updates,
-                fallback_reason="enrichment_error",
+                fallback_reason=(
+                    f"enrichment_error:{exc.__class__.__name__}: {exc}"
+                ),
             )
         deep = enriched[0] if enriched else None
         if isinstance(deep, Mapping) and deep.get("material_hint"):

--- a/main_logic/topic/deep_research.py
+++ b/main_logic/topic/deep_research.py
@@ -1,0 +1,130 @@
+"""Delivery-time deep research helpers for proactive topic hooks.
+
+This module owns the small "search first, then chat" preparation step behind
+``TopicHookPool._deepen_material``. The first version intentionally preserves
+the existing one-query behavior while giving later PRs a narrow place to add
+planning, reflection, and a separate research knowledge store.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+DeriveQuery = Callable[..., Awaitable[str | None]]
+EnrichMaterials = Callable[..., Awaitable[list[dict[str, Any]]]]
+
+
+@dataclass(frozen=True)
+class DeepResearchBudget:
+    """Hard limits for delivery-time research work."""
+
+    max_rounds: int = 1
+    per_call_timeout: float = 8.0
+    total_wall_clock: float = 12.0
+
+    def normalized(self) -> "DeepResearchBudget":
+        return DeepResearchBudget(
+            max_rounds=max(0, int(self.max_rounds)),
+            per_call_timeout=max(0.001, float(self.per_call_timeout)),
+            total_wall_clock=max(0.001, float(self.total_wall_clock)),
+        )
+
+
+@dataclass
+class DeepResearchResult:
+    """Result prepared for ``_deepen_material`` to merge into a material."""
+
+    material_updates: dict[str, Any] = field(default_factory=dict)
+    knowledge_items: list[dict[str, Any]] = field(default_factory=list)
+    fallback_reason: str = ""
+
+
+async def _default_derive_query(**kwargs: Any) -> str | None:
+    from main_logic.activity.llm_enrichment import derive_deep_search_query
+
+    return await derive_deep_search_query(**kwargs)
+
+
+async def _default_enrich_materials(
+    materials: list[Mapping[str, Any]], **kwargs: Any
+) -> list[dict[str, Any]]:
+    from main_logic.topic.materials import enrich_topic_materials_online
+
+    return await enrich_topic_materials_online(materials, **kwargs)
+
+
+async def run_deep_research(
+    *,
+    material: Mapping[str, Any],
+    lang: str,
+    budget: DeepResearchBudget | None = None,
+    derive_query: DeriveQuery | None = None,
+    enrich_materials: EnrichMaterials | None = None,
+) -> DeepResearchResult:
+    """Prepare deeper material updates while preserving floor fallback.
+
+    The current implementation is intentionally one round: derive one focused
+    query, re-run the existing online enrichment, and return only the fields
+    that should be merged back into the material. Later PRs can expand inside
+    this function without changing ``TopicHookPool`` again.
+    """
+
+    normalized_budget = (budget or DeepResearchBudget()).normalized()
+
+    async def _run_once() -> DeepResearchResult:
+        if normalized_budget.max_rounds <= 0:
+            return DeepResearchResult(fallback_reason="budget_exhausted")
+
+        derive = derive_query or _default_derive_query
+        enrich = enrich_materials or _default_enrich_materials
+
+        floor_hint = material.get("material_hint")
+        query = await derive(
+            interest=str(material.get("interest") or ""),
+            keywords=list(material.get("keywords") or []),
+            floor_angle=str(material.get("online_angle") or ""),
+            lang=lang,
+            timeout=normalized_budget.per_call_timeout,
+        )
+        if not query:
+            return DeepResearchResult(fallback_reason="empty_query")
+
+        probe = dict(material)
+        probe["deep_query"] = query
+        probe.pop("material_hint", None)
+        updates: dict[str, Any] = {"deep_query": query}
+
+        try:
+            enriched = await enrich([probe], lang=lang, max_materials=1)
+        except Exception:
+            if floor_hint is not None:
+                updates["material_hint"] = floor_hint
+            return DeepResearchResult(
+                material_updates=updates,
+                fallback_reason="enrichment_error",
+            )
+        deep = enriched[0] if enriched else None
+        if isinstance(deep, Mapping) and deep.get("material_hint"):
+            for key in ("material_hint", "online_used", "online_query", "online_angle"):
+                if key in deep:
+                    updates[key] = deep[key]
+            return DeepResearchResult(material_updates=updates)
+
+        if floor_hint is not None:
+            updates["material_hint"] = floor_hint
+        return DeepResearchResult(
+            material_updates=updates,
+            fallback_reason="empty_enrichment",
+        )
+
+    try:
+        return await asyncio.wait_for(
+            _run_once(),
+            timeout=normalized_budget.total_wall_clock,
+        )
+    except asyncio.TimeoutError:
+        return DeepResearchResult(fallback_reason="timeout")
+    except Exception as exc:
+        return DeepResearchResult(fallback_reason=f"error:{exc.__class__.__name__}")

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -17,6 +17,7 @@ from datetime import date, datetime
 from typing import Any
 
 from main_logic.topic.common import ZH_TOPIC_STOP_CHARS, clean_text, topic_units
+from main_logic.topic.deep_research import run_deep_research
 from main_logic.topic.materials import enrich_topic_materials_online
 from main_logic.topic.signals import TopicSignalStore
 
@@ -515,7 +516,7 @@ class TopicHookPool:
     async def _deepen_material(
         self, name: str, material: dict[str, Any], lang: str
     ) -> None:
-        """Delivery-time deep search: derive a focused query and re-enrich.
+        """Delivery-time deep search: prepare a focused online lead.
 
         Idempotent per material (``deep_search_done``) so a rescheduled trigger
         reuses the prepared lead instead of re-searching. Any failure leaves the
@@ -527,39 +528,15 @@ class TopicHookPool:
         if material.get("deep_search_done"):
             return
         material["deep_search_done"] = True
-        try:
-            from main_logic.activity.llm_enrichment import derive_deep_search_query
-            query = await derive_deep_search_query(
-                interest=str(material.get("interest") or ""),
-                keywords=list(material.get("keywords") or []),
-                floor_angle=str(material.get("online_angle") or ""),
-                lang=lang,
-            )
-        except Exception as exc:
-            logger.debug("[%s] deep search query derivation failed: %s", name, exc)
-            return
-        if not query:
-            return
-        material["deep_query"] = query
-        # Re-run online enrichment with the derived query. Clear the floor hint
-        # so the deeper result can replace it; restore the floor if the deep
-        # fetch turns up nothing.
-        floor_hint = material.get("material_hint")
-        material.pop("material_hint", None)
-        try:
-            enriched = await enrich_topic_materials_online(
-                [material], lang=lang, max_materials=1
-            )
-        except Exception as exc:
-            logger.debug("[%s] deep search enrichment failed: %s", name, exc)
-            enriched = None
-        deep = enriched[0] if enriched else None
-        if isinstance(deep, Mapping) and deep.get("material_hint"):
-            for key in ("material_hint", "online_used", "online_query", "online_angle"):
-                if key in deep:
-                    material[key] = deep[key]
-        elif floor_hint is not None:
-            material["material_hint"] = floor_hint
+        result = await run_deep_research(
+            material=material,
+            lang=lang,
+            enrich_materials=enrich_topic_materials_online,
+        )
+        if result.material_updates:
+            material.update(result.material_updates)
+        if result.fallback_reason:
+            logger.debug("[%s] deep search fallback: %s", name, result.fallback_reason)
 
     def _prune_used_topics(self, name: str, *, now: float | None = None) -> list[dict[str, Any]]:
         current_time = float(now if now is not None else time.time())

--- a/tests/unit/test_topic_deep_research.py
+++ b/tests/unit/test_topic_deep_research.py
@@ -109,6 +109,7 @@ async def test_run_deep_research_forwards_per_call_timeout_to_enrich():
         enrich_materials=fake_enrich,
     )
 
+    assert "timeout_s" in captured
     assert captured["timeout_s"] == 2.5
 
 

--- a/tests/unit/test_topic_deep_research.py
+++ b/tests/unit/test_topic_deep_research.py
@@ -70,7 +70,7 @@ async def test_run_deep_research_restores_floor_when_enrich_finds_nothing():
 @pytest.mark.asyncio
 async def test_run_deep_research_budget_timeout_returns_no_updates():
     async def slow_derive(**kwargs):
-        await asyncio.sleep(0.05)
+        await asyncio.Future()
         return "late query"
 
     async def fake_enrich(materials, **kwargs):
@@ -79,13 +79,37 @@ async def test_run_deep_research_budget_timeout_returns_no_updates():
     result = await run_deep_research(
         material={"interest": "x", "keywords": ["x"]},
         lang="zh-CN",
-        budget=DeepResearchBudget(total_wall_clock=0.01),
+        budget=DeepResearchBudget(total_wall_clock=0.05),
         derive_query=slow_derive,
         enrich_materials=fake_enrich,
     )
 
     assert result.material_updates == {}
     assert result.fallback_reason == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_run_deep_research_forwards_per_call_timeout_to_enrich():
+    captured = {}
+
+    async def fake_derive(**kwargs):
+        return "deep query"
+
+    async def fake_enrich(materials, **kwargs):
+        captured["timeout_s"] = kwargs.get("timeout_s")
+        material = dict(materials[0])
+        material["material_hint"] = {"summary": "deep"}
+        return [material]
+
+    await run_deep_research(
+        material={"interest": "x", "keywords": ["x"]},
+        lang="zh-CN",
+        budget=DeepResearchBudget(per_call_timeout=2.5),
+        derive_query=fake_derive,
+        enrich_materials=fake_enrich,
+    )
+
+    assert captured["timeout_s"] == 2.5
 
 
 @pytest.mark.asyncio
@@ -111,4 +135,4 @@ async def test_run_deep_research_keeps_query_and_floor_when_enrich_raises():
         "deep_query": "deep query before failure",
         "material_hint": {"summary": "floor"},
     }
-    assert result.fallback_reason == "enrichment_error"
+    assert result.fallback_reason == "enrichment_error:RuntimeError: fetch failed"

--- a/tests/unit/test_topic_deep_research.py
+++ b/tests/unit/test_topic_deep_research.py
@@ -1,0 +1,114 @@
+import asyncio
+
+import pytest
+
+from main_logic.topic.deep_research import DeepResearchBudget, run_deep_research
+
+
+@pytest.mark.asyncio
+async def test_run_deep_research_returns_updates_and_preserves_future_knowledge_slot():
+    async def fake_derive(**kwargs):
+        return "文本世界模型 幻觉 最新研究"
+
+    async def fake_enrich(materials, **kwargs):
+        material = dict(materials[0])
+        material["material_hint"] = {"summary": f"deep:{material['deep_query']}"}
+        material["online_used"] = True
+        material["online_query"] = material["deep_query"]
+        material["online_angle"] = "最新研究综述"
+        return [material]
+
+    result = await run_deep_research(
+        material={
+            "interest": "文本世界模型",
+            "keywords": ["文本世界模型", "幻觉"],
+            "material_hint": {"summary": "floor"},
+            "online_angle": "floor angle",
+        },
+        lang="zh-CN",
+        derive_query=fake_derive,
+        enrich_materials=fake_enrich,
+    )
+
+    assert result.material_updates == {
+        "deep_query": "文本世界模型 幻觉 最新研究",
+        "material_hint": {"summary": "deep:文本世界模型 幻觉 最新研究"},
+        "online_used": True,
+        "online_query": "文本世界模型 幻觉 最新研究",
+        "online_angle": "最新研究综述",
+    }
+    assert result.knowledge_items == []
+    assert result.fallback_reason == ""
+
+
+@pytest.mark.asyncio
+async def test_run_deep_research_restores_floor_when_enrich_finds_nothing():
+    async def fake_derive(**kwargs):
+        return "some deep query"
+
+    async def fake_enrich(materials, **kwargs):
+        return [dict(materials[0])]
+
+    result = await run_deep_research(
+        material={
+            "interest": "x",
+            "keywords": ["x"],
+            "material_hint": {"summary": "floor"},
+        },
+        lang="zh-CN",
+        derive_query=fake_derive,
+        enrich_materials=fake_enrich,
+    )
+
+    assert result.material_updates == {
+        "deep_query": "some deep query",
+        "material_hint": {"summary": "floor"},
+    }
+    assert result.fallback_reason == "empty_enrichment"
+
+
+@pytest.mark.asyncio
+async def test_run_deep_research_budget_timeout_returns_no_updates():
+    async def slow_derive(**kwargs):
+        await asyncio.sleep(0.05)
+        return "late query"
+
+    async def fake_enrich(materials, **kwargs):
+        raise AssertionError("enrich should not run after timeout")
+
+    result = await run_deep_research(
+        material={"interest": "x", "keywords": ["x"]},
+        lang="zh-CN",
+        budget=DeepResearchBudget(total_wall_clock=0.01),
+        derive_query=slow_derive,
+        enrich_materials=fake_enrich,
+    )
+
+    assert result.material_updates == {}
+    assert result.fallback_reason == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_run_deep_research_keeps_query_and_floor_when_enrich_raises():
+    async def fake_derive(**kwargs):
+        return "deep query before failure"
+
+    async def failing_enrich(materials, **kwargs):
+        raise RuntimeError("fetch failed")
+
+    result = await run_deep_research(
+        material={
+            "interest": "x",
+            "keywords": ["x"],
+            "material_hint": {"summary": "floor"},
+        },
+        lang="zh-CN",
+        derive_query=fake_derive,
+        enrich_materials=failing_enrich,
+    )
+
+    assert result.material_updates == {
+        "deep_query": "deep query before failure",
+        "material_hint": {"summary": "floor"},
+    }
+    assert result.fallback_reason == "enrichment_error"


### PR DESCRIPTION
## 改动概述 / Summary

- 新增 `main_logic/topic/deep_research.py`，把投递前 deep search 的现有「派生一条 `deep_query` + 重新 online enrich + floor fallback」行为收口到 `run_deep_research(...)`。
- `_deepen_material` 只保留开关、幂等标记和 material 回填，不在 pipeline 里继续堆 deep search 细节。
- 新增 `DeepResearchBudget` 与 `DeepResearchResult`，为后续 #1847 的 plan/gather/reflect/synthesize 小 PR 留出窄接口；本 PR 不实现多轮、不引 MCP runtime、不做知识库存储。
- 补充 `tests/unit/test_topic_deep_research.py` 覆盖 deep result 回填、floor fallback、超时、enrich 异常保持 floor 的行为。

关联：#1847

## 回归报告 / Regression Report

本 PR 触及 `main_logic/topic/pipeline.py` 和新增 `main_logic/topic/deep_research.py`，属于 `main_logic` 范围。

- 改动内容：将 `_deepen_material` 内部原有 deep search 逻辑抽到 `run_deep_research(...)`，pipeline 侧改为调用新模块并合并返回的 `material_updates`。
- 改动理由：#1847 后续需要在唯一接缝 `_deepen_material` 后扩展 bounded deep-research loop。先把现有行为收口成独立模块，避免后续把 plan/reflect/fetch/synthesis 全塞进 pipeline。
- 必要性：这是后续拆分 PR 的地基，当前 PR 只做行为等价的骨架和预算接口，不引入新机制。
- 前后表现：
  - 之前：`_deepen_material` 直接派生一条 `deep_query`，调用 `enrich_topic_materials_online`，成功覆盖 floor，失败保留 floor。
  - 之后：`_deepen_material` 调 `run_deep_research(...)` 获得同样的 material updates；成功/空结果/异常/超时仍保留 floor fallback，不影响投递、quota、privacy、re-gate。
- 潜在回归点：
  - deep query 派生失败时不能影响开口。
  - online enrich 空结果或异常时必须保留 floor hint。
  - reschedule 时 `deep_search_done` 仍需保持幂等。
  - delivery bridge 仍只能接收准备好的 material，不能被 deep research 失败阻断。
- 验证：见下方 Testing。

## 不拆分理由 / Why Not Split

不适用。本 PR 只改 3 个文件，是 #1847 的第一个骨架 PR；plan、media_intent、多 query、reflect、synthesize、知识库/回收机制都会后续单独拆 PR。

## 测试 / Testing

- `uv run ruff check main_logic/topic/deep_research.py main_logic/topic/pipeline.py tests/unit/test_topic_deep_research.py`
- `uv run pytest tests/unit/test_topic_delivery.py tests/unit/test_topic_pipeline.py tests/unit/test_topic_materials.py tests/unit/test_topic_llm_enrichment.py tests/unit/test_topic_deep_research.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 新增“深度研究”模块：支持配置研究预算（最大轮次、单次超时、总耗时），并以标准化结果输出（字段更新与回退原因）。
  * 深度在线检索升级为“单轮深度聚焦”：根据派生线索发起在线富集，将命中的在线字段与提示信息合并回结果，并在失败/空结果时提供明确回退原因。

* **测试**
  * 新增/扩展异步单元测试：覆盖字段合并、空结果回退、总耗时超时、超时参数透传以及在线富集异常场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->