### PR TITLE
[codex] Configure asyncio default executor size

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -100,6 +100,7 @@ from utils.storage_location_bootstrap import get_storage_startup_blocking_reason
 # 将日志初始化提前，确保导入阶段异常也能落盘
 from utils.logger_config import setup_logging # noqa: E402
 from utils.ssl_env_diagnostics import probe_ssl_environment, write_ssl_diagnostic # noqa: E402
+from utils.asyncio_executor import configure_default_executor # noqa: E402
 
 _main_log_level = getattr(logging, (os.environ.get("NEKO_LOG_LEVEL") or "INFO").upper(), logging.INFO)
 logger, log_config = setup_logging(service_name="Main", log_level=_main_log_level, silent=not _IS_MAIN_PROCESS)
@@ -2260,6 +2261,7 @@ async def on_startup():
     if _IS_MAIN_PROCESS:
         global _server_loop
         _server_loop = asyncio.get_running_loop()
+        configure_default_executor(_server_loop, logger=logger)
 
         init_shared_state(
             role_state=role_state,

--- a/tests/unit/test_asyncio_executor.py
+++ b/tests/unit/test_asyncio_executor.py
@@ -1,0 +1,19 @@
+from utils.asyncio_executor import resolve_default_executor_max_workers
+
+
+def test_default_executor_workers_have_low_end_floor():
+    assert resolve_default_executor_max_workers(1) == 16
+    assert resolve_default_executor_max_workers(4) == 16
+
+
+def test_default_executor_workers_fall_back_when_cpu_count_is_unknown(monkeypatch):
+    monkeypatch.setattr("utils.asyncio_executor.os.cpu_count", lambda: None)
+    assert resolve_default_executor_max_workers(None) == 16
+
+
+def test_default_executor_workers_follow_python_default_in_middle():
+    assert resolve_default_executor_max_workers(20) == 24
+
+
+def test_default_executor_workers_are_capped():
+    assert resolve_default_executor_max_workers(128) == 32

--- a/tests/unit/test_asyncio_executor.py
+++ b/tests/unit/test_asyncio_executor.py
@@ -1,9 +1,18 @@
-from utils.asyncio_executor import resolve_default_executor_max_workers
+import concurrent.futures
+from unittest.mock import Mock
+
+from utils.asyncio_executor import (
+    DEFAULT_EXECUTOR_THREAD_PREFIX,
+    configure_default_executor,
+    resolve_default_executor_max_workers,
+)
 
 
 def test_default_executor_workers_have_low_end_floor():
     assert resolve_default_executor_max_workers(1) == 16
     assert resolve_default_executor_max_workers(4) == 16
+    assert resolve_default_executor_max_workers(11) == 16
+    assert resolve_default_executor_max_workers(12) == 16
 
 
 def test_default_executor_workers_fall_back_when_cpu_count_is_unknown(monkeypatch):
@@ -16,4 +25,23 @@ def test_default_executor_workers_follow_python_default_in_middle():
 
 
 def test_default_executor_workers_are_capped():
+    assert resolve_default_executor_max_workers(27) == 31
+    assert resolve_default_executor_max_workers(28) == 32
     assert resolve_default_executor_max_workers(128) == 32
+
+
+def test_configure_default_executor_installs_named_thread_pool(monkeypatch):
+    monkeypatch.setattr("utils.asyncio_executor.os.cpu_count", lambda: 4)
+    loop = Mock()
+
+    max_workers = configure_default_executor(loop)
+
+    assert max_workers == 16
+    loop.set_default_executor.assert_called_once()
+    executor = loop.set_default_executor.call_args.args[0]
+    try:
+        assert isinstance(executor, concurrent.futures.ThreadPoolExecutor)
+        assert executor._max_workers == 16
+        assert executor._thread_name_prefix == DEFAULT_EXECUTOR_THREAD_PREFIX
+    finally:
+        executor.shutdown(wait=False)

--- a/utils/asyncio_executor.py
+++ b/utils/asyncio_executor.py
@@ -1,4 +1,6 @@
+import asyncio
 import concurrent.futures
+import logging
 import os
 
 
@@ -10,9 +12,13 @@ DEFAULT_EXECUTOR_THREAD_PREFIX = "neko-asyncio"
 def resolve_default_executor_max_workers(cpu_count: int | None = None) -> int:
     """Return the process-wide asyncio default executor size.
 
-    Python's default is ``min(32, os.cpu_count() + 4)``. Keep that behavior for
-    mid/high-core machines, but enforce a floor for low-end devices because this
-    app offloads many blocking IO and queue-wait operations through
+    Args:
+        cpu_count: Optional override used by tests. When omitted, this function
+            uses ``os.cpu_count()``.
+
+    Python's default is ``min(32, (os.cpu_count() or 1) + 4)``. Keep that
+    behavior for mid/high-core machines, but enforce a floor for low-end devices
+    because this app offloads many blocking IO and queue-wait operations through
     ``asyncio.to_thread`` / ``run_in_executor(None, ...)``.
     """
     if cpu_count is None:
@@ -23,7 +29,10 @@ def resolve_default_executor_max_workers(cpu_count: int | None = None) -> int:
     )
 
 
