### PR TITLE
为翻译字幕框添加溢出内容的鼠标滚轮滚动与慢速自动滚动；新译文超出可视区域时自动平滑向下滚动，用户滚轮操作会接管并取消自动滚动，同时保留透明…

### DIFF
--- a/static/css/subtitle.css
+++ b/static/css/subtitle.css
@@ -147,10 +147,6 @@ body.subtitle-window-host.subtitle-linux-host #subtitle-display {
     touch-action: pan-y;
 }
 
-#subtitle-scroll[data-subtitle-scrollable="true"] {
-    pointer-events: auto;
-}
-
 #subtitle-scroll::-webkit-scrollbar {
     width: 0;
     height: 0;

--- a/static/css/subtitle.css
+++ b/static/css/subtitle.css
@@ -135,7 +135,8 @@ body.subtitle-window-host.subtitle-linux-host #subtitle-display {
     width: 100%;
     min-width: 0;
     max-height: var(--subtitle-content-max-height, 120px);
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     overscroll-behavior: none;
     pointer-events: none;
     scrollbar-gutter: auto;
@@ -143,6 +144,11 @@ body.subtitle-window-host.subtitle-linux-host #subtitle-display {
     scrollbar-color: transparent transparent;
     padding: 2px 0;
     text-align: center;
+    touch-action: pan-y;
+}
+
+#subtitle-scroll[data-subtitle-scrollable="true"] {
+    pointer-events: auto;
 }
 
 #subtitle-scroll::-webkit-scrollbar {

--- a/static/subtitle-shared.js
+++ b/static/subtitle-shared.js
@@ -20,6 +20,9 @@
     var DEFAULT_UI_LOCALE = 'zh-CN';
     var CONTROLS_HIDE_DELAY_MS = 1200;
     var PANEL_TEXT_HORIZONTAL_RESERVE = 110;
+    var AUTO_SCROLL_DELAY_MS = 120;
+    var AUTO_SCROLL_SPEED_PX_PER_SECOND = 90;
+    var AUTO_SCROLL_USER_OVERRIDE_MS = 2500;
     var SETTINGS_KEYS = {
         subtitleEnabled: 'subtitleEnabled',
         userLanguage: 'userLanguage',
@@ -665,6 +668,196 @@
             display.style.setProperty('--subtitle-max-width', resolved.width + 'px');
         }
         return resolved;
