### PR TITLE
[codex] Offload async LLM client construction

### DIFF
--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -34,7 +34,7 @@ import httpx
 
 from config import OPENCLAW_MAGIC_INTENT_MAX_TOKENS
 from utils.file_utils import robust_json_loads
-from utils.llm_client import create_chat_llm, strip_thinking_segments
+from utils.llm_client import create_chat_llm_async, strip_thinking_segments
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
 
@@ -366,7 +366,7 @@ class OpenClawAdapter:
 
         llm = None
         try:
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 model=model,
                 base_url=base_url,
                 api_key=api_key or None,

--- a/main_logic/activity/llm_enrichment.py
+++ b/main_logic/activity/llm_enrichment.py
@@ -388,7 +388,7 @@ async def _invoke_emotion_tier(prompt: str, *, timeout: float, label: str) -> st
     without a live model.
     """
     from utils.config_manager import get_config_manager
-    from utils.llm_client import HumanMessage, create_chat_llm
+    from utils.llm_client import HumanMessage, create_chat_llm_async
     from utils.token_tracker import set_call_type
 
     try:
@@ -406,7 +406,7 @@ async def _invoke_emotion_tier(prompt: str, *, timeout: float, label: str) -> st
 
     set_call_type('activity_enrichment')
     try:
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             model, base_url, api_key,
             temperature=0.4,
             max_completion_tokens=512,
@@ -440,7 +440,7 @@ async def _invoke_capable_tier(prompt: str, *, timeout: float, label: str) -> st
     Returns raw response text or None on any failure.
     """
     from utils.config_manager import get_config_manager
-    from utils.llm_client import HumanMessage, create_chat_llm
+    from utils.llm_client import HumanMessage, create_chat_llm_async
     from utils.token_tracker import set_call_type
 
     try:
@@ -458,7 +458,7 @@ async def _invoke_capable_tier(prompt: str, *, timeout: float, label: str) -> st
 
     set_call_type('topic_deep_search')
     try:
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             model, base_url, api_key,
             temperature=0.3,
             max_completion_tokens=128,

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -19,7 +19,7 @@ import json
 import re
 import time
 from typing import Optional, Callable, Dict, Any, Awaitable, List
-from utils.llm_client import SystemMessage, HumanMessage, AIMessage, LLMStreamChunk, create_chat_llm
+from utils.llm_client import SystemMessage, HumanMessage, AIMessage, LLMStreamChunk, create_chat_llm, create_chat_llm_async
 from openai import APIConnectionError, AuthenticationError, InternalServerError, RateLimitError
 from utils.frontend_utils import calculate_text_similarity
 from utils.tokenize import count_tokens, truncate_to_tokens
@@ -1501,7 +1501,7 @@ class OmniOfflineClient:
             # 先创建新 client，成功后再原子替换，避免半切换状态。
             # max_completion_tokens 跟随当前 max_response_length 同步设置
             # （和 __init__ 一致）。
