### PR TITLE
Fix CosyVoice clone listing visibility

### DIFF
--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -282,7 +282,7 @@ def test_get_voices_merges_mimo_bucket(monkeypatch):
     monkeypatch.setattr(cm, "get_core_config", lambda: {})
     monkeypatch.setattr(cm, "_is_local_tts_storage_active", lambda *a, **k: False)
     monkeypatch.setattr(cm, "is_free_voice", lambda: False)
-    monkeypatch.setattr(cm, "_get_cosyvoice_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_cosyvoice_storage_keys", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cm, "_get_minimax_storage_keys", lambda: [])
     monkeypatch.setattr(cm, "_get_elevenlabs_storage_keys", lambda: [])
 
@@ -311,11 +311,17 @@ def test_get_voices_merges_cosyvoice_provider_bucket_for_listing_when_main_cloud
 ):
     cm = get_config_manager()
     voice_id = f"{expected_provider}-clone-x"
-    core_config = {"CORE_API_TYPE": core_api_type, key_field: api_key}
+    main_voice_id = "domestic-main-voice"
+    core_config = {
+        "CORE_API_TYPE": core_api_type,
+        "AUDIO_API_KEY": "domestic-main-key",
+        key_field: api_key,
+    }
     monkeypatch.setattr(cm, "get_model_api_config", lambda t: dict(tts_config))
     monkeypatch.setattr(cm, "get_core_config", lambda: dict(core_config))
     monkeypatch.setattr(cm, "load_voice_storage", lambda: {
-        bucket: {voice_id: {"source": "clone"}}  # provider stamped by merge
+        "domestic-main-key": {main_voice_id: {"source": "main"}},
+        bucket: {voice_id: {"source": "clone"}},  # provider stamped by merge
     })
     monkeypatch.setattr(cm, "_get_minimax_storage_keys", lambda: [])
     monkeypatch.setattr(cm, "_get_elevenlabs_storage_keys", lambda: [])
@@ -325,6 +331,7 @@ def test_get_voices_merges_cosyvoice_provider_bucket_for_listing_when_main_cloud
 
     assert voice_id in voices
     assert voices[voice_id]["provider"] == expected_provider
+    assert main_voice_id not in voices
 
 
 @pytest.mark.unit
@@ -413,7 +420,7 @@ def test_get_voices_strips_sample_b64_for_listing(monkeypatch):
     monkeypatch.setattr(cm, "get_core_config", lambda: {})
     monkeypatch.setattr(cm, "_is_local_tts_storage_active", lambda *a, **k: False)
     monkeypatch.setattr(cm, "is_free_voice", lambda: False)
-    monkeypatch.setattr(cm, "_get_cosyvoice_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_cosyvoice_storage_keys", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cm, "_get_minimax_storage_keys", lambda: [])
     monkeypatch.setattr(cm, "_get_elevenlabs_storage_keys", lambda: [])
 