+    }
+
+    function getSubtitleScrollNode(target) {
+        if (target && typeof target.scrollTop === 'number' &&
+            typeof target.scrollHeight === 'number') {
+            return target;
+        }
+        if (target && target.scroll) return target.scroll;
+        return query(document, '#subtitle-scroll');
+    }
+
+    function getSubtitleScrollMax(scroll) {
+        if (!scroll) return 0;
+        return Math.max(0, (scroll.scrollHeight || 0) - (scroll.clientHeight || 0));
+    }
+
+    function isSubtitleScrollScrollable(scroll) {
+        return getSubtitleScrollMax(scroll) > 1;
+    }
+
+    function updateSubtitleScrollState(target) {
+        var scroll = getSubtitleScrollNode(target);
+        if (!scroll || !scroll.dataset) return false;
+        var scrollable = isSubtitleScrollScrollable(scroll);
+        scroll.dataset.subtitleScrollable = scrollable ? 'true' : 'false';
+        return scrollable;
+    }
+
+    function cancelSubtitleAutoScroll(target) {
+        var scroll = getSubtitleScrollNode(target);
+        var state = scroll && scroll._nekoSubtitleAutoScroll;
+        if (!state) return;
+        if (state.timerId !== null && typeof state.timerId !== 'undefined') {
+            clearTimeout(state.timerId);
+        }
+        if (state.frameId !== null && typeof state.frameId !== 'undefined') {
+            cancelAnimationFrame(state.frameId);
+        }
+        scroll._nekoSubtitleAutoScroll = null;
+    }
+
+    function scrollSubtitleToBottom(target) {
+        var scroll = getSubtitleScrollNode(target);
+        if (!scroll) return 0;
+        cancelSubtitleAutoScroll(scroll);
+        updateSubtitleScrollState(scroll);
+        scroll.scrollTop = getSubtitleScrollMax(scroll);
+        return scroll.scrollTop;
+    }
+
+    function requestSubtitleAutoScroll(target, options) {
+        var scroll = getSubtitleScrollNode(target);
+        if (!scroll) return 0;
+        if (!updateSubtitleScrollState(scroll)) {
+            cancelSubtitleAutoScroll(scroll);
+            scroll.scrollTop = 0;
+            return 0;
+        }
+
+        var lastUserScrollAt = Number(scroll._nekoSubtitleLastUserScrollAt) || 0;
+        if (!(options && options.force) &&
+            lastUserScrollAt &&
+            Date.now() - lastUserScrollAt < AUTO_SCROLL_USER_OVERRIDE_MS) {
+            return scroll.scrollTop;
+        }
+
+        var maxScrollTop = getSubtitleScrollMax(scroll);
+        if (scroll.scrollTop >= maxScrollTop - 1) {
+            return scroll.scrollTop;
+        }
+
+        var activeState = scroll._nekoSubtitleAutoScroll;
+        var speed = Math.max(1, Number(options && options.speedPixelsPerSecond) || AUTO_SCROLL_SPEED_PX_PER_SECOND);
+        if (activeState) {
+            activeState.speed = speed;
+            return scroll.scrollTop;
+        }
+
+        var delayMs = Math.max(0, Number(options && options.delayMs));
+        if (!Number.isFinite(delayMs)) {
+            delayMs = AUTO_SCROLL_DELAY_MS;
+        }
+
+        var state = {
+            frameId: null,
+            timerId: null,
+            lastTimestamp: 0,
+            speed: speed
+        };
+        scroll._nekoSubtitleAutoScroll = state;
+
+        function step(timestamp) {
+            if (scroll._nekoSubtitleAutoScroll !== state) return;
+            if (!updateSubtitleScrollState(scroll)) {
+                cancelSubtitleAutoScroll(scroll);
+                return;
+            }
+            var targetTop = getSubtitleScrollMax(scroll);
+            if (scroll.scrollTop >= targetTop - 1) {
+                scroll.scrollTop = targetTop;
+                cancelSubtitleAutoScroll(scroll);
+                return;
+            }
+            if (!state.lastTimestamp) {
+                state.lastTimestamp = timestamp || 0;
+                state.frameId = requestAnimationFrame(step);
+                return;
+            }
+            var elapsedMs = Math.max(0, Math.min(120, (timestamp || 0) - state.lastTimestamp));
+            state.lastTimestamp = timestamp || state.lastTimestamp;
+            var distance = state.speed * elapsedMs / 1000;
+            scroll.scrollTop = Math.min(targetTop, scroll.scrollTop + distance);
+            state.frameId = requestAnimationFrame(step);
+        }
+
+        state.timerId = setTimeout(function() {
+            if (scroll._nekoSubtitleAutoScroll !== state) return;
+            state.timerId = null;
+            state.frameId = requestAnimationFrame(step);
+        }, delayMs);
+
+        return scroll.scrollTop;
+    }
+
+    function getWheelScrollDelta(e, scroll) {
+        if (!e) return 0;
+        var delta = Number(e.deltaY) || 0;
+        if (!delta && e.shiftKey) {
+            delta = Number(e.deltaX) || 0;
+        }
+        if (!delta) return 0;
+        if (e.deltaMode === 1) {
+            delta *= 32;
+        } else if (e.deltaMode === 2) {
+            delta *= Math.max(1, scroll && scroll.clientHeight ? scroll.clientHeight : 1);
+        }
+        return delta;
+    }
+
+    function attachSubtitleScroll(refs) {
+        var scroll = refs && refs.scroll;
+        if (!scroll) return function() {};
+        var mutationObserver = null;
+        var resizeObserver = null;
+        var scheduleUpdateId = null;
+
+        function scheduleScrollStateUpdate() {
+            if (scheduleUpdateId !== null) return;
+            scheduleUpdateId = setTimeout(function() {
+                scheduleUpdateId = null;
+                updateSubtitleScrollState(scroll);
+            }, 0);
+        }
+
+        var onWheel = function(e) {
+            if (!updateSubtitleScrollState(scroll)) return;
+            var delta = getWheelScrollDelta(e, scroll);
+            if (!delta) return;
+            cancelSubtitleAutoScroll(scroll);
+            scroll._nekoSubtitleLastUserScrollAt = Date.now();
+            var maxScrollTop = getSubtitleScrollMax(scroll);
+            scroll.scrollTop = Math.max(0, Math.min(maxScrollTop, scroll.scrollTop + delta));
+            if (e.preventDefault) e.preventDefault();
+            if (e.stopPropagation) e.stopPropagation();
+        };
+
+        updateSubtitleScrollState(scroll);
+        if (window.MutationObserver) {
+            mutationObserver = new MutationObserver(scheduleScrollStateUpdate);
+            mutationObserver.observe(scroll, {
+                childList: true,
+                characterData: true,
+                subtree: true
+            });
+        }
+        if (window.ResizeObserver) {
+            resizeObserver = new ResizeObserver(scheduleScrollStateUpdate);
+            resizeObserver.observe(scroll);
+        }
+        scroll.addEventListener('wheel', onWheel, { passive: false });
+        return function() {
+            if (scheduleUpdateId !== null) {
+                clearTimeout(scheduleUpdateId);
+                scheduleUpdateId = null;
+            }
+            cancelSubtitleAutoScroll(scroll);
+            if (mutationObserver) mutationObserver.disconnect();
+            if (resizeObserver) resizeObserver.disconnect();
+            scroll.removeEventListener('wheel', onWheel, { passive: false });
+        };
     }
 
     function applySettingsToUi(refs, state, options) {
@@ -1576,6 +1769,7 @@
 
         applyState(state, { changedKeys: [], source: 'init' });
         applyPanelState(panelState, 'subtitle-ui-init');
+        cleanupFns.push(attachSubtitleScroll(refs));
         cleanupFns.push(subscribeSettings(applyState, { immediate: false }));
 
         function setPanelLocked(nextLocked, source) {
@@ -1912,6 +2106,9 @@
         measureSubtitleLayout: measureSubtitleLayout,
         getPanelBounds: getPanelBounds,
         applySubtitlePanelBounds: applySubtitlePanelBounds,
+        scrollSubtitleToBottom: scrollSubtitleToBottom,
+        requestSubtitleAutoScroll: requestSubtitleAutoScroll,
+        cancelSubtitleAutoScroll: cancelSubtitleAutoScroll,
         initSubtitleUI: initSubtitleUI
     };
 })();