-            new_llm = create_chat_llm(
+            new_llm = await create_chat_llm_async(
                 new_model, base_url, api_key,
                 streaming=True, max_retries=0,
                 # 普通 budget；summary 的 3000 抬升只在 stream_text 内临时生效。
@@ -1659,7 +1659,7 @@ class OmniOfflineClient:
         # （scripts/check_no_temperature.py 会守门）。emotion-tier 模型自带
         # 一个合适的 temperature，不需要 caller 干预。
         try:
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 emotion_model, emotion_base_url, emotion_api_key,
                 max_completion_tokens=120,
                 timeout=30,

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -580,6 +580,7 @@ class OmniOfflineClient:
         # 视觉模型独立配置（如果未指定则回退到主配置）
         self.vision_base_url = vision_base_url if vision_base_url else base_url
         self.vision_api_key = vision_api_key if vision_api_key else api_key
+        self._model_switch_lock = asyncio.Lock()
         self.on_text_delta = on_text_delta
         self.on_input_transcript = on_input_transcript
         self.on_output_transcript = on_output_transcript
@@ -1487,7 +1488,15 @@ class OmniOfflineClient:
             new_model: The model to switch to
             use_vision_config: If True, use vision_base_url and vision_api_key
         """
-        if new_model and new_model != self.model:
+        lock = getattr(self, "_model_switch_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._model_switch_lock = lock
+
+        async with lock:
+            if not new_model or new_model == self.model:
+                return
+
             logger.info(f"Switching model from {self.model} to {new_model}")
 
             # 选择使用的 API 配置

--- a/main_routers/card_assist_router.py
+++ b/main_routers/card_assist_router.py
@@ -241,12 +241,12 @@ def _clean_plain_field_value(raw: str) -> str:
     return text
 
 
-def _build_assist_llm():
+async def _build_assist_llm():
     """Construct an LLM client backed by the agent API config. Returns
     ``(llm, error_dict_or_None)``. Caller must ``await llm.aclose()`` if llm is
     not None.
     """
-    from utils.llm_client import create_chat_llm
+    from utils.llm_client import create_chat_llm_async
     try:
         cm = get_config_manager()
         api_cfg = cm.get_model_api_config("agent")
@@ -262,7 +262,7 @@ def _build_assist_llm():
                       "message": "agent model not set"}
     try:
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             model,
             base_url,
             api_key,
@@ -306,7 +306,7 @@ async def _invoke_assist_detailed(prompt: Any) -> tuple[str | None, dict | None]
     a plain string (treated as one user message) or a list of OpenAI-style
     role/content dicts. Returns ``(content_or_None, error_dict_or_None)``.
     """
-    llm, err = _build_assist_llm()
+    llm, err = await _build_assist_llm()
     if err is not None:
         return None, err
     quota_err = await _reserve_agent_quota("card_assist.invoke")

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -46,7 +46,7 @@ from config.prompts.prompts_galgame import (
 from config.prompts.prompts_sys import _loc
 from utils.file_utils import robust_json_loads
 from utils.language_utils import detect_language, normalize_language_code
-from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm
+from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm_async
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
 
@@ -313,7 +313,7 @@ async def generate_galgame_options(request: Request):
     ))
 
     set_call_type("galgame_options")
-    llm = create_chat_llm(
+    llm = await create_chat_llm_async(
         model,
         base_url,
         api_key,

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -313,14 +313,14 @@ async def generate_galgame_options(request: Request):
     ))
 
     set_call_type("galgame_options")
-    llm = await create_chat_llm_async(
-        model,
-        base_url,
-        api_key,
-        max_completion_tokens=GALGAME_OPTION_MAX_TOKENS,
-        timeout=GALGAME_OPTION_TIMEOUT_SECONDS,
-    )
     try:
+        llm = await create_chat_llm_async(
+            model,
+            base_url,
+            api_key,
+            max_completion_tokens=GALGAME_OPTION_MAX_TOKENS,
+            timeout=GALGAME_OPTION_TIMEOUT_SECONDS,
+        )
         async with llm:
             result = await asyncio.wait_for(
                 llm.ainvoke([

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1869,11 +1869,11 @@ async def _run_pregame_context_ai(
 
     try:
         from utils.file_utils import robust_json_loads
-        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm
+        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm_async
         from utils.token_tracker import set_call_type
 
         set_call_type("game_pregame_context")
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             char_info["model"],
             char_info["base_url"],
             char_info["api_key"],
@@ -2512,11 +2512,11 @@ async def _run_game_context_organizer_ai(state: dict, snapshot: list[dict]) -> d
 
     try:
         from utils.file_utils import robust_json_loads
-        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm
+        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm_async
         from utils.token_tracker import set_call_type
 
         set_call_type("game_context_organizer")
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             char_info["model"],
             char_info["base_url"],
             char_info["api_key"],
@@ -3317,11 +3317,11 @@ async def _select_game_archive_memory_highlights(archive: dict) -> dict:
         source = truncate_head_tail_tokens(source, 2000, 2000)
         user_prompt = get_game_archive_memory_highlighter_user_prompt(language).format(source=source)
         from utils.file_utils import robust_json_loads
-        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm
+        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm_async
         from utils.token_tracker import set_call_type
 
         set_call_type("game_memory_archive")
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             char_info["model"],
             char_info["base_url"],
             char_info["api_key"],
@@ -7861,11 +7861,11 @@ async def game_quick_lines(game_type: str, request: Request):
         )
 
         from utils.file_utils import robust_json_loads
-        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm
+        from utils.llm_client import HumanMessage, SystemMessage, create_chat_llm_async
         from utils.token_tracker import set_call_type
 
         set_call_type("game_quick_lines")
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             char_info['model'],
             char_info['base_url'],
             char_info['api_key'],

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -55,7 +55,7 @@ from uuid import uuid4
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, Response
 from openai import APIConnectionError, InternalServerError, RateLimitError
-from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm
+from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm_async
 from utils.tokenize import count_tokens
 import ssl
 import httpx
@@ -2837,13 +2837,13 @@ async def _deliver_break_reminder_via_llm(
 
     try:
         async with asyncio.timeout(timeout_seconds):
-            async with create_chat_llm(
+            async with (await create_chat_llm_async(
                 correction_model, correction_base_url, correction_api_key,
                 temperature=1.0,
                 max_completion_tokens=PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
                 streaming=True,
                 timeout=timeout_seconds,  # mirror the asyncio.timeout() wrapping this stream
-            ) as llm:
+            )) as llm:
                 async for chunk in llm.astream(messages):
                     if mgr.state.is_proactive_preempted(proactive_sid):
                         aborted = True
@@ -3395,7 +3395,7 @@ async def emotion_analysis(request: Request):
         set_call_type("emotion")
 
         # 异步调用模型（使用统一工厂，自动处理 extra_body / provider 兼容）
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             model,
             emotion_base_url,
             api_key,
@@ -5773,9 +5773,9 @@ async def proactive_chat(request: Request):
                 "detail": str(e)
             }, status_code=500))
 
-        def _make_llm(temperature: float = 1.0,
-                      max_completion_tokens: int = PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
-                      use_vision: bool = False, disable_thinking: bool = True):
+        async def _make_llm(temperature: float = 1.0,
+                            max_completion_tokens: int = PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
+                            use_vision: bool = False, disable_thinking: bool = True):
             """
             Create an LLM instance. use_vision=True uses the vision model; when disable_thinking=False, extra_body is not injected.
             """
@@ -5792,7 +5792,7 @@ async def proactive_chat(request: Request):
             )
             if not disable_thinking:
                 kw["extra_body"] = None  # skip auto-resolved extra_body
-            return create_chat_llm(m, bu, ak, **kw)  # noqa: LLM_OUTPUT_BUDGET  # budget + timeout set in kw above (splat invisible to the lint).
+            return await create_chat_llm_async(m, bu, ak, **kw)  # noqa: LLM_OUTPUT_BUDGET  # budget + timeout set in kw above (splat invisible to the lint).
 
         async def _llm_call_with_retry(
             system_prompt: str, label: str, *,
@@ -5825,10 +5825,10 @@ async def proactive_chat(request: Request):
             for attempt in range(max_retries):
                 try:
                     # 使用 async with 确保 ChatOpenAI (AsyncOpenAI) 实例被正确关闭
-                    async with _make_llm(temperature=temperature,
-                                        max_completion_tokens=max_completion_tokens,
-                                        use_vision=use_vision,
-                                        disable_thinking=disable_thinking) as llm:
+                    async with (await _make_llm(temperature=temperature,
+                                                max_completion_tokens=max_completion_tokens,
+                                                use_vision=use_vision,
+                                                disable_thinking=disable_thinking)) as llm:
                         response = await asyncio.wait_for(
                             llm.ainvoke(messages),
                             timeout=timeout
@@ -6651,9 +6651,9 @@ async def proactive_chat(request: Request):
         try:
             async with asyncio.timeout(25.0):
                 # 使用 async with 确保 ChatOpenAI 正确关闭
-                async with _make_llm(temperature=1.0,
-                                    max_completion_tokens=PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
-                                    use_vision=phase2_use_vision, disable_thinking=True) as llm:
+                async with (await _make_llm(temperature=1.0,
+                                            max_completion_tokens=PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
+                                            use_vision=phase2_use_vision, disable_thinking=True)) as llm:
                     async for chunk in llm.astream(messages):
                         # Phase 2 preempt check：每 chunk 顶端做 O(1) 状态机读，
                         # 用户抢占立刻跳出；_emit_safe 里还有一次保险。
@@ -6780,12 +6780,12 @@ async def proactive_chat(request: Request):
                 _fix_text = ""
                 try:
                     async with asyncio.timeout(20.0):
-                        async with _make_llm(
+                        async with (await _make_llm(
                             temperature=1.0,
                             max_completion_tokens=PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
                             use_vision=phase2_use_vision,
                             disable_thinking=True,
-                        ) as _fix_llm:
+                        )) as _fix_llm:
                             _fix_resp = await _fix_llm.ainvoke(
                                 [messages[0], HumanMessage(content=_fix_human_content)]
                             )
@@ -6942,12 +6942,12 @@ async def proactive_chat(request: Request):
                 }))
             try:
                 async with asyncio.timeout(20.0):
