### PR TITLE
Add generic session context append API

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3982,8 +3982,6 @@ class LLMSessionManager:
 
         if clear_main_cache:
             self.message_cache_for_new_session = []
-            if from_final_swap:
-                self.next_session_context_messages = []
             self.initial_next_session_context_snapshot_len = 0
 
     async def _cleanup_pending_session_resources(self):
@@ -8106,7 +8104,12 @@ class LLMSessionManager:
             # 发送音频，此时 self.session 已是新 session，音频会正确发往新会话。
             await self._flush_hot_swap_audio_cache()
 
-        
+            transferred_next_context_count = (
+                self.initial_next_session_context_snapshot_len
+                + len(incremental_next_session_context)
+            )
+            self._consume_next_session_context_messages(transferred_next_context_count)
+
             # Reset all preparation states and clear the *main* cache now that it's fully transferred
             # pending_session已在swap后立即清除，这里只需要重置其他状态
             await self._reset_preparation_state(

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1273,8 +1273,11 @@ class LLMSessionManager:
         if lifetime in {"current_session", "session_family"} and not wrote_active_history:
             prime_context = getattr(session, "prime_context", None)
             if callable(prime_context):
-                await prime_context(f"{role}: {content}", skipped=(audience == "model"))
-                targets.append("realtime_prime")
+                try:
+                    await prime_context(f"{role}: {content}", skipped=(audience == "model"))
+                    targets.append("realtime_prime")
+                except Exception as exc:
+                    print(f"[{self.lanlan_name}] context append realtime_prime failed: {exc}")
 
         if not targets:
             return ContextAppendResult(appended=False, reason="no_context_target")
@@ -1349,11 +1352,17 @@ class LLMSessionManager:
             payload.get("ordering_key") or f"~{int(payload.get('_sequence', 0)):020d}",
             int(payload.get("_sequence", 0)),
         ))
+        retry: list[dict] = []
         for payload in pending:
             try:
-                await self._append_context_to_targets(payload)
+                result = await self._append_context_to_targets(payload)
+                if not result.appended:
+                    retry.append(payload)
             except Exception as exc:
+                retry.append(payload)
                 print(f"[{self.lanlan_name}] context append flush failed: {exc}")
+        if retry:
+            self.pending_context_appends = retry + self.pending_context_appends
 
     def is_goodbye_silent(self) -> bool:
         """Whether cat-mode silence after being asked to leave is in effect."""

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1285,6 +1285,48 @@ class LLMSessionManager:
         cache.append({"role": speaker, "text": text})
         return True
 
+    def _context_payload_cache_key(self, payload: Mapping[str, Any]) -> tuple[str, str]:
+        role = str(payload.get("role") or "").strip().lower()
+        if role == "user":
+            speaker = getattr(self, "master_name", "user")
+        elif role == "assistant":
+            speaker = getattr(self, "lanlan_name", "assistant")
+        else:
+            speaker = "system"
+        return (speaker, str(payload.get("text") or ""))
+
+    def _mark_pending_context_appends_delivered_in_start_prompt(self, snapshot: list[dict]) -> None:
+        pending = getattr(self, "pending_context_appends", None)
+        if not isinstance(pending, list) or not pending or not snapshot:
+            return
+        available: dict[tuple[str, str], int] = {}
+        for entry in snapshot:
+            if not isinstance(entry, Mapping):
+                continue
+            key = (str(entry.get("role") or ""), str(entry.get("text") or ""))
+            available[key] = available.get(key, 0) + 1
+        for payload in pending:
+            if (
+                not isinstance(payload, dict)
+                or not payload.get("_durable_cached")
+                or payload.get("_delivered_in_start_prompt")
+            ):
+                continue
+            key = self._context_payload_cache_key(payload)
+            count = available.get(key, 0)
+            if count <= 0:
+                continue
+            payload["_delivered_in_start_prompt"] = True
+            available[key] = count - 1
+
+    def _clear_pending_context_start_prompt_marks(self) -> None:
+        pending = getattr(self, "pending_context_appends", None)
+        if not isinstance(pending, list):
+            return
+        for payload in pending:
+            if isinstance(payload, dict):
+                payload.pop("_delivered_in_start_prompt", None)
+
     def _snapshot_next_session_context_messages(self) -> list[dict]:
         cache = getattr(self, "next_session_context_messages", None)
         if not isinstance(cache, list) or not cache:
@@ -1316,7 +1358,7 @@ class LLMSessionManager:
             return consumed_count
         try:
             await prime_context(self._convert_cache_to_str(late_context), skipped=True)
-        except (web_exceptions.ConnectionClosed, AttributeError) as exc:
+        except Exception as exc:
             logger.warning(
                 "[%s] final-swap late next-session context prime failed: %s",
                 self.lanlan_name,
@@ -1333,6 +1375,8 @@ class LLMSessionManager:
         audience = payload["audience"]
         lifetime = payload["lifetime"]
         targets: list[str] = []
+        if payload.get("_delivered_in_start_prompt") and lifetime in {"next_session", "session_family"}:
+            return ContextAppendResult(appended=True, targets=("start_prompt",))
         if lifetime in {"next_session", "session_family"}:
             if payload.get("_durable_cached"):
                 targets.append("new_session_cache")
@@ -5138,6 +5182,7 @@ class LLMSessionManager:
             logger.info(f"[语音会话诊断] 开始获取记忆上下文 (端口 {self.memory_server_port})")
             _mem_start = time.time()
             _new_dialog_task = asyncio.create_task(_fetch_new_dialog())
+            llm_next_context_count_to_consume_after_start = 0
 
             # 定义 LLM Session 启动协程
             async def start_llm_session():
@@ -5147,6 +5192,7 @@ class LLMSessionManager:
                 first.  Only after connect() succeeds is it promoted to self.session.
                 On failure the half-initialised session is closed and an exception raised.
                 """
+                nonlocal llm_next_context_count_to_consume_after_start
                 # 强 CAS 语义：只允许在 self.session 为 None（start_session 已清场）
                 # 或已经是自己的 new_session 时赋值。任何其他状态都视为并发落败，
                 # 必须关闭本次 new_session，避免覆盖赢家造成孤儿。
@@ -5158,6 +5204,9 @@ class LLMSessionManager:
                 _lang = normalize_language_code(self.user_language, format='short')
                 initial_prompt = await self._build_initial_prompt()
                 next_session_context_messages = self._snapshot_next_session_context_messages()
+                self._mark_pending_context_appends_delivered_in_start_prompt(
+                    next_session_context_messages
+                )
 
                 # 等待上面预先发出的 /new_dialog 完成
                 try:
@@ -5276,11 +5325,12 @@ class LLMSessionManager:
                         self.session = new_session
                         if not self.current_speech_id:
                             self.current_speech_id = str(uuid4())
-                        self._consume_next_session_context_messages(len(next_session_context_messages))
+                        llm_next_context_count_to_consume_after_start = len(next_session_context_messages)
                     else:
                         concurrent_winner = True
 
                 if concurrent_winner:
+                    self._clear_pending_context_start_prompt_marks()
                     logger.warning("⚠️ start_llm_session: 检测到并发 start_session 已抢先建立 session，关闭本次 new_session 避免孤儿泄漏")
                     try:
                         await new_session.close()
@@ -5384,6 +5434,10 @@ class LLMSessionManager:
 
                 # 处理在session启动期间可能已经缓存的输入数据
                 await self._flush_pending_input_data()
+                self._consume_next_session_context_messages(
+                    llm_next_context_count_to_consume_after_start
+                )
+                llm_next_context_count_to_consume_after_start = 0
 
                 # WebSocket 重连后，投递因断线积压的 agent 任务回调
                 if self.pending_agent_callbacks:
@@ -8147,12 +8201,11 @@ class LLMSessionManager:
                 except Exception as e:
                     logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
 
-            next_context_count_before_promote = len(self._snapshot_next_session_context_messages())
-
             # ── 步骤 3：promote 新 session ────────────────────────────────────────
             # 旧 listener 已停、旧 session 已关，现在切换 self.session；
             # 此后旧 task 的任何回调若再执行也已看不到旧 ws。
             self.session = new_session
+            next_context_count_at_promote = len(self._snapshot_next_session_context_messages())
             await self._apply_pending_tts_route_after_swap()
             self.current_speech_id = str(uuid4())
             self._tts_done_queued_for_turn = False
@@ -8181,9 +8234,8 @@ class LLMSessionManager:
             )
             consumed_next_context_count = await self._prime_late_next_session_context_after_swap(
                 transferred_next_context_count,
-                next_context_count_before_promote,
+                next_context_count_at_promote,
             )
-            self._consume_next_session_context_messages(consumed_next_context_count)
 
             # ── 步骤 4：启动新 listener ───────────────────────────────────────────
             if self.session and hasattr(self.session, 'handle_messages'):
@@ -8193,6 +8245,7 @@ class LLMSessionManager:
             # 必须在 promote 之后调用：_flush_hot_swap_audio_cache 使用 self.session
             # 发送音频，此时 self.session 已是新 session，音频会正确发往新会话。
             await self._flush_hot_swap_audio_cache()
+            self._consume_next_session_context_messages(consumed_next_context_count)
 
             # Reset all preparation states and clear the *main* cache now that it's fully transferred
             # pending_session已在swap后立即清除，这里只需要重置其他状态

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1210,7 +1210,9 @@ class LLMSessionManager:
         new_key = self._context_append_request_key(payload)
         if timestamp is not None and new_key is not None:
             seen[new_key] = timestamp
-            seen.move_to_end(new_key)
+            self._context_append_request_ids = OrderedDict(
+                sorted(seen.items(), key=lambda item: item[1])
+            )
 
     def _remember_context_append_request_id(self, payload: Mapping[str, Any]) -> None:
         key = self._context_append_request_key(payload)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1295,7 +1295,12 @@ class LLMSessionManager:
             speaker = "system"
         return (speaker, str(payload.get("text") or ""))
 
-    def _mark_pending_context_appends_delivered_in_start_prompt(self, snapshot: list[dict]) -> None:
+    def _mark_pending_context_appends_delivered_in_start_prompt(
+        self,
+        snapshot: list[dict],
+        *,
+        owner: object | None = None,
+    ) -> None:
         pending = getattr(self, "pending_context_appends", None)
         if not isinstance(pending, list) or not pending or not snapshot:
             return
@@ -1317,15 +1322,19 @@ class LLMSessionManager:
             if count <= 0:
                 continue
             payload["_delivered_in_start_prompt"] = True
+            payload["_delivered_in_start_prompt_owner"] = owner
             available[key] = count - 1
 
-    def _clear_pending_context_start_prompt_marks(self) -> None:
+    def _clear_pending_context_start_prompt_marks(self, *, owner: object | None = None) -> None:
         pending = getattr(self, "pending_context_appends", None)
         if not isinstance(pending, list):
             return
         for payload in pending:
             if isinstance(payload, dict):
+                if owner is not None and payload.get("_delivered_in_start_prompt_owner") is not owner:
+                    continue
                 payload.pop("_delivered_in_start_prompt", None)
+                payload.pop("_delivered_in_start_prompt_owner", None)
 
     def _snapshot_next_session_context_messages(self) -> list[dict]:
         cache = getattr(self, "next_session_context_messages", None)
@@ -5228,8 +5237,10 @@ class LLMSessionManager:
                 _lang = normalize_language_code(self.user_language, format='short')
                 initial_prompt = await self._build_initial_prompt()
                 next_session_context_messages = self._snapshot_next_session_context_messages()
+                start_prompt_context_owner = object()
                 self._mark_pending_context_appends_delivered_in_start_prompt(
-                    next_session_context_messages
+                    next_session_context_messages,
+                    owner=start_prompt_context_owner,
                 )
 
                 # 等待上面预先发出的 /new_dialog 完成
@@ -5354,7 +5365,7 @@ class LLMSessionManager:
                         concurrent_winner = True
 
                 if concurrent_winner:
-                    self._clear_pending_context_start_prompt_marks()
+                    self._clear_pending_context_start_prompt_marks(owner=start_prompt_context_owner)
                     logger.warning("⚠️ start_llm_session: 检测到并发 start_session 已抢先建立 session，关闭本次 new_session 避免孤儿泄漏")
                     try:
                         await new_session.close()

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1177,7 +1177,29 @@ class LLMSessionManager:
             if seen[oldest_key] >= cutoff:
                 break
             seen.pop(oldest_key, None)
+            entries = getattr(self, "_context_append_durable_cache_entries", None)
+            if isinstance(entries, dict):
+                entries.pop(oldest_key, None)
         return key in seen
+
+    def _context_append_durable_cache_contains(self, payload: Mapping[str, Any]) -> bool:
+        key = self._context_append_durable_cache_key(payload)
+        if key is None:
+            return False
+        entries = getattr(self, "_context_append_durable_cache_entries", None)
+        expected_entry = None
+        if isinstance(entries, dict):
+            expected_entry = entries.get(key)
+        if expected_entry is None:
+            expected_entry = self._context_payload_cache_key(payload)
+        cache = getattr(self, "next_session_context_messages", None)
+        if not isinstance(cache, list):
+            return False
+        return expected_entry in {
+            (str(entry.get("role") or ""), str(entry.get("text") or ""))
+            for entry in cache
+            if isinstance(entry, Mapping)
+        }
 
     def _remember_context_append_durable_cache(self, payload: Mapping[str, Any]) -> None:
         key = self._context_append_durable_cache_key(payload)
@@ -1187,10 +1209,16 @@ class LLMSessionManager:
         if not isinstance(seen, OrderedDict):
             seen = OrderedDict()
             self._context_append_durable_cache_keys = seen
+        entries = getattr(self, "_context_append_durable_cache_entries", None)
+        if not isinstance(entries, dict):
+            entries = {}
+            self._context_append_durable_cache_entries = entries
+        entries[key] = self._context_payload_cache_key(payload)
         seen[key] = time.time()
         seen.move_to_end(key)
         while len(seen) > _CONTEXT_APPEND_DEDUP_MAX_ENTRIES:
-            seen.popitem(last=False)
+            stale_key, _ = seen.popitem(last=False)
+            entries.pop(stale_key, None)
 
     def _forget_context_append_durable_cache(self, payload: Mapping[str, Any]) -> None:
         key = self._context_append_durable_cache_key(payload)
@@ -1199,6 +1227,9 @@ class LLMSessionManager:
         seen = getattr(self, "_context_append_durable_cache_keys", None)
         if isinstance(seen, OrderedDict):
             seen.pop(key, None)
+        entries = getattr(self, "_context_append_durable_cache_entries", None)
+        if isinstance(entries, dict):
+            entries.pop(key, None)
 
     def _promote_context_append_request_id_to_current_session(self, payload: dict) -> None:
         if (
@@ -1439,9 +1470,14 @@ class LLMSessionManager:
         if payload.get("_delivered_in_start_prompt") and lifetime in {"next_session", "session_family"}:
             return ContextAppendResult(appended=True, targets=("start_prompt",))
         if lifetime in {"next_session", "session_family"}:
-            if payload.get("_durable_cached") or self._context_append_durable_cache_seen(payload):
+            durable_cache_remembered = (
+                payload.get("_durable_cached")
+                or self._context_append_durable_cache_seen(payload)
+            )
+            if durable_cache_remembered and self._context_append_durable_cache_contains(payload):
                 targets.append("new_session_cache")
             elif self._append_context_to_new_session_cache(role, content):
+                payload["_durable_cached"] = True
                 self._remember_context_append_durable_cache(payload)
                 targets.append("new_session_cache")
         session = getattr(self, "session", None)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -127,6 +127,10 @@ _CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
     "topic.material": 1000,
     "realtime.prime": 1000,
 }
+_CONTEXT_APPEND_BARE_PRIME_SOURCES = frozenset({
+    "game.realtime_context",
+    "game.postgame",
+})
 
 # recall 占位语音用的合成 worker-sid 后缀。仅用于在 TTS worker 层把 filler 切成
 # 一段独立 utterance（见 _emit_recall_filler_tts）；``send_speech`` 在发往前端前会
@@ -1413,7 +1417,9 @@ class LLMSessionManager:
             prime_context = getattr(session, "prime_context", None)
             if callable(prime_context):
                 try:
-                    await prime_context(f"{role}: {content}", skipped=(audience == "model"))
+                    source = str(payload.get("source") or "")
+                    prime_text = content if source in _CONTEXT_APPEND_BARE_PRIME_SOURCES else f"{role}: {content}"
+                    await prime_context(prime_text, skipped=(audience == "model"))
                     targets.append("realtime_prime")
                     current_session_delivered = True
                 except Exception as exc:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1154,6 +1154,14 @@ class LLMSessionManager:
         while len(seen) > _CONTEXT_APPEND_DEDUP_MAX_ENTRIES:
             seen.popitem(last=False)
 
+    def _forget_context_append_request_id(self, source: str, request_id: str | None) -> None:
+        request_id = str(request_id or "").strip()
+        if not request_id:
+            return
+        seen = getattr(self, "_context_append_request_ids", None)
+        if isinstance(seen, OrderedDict):
+            seen.pop((source, request_id), None)
+
     def _context_append_request_seen(self, source: str, request_id: str | None) -> bool:
         request_id = str(request_id or "").strip()
         if not request_id:
@@ -1250,6 +1258,7 @@ class LLMSessionManager:
                 targets.append("new_session_cache")
         session = getattr(self, "session", None)
         history = getattr(session, "_conversation_history", None)
+        wrote_active_history = False
         if lifetime in {"current_session", "session_family"} and isinstance(history, list):
             if role == "assistant":
                 message = AIMessage(content=content)
@@ -1259,8 +1268,9 @@ class LLMSessionManager:
                 message = HumanMessage(content=f"system: {content}")
             history.append(message)
             targets.append("active_history")
+            wrote_active_history = True
 
-        if lifetime in {"current_session", "session_family"}:
+        if lifetime in {"current_session", "session_family"} and not wrote_active_history:
             prime_context = getattr(session, "prime_context", None)
             if callable(prime_context):
                 await prime_context(f"{role}: {content}", skipped=(audience == "model"))
@@ -1298,6 +1308,9 @@ class LLMSessionManager:
             return ContextAppendResult(appended=False, reason="invalid_context")
         if self._context_append_request_seen(payload["source"], payload["request_id"]):
             return ContextAppendResult(appended=False, deduped=True, reason="duplicate_request_id")
+        reserved_request_id = bool(payload["request_id"])
+        if reserved_request_id:
+            self._remember_context_append_request_id(payload["source"], payload["request_id"])
 
         pending_needed = (
             payload["timing"] == "when_ready"
@@ -1315,12 +1328,16 @@ class LLMSessionManager:
             self._context_append_sequence = sequence + 1
             payload["_sequence"] = sequence
             pending.append(payload)
-            self._remember_context_append_request_id(payload["source"], payload["request_id"])
             return ContextAppendResult(appended=True, targets=("pending_ready",))
 
-        result = await self._append_context_to_targets(payload)
-        if result.appended:
-            self._remember_context_append_request_id(payload["source"], payload["request_id"])
+        try:
+            result = await self._append_context_to_targets(payload)
+        except Exception:
+            if reserved_request_id:
+                self._forget_context_append_request_id(payload["source"], payload["request_id"])
+            raise
+        if not result.appended and reserved_request_id:
+            self._forget_context_append_request_id(payload["source"], payload["request_id"])
         return result
 
     async def _flush_pending_context_appends(self) -> None:
@@ -5212,11 +5229,11 @@ class LLMSessionManager:
                 # 通知前端 session 已成功启动
                 await self.send_session_started(input_mode)
 
-                # 标记session为就绪状态并处理可能已缓存的输入数据
+                # 在 queued context 写入 session 前保持输入闸门关闭；否则第一条
+                # 缓存/并发用户输入可能抢在上下文前面进入模型。
                 async with self.input_cache_lock:
+                    await self._flush_pending_context_appends()
                     self.session_ready = True
-
-                await self._flush_pending_context_appends()
 
                 # 处理在session启动期间可能已经缓存的输入数据
                 await self._flush_pending_input_data()

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1009,6 +1009,7 @@ class LLMSessionManager:
         self.pending_context_appends: list[dict] = []
         self._context_append_sequence = 0
         self._context_append_request_ids: OrderedDict[tuple[Any, ...], float] = OrderedDict()
+        self._context_append_inflight_results: dict[tuple[Any, ...], asyncio.Future[ContextAppendResult]] = {}
         self.input_cache_lock = asyncio.Lock()  # 保护输入缓存的锁
         
         # 热切换音频缓存机制：确保热切换期间的用户输入语音不丢失
@@ -1518,11 +1519,31 @@ class LLMSessionManager:
         )
         if pending_needed and payload["lifetime"] == "current_session":
             payload["_dedup_pending_ready"] = True
+        request_key = self._context_append_request_key(payload)
         if self._context_append_request_seen(payload):
+            inflight = getattr(self, "_context_append_inflight_results", None)
+            if isinstance(inflight, dict) and request_key in inflight:
+                original_result = await asyncio.shield(inflight[request_key])
+                if original_result.appended:
+                    return ContextAppendResult(
+                        appended=False,
+                        deduped=True,
+                        targets=original_result.targets,
+                        reason="duplicate_request_id",
+                    )
+                return original_result
             return ContextAppendResult(appended=False, deduped=True, reason="duplicate_request_id")
         reserved_request_id = bool(payload["request_id"])
+        inflight_result: asyncio.Future[ContextAppendResult] | None = None
         if reserved_request_id:
             self._remember_context_append_request_id(payload)
+            if request_key is not None:
+                inflight = getattr(self, "_context_append_inflight_results", None)
+                if not isinstance(inflight, dict):
+                    inflight = {}
+                    self._context_append_inflight_results = inflight
+                inflight_result = asyncio.get_running_loop().create_future()
+                inflight[request_key] = inflight_result
 
         if pending_needed:
             if payload["lifetime"] in {"next_session", "session_family"}:
@@ -1541,16 +1562,38 @@ class LLMSessionManager:
             payload["_sequence"] = sequence
             payload["_pending_ready"] = True
             pending.append(payload)
-            return ContextAppendResult(appended=True, targets=("pending_ready",))
+            result = ContextAppendResult(appended=True, targets=("pending_ready",))
+            if inflight_result is not None and not inflight_result.done():
+                inflight_result.set_result(result)
+            if request_key is not None:
+                inflight = getattr(self, "_context_append_inflight_results", None)
+                if isinstance(inflight, dict):
+                    inflight.pop(request_key, None)
+            return result
 
         try:
             result = await self._append_context_to_targets(payload)
         except Exception:
             if reserved_request_id:
                 self._forget_context_append_request_id(payload)
+            if inflight_result is not None and not inflight_result.done():
+                inflight_result.set_result(ContextAppendResult(
+                    appended=False,
+                    reason="context_inject_failed",
+                ))
+            if request_key is not None:
+                inflight = getattr(self, "_context_append_inflight_results", None)
+                if isinstance(inflight, dict):
+                    inflight.pop(request_key, None)
             raise
         if not result.appended and reserved_request_id:
             self._forget_context_append_request_id(payload)
+        if inflight_result is not None and not inflight_result.done():
+            inflight_result.set_result(result)
+        if request_key is not None:
+            inflight = getattr(self, "_context_append_inflight_results", None)
+            if isinstance(inflight, dict):
+                inflight.pop(request_key, None)
         return result
 
     async def _flush_pending_context_appends(self) -> int:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1010,6 +1010,7 @@ class LLMSessionManager:
         self._context_append_sequence = 0
         self._context_append_request_ids: OrderedDict[tuple[Any, ...], float] = OrderedDict()
         self._context_append_inflight_results: dict[tuple[Any, ...], asyncio.Future[ContextAppendResult]] = {}
+        self._require_context_append_current_delivery = False
         self.input_cache_lock = asyncio.Lock()  # 保护输入缓存的锁
         
         # 热切换音频缓存机制：确保热切换期间的用户输入语音不丢失
@@ -1515,7 +1516,10 @@ class LLMSessionManager:
 
         current_session_delivery_required = (
             current_session_required
-            and not bool(getattr(self, "is_preparing_new_session", False))
+            and (
+                not bool(getattr(self, "is_preparing_new_session", False))
+                or bool(getattr(self, "_require_context_append_current_delivery", False))
+            )
         )
         if current_session_delivery_required and not current_session_delivered:
             return ContextAppendResult(
@@ -4248,6 +4252,7 @@ class LLMSessionManager:
         before clearing references — prevents >2 concurrent OmniRealtimeClient.
         """
         self.is_preparing_new_session = False
+        self._require_context_append_current_delivery = False
         self.summary_triggered_time = None
         self.initial_cache_snapshot_len = 0
         
@@ -8390,6 +8395,7 @@ class LLMSessionManager:
             # 旧 listener 已停、旧 session 已关，现在切换 self.session；
             # 此后旧 task 的任何回调若再执行也已看不到旧 ws。
             self.session = new_session
+            self._require_context_append_current_delivery = True
             next_context_count_at_promote = len(self._snapshot_next_session_context_messages())
             await self._apply_pending_tts_route_after_swap()
             self.current_speech_id = str(uuid4())

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1241,11 +1241,12 @@ class LLMSessionManager:
         if not isinstance(cache, list):
             cache = []
             self.next_session_context_messages = cache
-        speaker = (
-            getattr(self, "master_name", "user")
-            if role == "user"
-            else getattr(self, "lanlan_name", "assistant")
-        )
+        if role == "user":
+            speaker = getattr(self, "master_name", "user")
+        elif role == "assistant":
+            speaker = getattr(self, "lanlan_name", "assistant")
+        else:
+            speaker = "system"
         cache.append({"role": speaker, "text": text})
         return True
 
@@ -1261,6 +1262,31 @@ class LLMSessionManager:
         cache = getattr(self, "next_session_context_messages", None)
         if isinstance(cache, list):
             del cache[:count]
+
+    async def _prime_late_next_session_context_after_swap(self, start_index: int) -> int:
+        consumed_count = max(0, start_index)
+        session = getattr(self, "session", None)
+        prime_context = getattr(session, "prime_context", None)
+        if not callable(prime_context):
+            return consumed_count
+
+        for _ in range(_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES):
+            snapshot = self._snapshot_next_session_context_messages()
+            late_context = snapshot[consumed_count:]
+            if not late_context:
+                break
+            try:
+                await prime_context(self._convert_cache_to_str(late_context), skipped=True)
+            except (web_exceptions.ConnectionClosed, AttributeError) as exc:
+                logger.warning(
+                    "[%s] final-swap late next-session context prime failed: %s",
+                    self.lanlan_name,
+                    exc,
+                )
+                break
+            consumed_count += len(late_context)
+
+        return consumed_count
 
     async def _append_context_to_targets(self, payload: dict) -> ContextAppendResult:
         role = payload["role"]
@@ -8108,7 +8134,10 @@ class LLMSessionManager:
                 self.initial_next_session_context_snapshot_len
                 + len(incremental_next_session_context)
             )
