### PR TITLE
Fix mini-game LLM context growth and cache churn

### DIFF
--- a/config/prompts/prompts_game_route.py
+++ b/config/prompts/prompts_game_route.py
@@ -592,6 +592,45 @@ GAME_ARCHIVE_MEMORY_SUMMARY_LABELS = {
 }
 
 
+GAME_ARCHIVE_FALLBACK_HIGHLIGHT_LABELS = {
+    "zh": {
+        "user_and_assistant": "玩家最后说「{last_user}」，你回应「{last_assistant}」。",
+        "user_only": "玩家最后在这局游戏里说「{last_user}」。",
+        "assistant_only": "你最后在这局游戏里说「{last_assistant}」。",
+    },
+    "en": {
+        "user_and_assistant": "The player last said \"{last_user}\", and you replied \"{last_assistant}\".",
+        "user_only": "The player last said \"{last_user}\" in this game.",
+        "assistant_only": "You last said \"{last_assistant}\" in this game.",
+    },
+    "ja": {
+        "user_and_assistant": "プレイヤーは最後に「{last_user}」と言い、あなたは「{last_assistant}」と返しました。",
+        "user_only": "プレイヤーはこのゲームで最後に「{last_user}」と言いました。",
+        "assistant_only": "あなたはこのゲームで最後に「{last_assistant}」と言いました。",
+    },
+    "ko": {
+        "user_and_assistant": "플레이어가 마지막으로 \"{last_user}\"라고 했고, 당신은 \"{last_assistant}\"라고 답했습니다.",
+        "user_only": "플레이어가 이 게임에서 마지막으로 \"{last_user}\"라고 말했습니다.",
+        "assistant_only": "당신은 이 게임에서 마지막으로 \"{last_assistant}\"라고 말했습니다.",
+    },
+    "ru": {
+        "user_and_assistant": "Игрок в конце сказал: «{last_user}», а ты ответила: «{last_assistant}».",
+        "user_only": "Последняя реплика игрока в этой игре: «{last_user}».",
+        "assistant_only": "Твоя последняя реплика в этой игре: «{last_assistant}».",
+    },
+    "es": {
+        "user_and_assistant": "El jugador dijo por último \"{last_user}\" y tú respondiste \"{last_assistant}\".",
+        "user_only": "El jugador dijo por último \"{last_user}\" en esta partida.",
+        "assistant_only": "Tú dijiste por último \"{last_assistant}\" en esta partida.",
+    },
+    "pt": {
+        "user_and_assistant": "O jogador disse por último \"{last_user}\" e você respondeu \"{last_assistant}\".",
+        "user_only": "O jogador disse por último \"{last_user}\" neste jogo.",
+        "assistant_only": "Você disse por último \"{last_assistant}\" neste jogo.",
+    },
+}
+
+
 GAME_POSTGAME_CONTEXT_LABELS = {
     "zh": {
         "header": "[Game Module Postgame Context]",
@@ -1038,7 +1077,7 @@ GAME_RECENT_HISTORY_MESSAGE_LABELS = {
         "player_line": "Jogador: {text}",
         "game_event_text": "Evento de jogo {kind}: texto original do evento \"{text}\"",
         "game_event": "Evento de jogo {kind}",
-        "previous_character_output": "Saida anterior da personagem: {text}",
+        "previous_character_output": "Saída anterior da personagem: {text}",
     },
 }
 
@@ -1203,6 +1242,10 @@ def get_game_archive_memory_text_labels(lang: str | None = None) -> dict[str, st
 
 def get_game_archive_memory_summary_labels(lang: str | None = None) -> dict[str, str]:
     return _labels(GAME_ARCHIVE_MEMORY_SUMMARY_LABELS, lang)
+
+
+def get_game_archive_fallback_highlight_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_ARCHIVE_FALLBACK_HIGHLIGHT_LABELS, lang)
 
 
 def get_game_postgame_context_labels(lang: str | None = None) -> dict[str, str]:

--- a/config/prompts/prompts_game_route.py
+++ b/config/prompts/prompts_game_route.py
@@ -997,6 +997,52 @@ GAME_CONTEXT_FORMATTER_LABELS = {
 }
 
 
+GAME_RECENT_HISTORY_MESSAGE_LABELS = {
+    "zh": {
+        "player_line": "玩家：{text}",
+        "game_event_text": "游戏事件 {kind}：事件原文「{text}」",
+        "game_event": "游戏事件 {kind}",
+        "previous_character_output": "历史猫娘输出：{text}",
+    },
+    "en": {
+        "player_line": "Player: {text}",
+        "game_event_text": "Game event {kind}: event text \"{text}\"",
+        "game_event": "Game event {kind}",
+        "previous_character_output": "Previous character output: {text}",
+    },
+    "ja": {
+        "player_line": "プレイヤー：{text}",
+        "game_event_text": "ゲームイベント {kind}：イベント原文「{text}」",
+        "game_event": "ゲームイベント {kind}",
+        "previous_character_output": "直前のキャラクター出力：{text}",
+    },
+    "ko": {
+        "player_line": "플레이어: {text}",
+        "game_event_text": "게임 이벤트 {kind}: 이벤트 원문 \"{text}\"",
+        "game_event": "게임 이벤트 {kind}",
+        "previous_character_output": "이전 캐릭터 출력: {text}",
+    },
+    "ru": {
+        "player_line": "Игрок: {text}",
+        "game_event_text": "Игровое событие {kind}: исходный текст события «{text}»",
+        "game_event": "Игровое событие {kind}",
+        "previous_character_output": "Предыдущая реплика персонажа: {text}",
+    },
+    "es": {
+        "player_line": "Jugador: {text}",
+        "game_event_text": "Evento de juego {kind}: texto original del evento \"{text}\"",
+        "game_event": "Evento de juego {kind}",
+        "previous_character_output": "Salida anterior del personaje: {text}",
+    },
+    "pt": {
+        "player_line": "Jogador: {text}",
+        "game_event_text": "Evento de jogo {kind}: texto original do evento \"{text}\"",
+        "game_event": "Evento de jogo {kind}",
+        "previous_character_output": "Saida anterior da personagem: {text}",
+    },
+}
+
+
 def get_game_context_organizer_system_prompt(lang: str | None = None) -> str:
     return _localized_template(GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPTS, lang)
 
@@ -1047,3 +1093,7 @@ def get_compact_realtime_context_texts(lang: str | None = None) -> dict[str, str
 
 def get_game_context_formatter_labels(lang: str | None = None) -> dict[str, str]:
     return _labels(GAME_CONTEXT_FORMATTER_LABELS, lang)
+
+
+def get_game_recent_history_message_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_RECENT_HISTORY_MESSAGE_LABELS, lang)

--- a/config/prompts/prompts_game_route.py
+++ b/config/prompts/prompts_game_route.py
@@ -159,7 +159,7 @@ GAME_ARCHIVE_MEMORY_HIGHLIGHTER_SYSTEM_PROMPTS = {
 - postgame_tone 用短语描述赛后语气，例如普通、得意、闹别扭、低落稍缓；没有可靠证据就留空。
 - memory_summary 用 0-1 句写给后续聊天看的本局摘要；不要编造关系修复。
 - 不要写流水统计、不要写“记录了几条事件”、不要把记录写成玩家逐字发言。
-- 只有材料中明确标为玩家发言的内容才是玩家说的话；游戏事件里的事件原文不是玩家原话，不能写成“玩家说/玩家喊”。
+- 只有材料中以“玩家：”开头的内容才是玩家说的话；游戏事件里的“事件原文”不是玩家原话，不能写成“玩家说/玩家喊”。
 - 官方结果永远以材料里的 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只能记录成口头让步/安抚/玩笑，不能写成真实结果改变。
 - 如果保留官方结果，必须沿用材料里的固定顺序或明确写出谁领先谁；不要写无主体裸结果（例如“8:0”“0:10”），也不要前后混用不同视角。
 - 普通本局事件如果没有关系或情绪价值，可以不选。
@@ -176,7 +176,7 @@ Rules:
 - postgame_tone: a short phrase for postgame tone, such as ordinary, proud, sulking, slightly less down; leave empty without reliable evidence.
 - memory_summary: 0-1 sentence for later chat; do not invent relationship repair.
 - Do not write play-by-play stats, do not say how many events were recorded, and do not turn records into verbatim player utterances.
-- Only content explicitly marked as player speech in the material is the player's speech. Event text inside game-event lines is not a player quote.
+- Only content beginning with the literal marker "Player:" in the material is the player's speech. The literal "event text" inside "Game event" lines is not a player quote.
 - Official result always follows finalScore / last_state.score in the material. Verbal concessions are only concessions, comfort, or jokes; they do not change the real result.
 - If you keep the official result, preserve the material's fixed order or explicitly name who leads whom; do not write bare subjectless scores.
 - Skip ordinary session events with no relationship or emotional value.
@@ -193,7 +193,7 @@ Rules:
 - postgame_tone は普通、得意げ、すね気味、少し落ち着いた等の短い語句。証拠がなければ空欄。
 - memory_summary は後続チャット向けの 0-1 文。本局の要約にし、関係修復を捏造しないでください。
 - 統計の羅列や「何件記録した」は書かず、記録をプレイヤーの逐語発言にしないでください。
-- 材料内でプレイヤー発言として明示された内容だけがプレイヤーの発言です。ゲームイベント行のイベント原文はプレイヤー発言ではありません。
+- 材料内でリテラル marker「プレイヤー：」から始まる内容だけがプレイヤーの発言です。「ゲームイベント」行の「イベント原文」はプレイヤー発言ではありません。
 - 公式結果は常に材料内の finalScore / last_state.score に従います。口頭の譲歩や冗談は実際の結果変更ではありません。
 - 公式結果を書く場合は材料の固定順を保つか、誰が誰をリードしたか明示してください。
 - 関係や感情の価値がない普通のイベントは選ばなくてかまいません。
@@ -210,7 +210,7 @@ Rules:
 - postgame_tone 은 보통, 의기양양, 삐침, 조금 누그러짐 같은 짧은 구절입니다. 증거가 없으면 비워 둡니다.
 - memory_summary 는 이후 채팅을 위한 0-1문장 요약입니다. 관계 회복을 지어내지 마세요.
 - 진행 통계, "몇 개 이벤트를 기록했다" 같은 말, 플레이어의 축어 발화처럼 보이는 기록을 쓰지 마세요.
-- 자료에서 플레이어 발화로 명확히 표시된 내용만 플레이어가 한 말입니다. 게임 이벤트 줄의 이벤트 원문은 플레이어 원문이 아닙니다.
+- 자료에서 literal marker "플레이어:" 로 시작하는 내용만 플레이어가 한 말입니다. "게임 이벤트" 줄의 "이벤트 원문"은 플레이어 원문이 아닙니다.
 - 공식 결과는 항상 자료의 finalScore / last_state.score 를 따릅니다. 말로 한 양보나 농담은 실제 결과 변경이 아닙니다.
 - 공식 결과를 남긴다면 자료의 고정 순서를 유지하거나 누가 누구에게 앞섰는지 명확히 쓰세요.
 - 관계나 감정 가치가 없는 평범한 이벤트는 선택하지 않아도 됩니다.
@@ -227,7 +227,7 @@ Rules:
 - postgame_tone: короткая фраза о тоне после игры; без надежных доказательств оставь пустым.
 - memory_summary: 0-1 предложение для дальнейшего чата; не выдумывай восстановление отношений.
 - Не пиши потоковую статистику, не сообщай количество записанных событий и не превращай записи в дословные слова игрока.
-- Только содержимое, явно помеченное в материале как речь игрока, является словами игрока. Текст события в строках игровых событий не является цитатой игрока.
+- Только строки материала, начинающиеся с literal marker "Игрок:", являются словами игрока. "текст события" в строках "Игровое событие" не является цитатой игрока.
 - Официальный результат всегда следует finalScore / last_state.score в материале. Устные уступки являются только уступками, утешением или шуткой и не меняют реальный результат.
 - Если сохраняешь официальный результат, придерживайся фиксированного порядка материала или явно укажи, кто кого опережает.
 - Обычные события без ценности для отношений или эмоций можно не выбирать.
@@ -244,7 +244,7 @@ Reglas:
 - postgame_tone: una frase breve para el tono postpartida, por ejemplo normal, orgullosa, enfurruñada, algo menos decaída; déjalo vacío sin evidencia fiable.
 - memory_summary: 0-1 frase para chats posteriores; no inventes reparación de la relación.
 - No escribas estadísticas jugada por jugada, no digas cuántos eventos se registraron y no conviertas registros en citas literales del jugador.
-- Solo el contenido marcado explícitamente como habla del jugador en el material es habla del jugador. El texto de evento dentro de líneas de evento de juego no es una cita del jugador.
+- Solo el contenido que empieza con el marcador literal "Jugador:" en el material es habla del jugador. "texto del evento" dentro de líneas "Evento de juego" no es una cita del jugador.
 - El resultado oficial siempre sigue finalScore / last_state.score del material. Concesiones verbales solo son concesiones, consuelo o bromas; no cambian el resultado real.
 - Si conservas el resultado oficial, preserva el orden fijo del material o indica explícitamente quién va por delante; no escribas marcadores sin sujeto.
 - Omite eventos ordinarios sin valor relacional o emocional.
@@ -261,7 +261,7 @@ Regras:
 - postgame_tone: uma frase curta para o tom pós-jogo, como normal, orgulhosa, emburrada, um pouco menos abatida; deixe vazio sem evidência confiável.
 - memory_summary: 0-1 frase para chats posteriores; não invente reparação de relação.
 - Não escreva estatísticas lance a lance, não diga quantos eventos foram registrados e não transforme registros em falas literais do jogador.
-- Apenas conteúdo explicitamente marcado como fala do jogador no material é fala do jogador. O texto de evento dentro de linhas de evento de jogo não é citação do jogador.
+- Apenas conteúdo que começa com o marcador literal "Jogador:" no material é fala do jogador. "texto do evento" dentro de linhas "Evento de jogo" não é citação do jogador.
 - O resultado oficial sempre segue finalScore / last_state.score do material. Concessões verbais são apenas concessões, conforto ou brincadeiras; não mudam o resultado real.
 - Se mantiver o resultado oficial, preserve a ordem fixa do material ou diga explicitamente quem lidera; não escreva placares sem sujeito.
 - Ignore eventos comuns sem valor relacional ou emocional.
@@ -286,7 +286,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "最终/最近结果: {score_text}",
         "score_explanation": "结果说明: 上面的最终/最近结果是游戏模块给出的官方结果，来源优先级为 finalScore / last_state.score；当数据是分差结构时固定顺序是玩家在前、当前角色在后；筛选重点时不要改成相反视角。",
         "verbal_concession_explanation": "口头让步说明: 局内如果出现“算你赢”“让你赢回来”“口头认输”等，只能记录为口头让步、安抚或玩笑；不能改写官方结果或真实胜负。",
-        "role_explanation": "角色说明: 只有明确标为玩家发言的行才是玩家亲口说的话；游戏事件行里的事件原文是游戏模块/猫娘气泡或事件标签，不要归因给玩家。",
+        "role_explanation": "角色说明: 只有“玩家：...”行是玩家亲口说的话；“游戏事件”行里的“事件原文”是游戏模块/猫娘气泡或事件标签，不要归因给玩家。",
         "pregame_context": "开局上下文: {context}",
         "degraded": "局内上下文整理状态: 已降级为纯游戏模式；不要输出关系摘要、信号解释或不可验证的状态延续。",
         "rolling_summary": "局内滚动摘要: {summary}",
@@ -300,7 +300,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Final/recent result: {score_text}",
         "score_explanation": "Result note: the final/recent result above is the official result from the game module, prioritized from finalScore / last_state.score. If the data is a score-difference structure, the fixed order is player first and current character second; do not flip the viewpoint.",
         "verbal_concession_explanation": 'Verbal-concession note: in-session phrases like "you win", "I\'ll let you win it back", or "I concede" may only be recorded as verbal concessions, comfort, or jokes; they do not rewrite the official result or real win/loss.',
-        "role_explanation": "Role note: only lines explicitly marked as player speech are the player's own words. Event text inside game-event lines is a game-module/character bubble or event label; do not attribute it to the player.",
+        "role_explanation": 'Role note: only lines beginning with the literal marker "Player:" are the player\'s own words. "event text" inside "Game event" lines is a game-module/character bubble or event label; do not attribute it to the player.',
         "pregame_context": "Opening context: {context}",
         "degraded": "In-session context status: degraded to pure game mode; do not output relationship summaries, signal explanations, or unverifiable state carryover.",
         "rolling_summary": "In-session rolling summary: {summary}",
@@ -314,7 +314,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "最終/直近結果: {score_text}",
         "score_explanation": "結果説明: 上の最終/直近結果はゲームモジュールの公式結果で、finalScore / last_state.score を優先します。差分構造では固定順はプレイヤーが先、現在のキャラが後です。視点を反転しないでください。",
         "verbal_concession_explanation": "口頭譲歩の説明: 「勝ちでいい」「勝たせる」「降参」などは口頭譲歩、慰め、冗談としてだけ記録し、公式結果や実際の勝敗を書き換えません。",
-        "role_explanation": "役割説明: プレイヤー発言として明示された行だけがプレイヤー本人の発言です。ゲームイベント行のイベント原文はゲームモジュール/キャラのバブルまたはイベントラベルであり、プレイヤーに帰属させないでください。",
+        "role_explanation": "役割説明: literal marker「プレイヤー：...」で始まる行だけがプレイヤー本人の発言です。「ゲームイベント」行の「イベント原文」はゲームモジュール/キャラのバブルまたはイベントラベルであり、プレイヤーに帰属させないでください。",
         "pregame_context": "開局コンテキスト: {context}",
         "degraded": "局内コンテキスト整理状態: 純ゲームモードに降格済み。関係要約、シグナル解釈、検証不能な状態継続を出力しないでください。",
         "rolling_summary": "局内ローリング要約: {summary}",
@@ -328,7 +328,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "최종/최근 결과: {score_text}",
         "score_explanation": "결과 설명: 위 최종/최근 결과는 게임 모듈의 공식 결과이며 finalScore / last_state.score 를 우선합니다. 점수 차이 구조라면 고정 순서는 플레이어가 먼저, 현재 캐릭터가 나중입니다. 시점을 뒤집지 마세요.",
         "verbal_concession_explanation": '말로 한 양보 설명: 진행 중 "네가 이긴 걸로", "이기게 해줄게", "항복" 같은 말은 말로 한 양보, 위로, 농담으로만 기록하며 공식 결과나 실제 승패를 바꾸지 않습니다.',
-        "role_explanation": "역할 설명: 플레이어 발화로 명시된 줄만 플레이어가 직접 한 말입니다. 게임 이벤트 줄의 이벤트 원문은 게임 모듈/캐릭터 말풍선 또는 이벤트 라벨이며 플레이어에게 귀속하지 마세요.",
+        "role_explanation": '역할 설명: literal marker "플레이어:" 로 시작하는 줄만 플레이어가 직접 한 말입니다. "게임 이벤트" 줄의 "이벤트 원문"은 게임 모듈/캐릭터 말풍선 또는 이벤트 라벨이며 플레이어에게 귀속하지 마세요.',
         "pregame_context": "시작 컨텍스트: {context}",
         "degraded": "진행 중 컨텍스트 정리 상태: 순수 게임 모드로 강등됨. 관계 요약, 신호 해석, 검증할 수 없는 상태 지속을 출력하지 마세요.",
         "rolling_summary": "진행 중 롤링 요약: {summary}",
@@ -342,7 +342,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Финальный/последний результат: {score_text}",
         "score_explanation": "Пояснение результата: финальный/последний результат выше является официальным результатом игрового модуля, с приоритетом finalScore / last_state.score. Если данные являются структурой разницы счета, фиксированный порядок: сначала игрок, затем текущий персонаж; не меняй точку зрения.",
         "verbal_concession_explanation": 'Пояснение устных уступок: фразы вроде "ты выиграл", "дам тебе отыграться" или "сдаюсь" можно записывать только как устную уступку, утешение или шутку; они не меняют официальный результат.',
-        "role_explanation": "Пояснение ролей: словами игрока являются только строки, явно помеченные как речь игрока. Текст события в строках игровых событий — это реплика игрового модуля/персонажа или метка события; не приписывай его игроку.",
+        "role_explanation": 'Пояснение ролей: только строки с literal marker "Игрок:" являются словами игрока. "текст события" в строках "Игровое событие" — это реплика игрового модуля/персонажа или метка события; не приписывай его игроку.',
         "pregame_context": "Начальный контекст: {context}",
         "degraded": "Статус контекста сессии: понижен до чистого игрового режима; не выводи summaries отношений, объяснения сигналов или непроверяемое продолжение состояния.",
         "rolling_summary": "Rolling summary сессии: {summary}",
@@ -356,7 +356,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Resultado final/reciente: {score_text}",
         "score_explanation": "Nota de resultado: el resultado final/reciente anterior es el resultado oficial del módulo de juego, priorizado desde finalScore / last_state.score. Si los datos son una estructura de diferencia de puntuación, el orden fijo es jugador primero y personaje actual segundo; no inviertas el punto de vista.",
         "verbal_concession_explanation": 'Nota de concesión verbal: frases dentro de la sesión como "tú ganas", "te dejo remontar" o "me rindo" solo pueden registrarse como concesiones verbales, consuelo o bromas; no reescriben el resultado oficial ni la victoria/derrota real.',
-        "role_explanation": "Nota de rol: solo las líneas marcadas explícitamente como habla del jugador son palabras propias del jugador. El texto de evento dentro de líneas de evento de juego es una burbuja del módulo/personaje o etiqueta de evento; no se lo atribuyas al jugador.",
+        "role_explanation": 'Nota de rol: solo las líneas que empiezan con el marcador literal "Jugador:" son palabras propias del jugador. "texto del evento" dentro de líneas "Evento de juego" es una burbuja del módulo/personaje o etiqueta de evento; no se la atribuyas al jugador.',
         "pregame_context": "Contexto inicial: {context}",
         "degraded": "Estado del contexto de sesión: degradado a modo de juego puro; no generes resúmenes de relación, explicaciones de señales ni continuidad de estado no verificable.",
         "rolling_summary": "Resumen continuo de la sesión: {summary}",
@@ -370,7 +370,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Resultado final/recente: {score_text}",
         "score_explanation": "Nota de resultado: o resultado final/recente acima é o resultado oficial do módulo de jogo, priorizado a partir de finalScore / last_state.score. Se os dados forem uma estrutura de diferença de placar, a ordem fixa é jogador primeiro e personagem atual em segundo; não inverta o ponto de vista.",
         "verbal_concession_explanation": 'Nota de concessão verbal: frases dentro da sessão como "você venceu", "vou deixar você virar" ou "desisto" só podem ser registradas como concessões verbais, conforto ou brincadeiras; não reescrevem o resultado oficial nem a vitória/derrota real.',
-        "role_explanation": "Nota de papel: apenas linhas marcadas explicitamente como fala do jogador são palavras do próprio jogador. O texto do evento dentro de linhas de evento de jogo é uma fala do módulo/personagem ou etiqueta de evento; não atribua isso ao jogador.",
+        "role_explanation": 'Nota de papel: apenas linhas que começam com o marcador literal "Jogador:" são palavras do próprio jogador. "texto do evento" dentro de linhas "Evento de jogo" é uma fala do módulo/personagem ou etiqueta de evento; não atribua isso ao jogador.',
         "pregame_context": "Contexto inicial: {context}",
         "degraded": "Estado do contexto da sessão: degradado para modo de jogo puro; não gere resumos de relação, explicações de sinais ou continuidade de estado não verificável.",
         "rolling_summary": "Resumo contínuo da sessão: {summary}",

--- a/config/prompts/prompts_game_route.py
+++ b/config/prompts/prompts_game_route.py
@@ -159,7 +159,7 @@ GAME_ARCHIVE_MEMORY_HIGHLIGHTER_SYSTEM_PROMPTS = {
 - postgame_tone 用短语描述赛后语气，例如普通、得意、闹别扭、低落稍缓；没有可靠证据就留空。
 - memory_summary 用 0-1 句写给后续聊天看的本局摘要；不要编造关系修复。
 - 不要写流水统计、不要写“记录了几条事件”、不要把记录写成玩家逐字发言。
-- 只有材料中以“玩家：”开头的内容才是玩家说的话；游戏事件里的“事件原文”不是玩家原话，不能写成“玩家说/玩家喊”。
+- 只有材料中明确标为玩家发言的内容才是玩家说的话；游戏事件里的事件原文不是玩家原话，不能写成“玩家说/玩家喊”。
 - 官方结果永远以材料里的 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只能记录成口头让步/安抚/玩笑，不能写成真实结果改变。
 - 如果保留官方结果，必须沿用材料里的固定顺序或明确写出谁领先谁；不要写无主体裸结果（例如“8:0”“0:10”），也不要前后混用不同视角。
 - 普通本局事件如果没有关系或情绪价值，可以不选。
@@ -176,7 +176,7 @@ Rules:
 - postgame_tone: a short phrase for postgame tone, such as ordinary, proud, sulking, slightly less down; leave empty without reliable evidence.
 - memory_summary: 0-1 sentence for later chat; do not invent relationship repair.
 - Do not write play-by-play stats, do not say how many events were recorded, and do not turn records into verbatim player utterances.
-- Only content beginning with the literal marker "玩家：" in the material is the player's speech. The literal "事件原文" inside "游戏事件" lines is not a player quote.
+- Only content explicitly marked as player speech in the material is the player's speech. Event text inside game-event lines is not a player quote.
 - Official result always follows finalScore / last_state.score in the material. Verbal concessions are only concessions, comfort, or jokes; they do not change the real result.
 - If you keep the official result, preserve the material's fixed order or explicitly name who leads whom; do not write bare subjectless scores.
 - Skip ordinary session events with no relationship or emotional value.
@@ -193,7 +193,7 @@ Rules:
 - postgame_tone は普通、得意げ、すね気味、少し落ち着いた等の短い語句。証拠がなければ空欄。
 - memory_summary は後続チャット向けの 0-1 文。本局の要約にし、関係修復を捏造しないでください。
 - 統計の羅列や「何件記録した」は書かず、記録をプレイヤーの逐語発言にしないでください。
-- 材料内でリテラル marker「玩家：」から始まる内容だけがプレイヤーの発言です。「游戏事件」行の「事件原文」はプレイヤー発言ではありません。
+- 材料内でプレイヤー発言として明示された内容だけがプレイヤーの発言です。ゲームイベント行のイベント原文はプレイヤー発言ではありません。
 - 公式結果は常に材料内の finalScore / last_state.score に従います。口頭の譲歩や冗談は実際の結果変更ではありません。
 - 公式結果を書く場合は材料の固定順を保つか、誰が誰をリードしたか明示してください。
 - 関係や感情の価値がない普通のイベントは選ばなくてかまいません。
@@ -210,7 +210,7 @@ Rules:
 - postgame_tone 은 보통, 의기양양, 삐침, 조금 누그러짐 같은 짧은 구절입니다. 증거가 없으면 비워 둡니다.
 - memory_summary 는 이후 채팅을 위한 0-1문장 요약입니다. 관계 회복을 지어내지 마세요.
 - 진행 통계, "몇 개 이벤트를 기록했다" 같은 말, 플레이어의 축어 발화처럼 보이는 기록을 쓰지 마세요.
-- 자료에서 리터럴 marker "玩家：" 로 시작하는 내용만 플레이어가 한 말입니다. "游戏事件" 줄의 "事件原文"은 플레이어 원문이 아닙니다.
+- 자료에서 플레이어 발화로 명확히 표시된 내용만 플레이어가 한 말입니다. 게임 이벤트 줄의 이벤트 원문은 플레이어 원문이 아닙니다.
 - 공식 결과는 항상 자료의 finalScore / last_state.score 를 따릅니다. 말로 한 양보나 농담은 실제 결과 변경이 아닙니다.
 - 공식 결과를 남긴다면 자료의 고정 순서를 유지하거나 누가 누구에게 앞섰는지 명확히 쓰세요.
 - 관계나 감정 가치가 없는 평범한 이벤트는 선택하지 않아도 됩니다.
@@ -227,7 +227,7 @@ Rules:
 - postgame_tone: короткая фраза о тоне после игры; без надежных доказательств оставь пустым.
 - memory_summary: 0-1 предложение для дальнейшего чата; не выдумывай восстановление отношений.
 - Не пиши потоковую статистику, не сообщай количество записанных событий и не превращай записи в дословные слова игрока.
-- Только строки материала, начинающиеся с literal marker "玩家：", являются словами игрока. "事件原文" в строках "游戏事件" не является цитатой игрока.
+- Только содержимое, явно помеченное в материале как речь игрока, является словами игрока. Текст события в строках игровых событий не является цитатой игрока.
 - Официальный результат всегда следует finalScore / last_state.score в материале. Устные уступки являются только уступками, утешением или шуткой и не меняют реальный результат.
 - Если сохраняешь официальный результат, придерживайся фиксированного порядка материала или явно укажи, кто кого опережает.
 - Обычные события без ценности для отношений или эмоций можно не выбирать.
@@ -244,7 +244,7 @@ Reglas:
 - postgame_tone: una frase breve para el tono postpartida, por ejemplo normal, orgullosa, enfurruñada, algo menos decaída; déjalo vacío sin evidencia fiable.
 - memory_summary: 0-1 frase para chats posteriores; no inventes reparación de la relación.
 - No escribas estadísticas jugada por jugada, no digas cuántos eventos se registraron y no conviertas registros en citas literales del jugador.
-- Solo el contenido que empieza con el marcador literal "玩家：" en el material es habla del jugador. "事件原文" dentro de líneas "游戏事件" no es una cita del jugador.
+- Solo el contenido marcado explícitamente como habla del jugador en el material es habla del jugador. El texto de evento dentro de líneas de evento de juego no es una cita del jugador.
 - El resultado oficial siempre sigue finalScore / last_state.score del material. Concesiones verbales solo son concesiones, consuelo o bromas; no cambian el resultado real.
 - Si conservas el resultado oficial, preserva el orden fijo del material o indica explícitamente quién va por delante; no escribas marcadores sin sujeto.
 - Omite eventos ordinarios sin valor relacional o emocional.
@@ -261,7 +261,7 @@ Regras:
 - postgame_tone: uma frase curta para o tom pós-jogo, como normal, orgulhosa, emburrada, um pouco menos abatida; deixe vazio sem evidência confiável.
 - memory_summary: 0-1 frase para chats posteriores; não invente reparação de relação.
 - Não escreva estatísticas lance a lance, não diga quantos eventos foram registrados e não transforme registros em falas literais do jogador.
-- Apenas conteúdo que começa com o marcador literal "玩家：" no material é fala do jogador. "事件原文" dentro de linhas "游戏事件" não é citação do jogador.
+- Apenas conteúdo explicitamente marcado como fala do jogador no material é fala do jogador. O texto de evento dentro de linhas de evento de jogo não é citação do jogador.
 - O resultado oficial sempre segue finalScore / last_state.score do material. Concessões verbais são apenas concessões, conforto ou brincadeiras; não mudam o resultado real.
 - Se mantiver o resultado oficial, preserve a ordem fixa do material ou diga explicitamente quem lidera; não escreva placares sem sujeito.
 - Ignore eventos comuns sem valor relacional ou emocional.
@@ -286,7 +286,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "最终/最近结果: {score_text}",
         "score_explanation": "结果说明: 上面的最终/最近结果是游戏模块给出的官方结果，来源优先级为 finalScore / last_state.score；当数据是分差结构时固定顺序是玩家在前、当前角色在后；筛选重点时不要改成相反视角。",
         "verbal_concession_explanation": "口头让步说明: 局内如果出现“算你赢”“让你赢回来”“口头认输”等，只能记录为口头让步、安抚或玩笑；不能改写官方结果或真实胜负。",
-        "role_explanation": "角色说明: 只有“玩家：...”行是玩家亲口说的话；“游戏事件”行里的事件原文是游戏模块/猫娘气泡或事件标签，不要归因给玩家。",
+        "role_explanation": "角色说明: 只有明确标为玩家发言的行才是玩家亲口说的话；游戏事件行里的事件原文是游戏模块/猫娘气泡或事件标签，不要归因给玩家。",
         "pregame_context": "开局上下文: {context}",
         "degraded": "局内上下文整理状态: 已降级为纯游戏模式；不要输出关系摘要、信号解释或不可验证的状态延续。",
         "rolling_summary": "局内滚动摘要: {summary}",
@@ -300,7 +300,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Final/recent result: {score_text}",
         "score_explanation": "Result note: the final/recent result above is the official result from the game module, prioritized from finalScore / last_state.score. If the data is a score-difference structure, the fixed order is player first and current character second; do not flip the viewpoint.",
         "verbal_concession_explanation": 'Verbal-concession note: in-session phrases like "you win", "I\'ll let you win it back", or "I concede" may only be recorded as verbal concessions, comfort, or jokes; they do not rewrite the official result or real win/loss.',
-        "role_explanation": 'Role note: only lines beginning with the literal marker "玩家：" are the player\'s own words. "事件原文" inside "游戏事件" lines is a game-module/character bubble or event label; do not attribute it to the player.',
+        "role_explanation": "Role note: only lines explicitly marked as player speech are the player's own words. Event text inside game-event lines is a game-module/character bubble or event label; do not attribute it to the player.",
         "pregame_context": "Opening context: {context}",
         "degraded": "In-session context status: degraded to pure game mode; do not output relationship summaries, signal explanations, or unverifiable state carryover.",
         "rolling_summary": "In-session rolling summary: {summary}",
@@ -314,7 +314,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "最終/直近結果: {score_text}",
         "score_explanation": "結果説明: 上の最終/直近結果はゲームモジュールの公式結果で、finalScore / last_state.score を優先します。差分構造では固定順はプレイヤーが先、現在のキャラが後です。視点を反転しないでください。",
         "verbal_concession_explanation": "口頭譲歩の説明: 「勝ちでいい」「勝たせる」「降参」などは口頭譲歩、慰め、冗談としてだけ記録し、公式結果や実際の勝敗を書き換えません。",
-        "role_explanation": "役割説明: literal marker「玩家：...」で始まる行だけがプレイヤー本人の発言です。「游戏事件」行の「事件原文」はゲームモジュール/キャラのバブルまたはイベントラベルであり、プレイヤーに帰属させないでください。",
+        "role_explanation": "役割説明: プレイヤー発言として明示された行だけがプレイヤー本人の発言です。ゲームイベント行のイベント原文はゲームモジュール/キャラのバブルまたはイベントラベルであり、プレイヤーに帰属させないでください。",
         "pregame_context": "開局コンテキスト: {context}",
         "degraded": "局内コンテキスト整理状態: 純ゲームモードに降格済み。関係要約、シグナル解釈、検証不能な状態継続を出力しないでください。",
         "rolling_summary": "局内ローリング要約: {summary}",
@@ -328,7 +328,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "최종/최근 결과: {score_text}",
         "score_explanation": "결과 설명: 위 최종/최근 결과는 게임 모듈의 공식 결과이며 finalScore / last_state.score 를 우선합니다. 점수 차이 구조라면 고정 순서는 플레이어가 먼저, 현재 캐릭터가 나중입니다. 시점을 뒤집지 마세요.",
         "verbal_concession_explanation": '말로 한 양보 설명: 진행 중 "네가 이긴 걸로", "이기게 해줄게", "항복" 같은 말은 말로 한 양보, 위로, 농담으로만 기록하며 공식 결과나 실제 승패를 바꾸지 않습니다.',
-        "role_explanation": '역할 설명: literal marker "玩家：..." 로 시작하는 줄만 플레이어가 직접 한 말입니다. "游戏事件" 줄의 "事件原文"은 게임 모듈/캐릭터 말풍선 또는 이벤트 라벨이며 플레이어에게 귀속하지 마세요.',
+        "role_explanation": "역할 설명: 플레이어 발화로 명시된 줄만 플레이어가 직접 한 말입니다. 게임 이벤트 줄의 이벤트 원문은 게임 모듈/캐릭터 말풍선 또는 이벤트 라벨이며 플레이어에게 귀속하지 마세요.",
         "pregame_context": "시작 컨텍스트: {context}",
         "degraded": "진행 중 컨텍스트 정리 상태: 순수 게임 모드로 강등됨. 관계 요약, 신호 해석, 검증할 수 없는 상태 지속을 출력하지 마세요.",
         "rolling_summary": "진행 중 롤링 요약: {summary}",
@@ -342,7 +342,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Финальный/последний результат: {score_text}",
         "score_explanation": "Пояснение результата: финальный/последний результат выше является официальным результатом игрового модуля, с приоритетом finalScore / last_state.score. Если данные являются структурой разницы счета, фиксированный порядок: сначала игрок, затем текущий персонаж; не меняй точку зрения.",
         "verbal_concession_explanation": 'Пояснение устных уступок: фразы вроде "ты выиграл", "дам тебе отыграться" или "сдаюсь" можно записывать только как устную уступку, утешение или шутку; они не меняют официальный результат.',
-        "role_explanation": 'Пояснение ролей: только строки с literal marker "玩家：..." являются словами игрока. "事件原文" в строках "游戏事件" — это реплика игрового модуля/персонажа или метка события; не приписывай его игроку.',
+        "role_explanation": "Пояснение ролей: словами игрока являются только строки, явно помеченные как речь игрока. Текст события в строках игровых событий — это реплика игрового модуля/персонажа или метка события; не приписывай его игроку.",
         "pregame_context": "Начальный контекст: {context}",
         "degraded": "Статус контекста сессии: понижен до чистого игрового режима; не выводи summaries отношений, объяснения сигналов или непроверяемое продолжение состояния.",
         "rolling_summary": "Rolling summary сессии: {summary}",
@@ -356,7 +356,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Resultado final/reciente: {score_text}",
         "score_explanation": "Nota de resultado: el resultado final/reciente anterior es el resultado oficial del módulo de juego, priorizado desde finalScore / last_state.score. Si los datos son una estructura de diferencia de puntuación, el orden fijo es jugador primero y personaje actual segundo; no inviertas el punto de vista.",
         "verbal_concession_explanation": 'Nota de concesión verbal: frases dentro de la sesión como "tú ganas", "te dejo remontar" o "me rindo" solo pueden registrarse como concesiones verbales, consuelo o bromas; no reescriben el resultado oficial ni la victoria/derrota real.',
-        "role_explanation": 'Nota de rol: solo las líneas que empiezan con el marcador literal "玩家：" son palabras propias del jugador. "事件原文" dentro de líneas "游戏事件" es una burbuja del módulo/personaje o etiqueta de evento; no se la atribuyas al jugador.',
+        "role_explanation": "Nota de rol: solo las líneas marcadas explícitamente como habla del jugador son palabras propias del jugador. El texto de evento dentro de líneas de evento de juego es una burbuja del módulo/personaje o etiqueta de evento; no se lo atribuyas al jugador.",
         "pregame_context": "Contexto inicial: {context}",
         "degraded": "Estado del contexto de sesión: degradado a modo de juego puro; no generes resúmenes de relación, explicaciones de señales ni continuidad de estado no verificable.",
         "rolling_summary": "Resumen continuo de la sesión: {summary}",
@@ -370,7 +370,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Resultado final/recente: {score_text}",
         "score_explanation": "Nota de resultado: o resultado final/recente acima é o resultado oficial do módulo de jogo, priorizado a partir de finalScore / last_state.score. Se os dados forem uma estrutura de diferença de placar, a ordem fixa é jogador primeiro e personagem atual em segundo; não inverta o ponto de vista.",
         "verbal_concession_explanation": 'Nota de concessão verbal: frases dentro da sessão como "você venceu", "vou deixar você virar" ou "desisto" só podem ser registradas como concessões verbais, conforto ou brincadeiras; não reescrevem o resultado oficial nem a vitória/derrota real.',
-        "role_explanation": 'Nota de papel: apenas linhas que começam com o marcador literal "玩家：" são palavras do próprio jogador. "事件原文" dentro de linhas "游戏事件" é uma fala do módulo/personagem ou etiqueta de evento; não atribua isso ao jogador.',
+        "role_explanation": "Nota de papel: apenas linhas marcadas explicitamente como fala do jogador são palavras do próprio jogador. O texto do evento dentro de linhas de evento de jogo é uma fala do módulo/personagem ou etiqueta de evento; não atribua isso ao jogador.",
         "pregame_context": "Contexto inicial: {context}",
         "degraded": "Estado do contexto da sessão: degradado para modo de jogo puro; não gere resumos de relação, explicações de sinais ou continuidade de estado não verificável.",
         "rolling_summary": "Resumo contínuo da sessão: {summary}",
@@ -1043,6 +1043,136 @@ GAME_RECENT_HISTORY_MESSAGE_LABELS = {
 }
 
 
+GAME_DIALOG_MEMORY_LINE_LABELS = {
+    "zh": {
+        "player_line": "玩家：{text}",
+        "player_fallback": "玩家发来了一条游戏期间输入",
+        "assistant_line": "{source}：{line}{suffix}",
+        "assistant_empty": "游戏 LLM 返回为空",
+        "game_event_text_and_reply": "游戏事件 {kind}（{label}）：事件原文「{text}」；猫娘回应「{line}」",
+        "game_event_reply": "游戏事件 {kind}（{label}）：猫娘回应「{line}」",
+        "game_event_text": "游戏事件 {kind}（{label}）：事件原文「{text}」",
+        "game_event": "游戏事件 {kind}（{label}）",
+        "event_default": "游戏事件",
+        "event_goal_scored": "猫娘进球",
+        "event_goal_conceded": "玩家进球 / 猫娘丢球",
+        "event_own_goal_by_ai": "猫娘乌龙",
+        "event_own_goal_by_player": "玩家乌龙",
+        "event_steal": "猫娘抢到球",
+        "event_stolen": "猫娘被抢断",
+        "event_mailbox_batch": "累积上下文",
+    },
+    "en": {
+        "player_line": "Player: {text}",
+        "player_fallback": "The player sent an in-game input.",
+        "assistant_line": "{source}: {line}{suffix}",
+        "assistant_empty": "Game LLM returned an empty response.",
+        "game_event_text_and_reply": "Game event {kind} ({label}): event text \"{text}\"; character reply \"{line}\"",
+        "game_event_reply": "Game event {kind} ({label}): character reply \"{line}\"",
+        "game_event_text": "Game event {kind} ({label}): event text \"{text}\"",
+        "game_event": "Game event {kind} ({label})",
+        "event_default": "Game event",
+        "event_goal_scored": "Character scored",
+        "event_goal_conceded": "Player scored / character conceded",
+        "event_own_goal_by_ai": "Character own goal",
+        "event_own_goal_by_player": "Player own goal",
+        "event_steal": "Character stole the ball",
+        "event_stolen": "Character was dispossessed",
+        "event_mailbox_batch": "Accumulated context",
+    },
+    "ja": {
+        "player_line": "プレイヤー：{text}",
+        "player_fallback": "プレイヤーがゲーム中の入力を送りました。",
+        "assistant_line": "{source}：{line}{suffix}",
+        "assistant_empty": "ゲーム LLM の応答は空でした。",
+        "game_event_text_and_reply": "ゲームイベント {kind}（{label}）：イベント原文「{text}」；キャラの返答「{line}」",
+        "game_event_reply": "ゲームイベント {kind}（{label}）：キャラの返答「{line}」",
+        "game_event_text": "ゲームイベント {kind}（{label}）：イベント原文「{text}」",
+        "game_event": "ゲームイベント {kind}（{label}）",
+        "event_default": "ゲームイベント",
+        "event_goal_scored": "キャラが得点",
+        "event_goal_conceded": "プレイヤーが得点 / キャラが失点",
+        "event_own_goal_by_ai": "キャラのオウンゴール",
+        "event_own_goal_by_player": "プレイヤーのオウンゴール",
+        "event_steal": "キャラがボールを奪取",
+        "event_stolen": "キャラがボールを奪われた",
+        "event_mailbox_batch": "累積コンテキスト",
+    },
+    "ko": {
+        "player_line": "플레이어: {text}",
+        "player_fallback": "플레이어가 게임 중 입력을 보냈습니다.",
+        "assistant_line": "{source}: {line}{suffix}",
+        "assistant_empty": "게임 LLM 이 빈 응답을 반환했습니다.",
+        "game_event_text_and_reply": "게임 이벤트 {kind} ({label}): 이벤트 원문 \"{text}\"; 캐릭터 응답 \"{line}\"",
+        "game_event_reply": "게임 이벤트 {kind} ({label}): 캐릭터 응답 \"{line}\"",
+        "game_event_text": "게임 이벤트 {kind} ({label}): 이벤트 원문 \"{text}\"",
+        "game_event": "게임 이벤트 {kind} ({label})",
+        "event_default": "게임 이벤트",
+        "event_goal_scored": "캐릭터 득점",
+        "event_goal_conceded": "플레이어 득점 / 캐릭터 실점",
+        "event_own_goal_by_ai": "캐릭터 자책골",
+        "event_own_goal_by_player": "플레이어 자책골",
+        "event_steal": "캐릭터가 공을 빼앗음",
+        "event_stolen": "캐릭터가 공을 빼앗김",
+        "event_mailbox_batch": "누적 컨텍스트",
+    },
+    "ru": {
+        "player_line": "Игрок: {text}",
+        "player_fallback": "Игрок отправил ввод во время игры.",
+        "assistant_line": "{source}: {line}{suffix}",
+        "assistant_empty": "Игровая LLM вернула пустой ответ.",
+        "game_event_text_and_reply": "Игровое событие {kind} ({label}): текст события «{text}»; ответ персонажа «{line}»",
+        "game_event_reply": "Игровое событие {kind} ({label}): ответ персонажа «{line}»",
+        "game_event_text": "Игровое событие {kind} ({label}): текст события «{text}»",
+        "game_event": "Игровое событие {kind} ({label})",
+        "event_default": "Игровое событие",
+        "event_goal_scored": "Персонаж забил",
+        "event_goal_conceded": "Игрок забил / персонаж пропустил",
+        "event_own_goal_by_ai": "Автогол персонажа",
+        "event_own_goal_by_player": "Автогол игрока",
+        "event_steal": "Персонаж отобрал мяч",
+        "event_stolen": "У персонажа отобрали мяч",
+        "event_mailbox_batch": "Накопленный контекст",
+    },
+    "es": {
+        "player_line": "Jugador: {text}",
+        "player_fallback": "El jugador envió una entrada durante el juego.",
+        "assistant_line": "{source}: {line}{suffix}",
+        "assistant_empty": "El LLM del juego devolvió una respuesta vacía.",
+        "game_event_text_and_reply": "Evento de juego {kind} ({label}): texto del evento \"{text}\"; respuesta del personaje \"{line}\"",
+        "game_event_reply": "Evento de juego {kind} ({label}): respuesta del personaje \"{line}\"",
+        "game_event_text": "Evento de juego {kind} ({label}): texto del evento \"{text}\"",
+        "game_event": "Evento de juego {kind} ({label})",
+        "event_default": "Evento de juego",
+        "event_goal_scored": "El personaje anotó",
+        "event_goal_conceded": "El jugador anotó / el personaje concedió",
+        "event_own_goal_by_ai": "Autogol del personaje",
+        "event_own_goal_by_player": "Autogol del jugador",
+        "event_steal": "El personaje robó el balón",
+        "event_stolen": "Al personaje le robaron el balón",
+        "event_mailbox_batch": "Contexto acumulado",
+    },
+    "pt": {
+        "player_line": "Jogador: {text}",
+        "player_fallback": "O jogador enviou uma entrada durante o jogo.",
+        "assistant_line": "{source}: {line}{suffix}",
+        "assistant_empty": "O LLM do jogo retornou uma resposta vazia.",
+        "game_event_text_and_reply": "Evento de jogo {kind} ({label}): texto do evento \"{text}\"; resposta da personagem \"{line}\"",
+        "game_event_reply": "Evento de jogo {kind} ({label}): resposta da personagem \"{line}\"",
+        "game_event_text": "Evento de jogo {kind} ({label}): texto do evento \"{text}\"",
+        "game_event": "Evento de jogo {kind} ({label})",
+        "event_default": "Evento de jogo",
+        "event_goal_scored": "A personagem marcou",
+        "event_goal_conceded": "O jogador marcou / a personagem sofreu ponto",
+        "event_own_goal_by_ai": "Gol contra da personagem",
+        "event_own_goal_by_player": "Gol contra do jogador",
+        "event_steal": "A personagem roubou a bola",
+        "event_stolen": "A personagem perdeu a bola",
+        "event_mailbox_batch": "Contexto acumulado",
+    },
+}
+
+
 def get_game_context_organizer_system_prompt(lang: str | None = None) -> str:
     return _localized_template(GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPTS, lang)
 
@@ -1097,3 +1227,7 @@ def get_game_context_formatter_labels(lang: str | None = None) -> dict[str, str]
 
 def get_game_recent_history_message_labels(lang: str | None = None) -> dict[str, str]:
     return _labels(GAME_RECENT_HISTORY_MESSAGE_LABELS, lang)
+
+
+def get_game_dialog_memory_line_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_DIALOG_MEMORY_LINE_LABELS, lang)

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -65,6 +65,7 @@ from config.prompts.prompts_game_route import (
     get_game_postgame_context_labels,
     get_game_postgame_event_texts,
     get_game_postgame_realtime_nudge_labels,
+    get_game_recent_history_message_labels,
 )
 from .shared_state import get_config_manager, get_session_manager
 from main_logic.mirror_meta import (
@@ -1374,17 +1375,98 @@ def _format_game_context_for_prompt(context: Any, language: str | None = None) -
     return "\n".join(parts) + "\n"
 
 
-def _build_game_context_prompt_payload(state: dict | None) -> dict | None:
+def _build_game_context_prompt_payload(state: dict | None, *, include_recent: bool = True) -> dict | None:
     if not isinstance(state, dict):
         return None
     organizer = _normalize_game_context_organizer_state(state.get("game_context_organizer"))
     return {
         "summary": str(state.get("game_context_summary") or ""),
         "signals": _normalize_game_context_signals(state.get("game_context_signals")),
-        "recent_dialogues": _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_KEEP_COUNT),
+        "recent_dialogues": (
+            _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_KEEP_COUNT)
+            if include_recent else []
+        ),
         "degraded": organizer.get("degraded") is True,
         "organizer": organizer,
     }
+
+
+def _game_dialog_history_user_text(item: dict, labels: dict[str, str]) -> str:
+    item_type = item.get("type")
+    dialog_id = str(item.get("id") or "").strip()
+    prefix = f"{dialog_id}: " if dialog_id else ""
+    if item_type == "user":
+        text = str(item.get("text") or "").strip()
+        return f"{prefix}{labels['player_line'].format(text=text)}" if text else ""
+    if item_type == "game_event":
+        kind = str(item.get("kind") or "event")
+        text = str(item.get("text") or "").strip()
+        if text:
+            return f"{prefix}{labels['game_event_text'].format(kind=kind, text=text)}"
+        return f"{prefix}{labels['game_event'].format(kind=kind)}"
+    return ""
+
+
+def _game_dialog_history_assistant_text(item: dict) -> str:
+    item_type = item.get("type")
+    dialog_id = str(item.get("id") or "").strip()
+    prefix = f"{dialog_id}: " if dialog_id else ""
+    if item_type == "assistant":
+        line = str(item.get("line") or "").strip()
+    elif item_type == "game_event":
+        line = str(item.get("result_line") or "").strip()
+    else:
+        return ""
+    if not line:
+        return ""
+    control = item.get("control") if isinstance(item.get("control"), dict) else {}
+    control_bits = []
+    if control.get("mood"):
+        control_bits.append(f"mood={control['mood']}")
+    if control.get("difficulty"):
+        control_bits.append(f"difficulty={control['difficulty']}")
+    suffix = f" ({', '.join(control_bits)})" if control_bits else ""
+    return f"{prefix}{line}{suffix}"
+
+
+def _build_game_recent_history_messages(state: dict | None, language: str | None = None) -> list:
+    if not isinstance(state, dict):
+        return []
+    from utils.llm_client import AIMessage, HumanMessage
+
+    labels = get_game_recent_history_message_labels(language)
+    messages = []
+    last_role = "system"
+    for item in _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_KEEP_COUNT):
+        if not isinstance(item, dict):
+            continue
+        user_text = _game_dialog_history_user_text(item, labels)
+        assistant_text = _game_dialog_history_assistant_text(item)
+        if user_text:
+            messages.append(HumanMessage(content=user_text))
+            last_role = "human"
+        if assistant_text:
+            if last_role == "human":
+                messages.append(AIMessage(content=assistant_text))
+                last_role = "ai"
+            else:
+                messages.append(HumanMessage(content=labels["previous_character_output"].format(text=assistant_text)))
+                last_role = "human"
+    return messages
+
+
+def _reset_game_session_text_history_for_turn(entry: dict, route_state: dict | None) -> None:
+    session = entry.get("session") if isinstance(entry, dict) else None
+    if session is None:
+        return
+    from utils.llm_client import SystemMessage
+
+    instructions = str(entry.get("instructions") or getattr(session, "_instructions", "") or "")
+    language = entry.get("user_language") if isinstance(entry, dict) else None
+    history = [SystemMessage(content=instructions)] if instructions else []
+    history.extend(_build_game_recent_history_messages(route_state, language))
+    session._instructions = instructions
+    session._conversation_history = history
 
 
 def _normalize_quick_lines(value: Any, allowed_keys: set[str] | None = None) -> Dict[str, list[str]]:
