### PR TITLE
补齐 API 管理簿中 MiMo 和 vLLM-Omni 的 i18n 文案

### DIFF
--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1063,10 +1063,12 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Intl)",
+            "mimo": "MiMo (Xiaomi)",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
-            "openrouter": "OpenRouter"
+            "openrouter": "OpenRouter",
+            "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "Free version does not require API Key",
         "pleaseEnterApiKey": "Please enter your API Key",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1063,10 +1063,12 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Int.)",
+            "mimo": "MiMo (Xiaomi)",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude (antrópico)",
             "grok": "Grok (xAI)",
-            "openrouter": "enrutador abierto"
+            "openrouter": "enrutador abierto",
+            "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "La versión gratuita no requiere clave API",
         "pleaseEnterApiKey": "Por favor ingrese su clave API",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1067,7 +1067,7 @@
             "elevenlabs": "ElevenLabs",
             "claude": "Claude (antrópico)",
             "grok": "Grok (xAI)",
-            "openrouter": "enrutador abierto",
+            "openrouter": "OpenRouter (agregador de modelos)",
             "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "La versión gratuita no requiere clave API",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1063,10 +1063,12 @@
             "doubao": "ByteDance（Doubao）",
             "minimax": "MiniMax（中国版）",
             "minimax_intl": "MiniMax（国際版）",
+            "mimo": "MiMo（Xiaomi）",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
-            "openrouter": "OpenRouter"
+            "openrouter": "OpenRouter",
+            "vllm_omni": "vLLM-Omni（TTS）"
         },
         "freeVersionNoApiKey": "無料版はAPIキー不要です",
         "pleaseEnterApiKey": "APIキーを入力してください",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1063,10 +1063,12 @@
             "doubao": "ByteDance(Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax(국제 서버)",
+            "mimo": "MiMo(Xiaomi)",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude(Anthropic)",
             "grok": "Grok(xAI)",
-            "openrouter": "OpenRouter"
+            "openrouter": "OpenRouter",
+            "vllm_omni": "vLLM-Omni(TTS)"
         },
         "freeVersionNoApiKey": "무료 버전에는 API 키가 필요하지 않습니다.",
         "pleaseEnterApiKey": "API 키를 입력하세요.",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1063,10 +1063,12 @@
             "doubao": "ByteDance (Dubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Internacional)",
+            "mimo": "MiMo (Xiaomi)",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude (Antrópico)",
             "grok": "Grok (xAI)",
-            "openrouter": "OpenRouter"
+            "openrouter": "OpenRouter",
+            "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "A versão gratuita não requer chave API",
         "pleaseEnterApiKey": "Por favor insira sua chave API",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1063,10 +1063,12 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (Китай)",
             "minimax_intl": "MiniMax (международный)",
+            "mimo": "MiMo (Xiaomi)",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
-            "openrouter": "OpenRouter"
+            "openrouter": "OpenRouter",
+            "vllm_omni": "vLLM-Omni (TTS)"
         },
         "freeVersionNoApiKey": "Бесплатная версия не требует API Key",
         "pleaseEnterApiKey": "Введите ваш API Key",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1063,10 +1063,12 @@
             "doubao": "豆包（字节跳动）",
             "minimax": "MiniMax（国服）",
             "minimax_intl": "MiniMax（国际服）",
+            "mimo": "MiMo（小米）",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
-            "openrouter": "OpenRouter"
+            "openrouter": "OpenRouter",
+            "vllm_omni": "vLLM-Omni（TTS）"
         },
         "freeVersionNoApiKey": "免费版无需API Key",
         "pleaseEnterApiKey": "请输入您的API Key",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1063,10 +1063,12 @@
             "doubao": "豆包（字節跳動）",
             "minimax": "MiniMax（中國）",
             "minimax_intl": "MiniMax（國際服）",
+            "mimo": "MiMo（小米）",
             "elevenlabs": "ElevenLabs",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
-            "openrouter": "OpenRouter"
+            "openrouter": "OpenRouter",
+            "vllm_omni": "vLLM-Omni（TTS）"
         },
         "freeVersionNoApiKey": "免費版無需API Key",
         "pleaseEnterApiKey": "請輸入您的API Key",


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

补齐 API 管理簿中 MiMo 和 vLLM-Omni 的 i18n 文案，避免设置页显示缺失 key

## 测试 / Testing

手动进入确认

## 对比

改动前:
<img width="1860" height="1409" alt="image" src="https://github.com/user-attachments/assets/4bd5eb3a-61a5-442a-a16b-5d10a3677e89" />

改动后:
<img width="1860" height="1409" alt="QQ20260618-115928" src="https://github.com/user-attachments/assets/b97874bc-7e75-49a3-ad68-e8ea01302066" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 在所有支持的语言版本中，API 密钥管理簿新增两个供应商的本地化显示名称：MiMo（小米）与 vLLM-Omni（TTS），提升供应商列表展示一致性。
* **改进**
  * 调整并补全部分供应商在列表中的呈现顺序；西语等语言版本中，OpenRouter 的显示文案同步更新（其含义保持一致）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->