-            self._consume_next_session_context_messages(transferred_next_context_count)
+            consumed_next_context_count = await self._prime_late_next_session_context_after_swap(
+                transferred_next_context_count
+            )
+            self._consume_next_session_context_messages(consumed_next_context_count)
 
             # Reset all preparation states and clear the *main* cache now that it's fully transferred
             # pending_session已在swap后立即清除，这里只需要重置其他状态

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1422,11 +1422,11 @@ class LLMSessionManager:
             else:
                 current_session_failed_reason = "no_current_session_target"
 
-        if (
-            payload.get("_pending_ready")
-            and current_session_required
-            and not current_session_delivered
-        ):
+        current_session_delivery_required = (
+            current_session_required
+            and not bool(getattr(self, "is_preparing_new_session", False))
+        )
+        if current_session_delivery_required and not current_session_delivered:
             return ContextAppendResult(
                 appended=False,
                 targets=tuple(targets),

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1250,6 +1250,19 @@ class LLMSessionManager:
         cache.append({"role": speaker, "text": text})
         return True
 
+    def _snapshot_next_session_context_messages(self) -> list[dict]:
+        cache = getattr(self, "next_session_context_messages", None)
+        if not isinstance(cache, list) or not cache:
+            return []
+        return list(cache)
+
+    def _consume_next_session_context_messages(self, count: int) -> None:
+        if count <= 0:
+            return
+        cache = getattr(self, "next_session_context_messages", None)
+        if isinstance(cache, list):
+            del cache[:count]
+
     async def _append_context_to_targets(self, payload: dict) -> ContextAppendResult:
         role = payload["role"]
         content = payload["text"]
@@ -5069,11 +5082,16 @@ class LLMSessionManager:
                 guard_max_length = self._get_text_guard_max_length()
                 _lang = normalize_language_code(self.user_language, format='short')
                 initial_prompt = await self._build_initial_prompt()
+                next_session_context_messages = self._snapshot_next_session_context_messages()
 
                 # 等待上面预先发出的 /new_dialog 完成
                 try:
                     _nd_text = await _new_dialog_task
-                    initial_prompt += _nd_text + _loc(CONTEXT_SUMMARY_READY, _lang).format(name=self.lanlan_name, master=self.master_name)
+                    initial_prompt += (
+                        _nd_text
+                        + self._convert_cache_to_str(next_session_context_messages)
+                        + _loc(CONTEXT_SUMMARY_READY, _lang).format(name=self.lanlan_name, master=self.master_name)
+                    )
                     logger.info(f"[语音会话诊断] 记忆上下文获取完成 (耗时: {time.time() - _mem_start:.2f}秒)")
                 except ConnectionError:
                     raise
@@ -5183,6 +5201,7 @@ class LLMSessionManager:
                         self.session = new_session
                         if not self.current_speech_id:
                             self.current_speech_id = str(uuid4())
+                        self._consume_next_session_context_messages(len(next_session_context_messages))
                     else:
                         concurrent_winner = True
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1154,6 +1154,43 @@ class LLMSessionManager:
             return (source, request_id, lifetime, session_id)
         return (source, request_id, lifetime)
 
+    def _context_append_durable_cache_key(self, payload: Mapping[str, Any]) -> tuple[Any, ...] | None:
+        request_id = str(payload.get("request_id") or "").strip()
+        lifetime = str(payload.get("lifetime") or "").strip().lower()
+        if not request_id or lifetime not in {"next_session", "session_family"}:
+            return None
+        source = str(payload.get("source") or "").strip()
+        return (source, request_id, lifetime)
+
+    def _context_append_durable_cache_seen(self, payload: Mapping[str, Any]) -> bool:
+        key = self._context_append_durable_cache_key(payload)
+        if key is None:
+            return False
+        seen = getattr(self, "_context_append_durable_cache_keys", None)
+        if not isinstance(seen, OrderedDict):
+            return False
+        now = time.time()
+        cutoff = now - _CONTEXT_APPEND_DEDUP_TTL_SECONDS
+        while seen:
+            oldest_key = next(iter(seen))
+            if seen[oldest_key] >= cutoff:
+                break
+            seen.pop(oldest_key, None)
+        return key in seen
+
+    def _remember_context_append_durable_cache(self, payload: Mapping[str, Any]) -> None:
+        key = self._context_append_durable_cache_key(payload)
+        if key is None:
+            return
+        seen = getattr(self, "_context_append_durable_cache_keys", None)
+        if not isinstance(seen, OrderedDict):
+            seen = OrderedDict()
+            self._context_append_durable_cache_keys = seen
+        seen[key] = time.time()
+        seen.move_to_end(key)
+        while len(seen) > _CONTEXT_APPEND_DEDUP_MAX_ENTRIES:
+            seen.popitem(last=False)
+
     def _promote_context_append_request_id_to_current_session(self, payload: dict) -> None:
         if (
             str(payload.get("lifetime") or "").strip().lower() != "current_session"
@@ -1391,9 +1428,10 @@ class LLMSessionManager:
         if payload.get("_delivered_in_start_prompt") and lifetime in {"next_session", "session_family"}:
             return ContextAppendResult(appended=True, targets=("start_prompt",))
         if lifetime in {"next_session", "session_family"}:
-            if payload.get("_durable_cached"):
+            if payload.get("_durable_cached") or self._context_append_durable_cache_seen(payload):
                 targets.append("new_session_cache")
             elif self._append_context_to_new_session_cache(role, content):
+                self._remember_context_append_durable_cache(payload)
                 targets.append("new_session_cache")
         session = getattr(self, "session", None)
         history = getattr(session, "_conversation_history", None)
@@ -1490,6 +1528,8 @@ class LLMSessionManager:
                     payload["role"],
                     payload["text"],
                 )
+                if payload["_durable_cached"]:
+                    self._remember_context_append_durable_cache(payload)
             pending = getattr(self, "pending_context_appends", None)
             if not isinstance(pending, list):
                 pending = []

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -8121,15 +8121,6 @@ class LLMSessionManager:
                 # 旧session已关闭无法回滚，抛出异常让 except 块走重建流程
                 raise RuntimeError("新session的WebSocket在swap后已失效，热切换失败")
 
-            # ── 步骤 4：启动新 listener ───────────────────────────────────────────
-            if self.session and hasattr(self.session, 'handle_messages'):
-                self.message_handler_task = asyncio.create_task(self.session.handle_messages())
-
-            # ── 步骤 5：flush 热切换音频缓存到新 session ─────────────────────────
-            # 必须在 promote 之后调用：_flush_hot_swap_audio_cache 使用 self.session
-            # 发送音频，此时 self.session 已是新 session，音频会正确发往新会话。
-            await self._flush_hot_swap_audio_cache()
-
             transferred_next_context_count = (
                 self.initial_next_session_context_snapshot_len
                 + len(incremental_next_session_context)
@@ -8138,6 +8129,15 @@ class LLMSessionManager:
                 transferred_next_context_count
             )
             self._consume_next_session_context_messages(consumed_next_context_count)
+
+            # ── 步骤 4：启动新 listener ───────────────────────────────────────────
+            if self.session and hasattr(self.session, 'handle_messages'):
+                self.message_handler_task = asyncio.create_task(self.session.handle_messages())
+
+            # ── 步骤 5：flush 热切换音频缓存到新 session ─────────────────────────
+            # 必须在 promote 之后调用：_flush_hot_swap_audio_cache 使用 self.session
+            # 发送音频，此时 self.session 已是新 session，音频会正确发往新会话。
+            await self._flush_hot_swap_audio_cache()
 
             # Reset all preparation states and clear the *main* cache now that it's fully transferred
             # pending_session已在swap后立即清除，这里只需要重置其他状态

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1386,6 +1386,13 @@ class LLMSessionManager:
         if isinstance(pending, list) and pending:
             print(f"[{self.lanlan_name}] context append ready drain left {len(pending)} pending item(s)")
 
+    def _clear_pending_context_appends(self) -> None:
+        pending = getattr(self, "pending_context_appends", None)
+        if isinstance(pending, list):
+            pending.clear()
+        else:
+            self.pending_context_appends = []
+
     def is_goodbye_silent(self) -> bool:
         """Whether cat-mode silence after being asked to leave is in effect."""
         return bool(getattr(self, "goodbye_silent", False))
@@ -5209,6 +5216,7 @@ class LLMSessionManager:
                 # 清空输入缓存（新对话时不需要保留旧的输入）
                 async with self.input_cache_lock:
                     self.pending_input_data.clear()
+                    self._clear_pending_context_appends()
 
             # 并行启动 TTS 和 LLM Session
             logger.info("🚀 并行启动 TTS 和 LLM Session...")
@@ -8684,6 +8692,7 @@ class LLMSessionManager:
                 async with self.input_cache_lock:
                     self.session_ready = False
                     self.pending_input_data.clear()
+                    self._clear_pending_context_appends()
                 async with self.lock:
                     if expected_session is None or expected_session is self.session:
                         self._starting_session_count = 0
@@ -8780,6 +8789,7 @@ class LLMSessionManager:
         async with self.input_cache_lock:
             self.session_ready = False
             self.pending_input_data.clear()
+            self._clear_pending_context_appends()
 
         self.last_time = None
         if not by_server:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1403,7 +1403,7 @@ class LLMSessionManager:
                     await prime_context(f"{role}: {content}", skipped=(audience == "model"))
                     targets.append("realtime_prime")
                 except Exception as exc:
-                    print(f"[{self.lanlan_name}] context append realtime_prime failed: {exc}")
+                    logger.warning("[%s] context append realtime_prime failed: %s", self.lanlan_name, exc)
 
         if not targets:
             return ContextAppendResult(appended=False, reason="no_context_target")
@@ -1497,7 +1497,7 @@ class LLMSessionManager:
                     flushed += 1
             except Exception as exc:
                 retry.append(payload)
-                print(f"[{self.lanlan_name}] context append flush failed: {exc}")
+                logger.warning("[%s] context append flush failed: %s", self.lanlan_name, exc)
         if retry:
             self.pending_context_appends = retry + self.pending_context_appends
         return flushed
@@ -1517,7 +1517,11 @@ class LLMSessionManager:
                 return
         pending = getattr(self, "pending_context_appends", None)
         if isinstance(pending, list) and pending:
-            print(f"[{self.lanlan_name}] context append ready drain left {len(pending)} pending item(s)")
+            logger.warning(
+                "[%s] context append ready drain left %d pending item(s)",
+                self.lanlan_name,
+                len(pending),
+            )
 
     def _clear_pending_context_appends(self) -> None:
         pending = getattr(self, "pending_context_appends", None)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1389,9 +1389,17 @@ class LLMSessionManager:
     def _clear_pending_context_appends(self) -> None:
         pending = getattr(self, "pending_context_appends", None)
         if isinstance(pending, list):
+            stale_payloads = list(pending)
             pending.clear()
         else:
+            stale_payloads = []
             self.pending_context_appends = []
+        for payload in stale_payloads:
+            if isinstance(payload, dict) and payload.get("request_id"):
+                self._forget_context_append_request_id(
+                    payload.get("source", ""),
+                    payload.get("request_id", ""),
+                )
 
     def is_goodbye_silent(self) -> bool:
         """Whether cat-mode silence after being asked to leave is in effect."""

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1385,6 +1385,9 @@ class LLMSessionManager:
         session = getattr(self, "session", None)
         history = getattr(session, "_conversation_history", None)
         wrote_active_history = False
+        current_session_required = lifetime in {"current_session", "session_family"}
+        current_session_delivered = False
+        current_session_failed_reason: str | None = None
         if lifetime in {"current_session", "session_family"} and isinstance(history, list):
             if role == "assistant":
                 message = AIMessage(content=content)
@@ -1395,6 +1398,7 @@ class LLMSessionManager:
             history.append(message)
             targets.append("active_history")
             wrote_active_history = True
+            current_session_delivered = True
 
         if lifetime in {"current_session", "session_family"} and not wrote_active_history:
             prime_context = getattr(session, "prime_context", None)
@@ -1402,8 +1406,23 @@ class LLMSessionManager:
                 try:
                     await prime_context(f"{role}: {content}", skipped=(audience == "model"))
                     targets.append("realtime_prime")
+                    current_session_delivered = True
                 except Exception as exc:
+                    current_session_failed_reason = "realtime_prime_failed"
                     logger.warning("[%s] context append realtime_prime failed: %s", self.lanlan_name, exc)
+            else:
+                current_session_failed_reason = "no_current_session_target"
+
+        if (
+            payload.get("_pending_ready")
+            and current_session_required
+            and not current_session_delivered
+        ):
+            return ContextAppendResult(
+                appended=False,
+                targets=tuple(targets),
+                reason=current_session_failed_reason or "current_session_target_unavailable",
+            )
 
         if not targets:
             return ContextAppendResult(appended=False, reason="no_context_target")
@@ -1463,6 +1482,7 @@ class LLMSessionManager:
             sequence = int(getattr(self, "_context_append_sequence", 0))
             self._context_append_sequence = sequence + 1
             payload["_sequence"] = sequence
+            payload["_pending_ready"] = True
             pending.append(payload)
             return ContextAppendResult(appended=True, targets=("pending_ready",))
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1192,6 +1192,14 @@ class LLMSessionManager:
         while len(seen) > _CONTEXT_APPEND_DEDUP_MAX_ENTRIES:
             seen.popitem(last=False)
 
+    def _forget_context_append_durable_cache(self, payload: Mapping[str, Any]) -> None:
+        key = self._context_append_durable_cache_key(payload)
+        if key is None:
+            return
+        seen = getattr(self, "_context_append_durable_cache_keys", None)
+        if isinstance(seen, OrderedDict):
+            seen.pop(key, None)
+
     def _promote_context_append_request_id_to_current_session(self, payload: dict) -> None:
         if (
             str(payload.get("lifetime") or "").strip().lower() != "current_session"
@@ -1656,7 +1664,7 @@ class LLMSessionManager:
                 len(pending),
             )
 
-    def _clear_pending_context_appends(self) -> None:
+    def _clear_pending_context_appends(self, *, release_durable_cached: bool = False) -> None:
         pending = getattr(self, "pending_context_appends", None)
         if isinstance(pending, list):
             stale_payloads = list(pending)
@@ -1668,9 +1676,11 @@ class LLMSessionManager:
             if (
                 isinstance(payload, dict)
                 and payload.get("request_id")
-                and not payload.get("_durable_cached")
+                and (release_durable_cached or not payload.get("_durable_cached"))
             ):
                 self._forget_context_append_request_id(payload)
+                if release_durable_cached:
+                    self._forget_context_append_durable_cache(payload)
 
     def is_goodbye_silent(self) -> bool:
         """Whether cat-mode silence after being asked to leave is in effect."""
@@ -5507,7 +5517,7 @@ class LLMSessionManager:
                 # 清空输入缓存（新对话时不需要保留旧的输入）
                 async with self.input_cache_lock:
                     self.pending_input_data.clear()
-                    self._clear_pending_context_appends()
+                    self._clear_pending_context_appends(release_durable_cached=True)
 
             # 并行启动 TTS 和 LLM Session
             logger.info("🚀 并行启动 TTS 和 LLM Session...")

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -24,11 +24,12 @@ import os
 import struct  # For packing audio data
 import re
 import time
-from collections import deque
+from collections import OrderedDict, deque
+from dataclasses import dataclass
 from difflib import SequenceMatcher
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Mapping, Optional
 
 
 # Sentinel for `send_lanlan_response(request_id=...)` so we can tell apart
@@ -41,6 +42,20 @@ _MAGIC_COMMAND_IMAGE_DROP_REQUEST_MAX = 64
 _VOICE_PROACTIVE_ACK_GRACE_S = 0.05
 _TEXT_SESSION_INPUT_TYPES = frozenset({"text", "avatar_drop_image", "user_image"})
 _IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
+_CONTEXT_APPEND_DEDUP_TTL_SECONDS = 120.0
+_CONTEXT_APPEND_DEDUP_MAX_ENTRIES = 256
+_CONTEXT_APPEND_DEFAULT_MAX_TOKENS = 1000
+_CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
+    "game.icebreaker": 500,
+    "game.scripted": 1000,
+    "game.realtime_context": 1000,
+    "game.postgame": 1500,
+    "proactive.context": 1000,
+    "proactive.callback": 1000,
+    "topic.hook": 1000,
+    "topic.material": 1000,
+    "realtime.prime": 1000,
+}
 from datetime import datetime
 from websockets import exceptions as web_exceptions
 from fastapi import WebSocket, WebSocketDisconnect
@@ -761,6 +776,14 @@ def enqueue_voice_migration_notice(legacy_names: list) -> None:
 _START_LLM_CONCURRENT_ABORTED = object()
 
 
+@dataclass(frozen=True)
+class ContextAppendResult:
+    appended: bool
+    deduped: bool = False
+    targets: tuple[str, ...] = ()
+    reason: str | None = None
+
+
 # --- 一个带有定期上下文压缩+在线热切换的语音会话管理器 ---
 class LLMSessionManager:
     def __init__(self, sync_message_queue, lanlan_name, lanlan_prompt):
@@ -977,6 +1000,9 @@ class LLMSessionManager:
         # 输入数据缓存机制：确保session初始化期间的输入不丢失
         self.session_ready = False  # Session是否完全就绪
         self.pending_input_data = []  # 待处理的输入数据: [message_dict, ...]
+        self.pending_context_appends: list[dict] = []
+        self._context_append_sequence = 0
+        self._context_append_request_ids: OrderedDict[tuple[str, str], float] = OrderedDict()
         self.input_cache_lock = asyncio.Lock()  # 保护输入缓存的锁
         
         # 热切换音频缓存机制：确保热切换期间的用户输入语音不丢失
@@ -1107,9 +1133,100 @@ class LLMSessionManager:
         task.add_done_callback(self._bg_tasks.discard)
         return task
 
-    def _append_icebreaker_context_to_new_session_cache(self, role: str, text: str) -> None:
-        if not getattr(self, "is_preparing_new_session", False):
+    def _remember_context_append_request_id(self, source: str, request_id: str) -> None:
+        request_id = str(request_id or "").strip()
+        if not request_id:
             return
+        seen = getattr(self, "_context_append_request_ids", None)
+        if not isinstance(seen, OrderedDict):
+            seen = OrderedDict()
+            self._context_append_request_ids = seen
+        now = time.time()
+        cutoff = now - _CONTEXT_APPEND_DEDUP_TTL_SECONDS
+        while seen:
+            oldest_key = next(iter(seen))
+            if seen[oldest_key] >= cutoff:
+                break
+            seen.pop(oldest_key, None)
+        key = (source, request_id)
+        seen[key] = now
+        seen.move_to_end(key)
+        while len(seen) > _CONTEXT_APPEND_DEDUP_MAX_ENTRIES:
+            seen.popitem(last=False)
+
+    def _context_append_request_seen(self, source: str, request_id: str | None) -> bool:
+        request_id = str(request_id or "").strip()
+        if not request_id:
+            return False
+        seen = getattr(self, "_context_append_request_ids", None)
+        if not isinstance(seen, OrderedDict):
+            return False
+        now = time.time()
+        cutoff = now - _CONTEXT_APPEND_DEDUP_TTL_SECONDS
+        while seen:
+            oldest_key = next(iter(seen))
+            if seen[oldest_key] >= cutoff:
+                break
+            seen.pop(oldest_key, None)
+        return (source, request_id) in seen
+
+    def _normalize_context_append(
+        self,
+        *,
+        source: str,
+        role: str,
+        text: str,
+        audience: str,
+        timing: str,
+        lifetime: str,
+        request_id: str | None,
+        ordering_key: str | None,
+        metadata: Mapping[str, Any] | None,
+    ) -> dict | None:
+        normalized_source = str(source or "").strip()
+        normalized_role = str(role or "").strip().lower()
+        normalized_audience = str(audience or "").strip().lower()
+        normalized_timing = str(timing or "").strip().lower()
+        normalized_lifetime = str(lifetime or "").strip().lower()
+        if (
+            not normalized_source
+            or normalized_role not in {"assistant", "user", "system"}
+            or normalized_audience not in {"model", "user_and_model"}
+            or normalized_timing not in {"now", "when_ready"}
+            or normalized_lifetime not in {"current_session", "next_session", "session_family"}
+        ):
+            return None
+        content = self._normalize_context_text_for_source(normalized_source, text)
+        if not content:
+            return None
+        safe_metadata = dict(metadata or {}) if isinstance(metadata, Mapping) else {}
+        return {
+            "source": normalized_source,
+            "role": normalized_role,
+            "text": content,
+            "audience": normalized_audience,
+            "timing": normalized_timing,
+            "lifetime": normalized_lifetime,
+            "request_id": str(request_id or "").strip(),
+            "ordering_key": str(ordering_key or "").strip(),
+            "metadata": safe_metadata,
+        }
+
+    def _normalize_context_text_for_source(self, source: str, text: Any) -> str:
+        content = str(text or "").strip()
+        if not content:
+            return ""
+        max_tokens = _CONTEXT_APPEND_SOURCE_MAX_TOKENS.get(
+            str(source or "").strip(),
+            _CONTEXT_APPEND_DEFAULT_MAX_TOKENS,
+        )
+        try:
+            from utils.tokenize import truncate_to_tokens
+            return truncate_to_tokens(content[: max(max_tokens * 8, max_tokens)], max_tokens).strip()
+        except Exception:
+            return content[: max(max_tokens * 8, max_tokens)].strip()
+
+    def _append_context_to_new_session_cache(self, role: str, text: str) -> bool:
         cache = getattr(self, "message_cache_for_new_session", None)
         if not isinstance(cache, list):
             cache = []
@@ -1120,28 +1237,106 @@ class LLMSessionManager:
             else getattr(self, "lanlan_name", "assistant")
         )
         cache.append({"role": speaker, "text": text})
+        return True
 
-    async def append_icebreaker_context_async(self, role: str, text: str) -> bool:
-        """Append icebreaker turns through the existing conversation/cache path."""
-        normalized_role = str(role or "").strip().lower()
-        content = str(text or "").strip()
-        if normalized_role not in {"assistant", "user"} or not content:
-            return False
-        self._append_icebreaker_context_to_new_session_cache(normalized_role, content)
-
+    async def _append_context_to_targets(self, payload: dict) -> ContextAppendResult:
+        role = payload["role"]
+        content = payload["text"]
+        audience = payload["audience"]
+        lifetime = payload["lifetime"]
+        targets: list[str] = []
+        if lifetime in {"next_session", "session_family"}:
+            if self._append_context_to_new_session_cache(role, content):
+                targets.append("new_session_cache")
         session = getattr(self, "session", None)
         history = getattr(session, "_conversation_history", None)
-        if isinstance(history, list):
-            message = AIMessage(content=content) if normalized_role == "assistant" else HumanMessage(content=content)
+        if lifetime in {"current_session", "session_family"} and isinstance(history, list):
+            if role == "assistant":
+                message = AIMessage(content=content)
+            elif role == "user":
+                message = HumanMessage(content=content)
+            else:
+                message = HumanMessage(content=f"system: {content}")
             history.append(message)
-            return True
+            targets.append("active_history")
 
-        prime_context = getattr(session, "prime_context", None)
-        if callable(prime_context):
-            await prime_context(f"{normalized_role}: {content}", skipped=True)
-            return True
+        if lifetime in {"current_session", "session_family"}:
+            prime_context = getattr(session, "prime_context", None)
+            if callable(prime_context):
+                await prime_context(f"{role}: {content}", skipped=(audience == "model"))
+                targets.append("realtime_prime")
 
