### PR TITLE
fix(topic): recheck privacy before deep topic delivery

### DIFF
--- a/docs/design/deep-topic-hooks.md
+++ b/docs/design/deep-topic-hooks.md
@@ -81,10 +81,10 @@ prompt 只给「明显反复出现 → 高分，顺口一提 → 低分；如实
 `_topic_was_used_today` 主判据是当日已用话题的关键词重合。ngram veto 是**并行兜底**：要求 query/标题间相似度 ≥ 0.6 **且** 共享 ≥ 2 个 2-gram 单元（`_material_bigram_units`，丢弃单字 CJK 噪声）才算重复。
 **理由**：用户不完全信任机械 ngram，但保留它以防关键词漏判；两个条件取「且」是为了让机械 veto 足够保守，不误杀。若日后 ngram 指标暴露严重问题，可单独摘掉这条兜底而不动主判据。
 
-### 隐私语义：只管积累，不管投递
+### 隐私语义：积累清空，投递前也保守复查
 
 隐私模式开启时，`enrich_topic_pool`（pipeline.py）**早退并清空整个池**（user/ai 回合、signal store、materials 全清）。因此隐私态下造不出新的敏感话题。
-**结论**：投递阶段**不**再查隐私。已经排队的 hook 是隐私前快照造的，晚一点投出去可接受。`topic_hook_delivery_allowed`（`main_logic/core.py`）只保留活动倾向门，不查 `is_privacy_mode_enabled()`。详见 commit「drop redundant privacy recheck」。
+**结论**：投递阶段也要保守复查隐私。已经排队的 hook 可能来自隐私前快照，但 deep topic 是可有可无的新开场；如果用户在 quiet window / deep search / delivery pacing 期间打开隐私，宁可 defer / retry，也不要把旧素材突然说出来。`topic_hook_delivery_allowed`（`main_logic/core.py`）会同步查 `is_privacy_mode_enabled()`，读取失败时 fail-closed。
 
 ### 活动倾向门：投递路径上守，retry 路径不守
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -6892,12 +6892,13 @@ class LLMSessionManager:
 
         Deep topic hooks are brand-new text openers — the most intrusive,
         "better none than forced" kind of proactive content. They must honour the same
-        activity gate as ``/api/proactive_chat``: never surface while the
-        user's propensity is ``closed`` (privacy blacklist) or
-        ``restricted_screen_only`` (gaming / focused_work). Unlike the
-        proactive reminiscence path there is NO open-thread exception — a
-        fresh deep topic is not a follow-up to something already on the
-        table, so it shouldn't borrow that escape hatch.
+        privacy and activity gates as ``/api/proactive_chat``: never surface
+        while privacy mode is active, or while the user's propensity is
+        ``closed`` (privacy blacklist) or ``restricted_screen_only`` (gaming /
+        focused_work). Unlike the proactive reminiscence path there is NO
+        open-thread exception — a fresh deep topic is not a follow-up to
+        something already on the table, so it shouldn't borrow that escape
+        hatch.
 
         Voice sessions never receive deep topic hooks. A topic hook is a
         text-mode opener; injecting one mid voice conversation would cut across
@@ -6917,13 +6918,20 @@ class LLMSessionManager:
         already-pending / extras-only paths are closed separately in
         ``_reset_proactive_gate`` + ``_drop_pending_topic_hooks_for_voice``.
 