-def configure_default_executor(loop, logger=None) -> int:
+def configure_default_executor(
+    loop: asyncio.AbstractEventLoop,
+    logger: logging.Logger | None = None,
+) -> int:
     """Install a shared default executor for asyncio offload calls."""
     max_workers = resolve_default_executor_max_workers()
     loop.set_default_executor(

--- a/utils/asyncio_executor.py
+++ b/utils/asyncio_executor.py
@@ -1,0 +1,37 @@
+import concurrent.futures
+import os
+
+
+MIN_DEFAULT_EXECUTOR_WORKERS = 16
+MAX_DEFAULT_EXECUTOR_WORKERS = 32
+DEFAULT_EXECUTOR_THREAD_PREFIX = "neko-asyncio"
+
+
+def resolve_default_executor_max_workers(cpu_count: int | None = None) -> int:
+    """Return the process-wide asyncio default executor size.
+
+    Python's default is ``min(32, os.cpu_count() + 4)``. Keep that behavior for
+    mid/high-core machines, but enforce a floor for low-end devices because this
+    app offloads many blocking IO and queue-wait operations through
+    ``asyncio.to_thread`` / ``run_in_executor(None, ...)``.
+    """
+    if cpu_count is None:
+        cpu_count = os.cpu_count() or 1
+    return min(
+        MAX_DEFAULT_EXECUTOR_WORKERS,
+        max(MIN_DEFAULT_EXECUTOR_WORKERS, cpu_count + 4),
+    )
+
+
+def configure_default_executor(loop, logger=None) -> int:
+    """Install a shared default executor for asyncio offload calls."""
+    max_workers = resolve_default_executor_max_workers()
+    loop.set_default_executor(
+        concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix=DEFAULT_EXECUTOR_THREAD_PREFIX,
+        )
+    )
+    if logger is not None:
+        logger.info("[asyncio] default executor max_workers=%s", max_workers)
+    return max_workers


### PR DESCRIPTION
## 改动概述 / Summary

- configure the main server event loop default executor at startup
- keep Python default sizing behavior for mid/high-core machines while enforcing a 16-worker floor and 32-worker cap
- add focused unit coverage for the worker-count calculation

## 回归报告 / Regression Report

- 改动内容：main_server startup now installs a process-wide asyncio default executor via utils.asyncio_executor.
- 理由 / 必要性：the app uses asyncio.to_thread / run_in_executor(None, ...) for blocking IO, SSL/client setup, queue waits, file/image work, and audio processing; low-core machines could otherwise get a very small default pool.
- 前后表现：mid/high-core machines keep Python default sizing behavior, while low-core machines get at least 16 workers; all machines remain capped at 32 workers.
- 潜在回归点：more idle-capacity threads may be created on demand under load; validation covers worker-count boundaries and Python compilation of the startup integration.

## 不拆分理由 / Why Not Split

不适用：本 PR 只改动 3 个文件，且行为集中在 asyncio default executor sizing.

## 测试 / Testing

- uv run python -m pytest tests/unit/test_asyncio_executor.py -q
- uv run python -m py_compile utils/asyncio_executor.py app/main_server.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **性能优化**
  * 改进异步执行器配置，优化默认线程池大小计算和分配机制，提高应用异步任务处理性能。

* **测试**
  * 新增异步执行器单元测试，确保线程池工作线程数计算的正确性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->