### PR TITLE
修复 API 设置页启用 MiMo Token Plan 后滚动位置异常，避免页面下半部分空白，并补充前端回归测试

### DIFF
--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -29,8 +29,11 @@
 
 html,
 body {
-height: 100%;
+height: 100vh;
+height: 100dvh;
 min-height: 100vh;
+max-height: 100vh;
+max-height: 100dvh;
 width: 100%;
 margin: 0;
 padding: 0;
@@ -43,11 +46,15 @@ flex-direction: column;
 }
 
 #main-content {
-height: 100%;
+height: 100vh;
+height: 100dvh;
+max-height: 100vh;
+max-height: 100dvh;
 min-height: 0;
 width: 100%;
 display: flex;
-flex: 1 1 auto;
+flex: 0 0 100vh;
+flex-basis: 100dvh;
 flex-direction: column;
 background: #fff;
 overflow: hidden;
@@ -64,7 +71,7 @@ position: relative;
 height: 100%;
 min-height: 0;
 display: flex;
-flex: 1 1 auto;
+flex: 1 1 0;
 flex-direction: column;
 overflow: hidden;
 }
@@ -908,6 +915,7 @@ opacity: 0.95 !important;
 /* 启用自定义API配置开关样式 */
 /* 禁用TTS开关样式 */
 .disable-tts-toggle {
+    position: relative;
     display: inline-flex;
     align-items: center;
     cursor: pointer;
@@ -920,6 +928,8 @@ opacity: 0.95 !important;
 
 .disable-tts-toggle input[type="checkbox"] {
     position: absolute;
+    top: 0;
+    left: 0;
     width: 1px;
     height: 1px;
     padding: 0;

--- a/static/css/api_key_settings.css
+++ b/static/css/api_key_settings.css
@@ -53,7 +53,7 @@ max-height: 100dvh;
 min-height: 0;
 width: 100%;
 display: flex;
-flex: 0 0 100vh;
+flex: 1 0 100vh;
 flex-basis: 100dvh;
 flex-direction: column;
 background: #fff;

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -243,7 +243,9 @@ function getEffectiveAssistUrl(providerKey, profile, { useTokenPlan = true } = {
 
 function isApiSettingsScrolledToBottom(container, tolerance = 4) {
     if (!container) return false;
-    return container.scrollHeight - container.clientHeight - container.scrollTop <= tolerance;
+    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    if (maxScrollTop <= tolerance) return false; // 展开前无有效滚动区，不应触发吸底
+    return maxScrollTop - container.scrollTop <= tolerance;
 }
 
 function keepApiSettingsBottomIfNeeded(shouldStickToBottom) {

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -241,6 +241,20 @@ function getEffectiveAssistUrl(providerKey, profile, { useTokenPlan = true } = {
     return getProviderOpenrouterUrl(providerKey, profile);
 }
 
+function isApiSettingsScrolledToBottom(container, tolerance = 4) {
+    if (!container) return false;
+    return container.scrollHeight - container.clientHeight - container.scrollTop <= tolerance;
+}
+
+function keepApiSettingsBottomIfNeeded(shouldStickToBottom) {
+    if (!shouldStickToBottom) return;
+    requestAnimationFrame(() => {
+        const container = document.querySelector('.container-content');
+        if (!container) return;
+        container.scrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    });
+}
+
 function updateMimoTokenPlanControls() {
     const showMimoControls = isMimoAssistSelected();
     const active = isMimoTokenPlanActive();
@@ -249,6 +263,8 @@ function updateMimoTokenPlanControls() {
     const keyRow = document.getElementById('mimoTokenPlanKeyRow');
     const tokenPlanInput = document.getElementById('mimoTokenPlanKeyInput');
     const assistInput = document.getElementById('assistApiKeyInput');
+    const scrollContainer = document.querySelector('.container-content');
+    const wasAtBottom = isApiSettingsScrolledToBottom(scrollContainer);
 
     if (toggleRow) toggleRow.style.display = showMimoControls ? 'inline-flex' : 'none';
     if (toggle) toggle.disabled = !showMimoControls;
@@ -266,6 +282,8 @@ function updateMimoTokenPlanControls() {
             assistInput.placeholder = window.t ? window.t('api.assistApiKeyPlaceholder') : '留空使用管理簿对应 Key';
         }
     }
+
+    keepApiSettingsBottomIfNeeded(wasAtBottom);
 }
 
 function isAliyunUsApiUrl(url) {

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -416,6 +416,57 @@ def test_mimo_token_plan_toggle_wraps_below_assist_provider(mock_page: Page, run
 
 
 @pytest.mark.frontend
+def test_mimo_token_plan_keeps_settings_scroll_container_stable(mock_page: Page, running_server: str):
+    """Expanding Token Plan at the bottom should not leave the page at the old scroll limit."""
+    mock_page.set_viewport_size({"width": 1816, "height": 1376})
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='mimo']", state="attached", timeout=10000)
+
+    mock_page.select_option("#assistApiSelect", "mimo")
+    expect(mock_page.locator("#mimoTokenPlanToggleRow")).to_be_visible(timeout=5000)
+
+    metrics = mock_page.evaluate("""
+        async () => {
+            const content = document.querySelector('.container-content');
+            content.scrollTop = content.scrollHeight;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
+            const toggle = document.getElementById('useMimoTokenPlan');
+            const beforeMaxScroll = content.scrollHeight - content.clientHeight;
+            const beforeScrollTop = content.scrollTop;
+            toggle.checked = true;
+            toggle.dispatchEvent(new Event('change', { bubbles: true }));
+            await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+            const rect = content.getBoundingClientRect();
+            const customRect = document.getElementById('custom-api-section').getBoundingClientRect();
+            const afterMaxScroll = content.scrollHeight - content.clientHeight;
+            return {
+                beforeMaxScroll,
+                beforeScrollTop,
+                afterMaxScroll,
+                afterScrollTop: content.scrollTop,
+                contentBottom: rect.bottom,
+                documentScrollHeight: document.documentElement.scrollHeight,
+                viewportHeight: window.innerHeight,
+                customTop: customRect.top,
+                customDisplay: getComputedStyle(document.getElementById('custom-api-section')).display,
+            };
+        }
+    """)
+
+    assert abs(metrics["beforeScrollTop"] - metrics["beforeMaxScroll"]) <= 2
+    assert metrics["afterMaxScroll"] > metrics["beforeMaxScroll"]
+    assert abs(metrics["afterScrollTop"] - metrics["afterMaxScroll"]) <= 2
+    assert abs(metrics["contentBottom"] - metrics["viewportHeight"]) <= 2
+    assert metrics["documentScrollHeight"] <= metrics["viewportHeight"] + 2
+    assert metrics["customDisplay"] != "none"
+    assert 0 <= metrics["customTop"] < metrics["viewportHeight"]
+
+
+@pytest.mark.frontend
 def test_mimo_token_plan_connectivity_tries_endpoint_candidates(mock_page: Page, running_server: str):
     """Token Plan connectivity should try regional MiMo endpoints until one succeeds."""
     mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")

--- a/tests/frontend/test_api_settings.py
+++ b/tests/frontend/test_api_settings.py
@@ -457,6 +457,8 @@ def test_mimo_token_plan_keeps_settings_scroll_container_stable(mock_page: Page,
         }
     """)
 
+    # 前提：该视口下内容本就需要滚动，否则 before/after 都为 0，断言失去意义。
+    assert metrics["beforeMaxScroll"] > 0
     assert abs(metrics["beforeScrollTop"] - metrics["beforeMaxScroll"]) <= 2
     assert metrics["afterMaxScroll"] > metrics["beforeMaxScroll"]
     assert abs(metrics["afterScrollTop"] - metrics["afterMaxScroll"]) <= 2
@@ -464,6 +466,53 @@ def test_mimo_token_plan_keeps_settings_scroll_container_stable(mock_page: Page,
     assert metrics["documentScrollHeight"] <= metrics["viewportHeight"] + 2
     assert metrics["customDisplay"] != "none"
     assert 0 <= metrics["customTop"] < metrics["viewportHeight"]
+
+
+@pytest.mark.frontend
+def test_mimo_token_plan_does_not_force_scroll_when_not_scrollable(mock_page: Page, running_server: str):
+    """When the settings fit without scrolling, enabling Token Plan must not yank the user to the bottom."""
+    mock_page.set_viewport_size({"width": 1816, "height": 1376})
+    mock_page.add_init_script("window.localStorage.setItem('neko_tutorial_settings', 'seen')")
+    mock_page.goto(f"{running_server}/api_key")
+    expect(mock_page.locator("#loading-overlay")).to_be_hidden(timeout=15000)
+    mock_page.wait_for_selector("#assistApiSelect option[value='mimo']", state="attached", timeout=10000)
+
+    mock_page.select_option("#assistApiSelect", "mimo")
+    expect(mock_page.locator("#mimoTokenPlanToggleRow")).to_be_visible(timeout=5000)
+
+    # Grow the viewport past the content height so the scroll container is no longer
+    # scrollable, exercising the "not scrollable before expansion" boundary.
+    content_height = mock_page.evaluate(
+        "() => document.querySelector('.container-content').scrollHeight"
+    )
+    mock_page.set_viewport_size({"width": 1816, "height": int(content_height) + 400})
+
+    metrics = mock_page.evaluate("""
+        async () => {
+            const content = document.querySelector('.container-content');
+            content.scrollTop = 0;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
+            const toggle = document.getElementById('useMimoTokenPlan');
+            const beforeMaxScroll = content.scrollHeight - content.clientHeight;
+            toggle.checked = true;
+            toggle.dispatchEvent(new Event('change', { bubbles: true }));
+            await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+            return {
+                beforeMaxScroll,
+                afterMaxScroll: content.scrollHeight - content.clientHeight,
+                afterScrollTop: content.scrollTop,
+                customDisplay: getComputedStyle(document.getElementById('custom-api-section')).display,
+            };
+        }
+    """)
+
+    # 前提：展开前容器不可滚动（maxScroll≈0），覆盖 isApiSettingsScrolledToBottom 的吸底守卫。
+    assert metrics["beforeMaxScroll"] <= 4
+    # 修复点：用户原本在顶部且不可滚动，启用 Token Plan 后不得被强制吸到底部。
+    assert metrics["afterScrollTop"] <= 2
+    assert metrics["customDisplay"] != "none"
 
 
 @pytest.mark.frontend


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复 API 设置页启用 MiMo Token Plan 后滚动位置异常，避免页面下半部分空白

## 测试 / Testing

手动开启按钮测试

## 对比

之前:
<img width="1860" height="1409" alt="image" src="https://github.com/user-attachments/assets/f047635a-25ab-4fd4-afd3-f165e11de7ce" />

之后:
<img width="1860" height="1409" alt="image" src="https://github.com/user-attachments/assets/7cb438b7-e779-42f2-be1d-f5361e1a0c38" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进 API 密钥设置页面的高度与布局计算，采用 `vh/dvh` 适配动态工具栏等场景。
  * 切换 MiMo Token Plan 后，滚动位置更稳定：必要时保持在底部附近；在不可滚动时不强制拖到底部。
  * “禁用 TTS”开关布局更稳健。

* **测试**
  * 新增前端回归用例，覆盖滚动位置稳定性与“不强制吸底”的行为验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->