--- a/static/subtitle-shared.js
+++ b/static/subtitle-shared.js
@@ -826,10 +826,12 @@
             if (!updateSubtitleScrollState(scroll)) return;
             var delta = getWheelScrollDelta(e, scroll);
             if (!delta) return;
+            var maxScrollTop = getSubtitleScrollMax(scroll);
+            var nextScrollTop = Math.max(0, Math.min(maxScrollTop, scroll.scrollTop + delta));
+            if (Math.abs(nextScrollTop - scroll.scrollTop) < 1) return;
             cancelSubtitleAutoScroll(scroll);
             scroll._nekoSubtitleLastUserScrollAt = Date.now();
-            var maxScrollTop = getSubtitleScrollMax(scroll);
-            scroll.scrollTop = Math.max(0, Math.min(maxScrollTop, scroll.scrollTop + delta));
+            scroll.scrollTop = nextScrollTop;
             if (e.preventDefault) e.preventDefault();
             if (e.stopPropagation) e.stopPropagation();
         };

--- a/static/subtitle-window.js
+++ b/static/subtitle-window.js
@@ -99,6 +99,9 @@
             subtitleWindowController.refs.text.textContent = currentTranscript;
         }
         resizeWindowToTranscript();
+        if (SubtitleShared && typeof SubtitleShared.requestSubtitleAutoScroll === 'function') {
+            SubtitleShared.requestSubtitleAutoScroll(subtitleWindowController && subtitleWindowController.refs);
+        }
     }
 
     function applyTranslatedTranscript(data) {
@@ -153,6 +156,10 @@
         return rect.width > 0 && rect.height > 0;
     }
 
