### PR TITLE
fix(tutorial): clear externalized chat input lock on exit

### DIFF
--- a/static/tutorial/core/interaction-takeover.js
+++ b/static/tutorial/core/interaction-takeover.js
@@ -463,6 +463,8 @@
 
         clearExternalizedChatFx() {
             this.externalizedChatSpotlightKind = '';
+            this.clearExternalizedChatGuideMessages();
+            this.setExternalizedChatInputLocked(false, 'clear-externalized-chat-fx');
             this.setExternalizedChatSpotlight('');
             this.setExternalizedChatCursor('');
             this.setExternalizedChatAvatarToolMenuOpen(false, 'clear-externalized-chat-fx');

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -368,6 +368,7 @@ def test_tutorial_exit_clears_externalized_guide_chat_messages():
     assert "this.clearGuideChatMessages();" in destroy_block
     assert "clearExternalizedChatGuideMessages()" in takeover
     assert "this.clearExternalizedChatGuideMessages();" in fx_block
+    assert "this.setExternalizedChatInputLocked(false, 'clear-externalized-chat-fx');" in fx_block
 
 
 def test_pc_external_chat_ghost_cursor_routes_to_global_overlay_only():


### PR DESCRIPTION
## Summary

Fixes the externalized chat cleanup path so tutorial exits clear both guide chat artifacts and the chat input lock.

## Root Cause

`clearExternalizedChatFx()` runs from `destroy()` and other tutorial exit paths, but it no longer sent `yui_guide_set_chat_input_locked` with `locked: false`. If a guide step locked the externalized chat input and the user skipped or otherwise exited, the React chat host could keep `homeTutorialInputLocked` / `compactInputLocked` set until reload.

## Changes

- Restore input-lock cleanup in `clearExternalizedChatFx()`.
- Ensure guide chat messages are cleared from the same safety cleanup path.
- Extend the static tutorial exit contract test to require the input-lock reset.

## Validation

- `node --check static/tutorial/core/interaction-takeover.js`
- `uv run pytest tests/unit/test_avatar_floating_day1_round_contracts.py::test_tutorial_exit_clears_externalized_guide_chat_messages -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化教程退出时的聊天清理流程，确保导览消息正确清除且聊天输入框在清理后正确解锁

<!-- end of auto-generated comment: release notes by coderabbit.ai -->