### PR TITLE
fix(topic): keep privacy gate accumulation-only

### DIFF
--- a/docs/design/deep-topic-hooks.md
+++ b/docs/design/deep-topic-hooks.md
@@ -81,10 +81,10 @@ prompt 只给「明显反复出现 → 高分，顺口一提 → 低分；如实
 `_topic_was_used_today` 主判据是当日已用话题的关键词重合。ngram veto 是**并行兜底**：要求 query/标题间相似度 ≥ 0.6 **且** 共享 ≥ 2 个 2-gram 单元（`_material_bigram_units`，丢弃单字 CJK 噪声）才算重复。
 **理由**：用户不完全信任机械 ngram，但保留它以防关键词漏判；两个条件取「且」是为了让机械 veto 足够保守，不误杀。若日后 ngram 指标暴露严重问题，可单独摘掉这条兜底而不动主判据。
 
-### 隐私语义：积累清空，投递前也保守复查
+### 隐私语义：只管积累，不管投递
 
 隐私模式开启时，`enrich_topic_pool`（pipeline.py）**早退并清空整个池**（user/ai 回合、signal store、materials 全清）。因此隐私态下造不出新的敏感话题。
-**结论**：投递阶段也要保守复查隐私。已经排队的 hook 可能来自隐私前快照，但 deep topic 是可有可无的新开场；如果用户在 quiet window / deep search / delivery pacing 期间打开隐私，宁可 defer / retry，也不要把旧素材突然说出来。`topic_hook_delivery_allowed`（`main_logic/core.py`）会同步查 `is_privacy_mode_enabled()`，读取失败时 fail-closed。
+**结论**：投递阶段**不**再查隐私。已经排队的 hook 是隐私前快照造的，晚一点投出去可接受；否则需要把全局 privacy preference 读取铺进通用投递门，扩大 deep topic 的运行时耦合面。`topic_hook_delivery_allowed`（`main_logic/core.py`）只保留语音与活动倾向门，不查 `is_privacy_mode_enabled()`。
 
 ### 活动倾向门：投递路径上守，retry 路径不守
 

--- a/docs/design/deep-topic-hooks.md
+++ b/docs/design/deep-topic-hooks.md
@@ -84,7 +84,7 @@ prompt 只给「明显反复出现 → 高分，顺口一提 → 低分；如实
 ### 隐私语义：只管积累，不管投递
 
 隐私模式开启时，`enrich_topic_pool`（pipeline.py）**早退并清空整个池**（user/ai 回合、signal store、materials 全清）。因此隐私态下造不出新的敏感话题。
-**结论**：投递阶段**不**再查隐私。已经排队的 hook 是隐私前快照造的，晚一点投出去可接受；否则需要把全局 privacy preference 读取铺进通用投递门，扩大 deep topic 的运行时耦合面。`topic_hook_delivery_allowed`（`main_logic/core.py`）只保留语音与活动倾向门，不查 `is_privacy_mode_enabled()`。
+**结论**：投递阶段**不**再查隐私。已经排队的 hook 是隐私前快照造的，晚一点投出去可接受；否则需要把全局 privacy preference 读取铺进通用投递门，扩大 deep topic 的运行时耦合面。`TopicHookPool` 会在分析/联网增强 await 之后、以及 trigger task 的 `_deepen_material` await 之后重新执行累积侧隐私检查并清空材料；`topic_hook_delivery_allowed`（`main_logic/core.py`）只保留语音与活动倾向门，不查 `is_privacy_mode_enabled()`。
 
 ### 活动倾向门：投递路径上守，retry 路径不守
 
@@ -137,7 +137,7 @@ prompt 只给「明显反复出现 → 高分，顺口一提 → 低分；如实
 
 - 触发条件与现有开口完全相同（pool 的 debounce + quiet window + gap + quota + privacy + seq）。
 - `_run_trigger` 在调投递桥之前先 `await self._deepen_material(...)`：用更强档位（`summary` tier，`derive_deep_search_query`）从 interest + keywords（+ A 的便宜 floor 线索 `online_angle`）衍生一条聚焦 deep query，再用它重跑联网增强、覆盖 floor 的 `material_hint`。这一步跑在 trigger task 里，**不阻塞用户对话**。
