### PR TITLE
[codex] Dedupe followup candidates before top-k

### DIFF
--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -2021,7 +2021,11 @@ class ReflectionEngine:
 
     @staticmethod
     def _followup_render_key(value) -> str:
-        """Return the text key used when deciding whether a followup can render."""
+        """Return the text key used when deciding whether a followup can render.
+
+        Keep this local instead of importing main_logic.topic.common.clean_text:
+        memory is a lower layer and should not depend on prompt-rendering code.
+        """
         text = " ".join(str(value or "").strip().split())
         if not text:
             return ""

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -2020,6 +2020,16 @@ class ReflectionEngine:
         )
 
     @staticmethod
+    def _followup_render_key(value) -> str:
+        """Return the text key used when deciding whether a followup can render."""
+        text = " ".join(str(value or "").strip().split())
+        if not text:
+            return ""
+        if len(text) > 120:
+            return text[:120].rstrip() + "..."
+        return text
+
+    @staticmethod
     def _filter_followup_candidates(pending: list[dict]) -> list[dict]:
         """Filter pending reflections for proactive chat candidacy.
 
@@ -2047,6 +2057,7 @@ class ReflectionEngine:
             return []
         now = datetime.now()
         eligible = []
+        seen_text_keys: set[str] = set()
         for r in pending:
             next_eligible = r.get('next_eligible_at')
             if next_eligible:
@@ -2057,6 +2068,12 @@ class ReflectionEngine:
                     pass
             if evidence_score(r, now) < 0:
                 continue
+            text_key = ReflectionEngine._followup_render_key(r.get('text'))
+            if not text_key:
+                continue
+            if text_key in seen_text_keys:
+                continue
+            seen_text_keys.add(text_key)
             eligible.append(r)
         from config import (
             REFLECTION_SURFACE_TOP_K,

--- a/tests/unit/test_reflection_filters.py
+++ b/tests/unit/test_reflection_filters.py
@@ -133,6 +133,28 @@ async def test_followup_still_excludes_negative(tmp_path):
     assert result == []
 
 
+@pytest.mark.asyncio
+async def test_followup_filters_blank_and_duplicate_text_before_top_k(tmp_path):
+    """Blank/duplicate reflections should not consume the followup top-K slots."""
+    _, _, _, re, _ = _install(str(tmp_path))
+    await re.asave_reflections("小天", [
+        _seed("ref_alpha", "pending", text="用户最近在纠结直播里的角色风格"),
+        _seed("ref_blank", "pending", text="   "),
+        _seed("ref_dup", "pending", text=" 用户最近在纠结直播里的角色风格 "),
+        _seed("ref_beta", "pending", text="用户还没决定暑假去哪座城市"),
+        _seed("ref_gamma", "pending", text="用户想继续聊桌面宠物的互动边界"),
+    ])
+
+    with patch("config.REFLECTION_FOLLOWUP_WEIGHTED", False):
+        result = await re.aget_followup_topics("小天")
+
+    assert [r["id"] for r in result] == [
+        "ref_alpha",
+        "ref_beta",
+        "ref_gamma",
+    ]
+
+
 # ── Change 3: arecord_mentions for confirmed reflection ─────────────
 
 

--- a/tests/unit/test_reflection_filters.py
+++ b/tests/unit/test_reflection_filters.py
@@ -145,7 +145,8 @@ async def test_followup_filters_blank_and_duplicate_text_before_top_k(tmp_path):
         _seed("ref_gamma", "pending", text="用户想继续聊桌面宠物的互动边界"),
     ])
 
-    with patch("config.REFLECTION_FOLLOWUP_WEIGHTED", False):
+    with patch("config.REFLECTION_FOLLOWUP_WEIGHTED", False), \
+         patch("config.REFLECTION_SURFACE_TOP_K", 3):
         result = await re.aget_followup_topics("小天")
 
     assert [r["id"] for r in result] == [


### PR DESCRIPTION
## 改动概述 / Summary
- Filter blank followup reflection text before candidate top-K selection.
- Deduplicate followup candidates by the same cleaned/renderable text key used by prompt rendering.
- Keep system_router's surfaced-id filtering as a defensive guard and add a regression test for upstream candidate selection.

## 回归报告 / Regression Report
- 改动了什么：memory/reflection.py now drops blank followup texts and deduplicates candidates by cleaned render text before REFLECTION_SURFACE_TOP_K / weighted sampling. tests/unit/test_reflection_filters.py covers blank and duplicate candidates no longer consuming top-K slots.
- 理由 / 必要性：the followup endpoint capped candidates before the prompt renderer filtered blank or duplicate text, so dirty pending reflections could reduce visible reminiscence recall to fewer than three items.
- 改动前后对比：before, [valid, blank, duplicate, valid, valid] could return only the first valid item to the renderer; after, it returns the first three renderable unique candidates.
- 潜在回归点：followup ordering remains first-eligible when weighted sampling is disabled, but duplicate texts now keep only the first eligible reflection. Validated with targeted reflection and system-router topic-hook tests.

## 不拆分理由 / Why Not Split
不适用。This PR touches one production file and one test file.

## 测试 / Testing
- uv run pytest tests/unit/test_reflection_filters.py tests/unit/test_system_router_topic_hooks.py
- uv run ruff check memory/reflection.py tests/unit/test_reflection_filters.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 优化后续话题筛选：对候选反射文本进行空白归一与长度上限裁剪，并以“渲染文本去重键”进行去重，避免重复/空白文本占用后续候选池的名额，从而提升推荐的准确性与多样性。

* **Tests**
  * 新增单元测试，验证在应用 Top-K 之前会先过滤空白与重复文本，确保返回的反射结果顺序与筛选规则一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->