+    function isScrollableElement(el) {
+        return !!(el && (el.scrollHeight || 0) - (el.clientHeight || 0) > 1);
+    }
+
     function pushElementRect(rects, el, padding) {
         if (!isVisibleElement(el)) return;
         var rect = inflateRect(el.getBoundingClientRect(), padding);
@@ -181,6 +188,9 @@
         var rects = [];
         if (!refs || !refs.display || refs.display.classList.contains('hidden')) return rects;
 
+        if (isScrollableElement(refs.scroll)) {
+            pushElementRect(rects, refs.scroll, 6);
+        }
         pushElementRect(rects, refs.text, 10);
 
         if (refs.display.dataset.subtitlePanelState === 'controls' ||

--- a/static/subtitle-window.js
+++ b/static/subtitle-window.js
@@ -156,10 +156,6 @@
         return rect.width > 0 && rect.height > 0;
     }
 
-    function isScrollableElement(el) {
-        return !!(el && (el.scrollHeight || 0) - (el.clientHeight || 0) > 1);
-    }
-
     function pushElementRect(rects, el, padding) {
         if (!isVisibleElement(el)) return;
         var rect = inflateRect(el.getBoundingClientRect(), padding);
@@ -188,9 +184,6 @@
         var rects = [];
         if (!refs || !refs.display || refs.display.classList.contains('hidden')) return rects;
 
-        if (isScrollableElement(refs.scroll)) {
-            pushElementRect(rects, refs.scroll, 6);
-        }
         pushElementRect(rects, refs.text, 10);
 
         if (refs.display.dataset.subtitlePanelState === 'controls' ||

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -281,16 +281,24 @@ function hideSubtitle() {
  * 长文本自动缩小字号以保持在可视范围内。
  */
 var _subtitleFontResizeTimer = null;
+function requestSubtitleContentAutoScroll() {
+    if (SubtitleShared && typeof SubtitleShared.requestSubtitleAutoScroll === 'function') {
+        SubtitleShared.requestSubtitleAutoScroll(document.getElementById('subtitle-scroll'));
+    }
+}
+
 function writeSubtitleText(text) {
     const subtitleText = document.getElementById('subtitle-text');
     if (!subtitleText) return;
     subtitleText.textContent = text || '';
+    requestSubtitleContentAutoScroll();
     syncSubtitleRenderState('subtitle-text-write');
 
     // 自适应字号：防抖测量，避免流式高频触发
     if (_subtitleFontResizeTimer) clearTimeout(_subtitleFontResizeTimer);
     if (!text || !text.trim()) {
         subtitleText.style.fontSize = '';
+        requestSubtitleContentAutoScroll();
         syncSubtitleRenderState('subtitle-text-clear');
         return;
     }
@@ -318,6 +326,7 @@ function writeSubtitleText(text) {
             })
             : { fontSize: 17 };
         subtitleText.style.fontSize = layout.fontSize < 17 ? layout.fontSize + 'px' : '';
+        requestSubtitleContentAutoScroll();
         syncSubtitleRenderState('subtitle-text-resize');
     }, 200);
 }

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -298,7 +298,6 @@ function writeSubtitleText(text) {
     if (_subtitleFontResizeTimer) clearTimeout(_subtitleFontResizeTimer);
     if (!text || !text.trim()) {
         subtitleText.style.fontSize = '';
-        requestSubtitleContentAutoScroll();
         syncSubtitleRenderState('subtitle-text-clear');
         return;
     }

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -553,6 +553,10 @@ def test_web_subtitle_transparent_area_passes_through_while_text_stays_interacti
                 width: 360,
                 height: 80,
             }));