-- **准备就绪后重新过开口门**：deep 跑完才调 `trigger_topic_hook_once`，其顶部的 `topic_hook_delivery_allowed()` 就是 prepare 之后的再校验——条件仍满足就开口，否则返回 False，pool reschedule 等下个窗口。
+- **准备就绪后重新过门**：deep 跑完后先在 `TopicHookPool` 内重查 privacy，若隐私已开则清空该角色 topic pool 并放弃本次 trigger；privacy 仍关才调 `trigger_topic_hook_once`，其顶部的 `topic_hook_delivery_allowed()` 继续做语音与 activity 再校验——条件仍满足就开口，否则返回 False，pool reschedule 等下个窗口。
 - **floor 永远兜底**：deep query 衍生失败/超时，或 deep 检索没结果，都回落到 A 的 keyword 兜底 `material_hint`。
 - **缓存防重搜**：`deep_search_done` 写在 live material 上，reschedule 重试复用已备好的 deep 结果而不重复搜；它在衍生前就置位，避免 flaky 衍生每次 reschedule 都重试（代价：一次性失败后该物料本轮不再尝试 deep，但 floor 仍投递）。
 - **query 来源对偶**：小模型只识别话题 + keywords；deep query 由大模型 author（`deep_query` 字段，`_query_for_material` 优先用它）——这正是当初从小模型拿掉 `search_query` 的原因。

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -6892,9 +6892,10 @@ class LLMSessionManager:
 
         Deep topic hooks are brand-new text openers — the most intrusive,
         "better none than forced" kind of proactive content. They must honour the same