-        return bool(getattr(self, "is_preparing_new_session", False))
+        if not targets:
+            return ContextAppendResult(appended=False, reason="no_context_target")
+        return ContextAppendResult(appended=True, targets=tuple(targets))
+
+    async def append_context(
+        self,
+        *,
+        source: str,
+        role: str,
+        text: str,
+        audience: str = "model",
+        timing: str = "now",
+        lifetime: str = "current_session",
+        request_id: str | None = None,
+        ordering_key: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> ContextAppendResult:
+        payload = self._normalize_context_append(
+            source=source,
+            role=role,
+            text=text,
+            audience=audience,
+            timing=timing,
+            lifetime=lifetime,
+            request_id=request_id,
+            ordering_key=ordering_key,
+            metadata=metadata,
+        )
+        if payload is None:
+            return ContextAppendResult(appended=False, reason="invalid_context")
+        if self._context_append_request_seen(payload["source"], payload["request_id"]):
+            return ContextAppendResult(appended=False, deduped=True, reason="duplicate_request_id")
+
+        pending_needed = (
+            payload["timing"] == "when_ready"
+            and (
+                not bool(getattr(self, "session_ready", False))
+                or getattr(self, "session", None) is None
+            )
+        )
+        if pending_needed:
+            pending = getattr(self, "pending_context_appends", None)
+            if not isinstance(pending, list):
+                pending = []
+                self.pending_context_appends = pending
+            sequence = int(getattr(self, "_context_append_sequence", 0))
+            self._context_append_sequence = sequence + 1
+            payload["_sequence"] = sequence
+            pending.append(payload)
+            self._remember_context_append_request_id(payload["source"], payload["request_id"])
+            return ContextAppendResult(appended=True, targets=("pending_ready",))
+
+        result = await self._append_context_to_targets(payload)
+        if result.appended:
+            self._remember_context_append_request_id(payload["source"], payload["request_id"])
+        return result
+
+    async def _flush_pending_context_appends(self) -> None:
+        pending = getattr(self, "pending_context_appends", None)
+        if not isinstance(pending, list) or not pending:
+            return
+        self.pending_context_appends = []
+        pending.sort(key=lambda payload: (
+            payload.get("ordering_key") or f"~{int(payload.get('_sequence', 0)):020d}",
+            int(payload.get("_sequence", 0)),
+        ))
+        for payload in pending:
+            try:
+                await self._append_context_to_targets(payload)
+            except Exception as exc:
+                print(f"[{self.lanlan_name}] context append flush failed: {exc}")
 
     def is_goodbye_silent(self) -> bool:
         """Whether cat-mode silence after being asked to leave is in effect."""
@@ -5021,6 +5216,8 @@ class LLMSessionManager:
                 async with self.input_cache_lock:
                     self.session_ready = True
 
+                await self._flush_pending_context_appends()
+
                 # 处理在session启动期间可能已经缓存的输入数据
                 await self._flush_pending_input_data()
 
@@ -7494,31 +7691,22 @@ class LLMSessionManager:
         hot-swap fire at different lifecycle points).
         """
         try:
-            from utils.tokenize import truncate_to_tokens
             from config import (
-                AGENT_CALLBACK_TEXT_MAX_TOKENS,
                 AGENT_CALLBACK_QUEUE_MAX_ITEMS,
             )
-            # Per-item input budget: summary/detail flow into the LLM verbatim
-            # (text-mode drain + voice hot-swap). task_result callbacks are
-            # already TASK_*-capped upstream, but push_message/proactive_message
-            # text is aggregated uncapped by proactive_bridge — cap it here, the
-            # single chokepoint both queues pass through.
-            #
-            # Cheap CHAR pre-cap BEFORE tokenizing: a malformed/huge plugin
-            # message must not make tiktoken encode megabytes synchronously on
-            # the event loop. 8x headroom over the token budget is safe for any
-            # language (English ~4 char/token, CJK <1), so the char cut never
-            # removes content the token cap would have kept.
-            _char_precap = AGENT_CALLBACK_TEXT_MAX_TOKENS * 8
-            summary_raw = str(callback.get("summary") or "").strip()[:_char_precap]
-            detail_raw = str(callback.get("detail") or "").strip()[:_char_precap]
-            summary = truncate_to_tokens(summary_raw, AGENT_CALLBACK_TEXT_MAX_TOKENS)
+            context_source = "topic.hook" if callback.get("channel") == "topic_hook" else "proactive.callback"
+            # Per-item input budget: summary/detail flow into the LLM verbatim.
+            # Reuse the same source-policy normalizer as append_context() so
+            # proactive/topic callbacks do not grow a parallel budget path.
+            summary_raw = str(callback.get("summary") or "").strip()
+            detail_raw = str(callback.get("detail") or "").strip()
+            summary = self._normalize_context_text_for_source(context_source, summary_raw)
             # summary/detail frequently carry the SAME body (proactive_bridge
             # sets both to the aggregated text) — reuse the encode, don't do it
             # twice.
-            detail = summary if detail_raw == summary_raw else truncate_to_tokens(
-                detail_raw, AGENT_CALLBACK_TEXT_MAX_TOKENS
+            detail = summary if detail_raw == summary_raw else self._normalize_context_text_for_source(
+                context_source,
+                detail_raw,
             )
             # Write the capped text back so the text-mode drain (which reads the
             # callback dict directly) injects the truncated body too.
@@ -7561,6 +7749,7 @@ class LLMSessionManager:
                 "summary": summary,
                 "detail": detail,
                 "status": status,
+                "context_source": context_source,
                 "source_kind": callback.get("source_kind") or "unknown",
                 "source_name": source_name,
                 "error_message": error_message,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1004,7 +1004,7 @@ class LLMSessionManager:
         self.pending_input_data = []  # 待处理的输入数据: [message_dict, ...]
         self.pending_context_appends: list[dict] = []
         self._context_append_sequence = 0
-        self._context_append_request_ids: OrderedDict[tuple[str, str], float] = OrderedDict()
+        self._context_append_request_ids: OrderedDict[tuple[Any, ...], float] = OrderedDict()
         self.input_cache_lock = asyncio.Lock()  # 保护输入缓存的锁
         
         # 热切换音频缓存机制：确保热切换期间的用户输入语音不丢失
@@ -1135,9 +1135,45 @@ class LLMSessionManager:
         task.add_done_callback(self._bg_tasks.discard)
         return task
 
-    def _remember_context_append_request_id(self, source: str, request_id: str) -> None:
-        request_id = str(request_id or "").strip()
+    def _context_append_request_key(self, payload: Mapping[str, Any]) -> tuple[Any, ...] | None:
+        request_id = str(payload.get("request_id") or "").strip()
         if not request_id:
+            return None
+        source = str(payload.get("source") or "").strip()
+        lifetime = str(payload.get("lifetime") or "current_session").strip().lower()
+        if lifetime == "current_session":
+            if payload.get("_dedup_pending_ready"):
+                return (source, request_id, lifetime, "pending_ready")
+            session_id = payload.get("_dedup_session_id")
+            if session_id is None:
+                session_id = id(getattr(self, "session", None))
+            return (source, request_id, lifetime, session_id)
+        return (source, request_id, lifetime)
+
+    def _promote_context_append_request_id_to_current_session(self, payload: dict) -> None:
+        if (
+            str(payload.get("lifetime") or "").strip().lower() != "current_session"
+            or not payload.get("_dedup_pending_ready")
+            or not payload.get("request_id")
+        ):
+            return
+        seen = getattr(self, "_context_append_request_ids", None)
+        if not isinstance(seen, OrderedDict):
+            return
+        old_key = self._context_append_request_key(payload)
+        if old_key is None:
+            return
+        timestamp = seen.pop(old_key, None)
+        payload.pop("_dedup_pending_ready", None)
+        payload["_dedup_session_id"] = id(getattr(self, "session", None))
+        new_key = self._context_append_request_key(payload)
+        if timestamp is not None and new_key is not None:
+            seen[new_key] = timestamp
+            seen.move_to_end(new_key)
+
+    def _remember_context_append_request_id(self, payload: Mapping[str, Any]) -> None:
+        key = self._context_append_request_key(payload)
+        if key is None:
             return
         seen = getattr(self, "_context_append_request_ids", None)
         if not isinstance(seen, OrderedDict):
@@ -1150,23 +1186,22 @@ class LLMSessionManager:
             if seen[oldest_key] >= cutoff:
                 break
             seen.pop(oldest_key, None)
-        key = (source, request_id)
         seen[key] = now
         seen.move_to_end(key)
         while len(seen) > _CONTEXT_APPEND_DEDUP_MAX_ENTRIES:
             seen.popitem(last=False)
 
-    def _forget_context_append_request_id(self, source: str, request_id: str | None) -> None:
-        request_id = str(request_id or "").strip()
-        if not request_id:
+    def _forget_context_append_request_id(self, payload: Mapping[str, Any]) -> None:
+        key = self._context_append_request_key(payload)
+        if key is None:
             return
         seen = getattr(self, "_context_append_request_ids", None)
         if isinstance(seen, OrderedDict):
-            seen.pop((source, request_id), None)
+            seen.pop(key, None)
 
-    def _context_append_request_seen(self, source: str, request_id: str | None) -> bool:
-        request_id = str(request_id or "").strip()
-        if not request_id:
+    def _context_append_request_seen(self, payload: Mapping[str, Any]) -> bool:
+        key = self._context_append_request_key(payload)
+        if key is None:
             return False
         seen = getattr(self, "_context_append_request_ids", None)
         if not isinstance(seen, OrderedDict):
@@ -1178,7 +1213,7 @@ class LLMSessionManager:
             if seen[oldest_key] >= cutoff:
                 break
             seen.pop(oldest_key, None)
-        return (source, request_id) in seen
+        return key in seen
 
     def _normalize_context_append(
         self,
@@ -1263,28 +1298,32 @@ class LLMSessionManager:
         if isinstance(cache, list):
             del cache[:count]
 
-    async def _prime_late_next_session_context_after_swap(self, start_index: int) -> int:
+    async def _prime_late_next_session_context_after_swap(
+        self,
+        start_index: int,
+        end_index: int | None = None,
+    ) -> int:
         consumed_count = max(0, start_index)
         session = getattr(self, "session", None)
         prime_context = getattr(session, "prime_context", None)
         if not callable(prime_context):
             return consumed_count
 
-        for _ in range(_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES):
-            snapshot = self._snapshot_next_session_context_messages()
-            late_context = snapshot[consumed_count:]
-            if not late_context:
-                break
-            try:
-                await prime_context(self._convert_cache_to_str(late_context), skipped=True)
-            except (web_exceptions.ConnectionClosed, AttributeError) as exc:
-                logger.warning(
-                    "[%s] final-swap late next-session context prime failed: %s",
-                    self.lanlan_name,
-                    exc,
-                )
-                break
-            consumed_count += len(late_context)
+        snapshot = self._snapshot_next_session_context_messages()
+        stop_index = len(snapshot) if end_index is None else max(consumed_count, min(end_index, len(snapshot)))
+        late_context = snapshot[consumed_count:stop_index]
+        if not late_context:
+            return consumed_count
+        try:
+            await prime_context(self._convert_cache_to_str(late_context), skipped=True)
+        except (web_exceptions.ConnectionClosed, AttributeError) as exc:
+            logger.warning(
+                "[%s] final-swap late next-session context prime failed: %s",
+                self.lanlan_name,
+                exc,
+            )
+            return consumed_count
+        consumed_count += len(late_context)
 
         return consumed_count
 
@@ -1295,7 +1334,9 @@ class LLMSessionManager:
         lifetime = payload["lifetime"]
         targets: list[str] = []
         if lifetime in {"next_session", "session_family"}:
-            if self._append_context_to_new_session_cache(role, content):
+            if payload.get("_durable_cached"):
+                targets.append("new_session_cache")
+            elif self._append_context_to_new_session_cache(role, content):
                 targets.append("new_session_cache")
         session = getattr(self, "session", None)
         history = getattr(session, "_conversation_history", None)
@@ -1350,12 +1391,6 @@ class LLMSessionManager:
         )
         if payload is None:
             return ContextAppendResult(appended=False, reason="invalid_context")
-        if self._context_append_request_seen(payload["source"], payload["request_id"]):
-            return ContextAppendResult(appended=False, deduped=True, reason="duplicate_request_id")
-        reserved_request_id = bool(payload["request_id"])
-        if reserved_request_id:
-            self._remember_context_append_request_id(payload["source"], payload["request_id"])
-
         pending_needed = (
             payload["timing"] == "when_ready"
             and (
@@ -1363,7 +1398,20 @@ class LLMSessionManager:
                 or getattr(self, "session", None) is None
             )
         )
+        if pending_needed and payload["lifetime"] == "current_session":
+            payload["_dedup_pending_ready"] = True
+        if self._context_append_request_seen(payload):
+            return ContextAppendResult(appended=False, deduped=True, reason="duplicate_request_id")
+        reserved_request_id = bool(payload["request_id"])
+        if reserved_request_id:
+            self._remember_context_append_request_id(payload)
+
         if pending_needed:
+            if payload["lifetime"] in {"next_session", "session_family"}:
+                payload["_durable_cached"] = self._append_context_to_new_session_cache(
+                    payload["role"],
+                    payload["text"],
+                )
             pending = getattr(self, "pending_context_appends", None)
             if not isinstance(pending, list):
                 pending = []
@@ -1378,10 +1426,10 @@ class LLMSessionManager:
             result = await self._append_context_to_targets(payload)
         except Exception:
             if reserved_request_id:
-                self._forget_context_append_request_id(payload["source"], payload["request_id"])
+                self._forget_context_append_request_id(payload)
             raise
         if not result.appended and reserved_request_id:
-            self._forget_context_append_request_id(payload["source"], payload["request_id"])
+            self._forget_context_append_request_id(payload)
         return result
 
     async def _flush_pending_context_appends(self) -> int:
@@ -1401,6 +1449,7 @@ class LLMSessionManager:
                 if not result.appended:
                     retry.append(payload)
                 else:
+                    self._promote_context_append_request_id_to_current_session(payload)
                     flushed += 1
             except Exception as exc:
                 retry.append(payload)
@@ -1414,11 +1463,13 @@ class LLMSessionManager:
             pending = getattr(self, "pending_context_appends", None)
             if not isinstance(pending, list) or not pending:
                 return
+            before_ids = {id(payload) for payload in pending}
             flushed = await self._flush_pending_context_appends()
             pending = getattr(self, "pending_context_appends", None)
             if not isinstance(pending, list) or not pending:
                 return
-            if flushed <= 0:
+            after_ids = {id(payload) for payload in pending}
+            if flushed <= 0 and after_ids <= before_ids:
                 return
         pending = getattr(self, "pending_context_appends", None)
         if isinstance(pending, list) and pending:
@@ -1433,11 +1484,12 @@ class LLMSessionManager:
             stale_payloads = []
             self.pending_context_appends = []
         for payload in stale_payloads:
-            if isinstance(payload, dict) and payload.get("request_id"):
-                self._forget_context_append_request_id(
-                    payload.get("source", ""),
-                    payload.get("request_id", ""),
-                )
+            if (
+                isinstance(payload, dict)
+                and payload.get("request_id")
+                and not payload.get("_durable_cached")
+            ):
+                self._forget_context_append_request_id(payload)
 
     def is_goodbye_silent(self) -> bool:
         """Whether cat-mode silence after being asked to leave is in effect."""
@@ -8095,6 +8147,8 @@ class LLMSessionManager:
                 except Exception as e:
                     logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
 
+            next_context_count_before_promote = len(self._snapshot_next_session_context_messages())
+
             # ── 步骤 3：promote 新 session ────────────────────────────────────────
             # 旧 listener 已停、旧 session 已关，现在切换 self.session；
             # 此后旧 task 的任何回调若再执行也已看不到旧 ws。
@@ -8126,7 +8180,8 @@ class LLMSessionManager:
                 + len(incremental_next_session_context)
             )
             consumed_next_context_count = await self._prime_late_next_session_context_after_swap(
-                transferred_next_context_count
+                transferred_next_context_count,
+                next_context_count_before_promote,
             )
             self._consume_next_session_context_messages(consumed_next_context_count)
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -30,33 +30,6 @@ from difflib import SequenceMatcher
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Optional
-
-
-# Sentinel for `send_lanlan_response(request_id=...)` so we can tell apart
-# "caller didn't pass it (use shared field as fallback)" from "caller
-# explicitly passed None to mean 'no request id'". A normal default of
-# None collapses both into the same code path and would let recovery /
-# proactive paths accidentally bind their messages to a newer request_id.
-_REQUEST_ID_UNSET: Any = object()
-_MAGIC_COMMAND_IMAGE_DROP_REQUEST_MAX = 64
-_VOICE_PROACTIVE_ACK_GRACE_S = 0.05
-_TEXT_SESSION_INPUT_TYPES = frozenset({"text", "avatar_drop_image", "user_image"})
-_IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
-_CONTEXT_APPEND_DEDUP_TTL_SECONDS = 120.0
-_CONTEXT_APPEND_DEDUP_MAX_ENTRIES = 256
-_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES = 8
-_CONTEXT_APPEND_DEFAULT_MAX_TOKENS = 1000
-_CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
-    "game.icebreaker": 500,
-    "game.scripted": 1000,
-    "game.realtime_context": 1000,
-    "game.postgame": 1500,
-    "proactive.context": 1000,
-    "proactive.callback": 1000,
-    "topic.hook": 1000,
-    "topic.material": 1000,
-    "realtime.prime": 1000,
-}
 from datetime import datetime
 from websockets import exceptions as web_exceptions
 from fastapi import WebSocket, WebSocketDisconnect
@@ -128,6 +101,32 @@ from config.prompts.prompts_memory import (
     RECALL_MEMORY_TOOL_FILLER,
     RECALL_MEMORY_TOOL_FOUND_HEADER,
 )
+
+# Sentinel for `send_lanlan_response(request_id=...)` so we can tell apart
+# "caller didn't pass it (use shared field as fallback)" from "caller
+# explicitly passed None to mean 'no request id'". A normal default of
+# None collapses both into the same code path and would let recovery /
+# proactive paths accidentally bind their messages to a newer request_id.
+_REQUEST_ID_UNSET: Any = object()
+_MAGIC_COMMAND_IMAGE_DROP_REQUEST_MAX = 64
+_VOICE_PROACTIVE_ACK_GRACE_S = 0.05
+_TEXT_SESSION_INPUT_TYPES = frozenset({"text", "avatar_drop_image", "user_image"})
+_IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
+_CONTEXT_APPEND_DEDUP_TTL_SECONDS = 120.0
+_CONTEXT_APPEND_DEDUP_MAX_ENTRIES = 256
+_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES = 8
+_CONTEXT_APPEND_DEFAULT_MAX_TOKENS = 1000
+_CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
+    "game.icebreaker": 500,
+    "game.scripted": 1000,
+    "game.realtime_context": 1000,
+    "game.postgame": 1500,
+    "proactive.context": 1000,
+    "proactive.callback": 1000,
+    "topic.hook": 1000,
+    "topic.material": 1000,
+    "realtime.prime": 1000,
+}
 
 # recall 占位语音用的合成 worker-sid 后缀。仅用于在 TTS worker 层把 filler 切成
 # 一段独立 utterance（见 _emit_recall_filler_tts）；``send_speech`` 在发往前端前会

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1614,7 +1614,7 @@ class LLMSessionManager:
         ))
         retry: list[dict] = []
         flushed = 0
-        for payload in pending:
+        for index, payload in enumerate(pending):
             try:
                 result = await self._append_context_to_targets(payload)
                 if not result.appended:
@@ -1622,6 +1622,12 @@ class LLMSessionManager:
                 else:
                     self._promote_context_append_request_id_to_current_session(payload)
                     flushed += 1
+            except asyncio.CancelledError:
+                retry.append(payload)
+                retry.extend(pending[index + 1:])
+                if retry:
+                    self.pending_context_appends = retry + self.pending_context_appends
+                raise
             except Exception as exc:
                 retry.append(payload)
                 logger.warning("[%s] context append flush failed: %s", self.lanlan_name, exc)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1573,6 +1573,15 @@ class LLMSessionManager:
 
         try:
             result = await self._append_context_to_targets(payload)
+        except asyncio.CancelledError:
+            if reserved_request_id:
+                self._forget_context_append_request_id(payload)
+            if inflight_result is not None and not inflight_result.done():
+                inflight_result.set_result(ContextAppendResult(
+                    appended=False,
+                    reason="context_inject_cancelled",
+                ))
+            raise
         except Exception:
             if reserved_request_id:
                 self._forget_context_append_request_id(payload)
@@ -1581,19 +1590,17 @@ class LLMSessionManager:
                     appended=False,
                     reason="context_inject_failed",
                 ))
+            raise
+        else:
+            if not result.appended and reserved_request_id:
+                self._forget_context_append_request_id(payload)
+            if inflight_result is not None and not inflight_result.done():
+                inflight_result.set_result(result)
+        finally:
             if request_key is not None:
                 inflight = getattr(self, "_context_append_inflight_results", None)
                 if isinstance(inflight, dict):
                     inflight.pop(request_key, None)
-            raise
-        if not result.appended and reserved_request_id:
-            self._forget_context_append_request_id(payload)
-        if inflight_result is not None and not inflight_result.done():
-            inflight_result.set_result(result)
-        if request_key is not None:
-            inflight = getattr(self, "_context_append_inflight_results", None)
-            if isinstance(inflight, dict):
-                inflight.pop(request_key, None)
         return result
 
     async def _flush_pending_context_appends(self) -> int:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -44,6 +44,7 @@ _TEXT_SESSION_INPUT_TYPES = frozenset({"text", "avatar_drop_image", "user_image"
 _IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
 _CONTEXT_APPEND_DEDUP_TTL_SECONDS = 120.0
 _CONTEXT_APPEND_DEDUP_MAX_ENTRIES = 256
+_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES = 8
 _CONTEXT_APPEND_DEFAULT_MAX_TOKENS = 1000
 _CONTEXT_APPEND_SOURCE_MAX_TOKENS = {
     "game.icebreaker": 500,
@@ -867,9 +868,11 @@ class LLMSessionManager:
         self.use_tts = False
         self.generation_config = {}  # Qwen暂时不用
         self.message_cache_for_new_session = []
+        self.next_session_context_messages: list[dict] = []
         self.is_preparing_new_session = False
         self.summary_triggered_time = None
         self.initial_cache_snapshot_len = 0
+        self.initial_next_session_context_snapshot_len = 0
         self.pending_session_warmed_up_event = None
         self.pending_session_final_prime_complete_event = None
         self.session_start_time = None
@@ -1235,10 +1238,10 @@ class LLMSessionManager:
             return content[: max(max_tokens * 8, max_tokens)].strip()
 
     def _append_context_to_new_session_cache(self, role: str, text: str) -> bool:
-        cache = getattr(self, "message_cache_for_new_session", None)
+        cache = getattr(self, "next_session_context_messages", None)
         if not isinstance(cache, list):
             cache = []
-            self.message_cache_for_new_session = cache
+            self.next_session_context_messages = cache
         speaker = (
             getattr(self, "master_name", "user")
             if role == "user"
@@ -1343,26 +1346,45 @@ class LLMSessionManager:
             self._forget_context_append_request_id(payload["source"], payload["request_id"])
         return result
 
-    async def _flush_pending_context_appends(self) -> None:
+    async def _flush_pending_context_appends(self) -> int:
         pending = getattr(self, "pending_context_appends", None)
         if not isinstance(pending, list) or not pending:
-            return
+            return 0
         self.pending_context_appends = []
         pending.sort(key=lambda payload: (
             payload.get("ordering_key") or f"~{int(payload.get('_sequence', 0)):020d}",
             int(payload.get("_sequence", 0)),
         ))
         retry: list[dict] = []
+        flushed = 0
         for payload in pending:
             try:
                 result = await self._append_context_to_targets(payload)
                 if not result.appended:
                     retry.append(payload)
+                else:
+                    flushed += 1
             except Exception as exc:
                 retry.append(payload)
                 print(f"[{self.lanlan_name}] context append flush failed: {exc}")
         if retry:
             self.pending_context_appends = retry + self.pending_context_appends
+        return flushed
+
+    async def _drain_pending_context_appends_before_ready(self) -> None:
+        for _ in range(_CONTEXT_APPEND_READY_FLUSH_MAX_PASSES):
+            pending = getattr(self, "pending_context_appends", None)
+            if not isinstance(pending, list) or not pending:
+                return
+            flushed = await self._flush_pending_context_appends()
+            pending = getattr(self, "pending_context_appends", None)
+            if not isinstance(pending, list) or not pending:
+                return
+            if flushed <= 0:
+                return
+        pending = getattr(self, "pending_context_appends", None)
+        if isinstance(pending, list) and pending:
+            print(f"[{self.lanlan_name}] context append ready drain left {len(pending)} pending item(s)")
 
     def is_goodbye_silent(self) -> bool:
         """Whether cat-mode silence after being asked to leave is in effect."""
@@ -2194,6 +2216,7 @@ class LLMSessionManager:
                         self.summary_triggered_time = datetime.now()
                         self.message_cache_for_new_session = []
                         self.initial_cache_snapshot_len = 0
+                        self.initial_next_session_context_snapshot_len = 0
                         self.sync_message_queue.put({'type': 'system', 'data': 'renew session'})
 
                 # 2. agent 任务结果即时触发（无需等待 40s）：有挂起的额外提示 → 立刻启动预热
@@ -3932,6 +3955,9 @@ class LLMSessionManager:
 
         if clear_main_cache:
             self.message_cache_for_new_session = []
+            if from_final_swap:
+                self.next_session_context_messages = []
+            self.initial_next_session_context_snapshot_len = 0
 
     async def _cleanup_pending_session_resources(self):
         """[Hot-swap related] Safely cleans up ONLY PENDING connector and session if they exist AND are not the current main session."""
@@ -5174,10 +5200,12 @@ class LLMSessionManager:
             # 重置状态
             if new:
                 self.message_cache_for_new_session = []
+                self.next_session_context_messages = []
                 self.last_time = None
                 self.is_preparing_new_session = False
                 self.summary_triggered_time = None
                 self.initial_cache_snapshot_len = 0
+                self.initial_next_session_context_snapshot_len = 0
                 # 清空输入缓存（新对话时不需要保留旧的输入）
                 async with self.input_cache_lock:
                     self.pending_input_data.clear()
@@ -5241,7 +5269,7 @@ class LLMSessionManager:
                 # 在 queued context 写入 session 前保持输入闸门关闭；否则第一条
                 # 缓存/并发用户输入可能抢在上下文前面进入模型。
                 async with self.input_cache_lock:
-                    await self._flush_pending_context_appends()
+                    await self._drain_pending_context_appends_before_ready()
                     self.session_ready = True
 
                 # 处理在session启动期间可能已经缓存的输入数据
@@ -5596,6 +5624,8 @@ class LLMSessionManager:
                 logger.info("🔄 热切换准备: 创建语音模式 OmniRealtimeClient")
             
             initial_prompt = await self._build_initial_prompt()
+            next_session_context_messages = list(getattr(self, "next_session_context_messages", []) or [])
+            self.initial_next_session_context_snapshot_len = len(next_session_context_messages)
             self.initial_cache_snapshot_len = len(self.message_cache_for_new_session)
             from utils.internal_http_client import get_internal_http_client
             _hs_client = get_internal_http_client()
@@ -5610,7 +5640,11 @@ class LLMSessionManager:
                 raise ConnectionError(f"❌ 记忆服务响应超时！请检查记忆服务是否正常运行 (端口 {self.memory_server_port})")
             if not resp.is_success:
                 raise ConnectionError(f"❌ 记忆服务热切换时返回非2xx状态 {resp.status_code}: {resp.text[:200]}")
-            initial_prompt += resp.text + self._convert_cache_to_str(self.message_cache_for_new_session)
+            initial_prompt += (
+                resp.text
+                + self._convert_cache_to_str(next_session_context_messages)
+                + self._convert_cache_to_str(self.message_cache_for_new_session)
+            )
             print(initial_prompt)
             self._bind_session_lifecycle_callbacks(self.pending_session)
             await self.pending_session.connect(initial_prompt, native_audio=not self.pending_use_tts)
@@ -5653,6 +5687,7 @@ class LLMSessionManager:
                 self.summary_triggered_time = datetime.now()
                 self.message_cache_for_new_session = []
                 self.initial_cache_snapshot_len = 0
+                self.initial_next_session_context_snapshot_len = 0
                 # 立即启动后台预热，不等待10秒
                 self.pending_session_warmed_up_event = asyncio.Event()
                 if not self.background_preparation_task or self.background_preparation_task.done():
@@ -7897,7 +7932,14 @@ class LLMSessionManager:
         try:
             new_session = None  # 提前初始化，确保 except 块安全访问（实际赋值在 PERFORM ACTUAL HOT SWAP 段）
             old_listener_cancel_timed_out = False  # 旧 listener 取消超时标志，供 except 块做 fail-close 决策
-            incremental_cache = self.message_cache_for_new_session[self.initial_cache_snapshot_len:]
+            next_session_context_messages = getattr(self, "next_session_context_messages", []) or []
+            incremental_next_session_context = next_session_context_messages[
+                self.initial_next_session_context_snapshot_len:
+            ]
+            incremental_cache = (
+                list(incremental_next_session_context)
+                + self.message_cache_for_new_session[self.initial_cache_snapshot_len:]
+            )
             # 1. Send incremental cache (or a heartbeat) to PENDING session for its *second* ignored response
             if incremental_cache:
                 final_prime_text = self._convert_cache_to_str(incremental_cache)

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1740,7 +1740,7 @@ class OmniRealtimeClient:
                 return
             if skipped:
                 self._skip_until_next_response = True
-            await self._create_response_gemini(instructions)
+            await self._create_response_gemini(instructions, raise_on_error=True)
             return
 
         # 跳过空内容的发送，避免触发 API 错误
@@ -1776,7 +1776,7 @@ class OmniRealtimeClient:
 
         This is Gemini Live's idiomatic equivalent of OpenAI-Realtime's
         ``conversation.item.create(role=user) + response.create``. Shared by
-        ``_create_response_gemini`` (hot-swap priming — tolerates errors) and
+        ``_create_response_gemini`` (callers choose error policy) and
         ``inject_text_and_request_response`` (proactive — must propagate
         errors so the caller can re-queue). Errors propagate here; callers
         that need to swallow wrap it.
@@ -1792,7 +1792,7 @@ class OmniRealtimeClient:
             turn_complete=True,
         )
 
-    async def _create_response_gemini(self, instructions: str) -> None:
+    async def _create_response_gemini(self, instructions: str, *, raise_on_error: bool = False) -> None:
         """Send text content to Gemini and trigger response."""
         if not self._gemini_session:
             logger.warning("Gemini session not available for create_response")
@@ -1808,6 +1808,8 @@ class OmniRealtimeClient:
             logger.info("Gemini: sent client content, waiting for response")
         except Exception as e:
             logger.error(f"Error sending client content to Gemini: {e}")
+            if raise_on_error:
+                raise
 
     def is_active_response(self) -> bool:
         """Return True iff the realtime session is currently producing a response.

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1796,6 +1796,8 @@ class OmniRealtimeClient:
         """Send text content to Gemini and trigger response."""
         if not self._gemini_session:
             logger.warning("Gemini session not available for create_response")