--- a/tests/unit/test_mimo_voice_clone.py
+++ b/tests/unit/test_mimo_voice_clone.py
@@ -292,6 +292,42 @@ def test_get_voices_merges_mimo_bucket(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("key_field, api_key, bucket, expected_provider", [
+    ("ASSIST_API_KEY_QWEN", "domestic-key-12345678", "domestic-key-12345678", "cosyvoice"),
+    ("ASSIST_API_KEY_QWEN_INTL", "intl-key-12345678", "__COSYVOICE_INTL__12345678", "cosyvoice_intl"),
+])
+@pytest.mark.parametrize("tts_config, core_api_type", [
+    ({}, "free"),
+    ({"is_custom": True, "base_url": "ws://127.0.0.1:9880", "api_key": ""}, "openai"),
+])
+def test_get_voices_merges_cosyvoice_provider_bucket_for_listing_when_main_cloud_hidden(
+    monkeypatch,
+    key_field,
+    api_key,
+    bucket,
+    expected_provider,
+    tts_config,
+    core_api_type,
+):
+    cm = get_config_manager()
+    voice_id = f"{expected_provider}-clone-x"
+    core_config = {"CORE_API_TYPE": core_api_type, key_field: api_key}
+    monkeypatch.setattr(cm, "get_model_api_config", lambda t: dict(tts_config))
+    monkeypatch.setattr(cm, "get_core_config", lambda: dict(core_config))
+    monkeypatch.setattr(cm, "load_voice_storage", lambda: {
+        bucket: {voice_id: {"source": "clone"}}  # provider stamped by merge
+    })
+    monkeypatch.setattr(cm, "_get_minimax_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_elevenlabs_storage_keys", lambda: [])
+    monkeypatch.setattr(cm, "_get_mimo_storage_keys", lambda: [])
+
+    voices = cm.get_voices_for_current_api(for_listing=True)
+
+    assert voice_id in voices
+    assert voices[voice_id]["provider"] == expected_provider
+
+
+@pytest.mark.unit
 def test_registry_declares_clone_and_preset_for_mimo():
     import utils.tts_provider_registry as reg
     mimo = reg.get("mimo")

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2932,6 +2932,10 @@ class ConfigManager:
         ``validate_voice_id`` / ``cleanup_invalid_voice_ids`` must see every voice actually
         present in storage, otherwise the free edition would misjudge voice_ids users saved
         during a paid period as nonexistent and clear them outright during cleanup.
+
+        Provider-keyed CosyVoice clone buckets are still merged below: if a
+        clone provider API key is configured and has stored voices, the clone
+        list should show those voices even when the main cloud bucket is hidden.
         """
         voice_storage = self.load_voice_storage()
         storage_key = ''
@@ -2960,9 +2964,7 @@ class ConfigManager:
                     all_voices = voice_storage.get(storage_key, {})
                     result = dict(all_voices)
 
-        cosyvoice_storage_keys = []
-        if not is_local_tts and not hide_cloud_main:
-            cosyvoice_storage_keys = self._get_cosyvoice_storage_keys()
+        cosyvoice_storage_keys = self._get_cosyvoice_storage_keys()
 
         # 确保主分区音色有 provider 字段
         default_provider = self._infer_provider_from_storage_key(storage_key) if storage_key else 'cosyvoice'

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2808,9 +2808,10 @@ class ConfigManager:
             'provider_label': '阿里国际版CosyVoice' if normalized_provider == 'cosyvoice_intl' else '阿里百炼CosyVoice',
         }
 
-    def _get_cosyvoice_storage_keys(self) -> list[tuple[str, str]]:
+    def _get_cosyvoice_storage_keys(self, voice_storage: dict | None = None) -> list[tuple[str, str]]:
         """Return the voice_storage key for the current Alibaba CN/international API key."""
-        voice_storage = self.load_voice_storage()
+        if voice_storage is None:
+            voice_storage = self.load_voice_storage()
         result: list[tuple[str, str]] = []
         seen = set()
 
@@ -2964,7 +2965,7 @@ class ConfigManager:
                     all_voices = voice_storage.get(storage_key, {})
                     result = dict(all_voices)
 
-        cosyvoice_storage_keys = self._get_cosyvoice_storage_keys()
+        cosyvoice_storage_keys = self._get_cosyvoice_storage_keys(voice_storage)
 
         # 确保主分区音色有 provider 字段
         default_provider = self._infer_provider_from_storage_key(storage_key) if storage_key else 'cosyvoice'
@@ -4492,13 +4493,13 @@ class ConfigManager:
 
     def is_free_voice(self) -> bool:
         """Whether the built-in free voice is in use (core=free). The single source of truth for
-        "is voice free" — free preset voices, hidden cloud clone voices and the default YUI
+        "is voice free" — free preset voices, hidden main cloud voices and the default YUI
         fallback all read it. Dual of is_agent_free().
 
         Realtime and text TTS share the same voice and follow core, independent of assist:
-        the CosyVoice/Qwen clone voices hidden by hide_cloud_main merely reuse the assist
-        key; the free edition (core=free) runs the free_mode worker at runtime and cannot
-        play them, hence hidden.
+        hide_cloud_main hides the main CosyVoice/Qwen cloud bucket in free mode. Provider-keyed
+        clone buckets are handled separately by get_voices_for_current_api(), and remain visible
+        when the corresponding CosyVoice clone API key is configured.
         """
         return (self.get_core_config().get('CORE_API_TYPE') or '') == 'free'
 


### PR DESCRIPTION
## Summary
- show provider-keyed CosyVoice clone buckets in the voice clone list when a CosyVoice API key is configured
- keep the main cloud bucket hidden for free/local TTS cases while still surfacing usable provider-specific clones
- add regression coverage for domestic and international CosyVoice buckets under free core and local TTS configs

## Tests
- `uv run pytest tests/unit/test_mimo_voice_clone.py -q`
- `uv run pytest tests/unit/test_api_config_manager.py -k "vllm_omni_does_not_expose_or_delete_local_tts_storage or vllm_omni_tts_slot_does_not_feed_cosyvoice_clone_runtime" -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 优化音声克隆分区的列表展示：当隐藏主云分区后，基于提供商配置的相关克隆分区仍会参与合并结果展示，且主云分区的对应条目不会出现在返回列表中。

* **测试**
  * 新增参数化单元测试，覆盖隐藏主云分区场景下的合并行为；同时增强既有测试的兼容性以适配相关调用方式变更。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->