-        privacy and activity gates as ``/api/proactive_chat``: never surface
-        while privacy mode is active, or while the user's propensity is
-        ``closed`` (privacy blacklist) or ``restricted_screen_only`` (gaming /
+        privacy accumulation gate and the same activity gate as
+        ``/api/proactive_chat``: privacy mode prevents accumulation upstream,
+        while delivery never surfaces when the user's propensity is ``closed``
+        (privacy blacklist) or ``restricted_screen_only`` (gaming /
         focused_work). Unlike the proactive reminiscence path there is NO
         open-thread exception — a fresh deep topic is not a follow-up to
         something already on the table, so it shouldn't borrow that escape
@@ -6918,20 +6919,14 @@ class LLMSessionManager:
         already-pending / extras-only paths are closed separately in
         ``_reset_proactive_gate`` + ``_drop_pending_topic_hooks_for_voice``.
 
-        Privacy mode is re-checked at delivery and fail-closed on read errors:
-        deep topic is optional, so a stale pre-privacy hook is less important
-        than avoiding a surprise opener after the user flips privacy on.
-        Activity snapshot lookup remains fail-open when no snapshot is
-        available, mirroring the proactive path's "snapshot None ⇒ open
-        propensity" default.
+        Privacy mode is deliberately NOT re-checked here: it gates
+        *accumulation* (the pool is wiped the moment privacy turns on, see
+        enrich_topic_pool), not delivery of a hook that was already built from
+        a pre-privacy snapshot. Activity snapshot lookup remains fail-open when
+        no snapshot is available, mirroring the proactive path's "snapshot None
+        ⇒ open propensity" default.
         """
         if self._voice_delivery_blocked():
-            return False
-        try:
-            from utils.preferences import is_privacy_mode_enabled
-            if is_privacy_mode_enabled():
-                return False
-        except Exception:
             return False
         tracker = getattr(self, '_activity_tracker', None)
         if tracker is None:

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -474,6 +474,10 @@ class TopicHookPool:
             # a reschedule reuses it instead of re-searching. The actual open is
             # re-gated by the delivery bridge AFTER this prepare completes.
             await self._deepen_material(name, current_material, lang)
+            if _privacy_mode_active():
+                self._purge_character_state(name)
+                logger.info("[%s] topic material trigger cancelled: privacy mode turned on during prepare", name)
+                return
             triggered = await self._topic_trigger(
                 lanlan_name=name,
                 material=deepcopy(current_material),

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1133,22 +1133,14 @@ def test_topic_hook_delivery_allowed_in_text_session():
     assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
 
 
-def test_topic_hook_delivery_blocked_when_privacy_enabled(monkeypatch):
-    """Deep topic is optional; delivery re-checks privacy before surfacing a
-    prebuilt hook, so flipping privacy on after accumulation still blocks it."""
-    monkeypatch.setattr("utils.preferences.is_privacy_mode_enabled", lambda: True)
-    mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
-
-
-def test_topic_hook_delivery_privacy_check_fails_closed(monkeypatch):
-    """If the privacy preference cannot be read, do not surface a new opener."""
+def test_topic_hook_delivery_does_not_recheck_privacy_preference(monkeypatch):
+    """Delivery only gates voice/activity; privacy wipes accumulation upstream."""
     def _raise_privacy_error():
-        raise RuntimeError("preferences unavailable")
+        raise AssertionError("delivery gate must not read the privacy preference")
 
     monkeypatch.setattr("utils.preferences.is_privacy_mode_enabled", _raise_privacy_error)
     mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
+    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
 
 
 async def test_deliver_proactive_batch_drops_topic_hook_in_voice():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1139,6 +1139,11 @@ def test_topic_hook_delivery_does_not_recheck_privacy_preference(monkeypatch):
         raise AssertionError("delivery gate must not read the privacy preference")
 
     monkeypatch.setattr("utils.preferences.is_privacy_mode_enabled", _raise_privacy_error)
+    monkeypatch.setattr(
+        "main_logic.core.is_privacy_mode_enabled",
+        _raise_privacy_error,
+        raising=False,
+    )
     mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
     assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
 

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -913,6 +913,51 @@ async def test_enrich_pool_discards_material_when_privacy_toggles_on_mid_analysi
 
 
 @pytest.mark.asyncio
+async def test_trigger_discards_material_when_privacy_toggles_on_during_deepen(monkeypatch):
+    from main_logic.topic import pipeline as topic_pipeline
+
+    privacy = {"on": False}
+    delivered = []
+    monkeypatch.setattr(topic_pipeline, "_privacy_mode_active", lambda: privacy["on"])
+
+    async def fake_analyzer(*, lang, global_signals):
+        return [
+            {
+                "interest": "深搜期间隐私切换的话题",
+                "keywords": ["privacy"],
+                "relevance": 95,
+                "risk": 10,
+            }
+        ]
+
+    async def fake_deepen(self, name, material, lang):
+        privacy["on"] = True
+        material["material_hint"] = {"summary": "prepared during privacy"}
+
+    async def fake_trigger(*, lanlan_name, material, lang):
+        delivered.append(material["interest"])
+        return True
+
+    monkeypatch.setattr(TopicHookPool, "_deepen_material", fake_deepen)
+
+    pool = TopicHookPool(
+        analyzer=fake_analyzer,
+        auto_schedule=False,
+        enable_online_enrichment=False,
+        topic_trigger=fake_trigger,
+        trigger_delay_seconds=0.01,
+        min_user_turns_for_topic=1,
+    )
+    pool.note_user_message("妮可", "一个足够具体、可以深挖的话题", lang="zh-CN")
+    await pool.process_now("妮可")
+    await asyncio.sleep(0.03)
+
+    assert delivered == []
+    assert pool.get_ready_materials("妮可") == []
+    assert pool._materials.get("妮可") in (None, [])
+
+
+@pytest.mark.asyncio
 async def test_deepen_material_uses_derived_query_and_overrides_floor(monkeypatch):
     from main_logic.topic import pipeline as topic_pipeline
 


### PR DESCRIPTION
## Summary
- Restore the deep-topic privacy contract to accumulation-only: privacy wipes/stops `TopicHookPool` upstream, but `topic_hook_delivery_allowed()` does not read the global privacy preference at delivery time.
- Replace #1859's delivery-time privacy tests with a contract test that fails if the delivery gate starts reading `is_privacy_mode_enabled()` again.
- Update the design note to explain why delivery keeps only the voice/activity gates.

## Why
#1859 made the delivery gate fail closed on the current privacy preference. That was conservative, but it changed the design decision from #1651: privacy is supposed to affect deep-topic accumulation, not delivery of a hook already built from a pre-privacy snapshot.

Keeping privacy out of the delivery gate also avoids spreading global preference I/O into the common proactive delivery path.

## 回归报告 / Regression Report

### 改动
- Removed the `is_privacy_mode_enabled()` delivery-time recheck from `LLMSessionManager.topic_hook_delivery_allowed()`.
- Clarified the method docstring and `docs/design/deep-topic-hooks.md`: privacy gates accumulation; delivery gates voice and activity propensity.
- Replaced the #1859 privacy fail-closed tests with `test_topic_hook_delivery_does_not_recheck_privacy_preference`, which asserts the delivery gate does not read the privacy preference.

### 必要性 / 背景
The original deep-topic design keeps privacy handling at accumulation time: when privacy turns on, `enrich_topic_pool` clears and stops collecting topic material. A hook already queued from a pre-privacy snapshot is allowed to finish through delivery. #1859 unintentionally changed that product contract.

### 前后行为对比
- Before #1859: privacy mode cleared/stopped accumulation, but delivery did not re-read global privacy preference.
- After #1859: delivery returned false when privacy was enabled or unreadable.
- This PR: restores the pre-#1859 behavior and pins it with a regression test.

### 潜在回归
- Privacy still clears/stops deep-topic accumulation upstream; those tests remain covered by `test_topic_pipeline`.
- Voice and activity gates are unchanged.
- Existing text-session fail-open behavior remains unchanged when no activity snapshot is available.

## 不拆分理由 / Why Not Split
This is one narrow contract correction across implementation, test, and design documentation. Splitting would separate the behavior from the regression test that prevents the same delivery-time privacy recheck from being reintroduced.

## Tests
- `uv run pytest tests/unit/test_proactive_sm_integration.py tests/unit/test_topic_pipeline.py tests/unit/test_topic_delivery.py -q`
- `uv run python scripts/check_docstring_no_cjk.py main_logic/core.py tests/unit/test_proactive_sm_integration.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **Bug Fixes**
  * 调整隐私校验时机：隐私不再在投递执行阶段重复读取；深度主题在“加深/准备完成后”会重新核对隐私，隐私开启则清空并取消触发，避免中途状态切换造成不一致。
* **Documentation**
  * 更新深度主题与隐私语义说明，明确“入池/清空”与“投递”阶段策略差异及重查顺序。
* **Tests**
  * 调整并新增测试，覆盖投递不重检隐私偏好、以及隐私在加深期间切换时丢弃材料/阻止后续触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->