+            if raise_on_error:
+                raise RuntimeError("Gemini session not available for create_response")
             return
 
         # 跳过空内容的发送，避免预热时污染 Gemini 对话历史

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1685,9 +1685,11 @@ class OmniRealtimeClient:
             # Gemini Live API 没有 session.update 机制，只能通过
             # send_client_content 注入上下文（会创建 user turn）。
             # on_response_done 由 _handle_messages_gemini 自然触发。
-            if skipped:
-                self._skip_until_next_response = True
-            await self._create_response_gemini(text)
+            await self._create_response_gemini_with_skip_guard(
+                text,
+                skipped=skipped,
+                raise_on_error=True,
+            )
             return
 
         if not skipped and "qwen" not in self._model_lower:
@@ -1738,9 +1740,11 @@ class OmniRealtimeClient:
             if not instructions or not instructions.strip():
                 logger.info("Gemini: skipping empty content in create_response")
                 return
-            if skipped:
-                self._skip_until_next_response = True
-            await self._create_response_gemini(instructions, raise_on_error=True)
+            await self._create_response_gemini_with_skip_guard(
+                instructions,
+                skipped=skipped,
+                raise_on_error=True,
+            )
             return
 
         # 跳过空内容的发送，避免触发 API 错误
@@ -1812,6 +1816,26 @@ class OmniRealtimeClient:
             logger.error(f"Error sending client content to Gemini: {e}")
             if raise_on_error:
                 raise