-        Fail-open (return True) when no snapshot is available, mirroring the
-        proactive path's "snapshot None ⇒ open propensity" default. Privacy
-        mode is deliberately NOT re-checked here: it gates *accumulation* (the
-        pool is wiped the moment privacy turns on, see enrich_topic_pool), not
-        delivery of a hook that was already built from a pre-privacy snapshot.
+        Privacy mode is re-checked at delivery and fail-closed on read errors:
+        deep topic is optional, so a stale pre-privacy hook is less important
+        than avoiding a surprise opener after the user flips privacy on.
+        Activity snapshot lookup remains fail-open when no snapshot is
+        available, mirroring the proactive path's "snapshot None ⇒ open
+        propensity" default.
         """
         if self._voice_delivery_blocked():
+            return False
+        try:
+            from utils.preferences import is_privacy_mode_enabled
+            if is_privacy_mode_enabled():
+                return False
+        except Exception:
             return False
         tracker = getattr(self, '_activity_tracker', None)
         if tracker is None:

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1133,6 +1133,24 @@ def test_topic_hook_delivery_allowed_in_text_session():
     assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
 
 
+def test_topic_hook_delivery_blocked_when_privacy_enabled(monkeypatch):
+    """Deep topic is optional; delivery re-checks privacy before surfacing a
+    prebuilt hook, so flipping privacy on after accumulation still blocks it."""
+    monkeypatch.setattr("utils.preferences.is_privacy_mode_enabled", lambda: True)
+    mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
+    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
+
+
+def test_topic_hook_delivery_privacy_check_fails_closed(monkeypatch):
+    """If the privacy preference cannot be read, do not surface a new opener."""
+    def _raise_privacy_error():
+        raise RuntimeError("preferences unavailable")
+
+    monkeypatch.setattr("utils.preferences.is_privacy_mode_enabled", _raise_privacy_error)
+    mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
+    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
+
+
 async def test_deliver_proactive_batch_drops_topic_hook_in_voice():
     """Release gate: in a voice session the topic_hook is dropped (ack=False, left
     for TopicHookPool to retry), while non-topic_hook cues pass through. The voice


### PR DESCRIPTION
## Summary
- Re-check privacy mode at deep-topic delivery time and fail closed if the preference read fails.
- Keep the existing voice/topic delivery behavior unchanged; topic hooks still defer instead of dropping when voice or activity gates block delivery.
- Update the deep-topic design note to reflect the conservative delivery-time privacy gate.

## Why
Deep topic hooks are optional new openers. If the user enables privacy during the quiet window, deep search, or proactive delivery pacing, a prebuilt hook should not surface later from a stale pre-privacy snapshot.

## 回归报告 / Regression Report

### 改动
- `topic_hook_delivery_allowed()` now re-checks `is_privacy_mode_enabled()` immediately before deep-topic delivery.
- Privacy preference read failures fail closed, so an optional topic opener is not surfaced when privacy state cannot be trusted.
- The design note now documents that privacy gates both accumulation and delivery.

### 必要性 / 背景
Deep topic is a low-frequency optional opener. A hook may be prepared before privacy mode is enabled, then delivered later after quiet-window/deep-search/proactive pacing. From a regression-safety standpoint, preserving that optional hook is less important than respecting the user's latest privacy state.

### 前后行为对比
- Before: privacy cleared/stopped topic accumulation, but a prebuilt hook could still pass the delivery gate if it was queued from an earlier pre-privacy snapshot.
- After: delivery also checks privacy and returns false when privacy is on or unreadable, allowing the pool to defer/retry without speaking stale material.

### 潜在回归
- Text-session topic delivery remains allowed when privacy is off and no activity snapshot is available.
- Activity/voice gates are unchanged.
- `_VOICE_PROACTIVE_ACK_GRACE_S` behavior is unchanged.
- #1846 follow-up/open-thread behavior is unchanged.

## 不拆分理由 / Why Not Split
This PR changes one narrow delivery gate plus its regression tests and design documentation. Splitting would separate the behavior from the tests/docs that define the same contract.

## Tests
- `uv run pytest tests/unit/test_proactive_sm_integration.py tests/unit/test_topic_pipeline.py tests/unit/test_topic_delivery.py -q`
- `uv run pytest tests/unit/test_system_router_topic_hooks.py tests/test_activity_tracker_followup.py -q`
- `uv run python scripts/check_docstring_no_cjk.py main_logic/core.py tests/unit/test_proactive_sm_integration.py`
- `git diff --check`