-                    async with _make_llm(
+                    async with (await _make_llm(
                         temperature=1.0,
                         max_completion_tokens=PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
                         use_vision=phase2_use_vision,
                         disable_thinking=True,
-                    ) as _regen_llm:
+                    )) as _regen_llm:
                         _regen_resp = await _regen_llm.ainvoke(regen_messages)
                         regen_text = (
                             _regen_resp.content if hasattr(_regen_resp, "content") else ""

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -404,7 +404,7 @@ class FactDedupResolver:
         from config import MEMORY_LIVENESS_MAX_ATTEMPTS
         from config.prompts.prompts_memory import get_fact_dedup_prompt
         from utils.language_utils import get_global_language
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
         from utils.token_tracker import set_call_type
 
         pending = await self.aload_pending(name)
@@ -442,7 +442,7 @@ class FactDedupResolver:
             # （background→background），用户路径无感。
             # max_retries=0: 禁 SDK 自动重试（这里没业务 retry，单次即终态）。
             from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
                 timeout=60, max_retries=0,

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -408,7 +408,7 @@ class FactStore:
         (thinking models enter thinking mode).
         Phase D: Stage-2 signal detection explicitly passes None to enable thinking."""
         from openai import APIConnectionError, InternalServerError, RateLimitError
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
 
         retries = 0
         while retries < max_retries:
@@ -423,7 +423,7 @@ class FactStore:
                 )
                 if extra_body is not _DEFAULT_EXTRA_BODY:
                     _llm_kwargs['extra_body'] = extra_body
-                llm = create_chat_llm(  # noqa: LLM_OUTPUT_BUDGET  # budget + timeout live in _llm_kwargs above (splat invisible to the lint); guard is generous for variable-length JSON.
+                llm = await create_chat_llm_async(  # noqa: LLM_OUTPUT_BUDGET  # budget + timeout live in _llm_kwargs above (splat invisible to the lint); guard is generous for variable-length JSON.
                     api_config['model'],
                     api_config['base_url'], api_config['api_key'],
                     **_llm_kwargs,
@@ -1391,11 +1391,11 @@ class FactStore:
         failure_reason: str | None = None
         event_when_raw: dict | None = None
         try:
-            from utils.llm_client import create_chat_llm
+            from utils.llm_client import create_chat_llm_async
             set_call_type("memory_recheck_fact")
             api_config = self._config_manager.get_model_api_config('summary')
             from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
                 timeout=60, max_retries=0,

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -1685,7 +1685,7 @@ class PersonaManager:
             # ── LLM (锁外) ──
             try:
                 from utils.token_tracker import set_call_type
-                from utils.llm_client import create_chat_llm
+                from utils.llm_client import create_chat_llm_async
                 set_call_type("memory_correction")
                 api_config = self._config_manager.get_model_api_config('correction')
                 # timeout: 见 MEMORY_LLM_HARD_TIMEOUT_SECONDS（上游转发
@@ -1697,7 +1697,7 @@ class PersonaManager:
                 # max_retries=0: 禁 SDK 自动重试（这里没业务 retry，单次即终态）。
                 # extra_body=None: 显式开 thinking。
                 from config import MEMORY_LLM_HARD_TIMEOUT_SECONDS, LLM_OUTPUT_GUARD_MAX_TOKENS
-                llm = create_chat_llm(
+                llm = await create_chat_llm_async(
                     api_config['model'],
                     api_config['base_url'], api_config['api_key'],
                     timeout=MEMORY_LLM_HARD_TIMEOUT_SECONDS, max_retries=0,

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -621,7 +621,7 @@ class MemoryRecallReranker:
         """
         from utils.file_utils import robust_json_loads
         from utils.token_tracker import set_call_type
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
 
         # The id-keyed indirection prevents the LLM from inventing
         # ids that aren't in the candidate set.
@@ -663,7 +663,7 @@ class MemoryRecallReranker:
         # APITimeoutError，外层 try/except 已会降级到 coarse rank。
         # max_retries=0: 禁 SDK 自动重试，超时直接降级。
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             api_config['model'],
             api_config['base_url'], api_config['api_key'],
             timeout=8, max_retries=0,

--- a/memory/refine.py
+++ b/memory/refine.py
@@ -426,7 +426,7 @@ class MemoryRefineEngine:
 
         from config.prompts.prompts_memory import get_memory_refine_prompt
         from utils.language_utils import get_global_language
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
 
         template = get_memory_refine_prompt(get_global_language())
         prompt = (
@@ -442,7 +442,7 @@ class MemoryRefineEngine:
         set_call_type("memory_refine")
         api_config = self._cm.get_model_api_config('correction')
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             api_config['model'],
             api_config['base_url'],
             api_config['api_key'],

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -791,7 +791,7 @@ class ReflectionEngine:
         """
         from config.prompts.prompts_memory import get_reflection_prompt
         from utils.language_utils import get_global_language
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
 
         unabsorbed = await self._fact_store.aget_unabsorbed_facts(lanlan_name)
         if len(unabsorbed) < MIN_FACTS_FOR_REFLECTION:
@@ -884,7 +884,7 @@ class ReflectionEngine:
             # extra_body=None: 显式开 thinking——synth 是创意+结构化合成，
             # 思考能改善 ontology 字段的一致性和 reflection text 的质量。
             from config import MEMORY_LLM_HARD_TIMEOUT_SECONDS, LLM_OUTPUT_GUARD_MAX_TOKENS
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
                 timeout=MEMORY_LLM_HARD_TIMEOUT_SECONDS, max_retries=0,
@@ -2190,7 +2190,7 @@ class ReflectionEngine:
     async def _check_feedback_locked(self, lanlan_name: str, user_messages: list[str]) -> list[dict] | None:
         from config.prompts.prompts_memory import get_reflection_feedback_prompt
         from utils.language_utils import get_global_language
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
 
         surfaced = await self.aload_surfaced(lanlan_name)
         pending_surfaced = [s for s in surfaced if s.get('feedback') is None]
@@ -2213,7 +2213,7 @@ class ReflectionEngine:
             # timeout=60: 后台 task 内调用，二分类任务 prompt + 输出都不大。
             # max_retries=0: 禁 SDK 自动重试。
             from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
                 timeout=60, max_retries=0,
@@ -2258,7 +2258,7 @@ class ReflectionEngine:
         """
         from config.prompts.prompts_memory import get_reflection_feedback_prompt
         from utils.language_utils import get_global_language
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
 
         if not confirmed or not user_messages:
             return []
@@ -2283,7 +2283,7 @@ class ReflectionEngine:
             # max_retries=0: 禁 SDK 自动重试，失败 cursor 不推进自然下轮重试。
             # extra_body=None: 显式开 thinking。
             from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
                 timeout=90, max_retries=0,
@@ -2814,11 +2814,11 @@ class ReflectionEngine:
         new_scope: str | None = None
         event_when_raw: dict | None = None
         try:
-            from utils.llm_client import create_chat_llm
+            from utils.llm_client import create_chat_llm_async
             set_call_type("memory_recheck_reflection")
             api_config = self._config_manager.get_model_api_config('summary')
             from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
                 timeout=60, max_retries=0,
@@ -3218,7 +3218,7 @@ class ReflectionEngine:
         """
         from config.prompts.prompts_memory import get_promotion_merge_prompt
         from utils.language_utils import get_global_language
-        from utils.llm_client import create_chat_llm
+        from utils.llm_client import create_chat_llm_async
 
         now = datetime.now()
         # Build the impression pool block with stable ordering — protected
@@ -3263,7 +3263,7 @@ class ReflectionEngine:
         # max_retries=0: 禁 SDK 自动重试，由 throttle/dead-letter 兜底。
         # extra_body=None: 显式开 thinking。
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             api_config['model'],
             api_config['base_url'], api_config['api_key'],
             timeout=90, max_retries=0,

--- a/plugin/plugins/galgame_plugin/llm_backend.py
+++ b/plugin/plugins/galgame_plugin/llm_backend.py
@@ -10,7 +10,7 @@ from typing import Any, Protocol, TYPE_CHECKING
 from plugin.sdk.plugin import SdkError
 from utils.config_manager import get_config_manager
 from utils.file_utils import robust_json_loads
-from utils.llm_client import create_chat_llm
+from utils.llm_client import create_chat_llm_async
 from utils.token_tracker import set_call_type
 
 from .context_tokens import truncate_tokens_heuristic
@@ -445,7 +445,7 @@ class GalgameLLMBackend:
             cached = self._llm_cache.get(cache_key)
             if cached is not None:
                 return cached
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 model=model,
                 base_url=base_url,
                 api_key=api_key,

--- a/plugin/plugins/qq_auto_reply/prompting.py
+++ b/plugin/plugins/qq_auto_reply/prompting.py
@@ -5,7 +5,7 @@ import re
 import time
 from typing import Optional
 
-from utils.llm_client import create_chat_llm, strip_thinking_segments
+from utils.llm_client import create_chat_llm_async, strip_thinking_segments
 from utils.token_tracker import set_call_type
 
 
@@ -213,7 +213,7 @@ class QQAutoReplyPromptingMixin:
             if not base_url or not model:
                 self.logger.warning("Fallback 生成跳过：agent 模型未配置")
                 return None
-            llm = create_chat_llm(
+            llm = await create_chat_llm_async(
                 model=model,
                 base_url=base_url,
                 api_key=api_key,

--- a/plugin/plugins/study_companion/tutor_llm_agent.py
+++ b/plugin/plugins/study_companion/tutor_llm_agent.py
@@ -56,6 +56,8 @@ class _LLMClientCache:
             llm = self._cache.get(key)
             if llm is None:
                 llm = factory()
+                if inspect.isawaitable(llm):
+                    llm = await llm
                 self._cache[key] = llm
         return self._cache[key]
 
@@ -477,15 +479,15 @@ class TutorLLMAgent:
         messages: list[dict[str, Any]],
         *,
         operation: str = LLM_OPERATION_CONCEPT_EXPLAIN,
-    ) -> str:
+        ) -> str:
         get_config_manager = getattr(_config_manager_module, "get_config_manager", None)
-        create_chat_llm = getattr(_llm_client_module, "create_chat_llm", None)
+        create_chat_llm_async = getattr(_llm_client_module, "create_chat_llm_async", None)
         set_call_type = getattr(_token_tracker_module, "set_call_type", None)
         missing_runtime_deps = [
             name
             for name, dep in (
                 ("utils.config_manager.get_config_manager", get_config_manager),
-                ("utils.llm_client.create_chat_llm", create_chat_llm),
+                ("utils.llm_client.create_chat_llm_async", create_chat_llm_async),
                 ("utils.token_tracker.set_call_type", set_call_type),
             )
             if not callable(dep)
@@ -538,7 +540,7 @@ class TutorLLMAgent:
         )
         llm = await self._client_cache.get_or_create(
             key,
-            lambda: create_chat_llm(
+            lambda: create_chat_llm_async(
                 model=model,
                 base_url=base_url,
                 api_key=api_key,

--- a/plugin/tests/unit/plugins/test_galgame_llm_backend.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_backend.py
@@ -250,7 +250,7 @@ async def test_llm_backend_create_chat_llm_does_not_receive_temperature(
 
     backend = GalgameLLMBackend(_Logger())
     monkeypatch.setattr(galgame_llm_backend, "get_config_manager", lambda: _Config())
-    monkeypatch.setattr(galgame_llm_backend, "create_chat_llm", _fake_create_chat_llm)
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", _fake_create_chat_llm)
 
     assert await backend._call_model(
         operation="explain_line",

--- a/scripts/check_llm_budget.py
+++ b/scripts/check_llm_budget.py
@@ -112,11 +112,11 @@ EXCLUDE_FILES = {
 
 # ── LLM_OUTPUT_BUDGET (construction site) ─────────────────────────────────
 
-# A construction is matched when the callee is the factory ``create_chat_llm``
+# A construction is matched when the callee is one of the chat factories
 # or any class name ending in ``ChatOpenAI`` (``ChatOpenAI`` / ``_ChatOpenAI``
 # / ``BUChatOpenAI``). Matched on a bare Name (``ChatOpenAI(...)``) or the last
 # Attribute component (``mod.ChatOpenAI(...)``).
-FACTORY_NAME = "create_chat_llm"
+FACTORY_NAMES = {"create_chat_llm", "create_chat_llm_async"}
 CHAT_CLASS_SUFFIX = "ChatOpenAI"
 
 # Token-budget kwargs (either satisfies the budget requirement) — the client
@@ -305,7 +305,7 @@ class LLMBudgetChecker(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         name = _callee_name(node)
         if name is not None:
-            if name == FACTORY_NAME or name.endswith(CHAT_CLASS_SUFFIX):
+            if name in FACTORY_NAMES or name.endswith(CHAT_CLASS_SUFFIX):
                 self._check_output_budget(node, name)
             if name in LLM_CALL_ATTRS:
                 self._check_input_budget(node, name)

--- a/tests/unit/test_check_llm_budget.py
+++ b/tests/unit/test_check_llm_budget.py
@@ -52,8 +52,18 @@ def test_output_missing_both_flagged():
     assert _codes(src).count("LLM_OUTPUT_BUDGET") == 1
 
 
+def test_output_async_factory_missing_both_flagged():
+    src = "llm = await create_chat_llm_async(model, base_url, api_key)"
+    assert _codes(src).count("LLM_OUTPUT_BUDGET") == 1
+
+
 def test_output_budget_and_timeout_clean():
     src = "llm = create_chat_llm(m, b, k, max_completion_tokens=100, timeout=30)"
+    assert "LLM_OUTPUT_BUDGET" not in _codes(src)
+
+
+def test_output_async_factory_budget_and_timeout_clean():
+    src = "llm = await create_chat_llm_async(m, b, k, max_completion_tokens=100, timeout=30)"
     assert "LLM_OUTPUT_BUDGET" not in _codes(src)
 
 

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -98,7 +98,7 @@ async def test_galgame_uses_summary_model_without_temperature(monkeypatch):
         "get_config_manager",
         lambda: config_manager,
     )
-    monkeypatch.setattr(galgame_router, "create_chat_llm", fake_create_chat_llm)
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", fake_create_chat_llm)
 
     response = await galgame_router.generate_galgame_options(
         FakeRequest(
@@ -151,7 +151,7 @@ async def test_galgame_option_generation_timeout_returns_fallback(monkeypatch):
 
     monkeypatch.setattr(galgame_router, "GALGAME_OPTION_TIMEOUT_SECONDS", 0.01)
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
-    monkeypatch.setattr(galgame_router, "create_chat_llm", fake_create_chat_llm)
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", fake_create_chat_llm)
 
     response = await galgame_router.generate_galgame_options(
         FakeRequest(
@@ -241,7 +241,7 @@ async def test_galgame_accepts_dict_shaped_options(model_output, expected, monke
             return SimpleNamespace(content=json.dumps(model_output, ensure_ascii=False))
 
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
-    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: MapLLM())
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", lambda *a, **kw: MapLLM())
 
     response = await galgame_router.generate_galgame_options(
         FakeRequest(
@@ -292,7 +292,7 @@ async def test_galgame_duplicate_labeled_entry_does_not_leak_to_other_labels(mon
             )
 
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
-    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: DupLLM())
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", lambda *a, **kw: DupLLM())
 
     response = await galgame_router.generate_galgame_options(
         FakeRequest(
@@ -351,7 +351,7 @@ async def test_galgame_partial_options_filled_from_fallback(monkeypatch):
             )
 
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
-    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: PartialLLM())
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", lambda *a, **kw: PartialLLM())
 
     response = await galgame_router.generate_galgame_options(
         FakeRequest(
@@ -397,7 +397,7 @@ async def test_galgame_unparseable_output_returns_fallback(monkeypatch, caplog):
             return SimpleNamespace(content=raw_content)
 
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
-    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: GarbageLLM())
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", lambda *a, **kw: GarbageLLM())
 
     # galgame_router.logger is a get_module_logger child whose N.E.K.O ancestor
     # gets configured with propagate=False once any service initializes logging
@@ -453,8 +453,7 @@ async def test_galgame_missing_model_base_url_returns_fallback(monkeypatch):
         lambda: FakeConfigManager({"model": "local-summary", "base_url": "", "api_key": ""}),
     )
     monkeypatch.setattr(
-        galgame_router,
-        "create_chat_llm",
+        "utils.llm_client.create_chat_llm",
         lambda *args, **kwargs: pytest.fail("LLM should not be created without a base_url"),
     )
 
@@ -490,8 +489,7 @@ async def test_galgame_options_skipped_when_session_takeover_active(monkeypatch)
     )
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
     monkeypatch.setattr(
-        galgame_router,
-        "create_chat_llm",
+        "utils.llm_client.create_chat_llm",
         lambda *args, **kwargs: pytest.fail(
             "LLM must not be called while the session is taken over"
         ),
@@ -553,7 +551,7 @@ async def test_galgame_options_generated_when_session_not_taken_over(monkeypatch
             )
 
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
-    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **k: FakeLLM())
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", lambda *a, **k: FakeLLM())
     monkeypatch.setattr(
         galgame_router,
         "get_session_manager",

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -173,6 +173,39 @@ async def test_galgame_option_generation_timeout_returns_fallback(monkeypatch):
     }
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_galgame_option_generation_init_error_returns_fallback(monkeypatch):
+    config_manager = FakeConfigManager(
+        {
+            "model": "local-summary",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "",
+        }
+    )
+
+    def fake_create_chat_llm(*_args, **_kwargs):
+        raise RuntimeError("client init failed")
+
+    monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", fake_create_chat_llm)
+
+    response = await galgame_router.generate_galgame_options(
+        FakeRequest(
+            {
+                "messages": [{"role": "assistant", "text": "What do you think?"}],
+                "language": "en",
+            }
+        )
+    )
+
+    data = _decode_response(response)
+    assert data["success"] is True
+    assert data["fallback"] is True
+    assert data["error"] == "client init failed"
+    assert _option_texts(data) == list(get_galgame_fallback_options("en"))
+
+
 @pytest.mark.parametrize(
     "model_output, expected",
     [

--- a/tests/unit/test_language_translation_chunks.py
+++ b/tests/unit/test_language_translation_chunks.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+
+import pytest
+
 from utils import tokenize
-from utils.language_utils import _split_text_into_token_chunks
+from utils.language_utils import TranslationService, _split_text_into_token_chunks
 
 
 def test_translation_token_chunks_preserve_original_unicode_text() -> None:
@@ -35,3 +39,39 @@ def test_translation_token_chunks_do_not_depend_on_truncated_decode(
     assert chunks == ["abcde", "fghij", "klmno", "pqrst", "uvwxy", "z"]
     assert "".join(chunks) == text
     assert calls.count(text) == 1
+
+
+@pytest.mark.asyncio
+async def test_translation_service_llm_client_creation_is_single_flight(
+    monkeypatch,
+) -> None:
+    class _ConfigManager:
+        def get_model_api_config(self, _group: str) -> dict[str, str]:
+            return {
+                "api_key": "test-key",
+                "base_url": "https://example.invalid/v1",
+                "model": "test-model",
+            }
+
+    created_clients: list[object] = []
+
+    async def fake_create_chat_llm_async(*_args: object, **_kwargs: object) -> object:
+        await asyncio.sleep(0)
+        client = object()
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        "utils.language_utils.create_chat_llm_async",
+        fake_create_chat_llm_async,
+    )
+
+    service = TranslationService(_ConfigManager())
+
+    clients = await asyncio.gather(
+        service._get_llm_client(),
+        service._get_llm_client(),
+    )
+
+    assert len(created_clients) == 1
+    assert clients == [created_clients[0], created_clients[0]]

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -161,8 +161,12 @@ async def test_create_chat_llm_async_closes_late_result_after_cancellation(
     await asyncio.wait_for(asyncio.to_thread(started.wait, 5), timeout=1)
 
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    try:
+        result = await task
+    except asyncio.CancelledError:
+        pass
+    else:
+        pytest.fail(f"expected cancellation, got {result!r}")
 
     release.set()
     await asyncio.wait_for(closed.wait(), timeout=2)

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -8,6 +8,7 @@ choices[0].message 是 None 的合法响应。原来 ainvoke/invoke 直接
 """
 from __future__ import annotations
 
+import asyncio
 import threading
 from unittest.mock import AsyncMock, MagicMock
 
@@ -127,3 +128,41 @@ async def test_create_chat_llm_async_offloads_factory(monkeypatch):
         )
     ]
     assert calls[0][0] != event_loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_create_chat_llm_async_closes_late_result_after_cancellation(
+    monkeypatch,
+):
+    started = threading.Event()
+    release = threading.Event()
+    closed = asyncio.Event()
+
+    class _LateLLM:
+        async def aclose(self) -> None:
+            closed.set()
+
+    def fake_create_chat_llm(*_args, **_kwargs):
+        started.set()
+        release.wait(timeout=5)
+        return _LateLLM()
+
+    monkeypatch.setattr(llm_client_module, "create_chat_llm", fake_create_chat_llm)
+
+    task = asyncio.create_task(
+        llm_client_module.create_chat_llm_async(
+            "model-a",
+            "https://example.com/v1",
+            "sk-test",
+            timeout=3,
+            max_completion_tokens=10,
+        )
+    )
+    await asyncio.wait_for(asyncio.to_thread(started.wait, 5), timeout=1)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    release.set()
+    await asyncio.wait_for(closed.wait(), timeout=2)

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -8,10 +8,12 @@ choices[0].message 是 None 的合法响应。原来 ainvoke/invoke 直接
 """
 from __future__ import annotations
 
+import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import utils.llm_client as llm_client_module
 from utils.llm_client import ChatOpenAI
 
 
@@ -91,3 +93,34 @@ class TestInvokeDefensiveRead:
         client = _make_client_with_response(_resp_with_none_content())
         out = client.invoke([{"role": "user", "content": "hi"}])
         assert out.content == ""
+
+
+@pytest.mark.asyncio
+async def test_create_chat_llm_async_offloads_factory(monkeypatch):
+    event_loop_thread_id = threading.get_ident()
+    calls = []
+    sentinel = object()
+
+    def fake_create_chat_llm(*args, **kwargs):
+        calls.append((threading.get_ident(), args, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(llm_client_module, "create_chat_llm", fake_create_chat_llm)
+
+    result = await llm_client_module.create_chat_llm_async(
+        "model-a",
+        "https://example.com/v1",
+        "sk-test",
+        timeout=3,
+        max_retries=0,
+    )
+
+    assert result is sentinel
+    assert calls == [
+        (
+            calls[0][0],
+            ("model-a", "https://example.com/v1", "sk-test"),
+            {"timeout": 3, "max_retries": 0},
+        )
+    ]
+    assert calls[0][0] != event_loop_thread_id

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -14,12 +14,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import utils.llm_client as llm_client_module
-from utils.llm_client import ChatOpenAI
 
 
-def _make_client_with_response(resp) -> ChatOpenAI:
+def _make_client_with_response(resp) -> llm_client_module.ChatOpenAI:
     """Construct a ChatOpenAI and stub both sync/async create() to return resp."""
-    client = ChatOpenAI(model="free-agent-model", base_url="https://example.com/v1", api_key="free-access")
+    client = llm_client_module.ChatOpenAI(
+        model="free-agent-model",
+        base_url="https://example.com/v1",
+        api_key="free-access",
+    )
     client._aclient = MagicMock()
     client._aclient.chat = MagicMock()
     client._aclient.chat.completions = MagicMock()

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -14,6 +14,7 @@ catch contract regressions in the tool plumbing.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -649,6 +650,56 @@ async def test_offline_switch_model_recomputes_genai_routing(monkeypatch):
     # base_url / api_key 必须同步到 vision 配置
     assert client.base_url == "https://generativelanguage.googleapis.com/v1beta/openai"
     assert client.api_key == "fake-gemini-key"
+
+
+@pytest.mark.asyncio
+async def test_offline_switch_model_serializes_concurrent_switches(monkeypatch):
+    from main_logic import omni_offline_client as _ofc
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.model = "gpt-4o-mini"
+    client.base_url = "https://api.openai.com/v1"
+    client.api_key = "sk-fake"
+    client.vision_model = "vision-model"
+    client.vision_base_url = "https://vision.example/v1"
+    client.vision_api_key = "vision-key"
+    client.max_response_length = 300
+    client._genai_client = None
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+
+    class _FakeLLM:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.closed = 0
+
+        async def aclose(self) -> None:
+            self.closed += 1
+
+    old_llm = _FakeLLM("old")
+    client.llm = old_llm
+    created: list[_FakeLLM] = []
+
+    async def fake_create_chat_llm_async(*_args, **_kwargs):
+        await asyncio.sleep(0)
+        llm = _FakeLLM("vision")
+        created.append(llm)
+        return llm
+
+    monkeypatch.setattr(_ofc, "create_chat_llm_async", fake_create_chat_llm_async)
+
+    await asyncio.gather(
+        client.switch_model("vision-model", use_vision_config=True),
+        client.switch_model("vision-model", use_vision_config=True),
+    )
+
+    assert len(created) == 1
+    assert client.llm is created[0]
+    assert client.model == "vision-model"
+    assert client.base_url == "https://vision.example/v1"
+    assert client.api_key == "vision-key"
+    assert old_llm.closed == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_web_scraper.py
+++ b/tests/unit/test_web_scraper.py
@@ -29,6 +29,12 @@ async def test_generate_diverse_queries_sends_user_message(monkeypatch):
         def __init__(self, **kwargs):
             captured["kwargs"] = kwargs
 
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
         async def ainvoke(self, messages):
             captured["messages"] = messages
             return AIMessage(content="关键词A\n关键词B\n关键词C")
@@ -37,7 +43,7 @@ async def test_generate_diverse_queries_sends_user_message(monkeypatch):
         return FakeLLM(**kwargs)
 
     monkeypatch.setattr(config_manager_module, "ConfigManager", FakeConfigManager)
-    monkeypatch.setattr(web_scraper, "create_chat_llm", fake_create_chat_llm)
+    monkeypatch.setattr("utils.llm_client.create_chat_llm", fake_create_chat_llm)
     monkeypatch.setattr(web_scraper, "is_china_region", lambda: True)
 
     result = await web_scraper.generate_diverse_queries("Project N.E.K.O.")

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -30,7 +30,7 @@ import os
 import hashlib
 from collections import OrderedDict
 from typing import Optional, Tuple, List, Any, Dict
-from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm
+from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm_async
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
@@ -1190,7 +1190,7 @@ async def translate_text(text: str, target_lang: str, source_lang: Optional[str]
         target_name = lang_names.get(target_lang, target_lang)
 
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             emotion_config['model'], emotion_config['base_url'],
             emotion_config['api_key'],
             timeout=10.0,
@@ -1283,7 +1283,7 @@ class TranslationService:
         self._cache_lock = None  # 懒加载：在首次使用时创建异步锁
         self._cache_lock_init_lock = threading.Lock()  # 用于保护异步锁的创建过程
 
-    def _get_llm_client(self):
+    async def _get_llm_client(self):
         """Get the LLM client (for translation, reusing the emotion model config)"""
         try:
             config = self.config_manager.get_model_api_config('emotion')
@@ -1296,7 +1296,7 @@ class TranslationService:
                 return self._llm_client
 
             from config import TRANSLATION_OUTPUT_MAX_TOKENS
-            self._llm_client = create_chat_llm(
+            self._llm_client = await create_chat_llm_async(
                 config['model'], config['base_url'], config['api_key'],
                 max_completion_tokens=TRANSLATION_OUTPUT_MAX_TOKENS,
                 timeout=30.0,
@@ -1374,7 +1374,7 @@ class TranslationService:
         if cached is not None:
             return cached
         
-        llm = self._get_llm_client()
+        llm = await self._get_llm_client()
         if llm is None:
             logger.warning("翻译服务：LLM客户端不可用，返回原文")
             return text

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -1295,14 +1295,18 @@ class TranslationService:
             if self._llm_client is not None:
                 return self._llm_client
 
-            from config import TRANSLATION_OUTPUT_MAX_TOKENS
-            self._llm_client = await create_chat_llm_async(
-                config['model'], config['base_url'], config['api_key'],
-                max_completion_tokens=TRANSLATION_OUTPUT_MAX_TOKENS,
-                timeout=30.0,
-            )
-            
-            return self._llm_client
+            async with self._get_cache_lock():
+                if self._llm_client is not None:
+                    return self._llm_client
+
+                from config import TRANSLATION_OUTPUT_MAX_TOKENS
+                self._llm_client = await create_chat_llm_async(
+                    config['model'], config['base_url'], config['api_key'],
+                    max_completion_tokens=TRANSLATION_OUTPUT_MAX_TOKENS,
+                    timeout=30.0,
+                )
+
+                return self._llm_client
         except Exception as e:
             logger.error(f"翻译服务：初始化LLM客户端失败: {e}")
             return None

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -19,11 +19,13 @@ Provides:
     the old langchain interface
   - ChatOpenAI wrapper with streaming, invoke, and resource management
   - ``create_chat_llm()`` factory that auto-resolves provider-specific config
+  - ``create_chat_llm_async()`` async factory for offloaded client construction
   - Serialization helpers (messages_to_dict, messages_from_dict, convert_to_messages)
   - OpenAIEmbeddings / SQLChatMessageHistory for memory subsystem
 """
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import json as _json
 import re