@@ -4175,7 +4257,7 @@ async def _build_and_register_game_session(
     else:
         route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), lanlan_name)
         pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
-        game_context = _build_game_context_prompt_payload(route_state)
+        game_context = _build_game_context_prompt_payload(route_state, include_recent=False)
         route_mode = _normalize_basketball_mode(route_state.get("mode") if isinstance(route_state, dict) else "")
     prompt_args = (
         game_type,
@@ -4267,7 +4349,7 @@ async def _refresh_game_session_instructions(
     else:
         route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), char_info["lanlan_name"])
         pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
-        game_context = _build_game_context_prompt_payload(route_state)
+        game_context = _build_game_context_prompt_payload(route_state, include_recent=False)
         route_mode = _normalize_basketball_mode(route_state.get("mode") if isinstance(route_state, dict) else "")
     prompt_args = (
         game_type,
@@ -5923,6 +6005,10 @@ async def _run_game_chat(
                     err_result["_postgame_entry"] = entry
                     err_result["_postgame_cache_session_id"] = chat_session_id
                 return err_result
+
+            if not allow_postgame:
+                history_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
+                _reset_game_session_text_history_for_turn(entry, history_state)
 
             # 清空上一次的回复
             reply_chunks.clear()

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -222,7 +222,8 @@ _BASKETBALL_GAME_MEMORY_POLICY_FIELDS = (
 _GAME_CONTEXT_ORGANIZE_TRIGGER_COUNT = 15
 _GAME_CONTEXT_RECENT_KEEP_COUNT = 6
 _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT = _GAME_CONTEXT_ORGANIZE_TRIGGER_COUNT
-_GAME_CONTEXT_DEGRADE_PENDING_COUNT = 40
+_GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT = 64
+_GAME_CONTEXT_FAILURE_FALLBACK_KEEP_COUNT = 8
 _GAME_CONTEXT_FINALIZE_WAIT_SECONDS = 5.0
 _GAME_CONTEXT_SIGNAL_GROUPS = GAME_CONTEXT_SIGNAL_GROUP_KEYS
 _LEGACY_SIGNAL_GROUP_ALIASES = {
@@ -1283,7 +1284,7 @@ def _dialog_id_index(dialog: list[dict], dialog_id: str) -> int:
     return -1
 
 
-def _game_context_recent_dialogues(state: dict, keep_count: int = _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT) -> list[dict]:
+def _game_context_recent_dialogues(state: dict, keep_count: int = _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT) -> list[dict]:
     dialog = [item for item in state.get("game_dialog_log") or [] if isinstance(item, dict)]
     if not dialog:
         return []
@@ -1355,7 +1356,7 @@ def _format_game_context_for_prompt(context: Any, language: str | None = None) -
     degraded = context.get("degraded") is True
     recent_lines = _game_context_dialog_lines(
         context.get("recent_dialogues") or [],
-        max_items=_GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT,
+        max_items=_GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT,
         language=language,
     )
     if degraded:
@@ -1394,7 +1395,7 @@ def _build_game_context_prompt_payload(state: dict | None, *, include_recent: bo
         "summary": str(state.get("game_context_summary") or ""),
         "signals": _normalize_game_context_signals(state.get("game_context_signals")),
         "recent_dialogues": (
-            _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT)
+            _game_context_recent_dialogues(state, _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT)
             if include_recent else []
         ),
         "degraded": organizer.get("degraded") is True,
@@ -1561,7 +1562,7 @@ def _build_game_recent_history_messages(state: dict | None, language: str | None
     labels = get_game_recent_history_message_labels(language)
     messages = []
     last_role = "system"
-    for item in _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT):
+    for item in _game_context_recent_dialogues(state, _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT):
         if not isinstance(item, dict):
             continue
         user_text = _game_dialog_history_user_text(item, labels)
@@ -2304,10 +2305,65 @@ def _game_context_pending_dialogues(state: dict) -> list[dict]:
     return dialog[last_idx + 1:]
 
 
+def _game_context_recent_id_limit(state: dict, pending_count: int) -> int:
+    organizer = _normalize_game_context_organizer_state(state.get("game_context_organizer"))
+    if (
+        pending_count > _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT
+        or organizer.get("running")
+        or int(organizer.get("failure_count") or 0) > 0
+    ):
+        return _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT
+    return _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT
+
+
+def _apply_game_context_failure_fallback(
+    state: dict,
+    pending: list[dict],
+    *,
+    reason: str,
+) -> bool:
+    if len(pending) < _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT:
+        return False
+    keep_count = _GAME_CONTEXT_FAILURE_FALLBACK_KEEP_COUNT
+    compacted = pending[:-keep_count]
+    kept = pending[-keep_count:]
+    if not compacted:
+        return False
+    last_compacted_id = str(compacted[-1].get("id") or "")
+    if not last_compacted_id:
+        return False
+
+    organizer = _normalize_game_context_organizer_state(state.get("game_context_organizer"))
+    organizer["last_organized_id"] = last_compacted_id
+    organizer["degraded"] = False
+    organizer["error"] = f"fallback_{reason}_after_{len(pending)}_pending_items"
+    state["game_context_organizer"] = organizer
+    state["game_context_recent_ids"] = [
+        str(item.get("id") or "")
+        for item in kept
+        if isinstance(item, dict) and item.get("id")
+    ]
+    logger.warning(
+        "🎮 局内上下文整理失败兜底推进: game=%s session=%s reason=%s compacted=%s kept=%s last=%s",
+        state.get("game_type"),
+        state.get("session_id"),
+        reason,
+        len(compacted),
+        len(kept),
+        last_compacted_id,
+    )
+    return True
+
+
 def _set_game_context_recent_ids(state: dict, dialogues: list[dict] | None = None) -> None:
     source = dialogues if dialogues is not None else _game_context_pending_dialogues(state)
+    if dialogues is None and len(source) > _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT:
+        if _apply_game_context_failure_fallback(state, source, reason="overflow"):
+            return
+        source = _game_context_pending_dialogues(state)
     ids = [str(item.get("id") or "") for item in source if isinstance(item, dict) and item.get("id")]
-    state["game_context_recent_ids"] = ids[-_GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT:]
+    limit = _game_context_recent_id_limit(state, len(ids))
+    state["game_context_recent_ids"] = ids[-limit:]
 
 
 def _should_schedule_game_context_organizer(state: dict) -> bool:
@@ -2464,6 +2520,19 @@ def _apply_game_context_organizer_success(state: dict, snapshot: list[dict], res
     organize_dialogues = snapshot[:-_GAME_CONTEXT_RECENT_KEEP_COUNT]
     if not organize_dialogues:
         return
+    target_last_id = str(organize_dialogues[-1].get("id") or "")
+    dialog = [item for item in state.get("game_dialog_log") or [] if isinstance(item, dict)]
+    organizer = _normalize_game_context_organizer_state(state.get("game_context_organizer"))
+    current_last_id = str(organizer.get("last_organized_id") or "")
+    current_idx = _dialog_id_index(dialog, current_last_id)
+    target_idx = _dialog_id_index(dialog, target_last_id)
+    if current_idx > target_idx >= 0:
+        organizer["running"] = False
+        organizer["error"] = "stale_organizer_result_ignored"
+        state["game_context_organizer"] = organizer
+        _set_game_context_recent_ids(state)
+        return
+
     summary = _normalize_short_text(
         result.get("rollingSummary") or result.get("rolling_summary") or result.get("summary"),
         max_chars=900,
@@ -2474,12 +2543,11 @@ def _apply_game_context_organizer_success(state: dict, snapshot: list[dict], res
         state.get("game_context_signals"),
         result.get("signals") if isinstance(result.get("signals"), dict) else {},
     )
-    organizer = _normalize_game_context_organizer_state(state.get("game_context_organizer"))
     organizer.update({
         "running": False,
         "degraded": False,
         "failure_count": 0,
-        "last_organized_id": str(organize_dialogues[-1].get("id") or ""),
+        "last_organized_id": target_last_id,
         "source": result.get("source") if isinstance(result.get("source"), dict) else result.get("source"),
         "error": "",
     })
@@ -2492,17 +2560,11 @@ def _apply_game_context_organizer_failure(state: dict, snapshot: list[dict], err
     organizer["running"] = False
     organizer["failure_count"] = int(organizer.get("failure_count") or 0) + 1
     organizer["error"] = type(error).__name__
-    pending_count = len(_game_context_pending_dialogues(state))
-    if pending_count >= _GAME_CONTEXT_DEGRADE_PENDING_COUNT:
-        organizer["degraded"] = True
-        organizer["error"] = f"degraded_after_{pending_count}_pending_items"
-        logger.warning(
-            "🎮 局内上下文整理达到硬上限，降级为纯游戏模式: game=%s session=%s pending=%s",
-            state.get("game_type"),
-            state.get("session_id"),
-            pending_count,
-        )
     state["game_context_organizer"] = organizer
+    pending = _game_context_pending_dialogues(state)
+    if _apply_game_context_failure_fallback(state, pending, reason="organizer_failure"):
+        return
+    _set_game_context_recent_ids(state)
 
 
 async def _run_game_context_organizer_task(state: dict, snapshot: list[dict]) -> None:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1402,42 +1402,73 @@ def _build_game_context_prompt_payload(state: dict | None, *, include_recent: bo
     }
 
 
+_GAME_INTERNAL_LOG_PREFIX_RE = re.compile(r"^\s*glog_\d+\s*[:：]\s*", re.IGNORECASE)
+_GAME_CONTROL_PAREN_TRAIL_RE = re.compile(
+    r"\s*[\(（][^()（）]*(?:mood|difficulty|reason|expression|intensity|balanceHint|balance_hint)\s*[:=][^()（）]*[\)）]\s*$",
+    re.IGNORECASE,
+)
+_GAME_CONTROL_JSON_TRAIL_RE = re.compile(
+    r"\s*\{[^{}]*(?:\"?(?:mood|difficulty|reason|expression|intensity|balanceHint|balance_hint)\"?\s*[:=])[^{}]*\}\s*$",
+    re.IGNORECASE,
+)
+_GAME_INTERNAL_CONTROL_LINE_RE = re.compile(
+    r"^\s*(?:reason|mood|difficulty|expression|intensity|balanceHint|balance_hint)\s*[:=]",
+    re.IGNORECASE,
+)
+_GAME_INTERNAL_ADVICE_RE = re.compile(
+    r"(?:balanceHint|balance_hint|system advice|system suggestion|系统建议|平衡建议|控制建议)",
+    re.IGNORECASE,
+)
+
+
+def _sanitize_game_visible_line(text: Any) -> str:
+    """Keep only natural player-visible speech; strip game route metadata leaks."""
+    lines: list[str] = []
+    for raw_line in str(text or "").replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        line = raw_line.strip()
+        if not line:
+            continue
+        line = _GAME_INTERNAL_LOG_PREFIX_RE.sub("", line).strip()
+        if not line:
+            continue
+        if _GAME_INTERNAL_CONTROL_LINE_RE.search(line) or _GAME_INTERNAL_ADVICE_RE.search(line):
+            continue
+        previous = None
+        while previous != line:
+            previous = line
+            line = _GAME_CONTROL_JSON_TRAIL_RE.sub("", line).strip()
+            line = _GAME_CONTROL_PAREN_TRAIL_RE.sub("", line).strip()
+        if not line:
+            continue
+        if _GAME_INTERNAL_CONTROL_LINE_RE.search(line) or _GAME_INTERNAL_ADVICE_RE.search(line):
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
 def _game_dialog_history_user_text(item: dict, labels: dict[str, str]) -> str:
     item_type = item.get("type")
-    dialog_id = str(item.get("id") or "").strip()
-    prefix = f"{dialog_id}: " if dialog_id else ""
     if item_type == "user":
         text = str(item.get("text") or "").strip()
-        return f"{prefix}{labels['player_line'].format(text=text)}" if text else ""
+        return labels["player_line"].format(text=text) if text else ""
     if item_type == "game_event":
         kind = str(item.get("kind") or "event")
         text = str(item.get("text") or "").strip()
         if text:
-            return f"{prefix}{labels['game_event_text'].format(kind=kind, text=text)}"
-        return f"{prefix}{labels['game_event'].format(kind=kind)}"
+            return labels["game_event_text"].format(kind=kind, text=text)
+        return labels["game_event"].format(kind=kind)
     return ""
 
 
 def _game_dialog_history_assistant_text(item: dict) -> str:
     item_type = item.get("type")
-    dialog_id = str(item.get("id") or "").strip()
-    prefix = f"{dialog_id}: " if dialog_id else ""
     if item_type == "assistant":
         line = str(item.get("line") or "").strip()
     elif item_type == "game_event":
         line = str(item.get("result_line") or "").strip()
     else:
         return ""
-    if not line:
-        return ""
-    control = item.get("control") if isinstance(item.get("control"), dict) else {}
-    control_bits = []
-    if control.get("mood"):
-        control_bits.append(f"mood={control['mood']}")
-    if control.get("difficulty"):
-        control_bits.append(f"difficulty={control['difficulty']}")
-    suffix = f" ({', '.join(control_bits)})" if control_bits else ""
-    return f"{prefix}{line}{suffix}"
+    return _sanitize_game_visible_line(line)
 
 
 def _build_game_recent_history_messages(state: dict | None, language: str | None = None) -> list:
@@ -4465,7 +4496,7 @@ def _parse_control_instructions(reply: str, game_type: str = "soccer") -> Dict[s
                 pass
 
     return {
-        'line': line_text,
+        'line': _sanitize_game_visible_line(line_text),
         'control': control,
     }
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -221,6 +221,7 @@ _BASKETBALL_GAME_MEMORY_POLICY_FIELDS = (
 )
 _GAME_CONTEXT_ORGANIZE_TRIGGER_COUNT = 15
 _GAME_CONTEXT_RECENT_KEEP_COUNT = 6
+_GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT = _GAME_CONTEXT_ORGANIZE_TRIGGER_COUNT
 _GAME_CONTEXT_DEGRADE_PENDING_COUNT = 40
 _GAME_CONTEXT_FINALIZE_WAIT_SECONDS = 5.0
 _GAME_CONTEXT_SIGNAL_GROUPS = GAME_CONTEXT_SIGNAL_GROUP_KEYS
@@ -1282,7 +1283,7 @@ def _dialog_id_index(dialog: list[dict], dialog_id: str) -> int:
     return -1
 
 
-def _game_context_recent_dialogues(state: dict, keep_count: int = _GAME_CONTEXT_RECENT_KEEP_COUNT) -> list[dict]:
+def _game_context_recent_dialogues(state: dict, keep_count: int = _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT) -> list[dict]:
     dialog = [item for item in state.get("game_dialog_log") or [] if isinstance(item, dict)]
     if not dialog:
         return []
@@ -1354,7 +1355,7 @@ def _format_game_context_for_prompt(context: Any, language: str | None = None) -
     degraded = context.get("degraded") is True
     recent_lines = _game_context_dialog_lines(
         context.get("recent_dialogues") or [],
-        max_items=_GAME_CONTEXT_RECENT_KEEP_COUNT,
+        max_items=_GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT,
         language=language,
     )
     if degraded:
@@ -1393,7 +1394,7 @@ def _build_game_context_prompt_payload(state: dict | None, *, include_recent: bo
         "summary": str(state.get("game_context_summary") or ""),
         "signals": _normalize_game_context_signals(state.get("game_context_signals")),
         "recent_dialogues": (
-            _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_KEEP_COUNT)
+            _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT)
             if include_recent else []
         ),
         "degraded": organizer.get("degraded") is True,
@@ -1447,7 +1448,7 @@ def _build_game_recent_history_messages(state: dict | None, language: str | None
     labels = get_game_recent_history_message_labels(language)
     messages = []
     last_role = "system"
-    for item in _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_KEEP_COUNT):
+    for item in _game_context_recent_dialogues(state, _GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT):
         if not isinstance(item, dict):
             continue
         user_text = _game_dialog_history_user_text(item, labels)
@@ -2191,9 +2192,9 @@ def _game_context_pending_dialogues(state: dict) -> list[dict]:
 
 
 def _set_game_context_recent_ids(state: dict, dialogues: list[dict] | None = None) -> None:
-    source = dialogues if dialogues is not None else state.get("game_dialog_log") or []
+    source = dialogues if dialogues is not None else _game_context_pending_dialogues(state)
     ids = [str(item.get("id") or "") for item in source if isinstance(item, dict) and item.get("id")]
-    state["game_context_recent_ids"] = ids[-_GAME_CONTEXT_RECENT_KEEP_COUNT:]
+    state["game_context_recent_ids"] = ids[-_GAME_CONTEXT_RECENT_WINDOW_MAX_COUNT:]
 
 
 def _should_schedule_game_context_organizer(state: dict) -> bool:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1419,6 +1419,40 @@ _GAME_INTERNAL_ADVICE_RE = re.compile(
     r"(?:balanceHint|balance_hint|system advice|system suggestion|系统建议|平衡建议|控制建议)",
     re.IGNORECASE,
 )
+_GAME_LLM_VISIBLE_EVENT_TOP_LEVEL_DROP_KEYS = frozenset({
+    "soccerGameMemoryEnabled",
+    "soccer_game_memory_enabled",
+    "soccerGameMemoryPlayerInteractionEnabled",
+    "soccer_game_memory_player_interaction_enabled",
+    "soccerGameMemoryEventReplyEnabled",
+    "soccer_game_memory_event_reply_enabled",
+    "soccerGameMemoryArchiveEnabled",
+    "soccer_game_memory_archive_enabled",
+    "soccerGameMemoryPostgameContextEnabled",
+    "soccer_game_memory_postgame_context_enabled",
+    "gameMemoryEnabled",
+    "game_memory_enabled",
+    "gameMemoryPlayerInteractionEnabled",
+    "game_memory_player_interaction_enabled",
+    "gameMemoryEventReplyEnabled",
+    "game_memory_event_reply_enabled",
+    "gameMemoryArchiveEnabled",
+    "game_memory_archive_enabled",
+    "gameMemoryPostgameContextEnabled",
+    "game_memory_postgame_context_enabled",
+    "lanlan_name",
+})
+_SOCCER_LLM_VISIBLE_SNAPSHOT_DROP_KEYS = frozenset({
+    "aiFreezeSec",
+    "playerKickStartleWindowSec",
+    "playerKickWallBounceForStartle",
+    "startle",
+    "startleDirectCdSec",
+    "startleGrazeCdSec",
+    "startleMutualLockSec",
+    "zoneoutCooldownSec",
+    "ballGhost",
+})
 
 
 def _sanitize_game_visible_line(text: Any) -> str:
@@ -1444,6 +1478,54 @@ def _sanitize_game_visible_line(text: Any) -> str:
             continue
         lines.append(line)
     return "\n".join(lines).strip()
+
+
+def _sanitize_soccer_llm_visible_snapshot(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_soccer_llm_visible_snapshot(item)
+            for key, item in value.items()
+            if key not in _SOCCER_LLM_VISIBLE_SNAPSHOT_DROP_KEYS
+        }
+    if isinstance(value, list):
+        return [_sanitize_soccer_llm_visible_snapshot(item) for item in value]
+    return value
+
+
+def _build_game_llm_visible_event(game_type: str, event: Any) -> Any:
+    """Build the event copy sent to the main game LLM without internal route fields."""
+    if not isinstance(event, dict):
+        return event
+
+    visible_event = {
+        key: value
+        for key, value in event.items()
+        if key not in _GAME_LLM_VISIBLE_EVENT_TOP_LEVEL_DROP_KEYS
+    }
+    if _normalize_game_memory_type(game_type) != "soccer":
+        return visible_event
+
+    if "currentState" in visible_event:
+        visible_event["currentState"] = _sanitize_soccer_llm_visible_snapshot(
+            visible_event.get("currentState")
+        )
+
+    pending_items = visible_event.get("pendingItems")
+    if isinstance(pending_items, list):
+        sanitized_items: list[Any] = []
+        for item in pending_items:
+            if not isinstance(item, dict):
+                sanitized_items.append(item)
+                continue
+            sanitized_item = dict(item)
+            if "snapshot" in sanitized_item:
+                sanitized_item["snapshot"] = _sanitize_soccer_llm_visible_snapshot(
+                    sanitized_item.get("snapshot")
+                )
+            sanitized_items.append(sanitized_item)
+        visible_event["pendingItems"] = sanitized_items
+
+    return visible_event
 
 
 def _game_dialog_history_user_text(item: dict, labels: dict[str, str]) -> str:
@@ -6115,10 +6197,11 @@ async def _run_game_chat(
 
             # 格式化事件为文本发送给 LLM
             import json as _json
-            if isinstance(event, dict):
-                event_payload = _json.dumps(event, ensure_ascii=False)
+            llm_visible_event = _build_game_llm_visible_event(game_type, event)
+            if isinstance(llm_visible_event, dict):
+                event_payload = _json.dumps(llm_visible_event, ensure_ascii=False)
             else:
-                event_payload = str(event)
+                event_payload = str(llm_visible_event)
             event_text = get_game_chat_event_user_prompt(entry.get("user_language")).format(event=event_payload)
 
             llm_started_at = time.perf_counter()

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -2325,16 +2325,16 @@ def _apply_game_context_failure_fallback(
     if len(pending) < _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT:
         return False
     keep_count = _GAME_CONTEXT_FAILURE_FALLBACK_KEEP_COUNT
-    compacted = pending[:-keep_count]
+    discarded = pending[:-keep_count]
     kept = pending[-keep_count:]
-    if not compacted:
+    if not discarded:
         return False
-    last_compacted_id = str(compacted[-1].get("id") or "")
-    if not last_compacted_id:
+    last_discarded_id = str(discarded[-1].get("id") or "")
+    if not last_discarded_id:
         return False
 
     organizer = _normalize_game_context_organizer_state(state.get("game_context_organizer"))
-    organizer["last_organized_id"] = last_compacted_id
+    organizer["last_organized_id"] = last_discarded_id
     organizer["degraded"] = False
     organizer["error"] = f"fallback_{reason}_after_{len(pending)}_pending_items"
     state["game_context_organizer"] = organizer
@@ -2344,13 +2344,13 @@ def _apply_game_context_failure_fallback(
         if isinstance(item, dict) and item.get("id")
     ]
     logger.warning(
-        "🎮 局内上下文整理失败兜底推进: game=%s session=%s reason=%s compacted=%s kept=%s last=%s",
+        "🎮 局内上下文整理失败兜底丢弃: game=%s session=%s reason=%s discarded=%s kept=%s last=%s",
         state.get("game_type"),
         state.get("session_id"),
         reason,
-        len(compacted),
+        len(discarded),
         len(kept),
-        last_compacted_id,
+        last_discarded_id,
     )
     return True
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -62,6 +62,7 @@ from config.prompts.prompts_game_route import (
     get_game_context_formatter_labels,
     get_game_context_organizer_system_prompt,
     get_game_context_organizer_user_prompt,
+    get_game_dialog_memory_line_labels,
     get_game_postgame_context_labels,
     get_game_postgame_event_texts,
     get_game_postgame_realtime_nudge_labels,
@@ -1298,13 +1299,18 @@ def _game_context_recent_dialogues(state: dict, keep_count: int = _GAME_CONTEXT_
     return dialog[-keep_count:]
 
 
-def _game_context_dialog_lines(dialogues: list[dict], *, max_items: int = 12) -> list[str]:
+def _game_context_dialog_lines(
+    dialogues: list[dict],
+    *,
+    max_items: int = 12,
+    language: str | None = None,
+) -> list[str]:
     lines: list[str] = []
     for item in dialogues[-max_items:]:
         if not isinstance(item, dict):
             continue
         dialog_id = str(item.get("id") or "").strip()
-        line = _dialog_memory_line(item)
+        line = _dialog_memory_line(item, language)
         if dialog_id and line:
             lines.append(f"{dialog_id}: {line}")
         elif line:
@@ -1346,7 +1352,11 @@ def _format_game_context_for_prompt(context: Any, language: str | None = None) -
         return ""
     labels = get_game_context_formatter_labels(language)
     degraded = context.get("degraded") is True
-    recent_lines = _game_context_dialog_lines(context.get("recent_dialogues") or [], max_items=_GAME_CONTEXT_RECENT_KEEP_COUNT)
+    recent_lines = _game_context_dialog_lines(
+        context.get("recent_dialogues") or [],
+        max_items=_GAME_CONTEXT_RECENT_KEEP_COUNT,
+        language=language,
+    )
     if degraded:
         parts = [
             labels["degraded_status"],
@@ -2259,7 +2269,11 @@ def _append_game_output(state: dict, output: dict) -> None:
     state["last_activity"] = time.time()
 
 
-def _build_game_context_organizer_payload(state: dict, snapshot: list[dict]) -> dict:
+def _build_game_context_organizer_payload(
+    state: dict,
+    snapshot: list[dict],
+    language: str | None = None,
+) -> dict:
     organize_dialogues = snapshot[:-_GAME_CONTEXT_RECENT_KEEP_COUNT]
     keep_dialogues = snapshot[-_GAME_CONTEXT_RECENT_KEEP_COUNT:]
     return {
@@ -2271,12 +2285,12 @@ def _build_game_context_organizer_payload(state: dict, snapshot: list[dict]) -> 
         "existingRollingSummary": str(state.get("game_context_summary") or ""),
         "existingSignals": _normalize_game_context_signals(state.get("game_context_signals")),
         "organizeDialogues": [
-            {"id": item.get("id"), "line": _dialog_memory_line(item)}
+            {"id": item.get("id"), "line": _dialog_memory_line(item, language)}
             for item in organize_dialogues
             if isinstance(item, dict)
         ],
         "keptRecentDialogues": [
-            {"id": item.get("id"), "line": _dialog_memory_line(item)}
+            {"id": item.get("id"), "line": _dialog_memory_line(item, language)}
             for item in keep_dialogues
             if isinstance(item, dict)
         ],
@@ -2286,9 +2300,10 @@ def _build_game_context_organizer_payload(state: dict, snapshot: list[dict]) -> 
 async def _run_game_context_organizer_ai(state: dict, snapshot: list[dict]) -> dict:
     """Summarize older in-game context and extract observable signals."""
     char_info = _get_game_route_summary_llm_info(str(state.get("lanlan_name") or ""))
-    payload = _build_game_context_organizer_payload(state, snapshot)
-    system_prompt = get_game_context_organizer_system_prompt(char_info.get("user_language"))
-    user_prompt = get_game_context_organizer_user_prompt(char_info.get("user_language")).format(
+    language = char_info.get("user_language")
+    payload = _build_game_context_organizer_payload(state, snapshot, language)
+    system_prompt = get_game_context_organizer_system_prompt(language)
+    user_prompt = get_game_context_organizer_user_prompt(language).format(
         payload=json.dumps(payload, ensure_ascii=False)
     )
 
@@ -2682,24 +2697,28 @@ def _extract_score_text(state: dict) -> str:
     return f"玩家 {player} : {ai} {state.get('lanlan_name') or 'AI'}"
 
 
-_GAME_EVENT_MEMORY_LABELS = {
-    "goal-scored": "猫娘进球",
-    "goal-conceded": "玩家进球 / 猫娘丢球",
-    "own-goal-by-ai": "猫娘乌龙",
-    "own-goal-by-player": "玩家乌龙",
-    "steal": "猫娘抢到球",
-    "stolen": "猫娘被抢断",
-    "mailbox-batch": "累积上下文",
+_GAME_EVENT_MEMORY_LABEL_KEYS = {
+    "goal-scored": "event_goal_scored",
+    "goal-conceded": "event_goal_conceded",
+    "own-goal-by-ai": "event_own_goal_by_ai",
+    "own-goal-by-player": "event_own_goal_by_player",
+    "steal": "event_steal",
+    "stolen": "event_stolen",
+    "mailbox-batch": "event_mailbox_batch",
 }
 
 
-def _dialog_memory_line(item: dict) -> str:
+def _dialog_memory_line(item: dict, language: str | None = None) -> str:
+    labels = get_game_dialog_memory_line_labels(language)
     item_type = item.get("type")
     ts_text = _format_ts(item.get("ts"))
     prefix = f"[{ts_text}] " if ts_text else ""
     if item_type == "user":
         text = str(item.get("text") or "").strip()
-        return f"{prefix}玩家：{text}" if text else f"{prefix}玩家发来了一条游戏期间输入"
+        return (
+            f"{prefix}{labels['player_line'].format(text=text)}"
+            if text else f"{prefix}{labels['player_fallback']}"
+        )
     if item_type == "assistant":
         line = str(item.get("line") or "").strip()
         control = item.get("control") if isinstance(item.get("control"), dict) else {}
@@ -2709,19 +2728,23 @@ def _dialog_memory_line(item: dict) -> str:
         if control.get("difficulty"):
             control_bits.append(f"difficulty={control['difficulty']}")
         suffix = f" ({', '.join(control_bits)})" if control_bits else ""
-        return f"{prefix}{item.get('source') or 'game_llm'}：{line}{suffix}" if line else f"{prefix}游戏 LLM 返回为空"
+        return (
+            f"{prefix}{labels['assistant_line'].format(source=item.get('source') or 'game_llm', line=line, suffix=suffix)}"
+            if line else f"{prefix}{labels['assistant_empty']}"
+        )
     if item_type == "game_event":
         kind = str(item.get("kind") or "event")
-        label = _GAME_EVENT_MEMORY_LABELS.get(kind, "游戏事件")
+        label_key = _GAME_EVENT_MEMORY_LABEL_KEYS.get(kind, "event_default")
+        label = labels.get(label_key, labels["event_default"])
         text = str(item.get("text") or "").strip()
         line = str(item.get("result_line") or "").strip()
         if text and line:
-            return f"{prefix}游戏事件 {kind}（{label}）：事件原文「{text}」；猫娘回应「{line}」"
+            return f"{prefix}{labels['game_event_text_and_reply'].format(kind=kind, label=label, text=text, line=line)}"
         if line:
-            return f"{prefix}游戏事件 {kind}（{label}）：猫娘回应「{line}」"
+            return f"{prefix}{labels['game_event_reply'].format(kind=kind, label=label, line=line)}"
         if text:
-            return f"{prefix}游戏事件 {kind}（{label}）：事件原文「{text}」"
-        return f"{prefix}游戏事件 {kind}（{label}）"
+            return f"{prefix}{labels['game_event_text'].format(kind=kind, label=label, text=text)}"
+        return f"{prefix}{labels['game_event'].format(kind=kind, label=label)}"
     return f"{prefix}{json.dumps(item, ensure_ascii=False)}"
 
 
@@ -2816,7 +2839,8 @@ def _archive_prompt_language(archive: dict) -> str:
 
 
 def _build_game_archive_memory_text(archive: dict) -> str:
-    labels = get_game_archive_memory_text_labels(_archive_prompt_language(archive))
+    language = _archive_prompt_language(archive)
+    labels = get_game_archive_memory_text_labels(language)
     degraded = _archive_game_context_degraded(archive)
     lines = [
         labels["record_header"],
@@ -2845,7 +2869,7 @@ def _build_game_archive_memory_text(archive: dict) -> str:
     ]
     if key_events:
         lines.append(labels["key_events"])
-        lines.extend(f"- {_dialog_memory_line(item)}" for item in key_events[-8:] if isinstance(item, dict))
+        lines.extend(f"- {_dialog_memory_line(item, language)}" for item in key_events[-8:] if isinstance(item, dict))
 
     pre_game_context = archive.get("preGameContext") if isinstance(archive.get("preGameContext"), dict) else {}
     if pre_game_context:
@@ -2867,7 +2891,7 @@ def _build_game_archive_memory_text(archive: dict) -> str:
     ]
     if last_dialogues:
         lines.append(labels["recent_dialogues"])
-        lines.extend(f"- {_dialog_memory_line(item)}" for item in last_dialogues if isinstance(item, dict))
+        lines.extend(f"- {_dialog_memory_line(item, language)}" for item in last_dialogues if isinstance(item, dict))
 
     return "\n".join(line for line in lines if line is not None)
 
@@ -2970,6 +2994,7 @@ def _normalize_game_archive_memory_highlights(value: Any) -> dict:
 
 
 def _fallback_game_archive_memory_highlights(archive: dict) -> dict:
+    language = _archive_prompt_language(archive)
     records: list[str] = []
     last_user = _archive_last_user_text(archive)
     last_assistant = _archive_last_assistant_line(archive)
@@ -2987,7 +3012,7 @@ def _fallback_game_archive_memory_highlights(archive: dict) -> dict:
             continue
         if not _game_dialog_item_allowed_for_memory(item, archive):
             continue
-        line = _dialog_memory_line(item)
+        line = _dialog_memory_line(item, language)
         if line:
             event_records.append(line)
         if len(event_records) >= 3:
@@ -3004,7 +3029,8 @@ def _fallback_game_archive_memory_highlights(archive: dict) -> dict:
 
 
 def _build_game_archive_memory_highlight_source(archive: dict) -> str:
-    labels = get_game_archive_highlight_source_labels(_archive_prompt_language(archive))
+    language = _archive_prompt_language(archive)
+    labels = get_game_archive_highlight_source_labels(language)
     dialogues = archive.get("full_dialogues") if isinstance(archive.get("full_dialogues"), list) else []
     if not dialogues:
         dialogues = archive.get("last_full_dialogues") if isinstance(archive.get("last_full_dialogues"), list) else []
@@ -3041,7 +3067,7 @@ def _build_game_archive_memory_highlight_source(archive: dict) -> str:
             lines.append(labels["selection_priority"])
     lines.append(labels["full_dialogues"])
     lines.extend(
-        f"- {_dialog_memory_line(item)}"
+        f"- {_dialog_memory_line(item, language)}"
         for item in dialogues
         if isinstance(item, dict) and _game_dialog_item_allowed_for_memory(item, archive)
     )
@@ -3345,7 +3371,8 @@ def _build_game_postgame_context_text(archive: dict) -> str:
     Reuse already-built game archive material only. Do not trigger another LLM
     pass here; the Realtime session only needs compact postgame continuity.
     """
-    labels = get_game_postgame_context_labels(_archive_prompt_language(archive))
+    language = _archive_prompt_language(archive)
+    labels = get_game_postgame_context_labels(language)
     degraded = _archive_game_context_degraded(archive)
     score_text = _archive_score_text(archive)
     highlights = _normalize_game_archive_memory_highlights(archive.get("memory_highlights"))
@@ -3400,7 +3427,7 @@ def _build_game_postgame_context_text(archive: dict) -> str:
             lines.append(signals_text)
 
     unorganized_lines = [
-        f"- {_dialog_memory_line(item)}"
+        f"- {_dialog_memory_line(item, language)}"
         for item in _archive_unorganized_dialogues(archive)
         if isinstance(item, dict)
     ]
@@ -3455,11 +3482,12 @@ def _build_game_postgame_realtime_nudge_instruction(archive: dict, options: dict
 
 
 def _build_game_postgame_event(game_type: str, archive: dict, options: dict) -> dict:
-    texts = get_game_postgame_event_texts(_archive_prompt_language(archive))
+    language = _archive_prompt_language(archive)
+    texts = get_game_postgame_event_texts(language)
     dialogues = archive.get("last_full_dialogues") if isinstance(archive.get("last_full_dialogues"), list) else []
     include_count = int(options.get("include_last_dialogues") or _DEFAULT_LAST_FULL_DIALOGUE_COUNT)
     formatted_dialogues = [
-        _dialog_memory_line(item)
+        _dialog_memory_line(item, language)
         for item in dialogues[-include_count:]
         if isinstance(item, dict)
     ]

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -54,6 +54,7 @@ from config.prompts.prompts_game_route import (
     GAME_CONTEXT_SIGNAL_GROUP_KEYS,
     get_compact_realtime_context_texts,
     get_game_chat_event_user_prompt,
+    get_game_archive_fallback_highlight_labels,
     get_game_archive_highlight_source_labels,
     get_game_archive_memory_highlighter_system_prompt,
     get_game_archive_memory_highlighter_user_prompt,
@@ -1421,6 +1422,16 @@ _GAME_INTERNAL_ADVICE_RE = re.compile(
     re.IGNORECASE,
 )
 _GAME_LLM_VISIBLE_EVENT_TOP_LEVEL_DROP_KEYS = frozenset({
+    "basketballGameMemoryEnabled",
+    "basketball_game_memory_enabled",
+    "basketballGameMemoryPlayerInteractionEnabled",
+    "basketball_game_memory_player_interaction_enabled",
+    "basketballGameMemoryEventReplyEnabled",
+    "basketball_game_memory_event_reply_enabled",
+    "basketballGameMemoryArchiveEnabled",
+    "basketball_game_memory_archive_enabled",
+    "basketballGameMemoryPostgameContextEnabled",
+    "basketball_game_memory_postgame_context_enabled",
     "soccerGameMemoryEnabled",
     "soccer_game_memory_enabled",
     "soccerGameMemoryPlayerInteractionEnabled",
@@ -1562,7 +1573,10 @@ def _build_game_recent_history_messages(state: dict | None, language: str | None
     labels = get_game_recent_history_message_labels(language)
     messages = []
     last_role = "system"
-    for item in _game_context_recent_dialogues(state, _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT):
+    dialogues = _game_context_recent_dialogues(state, _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT)
+    if dialogues and isinstance(dialogues[-1], dict) and dialogues[-1].get("type") == "user":
+        dialogues = dialogues[:-1]
+    for item in dialogues:
         if not isinstance(item, dict):
             continue
         user_text = _game_dialog_history_user_text(item, labels)
@@ -2357,7 +2371,7 @@ def _apply_game_context_failure_fallback(
 
 def _set_game_context_recent_ids(state: dict, dialogues: list[dict] | None = None) -> None:
     source = dialogues if dialogues is not None else _game_context_pending_dialogues(state)
-    if dialogues is None and len(source) > _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT:
+    if dialogues is None and len(source) >= _GAME_CONTEXT_FAILURE_VISIBLE_WINDOW_MAX_COUNT:
         if _apply_game_context_failure_fallback(state, source, reason="overflow"):
             return
         source = _game_context_pending_dialogues(state)
@@ -2556,7 +2570,20 @@ def _apply_game_context_organizer_success(state: dict, snapshot: list[dict], res
 
 
 def _apply_game_context_organizer_failure(state: dict, snapshot: list[dict], error: Exception) -> None:
+    organize_dialogues = snapshot[:-_GAME_CONTEXT_RECENT_KEEP_COUNT]
     organizer = _normalize_game_context_organizer_state(state.get("game_context_organizer"))
+    if organize_dialogues:
+        target_last_id = str(organize_dialogues[-1].get("id") or "")
+        dialog = [item for item in state.get("game_dialog_log") or [] if isinstance(item, dict)]
+        current_last_id = str(organizer.get("last_organized_id") or "")
+        current_idx = _dialog_id_index(dialog, current_last_id)
+        target_idx = _dialog_id_index(dialog, target_last_id)
+        if current_idx > target_idx >= 0:
+            organizer["running"] = False
+            organizer["error"] = organizer.get("error") or "stale_organizer_failure_ignored"
+            state["game_context_organizer"] = organizer
+            _set_game_context_recent_ids(state)
+            return
     organizer["running"] = False
     organizer["failure_count"] = int(organizer.get("failure_count") or 0) + 1
     organizer["error"] = type(error).__name__
@@ -3171,15 +3198,19 @@ def _normalize_game_archive_memory_highlights(value: Any) -> dict:
 
 def _fallback_game_archive_memory_highlights(archive: dict) -> dict:
     language = _archive_prompt_language(archive)
+    labels = get_game_archive_fallback_highlight_labels(language)
     records: list[str] = []
     last_user = _archive_last_user_text(archive)
     last_assistant = _archive_last_assistant_line(archive)
     if last_user and last_assistant:
-        records.append(f"玩家最后说「{last_user}」，你回应「{last_assistant}」。")
+        records.append(labels["user_and_assistant"].format(
+            last_user=last_user,
+            last_assistant=last_assistant,
+        ))
     elif last_user:
-        records.append(f"玩家最后在这局游戏里说「{last_user}」。")
+        records.append(labels["user_only"].format(last_user=last_user))
     elif last_assistant:
-        records.append(f"你最后在这局游戏里说「{last_assistant}」。")
+        records.append(labels["assistant_only"].format(last_assistant=last_assistant))
 
     event_records: list[str] = []
     key_events = archive.get("key_events") if isinstance(archive.get("key_events"), list) else []
@@ -4224,7 +4255,7 @@ def _build_postgame_context_snapshot(state: dict) -> dict:
     pre_game_context = state.get("preGameContext") if isinstance(state.get("preGameContext"), dict) else None
     return {
         "pre_game_context": pre_game_context,
-        "game_context": _build_game_context_prompt_payload(state),
+        "game_context": _build_game_context_prompt_payload(state, include_recent=False),
         "mode": _normalize_basketball_mode(state.get("mode")),
     }
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1582,7 +1582,11 @@ def _build_game_recent_history_messages(state: dict | None, language: str | None
         user_text = _game_dialog_history_user_text(item, labels)
         assistant_text = _game_dialog_history_assistant_text(item)
         if user_text:
-            messages.append(HumanMessage(content=user_text))
+            if last_role == "human" and messages:
+                previous_content = str(getattr(messages[-1], "content", "")).rstrip()
+                messages[-1].content = f"{previous_content}\n{user_text}" if previous_content else user_text
+            else:
+                messages.append(HumanMessage(content=user_text))
             last_role = "human"
         if assistant_text:
             if last_role == "human":
@@ -2589,7 +2593,8 @@ def _apply_game_context_organizer_failure(state: dict, snapshot: list[dict], err
     organizer["error"] = type(error).__name__
     state["game_context_organizer"] = organizer
     pending = _game_context_pending_dialogues(state)
-    if _apply_game_context_failure_fallback(state, pending, reason="organizer_failure"):
+    fallback_reason = f"organizer_failure_{type(error).__name__}"
+    if _apply_game_context_failure_fallback(state, pending, reason=fallback_reason):
         return
     _set_game_context_recent_ids(state)
 

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -258,8 +258,37 @@ def test_game_session_history_reset_rebuilds_bounded_recent_messages(monkeypatch
     assert "第 1 句" in joined
     assert "第 2 句" in joined
     assert "第 3 句" in joined
-    assert "回应 8 (mood=happy)" in joined
+    assert "回应 8" in joined
+    assert "mood=happy" not in joined
+    assert "glog_" not in joined
     assert "不应继续留在 history" not in joined
+
+
+@pytest.mark.unit
+def test_game_recent_history_hides_internal_ids_and_control_suffix(monkeypatch):
+    from utils.llm_client import AIMessage, HumanMessage
+
+    state = _new_state(monkeypatch)
+    game_router._append_game_dialog(state, {
+        "type": "game_event",
+        "kind": "user-text",
+        "text": "不要让了",
+        "result_line": 'glog_0040: 哼，那我认真一点咯。 (mood=angry, difficulty=lv2)',
+        "control": {"mood": "angry", "difficulty": "lv2", "reason": "test"},
+    })
+
+    history = game_router._build_game_recent_history_messages(state, "zh")
+
+    assert isinstance(history[0], HumanMessage)
+    assert isinstance(history[1], AIMessage)
+    joined = "\n".join(str(message.content) for message in history)
+    assert "游戏事件 user-text" in joined
+    assert "事件原文「不要让了」" in joined
+    assert "哼，那我认真一点咯。" in joined
+    assert "glog_" not in joined
+    assert "mood=" not in joined
+    assert "difficulty=" not in joined
+    assert "reason" not in joined
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -223,6 +223,29 @@ async def test_context_organizer_overflow_fallback_ignores_stale_success(monkeyp
 
 
 @pytest.mark.unit
+def test_context_organizer_failure_fallback_preserves_error_type(monkeypatch):
+    state = _new_state(monkeypatch)
+    state["game_dialog_log"] = [
+        {
+            "id": f"glog_{index:04d}",
+            "type": "user",
+            "text": f"line {index}",
+        }
+        for index in range(1, 65)
+    ]
+    snapshot = state["game_dialog_log"][:15]
+
+    game_router._apply_game_context_organizer_failure(state, snapshot, ValueError("bad json"))
+
+    assert state["game_context_organizer"]["last_organized_id"] == "glog_0056"
+    assert (
+        state["game_context_organizer"]["error"]
+        == "fallback_organizer_failure_ValueError_after_64_pending_items"
+    )
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(57, 65)]
+
+
+@pytest.mark.unit
 def test_degraded_context_does_not_schedule_organizer(monkeypatch):
     state = _new_state(monkeypatch)
     state["game_context_organizer"]["degraded"] = True
@@ -402,6 +425,30 @@ def test_game_session_history_reset_skips_pending_current_user_input(monkeypatch
     assert "previous reply" in joined
     assert "current pending input" not in joined
     assert sum(isinstance(message, HumanMessage) for message in session._conversation_history) == 1
+
+
+@pytest.mark.unit
+def test_game_recent_history_merges_consecutive_user_side_events(monkeypatch):
+    from utils.llm_client import HumanMessage
+
+    state = _new_state(monkeypatch)
+    game_router._append_game_dialog(state, {
+        "type": "game_event",
+        "kind": "mailbox-batch",
+        "text": "first queued event",
+    })
+    game_router._append_game_dialog(state, {
+        "type": "game_event",
+        "kind": "mailbox-batch",
+        "text": "second queued event",
+    })
+
+    history = game_router._build_game_recent_history_messages(state, "en")
+
+    assert len(history) == 1
+    assert isinstance(history[0], HumanMessage)
+    assert "first queued event" in history[0].content
+    assert "second queued event" in history[0].content
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -81,6 +81,7 @@ async def test_context_organizer_triggers_at_15_and_keeps_recent_window(monkeypa
     for index in range(1, 15):
         _append_user_line(state, index)
         assert "_game_context_organizer_task" not in state
+        assert state["game_context_recent_ids"] == [f"glog_{item_index:04d}" for item_index in range(1, index + 1)]
 
     _append_user_line(state, 15)
     task = state["_game_context_organizer_task"]
@@ -121,7 +122,7 @@ async def test_context_organizer_does_not_truncate_logs_added_while_running(monk
 
     assert len(state["game_dialog_log"]) == 17
     assert state["game_context_organizer"]["last_organized_id"] == "glog_0009"
-    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(12, 18)]
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(10, 18)]
     assert [item["id"] for item in state["game_dialog_log"][-2:]] == ["glog_0016", "glog_0017"]
 
 
@@ -144,6 +145,7 @@ async def test_context_organizer_failure_keeps_window_until_new_logs(monkeypatch
     assert state["game_context_summary"] == ""
     assert state["game_context_organizer"]["failure_count"] == 1
     assert state["game_context_organizer"]["degraded"] is False
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(1, 16)]
     assert state["_game_context_organizer_task"] is task
 
 
@@ -250,11 +252,11 @@ def test_game_session_history_reset_rebuilds_bounded_recent_messages(monkeypatch
     assert isinstance(history[0], SystemMessage)
     assert history[0].content == "稳定 system"
     assert session._instructions == "稳定 system"
-    assert len(history) == 1 + game_router._GAME_CONTEXT_RECENT_KEEP_COUNT * 2
+    assert len(history) == 1 + 8 * 2
     assert isinstance(history[1], HumanMessage)
     assert isinstance(history[2], AIMessage)
-    assert "第 1 句" not in joined
-    assert "第 2 句" not in joined
+    assert "第 1 句" in joined
+    assert "第 2 句" in joined
     assert "第 3 句" in joined
     assert "回应 8 (mood=happy)" in joined
     assert "不应继续留在 history" not in joined

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -175,7 +175,7 @@ async def test_context_organizer_failure_fallback_keeps_last_8_at_64(monkeypatch
 
     assert calls == 1
     assert state["game_context_organizer"]["degraded"] is False
-    assert state["game_context_organizer"]["error"] == "fallback_organizer_failure_after_64_pending_items"
+    assert state["game_context_organizer"]["error"] == "fallback_overflow_after_64_pending_items"
     assert state["game_context_organizer"]["last_organized_id"] == "glog_0056"
     assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(57, 65)]
 
@@ -210,16 +210,16 @@ async def test_context_organizer_overflow_fallback_ignores_stale_success(monkeyp
     for index in range(16, 66):
         _append_user_line(state, index)
 
-    assert state["game_context_organizer"]["last_organized_id"] == "glog_0057"
-    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(58, 66)]
+    assert state["game_context_organizer"]["last_organized_id"] == "glog_0056"
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(57, 66)]
 
     release.set()
     await task
 
     assert state["game_context_summary"] == ""
-    assert state["game_context_organizer"]["last_organized_id"] == "glog_0057"
+    assert state["game_context_organizer"]["last_organized_id"] == "glog_0056"
     assert state["game_context_organizer"]["error"] == "stale_organizer_result_ignored"
-    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(58, 66)]
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(57, 66)]
 
 
 @pytest.mark.unit
@@ -368,6 +368,40 @@ def test_game_session_history_reset_uses_recent_history_locale_labels(monkeypatc
     joined = "\n".join(str(getattr(message, "content", "")) for message in session._conversation_history)
     assert "Player: nice shot" in joined
     assert "玩家：nice shot" not in joined
+
+
+@pytest.mark.unit
+def test_game_session_history_reset_skips_pending_current_user_input(monkeypatch):
+    from utils.llm_client import HumanMessage, SystemMessage
+
+    class DummySession:
+        pass
+
+    state = _new_state(monkeypatch)
+    game_router._append_game_dialog(state, {
+        "type": "user",
+        "text": "previous turn",
+    })
+    game_router._append_game_dialog(state, {
+        "type": "assistant",
+        "line": "previous reply",
+    })
+    game_router._append_game_dialog(state, {
+        "type": "user",
+        "text": "current pending input",
+    })
+    session = DummySession()
+    session._instructions = "system"
+    session._conversation_history = [SystemMessage(content="system")]
+    entry = {"session": session, "instructions": "system", "user_language": "en"}
+
+    game_router._reset_game_session_text_history_for_turn(entry, state)
+
+    joined = "\n".join(str(getattr(message, "content", "")) for message in session._conversation_history)
+    assert "Player: previous turn" in joined
+    assert "previous reply" in joined
+    assert "current pending input" not in joined
+    assert sum(isinstance(message, HumanMessage) for message in session._conversation_history) == 1
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -186,6 +186,113 @@ def test_degraded_context_does_not_schedule_organizer(monkeypatch):
 
 
 @pytest.mark.unit
+def test_game_context_payload_can_exclude_recent_window_for_stable_system(monkeypatch):
+    state = _new_state(monkeypatch)
+    state["game_context_summary"] = "猫娘领先，玩家正在追分。"
+    state["game_context_signals"] = {
+        "session_facts": [{
+            "signalLabel": "当前比分",
+            "summary": "猫娘暂时领先。",
+            "evidence": [],
+            "lastRound": 2,
+            "count": 1,
+        }],
+    }
+    for index in range(1, 4):
+        game_router._append_game_dialog(state, {
+            "type": "game_event",
+            "kind": "user-text",
+            "text": f"第 {index} 句",
+            "result_line": f"回应 {index}",
+        })
+
+    payload = game_router._build_game_context_prompt_payload(state, include_recent=False)
+    formatted = game_router._format_game_context_for_prompt(payload, "zh")
+
+    assert payload["recent_dialogues"] == []
+    assert "局内滚动摘要：猫娘领先，玩家正在追分。" in formatted
+    assert "局内信号列表：" in formatted
+    assert "最近原文窗口：" not in formatted
+    assert "第 1 句" not in formatted
+
+
+@pytest.mark.unit
+def test_game_session_history_reset_rebuilds_bounded_recent_messages(monkeypatch):
+    from utils.llm_client import AIMessage, HumanMessage, SystemMessage
+
+    class DummySession:
+        pass
+
+    state = _new_state(monkeypatch)
+    for index in range(1, 9):
+        game_router._append_game_dialog(state, {
+            "type": "game_event",
+            "kind": "user-text",
+            "text": f"第 {index} 句",
+            "result_line": f"回应 {index}",
+            "control": {"mood": "happy"} if index == 8 else {},
+        })
+
+    session = DummySession()
+    session._instructions = "旧 system"
+    session._conversation_history = [
+        SystemMessage(content="旧 system"),
+        HumanMessage(content="不应继续留在 history 里的旧输入"),
+        AIMessage(content="不应继续留在 history 里的旧回复"),
+    ]
+    entry = {"session": session, "instructions": "稳定 system"}
+
+    game_router._reset_game_session_text_history_for_turn(entry, state)
+
+    history = session._conversation_history
+    joined = "\n".join(str(getattr(message, "content", "")) for message in history)
+
+    assert isinstance(history[0], SystemMessage)
+    assert history[0].content == "稳定 system"
+    assert session._instructions == "稳定 system"
+    assert len(history) == 1 + game_router._GAME_CONTEXT_RECENT_KEEP_COUNT * 2
+    assert isinstance(history[1], HumanMessage)
+    assert isinstance(history[2], AIMessage)
+    assert "第 1 句" not in joined
+    assert "第 2 句" not in joined
+    assert "第 3 句" in joined
+    assert "回应 8 (mood=happy)" in joined
+    assert "不应继续留在 history" not in joined
+
+
+@pytest.mark.unit
+def test_game_session_history_reset_uses_recent_history_locale_labels(monkeypatch):
+    from utils.llm_client import SystemMessage
+
+    class DummySession:
+        pass
+
+    state = _new_state(monkeypatch)
+    game_router._append_game_dialog(state, {
+        "type": "user",
+        "text": "nice shot",
+    })
+    game_router._append_game_dialog(state, {
+        "type": "assistant",
+        "line": "Thanks.",
+    })
+    session = DummySession()
+    session._instructions = "system"
+    session._conversation_history = [SystemMessage(content="system")]
+    entry = {
+        "session": session,
+        "instructions": "system",
+        "user_language": "en",
+    }
+
+    game_router._reset_game_session_text_history_for_turn(entry, state)
+
+    joined = "\n".join(str(getattr(message, "content", "")) for message in session._conversation_history)
+    assert "Player: nice shot" in joined
+    assert "玩家：nice shot" not in joined
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_finalize_waits_for_running_context_organizer_before_archive(monkeypatch):
     state = _mark_game_started(_new_state(monkeypatch))

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -293,6 +293,28 @@ def test_game_session_history_reset_uses_recent_history_locale_labels(monkeypatc
 
 
 @pytest.mark.unit
+def test_dialog_memory_line_uses_requested_english_locale():
+    user_line = game_router._dialog_memory_line({
+        "type": "user",
+        "text": "nice shot",
+    }, "en")
+    event_line = game_router._dialog_memory_line({
+        "type": "game_event",
+        "kind": "goal-scored",
+        "text": "what a shot",
+        "result_line": "That was clean.",
+    }, "en")
+
+    assert user_line == "Player: nice shot"
+    assert "Game event goal-scored (Character scored)" in event_line
+    assert 'event text "what a shot"' in event_line
+    assert 'character reply "That was clean."' in event_line
+    assert "玩家：" not in user_line
+    assert "事件原文" not in event_line
+    assert "游戏事件" not in event_line
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_finalize_waits_for_running_context_organizer_before_archive(monkeypatch):
     state = _mark_game_started(_new_state(monkeypatch))

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -148,10 +148,17 @@ async def test_context_organizer_failure_keeps_window_until_new_logs(monkeypatch
     assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(1, 16)]
     assert state["_game_context_organizer_task"] is task
 
+    _append_user_line(state, 16)
+    _append_user_line(state, 17)
+
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(1, 18)]
+    await state["_game_context_organizer_task"]
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(1, 18)]
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_context_organizer_degrades_at_40_pending_items(monkeypatch):
+async def test_context_organizer_failure_fallback_keeps_last_8_at_64(monkeypatch):
     state = _new_state(monkeypatch)
     calls = 0
 
@@ -162,17 +169,57 @@ async def test_context_organizer_degrades_at_40_pending_items(monkeypatch):
 
     monkeypatch.setattr(game_router, "_run_game_context_organizer_ai", fake_ai)
 
-    for index in range(1, 41):
+    for index in range(1, 65):
         _append_user_line(state, index)
     await state["_game_context_organizer_task"]
 
     assert calls == 1
-    assert state["game_context_organizer"]["degraded"] is True
-    assert state["game_context_organizer"]["error"] == "degraded_after_40_pending_items"
-    assert state["game_context_organizer"]["last_organized_id"] == ""
+    assert state["game_context_organizer"]["degraded"] is False
+    assert state["game_context_organizer"]["error"] == "fallback_organizer_failure_after_64_pending_items"
+    assert state["game_context_organizer"]["last_organized_id"] == "glog_0056"
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(57, 65)]
 
-    _append_user_line(state, 41)
-    assert calls == 1
+    for index in range(65, 72):
+        _append_user_line(state, index)
+
+    assert "_game_context_organizer_task" in state
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(57, 72)]
+    await state["_game_context_organizer_task"]
+    assert calls == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_context_organizer_overflow_fallback_ignores_stale_success(monkeypatch):
+    state = _new_state(monkeypatch)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_ai(_state, _snapshot):
+        started.set()
+        await release.wait()
+        return _fake_success_result()
+
+    monkeypatch.setattr(game_router, "_run_game_context_organizer_ai", fake_ai)
+
+    for index in range(1, 16):
+        _append_user_line(state, index)
+    task = state["_game_context_organizer_task"]
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    for index in range(16, 66):
+        _append_user_line(state, index)
+
+    assert state["game_context_organizer"]["last_organized_id"] == "glog_0057"
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(58, 66)]
+
+    release.set()
+    await task
+
+    assert state["game_context_summary"] == ""
+    assert state["game_context_organizer"]["last_organized_id"] == "glog_0057"
+    assert state["game_context_organizer"]["error"] == "stale_organizer_result_ignored"
+    assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(58, 66)]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -14,6 +14,7 @@ from config.prompts.prompts_game_route import (
     get_game_postgame_context_labels,
     get_game_postgame_event_texts,
     get_game_postgame_realtime_nudge_labels,
+    get_game_recent_history_message_labels,
 )
 from main_routers import game_router
 
@@ -35,6 +36,7 @@ def test_game_route_prompt_getters_return_locale_content(locale):
         get_game_archive_memory_summary_labels,
         get_game_archive_memory_text_labels,
         get_game_context_formatter_labels,
+        get_game_recent_history_message_labels,
         get_game_postgame_context_labels,
         get_game_postgame_realtime_nudge_labels,
         get_game_postgame_event_texts,

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -73,6 +73,19 @@ def test_naked_game_route_user_prompts_keep_chinese_watermark(locale):
 
 
 @pytest.mark.unit
+def test_english_archive_prompts_keep_literal_localized_markers():
+    system_prompt = get_game_archive_memory_highlighter_system_prompt("en")
+    source_labels = get_game_archive_highlight_source_labels("en")
+
+    assert 'literal marker "Player:"' in system_prompt
+    assert '"event text" inside "Game event" lines' in system_prompt
+    assert 'literal marker "Player:"' in source_labels["role_explanation"]
+    assert '"event text" inside "Game event" lines' in source_labels["role_explanation"]
+    assert "explicitly marked as player speech" not in system_prompt
+    assert "explicitly marked as player speech" not in source_labels["role_explanation"]
+
+
+@pytest.mark.unit
 def test_game_context_signal_normalizer_accepts_legacy_zh_group_keys():
     normalized = game_router._normalize_game_context_signals({
         "玩家信号": [{

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -11,6 +11,7 @@ from config.prompts.prompts_game_route import (
     get_game_context_formatter_labels,
     get_game_context_organizer_system_prompt,
     get_game_context_organizer_user_prompt,
+    get_game_dialog_memory_line_labels,
     get_game_postgame_context_labels,
     get_game_postgame_event_texts,
     get_game_postgame_realtime_nudge_labels,
@@ -19,7 +20,7 @@ from config.prompts.prompts_game_route import (
 from main_routers import game_router
 
 
-LOCALES = ("zh", "en", "ja", "ko", "ru")
+LOCALES = ("zh", "en", "ja", "ko", "ru", "es", "pt")
 LEGACY_SIGNAL_GROUP_KEYS = ("玩家信号", "关系互动信号", "猫娘信号", "本局事实", "口头声明")
 
 
@@ -36,6 +37,7 @@ def test_game_route_prompt_getters_return_locale_content(locale):
         get_game_archive_memory_summary_labels,
         get_game_archive_memory_text_labels,
         get_game_context_formatter_labels,
+        get_game_dialog_memory_line_labels,
         get_game_recent_history_message_labels,
         get_game_postgame_context_labels,
         get_game_postgame_realtime_nudge_labels,

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -2,6 +2,7 @@ import pytest
 
 from config.prompts.prompts_game_route import (
     GAME_CONTEXT_SIGNAL_GROUP_KEYS,
+    get_game_archive_fallback_highlight_labels,
     get_game_archive_highlight_source_labels,
     get_game_archive_memory_highlighter_system_prompt,
     get_game_archive_memory_highlighter_user_prompt,
@@ -34,6 +35,7 @@ def test_game_route_prompt_getters_return_locale_content(locale):
 
     label_getters = (
         get_game_archive_highlight_source_labels,
+        get_game_archive_fallback_highlight_labels,
         get_game_archive_memory_summary_labels,
         get_game_archive_memory_text_labels,
         get_game_context_formatter_labels,

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sqlite3
 from unittest.mock import AsyncMock
 
@@ -2110,6 +2111,79 @@ def test_game_route_helper_llm_info_does_not_mix_partial_summary_config(monkeypa
 
 
 @pytest.mark.unit
+def test_build_game_llm_visible_event_filters_soccer_internal_fields():
+    event = {
+        "kind": "mailbox-batch",
+        "lanlan_name": "Lan",
+        "soccerGameMemoryEnabled": True,
+        "soccer_game_memory_enabled": True,
+        "soccerGameMemoryPlayerInteractionEnabled": True,
+        "soccer_game_memory_player_interaction_enabled": True,
+        "soccerGameMemoryEventReplyEnabled": True,
+        "soccer_game_memory_event_reply_enabled": True,
+        "soccerGameMemoryArchiveEnabled": True,
+        "soccer_game_memory_archive_enabled": True,
+        "soccerGameMemoryPostgameContextEnabled": True,
+        "soccer_game_memory_postgame_context_enabled": True,
+        "gameMemoryEnabled": True,
+        "game_memory_enabled": True,
+        "gameMemoryPlayerInteractionEnabled": True,
+        "game_memory_player_interaction_enabled": True,
+        "gameMemoryEventReplyEnabled": True,
+        "game_memory_event_reply_enabled": True,
+        "balanceHint": {"message": "keep this pending judgment"},
+        "angerPressureCap": {"message": "keep this pending judgment", "reason": "internal-ish but undecided"},
+        "currentState": {
+            "round": 12,
+            "score": {"player": 1, "ai": 3},
+            "aiFreezeSec": 0.2,
+            "playerKickStartleWindowSec": 0.5,
+            "playerKickWallBounceForStartle": True,
+            "startle": {"directCdSec": 1},
+            "startleDirectCdSec": 1,
+            "startleGrazeCdSec": 2,
+            "startleMutualLockSec": 3,
+            "zoneoutCooldownSec": 4,
+            "ballGhost": True,
+        },
+        "pendingItems": [{
+            "kind": "goal-scored",
+            "priority": 8,
+            "source": "voice_input_gate",
+            "builtinFallback": "备用台词",
+            "snapshot": {
+                "round": 11,
+                "score": {"player": 1, "ai": 2},
+                "aiFreezeSec": 0.1,
+                "ballGhost": False,
+            },
+        }],
+    }
+
+    visible = game_router._build_game_llm_visible_event("soccer", event)
+
+    assert "lanlan_name" not in visible
+    assert "soccerGameMemoryEnabled" not in visible
+    assert "soccer_game_memory_enabled" not in visible
+    assert "gameMemoryEnabled" not in visible
+    assert "game_memory_enabled" not in visible
+    assert visible["balanceHint"] == event["balanceHint"]
+    assert visible["angerPressureCap"] == event["angerPressureCap"]
+    assert visible["pendingItems"][0]["priority"] == 8
+    assert visible["pendingItems"][0]["source"] == "voice_input_gate"
+    assert visible["pendingItems"][0]["builtinFallback"] == "备用台词"
+    for state in (visible["currentState"], visible["pendingItems"][0]["snapshot"]):
+        assert "aiFreezeSec" not in state
+        assert "playerKickStartleWindowSec" not in state
+        assert "playerKickWallBounceForStartle" not in state
+        assert "startle" not in state
+        assert "zoneoutCooldownSec" not in state
+        assert "ballGhost" not in state
+    assert event["currentState"]["aiFreezeSec"] == 0.2
+    assert event["pendingItems"][0]["snapshot"]["ballGhost"] is False
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_game_chat_event_user_turn_keeps_watermark(monkeypatch):
     class FakeSession:
@@ -2147,6 +2221,100 @@ async def test_game_chat_event_user_turn_keeps_watermark(monkeypatch):
     assert result["line"] == ""
     assert "======以上为游戏事件输入======" in fake_session.last_text
     assert '"kind": "goal-scored"' in fake_session.last_text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_game_chat_sends_filtered_llm_visible_event(monkeypatch):
+    class FakeSession:
+        def __init__(self):
+            self.last_text = ""
+
+        async def stream_text(self, text):
+            self.last_text = text
+
+        async def update_session(self, _config):
+            return None
+
+    fake_session = FakeSession()
+    key = game_router._game_session_key("Lan", "soccer", "match_filtered")
+    game_router._game_sessions[key] = {
+        "session": fake_session,
+        "reply_chunks": [],
+        "lanlan_name": "Lan",
+        "lanlan_prompt": "",
+        "user_language": "zh",
+        "game_type": "soccer",
+        "session_id": "match_filtered",
+        "last_activity": 0,
+        "lock": asyncio.Lock(),
+        "instructions": "stub",
+    }
+    monkeypatch.setattr(game_router, "_refresh_game_session_instructions", AsyncMock())
+
+    await game_router._run_game_chat(
+        "soccer",
+        "match_filtered",
+        {
+            "kind": "mailbox-batch",
+            "lanlan_name": "Lan",
+            "soccerGameMemoryEnabled": True,
+            "soccer_game_memory_enabled": True,
+            "soccerGameMemoryPlayerInteractionEnabled": True,
+            "soccer_game_memory_player_interaction_enabled": True,
+            "soccerGameMemoryEventReplyEnabled": True,
+            "soccer_game_memory_event_reply_enabled": True,
+            "gameMemoryEnabled": True,
+            "game_memory_enabled": True,
+            "balanceHint": {"message": "暂时保留"},
+            "angerPressureCap": {"message": "暂时保留", "reached": False},
+            "currentState": {
+                "round": 2,
+                "score": {"player": 1, "ai": 1},
+                "aiFreezeSec": 0,
+                "playerKickStartleWindowSec": 0,
+                "playerKickWallBounceForStartle": False,
+                "startle": {"directCdSec": 0, "grazeCdSec": 0, "mutualLockSec": 0},
+                "zoneoutCooldownSec": 0,
+                "ballGhost": False,
+            },
+            "pendingItems": [{
+                "kind": "user-voice",
+                "priority": 8,
+                "source": "voice_input_gate",
+                "builtinFallback": "备用台词",
+                "snapshot": {
+                    "round": 1,
+                    "score": {"player": 0, "ai": 1},
+                    "aiFreezeSec": 0.3,
+                    "ballGhost": True,
+                },
+            }],
+        },
+    )
+
+    payload_text = fake_session.last_text.split("======以下为游戏事件输入======", 1)[1]
+    payload_text = payload_text.split("======以上为游戏事件输入======", 1)[0].strip()
+    payload = json.loads(payload_text)
+
+    assert "lanlan_name" not in payload
+    assert "soccerGameMemoryEnabled" not in payload
+    assert "soccer_game_memory_enabled" not in payload
+    assert "gameMemoryEnabled" not in payload
+    assert "game_memory_enabled" not in payload
+    assert "aiFreezeSec" not in payload["currentState"]
+    assert "playerKickStartleWindowSec" not in payload["currentState"]
+    assert "playerKickWallBounceForStartle" not in payload["currentState"]
+    assert "startle" not in payload["currentState"]
+    assert "zoneoutCooldownSec" not in payload["currentState"]
+    assert "ballGhost" not in payload["currentState"]
+    assert "aiFreezeSec" not in payload["pendingItems"][0]["snapshot"]
+    assert "ballGhost" not in payload["pendingItems"][0]["snapshot"]
+    assert payload["pendingItems"][0]["priority"] == 8
+    assert payload["pendingItems"][0]["source"] == "voice_input_gate"
+    assert payload["pendingItems"][0]["builtinFallback"] == "备用台词"
+    assert isinstance(payload["balanceHint"].get("message"), str)
+    assert payload["angerPressureCap"]["message"] == "暂时保留"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -62,6 +62,33 @@ def test_parse_control_instructions_extracts_json_line():
 
 
 @pytest.mark.unit
+def test_parse_control_instructions_sanitizes_visible_line_leaks():
+    result = game_router._parse_control_instructions(
+        'glog_0040: 哼，那我认真一点咯。 (mood=angry, difficulty=lv2)\n'
+        'reason="balance tuning"\n'
+        '{"mood":"angry","difficulty":"lv2","reason":"压一压节奏"}'
+    )
+
+    assert result == {
+        "line": "哼，那我认真一点咯。",
+        "control": {"mood": "angry", "difficulty": "lv2", "reason": "压一压节奏"},
+    }
+
+
+@pytest.mark.unit
+def test_parse_control_instructions_drops_internal_advice_lines_from_visible_line():
+    result = game_router._parse_control_instructions(
+        '根据系统建议降低难度。\n'
+        '看你追得这么急，我就稍微认真一点点。'
+    )
+
+    assert result == {
+        "line": "看你追得这么急，我就稍微认真一点点。",
+        "control": {},
+    }
+
+
+@pytest.mark.unit
 def test_basketball_prompt_and_control_contract():
     prompt = game_router._build_game_prompt(
         "basketball",
@@ -1935,7 +1962,7 @@ def test_memory_highlight_source_explains_game_event_text_is_not_user_speech():
     })
 
     assert "只有“玩家：...”行是玩家亲口说的话" in source
-    assert "事件原文是游戏模块/猫娘气泡或事件标签，不要归因给玩家" in source
+    assert "“事件原文”是游戏模块/猫娘气泡或事件标签，不要归因给玩家" in source
     assert "游戏事件 goal-conceded（玩家进球 / 猫娘丢球）" in source
     assert "固定顺序是玩家在前、当前角色在后" in source
     assert "官方结果，来源优先级为 finalScore / last_state.score" in source
@@ -1967,12 +1994,10 @@ def test_memory_highlight_source_keeps_role_markers_aligned_in_english(monkeypat
         ],
     })
 
-    assert 'literal marker "玩家："' in source
-    assert '"事件原文" inside "游戏事件" lines' in source
-    assert "玩家：I almost caught up" in source
-    assert "游戏事件 goal-conceded" in source
-    assert "Player:" not in source
-    assert "Game event" not in source
+    assert 'literal marker "Player:"' in source
+    assert '"event text" inside "Game event" lines' in source
+    assert "Player: I almost caught up" in source
+    assert "Game event goal-conceded" in source
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -2002,6 +2002,30 @@ def test_memory_highlight_source_keeps_role_markers_aligned_in_english(monkeypat
 
 
 @pytest.mark.unit
+def test_archive_memory_fallback_highlights_use_requested_locale(monkeypatch):
+    monkeypatch.setattr(game_router, "_archive_prompt_language", lambda _archive: "en")
+
+    highlights = game_router._fallback_game_archive_memory_highlights({
+        "game_type": "soccer",
+        "session_id": "match_1",
+        "lanlan_name": "Lan",
+        "last_state": {"score": {"player": 1, "ai": 2}},
+        "soccer_game_memory_enabled": True,
+        "soccer_game_memory_player_interaction_enabled": True,
+        "last_full_dialogues": [
+            {"type": "user", "text": "That was close"},
+            {"type": "assistant", "line": "Almost."},
+        ],
+        "key_events": [],
+    })
+
+    assert highlights["important_records"] == [
+        'The player last said "That was close", and you replied "Almost.".'
+    ]
+    assert "玩家最后" not in highlights["important_records"][0]
+
+
+@pytest.mark.unit
 def test_memory_highlight_prompt_rejects_bare_or_reversed_scores(monkeypatch):
     captured = {}
 
@@ -2181,6 +2205,54 @@ def test_build_game_llm_visible_event_filters_soccer_internal_fields():
         assert "ballGhost" not in state
     assert event["currentState"]["aiFreezeSec"] == 0.2
     assert event["pendingItems"][0]["snapshot"]["ballGhost"] is False
+
+
+@pytest.mark.unit
+def test_build_game_llm_visible_event_filters_basketball_memory_flags():
+    event = {
+        "kind": "shot-made",
+        "basketballGameMemoryEnabled": True,
+        "basketball_game_memory_enabled": True,
+        "basketballGameMemoryPlayerInteractionEnabled": True,
+        "basketball_game_memory_player_interaction_enabled": True,
+        "basketballGameMemoryEventReplyEnabled": True,
+        "basketball_game_memory_event_reply_enabled": True,
+        "basketballGameMemoryArchiveEnabled": True,
+        "basketball_game_memory_archive_enabled": True,
+        "basketballGameMemoryPostgameContextEnabled": True,
+        "basketball_game_memory_postgame_context_enabled": True,
+        "currentState": {"mode": "shooter", "streak": 3},
+    }
+
+    visible = game_router._build_game_llm_visible_event("basketball", event)
+
+    assert visible == {
+        "kind": "shot-made",
+        "currentState": {"mode": "shooter", "streak": 3},
+    }
+    assert event["basketballGameMemoryEnabled"] is True
+
+
+@pytest.mark.unit
+def test_postgame_context_snapshot_excludes_recent_dialogues(monkeypatch):
+    state = {
+        "preGameContext": {"story": "opening"},
+        "game_context_summary": "summary",
+        "game_context_signals": {},
+        "game_context_organizer": {},
+        "game_dialog_log": [],
+    }
+    game_router._append_game_dialog(state, {
+        "type": "game_event",
+        "kind": "goal-scored",
+        "text": "scored",
+        "result_line": "Nice.",
+    })
+
+    snapshot = game_router._build_postgame_context_snapshot(state)
+
+    assert snapshot["game_context"]["summary"] == "summary"
+    assert snapshot["game_context"]["recent_dialogues"] == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# Fix mini-game LLM context growth and cache churn

## Summary

This PR fixes the mini-game main LLM context path so game turns no longer inherit an ever-growing OmniOfflineClient conversation history or churn the provider prompt cache through a moving recent-window prefix.

The main changes are:

- Rebuild the mini-game text session history from bounded route state before each main game LLM turn, instead of reusing the persistent OmniOfflineClient message history.
- Keep moving recent dialogue lines out of the stable system prompt; the system prompt now keeps stable rules/opening context plus rolling summary/signals.
- Localize the game dialogue/history markers used by LLM-facing prompt material while preserving the existing literal-marker semantics and prompt watermark.
- Clean main LLM visible history and current event payloads so internal IDs, control metadata, game-memory feature flags, and low-level soccer snapshot fields are not exposed to the dialogue model.
- Fix organizer failure behavior: normal operation still organizes at 15 pending items and returns to a short recent window; when the organizer fails or is still running, the visible recent window grows append-only up to 64 items instead of sliding FIFO at 15 items.
- At the 64-item hard fallback boundary, the oldest 56 items are intentionally discarded and the latest 8 remain visible.
- Ignore stale organizer results if an older async organizer task returns after the fallback boundary has already advanced.

## Why

The previous mini-game path had two related issues:

1. The main mini-game LLM reused OmniOfflineClient's persistent `_conversation_history`, so old game user/assistant messages remained in future requests even after the route-level organizer had compacted context.
2. The route-level recent window could become a 15-item FIFO window when organizer JSON output failed. That dropped older unorganized lines from the main LLM while also changing the message prefix every turn, which caused poor cache reuse.

Local proxy captures showed the contrast clearly:

- Normal chat requests can hit the cache in the ~91%-97% range in the same environment.
- Before this fix, mini-game event requests repeatedly had `0.0%` cache hit, and later requests grew to roughly 20k-22k input tokens.
- After this fix, comparable mini-game event requests show stable cached prefixes, commonly around `83%`-`89%` cache hit, with input size staying much lower and more bounded.

## Cost Impact Estimate / 成本影响估算

This PR also has a material cost impact for cloud-backed game LLM setups. The detailed estimate is kept in Chinese because the measurement notes and pricing comparison were prepared in that form.

以下估算基于本地 LLM proxy 统计和云模型价格表折算，用于衡量事故影响量级，不作为真实账单依据。当前测试使用的是本地 llama.cpp，不产生真实云 API 账单；真实云 API 成本应以 provider usage 为准。

估算背景：

- 修复前截图里，主游戏 LLM 请求输入量随回合近似线性增长：早期样本约 `2,938 -> 3,771 -> 4,634`，后期样本约 `19,782 -> 20,857 -> 21,671 -> 22,500`。每次主游戏 LLM 调用约增加 `0.8K-1.1K input tokens`。
- 这轮测试基本是一回合触发一次主游戏 LLM 调用，期间没有额外玩家自由对话。因此按约 `1K input tokens / 游戏内回合` 外推到 108 个游戏内回合。
- 第 1 次主 LLM 输入约 `2,938 tokens`，第 108 次约 `109.9K tokens`，累计输入约 `6.10M tokens`。修复前缓存命中接近 `0%`，所以按全部输入不命中缓存计算。
- 修复后：按修复后本地 proxy 最近一轮统计，约 `217.9K input tokens`，其中约 `159.9K cached input`、`58.0K uncached input`，输出约 `7.8K tokens`；整体缓存命中约 `75%`。

| 情况 | 输入量 | 缓存命中 | Qwen3.7-Plus 原价 | Qwen3.7-Plus 8折 | Qwen3.6-Flash | Qwen3.6-35B-A3B | Qwen3.6-27B |
|---|---:|---:|---:|---:|---:|---:|---:|
| 修复前（外推到约 108 个游戏内回合） | 约 6.10M | 0% | 约 12.21 元 | 约 9.77 元 | 约 7.34 元 | 约 11.00 元 | 约 18.34 元 |
| 只降低使用量，不吃缓存 | 约 217.9K | 0% | 约 0.50 元 | 约 0.40 元 | 约 0.32 元 | 约 0.48 元 | 约 0.79 元 |
| 降低使用量 + 当前缓存 | 约 217.9K | 约 75% | 约 0.24 元 | 约 0.19 元 | 约 0.15 元 | 约 0.48 元 | 约 0.79 元 |

| 改善来源 | Qwen3.7-Plus 原价 | Qwen3.7-Plus 8折 | Qwen3.6-Flash | Qwen3.6-35B-A3B | Qwen3.6-27B |
|---|---:|---:|---:|---:|---:|
| 使用量降低 | 约 24 倍 | 约 24 倍 | 约 23 倍 | 约 23 倍 | 约 23 倍 |
| 缓存命中恢复 | 约 2.1 倍 | 约 2.1 倍 | 约 2.1 倍 | 不支持 | 不支持 |
| 两者叠加 | 约 50 倍 | 约 50 倍 | 约 49 倍 | 约 23 倍 | 约 23 倍 |

Notes:

- `108` means 108 in-game rounds, not 108 free-form chat turns.
- This run was approximately one main game LLM call per in-game round, so the extrapolation uses that mapping.
- `+1000 tokens / round` comes from the observed before-fix trend, not a fixed constant.
- The before-fix estimate assumes near-`0%` cache hit.
- This is an impact estimate, not a billing statement. The local llama.cpp test does not create real cloud API charges.
- Qwen3.6-35B-A3B and Qwen3.6-27B do not support cache discount in this estimate, so their "usage reduction + current cache" row only reflects lower total input size.

## Regression Report / 回归报告

- Changed `main_routers/game_router.py` to rebuild mini-game main LLM message history from route-owned bounded context before each turn, instead of allowing game turns to inherit the generic OmniOfflineClient persistent conversation history.
- Moved the moving recent-window content out of the stable system prompt while keeping rolling summary/signals in the game context prompt.
- Added event/history sanitization so main-game dialogue prompts no longer expose internal route IDs, control suffixes, memory flags, or low-level soccer simulation fields that the dialogue model does not need.
- Updated organizer failure handling so failed or still-running compaction uses an append-only visible window up to 64 items instead of a 15-item FIFO sliding window. At the hard fallback boundary, the oldest 56 items are intentionally discarded and the latest 8 are kept.
- Before this change, repeated mini-game turns could grow input size, keep old Omni conversation messages alive, and repeatedly miss prompt cache. When organizer JSON failed, the recent window could slide and lose unorganized earlier lines without summary coverage.
- After this change, the main-game visible history is bounded and rebuilt, the stable prefix can be reused by providers, successful organizer compaction returns the recent window to the kept tail, and failure mode avoids per-turn FIFO churn until the hard discard fallback.
- Potential regression points: mini-game main LLM turn construction, organizer success/failure state updates, localized prompt markers, postgame/context archive inputs, and soccer event payload fields. These are covered by the focused game router, organizer, and route prompt i18n unit tests listed below.

## Why Not Split / 不拆分理由

Not applicable. This PR changes fewer than 20 non-test files; the touched code paths are tightly coupled around the same mini-game main LLM context/cache regression.

## Screenshots

Normal chat cache behavior in the same environment:

![Normal chat cache behavior](https://raw.githubusercontent.com/KirisameYuumio/N.E.K.O/refs/tags/pr-assets-1857/pr-assets/1857/normal-chat.png)

Before: mini-game requests with 0% cache hit and growing input:

![Before fix 1](https://raw.githubusercontent.com/KirisameYuumio/N.E.K.O/refs/tags/pr-assets-1857/pr-assets/1857/before-1.png)

![Before fix 2](https://raw.githubusercontent.com/KirisameYuumio/N.E.K.O/refs/tags/pr-assets-1857/pr-assets/1857/before-2.png)

After: mini-game requests with stable cached prefixes:

![After fix](https://raw.githubusercontent.com/KirisameYuumio/N.E.K.O/refs/tags/pr-assets-1857/pr-assets/1857/after.png)

## Implementation Notes

- This does not modify the OmniOfflineClient class itself. The mini-game route only resets the specific game session instance history before each turn.
- The organizer's normal threshold remains 15 pending items, with a successful compaction returning the recent window to the kept tail.
- The 64-item window is only a failure/running fallback, not the normal steady state.
- The hard fallback intentionally discards the oldest 56 pending items instead of adding another memory-compensation path.
- Current event sanitization only removes fields already confirmed to be internal to routing, memory policy, or low-level soccer simulation state.

## Test Plan

Ran:

```bash
uv run --no-sync pytest tests/unit/test_game_router.py tests/unit/test_game_context_organizer.py tests/unit/test_game_route_prompts_i18n.py -q
```

Result:

```text
170 passed, 2 warnings
```

Also ran focused lint after the first automated review batch:

```bash
uv run --no-sync ruff check config/prompts/prompts_game_route.py main_routers/game_router.py tests/unit/test_game_context_organizer.py tests/unit/test_game_route_prompts_i18n.py tests/unit/test_game_router.py
```

Result:

```text
All checks passed!
```

Manual/local validation from the LLM proxy request table:

- Normal chat cache hit remains high in the same environment.
- Before the fix, mini-game main LLM event requests showed repeated `0.0%` cache hit and grew to ~20k+ input tokens.
- After the fix, mini-game event requests commonly show ~83%-89% cache hit with stable cached-token prefixes.

## Notes

While working through this, I heard yuumio mutter a line that somehow captured the whole debugging arc, so I am leaving it here as a tiny footnote.

yuumio:坏了,翻大车


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修正多语言“玩家发言”与“游戏事件”判定标记，按语言使用正确前缀，并避免将事件文本错误归因为玩家内容。

* **New Features**
  * 扩展语言支持至西班牙语与葡萄牙语。
  * 强化语言感知的局内上下文/记忆渲染，增加最近历史与档案高亮的多语言回退标签；提升可见内容净化与事件展示的一致性。

* **Tests**
  * 新增/扩展 i18n、可见事件过滤、会话历史重建与最近窗口裁剪等单测覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->