+
+    async def _create_response_gemini_with_skip_guard(
+        self,
+        instructions: str,
+        *,
+        skipped: bool = False,
+        raise_on_error: bool = False,
+    ) -> None:
+        """Set Gemini skip state only for a successfully-started skipped turn."""
+        if not skipped:
+            await self._create_response_gemini(instructions, raise_on_error=raise_on_error)
+            return
+
+        previous_skip = self._skip_until_next_response
+        self._skip_until_next_response = True
+        try:
+            await self._create_response_gemini(instructions, raise_on_error=raise_on_error)
+        except Exception:
+            self._skip_until_next_response = previous_skip
+            raise
 
     def is_active_response(self) -> bool:
         """Return True iff the realtime session is currently producing a response.

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -7758,6 +7758,8 @@ async def game_realtime_context(game_type: str, request: Request):
     append_context = getattr(mgr, "append_context", None)
     if not callable(append_context):
         return {"ok": False, "reason": "context_method_unavailable", "lanlan_name": lanlan_name}
+    if _active_realtime_session(mgr) is not session:
+        return {"ok": False, "reason": "realtime_session_changed", "lanlan_name": lanlan_name}
     try:
         append_result = await append_context(
             source="game.realtime_context",

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3777,7 +3777,14 @@ def _is_gemini_realtime_session(session: Any) -> bool:
     return bool(getattr(session, "_is_gemini", False))
 
 
-async def _run_postgame_realtime_nudge_task(mgr: Any, archive: dict, options: dict, delays: tuple[float, ...]) -> None:
+async def _run_postgame_realtime_nudge_task(
+    mgr: Any,
+    archive: dict,
+    options: dict,
+    delays: tuple[float, ...],
+    *,
+    expected_session: Any | None = None,
+) -> None:
     lanlan_name = str(archive.get("lanlan_name") or "")
     instruction = _build_game_postgame_realtime_nudge_instruction(archive, options)
     _log_game_debug_material(
@@ -3791,9 +3798,19 @@ async def _run_postgame_realtime_nudge_task(mgr: Any, archive: dict, options: di
     for attempt, delay in enumerate(delays, start=1):
         try:
             await asyncio.sleep(delay)
-            if not _active_realtime_session(mgr):
+            active_session = _active_realtime_session(mgr)
+            if not active_session:
                 logger.info(
                     "🎮 赛后 Realtime 主动搭话跳过: game=%s session=%s lanlan=%s attempt=%d reason=no_active_realtime_session",
+                    archive.get("game_type"),
+                    archive.get("session_id"),
+                    lanlan_name,
+                    attempt,
+                )
+                return
+            if expected_session is not None and active_session is not expected_session:
+                logger.info(
+                    "🎮 赛后 Realtime 主动搭话跳过: game=%s session=%s lanlan=%s attempt=%d reason=realtime_session_changed",
                     archive.get("game_type"),
                     archive.get("session_id"),
                     lanlan_name,
@@ -3974,6 +3991,18 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
         len(text),
     )
 
+    if _active_realtime_session(mgr) is not session:
+        return {
+            "ok": True,
+            "mode": "realtime",
+            "action": "context",
+            "context_injected": True,
+            "nudge_scheduled": False,
+            "nudge_reason": "realtime_session_changed",
+            "reason": "realtime_session_changed",
+            "bytes": len(text),
+        }
+
     if getattr(append_result, "deduped", False):
         return {
             "ok": True,
@@ -3994,6 +4023,7 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
                 dict(archive),
                 dict(options),
                 _POSTGAME_REALTIME_NUDGE_DELAYS,
+                expected_session=session,
             ))
             nudge_scheduled = True
             nudge_reason = "scheduled"

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -7061,7 +7061,7 @@ async def game_project_context(game_type: str, request: Request):
             role=role,
             text=text,
             audience="model",
-            timing="now",
+            timing="when_ready",
             lifetime="session_family",
             request_id=request_id or None,
             ordering_key=session_id or None,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -40,8 +40,6 @@ from urllib.parse import urlparse
 
 _EXTERNAL_VOICE_DEDUP_TTL_SECONDS = 30.0
 _EXTERNAL_VOICE_DEDUP_MAX_ENTRIES = 64
-_ICEBREAKER_CONTEXT_DEDUP_TTL_SECONDS = 30.0
-_ICEBREAKER_CONTEXT_DEDUP_MAX_ENTRIES = 64
 _SSML_TAG_PATTERN = re.compile(
     r"</?(?:[a-z][\w-]*:)?(?:"
     r"speak|p|s|break|say-as|phoneme|sub|prosody|emphasis|voice|audio|mark|lang|w|token|express-as|effect"
@@ -106,7 +104,6 @@ from utils.logger_config import get_module_logger
 logger = get_module_logger(__name__, "Game")
 
 router = APIRouter(tags=["game"], prefix="/api/game")
-MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH = 2000
 
 # ── Session 池 ─────────────────────────────────────────────────────
 # key = f"{lanlan_name}:{game_type}:{session_id}"
@@ -3915,8 +3912,25 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
             "reason": "gemini_direct_response",
         }
 
+    append_context = getattr(mgr, "append_context", None)
+    if not callable(append_context):
+        return {"ok": False, "mode": "realtime", "action": "skip", "reason": "context_method_unavailable"}
     try:
-        await session.prime_context(text, skipped=True)
+        append_result = await append_context(
+            source="game.postgame",
+            role="system",
+            text=text,
+            audience="model",
+            timing="now",
+            lifetime="current_session",
+            request_id=str(archive.get("session_id") or "") or None,
+            ordering_key=str(archive.get("session_id") or "") or None,
+            metadata={
+                "game_type": archive.get("game_type"),
+                "lanlan_name": archive.get("lanlan_name"),
+                "kind": "postgame",
+            },
+        )
     except Exception as exc:
         logger.warning(
             "🎮 赛后 Realtime 上下文注入失败: game=%s session=%s lanlan=%s err=%s",
@@ -3926,6 +3940,13 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
             exc,
         )
         return {"ok": False, "mode": "realtime", "action": "skip", "reason": "context_inject_failed"}
+    if not getattr(append_result, "appended", False) and not getattr(append_result, "deduped", False):
+        return {
+            "ok": False,
+            "mode": "realtime",
+            "action": "skip",
+            "reason": getattr(append_result, "reason", None) or "context_inject_failed",
+        }
 
     logger.info(
         "🎮 赛后 Realtime 上下文已注入: game=%s session=%s lanlan=%s bytes=%d",
@@ -6977,8 +6998,6 @@ async def game_project_context(game_type: str, request: Request):
         return {"ok": False, "reason": "invalid_role"}
     if not text:
         return {"ok": False, "reason": "missing_text"}
-    if len(text) > MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH:
-        return {"ok": False, "reason": "invalid_text_length"}
     event = data.get("event") if isinstance(data.get("event"), dict) else {}
     request_id = str(data.get("request_id") or event.get("request_id") or "").strip()
 
@@ -7019,38 +7038,28 @@ async def game_project_context(game_type: str, request: Request):
     if stale_response:
         return stale_response
 
-    seen_context_ids = state.get("_icebreaker_context_seen_request_ids")
-    if not isinstance(seen_context_ids, OrderedDict):
-        seen_context_ids = OrderedDict()
-        state["_icebreaker_context_seen_request_ids"] = seen_context_ids
-    now = time.time()
-    ttl_cutoff = now - _ICEBREAKER_CONTEXT_DEDUP_TTL_SECONDS
-    while seen_context_ids:
-        oldest_id = next(iter(seen_context_ids))
-        if seen_context_ids[oldest_id] < ttl_cutoff:
-            seen_context_ids.pop(oldest_id, None)
-            continue
-        break
-    if request_id and request_id in seen_context_ids:
-        return {
-            "ok": True,
-            "deduped": True,
-            "method": "project_session_history",
-            "lanlan_name": lanlan_name,
-            "game_type": game_type,
-            "session_id": session_id,
-        }
-
     mgr = get_session_manager().get(lanlan_name)
     if not mgr:
         return {"ok": False, "reason": "no_session_manager", "lanlan_name": lanlan_name}
 
-    append_icebreaker_context_async = getattr(mgr, "append_icebreaker_context_async", None)
+    append_context = getattr(mgr, "append_context", None)
     try:
-        if callable(append_icebreaker_context_async):
-            ok = await append_icebreaker_context_async(role, text)
-        else:
+        if not callable(append_context):
             return {"ok": False, "reason": "context_method_unavailable", "lanlan_name": lanlan_name}
+        append_result = await append_context(
+            source="game.icebreaker",
+            role=role,
+            text=text,
+            audience="model",
+            timing="now",
+            lifetime="session_family",
+            request_id=request_id or None,
+            ordering_key=session_id or None,
+            metadata={
+                "game_type": game_type,
+                "session_id": session_id,
+            },
+        )
     except Exception as exc:
         logger.warning(
             "new_user_icebreaker context append failed for %s: %s",
@@ -7066,19 +7075,24 @@ async def game_project_context(game_type: str, request: Request):
             "game_type": game_type,
             "session_id": str(data.get("session_id") or ""),
         }
-    if ok is False:
+    if getattr(append_result, "deduped", False):
         return {
-            "ok": False,
-            "reason": "context_write_failed",
+            "ok": True,
+            "deduped": True,
+            "method": "project_session_history",
             "lanlan_name": lanlan_name,
             "game_type": game_type,
             "session_id": session_id,
         }
-    if request_id:
-        while len(seen_context_ids) >= _ICEBREAKER_CONTEXT_DEDUP_MAX_ENTRIES:
-            seen_context_ids.popitem(last=False)
-        seen_context_ids[request_id] = now
-        seen_context_ids.move_to_end(request_id)
+    ok = bool(getattr(append_result, "appended", False))
+    if ok is False:
+        return {
+            "ok": False,
+            "reason": getattr(append_result, "reason", None) or "context_write_failed",
+            "lanlan_name": lanlan_name,
+            "game_type": game_type,
+            "session_id": session_id,
+        }
 
     return {
         "ok": bool(ok),
@@ -7699,11 +7713,34 @@ async def game_realtime_context(game_type: str, request: Request):
             "items": len(data.get("pendingItems") or []),
         }
 
+    append_context = getattr(mgr, "append_context", None)
+    if not callable(append_context):
+        return {"ok": False, "reason": "context_method_unavailable", "lanlan_name": lanlan_name}
     try:
-        await session.prime_context(text, skipped=True)
+        append_result = await append_context(
+            source="game.realtime_context",
+            role="system",
+            text=text,
+            audience="model",
+            timing="now",
+            lifetime="current_session",
+            request_id=str(data.get("request_id") or "") or None,
+            ordering_key=str((data.get("state") or {}).get("sessionId") or data.get("session_id") or "") or None,
+            metadata={
+                "game_type": game_type,
+                "lanlan_name": lanlan_name,
+                "items": len(data.get("pendingItems") or []),
+            },
+        )
     except Exception as e:
         logger.warning("🎮 Realtime 上下文注入失败: game=%s lanlan=%s err=%s", game_type, lanlan_name, e)
         return {"ok": False, "reason": f"inject_failed: {e}", "lanlan_name": lanlan_name}
+    if not getattr(append_result, "appended", False) and not getattr(append_result, "deduped", False):
+        return {
+            "ok": False,
+            "reason": getattr(append_result, "reason", None) or "inject_failed",
+            "lanlan_name": lanlan_name,
+        }
 
     logger.info("🎮 Realtime 上下文已注入: game=%s lanlan=%s bytes=%d", game_type, lanlan_name, len(text))
     return {

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3843,6 +3843,15 @@ async def _run_postgame_realtime_nudge_task(mgr: Any, archive: dict, options: di
     )
 
 
+def _postgame_context_request_id(archive: dict) -> Optional[str]:
+    game_type = str(archive.get("game_type") or "game").strip() or "game"
+    session_id = str(archive.get("session_id") or "default").strip() or "default"
+    ended_at = str(archive.get("ended_at") or "").strip()
+    if not ended_at:
+        return None
+    return f"{game_type}:{session_id}:{ended_at}"
+
+
 async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) -> dict:
     session = _active_realtime_session(mgr)
     if not session:
@@ -3915,6 +3924,7 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
     append_context = getattr(mgr, "append_context", None)
     if not callable(append_context):
         return {"ok": False, "mode": "realtime", "action": "skip", "reason": "context_method_unavailable"}
+    postgame_request_id = _postgame_context_request_id(archive)
     try:
         append_result = await append_context(
             source="game.postgame",
@@ -3923,8 +3933,8 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
             audience="model",
             timing="now",
             lifetime="current_session",
-            request_id=str(archive.get("session_id") or "") or None,
-            ordering_key=str(archive.get("session_id") or "") or None,
+            request_id=postgame_request_id,
+            ordering_key=postgame_request_id,
             metadata={
                 "game_type": archive.get("game_type"),
                 "lanlan_name": archive.get("lanlan_name"),

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -113,6 +113,7 @@ _game_sessions: Dict[str, dict] = {}
 # 超时清理：30 分钟无活动自动销毁
 _SESSION_TIMEOUT_SECONDS = 30 * 60
 _GAME_ROUTE_ACTIVATION_LOG_LIMIT = 32
+MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH = 2000
 _BASKETBALL_SCORE_SESSION_TTL_SECONDS = 10 * 60
 _BASKETBALL_SCORING_MODES = {"shooter", "duel"}
 _basketball_recent_score_sessions: Dict[tuple[str, str], dict] = {}
@@ -7025,6 +7026,8 @@ async def game_project_context(game_type: str, request: Request):
         return {"ok": False, "reason": "invalid_role"}
     if not text:
         return {"ok": False, "reason": "missing_text"}
+    if len(text) > MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH:
+        return {"ok": False, "reason": "invalid_text_length"}
     event = data.get("event") if isinstance(data.get("event"), dict) else {}
     request_id = str(data.get("request_id") or event.get("request_id") or "").strip()
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -7114,8 +7114,8 @@ async def game_project_context(game_type: str, request: Request):
             "game_type": game_type,
             "session_id": session_id,
         }
-    ok = bool(getattr(append_result, "appended", False))
-    if ok is False:
+    ok = getattr(append_result, "appended", False)
+    if not ok:
         return {
             "ok": False,
             "reason": getattr(append_result, "reason", None) or "context_write_failed",
@@ -7125,7 +7125,7 @@ async def game_project_context(game_type: str, request: Request):
         }
 
     return {
-        "ok": bool(ok),
+        "ok": True,
         "method": "project_session_history",
         "lanlan_name": lanlan_name,
         "game_type": game_type,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3866,6 +3866,13 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
         lanlan_name=str(archive.get("lanlan_name") or ""),
         source="game_end",
     )
+    if _active_realtime_session(mgr) is not session:
+        return {
+            "ok": False,
+            "mode": "realtime",
+            "action": "skip",
+            "reason": "realtime_session_changed",
+        }
 
     if _is_gemini_realtime_session(session):
         instruction = _build_game_postgame_realtime_nudge_instruction(archive, options)
@@ -7679,6 +7686,18 @@ async def game_realtime_context(game_type: str, request: Request):
         data = await request.json()
     except Exception:
         return {"ok": False, "reason": "invalid_body"}
+    if not isinstance(data, dict):
+        return {"ok": False, "reason": "invalid_body"}
+
+    from .system_router import _validate_local_mutation_request
+
+    validation_error = _validate_local_mutation_request(
+        request,
+        payload=data,
+        error_defaults={"ok": False, "reason": "csrf_validation_failed"},
+    )
+    if validation_error is not None:
+        return validation_error
 
     lanlan_name = str(data.get("lanlan_name") or "").strip()
     if not lanlan_name:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3966,6 +3966,16 @@ async def _deliver_postgame_to_realtime(mgr: Any, archive: dict, options: dict) 
         len(text),
     )
 
+    if getattr(append_result, "deduped", False):
+        return {
+            "ok": True,
+            "mode": "realtime",
+            "action": "context",
+            "context_injected": True,
+            "nudge_scheduled": False,
+            "reason": "context_deduped",
+        }
+
     nudge_scheduled = False
     nudge_reason = "disabled"
     if options.get("trigger_voice", True):

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -3886,6 +3886,41 @@
     return base;
   }
 
+  function _getLocalMutationHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    const security = window.nekoLocalMutationSecurity;
+    if (security && typeof security.getMutationHeaders === 'function') {
+      return Promise.resolve(security.getMutationHeaders()).then((mutationHeaders) => {
+        return Object.assign(headers, mutationHeaders || {});
+      }).catch(() => headers);
+    }
+
+    const lanlanName = window.lanlan_config?.lanlan_name || '';
+    const suffix = lanlanName ? `?lanlan_name=${encodeURIComponent(lanlanName)}` : '';
+    return fetch(`/api/config/page_config${suffix}`, {
+      credentials: 'same-origin',
+      cache: 'no-store',
+    }).then((response) => {
+      if (!response.ok) return headers;
+      return response.json();
+    }).then((config) => {
+      if (config && typeof config.autostart_csrf_token === 'string' && config.autostart_csrf_token) {
+        headers['X-CSRF-Token'] = config.autostart_csrf_token;
+      }
+      return headers;
+    }).catch(() => headers);
+  }
+
+  function _refreshLocalMutationHeaders() {
+    const security = window.nekoLocalMutationSecurity;
+    if (security && typeof security.refreshToken === 'function') {
+      return Promise.resolve(security.refreshToken()).then(() => {
+        return _getLocalMutationHeaders();
+      }).catch(() => _getLocalMutationHeaders());
+    }
+    return _getLocalMutationHeaders();
+  }
+
   async function _sendRealtimeGameContext(source, items = []) {
     if (!_llm.realtimeContextEnabled) return;
     const now = performance.now();
@@ -3900,17 +3935,26 @@
       snapshot: item.snapshot,
     }));
     try {
-      const resp = await fetch('/api/game/soccer/realtime-context', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          source,
-          ...(_llm.routeLanlanName ? { lanlan_name: _llm.routeLanlanName } : {}),
-          state: stateNow,
-          pendingItems: safeItems,
-          i18n_language: _currentI18nLang(),
-        }),
+      const bodyJson = JSON.stringify({
+        source,
+        ...(_llm.routeLanlanName ? { lanlan_name: _llm.routeLanlanName } : {}),
+        state: stateNow,
+        pendingItems: safeItems,
+        i18n_language: _currentI18nLang(),
       });
+      const postWithHeaders = (headers) => fetch('/api/game/soccer/realtime-context', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers,
+        body: bodyJson,
+      });
+      let resp = await postWithHeaders(await _getLocalMutationHeaders());
+      if (resp.status === 403) {
+        const errorPayload = await resp.clone().json().catch(() => ({}));
+        if (errorPayload && errorPayload.error_code === 'csrf_validation_failed') {
+          resp = await postWithHeaders(await _refreshLocalMutationHeaders());
+        }
+      }
       const data = await resp.json().catch(() => ({}));
       if (data.ok) {
         console.log(`[SoccerRealtime] 注入成功 | 来源=${source} 条目=${safeItems.length} bytes=${data.bytes}`);

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -280,6 +280,56 @@ async def test_clear_pending_context_appends_drops_stale_ready_queue():
 
 
 @pytest.mark.asyncio
+async def test_clear_pending_context_appends_releases_only_stale_request_ids():
+    mgr = _make_manager()
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+
+    active = await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="already written",
+        request_id="active-request",
+    )
+    mgr.session = None
+    mgr.session_ready = False
+    queued = await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="queued for old session",
+        timing="when_ready",
+        request_id="queued-request",
+    )
+
+    assert active.appended is True
+    assert queued.appended is True
+
+    mgr._clear_pending_context_appends()
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    mgr.session_ready = True
+    retry_stale = await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="queued retry in new session",
+        request_id="queued-request",
+    )
+    retry_active = await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="already written duplicate",
+        request_id="active-request",
+    )
+
+    assert retry_stale.appended is True
+    assert retry_active.appended is False
+    assert retry_active.deduped is True
+    assert [message.content for message in history] == [
+        "system: already written",
+        "system: queued retry in new session",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_append_context_dedups_request_id_inside_manager():
     mgr = _make_manager()
     history = []

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from collections import OrderedDict
 from types import SimpleNamespace
 
 import pytest
@@ -752,6 +753,35 @@ async def test_append_context_dedups_request_id_inside_manager():
         "same hook",
         "same id, different source",
     ]
+
+
+def test_promoted_pending_request_id_keeps_ttl_eviction_order(monkeypatch):
+    mgr = _make_manager()
+    mgr.session = object()
+    mgr._context_append_request_ids = OrderedDict()
+    pending_payload = {
+        "source": "topic.hook",
+        "request_id": "old-hook",
+        "lifetime": "current_session",
+        "_dedup_pending_ready": True,
+    }
+    current_payload = {
+        "source": "topic.hook",
+        "request_id": "new-hook",
+        "lifetime": "current_session",
+        "_dedup_session_id": id(mgr.session),
+    }
+
+    monkeypatch.setattr(core_module.time, "time", lambda: 1000.0)
+    mgr._remember_context_append_request_id(pending_payload)
+    monkeypatch.setattr(core_module.time, "time", lambda: 1110.0)
+    mgr._remember_context_append_request_id(current_payload)
+
+    mgr._promote_context_append_request_id_to_current_session(pending_payload)
+
+    monkeypatch.setattr(core_module.time, "time", lambda: 1121.0)
+    assert mgr._context_append_request_seen(pending_payload) is False
+    assert mgr._context_append_request_seen(current_payload) is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -16,6 +16,7 @@ def _make_manager():
     mgr.session = None
     mgr.session_ready = True
     mgr.is_preparing_new_session = False
+    mgr._require_context_append_current_delivery = False
     mgr.message_cache_for_new_session = []
     mgr.next_session_context_messages = []
     mgr.initial_next_session_context_snapshot_len = 0
@@ -131,6 +132,34 @@ async def test_append_context_seeds_next_session_cache_when_preparing():
     assert result.targets == ("new_session_cache",)
     assert mgr.next_session_context_messages == [{"role": "Master", "text": "choice A"}]
     assert mgr.message_cache_for_new_session == []
+
+
+@pytest.mark.asyncio
+async def test_append_context_requires_current_delivery_after_swap_promotion():
+    mgr = _make_manager()
+    mgr.is_preparing_new_session = True
+    mgr._require_context_append_current_delivery = True
+
+    class _FailingPrimeSession:
+        async def prime_context(self, text, *, skipped=False):
+            raise RuntimeError("prime unavailable")
+
+    mgr.session = _FailingPrimeSession()
+
+    result = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="post promote setup",
+        audience="model",
+        lifetime="session_family",
+    )
+
+    assert result.appended is False
+    assert result.targets == ("new_session_cache",)
+    assert result.reason == "realtime_prime_failed"
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "post promote setup"},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -181,6 +181,57 @@ async def test_final_swap_reset_preserves_unconsumed_next_session_context():
 
 
 @pytest.mark.asyncio
+async def test_append_context_preserves_system_role_in_next_session_cache():
+    mgr = _make_manager()
+
+    result = await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="keep this as system context",
+        lifetime="next_session",
+    )
+
+    assert result.appended is True
+    assert result.targets == ("new_session_cache",)
+    assert mgr.next_session_context_messages == [
+        {"role": "system", "text": "keep this as system context"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_final_swap_primes_late_next_session_context_before_consuming():
+    mgr = _make_manager()
+    mgr.next_session_context_messages = [
+        {"role": "Lan", "text": "already transferred"},
+        {"role": "system", "text": "late before promote"},
+    ]
+
+    class _AppendingPrimeSession:
+        def __init__(self):
+            self.calls = []
+
+        async def prime_context(self, text, *, skipped=False):
+            self.calls.append((text, skipped))
+            if len(self.calls) == 1:
+                mgr.next_session_context_messages.append(
+                    {"role": "Master", "text": "late during prime"}
+                )
+
+    session = _AppendingPrimeSession()
+    mgr.session = session
+
+    consumed = await mgr._prime_late_next_session_context_after_swap(1)
+    mgr._consume_next_session_context_messages(consumed)
+
+    assert consumed == 3
+    assert session.calls == [
+        ("system | late before promote\n", True),
+        ("Master | late during prime\n", True),
+    ]
+    assert mgr.next_session_context_messages == []
+
+
+@pytest.mark.asyncio
 async def test_append_context_when_ready_flushes_before_user_input():
     mgr = _make_manager()
     mgr.session_ready = False

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -531,6 +531,51 @@ async def test_full_new_session_reset_releases_abandoned_durable_pending_dedup()
 
 
 @pytest.mark.asyncio
+async def test_ready_durable_context_retry_recreates_cache_after_reset():
+    mgr = _make_manager()
+
+    class _FailingPrimeSession:
+        async def prime_context(self, text, *, skipped=False):
+            raise RuntimeError("prime unavailable")
+
+    mgr.session = _FailingPrimeSession()
+    failed = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="durable realtime setup",
+        lifetime="session_family",
+        request_id="durable-realtime",
+    )
+
+    assert failed.appended is False
+    assert failed.reason == "realtime_prime_failed"
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "durable realtime setup"},
+    ]
+
+    mgr.next_session_context_messages = []
+    mgr._clear_pending_context_appends(release_durable_cached=True)
+    recovered_session = _FakePrimeSession()
+    mgr.session = recovered_session
+
+    retry = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="durable realtime setup",
+        lifetime="session_family",
+        request_id="durable-realtime",
+    )
+
+    assert retry.appended is True
+    assert retry.deduped is False
+    assert retry.targets == ("new_session_cache", "realtime_prime")
+    assert recovered_session.calls == [("assistant: durable realtime setup", True)]
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "durable realtime setup"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_when_ready_durable_context_retries_if_realtime_prime_fails():
     mgr = _make_manager()
     mgr.session_ready = False

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -134,6 +134,32 @@ async def test_append_context_next_session_context_survives_preparation_cache_re
 
 
 @pytest.mark.asyncio
+async def test_next_session_context_snapshot_consumes_only_rendered_prefix():
+    mgr = _make_manager()
+
+    await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="rendered in this start",
+        lifetime="next_session",
+    )
+    snapshot = mgr._snapshot_next_session_context_messages()
+    await mgr.append_context(
+        source="game.icebreaker",
+        role="user",
+        text="queued during connect",
+        lifetime="next_session",
+    )
+
+    mgr._consume_next_session_context_messages(len(snapshot))
+
+    assert snapshot == [{"role": "Lan", "text": "rendered in this start"}]
+    assert mgr.next_session_context_messages == [
+        {"role": "Master", "text": "queued during connect"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_append_context_when_ready_flushes_before_user_input():
     mgr = _make_manager()
     mgr.session_ready = False

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -39,7 +39,8 @@ class _FakeHybridTextSession(_FakePrimeSession):
 async def test_append_context_adds_active_history_message():
     mgr = _make_manager()
     history = []
-    mgr.session = SimpleNamespace(_conversation_history=history)
+    active_session = SimpleNamespace(_conversation_history=history)
+    mgr.session = active_session
 
     result = await mgr.append_context(
         source="game.icebreaker",
@@ -221,15 +222,16 @@ async def test_final_swap_primes_late_next_session_context_before_consuming():
     session = _AppendingPrimeSession()
     mgr.session = session
 
-    consumed = await mgr._prime_late_next_session_context_after_swap(1)
+    consumed = await mgr._prime_late_next_session_context_after_swap(1, 2)
     mgr._consume_next_session_context_messages(consumed)
 
-    assert consumed == 3
+    assert consumed == 2
     assert session.calls == [
         ("system | late before promote\n", True),
-        ("Master | late during prime\n", True),
     ]
-    assert mgr.next_session_context_messages == []
+    assert mgr.next_session_context_messages == [
+        {"role": "Master", "text": "late during prime"},
+    ]
 
 
 def test_final_swap_primes_late_context_before_flushing_cached_audio():
@@ -363,6 +365,47 @@ async def test_pending_context_drain_includes_items_queued_during_flush():
 
 
 @pytest.mark.asyncio
+async def test_pending_context_drain_keeps_going_when_failed_pass_queues_new_item():
+    mgr = _make_manager()
+    mgr.session_ready = False
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+
+    await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="stuck context",
+        timing="when_ready",
+        ordering_key="001",
+    )
+
+    original_append = mgr._append_context_to_targets
+    queued_late = False
+
+    async def fail_first_and_queue(payload):
+        nonlocal queued_late
+        if payload["text"] == "stuck context":
+            if not queued_late:
+                queued_late = True
+                await mgr.append_context(
+                    source="topic.hook",
+                    role="system",
+                    text="fresh context",
+                    timing="when_ready",
+                    ordering_key="002",
+                )
+            return core_module.ContextAppendResult(appended=False, reason="no_context_target")
+        return await original_append(payload)
+
+    mgr._append_context_to_targets = fail_first_and_queue
+    await mgr._drain_pending_context_appends_before_ready()
+
+    assert len(mgr.pending_context_appends) == 1
+    assert mgr.pending_context_appends[0]["text"] == "stuck context"
+    assert [message.content for message in history] == ["system: fresh context"]
+
+
+@pytest.mark.asyncio
 async def test_clear_pending_context_appends_drops_stale_ready_queue():
     mgr = _make_manager()
     mgr.session_ready = False
@@ -387,10 +430,48 @@ async def test_clear_pending_context_appends_drops_stale_ready_queue():
 
 
 @pytest.mark.asyncio
+async def test_when_ready_durable_context_is_cached_before_readiness_flush():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    queued = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="durable setup",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-request",
+    )
+
+    assert queued.appended is True
+    assert queued.targets == ("pending_ready",)
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "durable setup"},
+    ]
+
+    mgr._clear_pending_context_appends()
+    duplicate = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="durable setup replay",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-request",
+    )
+
+    assert duplicate.appended is False
+    assert duplicate.deduped is True
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "durable setup"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_clear_pending_context_appends_releases_only_stale_request_ids():
     mgr = _make_manager()
     history = []
-    mgr.session = SimpleNamespace(_conversation_history=history)
+    active_session = SimpleNamespace(_conversation_history=history)
+    mgr.session = active_session
 
     active = await mgr.append_context(
         source="topic.hook",
@@ -412,7 +493,7 @@ async def test_clear_pending_context_appends_releases_only_stale_request_ids():
     assert queued.appended is True
 
     mgr._clear_pending_context_appends()
-    mgr.session = SimpleNamespace(_conversation_history=history)
+    mgr.session = active_session
     mgr.session_ready = True
     retry_stale = await mgr.append_context(
         source="topic.hook",
@@ -434,6 +515,42 @@ async def test_clear_pending_context_appends_releases_only_stale_request_ids():
         "system: already written",
         "system: queued retry in new session",
     ]
+
+
+@pytest.mark.asyncio
+async def test_current_session_request_id_can_replay_after_session_replaced():
+    mgr = _make_manager()
+    first_session = _FakePrimeSession()
+    mgr.session = first_session
+
+    first = await mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same request in first session",
+        request_id="ctx-current",
+    )
+    duplicate = await mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same request duplicate",
+        request_id="ctx-current",
+    )
+
+    second_session = _FakePrimeSession()
+    mgr.session = second_session
+    replay = await mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same request in replacement session",
+        request_id="ctx-current",
+    )
+
+    assert first.appended is True
+    assert duplicate.appended is False
+    assert duplicate.deduped is True
+    assert replay.appended is True
+    assert first_session.calls == [("user: same request in first session", True)]
+    assert second_session.calls == [("user: same request in replacement session", True)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -160,6 +160,27 @@ async def test_next_session_context_snapshot_consumes_only_rendered_prefix():
 
 
 @pytest.mark.asyncio
+async def test_final_swap_reset_preserves_unconsumed_next_session_context():
+    mgr = _make_manager()
+    mgr.background_preparation_task = None
+    mgr.final_swap_task = None
+    mgr.pending_session_warmed_up_event = object()
+    mgr.pending_session_final_prime_complete_event = object()
+    mgr.pending_use_tts = True
+    mgr.next_session_context_messages = [{"role": "Lan", "text": "late context"}]
+    mgr.message_cache_for_new_session = [{"role": "Master", "text": "main cache"}]
+    mgr.initial_next_session_context_snapshot_len = 1
+
+    await mgr._reset_preparation_state(clear_main_cache=True, from_final_swap=True)
+
+    assert mgr.message_cache_for_new_session == []
+    assert mgr.next_session_context_messages == [{"role": "Lan", "text": "late context"}]
+    assert mgr.initial_next_session_context_snapshot_len == 0
+    assert mgr.pending_session_warmed_up_event is None
+    assert mgr.pending_use_tts is None
+
+
+@pytest.mark.asyncio
 async def test_append_context_when_ready_flushes_before_user_input():
     mgr = _make_manager()
     mgr.session_ready = False

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -92,7 +92,25 @@ async def test_append_context_primes_realtime_for_model_only_context():
 
     assert result.appended is True
     assert result.targets == ("realtime_prime",)
-    assert session.calls == [("user: score snapshot", True)]
+    assert session.calls == [("score snapshot", True)]
+
+
+@pytest.mark.asyncio
+async def test_append_context_keeps_role_prefix_for_generic_realtime_context():
+    mgr = _make_manager()
+    session = _FakePrimeSession()
+    mgr.session = session
+
+    result = await mgr.append_context(
+        source="proactive.context",
+        role="system",
+        text="background note",
+        audience="model",
+    )
+
+    assert result.appended is True
+    assert result.targets == ("realtime_prime",)
+    assert session.calls == [("system: background note", True)]
 
 
 @pytest.mark.asyncio
@@ -697,8 +715,8 @@ async def test_current_session_request_id_can_replay_after_session_replaced():
     assert duplicate.appended is False
     assert duplicate.deduped is True
     assert replay.appended is True
-    assert first_session.calls == [("user: same request in first session", True)]
-    assert second_session.calls == [("user: same request in replacement session", True)]
+    assert first_session.calls == [("same request in first session", True)]
+    assert second_session.calls == [("same request in replacement session", True)]
 
 
 @pytest.mark.asyncio
@@ -775,7 +793,7 @@ async def test_append_context_reserves_request_id_before_awaiting_prime():
     assert duplicate.appended is False
     assert duplicate.deduped is True
     assert duplicate.reason == "duplicate_request_id"
-    assert session.calls == [("user: same context", True)]
+    assert session.calls == [("same context", True)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -928,7 +928,6 @@ async def test_append_context_cancellation_releases_duplicate_waiter_and_request
         request_id="ctx-1",
     )
 
-    release.set()
     assert duplicate.appended is False
     assert duplicate.deduped is False
     assert duplicate.reason == "context_inject_cancelled"

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -256,6 +256,30 @@ async def test_pending_context_drain_includes_items_queued_during_flush():
 
 
 @pytest.mark.asyncio
+async def test_clear_pending_context_appends_drops_stale_ready_queue():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="old session only",
+        timing="when_ready",
+        lifetime="current_session",
+    )
+
+    assert len(mgr.pending_context_appends) == 1
+
+    mgr._clear_pending_context_appends()
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    await mgr._drain_pending_context_appends_before_ready()
+
+    assert mgr.pending_context_appends == []
+    assert history == []
+
+
+@pytest.mark.asyncio
 async def test_append_context_dedups_request_id_inside_manager():
     mgr = _make_manager()
     history = []

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -1,0 +1,197 @@
+from types import SimpleNamespace
+
+import pytest
+
+import main_logic.core as core_module
+from utils.llm_client import AIMessage, HumanMessage
+
+
+def _make_manager():
+    mgr = object.__new__(core_module.LLMSessionManager)
+    mgr.lanlan_name = "Lan"
+    mgr.master_name = "Master"
+    mgr.session = None
+    mgr.session_ready = True
+    mgr.is_preparing_new_session = False
+    mgr.message_cache_for_new_session = []
+    return mgr
+
+
+class _FakePrimeSession:
+    def __init__(self):
+        self.calls = []
+
+    async def prime_context(self, text, *, skipped=False):
+        self.calls.append((text, skipped))
+
+
+@pytest.mark.asyncio
+async def test_append_context_adds_active_history_message():
+    mgr = _make_manager()
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+
+    result = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="  tutorial finished  ",
+        audience="model",
+    )
+
+    assert result.appended is True
+    assert result.deduped is False
+    assert result.targets == ("active_history",)
+    assert isinstance(history[0], AIMessage)
+    assert history[0].content == "tutorial finished"
+
+
+@pytest.mark.asyncio
+async def test_append_context_primes_realtime_for_model_only_context():
+    mgr = _make_manager()
+    session = _FakePrimeSession()
+    mgr.session = session
+
+    result = await mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="score snapshot",
+        audience="model",
+    )
+
+    assert result.appended is True
+    assert result.targets == ("realtime_prime",)
+    assert session.calls == [("user: score snapshot", True)]
+
+
+@pytest.mark.asyncio
+async def test_append_context_seeds_next_session_cache_when_preparing():
+    mgr = _make_manager()
+    mgr.is_preparing_new_session = True
+
+    result = await mgr.append_context(
+        source="game.icebreaker",
+        role="user",
+        text="choice A",
+        audience="model",
+        lifetime="session_family",
+    )
+
+    assert result.appended is True
+    assert result.targets == ("new_session_cache",)
+    assert mgr.message_cache_for_new_session == [{"role": "Master", "text": "choice A"}]
+
+
+@pytest.mark.asyncio
+async def test_append_context_when_ready_flushes_before_user_input():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    queued = await mgr.append_context(
+        source="proactive.context",
+        role="system",
+        text="queued context",
+        audience="model",
+        timing="when_ready",
+        ordering_key="ctx-1",
+    )
+
+    assert queued.appended is True
+    assert queued.targets == ("pending_ready",)
+
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    mgr.session_ready = True
+    await mgr._flush_pending_context_appends()
+
+    assert len(history) == 1
+    assert isinstance(history[0], HumanMessage)
+    assert history[0].content == "system: queued context"
+
+
+@pytest.mark.asyncio
+async def test_append_context_when_ready_uses_ordering_key_for_flush_order():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="second context",
+        timing="when_ready",
+        ordering_key="002",
+    )
+    await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="first context",
+        timing="when_ready",
+        ordering_key="001",
+    )
+
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    mgr.session_ready = True
+    await mgr._flush_pending_context_appends()
+
+    assert [message.content for message in history] == [
+        "system: first context",
+        "system: second context",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_append_context_dedups_request_id_inside_manager():
+    mgr = _make_manager()
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+
+    first = await mgr.append_context(
+        source="topic.hook",
+        role="user",
+        text="same hook",
+        request_id="hook-1",
+    )
+    duplicate = await mgr.append_context(
+        source="topic.hook",
+        role="user",
+        text="same hook replay",
+        request_id="hook-1",
+    )
+    other_source = await mgr.append_context(
+        source="proactive.context",
+        role="user",
+        text="same id, different source",
+        request_id="hook-1",
+    )
+
+    assert first.appended is True
+    assert duplicate.appended is False
+    assert duplicate.deduped is True
+    assert other_source.appended is True
+    assert [message.content for message in history] == [
+        "same hook",
+        "same id, different source",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_append_context_applies_token_budget(monkeypatch):
+    mgr = _make_manager()
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+
+    def fake_truncate(text, max_tokens, *args, **kwargs):
+        assert max_tokens == 3
+        return "one two three"
+
+    monkeypatch.setattr(core_module, "_CONTEXT_APPEND_DEFAULT_MAX_TOKENS", 3)
+    monkeypatch.setattr("utils.tokenize.truncate_to_tokens", fake_truncate)
+
+    result = await mgr.append_context(
+        source="test.context",
+        role="user",
+        text="one two three four five",
+    )
+
+    assert result.appended is True
+    assert history[0].content == "one two three"

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -68,6 +68,8 @@ async def test_append_context_does_not_prime_text_session_after_history_append()
     assert result.appended is True
     assert result.targets == ("active_history",)
     assert len(session._conversation_history) == 1
+    assert isinstance(session._conversation_history[0], AIMessage)
+    assert session._conversation_history[0].content == "tutorial finished"
     assert session.calls == []
 
 
@@ -259,6 +261,7 @@ async def test_append_context_reserves_request_id_before_awaiting_prime():
     assert first_result.appended is True
     assert duplicate.appended is False
     assert duplicate.deduped is True
+    assert duplicate.reason == "duplicate_request_id"
     assert session.calls == [("user: same context", True)]
 
 

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -524,10 +524,13 @@ async def test_append_context_applies_token_budget(monkeypatch):
     mgr = _make_manager()
     history = []
     mgr.session = SimpleNamespace(_conversation_history=history)
+    truncate_calls = 0
 
     def fake_truncate(text, max_tokens, *args, **kwargs):
+        nonlocal truncate_calls
+        truncate_calls += 1
         assert max_tokens == 3
-        return "one two three"
+        return "__sentinel_truncated_context__"
 
     monkeypatch.setattr(core_module, "_CONTEXT_APPEND_DEFAULT_MAX_TOKENS", 3)
     monkeypatch.setattr("utils.tokenize.truncate_to_tokens", fake_truncate)
@@ -539,4 +542,5 @@ async def test_append_context_applies_token_budget(monkeypatch):
     )
 
     assert result.appended is True
-    assert history[0].content == "one two three"
+    assert truncate_calls == 1
+    assert history[0].content == "__sentinel_truncated_context__"

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -15,6 +15,8 @@ def _make_manager():
     mgr.session_ready = True
     mgr.is_preparing_new_session = False
     mgr.message_cache_for_new_session = []
+    mgr.next_session_context_messages = []
+    mgr.initial_next_session_context_snapshot_len = 0
     return mgr
 
 
@@ -106,7 +108,29 @@ async def test_append_context_seeds_next_session_cache_when_preparing():
 
     assert result.appended is True
     assert result.targets == ("new_session_cache",)
-    assert mgr.message_cache_for_new_session == [{"role": "Master", "text": "choice A"}]
+    assert mgr.next_session_context_messages == [{"role": "Master", "text": "choice A"}]
+    assert mgr.message_cache_for_new_session == []
+
+
+@pytest.mark.asyncio
+async def test_append_context_next_session_context_survives_preparation_cache_reset():
+    mgr = _make_manager()
+
+    result = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="carry this tutorial note",
+        audience="model",
+        lifetime="next_session",
+    )
+
+    mgr.message_cache_for_new_session = []
+
+    assert result.appended is True
+    assert result.targets == ("new_session_cache",)
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "carry this tutorial note"},
+    ]
 
 
 @pytest.mark.asyncio
@@ -186,6 +210,49 @@ async def test_pending_context_can_flush_before_session_ready_opens():
 
     assert mgr.session_ready is False
     assert [message.content for message in history] == ["system: queued context"]
+
+
+@pytest.mark.asyncio
+async def test_pending_context_drain_includes_items_queued_during_flush():
+    mgr = _make_manager()
+    mgr.session_ready = False
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+
+    await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="first context",
+        timing="when_ready",
+        ordering_key="001",
+    )
+
+    original_append = mgr._append_context_to_targets
+    queued_late = False
+
+    async def append_and_queue(payload):
+        nonlocal queued_late
+        result = await original_append(payload)
+        if not queued_late:
+            queued_late = True
+            await mgr.append_context(
+                source="topic.hook",
+                role="system",
+                text="second context",
+                timing="when_ready",
+                ordering_key="002",
+            )
+        return result
+
+    mgr._append_context_to_targets = append_and_queue
+    await mgr._drain_pending_context_appends_before_ready()
+
+    assert mgr.session_ready is False
+    assert mgr.pending_context_appends == []
+    assert [message.content for message in history] == [
+        "system: first context",
+        "system: second context",
+    ]
 
 
 @pytest.mark.asyncio
@@ -294,9 +361,10 @@ async def test_append_context_keeps_partial_targets_when_realtime_prime_fails():
     assert result.targets == ("new_session_cache",)
     assert duplicate.appended is False
     assert duplicate.deduped is True
-    assert mgr.message_cache_for_new_session == [
+    assert mgr.next_session_context_messages == [
         {"role": "Lan", "text": "cached for next session"},
     ]
+    assert mgr.message_cache_for_new_session == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -25,6 +26,12 @@ class _FakePrimeSession:
         self.calls.append((text, skipped))
 
 
+class _FakeHybridTextSession(_FakePrimeSession):
+    def __init__(self):
+        super().__init__()
+        self._conversation_history = []
+
+
 @pytest.mark.asyncio
 async def test_append_context_adds_active_history_message():
     mgr = _make_manager()
@@ -43,6 +50,25 @@ async def test_append_context_adds_active_history_message():
     assert result.targets == ("active_history",)
     assert isinstance(history[0], AIMessage)
     assert history[0].content == "tutorial finished"
+
+
+@pytest.mark.asyncio
+async def test_append_context_does_not_prime_text_session_after_history_append():
+    mgr = _make_manager()
+    session = _FakeHybridTextSession()
+    mgr.session = session
+
+    result = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="tutorial finished",
+        audience="model",
+    )
+
+    assert result.appended is True
+    assert result.targets == ("active_history",)
+    assert len(session._conversation_history) == 1
+    assert session.calls == []
 
 
 @pytest.mark.asyncio
@@ -140,6 +166,27 @@ async def test_append_context_when_ready_uses_ordering_key_for_flush_order():
 
 
 @pytest.mark.asyncio
+async def test_pending_context_can_flush_before_session_ready_opens():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    await mgr.append_context(
+        source="topic.hook",
+        role="system",
+        text="queued context",
+        timing="when_ready",
+        ordering_key="ctx",
+    )
+
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    await mgr._flush_pending_context_appends()
+
+    assert mgr.session_ready is False
+    assert [message.content for message in history] == ["system: queued context"]
+
+
+@pytest.mark.asyncio
 async def test_append_context_dedups_request_id_inside_manager():
     mgr = _make_manager()
     history = []
@@ -172,6 +219,47 @@ async def test_append_context_dedups_request_id_inside_manager():
         "same hook",
         "same id, different source",
     ]
+
+
+@pytest.mark.asyncio
+async def test_append_context_reserves_request_id_before_awaiting_prime():
+    mgr = _make_manager()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class _BlockingPrimeSession:
+        def __init__(self):
+            self.calls = []
+
+        async def prime_context(self, text, *, skipped=False):
+            self.calls.append((text, skipped))
+            entered.set()
+            await release.wait()
+
+    session = _BlockingPrimeSession()
+    mgr.session = session
+
+    first = asyncio.create_task(mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same context",
+        request_id="ctx-1",
+    ))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    duplicate = await mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same context replay",
+        request_id="ctx-1",
+    )
+    release.set()
+    first_result = await first
+
+    assert first_result.appended is True
+    assert duplicate.appended is False
+    assert duplicate.deduped is True
+    assert session.calls == [("user: same context", True)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -810,19 +810,72 @@ async def test_append_context_reserves_request_id_before_awaiting_prime():
     ))
     await asyncio.wait_for(entered.wait(), timeout=1)
 
-    duplicate = await mgr.append_context(
+    duplicate_task = asyncio.create_task(mgr.append_context(
         source="game.realtime_context",
         role="user",
         text="same context replay",
         request_id="ctx-1",
-    )
+    ))
+    await asyncio.sleep(0)
+    assert duplicate_task.done() is False
+
     release.set()
     first_result = await first
+    duplicate = await duplicate_task
 
     assert first_result.appended is True
     assert duplicate.appended is False
     assert duplicate.deduped is True
     assert duplicate.reason == "duplicate_request_id"
+    assert session.calls == [("same context", True)]
+
+
+@pytest.mark.asyncio
+async def test_append_context_duplicate_waits_for_failed_original_before_reporting():
+    mgr = _make_manager()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class _FailingBlockingPrimeSession:
+        def __init__(self):
+            self.calls = []
+
+        async def prime_context(self, text, *, skipped=False):
+            self.calls.append((text, skipped))
+            entered.set()
+            await release.wait()
+            raise RuntimeError("prime unavailable")
+
+    session = _FailingBlockingPrimeSession()
+    mgr.session = session
+
+    first = asyncio.create_task(mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same context",
+        request_id="ctx-1",
+    ))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    duplicate_task = asyncio.create_task(mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same context replay",
+        request_id="ctx-1",
+    ))
+    await asyncio.sleep(0)
+    assert duplicate_task.done() is False
+
+    release.set()
+    first_result = await first
+    duplicate = await duplicate_task
+
+    assert first_result.appended is False
+    assert first_result.deduped is False
+    assert first_result.reason == "realtime_prime_failed"
+    assert duplicate.appended is False
+    assert duplicate.deduped is False
+    assert duplicate.reason == "realtime_prime_failed"
     assert session.calls == [("same context", True)]
 
 

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -475,6 +475,57 @@ async def test_when_ready_durable_context_is_cached_before_readiness_flush():
 
 
 @pytest.mark.asyncio
+async def test_when_ready_durable_context_retries_if_realtime_prime_fails():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    queued = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="durable realtime setup",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-realtime",
+    )
+
+    class _FailingPrimeSession:
+        async def prime_context(self, text, *, skipped=False):
+            raise RuntimeError("prime unavailable")
+
+    mgr.session = _FailingPrimeSession()
+    flushed = await mgr._flush_pending_context_appends()
+
+    assert queued.appended is True
+    assert flushed == 0
+    assert len(mgr.pending_context_appends) == 1
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "durable realtime setup"},
+    ]
+
+    duplicate = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="durable realtime setup replay",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-realtime",
+    )
+    assert duplicate.appended is False
+    assert duplicate.deduped is True
+
+    recovered_session = _FakePrimeSession()
+    mgr.session = recovered_session
+    flushed = await mgr._flush_pending_context_appends()
+
+    assert flushed == 1
+    assert mgr.pending_context_appends == []
+    assert recovered_session.calls == [("assistant: durable realtime setup", True)]
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "durable realtime setup"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_when_ready_durable_context_delivered_in_start_prompt_is_not_replayed():
     mgr = _make_manager()
     mgr.session_ready = False

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -779,7 +779,7 @@ async def test_append_context_reserves_request_id_before_awaiting_prime():
 
 
 @pytest.mark.asyncio
-async def test_append_context_keeps_partial_targets_when_realtime_prime_fails():
+async def test_append_context_requires_current_delivery_when_ready_session_family_prime_fails():
     mgr = _make_manager()
 
     class _FailingPrimeSession:
@@ -803,12 +803,13 @@ async def test_append_context_keeps_partial_targets_when_realtime_prime_fails():
         request_id="ctx-partial",
     )
 
-    assert result.appended is True
+    assert result.appended is False
     assert result.targets == ("new_session_cache",)
-    assert duplicate.appended is False
-    assert duplicate.deduped is True
+    assert result.reason == "realtime_prime_failed"
+    assert duplicate.deduped is False
     assert mgr.next_session_context_messages == [
         {"role": "Lan", "text": "cached for next session"},
+        {"role": "Lan", "text": "cached for next session again"},
     ]
     assert mgr.message_cache_for_new_session == []
 

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -494,6 +494,43 @@ async def test_when_ready_durable_context_is_cached_before_readiness_flush():
 
 
 @pytest.mark.asyncio
+async def test_full_new_session_reset_releases_abandoned_durable_pending_dedup():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    queued = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="abandoned durable setup",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-request",
+    )
+
+    assert queued.appended is True
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "abandoned durable setup"},
+    ]
+
+    mgr.next_session_context_messages = []
+    mgr._clear_pending_context_appends(release_durable_cached=True)
+    retry = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="requeued durable setup",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-request",
+    )
+
+    assert retry.appended is True
+    assert retry.deduped is False
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "requeued durable setup"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_when_ready_durable_context_retries_if_realtime_prime_fails():
     mgr = _make_manager()
     mgr.session_ready = False

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 from types import SimpleNamespace
 
 import pytest
@@ -229,6 +230,14 @@ async def test_final_swap_primes_late_next_session_context_before_consuming():
         ("Master | late during prime\n", True),
     ]
     assert mgr.next_session_context_messages == []
+
+
+def test_final_swap_primes_late_context_before_flushing_cached_audio():
+    source = inspect.getsource(core_module.LLMSessionManager._perform_final_swap_sequence)
+
+    assert source.index("_prime_late_next_session_context_after_swap") < source.index(
+        "_flush_hot_swap_audio_cache"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -557,6 +557,41 @@ async def test_when_ready_durable_context_delivered_in_start_prompt_is_not_repla
 
 
 @pytest.mark.asyncio
+async def test_concurrent_loser_does_not_clear_winner_start_prompt_marks():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    queued = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="winner prompt context",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-winner",
+    )
+    snapshot = mgr._snapshot_next_session_context_messages()
+    winner_owner = object()
+    loser_owner = object()
+    mgr._mark_pending_context_appends_delivered_in_start_prompt(
+        snapshot,
+        owner=winner_owner,
+    )
+    mgr._clear_pending_context_start_prompt_marks(owner=loser_owner)
+
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    flushed = await mgr._flush_pending_context_appends()
+
+    assert queued.appended is True
+    assert flushed == 1
+    assert mgr.pending_context_appends == []
+    assert history == []
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "winner prompt context"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_late_prime_failure_still_allows_transferred_prefix_consumption():
     mgr = _make_manager()
     mgr.next_session_context_messages = [

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -880,6 +880,64 @@ async def test_append_context_duplicate_waits_for_failed_original_before_reporti
 
 
 @pytest.mark.asyncio
+async def test_append_context_cancellation_releases_duplicate_waiter_and_request_id():
+    mgr = _make_manager()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class _CancelledPrimeSession:
+        def __init__(self):
+            self.calls = []
+
+        async def prime_context(self, text, *, skipped=False):
+            self.calls.append((text, skipped))
+            entered.set()
+            await release.wait()
+
+    session = _CancelledPrimeSession()
+    mgr.session = session
+
+    first = asyncio.create_task(mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same context",
+        request_id="ctx-1",
+    ))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    duplicate_task = asyncio.create_task(mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same context replay",
+        request_id="ctx-1",
+    ))
+    await asyncio.sleep(0)
+    assert duplicate_task.done() is False
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    duplicate = await asyncio.wait_for(duplicate_task, timeout=1)
+
+    retry_session = _FakePrimeSession()
+    mgr.session = retry_session
+    retry = await mgr.append_context(
+        source="game.realtime_context",
+        role="user",
+        text="same context retry after cancellation",
+        request_id="ctx-1",
+    )
+
+    release.set()
+    assert duplicate.appended is False
+    assert duplicate.deduped is False
+    assert duplicate.reason == "context_inject_cancelled"
+    assert retry.appended is True
+    assert session.calls == [("same context", True)]
+    assert retry_session.calls == [("same context retry after cancellation", True)]
+
+
+@pytest.mark.asyncio
 async def test_append_context_requires_current_delivery_when_ready_session_family_prime_fails():
     mgr = _make_manager()
 

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -263,6 +263,71 @@ async def test_append_context_reserves_request_id_before_awaiting_prime():
 
 
 @pytest.mark.asyncio
+async def test_append_context_keeps_partial_targets_when_realtime_prime_fails():
+    mgr = _make_manager()
+
+    class _FailingPrimeSession:
+        async def prime_context(self, text, *, skipped=False):
+            raise RuntimeError("prime unavailable")
+
+    mgr.session = _FailingPrimeSession()
+
+    result = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="cached for next session",
+        lifetime="session_family",
+        request_id="ctx-partial",
+    )
+    duplicate = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="cached for next session again",
+        lifetime="session_family",
+        request_id="ctx-partial",
+    )
+
+    assert result.appended is True
+    assert result.targets == ("new_session_cache",)
+    assert duplicate.appended is False
+    assert duplicate.deduped is True
+    assert mgr.message_cache_for_new_session == [
+        {"role": "Lan", "text": "cached for next session"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pending_context_retries_when_all_targets_fail():
+    mgr = _make_manager()
+    mgr.session_ready = False
+    await mgr.append_context(
+        source="game.realtime_context",
+        role="system",
+        text="retry later",
+        timing="when_ready",
+        request_id="ctx-retry",
+    )
+
+    class _FailingPrimeSession:
+        async def prime_context(self, text, *, skipped=False):
+            raise RuntimeError("prime unavailable")
+
+    mgr.session = _FailingPrimeSession()
+    await mgr._flush_pending_context_appends()
+
+    assert len(mgr.pending_context_appends) == 1
+    duplicate = await mgr.append_context(
+        source="game.realtime_context",
+        role="system",
+        text="retry duplicate",
+        timing="when_ready",
+        request_id="ctx-retry",
+    )
+    assert duplicate.appended is False
+    assert duplicate.deduped is True
+
+
+@pytest.mark.asyncio
 async def test_append_context_applies_token_budget(monkeypatch):
     mgr = _make_manager()
     history = []

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -1003,6 +1003,60 @@ async def test_pending_context_retries_when_all_targets_fail():
 
 
 @pytest.mark.asyncio
+async def test_pending_context_flush_cancellation_restores_queue_and_request_ids():
+    mgr = _make_manager()
+    mgr.session_ready = False
+    await mgr.append_context(
+        source="game.realtime_context",
+        role="system",
+        text="first pending",
+        timing="when_ready",
+        request_id="ctx-cancel-1",
+        ordering_key="001",
+    )
+    await mgr.append_context(
+        source="game.realtime_context",
+        role="system",
+        text="second pending",
+        timing="when_ready",
+        request_id="ctx-cancel-2",
+        ordering_key="002",
+    )
+
+    original_append = mgr._append_context_to_targets
+
+    async def cancelled_append(_payload):
+        raise asyncio.CancelledError
+
+    mgr._append_context_to_targets = cancelled_append
+
+    with pytest.raises(asyncio.CancelledError):
+        await mgr._flush_pending_context_appends()
+
+    assert [payload["text"] for payload in mgr.pending_context_appends] == [
+        "first pending",
+        "second pending",
+    ]
+
+    mgr._clear_pending_context_appends()
+    mgr._append_context_to_targets = original_append
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    mgr.session_ready = True
+    retry = await mgr.append_context(
+        source="game.realtime_context",
+        role="system",
+        text="first pending retry",
+        timing="when_ready",
+        request_id="ctx-cancel-1",
+    )
+
+    assert retry.appended is True
+    assert retry.deduped is False
+    assert [message.content for message in history] == ["system: first pending retry"]
+
+
+@pytest.mark.asyncio
 async def test_append_context_applies_token_budget(monkeypatch):
     mgr = _make_manager()
     history = []

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -827,7 +827,6 @@ async def test_append_context_requires_current_delivery_when_ready_session_famil
     assert duplicate.deduped is False
     assert mgr.next_session_context_messages == [
         {"role": "Lan", "text": "cached for next session"},
-        {"role": "Lan", "text": "cached for next session again"},
     ]
     assert mgr.message_cache_for_new_session == []
 

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -242,6 +242,14 @@ def test_final_swap_primes_late_context_before_flushing_cached_audio():
     )
 
 
+def test_final_swap_consumes_next_session_context_after_cached_audio_flush():
+    source = inspect.getsource(core_module.LLMSessionManager._perform_final_swap_sequence)
+
+    assert source.index("_flush_hot_swap_audio_cache") < source.index(
+        "_consume_next_session_context_messages(consumed_next_context_count)"
+    )
+
+
 @pytest.mark.asyncio
 async def test_append_context_when_ready_flushes_before_user_input():
     mgr = _make_manager()
@@ -463,6 +471,60 @@ async def test_when_ready_durable_context_is_cached_before_readiness_flush():
     assert duplicate.deduped is True
     assert mgr.next_session_context_messages == [
         {"role": "Lan", "text": "durable setup"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_when_ready_durable_context_delivered_in_start_prompt_is_not_replayed():
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    queued = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="already in start prompt",
+        timing="when_ready",
+        lifetime="session_family",
+        request_id="durable-start",
+    )
+    snapshot = mgr._snapshot_next_session_context_messages()
+    mgr._mark_pending_context_appends_delivered_in_start_prompt(snapshot)
+
+    history = []
+    mgr.session = SimpleNamespace(_conversation_history=history)
+    await mgr._flush_pending_context_appends()
+
+    assert queued.appended is True
+    assert mgr.pending_context_appends == []
+    assert history == []
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "already in start prompt"},
+    ]
+
+    mgr._consume_next_session_context_messages(len(snapshot))
+    assert mgr.next_session_context_messages == []
+
+
+@pytest.mark.asyncio
+async def test_late_prime_failure_still_allows_transferred_prefix_consumption():
+    mgr = _make_manager()
+    mgr.next_session_context_messages = [
+        {"role": "Lan", "text": "already transferred"},
+        {"role": "system", "text": "late context"},
+    ]
+
+    class _FailingPrimeSession:
+        async def prime_context(self, text, *, skipped=False):
+            raise RuntimeError("provider rejected late prime")
+
+    mgr.session = _FailingPrimeSession()
+
+    consumed = await mgr._prime_late_next_session_context_after_swap(1, 2)
+    mgr._consume_next_session_context_messages(consumed)
+
+    assert consumed == 1
+    assert mgr.next_session_context_messages == [
+        {"role": "system", "text": "late context"},
     ]
 
 

--- a/tests/unit/test_game_llm_static_contracts.py
+++ b/tests/unit/test_game_llm_static_contracts.py
@@ -62,15 +62,19 @@ def test_soccer_quick_lines_and_pregame_prompts_are_localized():
 @pytest.mark.unit
 def test_soccer_realtime_context_posts_local_mutation_headers():
     html = ROOT.joinpath("templates/soccer_demo.html").read_text(encoding="utf-8")
+    headers_block = html.split("function _getLocalMutationHeaders()", 1)[1].split(
+        "function _refreshLocalMutationHeaders()",
+        1,
+    )[0]
     context_block = html.split("async function _sendRealtimeGameContext(source, items = [])", 1)[1].split(
         "async function _mirrorGameAssistantText",
         1,
     )[0]
 
-    assert "function _getLocalMutationHeaders()" in html
-    assert "window.nekoLocalMutationSecurity" in html
-    assert "getMutationHeaders" in html
-    assert "'X-CSRF-Token'" in html
+    assert "window.nekoLocalMutationSecurity" in headers_block
+    assert "getMutationHeaders" in headers_block
+    assert "headers['X-CSRF-Token'] = config.autostart_csrf_token;" in headers_block
+    assert "cache: 'no-store'" in headers_block
     assert "credentials: 'same-origin'" in context_block
     assert "headers,\n        body: bodyJson" in context_block
     assert "await postWithHeaders(await _getLocalMutationHeaders())" in context_block

--- a/tests/unit/test_game_llm_static_contracts.py
+++ b/tests/unit/test_game_llm_static_contracts.py
@@ -60,6 +60,25 @@ def test_soccer_quick_lines_and_pregame_prompts_are_localized():
 
 
 @pytest.mark.unit
+def test_soccer_realtime_context_posts_local_mutation_headers():
+    html = ROOT.joinpath("templates/soccer_demo.html").read_text(encoding="utf-8")
+    context_block = html.split("async function _sendRealtimeGameContext(source, items = [])", 1)[1].split(
+        "async function _mirrorGameAssistantText",
+        1,
+    )[0]
+
+    assert "function _getLocalMutationHeaders()" in html
+    assert "window.nekoLocalMutationSecurity" in html
+    assert "getMutationHeaders" in html
+    assert "'X-CSRF-Token'" in html
+    assert "credentials: 'same-origin'" in context_block
+    assert "headers,\n        body: bodyJson" in context_block
+    assert "await postWithHeaders(await _getLocalMutationHeaders())" in context_block
+    assert "errorPayload.error_code === 'csrf_validation_failed'" in context_block
+    assert "await postWithHeaders(await _refreshLocalMutationHeaders())" in context_block
+
+
+@pytest.mark.unit
 def test_pregame_prompt_must_not_be_format_called():
     """Pregame schema uses literal {} for JSON output; callers must not .format() it.
     If a future change needs a {placeholder}, every JSON literal must be doubled first."""

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -2840,6 +2840,25 @@ def test_postgame_context_snapshot_excludes_recent_dialogues(monkeypatch):
 
 
 @pytest.mark.unit
+def test_postgame_context_request_id_is_archive_scoped():
+    first = {
+        "game_type": "soccer",
+        "session_id": "default",
+        "ended_at": 10.5,
+    }
+    second = {
+        "game_type": "soccer",
+        "session_id": "default",
+        "ended_at": 11.5,
+    }
+
+    assert game_router._postgame_context_request_id(first) == "soccer:default:10.5"
+    assert game_router._postgame_context_request_id(second) == "soccer:default:11.5"
+    assert game_router._postgame_context_request_id(first) != game_router._postgame_context_request_id(second)
+    assert game_router._postgame_context_request_id({"game_type": "soccer", "session_id": "default"}) is None
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_game_chat_event_user_turn_keeps_watermark(monkeypatch):
     class FakeSession:

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -3389,6 +3389,30 @@ async def test_realtime_context_skips_gemini_prime_to_avoid_hidden_response(monk
     assert session.create_response_calls == []
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_realtime_context_endpoint_requires_local_mutation_csrf(monkeypatch, _fake_realtime):
+    session = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    mgr = _FakeRealtimeManager(session)
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
+
+    result = await game_router.game_realtime_context(
+        "soccer",
+        _FakeRequest({
+            "lanlan_name": "Lan",
+            "source": "game_event",
+            "currentState": {"score": {"player": 1, "ai": 2}},
+            "pendingItems": [{"type": "game_event", "kind": "goal-scored"}],
+        }, mutation_headers=False, path="/api/game/soccer/realtime-context"),
+    )
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 403
+    assert b"csrf_validation_failed" in result.body
+    assert mgr.append_context_calls == []
+    assert session.prime_context_calls == []
+
+
 class _FakeGameRouteManager:
     def __init__(self):
         self.is_active = False
@@ -4768,6 +4792,41 @@ async def test_game_end_skips_postgame_nudge_when_context_append_deduped(monkeyp
     assert result["postgame"]["reason"] == "context_deduped"
     assert mgr.voice_nudge_calls == 0
     assert session.prime_context_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_postgame_realtime_context_aborts_when_active_session_changes(monkeypatch, _fake_realtime):
+    original = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    replacement = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    mgr = _FakeRealtimeManager(original)
+
+    def swap_session(_archive):
+        mgr.session = replacement
+        return "[Game Module Postgame Context]\nrace"
+
+    monkeypatch.setattr(game_router, "_build_game_postgame_context_text", swap_session)
+
+    result = await game_router._deliver_postgame_to_realtime(
+        mgr,
+        {
+            "game_type": "soccer",
+            "session_id": "match_1",
+            "lanlan_name": "Lan",
+            "ended_at": "100.0",
+        },
+        {"trigger_voice": True},
+    )
+
+    assert result == {
+        "ok": False,
+        "mode": "realtime",
+        "action": "skip",
+        "reason": "realtime_session_changed",
+    }
+    assert mgr.append_context_calls == []
+    assert original.prime_context_calls == []
+    assert replacement.prime_context_calls == []
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -202,6 +202,28 @@ async def test_new_user_icebreaker_context_endpoint_awaits_async_append(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_new_user_icebreaker_context_endpoint_rejects_oversized_text(monkeypatch):
+    mgr = _FakeAppendContextManager(error=AssertionError("oversized icebreaker context must not append"))
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
+    monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
+
+    with reset_game_route_state():
+        _allow_icebreaker_route()
+        result = await game_router.game_project_context(
+            "new_user_icebreaker",
+            _FakeRequest({
+                "lanlan_name": "Lan",
+                "role": "assistant",
+                "text": "x" * (game_router.MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH + 1),
+                "session_id": "icebreaker-day1-test",
+            }),
+        )
+
+    assert result == {"ok": False, "reason": "invalid_text_length"}
+    assert mgr.calls == []
+
+
+@pytest.mark.asyncio
 async def test_new_user_icebreaker_context_rejects_stale_session(monkeypatch):
     mgr = _FakeAppendContextManager(error=AssertionError("stale icebreaker context must not append"))
     monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
@@ -3341,7 +3363,11 @@ class _FakeRealtimeManager:
         self.append_context_calls.append(kwargs)
         if self.append_context_result is not None:
             return self.append_context_result
-        await self.session.prime_context(f"{kwargs['role']}: {kwargs['text']}", skipped=True)
+        source = str(kwargs.get("source") or "")
+        text = kwargs["text"]
+        if source not in {"game.realtime_context", "game.postgame"}:
+            text = f"{kwargs['role']}: {text}"
+        await self.session.prime_context(text, skipped=True)
         return SimpleNamespace(appended=True, deduped=False, targets=("realtime_prime",), reason=None)
 
     async def trigger_voice_proactive_nudge(self, **kwargs):
@@ -4747,6 +4773,7 @@ async def test_game_end_injects_postgame_context_into_active_realtime(monkeypatc
     assert mgr.append_context_calls[0]["audience"] == "model"
     context_text, skipped = session.prime_context_calls[0]
     assert skipped is True
+    assert not context_text.startswith("system: ")
     assert "[Game Module Postgame Context]" in context_text
     assert "我是不是不适合玩这个？" in context_text
 

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -80,6 +80,19 @@ def _allow_local_mutation(request, payload=None, **kwargs):
     return None
 
 
+class _FakeAppendContextManager:
+    def __init__(self, result=None, error=None):
+        self.calls = []
+        self.result = result or SimpleNamespace(appended=True, deduped=False, reason=None)
+        self.error = error
+
+    async def append_context(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
 @pytest.mark.unit
 def test_basketball_removed_modes_are_not_public_or_scored():
     assert game_router._normalize_basketball_mode("horse") == "spectator"
@@ -128,15 +141,7 @@ def test_parse_control_instructions_extracts_json_line():
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_appends_session_history(monkeypatch):
-    class FakeManager:
-        def __init__(self):
-            self.calls = []
-
-        async def append_icebreaker_context_async(self, role, text):
-            self.calls.append((role, text))
-            return True
-
-    mgr = FakeManager()
+    mgr = _FakeAppendContextManager()
     monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
 
@@ -154,20 +159,25 @@ async def test_new_user_icebreaker_context_endpoint_appends_session_history(monk
 
         assert result["ok"] is True
         assert result["method"] == "project_session_history"
-        assert mgr.calls == [("assistant", "教程看完啦？")]
+        assert mgr.calls == [{
+            "source": "game.icebreaker",
+            "role": "assistant",
+            "text": "教程看完啦？",
+            "audience": "model",
+            "timing": "now",
+            "lifetime": "session_family",
+            "request_id": None,
+            "ordering_key": "icebreaker-day1-test",
+            "metadata": {
+                "game_type": "new_user_icebreaker",
+                "session_id": "icebreaker-day1-test",
+            },
+        }]
 
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_awaits_async_append(monkeypatch):
-    class FakeManager:
-        def __init__(self):
-            self.calls = []
-
-        async def append_icebreaker_context_async(self, role, text):
-            self.calls.append((role, text))
-            return True
-
-    mgr = FakeManager()
+    mgr = _FakeAppendContextManager()
     monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
 
@@ -185,16 +195,16 @@ async def test_new_user_icebreaker_context_endpoint_awaits_async_append(monkeypa
 
         assert result["ok"] is True
         assert result["method"] == "project_session_history"
-        assert mgr.calls == [("user", "icebreaker choice")]
+        assert mgr.calls[0]["role"] == "user"
+        assert mgr.calls[0]["text"] == "icebreaker choice"
+        assert mgr.calls[0]["source"] == "game.icebreaker"
+        assert mgr.calls[0]["lifetime"] == "session_family"
 
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_rejects_stale_session(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise AssertionError("stale icebreaker context must not append")
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    mgr = _FakeAppendContextManager(error=AssertionError("stale icebreaker context must not append"))
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
     _allow_icebreaker_route()
 
@@ -218,11 +228,8 @@ async def test_new_user_icebreaker_context_rejects_stale_session(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_rejects_inactive_route(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise AssertionError("inactive icebreaker route must not append")
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    mgr = _FakeAppendContextManager(error=AssertionError("inactive icebreaker route must not append"))
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
 
     with reset_game_route_state():
@@ -246,16 +253,8 @@ async def test_new_user_icebreaker_context_rejects_inactive_route(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_new_user_icebreaker_context_endpoint_dedups_request_id_in_route_state(monkeypatch):
-    class FakeManager:
-        def __init__(self):
-            self.calls = []
-
-        async def append_icebreaker_context_async(self, role, text):
-            self.calls.append((role, text))
-            return True
-
-    mgr = FakeManager()
+async def test_new_user_icebreaker_context_endpoint_delegates_request_id_to_manager(monkeypatch):
+    mgr = _FakeAppendContextManager()
     monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
 
     with reset_game_route_state():
@@ -270,15 +269,6 @@ async def test_new_user_icebreaker_context_endpoint_dedups_request_id_in_route_s
                 "event": {"request_id": "fallback-id"},
             }),
         )
-        duplicate = await game_router.game_project_context(
-            "new_user_icebreaker",
-            _FakeRequest({
-                "lanlan_name": "Lan",
-                "role": "assistant",
-                "text": "hello",
-                "request_id": "icebreaker-context-1",
-            }),
-        )
         next_request = await game_router.game_project_context(
             "new_user_icebreaker",
             _FakeRequest({
@@ -290,66 +280,42 @@ async def test_new_user_icebreaker_context_endpoint_dedups_request_id_in_route_s
         )
 
     assert first["ok"] is True
-    assert duplicate["ok"] is True
-    assert duplicate["deduped"] is True
     assert next_request["ok"] is True
-    assert mgr.calls == [("assistant", "hello"), ("assistant", "hello again")]
-
-
-@pytest.mark.asyncio
-async def test_new_user_icebreaker_context_dedup_duplicate_does_not_refresh_fifo(monkeypatch):
-    class FakeManager:
-        def __init__(self):
-            self.calls = []
-
-        async def append_icebreaker_context_async(self, role, text):
-            self.calls.append((role, text))
-            return True
-
-    mgr = FakeManager()
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
-    monkeypatch.setattr(game_router, "_ICEBREAKER_CONTEXT_DEDUP_MAX_ENTRIES", 2)
-
-    async def post(request_id, text):
-        return await game_router.game_project_context(
-            "new_user_icebreaker",
-            _FakeRequest({
-                "lanlan_name": "Lan",
-                "role": "assistant",
-                "text": text,
-                "request_id": request_id,
-            }),
-        )
-
-    with reset_game_route_state():
-        _allow_icebreaker_route("Lan", "icebreaker-day1-test")
-        first = await post("icebreaker-context-1", "one")
-        second = await post("icebreaker-context-2", "two")
-        duplicate_first = await post("icebreaker-context-1", "one duplicate")
-        third = await post("icebreaker-context-3", "three")
-        replay_first_after_capacity_evict = await post("icebreaker-context-1", "one replay")
-
-    assert first["ok"] is True
-    assert second["ok"] is True
-    assert duplicate_first["deduped"] is True
-    assert third["ok"] is True
-    assert replay_first_after_capacity_evict["ok"] is True
-    assert "deduped" not in replay_first_after_capacity_evict
-    assert mgr.calls == [
-        ("assistant", "one"),
-        ("assistant", "two"),
-        ("assistant", "three"),
-        ("assistant", "one replay"),
+    assert [call["request_id"] for call in mgr.calls] == [
+        "icebreaker-context-1",
+        "icebreaker-context-2",
     ]
 
 
 @pytest.mark.asyncio
-async def test_new_user_icebreaker_context_endpoint_does_not_mask_internal_type_error(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise TypeError("internal append bug")
+async def test_new_user_icebreaker_context_endpoint_reports_manager_dedup(monkeypatch):
+    mgr = _FakeAppendContextManager(result=SimpleNamespace(appended=False, deduped=True, reason="duplicate_request_id"))
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
 
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    with reset_game_route_state():
+        _allow_icebreaker_route("Lan", "icebreaker-day1-test")
+        result = await game_router.game_project_context(
+            "new_user_icebreaker",
+            _FakeRequest({
+                "lanlan_name": "Lan",
+                "role": "assistant",
+                "text": "hello",
+                "request_id": "icebreaker-context-1",
+            }),
+        )
+
+    assert result["ok"] is True
+    assert result["deduped"] is True
+    assert mgr.calls[0]["request_id"] == "icebreaker-context-1"
+
+
+@pytest.mark.asyncio
+async def test_new_user_icebreaker_context_endpoint_does_not_mask_internal_type_error(monkeypatch):
+    monkeypatch.setattr(
+        game_router,
+        "get_session_manager",
+        lambda: {"Lan": _FakeAppendContextManager(error=TypeError("internal append bug"))},
+    )
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
 
     with reset_game_route_state():
@@ -371,11 +337,8 @@ async def test_new_user_icebreaker_context_endpoint_does_not_mask_internal_type_
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_requires_local_mutation_csrf(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise AssertionError("CSRF rejection should happen before append")
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    mgr = _FakeAppendContextManager(error=AssertionError("CSRF rejection should happen before append"))
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
 
     result = await game_router.game_project_context(
         "new_user_icebreaker",
@@ -414,11 +377,11 @@ async def test_new_user_icebreaker_context_endpoint_rejects_unsupported_game_typ
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_handles_append_failure(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise RuntimeError("append failed")
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    monkeypatch.setattr(
+        game_router,
+        "get_session_manager",
+        lambda: {"Lan": _FakeAppendContextManager(error=RuntimeError("append failed"))},
+    )
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
     _allow_icebreaker_route()
 
@@ -439,11 +402,8 @@ async def test_new_user_icebreaker_context_endpoint_handles_append_failure(monke
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_handles_false_append(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            return False
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    mgr = _FakeAppendContextManager(result=SimpleNamespace(appended=False, deduped=False, reason="no_context_target"))
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
 
     with reset_game_route_state():
@@ -459,7 +419,7 @@ async def test_new_user_icebreaker_context_endpoint_handles_false_append(monkeyp
         )
 
     assert result["ok"] is False
-    assert result["reason"] == "context_write_failed"
+    assert result["reason"] == "no_context_target"
     assert result["lanlan_name"] == "Lan"
 
 
@@ -487,15 +447,7 @@ async def test_new_user_icebreaker_context_endpoint_rejects_empty_lanlan_name(mo
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_rejects_stale_session(monkeypatch):
-    class FakeManager:
-        def __init__(self):
-            self.calls = []
-
-        async def append_icebreaker_context_async(self, role, text):
-            self.calls.append((role, text))
-            return True
-
-    mgr = FakeManager()
+    mgr = _FakeAppendContextManager()
     monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
     with reset_game_route_state():
@@ -553,11 +505,11 @@ async def test_new_user_icebreaker_context_endpoint_requires_public_append_metho
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_handles_async_append_error(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise RuntimeError("session history unavailable")
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    monkeypatch.setattr(
+        game_router,
+        "get_session_manager",
+        lambda: {"Lan": _FakeAppendContextManager(error=RuntimeError("session history unavailable"))},
+    )
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
 
     with reset_game_route_state():
@@ -582,11 +534,11 @@ async def test_new_user_icebreaker_context_endpoint_handles_async_append_error(m
 
 @pytest.mark.asyncio
 async def test_new_user_icebreaker_context_endpoint_handles_async_append_error_from_manager(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise RuntimeError("session history unavailable")
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
+    monkeypatch.setattr(
+        game_router,
+        "get_session_manager",
+        lambda: {"Lan": _FakeAppendContextManager(error=RuntimeError("session history unavailable"))},
+    )
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
 
     with reset_game_route_state():
@@ -610,37 +562,22 @@ async def test_new_user_icebreaker_context_endpoint_handles_async_append_error_f
 
 
 @pytest.mark.asyncio
-async def test_new_user_icebreaker_context_endpoint_rejects_oversized_text(monkeypatch):
-    class FakeManager:
-        async def append_icebreaker_context_async(self, role, text):
-            raise AssertionError("oversized text should be rejected before append")
-
-    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": FakeManager()})
-
-    result = await game_router.game_project_context(
-        "new_user_icebreaker",
-        _FakeRequest({
-            "lanlan_name": "Lan",
-            "role": "user",
-            "text": "x" * (game_router.MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH + 1),
-        }),
-    )
-
-    assert result == {"ok": False, "reason": "invalid_text_length"}
-
-
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_llm_session_manager_appends_icebreaker_context_to_session_history():
+async def test_llm_session_manager_appends_generic_context_to_session_history():
     class FakeSession:
         def __init__(self):
             self._conversation_history = []
 
     mgr = LLMSessionManager.__new__(LLMSessionManager)
     mgr.session = FakeSession()
+    mgr.message_cache_for_new_session = []
+    mgr.session_ready = True
 
-    assert await mgr.append_icebreaker_context_async("assistant", " hi ") is True
-    assert await mgr.append_icebreaker_context_async("user", " choice ") is True
+    first = await mgr.append_context(source="game.icebreaker", role="assistant", text=" hi ")
+    second = await mgr.append_context(source="game.icebreaker", role="user", text=" choice ")
+    assert first.appended is True
+    assert second.appended is True
     assert isinstance(mgr.session._conversation_history[0], AIMessage)
     assert mgr.session._conversation_history[0].content == "hi"
     assert isinstance(mgr.session._conversation_history[1], HumanMessage)
@@ -3378,6 +3315,12 @@ class _FakeRealtimeManager:
         self.voice_nudge_calls = 0
         self.voice_nudge_kwargs = []
         self.voice_nudge_event = asyncio.Event()
+        self.append_context_calls = []
+
+    async def append_context(self, **kwargs):
+        self.append_context_calls.append(kwargs)
+        await self.session.prime_context(f"{kwargs['role']}: {kwargs['text']}", skipped=True)
+        return SimpleNamespace(appended=True, deduped=False, targets=("realtime_prime",), reason=None)
 
     async def trigger_voice_proactive_nudge(self, **kwargs):
         self.voice_nudge_calls += 1
@@ -4754,6 +4697,8 @@ async def test_game_end_injects_postgame_context_into_active_realtime(monkeypatc
     # now relies on plain prompt_ephemeral (server VAD + WAV nudge). The
     # postgame instruction reaches the model via prime_context (assert below).
     assert session.prime_context_calls
+    assert mgr.append_context_calls[0]["source"] == "game.postgame"
+    assert mgr.append_context_calls[0]["audience"] == "model"
     context_text, skipped = session.prime_context_calls[0]
     assert skipped is True
     assert "[Game Module Postgame Context]" in context_text

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -3439,6 +3439,36 @@ async def test_realtime_context_endpoint_requires_local_mutation_csrf(monkeypatc
     assert session.prime_context_calls == []
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_realtime_context_aborts_when_active_session_changes_before_append(monkeypatch, _fake_realtime):
+    original = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    replacement = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    mgr = _FakeRealtimeManager(original)
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
+
+    def swap_session(_game_type, _payload, _language=None):
+        mgr.session = replacement
+        return "[Game Realtime Context]\nrace"
+
+    monkeypatch.setattr(game_router, "_compact_realtime_context_text", swap_session)
+
+    result = await game_router.game_realtime_context(
+        "soccer",
+        _FakeRequest({
+            "lanlan_name": "Lan",
+            "source": "game_event",
+            "currentState": {"score": {"player": 1, "ai": 2}},
+            "pendingItems": [{"type": "game_event", "kind": "goal-scored"}],
+        }, path="/api/game/soccer/realtime-context"),
+    )
+
+    assert result == {"ok": False, "reason": "realtime_session_changed", "lanlan_name": "Lan"}
+    assert mgr.append_context_calls == []
+    assert original.prime_context_calls == []
+    assert replacement.prime_context_calls == []
+
+
 class _FakeGameRouteManager:
     def __init__(self):
         self.is_active = False

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -3323,7 +3323,7 @@ class _FakeRealtimeSession:
 
 
 class _FakeRealtimeManager:
-    def __init__(self, session):
+    def __init__(self, session, append_context_result=None):
         self.session = session
         self.is_active = True
         self.user_language = "zh-CN"
@@ -3335,9 +3335,12 @@ class _FakeRealtimeManager:
         self.voice_nudge_kwargs = []
         self.voice_nudge_event = asyncio.Event()
         self.append_context_calls = []
+        self.append_context_result = append_context_result
 
     async def append_context(self, **kwargs):
         self.append_context_calls.append(kwargs)
+        if self.append_context_result is not None:
+            return self.append_context_result
         await self.session.prime_context(f"{kwargs['role']}: {kwargs['text']}", skipped=True)
         return SimpleNamespace(appended=True, deduped=False, targets=("realtime_prime",), reason=None)
 
@@ -4722,6 +4725,49 @@ async def test_game_end_injects_postgame_context_into_active_realtime(monkeypatc
     assert skipped is True
     assert "[Game Module Postgame Context]" in context_text
     assert "我是不是不适合玩这个？" in context_text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_game_end_skips_postgame_nudge_when_context_append_deduped(monkeypatch, _fake_realtime):
+    session = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    mgr = _FakeRealtimeManager(
+        session,
+        append_context_result=SimpleNamespace(
+            appended=False,
+            deduped=True,
+            targets=(),
+            reason="duplicate_request_id",
+        ),
+    )
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {"Lan": mgr})
+    monkeypatch.setattr(game_router, "_POSTGAME_REALTIME_NUDGE_DELAYS", (0.0,))
+    state = game_router._activate_game_route("soccer", "match_1", "Lan")
+    _set_soccer_game_memory_policy(state, enabled=True)
+    _mark_game_started(state)
+    state["last_state"] = {"score": {"player": 1, "ai": 3}}
+    game_router._append_game_dialog(state, {
+        "type": "assistant",
+        "source": "game_llm",
+        "line": "别认输嘛，再来一脚。",
+    })
+
+    async def fake_submit(archive):
+        return {"ok": True, "status": "cached", "count": 1}
+
+    monkeypatch.setattr(game_router, "_submit_game_archive_to_memory", fake_submit)
+
+    result = await game_router.game_end(
+        "soccer",
+        _FakeRequest({"session_id": "match_1", "lanlan_name": "Lan", "reason": "manual"}),
+    )
+
+    assert result["postgame"]["mode"] == "realtime"
+    assert result["postgame"]["context_injected"] is True
+    assert result["postgame"]["nudge_scheduled"] is False
+    assert result["postgame"]["reason"] == "context_deduped"
+    assert mgr.voice_nudge_calls == 0
+    assert session.prime_context_calls == []
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -164,7 +164,7 @@ async def test_new_user_icebreaker_context_endpoint_appends_session_history(monk
             "role": "assistant",
             "text": "教程看完啦？",
             "audience": "model",
-            "timing": "now",
+            "timing": "when_ready",
             "lifetime": "session_family",
             "request_id": None,
             "ordering_key": "icebreaker-day1-test",

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -4853,6 +4853,34 @@ async def test_game_end_skips_postgame_nudge_when_context_append_deduped(monkeyp
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_postgame_realtime_nudge_skips_replacement_session(monkeypatch, _fake_realtime):
+    original = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    replacement = _fake_realtime(model_lower="qwen-realtime", delivered=True)
+    mgr = _FakeRealtimeManager(original)
+    monkeypatch.setattr(game_router, "_POSTGAME_REALTIME_NUDGE_DELAYS", (0.01,))
+
+    result = await game_router._deliver_postgame_to_realtime(
+        mgr,
+        {
+            "game_type": "soccer",
+            "session_id": "match_1",
+            "lanlan_name": "Lan",
+            "ended_at": "100.0",
+        },
+        {"trigger_voice": True},
+    )
+    mgr.session = replacement
+    await asyncio.sleep(0.05)
+
+    assert result["mode"] == "realtime"
+    assert result["nudge_scheduled"] is True
+    assert mgr.voice_nudge_calls == 0
+    assert len(original.prime_context_calls) == 1
+    assert replacement.prime_context_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_postgame_realtime_context_aborts_when_active_session_changes(monkeypatch, _fake_realtime):
     original = _fake_realtime(model_lower="qwen-realtime", delivered=True)
     replacement = _fake_realtime(model_lower="qwen-realtime", delivered=True)

--- a/tests/unit/test_new_user_icebreaker_context.py
+++ b/tests/unit/test_new_user_icebreaker_context.py
@@ -23,6 +23,7 @@ def _make_mgr(session=None):
     mgr.session_ready = True
     mgr.is_preparing_new_session = False
     mgr.message_cache_for_new_session = []
+    mgr.next_session_context_messages = []
     mgr.lanlan_name = "Lan"
     mgr.master_name = "Master"
     return mgr
@@ -52,10 +53,11 @@ async def test_icebreaker_context_appends_to_active_conversation_history():
     assert history[0].content == "你好呀"
     assert isinstance(history[1], HumanMessage)
     assert history[1].content == "继续打字"
-    assert mgr.message_cache_for_new_session == [
+    assert mgr.next_session_context_messages == [
         {"role": "Lan", "text": "你好呀"},
         {"role": "Master", "text": "继续打字"},
     ]
+    assert mgr.message_cache_for_new_session == []
 
 
 @pytest.mark.asyncio
@@ -73,28 +75,30 @@ async def test_icebreaker_context_primes_active_realtime_session():
 
 
 @pytest.mark.asyncio
-async def test_icebreaker_context_reuses_hot_swap_message_cache_when_preparing():
+async def test_icebreaker_context_records_next_session_messages_when_preparing():
     mgr = _make_mgr(None)
     mgr.is_preparing_new_session = True
 
     assert (await _append_icebreaker(mgr, "assistant", "先认识一下")).appended is True
     assert (await _append_icebreaker(mgr, "user", "看得差不多了")).appended is True
 
-    assert mgr.message_cache_for_new_session == [
+    assert mgr.next_session_context_messages == [
         {"role": "Lan", "text": "先认识一下"},
         {"role": "Master", "text": "看得差不多了"},
     ]
+    assert mgr.message_cache_for_new_session == []
 
 
 @pytest.mark.asyncio
-async def test_icebreaker_realtime_context_also_reuses_hot_swap_cache_when_preparing():
+async def test_icebreaker_realtime_context_also_records_next_session_messages_when_preparing():
     session = _FakeRealtimeSession()
     mgr = _make_mgr(session)
     mgr.is_preparing_new_session = True
 
     assert (await _append_icebreaker(mgr, "assistant", "先认识一下")).appended is True
 
-    assert mgr.message_cache_for_new_session == [{"role": "Lan", "text": "先认识一下"}]
+    assert mgr.next_session_context_messages == [{"role": "Lan", "text": "先认识一下"}]
+    assert mgr.message_cache_for_new_session == []
     assert session.prime_context_calls == [("assistant: 先认识一下", True)]
 
 

--- a/tests/unit/test_new_user_icebreaker_context.py
+++ b/tests/unit/test_new_user_icebreaker_context.py
@@ -20,6 +20,7 @@ class _FakeRealtimeSession:
 def _make_mgr(session=None):
     mgr = LLMSessionManager.__new__(LLMSessionManager)
     mgr.session = session
+    mgr.session_ready = True
     mgr.is_preparing_new_session = False
     mgr.message_cache_for_new_session = []
     mgr.lanlan_name = "Lan"
@@ -27,19 +28,34 @@ def _make_mgr(session=None):
     return mgr
 
 
+async def _append_icebreaker(mgr, role, text):
+    return await LLMSessionManager.append_context(
+        mgr,
+        source="game.icebreaker",
+        role=role,
+        text=text,
+        audience="model",
+        timing="now",
+        lifetime="session_family",
+    )
+
+
 @pytest.mark.asyncio
 async def test_icebreaker_context_appends_to_active_conversation_history():
     mgr = _make_mgr(_FakeSession())
 
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "assistant", "你好呀") is True
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "user", "继续打字") is True
+    assert (await _append_icebreaker(mgr, "assistant", "你好呀")).appended is True
+    assert (await _append_icebreaker(mgr, "user", "继续打字")).appended is True
 
     history = mgr.session._conversation_history
     assert isinstance(history[0], AIMessage)
     assert history[0].content == "你好呀"
     assert isinstance(history[1], HumanMessage)
     assert history[1].content == "继续打字"
-    assert mgr.message_cache_for_new_session == []
+    assert mgr.message_cache_for_new_session == [
+        {"role": "Lan", "text": "你好呀"},
+        {"role": "Master", "text": "继续打字"},
+    ]
 
 
 @pytest.mark.asyncio
@@ -47,8 +63,8 @@ async def test_icebreaker_context_primes_active_realtime_session():
     session = _FakeRealtimeSession()
     mgr = _make_mgr(session)
 
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "assistant", "先认识一下") is True
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "user", "我选第一个") is True
+    assert (await _append_icebreaker(mgr, "assistant", "先认识一下")).appended is True
+    assert (await _append_icebreaker(mgr, "user", "我选第一个")).appended is True
 
     assert session.prime_context_calls == [
         ("assistant: 先认识一下", True),
@@ -61,8 +77,8 @@ async def test_icebreaker_context_reuses_hot_swap_message_cache_when_preparing()
     mgr = _make_mgr(None)
     mgr.is_preparing_new_session = True
 
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "assistant", "先认识一下") is True
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "user", "看得差不多了") is True
+    assert (await _append_icebreaker(mgr, "assistant", "先认识一下")).appended is True
+    assert (await _append_icebreaker(mgr, "user", "看得差不多了")).appended is True
 
     assert mgr.message_cache_for_new_session == [
         {"role": "Lan", "text": "先认识一下"},
@@ -76,7 +92,7 @@ async def test_icebreaker_realtime_context_also_reuses_hot_swap_cache_when_prepa
     mgr = _make_mgr(session)
     mgr.is_preparing_new_session = True
 
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "assistant", "先认识一下") is True
+    assert (await _append_icebreaker(mgr, "assistant", "先认识一下")).appended is True
 
     assert mgr.message_cache_for_new_session == [{"role": "Lan", "text": "先认识一下"}]
     assert session.prime_context_calls == [("assistant: 先认识一下", True)]
@@ -86,6 +102,6 @@ async def test_icebreaker_realtime_context_also_reuses_hot_swap_cache_when_prepa
 async def test_icebreaker_context_rejects_empty_or_unknown_role():
     mgr = _make_mgr(_FakeSession())
 
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "assistant", "   ") is False
-    assert await LLMSessionManager.append_icebreaker_context_async(mgr, "system", "不要写入") is False
+    assert (await _append_icebreaker(mgr, "assistant", "   ")).appended is False
+    assert (await _append_icebreaker(mgr, "observer", "不要写入")).appended is False
     assert mgr.session._conversation_history == []

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -281,9 +281,10 @@ def test_icebreaker_context_append_does_not_touch_shared_websocket_router():
     assert "'/api/game/' + encodeURIComponent(GAME_TYPE) + '/context'" in runtime
     assert "request_id: String(extra.requestId || '')" in runtime
     assert "request_id = str(data.get(\"request_id\") or event.get(\"request_id\") or \"\").strip()" in game_router
-    assert "_icebreaker_context_seen_request_ids" in game_router
-    assert "append_icebreaker_context_async(role, text)" in game_router
-    assert "append_icebreaker_context_async(role, text, request_id)" not in game_router
+    assert "_icebreaker_context_seen_request_ids" not in game_router
+    assert "append_context(" in game_router
+    assert "source=\"game.icebreaker\"" in game_router
+    assert "append_icebreaker_context_async" not in game_router
     assert '@router.post("/{game_type}/context")' in game_router
     assert "startIcebreakerRoute(nextSession).then(function (started) {" in runtime
     assert "'/api/game/' + encodeURIComponent(GAME_TYPE) + path" in runtime
@@ -314,15 +315,18 @@ def test_icebreaker_context_reuses_existing_session_context_paths():
     assert "pending_icebreaker_context" not in core
     assert "_icebreaker_context_request_ids" not in core
     assert "def _flush_pending_icebreaker_context" not in core
-    assert "def append_icebreaker_context_async" in core
-    assert "def append_icebreaker_context_async(self, role: str, text: str) -> bool:" in core
+    assert "def append_icebreaker_context_async" not in core
     assert "append_icebreaker_context_async(self, role: str, text: str, request_id" not in core
     assert "def append_icebreaker_context(" not in core
+    assert "async def append_context(" in core
+    assert "source: str" in core
+    assert "audience: str = \"model\"" in core
+    assert "lifetime: str = \"current_session\"" in core
     assert "_normalize_scripted_context" not in core
     assert "_append_scripted_context_to_new_session_cache" not in core
     assert "_conversation_history" in core
     assert "message_cache_for_new_session" in core
-    assert 'await prime_context(f"{normalized_role}: {content}", skipped=True)' in core
+    assert 'await prime_context(f"{role}: {content}", skipped=(audience == "model"))' in core
 
 
 def test_icebreaker_context_appends_are_serialized_before_chat_progression():

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -284,6 +284,8 @@ def test_icebreaker_context_append_does_not_touch_shared_websocket_router():
     assert "_icebreaker_context_seen_request_ids" not in game_router
     assert "append_context(" in game_router
     assert "source=\"game.icebreaker\"" in game_router
+    assert "MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH = 2000" in game_router
+    assert "invalid_text_length" in game_router
     assert "append_icebreaker_context_async" not in game_router
     assert '@router.post("/{game_type}/context")' in game_router
     assert "startIcebreakerRoute(nextSession).then(function (started) {" in runtime
@@ -326,7 +328,8 @@ def test_icebreaker_context_reuses_existing_session_context_paths():
     assert "_append_scripted_context_to_new_session_cache" not in core
     assert "_conversation_history" in core
     assert "message_cache_for_new_session" in core
-    assert 'await prime_context(f"{role}: {content}", skipped=(audience == "model"))' in core
+    assert "_CONTEXT_APPEND_BARE_PRIME_SOURCES" in core
+    assert 'prime_text = content if source in _CONTEXT_APPEND_BARE_PRIME_SOURCES else f"{role}: {content}"' in core
 
 
 def test_icebreaker_context_appends_are_serialized_before_chat_progression():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -26,6 +26,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"
 # _loc、normalize_language_code、httpx 等），测试不直接跑整段函数，而是对
 # SM 的契约做黑盒回归 —— 让一个 minimal mgr 模拟真实 LLMSessionManager 的
 # state/session/lock 结构，然后直接调用 trigger_agent_callbacks 的关键分支。
+import main_logic.core as core_module
 from main_logic.core import (
     LLMSessionManager,
     _VOICE_PROACTIVE_ACK_GRACE_S,
@@ -120,6 +121,40 @@ def _make_mgr(session=None) -> LLMSessionManager:
     # 在测试里我们只关心 OmniOfflineClient 分支，其他分支显式构造。
     mgr.start_session = AsyncMock()
     return mgr
+
+
+def test_enqueue_agent_callback_uses_generic_context_source_budget(monkeypatch):
+    mgr = _make_mgr()
+    monkeypatch.setitem(core_module._CONTEXT_APPEND_SOURCE_MAX_TOKENS, "topic.hook", 2)
+    monkeypatch.setitem(core_module._CONTEXT_APPEND_SOURCE_MAX_TOKENS, "proactive.callback", 4)
+
+    def fake_truncate(text, max_tokens, *args, **kwargs):
+        return f"{max_tokens}:{text}"
+
+    monkeypatch.setattr("utils.tokenize.truncate_to_tokens", fake_truncate)
+
+    LLMSessionManager.enqueue_agent_callback(mgr, {
+        "channel": "topic_hook",
+        "status": "completed",
+        "summary": "topic summary",
+        "detail": "topic detail",
+        "origin": "event",
+        "source_kind": "topic",
+        "source_name": "deep_topic_hook",
+    })
+    LLMSessionManager.enqueue_agent_callback(mgr, {
+        "status": "completed",
+        "summary": "proactive summary",
+        "detail": "proactive detail",
+        "origin": "event",
+        "source_kind": "unknown",
+        "source_name": "push",
+    })
+
+    assert mgr.pending_agent_callbacks[0]["summary"] == "2:topic summary"
+    assert mgr.pending_extra_replies[0]["context_source"] == "topic.hook"
+    assert mgr.pending_agent_callbacks[1]["summary"] == "4:proactive summary"
+    assert mgr.pending_extra_replies[1]["context_source"] == "proactive.callback"
 
 
 def _make_voice_sess(*, is_responding=False, inject=None):
@@ -1056,6 +1091,7 @@ def test_submit_proactive_callback_persists_when_goodbye_silent():
             "summary": "queued",
             "detail": "",
             "status": "completed",
+            "context_source": "proactive.callback",
             "source_kind": "unknown",
             "source_name": "",
             "error_message": "",

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -27,11 +27,6 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"
 # SM 的契约做黑盒回归 —— 让一个 minimal mgr 模拟真实 LLMSessionManager 的
 # state/session/lock 结构，然后直接调用 trigger_agent_callbacks 的关键分支。
 import main_logic.core as core_module
-from main_logic.core import (
-    LLMSessionManager,
-    _VOICE_PROACTIVE_ACK_GRACE_S,
-    _proactive_expected_sid,
-)
 from main_logic.omni_offline_client import OmniOfflineClient
 from main_logic.proactive_delivery import DELIVERY_ACK_FUTURE_KEY, DELIVERY_RETRACTED_KEY
 from main_logic.session_state import (
@@ -69,8 +64,8 @@ class _FakeOmniOffline(OmniOfflineClient):
         pass
 
 
-def _make_mgr(session=None) -> LLMSessionManager:
-    mgr = LLMSessionManager.__new__(LLMSessionManager)
+def _make_mgr(session=None) -> core_module.LLMSessionManager:
+    mgr = core_module.LLMSessionManager.__new__(core_module.LLMSessionManager)
     mgr.lanlan_name = "Test"
     mgr.master_name = "Master"
     mgr.user_language = "en"
@@ -133,7 +128,7 @@ def test_enqueue_agent_callback_uses_generic_context_source_budget(monkeypatch):
 
     monkeypatch.setattr("utils.tokenize.truncate_to_tokens", fake_truncate)
 
-    LLMSessionManager.enqueue_agent_callback(mgr, {
+    core_module.LLMSessionManager.enqueue_agent_callback(mgr, {
         "channel": "topic_hook",
         "status": "completed",
         "summary": "topic summary",
@@ -142,7 +137,7 @@ def test_enqueue_agent_callback_uses_generic_context_source_budget(monkeypatch):
         "source_kind": "topic",
         "source_name": "deep_topic_hook",
     })
-    LLMSessionManager.enqueue_agent_callback(mgr, {
+    core_module.LLMSessionManager.enqueue_agent_callback(mgr, {
         "status": "completed",
         "summary": "proactive summary",
         "detail": "proactive detail",
@@ -218,7 +213,7 @@ async def test_voice_mode_idle_injects_and_drops_paired_cbs_and_extras():
     events: list[SessionEvent] = []
     mgr.state.subscribe(None, lambda ev, p: events.append(ev))
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     assert len(sess.injected) == 1
@@ -254,7 +249,7 @@ async def test_voice_mode_inject_preserves_passive_cb_and_its_extra():
     mgr.pending_agent_callbacks = [passive_cb, proactive_cb]
     mgr.pending_extra_replies = [passive_extra, proactive_extra]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     assert len(sess.injected) == 1
@@ -269,7 +264,7 @@ async def test_voice_mode_busy_defers_cbs_for_retry():
     original = [{"status": "completed", "summary": "deferred"}]
     mgr.pending_agent_callbacks = list(original)
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     assert sess.injected == []  # 没 inject
@@ -294,7 +289,7 @@ async def test_voice_mode_drop_uses_id_match_not_length_alignment():
     mgr.pending_agent_callbacks = [new_cb]
     mgr.pending_extra_replies = [stale_extra_a, stale_extra_b, new_extra]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     assert len(sess.injected) == 1
@@ -326,7 +321,7 @@ async def test_voice_mode_server_rejection_re_enqueues_cb():
     mgr.pending_agent_callbacks = [cb]
     mgr.pending_extra_replies = [extra]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     # 乐观剔除：两条队列都空
@@ -374,11 +369,11 @@ async def test_voice_mode_late_rejection_keeps_delivery_ack_pending():
     mgr.pending_agent_callbacks = [cb]
     mgr.pending_extra_replies = [extra]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     assert not future.done()
 
     captured_rejection[0]("response_already_active")
-    await asyncio.sleep(_VOICE_PROACTIVE_ACK_GRACE_S + 0.02)
+    await asyncio.sleep(core_module._VOICE_PROACTIVE_ACK_GRACE_S + 0.02)
 
     assert not future.done()
     assert mgr.pending_agent_callbacks == [cb]
@@ -399,10 +394,10 @@ async def test_voice_mode_success_resolves_delivery_ack_after_rejection_window()
     mgr.pending_agent_callbacks = [cb]
     mgr.pending_extra_replies = [extra]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     assert not future.done()
 
-    await asyncio.sleep(_VOICE_PROACTIVE_ACK_GRACE_S + 0.02)
+    await asyncio.sleep(core_module._VOICE_PROACTIVE_ACK_GRACE_S + 0.02)
 
     assert future.done()
     assert future.result() is True
@@ -422,7 +417,7 @@ async def test_voice_mode_rechecks_retracted_callbacks_before_inject():
         return True
     mgr._stream_cb_media = _stream_then_retract
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is False
     assert sess.injected == []
@@ -455,7 +450,7 @@ async def test_text_mode_acks_only_callbacks_that_reach_prompt():
         return True
     mgr._deliver_agent_callbacks_text = _deliver
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is True
     assert not dropped_future.done()
@@ -485,7 +480,7 @@ async def test_text_mode_resolves_delivery_ack_after_committed_output_before_com
     }
     mgr.pending_agent_callbacks = [cb]
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is True
     assert future.done()
@@ -504,7 +499,7 @@ async def test_text_mode_resolves_delivery_ack_false_when_prompt_has_no_committe
     }
     mgr.pending_agent_callbacks = [cb]
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is False
     assert future.done()
@@ -517,7 +512,7 @@ async def test_text_mode_requeues_callbacks_when_no_session_or_websocket_after_c
     cb = {"_callback_delivery_id": "id-no-session", "status": "completed", "summary": "keep queued"}
     mgr.pending_agent_callbacks = [cb]
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is False
     assert mgr.pending_agent_callbacks == [cb]
@@ -537,7 +532,7 @@ async def test_text_mode_retraction_after_claim_purges_paired_extra():
     mgr.pending_agent_callbacks = [cb]
     mgr.pending_extra_replies = [extra]
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is False
     assert sess.called_with == []
@@ -564,7 +559,7 @@ async def test_text_mode_committed_then_flush_exception_does_not_requeue_callbac
     }
     mgr.pending_agent_callbacks = [cb]
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is True
     assert future.done()
@@ -592,7 +587,7 @@ async def test_text_mode_success_keeps_late_extra_replies():
     mgr.pending_agent_callbacks = [initial_cb]
     mgr.pending_extra_replies = [initial_extra]
 
-    delivered = await LLMSessionManager.trigger_agent_callbacks(mgr)
+    delivered = await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert delivered is True
     assert mgr.pending_agent_callbacks == [late_cb]
@@ -617,7 +612,7 @@ def test_drain_agent_callbacks_purges_retracted_callbacks_and_extras():
     mgr.pending_agent_callbacks = [retracted_cb, active_cb]
     mgr.pending_extra_replies = [retracted_extra, active_extra]
 
-    rendered = LLMSessionManager.drain_agent_callbacks_for_llm(mgr)
+    rendered = core_module.LLMSessionManager.drain_agent_callbacks_for_llm(mgr)
 
     assert "shown" in rendered
     assert "cancelled" not in rendered
@@ -636,7 +631,7 @@ async def test_drain_agent_callbacks_resolves_delivery_ack():
     }
     mgr.pending_agent_callbacks = [cb]
 
-    rendered = LLMSessionManager.drain_agent_callbacks_for_llm(mgr)
+    rendered = core_module.LLMSessionManager.drain_agent_callbacks_for_llm(mgr)
 
     assert "shown" in rendered
     assert future.done()
@@ -677,7 +672,7 @@ async def test_drain_agent_callbacks_rechecks_topic_release_gate():
     mgr.pending_agent_callbacks = [topic_cb, normal_cb]
     mgr.pending_extra_replies = [topic_extra, normal_extra]
 
-    rendered = LLMSessionManager.drain_agent_callbacks_for_llm(mgr)
+    rendered = core_module.LLMSessionManager.drain_agent_callbacks_for_llm(mgr)
 
     assert "regular callback" in rendered
     assert "stale deep topic" not in rendered
@@ -713,7 +708,7 @@ async def test_voice_mode_reject_during_await_not_pruned():
     mgr.pending_agent_callbacks = [cb]
     mgr.pending_extra_replies = [extra]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     # 关键：cb 没被 prune 掉，两队列都还在，等下次 retry
@@ -749,8 +744,8 @@ async def test_voice_mode_concurrent_triggers_inject_once():
     mgr.pending_agent_callbacks = [cb]
     mgr.pending_extra_replies = [extra]
 
-    t1 = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
-    t2 = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
+    t1 = asyncio.create_task(core_module.LLMSessionManager.trigger_agent_callbacks(mgr))
+    t2 = asyncio.create_task(core_module.LLMSessionManager.trigger_agent_callbacks(mgr))
     # 等第一个 inject 真的进入持锁段，再给第二个 task 一个调度点去阻塞在锁上，
     # 然后才放行——确保「两个 task 竞争同一 snapshot」这个场景真的发生。
     await asyncio.wait_for(entered_inject.wait(), timeout=5)
@@ -784,7 +779,7 @@ async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
     original_extras = [{"summary": "hot-swap fallback"}]
     mgr.pending_extra_replies = list(original_extras)
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     assert mgr.pending_agent_callbacks == []  # proactive cb dropped
@@ -948,7 +943,7 @@ async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     original = [{"status": "completed", "summary": "retry on ws err"}]
     mgr.pending_agent_callbacks = list(original)
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     # inject 确实被调用过一次（证明走的是 inject-异常分支，而非更早的 guard 早退）
@@ -969,7 +964,7 @@ async def test_voice_mode_unstamped_cb_still_pruned_via_object_id_fallback():
     # 这里 extras 用空，因为没走 enqueue → 没配对 entries 是合理状态
     mgr.pending_extra_replies = []
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     assert len(sess.injected) == 1
@@ -1023,7 +1018,7 @@ async def test_text_mode_sm_denied_when_phase_active():
     await mgr.state.fire(SessionEvent.PROACTIVE_START)
     assert mgr.state.phase is ProactivePhase.PHASE1
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     # SM 拒绝 → prompt_ephemeral 未调用，callbacks 保留
     assert sess.called_with == []
@@ -1037,7 +1032,7 @@ async def test_text_mode_sm_denied_when_session_responding():
     mgr = _make_mgr(session=sess)
     mgr.pending_agent_callbacks = [{"status": "completed", "summary": "queued"}]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert sess.called_with == []
     # callbacks 保留以便下轮重试
@@ -1053,7 +1048,7 @@ async def test_goodbye_silent_defers_agent_callbacks_and_keeps_queue():
     cb = {"status": "completed", "summary": "queued"}
     mgr.pending_agent_callbacks = [cb]
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert sess.called_with == []
     assert mgr.pending_agent_callbacks == [cb]
@@ -1065,7 +1060,7 @@ def test_goodbye_silent_blocks_manager_release():
     mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
     mgr.goodbye_silent = True
 
-    assert LLMSessionManager._can_release_proactive(mgr) is False
+    assert core_module.LLMSessionManager._can_release_proactive(mgr) is False
 
 
 def test_submit_proactive_callback_persists_when_goodbye_silent():
@@ -1074,7 +1069,7 @@ def test_submit_proactive_callback_persists_when_goodbye_silent():
     mgr.goodbye_silent = True
     cb = {"status": "completed", "summary": "queued"}
 
-    LLMSessionManager.submit_proactive_callback(
+    core_module.LLMSessionManager.submit_proactive_callback(
         mgr,
         cb,
         priority=7,
@@ -1140,7 +1135,7 @@ async def test_submit_proactive_callback_does_not_fail_ack_when_goodbye_silent()
     future = asyncio.get_running_loop().create_future()
     cb = {"status": "completed", "summary": "queued", DELIVERY_ACK_FUTURE_KEY: future}
 
-    LLMSessionManager.submit_proactive_callback(mgr, cb)
+    core_module.LLMSessionManager.submit_proactive_callback(mgr, cb)
 
     assert mgr.pending_agent_callbacks == [cb]
     assert not future.done()
@@ -1152,7 +1147,7 @@ async def test_deliver_proactive_batch_does_not_fail_ack_when_inner_trigger_defe
     cb = {"status": "completed", "summary": "queued", DELIVERY_ACK_FUTURE_KEY: future}
     mgr.trigger_agent_callbacks = AsyncMock(return_value=False)
 
-    await LLMSessionManager._deliver_proactive_batch(mgr, [cb])
+    await core_module.LLMSessionManager._deliver_proactive_batch(mgr, [cb])
 
     assert mgr.pending_agent_callbacks == [cb]
     assert not future.done()
@@ -1164,7 +1159,7 @@ async def test_deliver_proactive_batch_leaves_ack_to_delivery_path():
     cb = {"status": "completed", "summary": "queued", DELIVERY_ACK_FUTURE_KEY: future}
     mgr.trigger_agent_callbacks = AsyncMock(return_value=True)
 
-    await LLMSessionManager._deliver_proactive_batch(mgr, [cb])
+    await core_module.LLMSessionManager._deliver_proactive_batch(mgr, [cb])
 
     assert not future.done()
 
@@ -1176,7 +1171,7 @@ def test_topic_hook_delivery_blocked_in_active_voice_session():
     mgr = _make_mgr(session=_make_voice_sess())
     mgr.is_active = True
     mgr.input_mode = 'audio'
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
+    assert core_module.LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
 
 
 def test_topic_hook_delivery_blocked_during_audio_startup_window():
@@ -1188,7 +1183,7 @@ def test_topic_hook_delivery_blocked_during_audio_startup_window():
     mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
     mgr._starting_session_count = 1
     mgr._starting_input_mode = 'audio'
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
+    assert core_module.LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
 
 
 def test_topic_hook_delivery_blocked_during_audio_to_text_teardown():
@@ -1203,15 +1198,15 @@ def test_topic_hook_delivery_blocked_during_audio_to_text_teardown():
     mgr.is_active = True
     # _is_voice_session_active_or_starting() is False here, but the live session
     # is still realtime → the union predicate must still block.
-    assert LLMSessionManager._is_voice_session_active_or_starting(mgr) is False
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
+    assert core_module.LLMSessionManager._is_voice_session_active_or_starting(mgr) is False
+    assert core_module.LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
 
 
 def test_topic_hook_delivery_allowed_in_text_session():
     """Non-regression: a text session still allows topic-hook delivery
     (fail-open when no activity snapshot is available)."""
     mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
+    assert core_module.LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
 
 
 def test_topic_hook_delivery_blocked_when_unfinished_thread_open():
@@ -1222,7 +1217,7 @@ def test_topic_hook_delivery_blocked_when_unfinished_thread_open():
         unfinished_thread=object(),
     )
 
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
+    assert core_module.LLMSessionManager.topic_hook_delivery_allowed(mgr) is False
 
 
 def test_topic_hook_delivery_does_not_recheck_privacy_preference(monkeypatch):
@@ -1237,7 +1232,7 @@ def test_topic_hook_delivery_does_not_recheck_privacy_preference(monkeypatch):
         raising=False,
     )
     mgr = _make_mgr(session=_FakeOmniOffline(delivered=True))
-    assert LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
+    assert core_module.LLMSessionManager.topic_hook_delivery_allowed(mgr) is True
 
 
 async def test_deliver_proactive_batch_drops_topic_hook_in_voice():
@@ -1256,7 +1251,7 @@ async def test_deliver_proactive_batch_drops_topic_hook_in_voice():
     mgr.enqueue_agent_callback = MagicMock()
     mgr.trigger_agent_callbacks = AsyncMock(return_value=True)
 
-    await LLMSessionManager._deliver_proactive_batch(mgr, [topic_cb, other_cb])
+    await core_module.LLMSessionManager._deliver_proactive_batch(mgr, [topic_cb, other_cb])
 
     # topic hook held at the gate: ack resolved False so TopicHookPool retries.
     assert hook_future.done() and hook_future.result() is False
@@ -1278,7 +1273,7 @@ async def test_deliver_proactive_batch_drops_topic_hook_when_release_predicate_c
     mgr.enqueue_agent_callback = MagicMock()
     mgr.trigger_agent_callbacks = AsyncMock(return_value=True)
 
-    await LLMSessionManager._deliver_proactive_batch(mgr, [topic_cb, other_cb])
+    await core_module.LLMSessionManager._deliver_proactive_batch(mgr, [topic_cb, other_cb])
 
     assert hook_future.done() and hook_future.result() is False
     mgr.enqueue_agent_callback.assert_called_once_with(other_cb)
@@ -1300,7 +1295,7 @@ async def test_drop_pending_topic_hooks_for_voice_sweeps_both_queues():
     mgr.pending_agent_callbacks = [topic_cb, other_cb]
     mgr.pending_extra_replies = [topic_extra, other_extra]
 
-    LLMSessionManager._drop_pending_topic_hooks_for_voice(mgr)
+    core_module.LLMSessionManager._drop_pending_topic_hooks_for_voice(mgr)
 
     assert mgr.pending_agent_callbacks == [other_cb]
     assert mgr.pending_extra_replies == [other_extra]
@@ -1319,7 +1314,7 @@ async def test_drop_pending_topic_hooks_for_voice_sweeps_extras_only():
     mgr.pending_agent_callbacks = []  # callback already drained + delivered in text
     mgr.pending_extra_replies = [topic_extra, other_extra]
 
-    LLMSessionManager._drop_pending_topic_hooks_for_voice(mgr)
+    core_module.LLMSessionManager._drop_pending_topic_hooks_for_voice(mgr)
 
     assert mgr.pending_extra_replies == [other_extra]
 
@@ -1341,7 +1336,7 @@ async def test_reset_proactive_gate_sweeps_already_pending_topic_hook_on_voice_s
     mgr.proactive_manager.drain_pending = MagicMock(return_value=[])
     mgr.proactive_manager.reset_gate = MagicMock()
 
-    LLMSessionManager._reset_proactive_gate(mgr)
+    core_module.LLMSessionManager._reset_proactive_gate(mgr)
 
     assert mgr.pending_agent_callbacks == []
     assert fut.done() and fut.result() is False
@@ -1356,7 +1351,7 @@ def test_reset_proactive_gate_keeps_topic_hook_on_text_start():
     mgr.proactive_manager.drain_pending = MagicMock(return_value=[])
     mgr.proactive_manager.reset_gate = MagicMock()
 
-    LLMSessionManager._reset_proactive_gate(mgr)
+    core_module.LLMSessionManager._reset_proactive_gate(mgr)
 
     assert mgr.pending_agent_callbacks == [topic_cb]
 
@@ -1379,7 +1374,7 @@ async def test_deliver_agent_callbacks_text_drops_topic_hook_when_voice_took_ove
     }
     snapshot = [topic_cb]
 
-    delivered = await LLMSessionManager._deliver_agent_callbacks_text(mgr, snapshot)
+    delivered = await core_module.LLMSessionManager._deliver_agent_callbacks_text(mgr, snapshot)
 
     assert delivered is False
     assert fut.done() and fut.result() is False
@@ -1402,7 +1397,7 @@ async def test_deliver_agent_callbacks_text_drops_topic_hook_when_voice_takes_ov
         "status": "completed", "summary": "deep topic", DELIVERY_ACK_FUTURE_KEY: fut,
     }
 
-    delivered = await LLMSessionManager._deliver_agent_callbacks_text(mgr, [topic_cb])
+    delivered = await core_module.LLMSessionManager._deliver_agent_callbacks_text(mgr, [topic_cb])
 
     assert delivered is False
     assert fut.done() and fut.result() is False
@@ -1430,7 +1425,7 @@ async def test_deliver_agent_callbacks_text_requeues_when_preempted_before_promp
 
     mgr.state.fire = _fire_and_rotate_sid
 
-    delivered = await LLMSessionManager._deliver_agent_callbacks_text(mgr, [cb])
+    delivered = await core_module.LLMSessionManager._deliver_agent_callbacks_text(mgr, [cb])
 
     assert delivered is False
     assert sess.called_with == []
@@ -1448,7 +1443,7 @@ async def test_deliver_agent_callbacks_text_keeps_topic_hook_in_plain_text_sessi
         "status": "completed", "summary": "deep topic",
     }
 
-    delivered = await LLMSessionManager._deliver_agent_callbacks_text(mgr, [topic_cb])
+    delivered = await core_module.LLMSessionManager._deliver_agent_callbacks_text(mgr, [topic_cb])
 
     assert delivered is True
     assert len(sess.called_with) == 1
@@ -1463,7 +1458,7 @@ async def test_text_mode_successful_delivery_fires_full_event_sequence():
     seen: list[tuple[SessionEvent, dict]] = []
     mgr.state.subscribe(None, lambda ev, p: seen.append((ev, dict(p))))
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     # 异步派发订阅回调
     for _ in range(3):
         await asyncio.sleep(0)
@@ -1499,7 +1494,7 @@ async def test_text_mode_exception_still_fires_done():
     seen_events: list[SessionEvent] = []
     mgr.state.subscribe(None, lambda ev, p: seen_events.append(ev))
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
     for _ in range(3):
         await asyncio.sleep(0)
 
@@ -1515,9 +1510,9 @@ async def test_contextvar_reset_after_delivery():
     mgr = _make_mgr(session=sess)
     mgr.pending_agent_callbacks = [{"status": "completed", "summary": "ctx"}]
 
-    assert _proactive_expected_sid.get() is None
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
-    assert _proactive_expected_sid.get() is None
+    assert core_module._proactive_expected_sid.get() is None
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
+    assert core_module._proactive_expected_sid.get() is None
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1533,7 +1528,7 @@ async def test_already_claimed_denies_agent_callback():
     router_won = await mgr.state.try_start_proactive(session=sess)
     assert router_won is True
 
-    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     assert mgr.state.phase is ProactivePhase.PHASE1
     assert sess.called_with == []
@@ -1556,7 +1551,7 @@ async def test_concurrent_claim_only_one_winner():
 
     async def agent_contender():
         await barrier.wait()
-        await LLMSessionManager.trigger_agent_callbacks(mgr)
+        await core_module.LLMSessionManager.trigger_agent_callbacks(mgr)
 
     t1 = asyncio.create_task(router_contender())
     t2 = asyncio.create_task(agent_contender())
@@ -1615,7 +1610,7 @@ async def test_user_input_between_claim_and_lock_is_detected():
     # 现在直接调 _deliver_agent_callbacks_text（绕过 trigger_agent_callbacks
     # 的 claim，因为我们已经手动模拟了 claim + user 抢占）
     callbacks_snapshot = [{"status": "completed", "summary": "slow"}]
-    await LLMSessionManager._deliver_agent_callbacks_text(mgr, callbacks_snapshot)
+    await core_module.LLMSessionManager._deliver_agent_callbacks_text(mgr, callbacks_snapshot)
 
     # 关键断言：current_speech_id 保留为用户的 sid，没被 proactive 覆盖
     assert mgr.current_speech_id == pre_user_sid
@@ -1653,7 +1648,7 @@ async def test_user_input_during_agent_delivery_sets_preempted():
     mgr.pending_agent_callbacks = [{"status": "completed", "summary": "slow"}]
 
     # 同时跑 agent callback delivery + 异步注入 USER_INPUT
-    task = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
+    task = asyncio.create_task(core_module.LLMSessionManager.trigger_agent_callbacks(mgr))
 
     # 等 state 进入 phase1
     for _ in range(20):

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -147,8 +147,10 @@ def test_enqueue_agent_callback_uses_generic_context_source_budget(monkeypatch):
     })
 
     assert mgr.pending_agent_callbacks[0]["summary"] == "2:topic summary"
+    assert mgr.pending_agent_callbacks[0]["detail"] == "2:topic detail"
     assert mgr.pending_extra_replies[0]["context_source"] == "topic.hook"
     assert mgr.pending_agent_callbacks[1]["summary"] == "4:proactive summary"
+    assert mgr.pending_agent_callbacks[1]["detail"] == "4:proactive detail"
     assert mgr.pending_extra_replies[1]["context_source"] == "proactive.callback"
 
 

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -39,6 +39,22 @@ async def test_prime_context_skipped_accumulates_cached_instructions():
     assert client.instructions == "base instructions\nassistant: hello\nuser: choice"
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gemini_create_response_propagates_send_failure(monkeypatch):
+    client = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    client._is_gemini = True
+    client._gemini_session = object()
+
+    async def fail_send_user_turn(_text):
+        raise RuntimeError("gemini send failed")
+
+    monkeypatch.setattr(client, "_gemini_send_user_turn", fail_send_user_turn)
+
+    with pytest.raises(RuntimeError, match="gemini send failed"):
+        await OmniRealtimeClient.create_response(client, "postgame context")
+
+
 @pytest.fixture
 def mock_websocket():
     """Returns a mock websocket object."""

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -55,6 +55,17 @@ async def test_gemini_create_response_propagates_send_failure(monkeypatch):
         await OmniRealtimeClient.create_response(client, "postgame context")
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gemini_create_response_raises_when_live_session_missing():
+    client = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    client._is_gemini = True
+    client._gemini_session = None
+
+    with pytest.raises(RuntimeError, match="Gemini session not available"):
+        await OmniRealtimeClient.create_response(client, "postgame context")
+
+
 @pytest.fixture
 def mock_websocket():
     """Returns a mock websocket object."""

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -57,6 +57,44 @@ async def test_gemini_create_response_propagates_send_failure(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_gemini_create_response_skipped_failure_restores_skip_state(monkeypatch):
+    client = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    client._is_gemini = True
+    client._gemini_session = object()
+    client._skip_until_next_response = False
+
+    async def fail_send_user_turn(_text):
+        raise RuntimeError("gemini send failed")
+
+    monkeypatch.setattr(client, "_gemini_send_user_turn", fail_send_user_turn)
+
+    with pytest.raises(RuntimeError, match="gemini send failed"):
+        await OmniRealtimeClient.create_response(client, "postgame context", skipped=True)
+
+    assert client._skip_until_next_response is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gemini_prime_context_skipped_failure_restores_skip_state(monkeypatch):
+    client = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    client._is_gemini = True
+    client._gemini_session = object()
+    client._skip_until_next_response = False
+
+    async def fail_send_user_turn(_text):
+        raise RuntimeError("gemini send failed")
+
+    monkeypatch.setattr(client, "_gemini_send_user_turn", fail_send_user_turn)
+
+    with pytest.raises(RuntimeError, match="gemini send failed"):
+        await OmniRealtimeClient.prime_context(client, "assistant: context", skipped=True)
+
+    assert client._skip_until_next_response is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_gemini_create_response_raises_when_live_session_missing():
     client = OmniRealtimeClient.__new__(OmniRealtimeClient)
     client._is_gemini = True


### PR DESCRIPTION
## Summary
- Add LLMSessionManager.append_context(...) as the generic context append API with source/role/audience/timing/lifetime/request_id/ordering_key metadata.
- Move request-id dedup, text normalization, token budget, pending-before-ready, active history, realtime prime, and new-session cache routing into the manager.
- Adopt the game icebreaker/realtime/postgame paths and reuse the same source policy for proactive/topic callback text budgeting.
- Remove the icebreaker-specific manager helper and route-local icebreaker dedup/char cap.

## 回归报告
- Change and necessity: PR #1839 solved the new-user icebreaker handoff but left feature-specific context append logic in the core manager and game route. This PR replaces that with one manager-owned append_context(...) path so future normalization, dedup, token budget, pending readiness, realtime prime, and cache behavior apply consistently across game, realtime, proactive, and topic context surfaces.
- Before behavior: icebreaker had its own append helper and route-local request-id dedup; game realtime/postgame routes could call prime_context(..., skipped=True) directly; proactive/topic callback text used a separate budget path.
- After behavior: callers pass source, role, audience, timing, lifetime, request_id, ordering_key, and metadata to LLMSessionManager.append_context(...). The manager owns source policy, request-id dedup, token truncation, pending-before-ready flush order, active history append, realtime prime, and new-session cache writes. Proactive/topic callbacks reuse the same source text budget policy without changing their ack/release queues.
- Potential regressions: incorrect target resolution could miss active history or realtime prime context; request-id dedup could drop legitimate repeated context if callers reuse IDs; pending ordering could reorder queued context incorrectly; callback text truncation could change proactive/topic prompt detail. Covered by manager contract tests, route adoption tests, topic delivery tests, and proactive integration tests.

## 不拆分理由
- The PR intentionally keeps the generic manager API and all immediate adopters together. Splitting the manager API from game/realtime/proactive/topic adoption would recreate the exact problem this follow-up fixes: an enhancement that only one path uses while peer paths keep bespoke behavior.

## Tests
- uv run pytest tests\unit\test_context_append_manager.py tests\unit\test_new_user_icebreaker_context.py tests\unit\test_new_user_icebreaker_static_contracts.py tests\unit\test_game_router.py tests\unit\test_topic_delivery.py tests\unit\test_proactive_sm_integration.py -q
- uv run python scripts\check_docstring_no_cjk.py --base origin/main
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 引入统一的上下文追加接口，返回追加/去重/失败原因；支持就绪前排队、稳定顺序注入与请求级去重。
* **改进**
  * 破冰、实时上下文、赛后注入均迁移到新机制；语音/代理回调按来源分配上下文预算并标注渲染来源；足球实时上下文启用本地 CSRF 鉴权头，校验失败后自动重试。
* **修复**
  * Gemini 发送失败与会话缺失更明确上抛异常；skipped 失败后自动恢复跳过状态。
* **测试**
  * 扩展注入/去重/竞态、足球静态合约与 Gemini 行为测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->