@@ -776,6 +778,11 @@ def create_chat_llm(
         **cache_kw,
         **kw,
     )
+
+
+async def create_chat_llm_async(*args: Any, **kwargs: Any) -> ChatOpenAI:
+    """Create a ChatOpenAI without blocking the running event loop."""
+    return await asyncio.to_thread(create_chat_llm, *args, **kwargs)
 
 
 # ────────────────────────────────────────────────────────────────

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -782,7 +782,26 @@ def create_chat_llm(
 
 async def create_chat_llm_async(*args: Any, **kwargs: Any) -> ChatOpenAI:
     """Create a ChatOpenAI without blocking the running event loop."""
-    return await asyncio.to_thread(create_chat_llm, *args, **kwargs)
+    loop = asyncio.get_running_loop()
+    task = asyncio.create_task(asyncio.to_thread(create_chat_llm, *args, **kwargs))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.add_done_callback(
+            lambda done: loop.create_task(_close_cancelled_chat_llm_result(done))
+        )
+        raise
+
+
+async def _close_cancelled_chat_llm_result(task: asyncio.Task[ChatOpenAI]) -> None:
+    try:
+        llm = task.result()
+    except Exception:
+        return
+    try:
+        await llm.aclose()
+    except Exception:
+        return
 
 
 # ────────────────────────────────────────────────────────────────

--- a/utils/screenshot_utils.py
+++ b/utils/screenshot_utils.py
@@ -24,7 +24,7 @@ from utils.token_tracker import set_call_type
 import asyncio
 from io import BytesIO
 from PIL import Image, ImageDraw, ImageFont
-from utils.llm_client import create_chat_llm
+from utils.llm_client import create_chat_llm_async
 
 logger = get_module_logger(__name__)
 
@@ -209,7 +209,7 @@ async def analyze_image_with_vision_model(
             user_text = _loc(VISION_USER_NO_TITLE, lang)
 
         set_call_type("vision")
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             model=vision_model,
             base_url=vision_base_url or None,
             api_key=vision_api_key,

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -29,7 +29,7 @@ from typing import Dict, List, Any, Optional, Union
 from urllib.parse import quote
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
-from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm
+from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm_async
 from bs4 import BeautifulSoup
 import os
 from pathlib import Path
@@ -1266,7 +1266,7 @@ async def generate_diverse_queries(window_title: str) -> List[str]:
         summary_config = config_manager.get_model_api_config('summary')
         
         from config import LLM_OUTPUT_GUARD_MAX_TOKENS
-        llm = create_chat_llm(
+        llm = await create_chat_llm_async(
             summary_config['model'], summary_config['base_url'],
             summary_config['api_key'],
             timeout=10.0, max_retries=0,


### PR DESCRIPTION
## Summary - Add `create_chat_llm_async()` to construct `ChatOpenAI` through `asyncio.to_thread`. - Migrate async request/background callsites that create short-lived LLM clients to the async factory. - Keep pure sync / long-lived cached construction paths unchanged.  ## Root Cause `create_chat_llm()` constructs `OpenAI` / `AsyncOpenAI` clients synchronously. When async routes or background tasks call it directly, SSL context construction and CA loading/parsing can run on the event loop and stall unrelated realtime work such as TTS delivery.  ## 回归报告 - 变更内容：新增统一 async factory，并把 `main_routers`、`main_logic`、`memory`、工具层和插件中处于 async call path 的短生命周期 LLM client 构造迁移到该 factory。 - 必要性：PR #1870 只在一个 endpoint 上局部 `to_thread`，但全局还有同类 async 构造点；统一入口能避免继续散落局部补丁。 - 前后行为：LLM 请求参数、timeout、token budget、`async with` / `aclose` 生命周期保持不变；只把 client 构造阶段移出 event loop。纯同步初始化和长期缓存 client 保持原路径。 - 潜在回归：测试 monkeypatch 目标需要改为底层 `utils.llm_client.create_chat_llm`；异步构造失败仍在原 callsite 的 try/except 内处理。已通过相关路由、memory、plugin 单元测试覆盖。  ## 不拆分理由 这批改动共享同一个根因和同一个修复入口：`create_chat_llm()` 在 async 路径同步构造 client。拆成多个 PR 会留下部分 async callsite 继续阻塞 event loop，也会让测试/守门脚本在中间态反复同步。纯同步/长期缓存路径已刻意保留，范围边界明确。  ## Validation - `uv run python -m pytest tests/unit/test_llm_client_response_safety.py tests/unit/test_topic_llm_enrichment.py tests/unit/test_web_scraper.py tests/unit/test_card_assist_action_recovery.py tests/unit/test_galgame_router.py tests/unit/test_game_router.py tests/unit/test_fact_dedup.py tests/unit/test_memory_recall.py tests/unit/test_persona_version_history.py tests/unit/test_reflection_filters.py tests/unit/test_reflection_idempotent.py tests/unit/test_reflection_ontology.py tests/unit/test_recent_compression_failure.py plugin/tests/unit/plugins/test_galgame_llm_backend.py plugin/tests/unit/plugins/test_study_companion.py plugin/tests/unit/plugins/test_study_companion_vision.py -q` - `uv run python scripts/check_no_temperature.py` - `uv run python scripts/check_llm_budget.py` - `uv run ruff check <changed files>`  <!-- This is an auto-generated comment: release notes by coderabbit.ai --> ## Summary by CodeRabbit  # 发布说明  * **Refactor**   * 全面将模型客户端改为异步创建与初始化，减少事件循环阻塞，并统一在对话、翻译、记忆、视觉分析及各插件链路中的用法。   * 模型切换加入并发保护，确保切换过程串行并提升资源释放可靠性。 * **Bug Fixes**   * 修复视觉分析异常分支的返回行为，保持预期输出。 * **Tests**   * 更新/新增异步工厂、取消清理、缓存复用、回退与预算规则相关单元/回归测试。 * **Chores**   * 更新 LLM 输出预算检测脚本以覆盖异步工厂调用。 <!-- end of auto-generated comment: release notes by coderabbit.ai --> 

Linked issue: #1871