+            document.getElementById('subtitle-text').textContent = Array.from(
+                { length: 20 },
+                (_, index) => `line ${index + 1}`
+            ).join('\\n');
         }
         """
     )
@@ -567,7 +571,7 @@ def test_web_subtitle_transparent_area_passes_through_while_text_stays_interacti
             const display = document.getElementById('subtitle-display');
             const text = document.getElementById('subtitle-text');
             const displayRect = display.getBoundingClientRect();
-            const textRect = text.getBoundingClientRect();
+            const textRect = text.getClientRects()[0] || text.getBoundingClientRect();
             const transparentPoint = {
                 x: Math.round(displayRect.left + 18),
                 y: Math.round(displayRect.top + 18),
@@ -4580,7 +4584,7 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
     assert result["panelHidden"] is True
     assert result["displayOverflow"] == "visible"
     assert result["scrollOverflow"] == "auto"
-    assert result["scrollPointerEvents"] == "auto"
+    assert result["scrollPointerEvents"] == "none"
     assert result["textPointerEvents"] == "auto"
     assert result["scrollRight"] <= result["settingsBtnLeft"] - 6
     assert result["hasDragHandle"] is False
@@ -4627,24 +4631,45 @@ def test_subtitle_scroll_box_accepts_mouse_wheel_for_long_translation(
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             scroll.scrollTop = 0;
-            const style = getComputedStyle(scroll);
+            const scrollStyle = getComputedStyle(scroll);
+            const textStyle = getComputedStyle(text);
             const wheelDown = new WheelEvent('wheel', {
                 bubbles: true,
                 cancelable: true,
                 deltaY: 80,
             });
-            const wheelDownResult = scroll.dispatchEvent(wheelDown);
+            const wheelDownResult = text.dispatchEvent(wheelDown);
             const afterDown = scroll.scrollTop;
             const wheelUp = new WheelEvent('wheel', {
                 bubbles: true,
                 cancelable: true,
                 deltaY: -40,
             });
-            const wheelUpResult = scroll.dispatchEvent(wheelUp);
+            const wheelUpResult = text.dispatchEvent(wheelUp);
+            const afterUp = scroll.scrollTop;
+
+            scroll.scrollTop = 0;
+            const wheelPastTop = new WheelEvent('wheel', {
+                bubbles: true,
+                cancelable: true,
+                deltaY: -80,
+            });
+            const wheelPastTopResult = text.dispatchEvent(wheelPastTop);
+            const afterPastTop = scroll.scrollTop;
+
+            scroll.scrollTop = scroll.scrollHeight - scroll.clientHeight;
+            const beforePastBottom = scroll.scrollTop;
+            const wheelPastBottom = new WheelEvent('wheel', {
+                bubbles: true,
+                cancelable: true,
+                deltaY: 80,
+            });
+            const wheelPastBottomResult = text.dispatchEvent(wheelPastBottom);
 
             return {
-                overflowY: style.overflowY,
-                pointerEvents: style.pointerEvents,
+                overflowY: scrollStyle.overflowY,
+                scrollPointerEvents: scrollStyle.pointerEvents,
+                textPointerEvents: textStyle.pointerEvents,
                 scrollHeight: scroll.scrollHeight,
                 clientHeight: scroll.clientHeight,
                 maxScrollTop: scroll.scrollHeight - scroll.clientHeight,
@@ -4653,14 +4678,22 @@ def test_subtitle_scroll_box_accepts_mouse_wheel_for_long_translation(
                 afterDown,
                 wheelUpResult,
                 wheelUpPrevented: wheelUp.defaultPrevented,
-                afterUp: scroll.scrollTop,
+                afterUp,
+                wheelPastTopResult,
+                wheelPastTopPrevented: wheelPastTop.defaultPrevented,
+                afterPastTop,
+                beforePastBottom,
+                wheelPastBottomResult,
+                wheelPastBottomPrevented: wheelPastBottom.defaultPrevented,
+                afterPastBottom: scroll.scrollTop,
             };
         }
         """
     )
 
     assert result["overflowY"] == "auto"
-    assert result["pointerEvents"] == "auto"
+    assert result["scrollPointerEvents"] == "none"
+    assert result["textPointerEvents"] == "auto"
     assert result["scrollHeight"] > result["clientHeight"]
     assert result["maxScrollTop"] > 0
     assert result["wheelDownResult"] is False
@@ -4669,6 +4702,12 @@ def test_subtitle_scroll_box_accepts_mouse_wheel_for_long_translation(
     assert result["wheelUpResult"] is False
     assert result["wheelUpPrevented"] is True
     assert result["afterUp"] < result["afterDown"]
+    assert result["wheelPastTopResult"] is True
+    assert result["wheelPastTopPrevented"] is False
+    assert result["afterPastTop"] == 0
+    assert result["wheelPastBottomResult"] is True
+    assert result["wheelPastBottomPrevented"] is False
+    assert result["afterPastBottom"] == result["beforePastBottom"]
 
 
 @pytest.mark.frontend
@@ -4728,7 +4767,7 @@ def test_subtitle_overflow_auto_scroll_is_slow_and_wheel_cancels_it(
                 cancelable: true,
                 deltaY: -999,
             });
