### PR TITLE
修复紧凑聊天框展开工具轮盘后历史记录区域被 Electron 鼠标穿透，导致无法滚动历史对话的问题

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5470,6 +5470,111 @@ describe('App', () => {
     }
   });
 
+  it('routes compact tool wheel background scrolling to the open inline history', () => {
+    const scrollTopByElement = new WeakMap<HTMLElement, number>();
+    const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const clientHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    const scrollTopDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTop');
+    const originalElementsFromPoint = document.elementsFromPoint;
+    let scrollRectSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('compact-export-history-scroll') ? 900 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('compact-export-history-scroll') ? 300 : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get() {
+        return scrollTopByElement.get(this) ?? 0;
+      },
+      set(value: number) {
+        scrollTopByElement.set(this, value);
+      },
+    });
+
+    try {
+      window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'true');
+      const messages = Array.from({ length: 8 }, (_, index) => parseChatMessage({
+        id: `compact-history-wheel-${index}`,
+        role: index % 2 === 0 ? 'assistant' : 'user',
+        author: index % 2 === 0 ? 'Neko' : 'You',
+        time: '10:00',
+        createdAt: index,
+        blocks: [{ type: 'text', text: `History row ${index}` }],
+        status: 'sent',
+      }));
+
+      render(
+        <App
+          chatSurfaceMode="compact"
+          compactChatState="input"
+          messages={messages}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: '更多工具' }));
+      const fan = document.body.querySelector<HTMLDivElement>('.compact-input-tool-fan')!;
+      const fanHitRegion = fan.querySelector<HTMLElement>('.compact-input-tool-fan-hit-region')!;
+      const scroll = document.body.querySelector<HTMLDivElement>('.compact-export-history-scroll')!;
+
+      scrollRectSpy = vi.spyOn(scroll, 'getBoundingClientRect').mockReturnValue({
+        left: 20,
+        top: 20,
+        right: 420,
+        bottom: 320,
+        width: 400,
+        height: 300,
+        x: 20,
+        y: 20,
+        toJSON: () => ({}),
+      } as DOMRect);
+      Object.defineProperty(document, 'elementsFromPoint', {
+        configurable: true,
+        value: () => [fanHitRegion, fan, scroll],
+      });
+
+      scroll.scrollTop = 120;
+      expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-screenshot');
+
+      act(() => {
+        fireEvent.wheel(fanHitRegion, { deltaY: 80, clientX: 160, clientY: 160 });
+      });
+
+      expect(scroll.scrollTop).toBe(200);
+      expect(scroll).toHaveAttribute('data-compact-scrollbar-visible', 'true');
+      expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-screenshot');
+    } finally {
+      if (scrollHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', scrollHeightDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      }
+      if (clientHeightDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientHeightDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
+      }
+      if (scrollTopDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollTop', scrollTopDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollTop');
+      }
+      Object.defineProperty(document, 'elementsFromPoint', {
+        configurable: true,
+        value: originalElementsFromPoint || (() => []),
+      });
+      scrollRectSpy?.mockRestore();
+    }
+  });
+
   it('keeps compact tool wheel detent audio silent for an empty URL and plays every detent when configured', () => {
     const playSfx = vi.fn();
     const preloadSfx = vi.fn();

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5471,6 +5471,7 @@ describe('App', () => {
   });
 
   it('routes compact tool wheel background scrolling to the open inline history', () => {
+    const previousHistoryOpen = window.localStorage.getItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
     const scrollTopByElement = new WeakMap<HTMLElement, number>();
     const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
     const clientHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
@@ -5551,7 +5552,20 @@ describe('App', () => {
       expect(scroll.scrollTop).toBe(200);
       expect(scroll).toHaveAttribute('data-compact-scrollbar-visible', 'true');
       expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-screenshot');
+
+      scroll.scrollTop = 0;
+      act(() => {
+        fireEvent.wheel(fanHitRegion, { deltaY: -80, clientX: 160, clientY: 160 });
+      });
+
+      expect(scroll.scrollTop).toBe(0);
+      expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-galgame');
     } finally {
+      if (previousHistoryOpen === null) {
+        window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, previousHistoryOpen);
+      }
       if (scrollHeightDescriptor) {
         Object.defineProperty(HTMLElement.prototype, 'scrollHeight', scrollHeightDescriptor);
       } else {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -17,6 +17,7 @@ import AvatarToolQuickbar from './AvatarToolQuickbar';
 import FullChatSurface from './FullChatSurface';
 import CompactExportHistoryPanel, {
   COMPACT_EXPORT_SELECTION_LIMIT,
+  COMPACT_HISTORY_ROUTED_WHEEL_EVENT,
   isCompactExportMessageSelectable,
   type CompactExportActionRequest,
   type CompactExportPreviewResult,
@@ -794,6 +795,18 @@ const compactCursorZoneSelector = [
   '[data-neko-sidepanel]',
 ].join(', ');
 
+const compactToolWheelControlWheelTargetSelector = [
+  '.compact-input-tool-item',
+  '.composer-icon-popover',
+  '.avatar-tool-quickbar',
+  '.avatar-tool-quickbar-edit',
+].join(', ');
+
+const compactHistoryOpenScrollSelector = [
+  '.compact-export-history-anchor[data-compact-export-history-visibility="open"]:not(.under-choice-prompt)',
+  '.compact-export-history-scroll',
+].join(' ');
+
 type ToolCursorVariantState = Record<string, CursorVariant>;
 type InteractionIntensity = NonNullable<AvatarInteractionPayload['intensity']>;
 type AvatarInteractionToolId = AvatarToolId;
@@ -912,6 +925,50 @@ function loadCursorImage(imagePath: string, cacheState: AvatarToolCacheState): P
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
+}
+
+function isPointInElementRect(element: Element, clientX: number, clientY: number): boolean {
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  return clientX >= rect.left
+    && clientX <= rect.right
+    && clientY >= rect.top
+    && clientY <= rect.bottom;
+}
+
+function isCompactToolWheelControlWheelTarget(target: EventTarget | null): boolean {
+  return target instanceof Element
+    && !!target.closest(compactToolWheelControlWheelTargetSelector);
+}
+
+function getCompactHistoryScrollFromElement(element: Element): HTMLDivElement | null {
+  const scrollNode = element.closest<HTMLDivElement>(compactHistoryOpenScrollSelector);
+  return scrollNode instanceof HTMLDivElement ? scrollNode : null;
+}
+
+function getCompactHistoryScrollUnderCompactToolWheel(
+  event: ReactWheelEvent<HTMLDivElement>,
+): HTMLDivElement | null {
+  if (isCompactToolWheelControlWheelTarget(event.target)) return null;
+  const clientX = event.clientX;
+  const clientY = event.clientY;
+  if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return null;
+  const fanElement = event.currentTarget;
+  const pointElements = typeof document.elementsFromPoint === 'function'
+    ? document.elementsFromPoint(clientX, clientY)
+    : [];
+
+  for (const element of pointElements) {
+    if (!(element instanceof Element)) continue;
+    if (fanElement === element || fanElement.contains(element)) continue;
+    const scrollNode = getCompactHistoryScrollFromElement(element);
+    if (scrollNode && isPointInElementRect(scrollNode, clientX, clientY)) {
+      return scrollNode;
+    }
+  }
+
+  return Array.from(document.querySelectorAll<HTMLDivElement>(compactHistoryOpenScrollSelector))
+    .find(scrollNode => isPointInElementRect(scrollNode, clientX, clientY)) ?? null;
 }
 
 async function resolveCompactCursorValue(
@@ -4113,16 +4170,42 @@ function CompactChatApp({
     return rawDelta;
   }, []);
 
+  const routeCompactToolWheelScrollToHistory = useCallback((
+    event: ReactWheelEvent<HTMLDivElement>,
+    normalizedDelta: number,
+  ) => {
+    if (!compactExportHistoryOpen) return false;
+    if (compactInputToolWheelDragActiveRef.current || compactInputToolWheelPointerRef.current) return false;
+    const scrollNode = getCompactHistoryScrollUnderCompactToolWheel(event);
+    if (!scrollNode) return false;
+
+    const maxScrollTop = Math.max(0, scrollNode.scrollHeight - scrollNode.clientHeight);
+    if (maxScrollTop <= 0) return false;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const nextScrollTop = clamp(scrollNode.scrollTop + normalizedDelta, 0, maxScrollTop);
+    if (nextScrollTop !== scrollNode.scrollTop) {
+      scrollNode.scrollTop = nextScrollTop;
+      scrollNode.dispatchEvent(new Event('scroll', { bubbles: true }));
+    }
+    scrollNode.dispatchEvent(new CustomEvent(COMPACT_HISTORY_ROUTED_WHEEL_EVENT, { bubbles: true }));
+    return true;
+  }, [compactExportHistoryOpen]);
+
   const rotateCompactInputToolWheelByScroll = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
     const normalizedDelta = getCompactInputToolWheelNormalizedDelta(event);
     if (Math.abs(normalizedDelta) < COMPACT_INPUT_TOOL_WHEEL_SCROLL_DEADZONE) return;
+
+    if (routeCompactToolWheelScrollToHistory(event, normalizedDelta)) return;
 
     event.preventDefault();
     event.stopPropagation();
 
     const direction: 1 | -1 = normalizedDelta > 0 ? 1 : -1;
     rotateCompactInputToolWheelSteps(direction, 1, { forceFast: true });
-  }, [getCompactInputToolWheelNormalizedDelta, rotateCompactInputToolWheelSteps]);
+  }, [getCompactInputToolWheelNormalizedDelta, rotateCompactInputToolWheelSteps, routeCompactToolWheelScrollToHistory]);
 
   const getCompactToolWheelBoundedDragPoint = useCallback((clientX: number, clientY: number): CompactToolWheelDragPoint => {
     if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4182,14 +4182,13 @@ function CompactChatApp({
     const maxScrollTop = Math.max(0, scrollNode.scrollHeight - scrollNode.clientHeight);
     if (maxScrollTop <= 0) return false;
 
+    const nextScrollTop = clamp(scrollNode.scrollTop + normalizedDelta, 0, maxScrollTop);
+    if (nextScrollTop === scrollNode.scrollTop) return false;
+
     event.preventDefault();
     event.stopPropagation();
 
-    const nextScrollTop = clamp(scrollNode.scrollTop + normalizedDelta, 0, maxScrollTop);
-    if (nextScrollTop !== scrollNode.scrollTop) {
-      scrollNode.scrollTop = nextScrollTop;
-      scrollNode.dispatchEvent(new Event('scroll', { bubbles: true }));
-    }
+    scrollNode.scrollTop = nextScrollTop;
     scrollNode.dispatchEvent(new CustomEvent(COMPACT_HISTORY_ROUTED_WHEEL_EVENT, { bubbles: true }));
     return true;
   }, [compactExportHistoryOpen]);

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -19,6 +19,7 @@ export const COMPACT_EXPORT_SELECTION_LIMIT = 100;
 
 const COMPACT_EXPORT_BOTTOM_THRESHOLD = 30;
 const COMPACT_HISTORY_SCROLL_SETTLE_FRAMES = 36;
+export const COMPACT_HISTORY_ROUTED_WHEEL_EVENT = 'neko:compact-history-routed-wheel';
 export const COMPACT_HISTORY_SCROLLBAR_VISIBLE_MS = 860;
 const COMPACT_HISTORY_SCROLLBAR_THUMB_MIN_HEIGHT = 24;
 export const COMPACT_HISTORY_ENTER_DELAY_STEP_MS = 42;
@@ -585,6 +586,22 @@ export default function CompactExportHistoryPanel({
     onAutoScrollToBottomChange(distanceToBottom <= COMPACT_EXPORT_BOTTOM_THRESHOLD);
     updateScrollbarThumbState();
   }
+
+  useEffect(() => {
+    const scrollNode = scrollRef.current;
+    if (!scrollNode) return undefined;
+
+    const handleRoutedWheel = () => {
+      if (!historyInteractive) return;
+      handleScroll();
+      revealScrollbarForWheel();
+    };
+
+    scrollNode.addEventListener(COMPACT_HISTORY_ROUTED_WHEEL_EVENT, handleRoutedWheel);
+    return () => {
+      scrollNode.removeEventListener(COMPACT_HISTORY_ROUTED_WHEEL_EVENT, handleRoutedWheel);
+    };
+  });
 
   function handleClick(event: ReactMouseEvent<HTMLElement>, message: ChatMessage, selectable: boolean) {
     if (!selectable) return;

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -249,6 +249,7 @@ export default function CompactExportHistoryPanel({
   const previewObjectUrlRef = useRef<string | null>(null);
   const enterDelayByMessageIdRef = useRef<Map<string, string>>(new Map());
   const previousVisibilityStateRef = useRef<'open' | 'closing' | null>(null);
+  const routedWheelHandlerRef = useRef<() => void>(() => {});
   // 记录上一次几何刷新时的可视窗口高度，用于判断 resize 方向（缩小 vs 增高）。
   const lastGeometryClientHeightRef = useRef<number | null>(null);
   const [exportFormat, setExportFormat] = useState<CompactExportFormat>('image');
@@ -587,21 +588,21 @@ export default function CompactExportHistoryPanel({
     updateScrollbarThumbState();
   }
 
+  routedWheelHandlerRef.current = () => {
+    if (!historyInteractive) return;
+    handleScroll();
+    revealScrollbarForWheel();
+  };
+
   useEffect(() => {
     const scrollNode = scrollRef.current;
     if (!scrollNode) return undefined;
-
-    const handleRoutedWheel = () => {
-      if (!historyInteractive) return;
-      handleScroll();
-      revealScrollbarForWheel();
-    };
-
+    const handleRoutedWheel = () => routedWheelHandlerRef.current();
     scrollNode.addEventListener(COMPACT_HISTORY_ROUTED_WHEEL_EVENT, handleRoutedWheel);
     return () => {
       scrollNode.removeEventListener(COMPACT_HISTORY_ROUTED_WHEEL_EVENT, handleRoutedWheel);
     };
-  });
+  }, [historyInteractive, previewOpen, visibilityState]);
 
   function handleClick(event: ReactMouseEvent<HTMLElement>, message: ChatMessage, selectable: boolean) {
     if (!selectable) return;

--- a/static/compact-history-pointer-events.test.cjs
+++ b/static/compact-history-pointer-events.test.cjs
@@ -4,20 +4,21 @@ const path = require('node:path');
 const test = require('node:test');
 
 const css = fs.readFileSync(path.join(__dirname, 'css', 'index.css'), 'utf8');
+const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 test('compact history remains hit-testable while the compact tool wheel is open', () => {
     const compactToolOpenGuard = ':not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"])';
 
     assert.doesNotMatch(
         css,
-        new RegExp(`${compactToolOpenGuard.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+\\.compact-export-history-anchor\\s+\\*\\s*\\{\\s*pointer-events:\\s*none\\s*!important;`),
+        new RegExp(`${escapeRegExp(compactToolOpenGuard)}\\s+\\.compact-export-history-anchor\\s+\\*\\s*\\{\\s*pointer-events:\\s*none\\s*!important;`),
         'the tool-wheel-open history override must not disable the whole history subtree'
     );
 
     const scrollSelector = `${compactToolOpenGuard} .compact-export-history-scroll`;
     const bubbleSelector = `${compactToolOpenGuard} .compact-export-history-bubble`;
     const autoPointerBlockPattern = new RegExp(
-        `${scrollSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*${bubbleSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*\\{\\s*pointer-events:\\s*auto\\s*!important;\\s*\\}`
+        `${escapeRegExp(scrollSelector)}\\s*,\\s*[^{}]*${escapeRegExp(bubbleSelector)}[^{}]*\\{[^{}]*pointer-events:\\s*auto\\s*!important;`
     );
 
     assert.match(

--- a/static/compact-history-pointer-events.test.cjs
+++ b/static/compact-history-pointer-events.test.cjs
@@ -1,0 +1,28 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const css = fs.readFileSync(path.join(__dirname, 'css', 'index.css'), 'utf8');
+
+test('compact history remains hit-testable while the compact tool wheel is open', () => {
+    const compactToolOpenGuard = ':not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"])';
+
+    assert.doesNotMatch(
+        css,
+        new RegExp(`${compactToolOpenGuard.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+\\.compact-export-history-anchor\\s+\\*\\s*\\{\\s*pointer-events:\\s*none\\s*!important;`),
+        'the tool-wheel-open history override must not disable the whole history subtree'
+    );
+
+    const scrollSelector = `${compactToolOpenGuard} .compact-export-history-scroll`;
+    const bubbleSelector = `${compactToolOpenGuard} .compact-export-history-bubble`;
+    const autoPointerBlockPattern = new RegExp(
+        `${scrollSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*${bubbleSelector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*\\{\\s*pointer-events:\\s*auto\\s*!important;\\s*\\}`
+    );
+
+    assert.match(
+        css,
+        autoPointerBlockPattern,
+        'history scroll and bubbles must stay pointer-events:auto so Electron does not make them click-through'
+    );
+});

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1572,15 +1572,24 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     pointer-events: auto;
 }
 
-/* 工具轮盘打开且历史操作/预览未打开时，历史记录退到工具轮盘下方，避免遮挡和抢命中。
-   历史操作/预览打开后，只让透明外壳穿透，消息气泡和控制条仍需可交互。 */
+/* 工具轮盘打开且历史操作/预览未打开时，历史记录退到工具轮盘下方，避免遮挡工具按钮。
+   但 scroll 区和气泡仍需保留命中：Electron 依赖这些 hit-region 收窄鼠标穿透区，否则滚轮事件进不了聊天窗口。 */
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-anchor {
     z-index: 1 !important;
 }
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-anchor,
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-anchor * {
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-panel,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-scroll-content,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-message {
     pointer-events: none !important;
+}
+
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-scroll,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-bubble,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-resize-bar,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"]:not([data-compact-export-controls-open="true"]):not([data-compact-export-preview-open="true"]) .compact-export-history-scrollbar-hit {
+    pointer-events: auto !important;
 }
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) #react-chat-window-root .app-shell[data-compact-tool-layer-open="true"][data-compact-export-controls-open="true"] .compact-export-history-anchor:not(.under-choice-prompt),


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复紧凑聊天框展开工具轮盘后历史记录区域被 Electron 鼠标穿透，导致无法滚动历史对话的问题；保留轮盘按钮优先命中，并为滚轮转发和 pointer-events 覆盖规则补充回归测试

## 测试 / Testing

手动测试轮盘和聊天记录


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 优化紧凑模式交互：展开工具轮盘且历史面板已打开时，鼠标滚轮会按命中位置路由到历史滚动区域，避免误触旋转流程。

* **Bug Fix**
  * 调整紧凑模式历史相关命中策略：在特定交互状态下保留滚动/气泡区域的可点击与可滚动行为，减少点击穿透风险。

* **测试**
  * 新增滚轮路由与指针事件相关用例，覆盖滚动增减、状态切换与渲染命中规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->