-            const wheelResult = scroll.dispatchEvent(wheelUp);
+            const wheelResult = text.dispatchEvent(wheelUp);
             const afterWheel = scroll.scrollTop;
             shared.requestSubtitleAutoScroll(scroll, {
                 speedPixelsPerSecond: 240,
@@ -5033,6 +5072,10 @@ def test_subtitle_window_native_passthrough_toggles_by_cursor_position(
                 width: 360,
                 height: 80,
             }));
+            document.getElementById('subtitle-text').textContent = Array.from(
+                { length: 20 },
+                (_, index) => `line ${index + 1}`
+            ).join('\\n');
         }
         """
     )
@@ -5045,7 +5088,8 @@ def test_subtitle_window_native_passthrough_toggles_by_cursor_position(
         async () => {
             document.dispatchEvent(new Event('DOMContentLoaded'));
             await new Promise((resolve) => setTimeout(resolve, 0));
-            const textRect = document.getElementById('subtitle-text').getBoundingClientRect();
+            const text = document.getElementById('subtitle-text');
+            const textRect = text.getClientRects()[0] || text.getBoundingClientRect();
             const textPoint = {
                 x: Math.round(textRect.left + textRect.width / 2),
                 y: Math.round(textRect.top + textRect.height / 2),

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -4579,8 +4579,8 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
     assert result["externalSettingsOpened"] == 1
     assert result["panelHidden"] is True
     assert result["displayOverflow"] == "visible"
-    assert result["scrollOverflow"] == "hidden"
-    assert result["scrollPointerEvents"] == "none"
+    assert result["scrollOverflow"] == "auto"
+    assert result["scrollPointerEvents"] == "auto"
     assert result["textPointerEvents"] == "auto"
     assert result["scrollRight"] <= result["settingsBtnLeft"] - 6
     assert result["hasDragHandle"] is False
@@ -4592,6 +4592,336 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
     assert result["scrollHeight"] <= 86
     assert result["scrollThumbBackground"] == "rgba(0, 0, 0, 0)"
     assert result["textMarginRight"] == "0px"
+
+
+@pytest.mark.frontend
+def test_subtitle_scroll_box_accepts_mouse_wheel_for_long_translation(
+    mock_page: Page,
+):
+    mock_page.set_viewport_size({"width": 360, "height": 120})
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+        path="/subtitle-scroll-wheel-harness",
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const shared = window.nekoSubtitleShared;
+            shared.initSubtitleUI({ host: 'window' });
+            shared.applySubtitlePanelBounds(document.getElementById('subtitle-display'), {
+                width: 240,
+                height: 60,
+            }, { host: 'window' });
+            const scroll = document.getElementById('subtitle-scroll');
+            const text = document.getElementById('subtitle-text');
+            text.textContent = Array.from({ length: 30 }, (_, index) => `line ${index + 1}`).join('\\n');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            scroll.scrollTop = 0;
+            const style = getComputedStyle(scroll);
+            const wheelDown = new WheelEvent('wheel', {
+                bubbles: true,
+                cancelable: true,
+                deltaY: 80,
+            });
+            const wheelDownResult = scroll.dispatchEvent(wheelDown);
+            const afterDown = scroll.scrollTop;
+            const wheelUp = new WheelEvent('wheel', {
+                bubbles: true,
+                cancelable: true,
+                deltaY: -40,
+            });
+            const wheelUpResult = scroll.dispatchEvent(wheelUp);
+
+            return {
+                overflowY: style.overflowY,
+                pointerEvents: style.pointerEvents,
+                scrollHeight: scroll.scrollHeight,
+                clientHeight: scroll.clientHeight,
+                maxScrollTop: scroll.scrollHeight - scroll.clientHeight,
+                wheelDownResult,
+                wheelDownPrevented: wheelDown.defaultPrevented,
+                afterDown,
+                wheelUpResult,
+                wheelUpPrevented: wheelUp.defaultPrevented,
+                afterUp: scroll.scrollTop,
+            };
+        }
+        """
+    )
+
+    assert result["overflowY"] == "auto"
+    assert result["pointerEvents"] == "auto"
+    assert result["scrollHeight"] > result["clientHeight"]
+    assert result["maxScrollTop"] > 0
+    assert result["wheelDownResult"] is False
+    assert result["wheelDownPrevented"] is True
+    assert result["afterDown"] > 0
+    assert result["wheelUpResult"] is False
+    assert result["wheelUpPrevented"] is True
+    assert result["afterUp"] < result["afterDown"]
+
+
+@pytest.mark.frontend
+def test_subtitle_overflow_auto_scroll_is_slow_and_wheel_cancels_it(
+    mock_page: Page,
+):
+    mock_page.set_viewport_size({"width": 360, "height": 120})
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+        path="/subtitle-auto-scroll-harness",
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const shared = window.nekoSubtitleShared;
+            shared.initSubtitleUI({ host: 'window' });
+            shared.applySubtitlePanelBounds(document.getElementById('subtitle-display'), {
+                width: 240,
+                height: 60,
+            }, { host: 'window' });
+            const scroll = document.getElementById('subtitle-scroll');
+            const text = document.getElementById('subtitle-text');
+            text.textContent = Array.from({ length: 30 }, (_, index) => `line ${index + 1}`).join('\\n');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const waitFrames = (count) => new Promise((resolve) => {
+                const tick = () => {
+                    count -= 1;
+                    if (count <= 0) {
+                        resolve();
+                        return;
+                    }
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            });
+
+            scroll.scrollTop = 0;
+            const maxScrollTop = scroll.scrollHeight - scroll.clientHeight;
+            shared.requestSubtitleAutoScroll(scroll, {
+                speedPixelsPerSecond: 240,
+                delayMs: 0,
+            });
+            await waitFrames(8);
+            const afterAuto = scroll.scrollTop;
+            const wheelUp = new WheelEvent('wheel', {
+                bubbles: true,
+                cancelable: true,
+                deltaY: -999,
+            });
+            const wheelResult = scroll.dispatchEvent(wheelUp);
+            const afterWheel = scroll.scrollTop;
+            shared.requestSubtitleAutoScroll(scroll, {
+                speedPixelsPerSecond: 240,
+                delayMs: 0,
+            });
+            await waitFrames(8);
+            const afterWheelWait = scroll.scrollTop;
+
+            return {
+                maxScrollTop,
+                afterAuto,
+                wheelResult,
+                wheelPrevented: wheelUp.defaultPrevented,
+                afterWheel,
+                afterWheelWait,
+                scrollableDataset: scroll.dataset.subtitleScrollable,
+            };
+        }
+        """
+    )
+
+    assert result["maxScrollTop"] > 0
+    assert 0 < result["afterAuto"] < result["maxScrollTop"]
+    assert result["wheelResult"] is False
+    assert result["wheelPrevented"] is True
+    assert result["afterWheel"] == 0
+    assert result["afterWheelWait"] == 0
+    assert result["scrollableDataset"] == "true"
+
+
+@pytest.mark.frontend
+def test_subtitle_translation_write_path_starts_overflow_auto_scroll(
+    mock_page: Page,
+):
+    mock_page.set_viewport_size({"width": 360, "height": 120})
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="show" style="display:flex; opacity:1; visibility:visible;">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-write-auto-scroll-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('subtitlePanelBounds', JSON.stringify({
+                width: 240,
+                height: 60,
+            }));
+            window.waitForStorageLocationStartupBarrier = () => Promise.resolve();
+            window.fetch = async (url) => {
+                if (String(url).includes('/api/config/user_language')) {
+                    return { json: async () => ({ success: true, language: 'en' }) };
+                }
+                if (String(url).includes('/api/translate')) {
+                    return {
+                        ok: true,
+                        json: async () => ({
+                            success: true,
+                            translated_text: Array.from({ length: 30 }, (_, index) => `line ${index + 1}`).join('\\n'),
+                            target_lang: 'en',
+                        }),
+                    };
+                }
+                throw new Error(`Unexpected fetch: ${url}`);
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const waitFrames = (count) => new Promise((resolve) => {
+                const tick = () => {
+                    count -= 1;
+                    if (count <= 0) {
+                        resolve();
+                        return;
+                    }
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            });
+            const scroll = document.getElementById('subtitle-scroll');
+            scroll.scrollTop = 0;
+            await window.subtitleBridge.finalizeTurnWithTranslation('A complete sentence.');
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const maxScrollTop = scroll.scrollHeight - scroll.clientHeight;
+            await waitFrames(20);
+            return {
+                maxScrollTop,
+                scrollTop: scroll.scrollTop,
+                scrollableDataset: scroll.dataset.subtitleScrollable,
+                textLength: document.getElementById('subtitle-text').textContent.length,
+            };
+        }
+        """
+    )
+
+    assert result["textLength"] > 0
+    assert result["maxScrollTop"] > 0
+    assert result["scrollTop"] > 0
+    assert result["scrollTop"] < result["maxScrollTop"]
+    assert result["scrollableDataset"] == "true"
+
+
+@pytest.mark.frontend
+def test_subtitle_window_transcript_event_starts_overflow_auto_scroll(
+    mock_page: Page,
+):
+    mock_page.set_viewport_size({"width": 360, "height": 120})
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-window-auto-scroll-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitlePanelBounds', JSON.stringify({
+                width: 240,
+                height: 60,
+            }));
+            window.nekoSubtitle = {
+                setSize: () => {},
+                changeSettings: () => {},
+                dragStart: () => {},
+                dragStop: () => {},
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-window.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const waitFrames = (count) => new Promise((resolve) => {
+                const tick = () => {
+                    count -= 1;
+                    if (count <= 0) {
+                        resolve();
+                        return;
+                    }
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            });
+            const scroll = document.getElementById('subtitle-scroll');
+            scroll.scrollTop = 0;
+            window.dispatchEvent(new CustomEvent('neko-ws-transcript', {
+                detail: {
+                    translated: true,
+                    transcript: Array.from({ length: 30 }, (_, index) => `line ${index + 1}`).join('\\n'),
+                },
+            }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const maxScrollTop = scroll.scrollHeight - scroll.clientHeight;
+            await waitFrames(20);
+            return {
+                maxScrollTop,
+                scrollTop: scroll.scrollTop,
+                scrollableDataset: scroll.dataset.subtitleScrollable,
+            };
+        }
+        """
+    )
+
+    assert result["maxScrollTop"] > 0
+    assert result["scrollTop"] > 0
+    assert result["scrollTop"] < result["maxScrollTop"]
+    assert result["scrollableDataset"] == "true"
 
 
 @pytest.mark.frontend
@@ -4889,7 +5219,7 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
     assert result["panelHidden"] is False
     assert result["overlapsVertically"] is False
     assert result["displayOverflow"] == "visible"
-    assert result["scrollOverflow"] == "hidden"
+    assert result["scrollOverflow"] == "auto"
     assert result["scrollPointerEvents"] == "none"
     assert result["textPointerEvents"] == "auto"
     assert result["scrollRight"] <= result["settingsBtnLeft"] - 6


### PR DESCRIPTION
…区域穿透行为

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

- 为翻译字幕框启用纵向溢出滚动，隐藏滚动条，同时保留透明区域穿透行为。
- 在字幕内容写入、字号自适应完成、Electron 字幕窗口 transcript 更新后触发慢速自动滚动。
- 保留用户鼠标滚轮接管能力：用户滚动会取消自动滚动；滚到顶部/底部后不再吞掉外层滚轮事件。
- 修复 review 后续问题：空文本分支不再重复请求自动滚动，长字幕也不会把整块滚动容器加入原生窗口命中区域。

## 测试 / Testing

- `uv run pytest tests/frontend/test_subtitle_incremental.py -q --maxfail=1`
- 手动使用翻译功能测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持字幕内容在更新后自动滚动到底部
  * 新增自动滚动控制：可请求、取消，并兼容翻译完成与实时转写触发
* **改进**
  * 优化长文本滚动：滚轮可直接滚动，且会中止正在进行的自动滚动
  * 调整字幕滚动区域的行为：仅允许纵向滚动，禁止横向滚动；触摸手势更聚焦纵向平移
* **测试**
  * 更新并新增字幕滚动与自动滚动相关用例，覆盖滚轮与事件触发场景
<!-- end of auto-generated comment: release notes by coderabbit.ai -->