### PR TITLE
Fix plugin host config and data root handling

### DIFF
--- a/plugin/core/context.py
+++ b/plugin/core/context.py
@@ -255,6 +255,45 @@ class PluginContext:
         except Exception:
             pass
 
+    def _refresh_instance_runtime_config(self, effective_config: Dict[str, Any]) -> None:
+        instance = getattr(self, "_instance", None)
+        refresh = getattr(instance, "refresh_runtime_config", None)
+        if not callable(refresh):
+            return
+        try:
+            refresh(effective_config)
+        except Exception as exc:
+            try:
+                self.logger.warning(
+                    "[PluginContext] Failed to refresh runtime config: plugin_id={}, err_type={}, err={}",
+                    self.plugin_id,
+                    type(exc).__name__,
+                    str(exc),
+                )
+            except Exception:
+                pass
+
+    def _set_effective_config_cache(self, config_obj: object) -> Dict[str, Any] | None:
+        if not isinstance(config_obj, dict):
+            self._effective_config = None
+            return None
+        config_copy = copy.deepcopy(config_obj)
+        self._effective_config = config_copy
+        self._refresh_instance_runtime_config(config_copy)
+        return config_copy
+
+    @staticmethod
+    def _merge_config_copy(base: object, updates: Dict[str, Any]) -> Dict[str, Any]:
+        merged = copy.deepcopy(base) if isinstance(base, dict) else {}
+        for key, value in updates.items():
+            if isinstance(merged.get(key), dict) and isinstance(value, dict):
+                current = merged[key]
+                if isinstance(current, dict):
+                    merged[key] = PluginContext._merge_config_copy(current, value)
+            else:
+                merged[key] = copy.deepcopy(value)
+        return merged
+
     def _get_sync_call_in_handler_policy(self) -> str:
         """获取同步调用策略，优先使用插件自身配置，其次使用全局配置。
 
@@ -1597,7 +1636,7 @@ class PluginContext:
                 )
                 config_obj = payload.get("config")
                 if isinstance(config_obj, dict):
-                    self._effective_config = copy.deepcopy(config_obj)
+                    self._set_effective_config_cache(config_obj)
                 return payload
             if payload_type == "base":
                 return await asyncio.wait_for(
@@ -1738,7 +1777,7 @@ class PluginContext:
         if isinstance(local_payload, dict):
             effective_obj = local_payload.get("config")
             if isinstance(effective_obj, dict) and profile_name is None:
-                self._effective_config = copy.deepcopy(effective_obj)
+                self._set_effective_config_cache(effective_obj)
             return local_payload
 
         try:
@@ -1813,6 +1852,9 @@ class PluginContext:
     async def update_own_config(self, updates: Dict[str, Any], timeout: float = 10.0) -> Dict[str, Any]:
         if not isinstance(updates, dict):
             raise TypeError("updates must be a dict")
+        optimistic_config = self._merge_config_copy(getattr(self, "_effective_config", None), updates)
+        self._set_effective_config_cache(optimistic_config)
+        request_timeout = min(float(timeout), 4.5)
         try:
             payload = await self._send_request_and_wait_async(
                 method_name="update_own_config",
@@ -1821,12 +1863,25 @@ class PluginContext:
                     "plugin_id": self.plugin_id,
                     "updates": updates,
                 },
-                timeout=timeout,
+                timeout=request_timeout,
                 wrap_result=True,
                 error_log_template=None,
             )
             config_obj = payload.get("config") if isinstance(payload, dict) else None
-            self._effective_config = copy.deepcopy(config_obj) if isinstance(config_obj, dict) else None
+            if isinstance(config_obj, dict):
+                if payload.get("persisted") is False:
+                    self._set_effective_config_cache(optimistic_config)
+                    payload = dict(payload)
+                    payload["config"] = copy.deepcopy(optimistic_config)
+                else:
+                    self._set_effective_config_cache(config_obj)
             return payload
         except TimeoutError as e:
-            raise TimeoutError(f"Plugin config update timed out after {timeout}s") from e
+            return {
+                "success": False,
+                "plugin_id": self.plugin_id,
+                "config": copy.deepcopy(optimistic_config),
+                "requires_reload": False,
+                "persisted": False,
+                "message": "Config persistence timed out; update is applied in plugin memory only",
+            }

--- a/plugin/core/context.py
+++ b/plugin/core/context.py
@@ -1916,6 +1916,13 @@ class PluginContext:
                 "persisted": False,
                 "message": "Config persistence timed out; update is applied in plugin memory only",
             }
+        except asyncio.CancelledError:
+            if isinstance(old_effective_config, dict):
+                self._set_effective_config_cache(old_effective_config)
+            else:
+                self._effective_config = None
+                self._refresh_instance_runtime_config({})
+            raise
         except Exception:
             if isinstance(old_effective_config, dict):
                 self._set_effective_config_cache(old_effective_config)

--- a/plugin/core/context.py
+++ b/plugin/core/context.py
@@ -1884,6 +1884,7 @@ class PluginContext:
         old_effective_config = copy.deepcopy(getattr(self, "_effective_config", None))
         optimistic_config = self._merge_config_copy(old_effective_config, updates)
         self._set_effective_config_cache(optimistic_config)
+        # Keep config writes from blocking plugin actions; timeouts fall back to the optimistic in-memory config.
         request_timeout = min(float(timeout), 4.5)
         try:
             payload = await self._send_request_and_wait_async(

--- a/plugin/core/context.py
+++ b/plugin/core/context.py
@@ -18,6 +18,7 @@ import threading
 import functools
 import itertools
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -286,10 +287,38 @@ class PluginContext:
     def _merge_config_copy(base: object, updates: Dict[str, Any]) -> Dict[str, Any]:
         merged = copy.deepcopy(base) if isinstance(base, dict) else {}
         for key, value in updates.items():
-            if isinstance(merged.get(key), dict) and isinstance(value, dict):
-                current = merged[key]
-                if isinstance(current, dict):
-                    merged[key] = PluginContext._merge_config_copy(current, value)
+            if not isinstance(key, str):
+                continue
+            if value == "__DELETE__":
+                merged.pop(key, None)
+                continue
+            if isinstance(value, Mapping):
+                value_mapping = {
+                    nested_key: nested_value
+                    for nested_key, nested_value in value.items()
+                    if isinstance(nested_key, str)
+                }
+                if value_mapping.get("__replace__") is True:
+                    merged[key] = {
+                        nested_key: copy.deepcopy(nested_value)
+                        for nested_key, nested_value in value_mapping.items()
+                        if nested_key != "__replace__"
+                    }
+                    continue
+                current = merged.get(key)
+                if isinstance(current, Mapping):
+                    current_mapping = {
+                        nested_key: nested_value
+                        for nested_key, nested_value in current.items()
+                        if isinstance(nested_key, str)
+                    }
+                    merged[key] = (
+                        PluginContext._merge_config_copy(current_mapping, value_mapping)
+                        if value_mapping
+                        else {}
+                    )
+                else:
+                    merged[key] = copy.deepcopy(value_mapping)
             else:
                 merged[key] = copy.deepcopy(value)
         return merged
@@ -1852,7 +1881,8 @@ class PluginContext:
     async def update_own_config(self, updates: Dict[str, Any], timeout: float = 10.0) -> Dict[str, Any]:
         if not isinstance(updates, dict):
             raise TypeError("updates must be a dict")
-        optimistic_config = self._merge_config_copy(getattr(self, "_effective_config", None), updates)
+        old_effective_config = copy.deepcopy(getattr(self, "_effective_config", None))
+        optimistic_config = self._merge_config_copy(old_effective_config, updates)
         self._set_effective_config_cache(optimistic_config)
         request_timeout = min(float(timeout), 4.5)
         try:
@@ -1885,3 +1915,10 @@ class PluginContext:
                 "persisted": False,
                 "message": "Config persistence timed out; update is applied in plugin memory only",
             }
+        except Exception:
+            if isinstance(old_effective_config, dict):
+                self._set_effective_config_cache(old_effective_config)
+            else:
+                self._effective_config = None
+                self._refresh_instance_runtime_config({})
+            raise

--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -43,7 +43,6 @@ from plugin.sdk.shared.core.result_contract import model_schema_from_type
 from plugin.sdk.shared.core.router import PluginRouter
 from plugin.sdk.plugin.ui import UI_ACTION_META_ATTR, UI_CONTEXT_META_ATTR
 from plugin.core.bus.types import dispatch_bus_change
-from utils.storage_layout import export_storage_layout_to_env, resolve_storage_layout
 from plugin.core.zmq_transport import (
     HostTransport, ChildTransport, CH_CMD, CH_RES, CH_STS, CH_MSG, CH_COMM, CH_RESP,
 )
@@ -63,12 +62,15 @@ def _sanitize_plugin_id(raw: Any, max_len: int = 64) -> str:
 
 def _resolve_current_storage_layout() -> dict[str, Any]:
     from utils.config_manager import get_config_manager
+    from utils.storage_layout import resolve_storage_layout
 
     return resolve_storage_layout(get_config_manager())
 
 
 def _refresh_child_storage_layout_env(logger_obj: Any) -> None:
     try:
+        from utils.storage_layout import export_storage_layout_to_env
+
         layout = _resolve_current_storage_layout()
         export_storage_layout_to_env(layout)
         logger_obj.debug(

--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -43,6 +43,7 @@ from plugin.sdk.shared.core.result_contract import model_schema_from_type
 from plugin.sdk.shared.core.router import PluginRouter
 from plugin.sdk.plugin.ui import UI_ACTION_META_ATTR, UI_CONTEXT_META_ATTR
 from plugin.core.bus.types import dispatch_bus_change
+from utils.storage_layout import export_storage_layout_to_env, resolve_storage_layout
 from plugin.core.zmq_transport import (
     HostTransport, ChildTransport, CH_CMD, CH_RES, CH_STS, CH_MSG, CH_COMM, CH_RESP,
 )
@@ -58,6 +59,30 @@ def _sanitize_plugin_id(raw: Any, max_len: int = 64) -> str:
         digest = hashlib.sha256(s.encode("utf-8", errors="ignore")).hexdigest()[:12]
         safe = f"{safe[:max_len - 13]}_{digest}"
     return safe
+
+
+def _resolve_current_storage_layout() -> dict[str, Any]:
+    from utils.config_manager import get_config_manager
+
+    return resolve_storage_layout(get_config_manager())
+
+
+def _refresh_child_storage_layout_env(logger_obj: Any) -> None:
+    try:
+        layout = _resolve_current_storage_layout()
+        export_storage_layout_to_env(layout)
+        logger_obj.debug(
+            "Plugin child storage layout env refreshed: selected_root={}, anchor_root={}, source={}",
+            layout.get("selected_root"),
+            layout.get("anchor_root"),
+            layout.get("source"),
+        )
+    except Exception as exc:
+        logger_obj.warning(
+            "Failed to refresh plugin child storage layout env; plugin data root may use fallback: err_type={}, err={}",
+            type(exc).__name__,
+            str(exc),
+        )
 
 
 _TIMEOUT_UNSET = object()
@@ -578,6 +603,10 @@ async def _handle_config_update_command(
             logger.debug("[Plugin Process] Config cache updated")
         else:
             ctx._effective_config = new_config
+
+        refresh_runtime_config = getattr(ctx, "_refresh_instance_runtime_config", None)
+        if callable(refresh_runtime_config) and isinstance(ctx._effective_config, dict):
+            refresh_runtime_config(ctx._effective_config)
         
         # 触发 config_change 生命周期事件（如果存在）
         lifecycle_events = events_by_type.get("lifecycle", {})
@@ -1761,6 +1790,7 @@ class PluginHost:
             return
 
         try:
+            _refresh_child_storage_layout_env(self.logger)
             await asyncio.to_thread(self.process.start)
         except Exception:
             self.logger.error(

--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -629,6 +629,8 @@ async def _handle_config_update_command(
                 logger.exception("[Plugin Process] config_change handler failed")
                 # 回滚配置到变更前状态
                 ctx._effective_config = old_config
+                if callable(refresh_runtime_config) and isinstance(old_config, dict):
+                    refresh_runtime_config(old_config)
                 logger.debug("[Plugin Process] Config rolled back after handler failure")
                 ret_payload["error"] = f"config_change handler failed: {e}"
                 res_sender.put(ret_payload, timeout=10.0)

--- a/plugin/sdk/shared/core/base.py
+++ b/plugin/sdk/shared/core/base.py
@@ -88,8 +88,13 @@ class NekoPluginBase:
         """Refresh SDK runtime helpers after the host effective config changes."""
         cfg = effective_config if isinstance(effective_config, dict) else resolve_effective_config(self.ctx)
         self.store.enabled = resolve_store_enabled(cfg)
-        db_enabled, _db_name = resolve_db_config(cfg)
+        db_enabled, db_name = resolve_db_config(cfg)
         self.db.enabled = db_enabled
+        configure_db_name = getattr(self.db, "configure_database_name", None)
+        if callable(configure_db_name):
+            configure_db_name(db_name)
+        elif hasattr(self.db, "db_name"):
+            self.db.db_name = db_name
         self.state.backend = resolve_state_backend(cfg)
 
     def get_input_schema(self) -> InputSchema:

--- a/plugin/sdk/shared/core/base.py
+++ b/plugin/sdk/shared/core/base.py
@@ -87,15 +87,21 @@ class NekoPluginBase:
     def refresh_runtime_config(self, effective_config: dict[str, object] | None = None) -> None:
         """Refresh SDK runtime helpers after the host effective config changes."""
         cfg = effective_config if isinstance(effective_config, dict) else resolve_effective_config(self.ctx)
-        self.store.enabled = resolve_store_enabled(cfg)
+        store_enabled = resolve_store_enabled(cfg)
         db_enabled, db_name = resolve_db_config(cfg)
-        self.db.enabled = db_enabled
+        state_backend = resolve_state_backend(cfg)
         configure_db_name = getattr(self.db, "configure_database_name", None)
+        normalize_state_backend = getattr(type(self.state), "normalize_backend", None)
+        if callable(normalize_state_backend):
+            state_backend = normalize_state_backend(state_backend)
+
         if callable(configure_db_name):
             configure_db_name(db_name)
         elif hasattr(self.db, "db_name"):
             self.db.db_name = db_name
-        self.state.backend = resolve_state_backend(cfg)
+        self.store.enabled = store_enabled
+        self.db.enabled = db_enabled
+        self.state.backend = state_backend
 
     def get_input_schema(self) -> InputSchema:
         schema = getattr(self, "input_schema", None)

--- a/plugin/sdk/shared/core/base.py
+++ b/plugin/sdk/shared/core/base.py
@@ -84,6 +84,14 @@ class NekoPluginBase:
         self.state = PluginStatePersistence(plugin_id=plugin_id, plugin_dir=plugin_dir, logger=self.logger, backend=state_backend)
         self._state_persistence = self.state
 
+    def refresh_runtime_config(self, effective_config: dict[str, object] | None = None) -> None:
+        """Refresh SDK runtime helpers after the host effective config changes."""
+        cfg = effective_config if isinstance(effective_config, dict) else resolve_effective_config(self.ctx)
+        self.store.enabled = resolve_store_enabled(cfg)
+        db_enabled, _db_name = resolve_db_config(cfg)
+        self.db.enabled = db_enabled
+        self.state.backend = resolve_state_backend(cfg)
+
     def get_input_schema(self) -> InputSchema:
         schema = getattr(self, "input_schema", None)
         if isinstance(schema, dict):

--- a/plugin/sdk/shared/storage/database.py
+++ b/plugin/sdk/shared/storage/database.py
@@ -280,13 +280,7 @@ class PluginDatabase(StorageResultTemplate):
         self.plugin_id = plugin_id
         self.plugin_dir = Path(plugin_dir)
         self.enabled = enabled
-        raw_db_name = db_name or "plugin.db"
-        db_path = Path(raw_db_name)
-        if db_path.is_absolute() or any(part == ".." for part in db_path.parts):
-            raise ValueError("db_name must stay within plugin_dir")
-        safe_name = db_path.name
-        if safe_name != raw_db_name or safe_name.strip() in {"", ".", ".."}:
-            raise ValueError("db_name must be a plain filename within plugin_dir")
+        safe_name = self._normalize_db_name(db_name)
         self.db_name = safe_name
         self._db_path = self.plugin_dir / safe_name
         self._local = threading.local()
@@ -295,6 +289,26 @@ class PluginDatabase(StorageResultTemplate):
         self._conn_lock = threading.Lock()
         self._active_sessions: set[_SqliteAsyncSession] = set()
         self._session_lock = threading.Lock()
+
+    @staticmethod
+    def _normalize_db_name(db_name: str | None) -> str:
+        raw_db_name = db_name or "plugin.db"
+        db_path = Path(raw_db_name)
+        if db_path.is_absolute() or any(part == ".." for part in db_path.parts):
+            raise ValueError("db_name must stay within plugin_dir")
+        safe_name = db_path.name
+        if safe_name != raw_db_name or safe_name.strip() in {"", ".", ".."}:
+            raise ValueError("db_name must be a plain filename within plugin_dir")
+        return safe_name
+
+    def configure_database_name(self, db_name: str | None) -> None:
+        safe_name = self._normalize_db_name(db_name)
+        if safe_name == self.db_name:
+            return
+        self._close_all_connections()
+        self._reset_kv_store()
+        self.db_name = safe_name
+        self._db_path = self.plugin_dir / safe_name
 
     def _reset_kv_store(self) -> None:
         kv_store = self._kv_store

--- a/plugin/sdk/shared/storage/database.py
+++ b/plugin/sdk/shared/storage/database.py
@@ -307,7 +307,8 @@ class PluginDatabase(StorageResultTemplate):
         safe_name = self._normalize_db_name(db_name)
         if safe_name == self.db_name:
             return
-        self._close_all_connections()
+        active_conn_ids = {id(session._conn) for session in self._snapshot_active_sessions()}
+        self._close_all_connections(exclude_conn_ids=active_conn_ids)
         self._reset_kv_store()
         self.db_name = safe_name
         self._db_path = self.plugin_dir / safe_name
@@ -359,11 +360,12 @@ class PluginDatabase(StorageResultTemplate):
         if getattr(self._local, "conn", None) is conn:
             self._local.conn = None
 
-    def _close_all_connections(self) -> None:
+    def _close_all_connections(self, *, exclude_conn_ids: set[int] | None = None) -> None:
         first_error: Exception | None = None
         closed_ids: set[int] = set()
+        excluded = exclude_conn_ids or set()
         local_conn = getattr(self._local, "conn", None)
-        if local_conn is not None:
+        if local_conn is not None and id(local_conn) not in excluded:
             try:
                 self._close_one_conn(local_conn)
             except Exception as error:
@@ -371,7 +373,7 @@ class PluginDatabase(StorageResultTemplate):
                     first_error = error
             closed_ids.add(id(local_conn))
         for conn in self._snapshot_conns():
-            if id(conn) in closed_ids:
+            if id(conn) in closed_ids or id(conn) in excluded:
                 continue
             try:
                 self._close_one_conn(conn)

--- a/plugin/sdk/shared/storage/database.py
+++ b/plugin/sdk/shared/storage/database.py
@@ -293,6 +293,8 @@ class PluginDatabase(StorageResultTemplate):
     @staticmethod
     def _normalize_db_name(db_name: str | None) -> str:
         raw_db_name = db_name or "plugin.db"
+        if "/" in raw_db_name or "\\" in raw_db_name:
+            raise ValueError("db_name must be a plain filename within plugin_dir")
         db_path = Path(raw_db_name)
         if db_path.is_absolute() or any(part == ".." for part in db_path.parts):
             raise ValueError("db_name must stay within plugin_dir")

--- a/plugin/sdk/shared/storage/state.py
+++ b/plugin/sdk/shared/storage/state.py
@@ -87,6 +87,14 @@ class PluginStatePersistence(StorageResultTemplate):
     """Async-first plugin state persistence."""
 
     STATE_VERSION = 1
+    VALID_BACKENDS = {"file", "memory", "off"}
+
+    @classmethod
+    def normalize_backend(cls, backend: str | None) -> str:
+        normalized_backend = (backend or "off").lower()
+        if normalized_backend not in cls.VALID_BACKENDS:
+            raise InvalidArgumentError("backend must be one of: file, memory, off")
+        return normalized_backend
 
     def __init__(
         self,
@@ -96,9 +104,7 @@ class PluginStatePersistence(StorageResultTemplate):
         logger: LoggerLike | None = None,
         backend: str = "off",
     ):
-        normalized_backend = (backend or "off").lower()
-        if normalized_backend not in {"file", "memory", "off"}:
-            raise InvalidArgumentError("backend must be one of: file, memory, off")
+        normalized_backend = self.normalize_backend(backend)
         super().__init__(logger=logger or get_plugin_logger(plugin_id, "storage.state"))
         self.plugin_id = plugin_id
         self.plugin_dir = Path(plugin_dir)

--- a/plugin/server/messaging/handlers/plugin_config.py
+++ b/plugin/server/messaging/handlers/plugin_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 from collections.abc import Mapping
 
 from plugin.logging_config import get_logger
@@ -11,6 +13,8 @@ from plugin.server.messaging.handlers.typing import SendResponse
 logger = get_logger("server.messaging.handlers.plugin_config")
 config_query_service = ConfigQueryService()
 config_command_service = ConfigCommandService()
+_CONFIG_UPDATE_PERSIST_BUDGET_SECONDS = 4.0
+_CONFIG_UPDATE_RESPONSE_GRACE_SECONDS = 0.25
 
 def _resolve_target_plugin_id(
     *,
@@ -228,10 +232,33 @@ async def handle_plugin_config_update(request: dict[str, object], send_response:
             message="Permission denied: can only update own config",
         )
         updates = _normalize_updates_payload(request.get("updates"))
-        payload = await config_command_service.update_plugin_config(
-            plugin_id=target_plugin_id,
-            updates=updates,
+        persist_budget = min(
+            _CONFIG_UPDATE_PERSIST_BUDGET_SECONDS,
+            max(0.01, float(timeout) - _CONFIG_UPDATE_RESPONSE_GRACE_SECONDS),
         )
+        try:
+            payload = await asyncio.wait_for(
+                config_command_service.update_plugin_config(
+                    plugin_id=target_plugin_id,
+                    updates=updates,
+                ),
+                timeout=persist_budget,
+            )
+        except TimeoutError:
+            logger.warning(
+                "PLUGIN_CONFIG_UPDATE persistence timed out before request deadline: plugin_id={}, req_id={}, budget={}",
+                target_plugin_id,
+                request_id,
+                persist_budget,
+            )
+            payload = {
+                "success": False,
+                "plugin_id": target_plugin_id,
+                "config": updates,
+                "requires_reload": False,
+                "persisted": False,
+                "message": "Config persistence timed out; update is applied in plugin memory only",
+            }
         send_response(from_plugin, request_id, payload, None, timeout=timeout)
     except ServerDomainError as error:
         logger.warning("PLUGIN_CONFIG_UPDATE failed: code={}, message={}", error.code, error.message)

--- a/plugin/tests/unit/core/test_context_runtime_config.py
+++ b/plugin/tests/unit/core/test_context_runtime_config.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugin.core.context import PluginContext
+
+
+class _Logger:
+    def warning(self, *args, **kwargs) -> None:
+        self.last_warning = (args, kwargs)
+
+    def debug(self, *args, **kwargs) -> None:
+        self.last_debug = (args, kwargs)
+
+
+class _Instance:
+    def __init__(self) -> None:
+        self.refreshed: list[dict[str, object]] = []
+
+    def refresh_runtime_config(self, effective_config: dict[str, object]) -> None:
+        self.refreshed.append(effective_config)
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_context_effective_config_refreshes_plugin_runtime_helpers(tmp_path: Path) -> None:
+    ctx = PluginContext(
+        plugin_id="demo",
+        config_path=tmp_path / "demo" / "plugin.toml",
+        logger=_Logger(),  # type: ignore[arg-type]
+        status_queue=None,
+    )
+    instance = _Instance()
+    ctx._instance = instance
+
+    async def _local_payload(**kwargs: object) -> dict[str, object]:
+        return {"config": {"plugin": {"store": {"enabled": True}}}}
+
+    ctx._get_local_config_payload = _local_payload  # type: ignore[method-assign]
+
+    payload = await ctx.get_own_effective_config()
+
+    assert payload == {"config": {"plugin": {"store": {"enabled": True}}}}
+    assert ctx._effective_config == {"plugin": {"store": {"enabled": True}}}
+    assert instance.refreshed == [{"plugin": {"store": {"enabled": True}}}]

--- a/plugin/tests/unit/core/test_context_runtime_config.py
+++ b/plugin/tests/unit/core/test_context_runtime_config.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import asyncio
+
 import pytest
 
 from plugin.core.context import PluginContext
@@ -119,6 +121,34 @@ async def test_context_update_own_config_rolls_back_rejected_updates(tmp_path: P
     ctx._send_request_and_wait_async = _reject  # type: ignore[method-assign]
 
     with pytest.raises(RuntimeError, match="protected config key"):
+        await ctx.update_own_config({"plugin": {"store": {"enabled": True}}})
+
+    assert ctx._effective_config == {"plugin": {"store": {"enabled": False}}}
+    assert instance.refreshed == [
+        {"plugin": {"store": {"enabled": True}}},
+        {"plugin": {"store": {"enabled": False}}},
+    ]
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_context_update_own_config_rolls_back_cancelled_updates(tmp_path: Path) -> None:
+    ctx = PluginContext(
+        plugin_id="demo",
+        config_path=tmp_path / "demo" / "plugin.toml",
+        logger=_Logger(),  # type: ignore[arg-type]
+        status_queue=None,
+    )
+    instance = _Instance()
+    ctx._instance = instance
+    ctx._effective_config = {"plugin": {"store": {"enabled": False}}}
+
+    async def _cancel(**kwargs: object) -> dict[str, object]:
+        raise asyncio.CancelledError()
+
+    ctx._send_request_and_wait_async = _cancel  # type: ignore[method-assign]
+
+    with pytest.raises(asyncio.CancelledError):
         await ctx.update_own_config({"plugin": {"store": {"enabled": True}}})
 
     assert ctx._effective_config == {"plugin": {"store": {"enabled": False}}}

--- a/plugin/tests/unit/core/test_context_runtime_config.py
+++ b/plugin/tests/unit/core/test_context_runtime_config.py
@@ -45,3 +45,84 @@ async def test_context_effective_config_refreshes_plugin_runtime_helpers(tmp_pat
     assert payload == {"config": {"plugin": {"store": {"enabled": True}}}}
     assert ctx._effective_config == {"plugin": {"store": {"enabled": True}}}
     assert instance.refreshed == [{"plugin": {"store": {"enabled": True}}}]
+
+
+@pytest.mark.plugin_unit
+def test_context_optimistic_merge_honors_delete_and_replace_markers() -> None:
+    base = {
+        "mcp_servers": {
+            "fetch": {"url": "https://example.test"},
+            "keep": {"url": "https://keep.test"},
+        },
+        "plugin": {"store": {"enabled": False, "kind": "old"}},
+    }
+
+    merged = PluginContext._merge_config_copy(
+        base,
+        {
+            "mcp_servers": {"fetch": "__DELETE__"},
+            "plugin": {"store": {"__replace__": True, "enabled": True}},
+        },
+    )
+
+    assert merged == {
+        "mcp_servers": {"keep": {"url": "https://keep.test"}},
+        "plugin": {"store": {"enabled": True}},
+    }
+    assert base["mcp_servers"]["fetch"] == {"url": "https://example.test"}
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_context_update_own_config_timeout_uses_host_merge_markers(tmp_path: Path) -> None:
+    ctx = PluginContext(
+        plugin_id="demo",
+        config_path=tmp_path / "demo" / "plugin.toml",
+        logger=_Logger(),  # type: ignore[arg-type]
+        status_queue=None,
+    )
+    ctx._effective_config = {
+        "mcp_servers": {
+            "fetch": {"url": "https://example.test"},
+            "keep": {"url": "https://keep.test"},
+        }
+    }
+
+    async def _timeout(**kwargs: object) -> dict[str, object]:
+        raise TimeoutError("slow persistence")
+
+    ctx._send_request_and_wait_async = _timeout  # type: ignore[method-assign]
+
+    payload = await ctx.update_own_config({"mcp_servers": {"fetch": "__DELETE__"}})
+
+    assert payload["persisted"] is False
+    assert payload["config"] == {"mcp_servers": {"keep": {"url": "https://keep.test"}}}
+    assert ctx._effective_config == {"mcp_servers": {"keep": {"url": "https://keep.test"}}}
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_context_update_own_config_rolls_back_rejected_updates(tmp_path: Path) -> None:
+    ctx = PluginContext(
+        plugin_id="demo",
+        config_path=tmp_path / "demo" / "plugin.toml",
+        logger=_Logger(),  # type: ignore[arg-type]
+        status_queue=None,
+    )
+    instance = _Instance()
+    ctx._instance = instance
+    ctx._effective_config = {"plugin": {"store": {"enabled": False}}}
+
+    async def _reject(**kwargs: object) -> dict[str, object]:
+        raise RuntimeError("protected config key")
+
+    ctx._send_request_and_wait_async = _reject  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="protected config key"):
+        await ctx.update_own_config({"plugin": {"store": {"enabled": True}}})
+
+    assert ctx._effective_config == {"plugin": {"store": {"enabled": False}}}
+    assert instance.refreshed == [
+        {"plugin": {"store": {"enabled": True}}},
+        {"plugin": {"store": {"enabled": False}}},
+    ]

--- a/plugin/tests/unit/core/test_host_storage_layout_env.py
+++ b/plugin/tests/unit/core/test_host_storage_layout_env.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from plugin.core import host as host_module
+from utils import storage_layout as storage_layout_module
 
 
 class _FakeCommManager:
@@ -66,7 +67,7 @@ async def test_plugin_process_start_refreshes_storage_layout_env(monkeypatch: py
         calls.append(layout)
         host_module.os.environ["NEKO_STORAGE_SELECTED_ROOT"] = str(layout["selected_root"])
 
-    monkeypatch.setattr(host_module, "export_storage_layout_to_env", _export)
+    monkeypatch.setattr(storage_layout_module, "export_storage_layout_to_env", _export)
 
     plugin_host = host_module.PluginProcessHost(
         plugin_id="demo",

--- a/plugin/tests/unit/core/test_host_storage_layout_env.py
+++ b/plugin/tests/unit/core/test_host_storage_layout_env.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugin.core import host as host_module
+
+
+class _FakeCommManager:
+    def send_plugin_response(self, *args, **kwargs) -> None:
+        self.response = (args, kwargs)
+
+    async def start(self, message_target_queue=None) -> None:
+        self.message_target_queue = message_target_queue
+
+    async def shutdown(self, timeout: float) -> None:
+        self.shutdown_timeout = timeout
+
+    async def send_stop_command(self) -> None:
+        self.stop_sent = True
+
+
+class _FakeProcess:
+    pid = 1234
+    exitcode = None
+
+    def __init__(self) -> None:
+        self.started = False
+
+    def is_alive(self) -> bool:
+        return self.started
+
+    def start(self) -> None:
+        self.started = True
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_plugin_process_start_refreshes_storage_layout_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    selected_root = tmp_path / "selected-root"
+    calls: list[dict[str, object]] = []
+
+    monkeypatch.delenv("NEKO_STORAGE_SELECTED_ROOT", raising=False)
+    monkeypatch.setattr(host_module.state, "register_downlink_sender", lambda *_args, **_kwargs: None)
+
+    class _FakeTransport:
+        downlink_endpoint = "ipc://down"
+        uplink_endpoint = "ipc://up"
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(host_module, "HostTransport", _FakeTransport)
+    monkeypatch.setattr(host_module, "PluginCommunicationResourceManager", lambda **_kwargs: _FakeCommManager())
+    monkeypatch.setattr(host_module.multiprocessing, "Event", lambda: object())
+    monkeypatch.setattr(host_module.multiprocessing, "Process", lambda **_kwargs: _FakeProcess())
+
+    monkeypatch.setattr(
+        host_module,
+        "_resolve_current_storage_layout",
+        lambda: {"selected_root": str(selected_root), "anchor_root": str(tmp_path / "anchor")},
+    )
+
+    def _export(layout: dict[str, object]) -> None:
+        calls.append(layout)
+        host_module.os.environ["NEKO_STORAGE_SELECTED_ROOT"] = str(layout["selected_root"])
+
+    monkeypatch.setattr(host_module, "export_storage_layout_to_env", _export)
+
+    plugin_host = host_module.PluginProcessHost(
+        plugin_id="demo",
+        entry_point="plugins.demo:DemoPlugin",
+        config_path=tmp_path / "demo" / "plugin.toml",
+    )
+
+    await plugin_host.start()
+
+    assert calls == [{"selected_root": str(selected_root), "anchor_root": str(tmp_path / "anchor")}]
+    assert host_module.os.environ["NEKO_STORAGE_SELECTED_ROOT"] == str(selected_root)

--- a/plugin/tests/unit/core/test_host_storage_layout_env.py
+++ b/plugin/tests/unit/core/test_host_storage_layout_env.py
@@ -36,6 +36,29 @@ class _FakeProcess:
         self.started = True
 
 
+class _FakeLogger:
+    def info(self, *_args, **_kwargs) -> None:
+        pass
+
+    def debug(self, *_args, **_kwargs) -> None:
+        pass
+
+    def warning(self, *_args, **_kwargs) -> None:
+        pass
+
+    def exception(self, *_args, **_kwargs) -> None:
+        pass
+
+
+class _FakeResponseSender:
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, object]] = []
+
+    def put(self, payload: dict[str, object], timeout: float) -> None:
+        self.payloads.append(payload)
+        self.timeout = timeout
+
+
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
 async def test_plugin_process_start_refreshes_storage_layout_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -79,3 +102,41 @@ async def test_plugin_process_start_refreshes_storage_layout_env(monkeypatch: py
 
     assert calls == [{"selected_root": str(selected_root), "anchor_root": str(tmp_path / "anchor")}]
     assert host_module.os.environ["NEKO_STORAGE_SELECTED_ROOT"] == str(selected_root)
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_config_update_rolls_back_runtime_helpers_when_config_change_fails() -> None:
+    class _Ctx:
+        def __init__(self) -> None:
+            self._effective_config = {"plugin": {"store": {"enabled": False}}}
+            self.refreshed: list[dict[str, object]] = []
+
+        def _refresh_instance_runtime_config(self, effective_config: dict[str, object]) -> None:
+            self.refreshed.append(host_module.copy.deepcopy(effective_config))
+
+    def _config_change(**_kwargs: object) -> None:
+        raise RuntimeError("boom")
+
+    ctx = _Ctx()
+    sender = _FakeResponseSender()
+    await host_module._handle_config_update_command(
+        msg={
+            "req_id": "req-1",
+            "config": {"plugin": {"store": {"enabled": True}}},
+            "mode": "temporary",
+        },
+        ctx=ctx,
+        events_by_type={"lifecycle": {"config_change": _config_change}},
+        plugin_id="demo",
+        res_sender=sender,
+        logger=_FakeLogger(),
+    )
+
+    assert ctx._effective_config == {"plugin": {"store": {"enabled": False}}}
+    assert ctx.refreshed == [
+        {"plugin": {"store": {"enabled": True}}},
+        {"plugin": {"store": {"enabled": False}}},
+    ]
+    assert sender.payloads[-1]["success"] is False
+    assert "config_change handler failed" in str(sender.payloads[-1]["error"])

--- a/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
+++ b/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
@@ -184,10 +184,19 @@ def test_neko_plugin_base_refreshes_store_enabled_after_effective_config_arrives
 
     assert base.store.enabled is False
 
-    ctx._effective_config = {"plugin": {"store": {"enabled": True}}}
+    ctx._effective_config = {
+        "plugin": {
+            "store": {"enabled": True},
+            "database": {"enabled": True, "name": "runtime.db"},
+        },
+        "plugin_state": {"backend": "file"},
+    }
     base.refresh_runtime_config()
 
     assert base.store.enabled is True
+    assert base.db.enabled is True
+    assert base.db.db_name == "runtime.db"
+    assert base.state.backend == "file"
 
 
 def test_neko_plugin_base_i18n_uses_plugin_toml_config(tmp_path: Path) -> None:

--- a/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
+++ b/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
@@ -177,6 +177,19 @@ def test_neko_plugin_base_init_wires_ctx_config_plugins() -> None:
     assert base.plugins is not None
 
 
+def test_neko_plugin_base_refreshes_store_enabled_after_effective_config_arrives() -> None:
+    ctx = _Ctx()
+    ctx._effective_config = {}
+    base = _DemoPlugin(ctx=ctx)
+
+    assert base.store.enabled is False
+
+    ctx._effective_config = {"plugin": {"store": {"enabled": True}}}
+    base.refresh_runtime_config()
+
+    assert base.store.enabled is True
+
+
 def test_neko_plugin_base_i18n_uses_plugin_toml_config(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "demo"
     locale_dir = plugin_dir / "locales"

--- a/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
+++ b/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
@@ -199,6 +199,53 @@ def test_neko_plugin_base_refreshes_store_enabled_after_effective_config_arrives
     assert base.state.backend == "file"
 
 
+def test_neko_plugin_base_refresh_validates_database_name_before_enabling() -> None:
+    ctx = _Ctx()
+    ctx._effective_config = {}
+    base = _DemoPlugin(ctx=ctx)
+
+    assert base.store.enabled is False
+    assert base.db.enabled is False
+    assert base.db.db_name == "plugin.db"
+
+    ctx._effective_config = {
+        "plugin": {
+            "store": {"enabled": True},
+            "database": {"enabled": True, "name": "nested/bad.db"},
+        },
+        "plugin_state": {"backend": "file"},
+    }
+
+    with pytest.raises(ValueError, match="plain filename"):
+        base.refresh_runtime_config()
+
+    assert base.store.enabled is False
+    assert base.db.enabled is False
+    assert base.db.db_name == "plugin.db"
+    assert base.state.backend == "off"
+
+
+def test_neko_plugin_base_refresh_normalizes_state_backend() -> None:
+    ctx = _Ctx()
+    base = _DemoPlugin(ctx=ctx)
+
+    base.refresh_runtime_config(
+        {
+            "plugin": {"store": {"enabled": True}, "database": {"enabled": True, "name": "runtime.db"}},
+            "plugin_state": {"backend": "Memory"},
+        }
+    )
+    assert base.state.backend == "memory"
+
+    base.refresh_runtime_config(
+        {
+            "plugin": {"store": {"enabled": True}, "database": {"enabled": True, "name": "runtime.db"}},
+            "plugin_state": {"backend": "OFF"},
+        }
+    )
+    assert base.state.backend == "off"
+
+
 def test_neko_plugin_base_i18n_uses_plugin_toml_config(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "demo"
     locale_dir = plugin_dir / "locales"

--- a/plugin/tests/unit/sdk/shared/test_sdk_v2_shared_runtime_storage_transport.py
+++ b/plugin/tests/unit/sdk/shared/test_sdk_v2_shared_runtime_storage_transport.py
@@ -307,8 +307,9 @@ def test_plugin_database_configure_database_name_updates_storage_path(tmp_path) 
     assert db.db_name == "new.db"
     assert db._db_path == plugin_dir / "new.db"
 
-    with pytest.raises(ValueError, match="plain filename"):
-        db.configure_database_name("nested/new.db")
+    for invalid_name in ("nested/new.db", r"nested\new.db"):
+        with pytest.raises(ValueError, match="plain filename"):
+            db.configure_database_name(invalid_name)
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/sdk/shared/test_sdk_v2_shared_runtime_storage_transport.py
+++ b/plugin/tests/unit/sdk/shared/test_sdk_v2_shared_runtime_storage_transport.py
@@ -313,6 +313,31 @@ def test_plugin_database_configure_database_name_updates_storage_path(tmp_path) 
 
 
 @pytest.mark.asyncio
+async def test_plugin_database_configure_database_name_preserves_active_sessions(tmp_path) -> None:
+    plugin_dir = tmp_path / "facade_configure_active"
+    plugin_dir.mkdir()
+    db = database.PluginDatabase(plugin_id="demo", plugin_dir=plugin_dir, enabled=True, db_name="old.db")
+    old_session = (await db.session()).unwrap()
+
+    await old_session.execute("CREATE TABLE marker (value TEXT)")
+    await old_session.execute("INSERT INTO marker (value) VALUES (?)", ("old",))
+    await old_session.commit()
+
+    db.configure_database_name("new.db")
+
+    cursor = await old_session.execute("SELECT value FROM marker")
+    assert cursor.fetchone()[0] == "old"
+    await old_session.close()
+
+    assert db.db_name == "new.db"
+    assert db._db_path == plugin_dir / "new.db"
+    assert db._snapshot_active_sessions() == []
+    assert (await db.kv.set("k", "new")).is_ok()
+    assert (await db.kv.get("k")).unwrap() == "new"
+    assert (plugin_dir / "new.db").exists()
+
+
+@pytest.mark.asyncio
 async def test_shared_memory_timeout_bool_and_impl_error_normalization() -> None:
     mem = runtime_memory.MemoryClient(object())
     timeout_error = await mem.query("bucket", "q", timeout=True)  # type: ignore[arg-type]

--- a/plugin/tests/unit/sdk/shared/test_sdk_v2_shared_runtime_storage_transport.py
+++ b/plugin/tests/unit/sdk/shared/test_sdk_v2_shared_runtime_storage_transport.py
@@ -294,6 +294,23 @@ async def test_shared_facade_validation_paths(tmp_path) -> None:
         state.PluginStatePersistence(plugin_id="demo", plugin_dir=plugin_dir, backend="weird")
 
 
+def test_plugin_database_configure_database_name_updates_storage_path(tmp_path) -> None:
+    plugin_dir = tmp_path / "facade_configure"
+    plugin_dir.mkdir()
+    db = database.PluginDatabase(plugin_id="demo", plugin_dir=plugin_dir, enabled=True, db_name="old.db")
+
+    assert db.db_name == "old.db"
+    assert db._db_path == plugin_dir / "old.db"
+
+    db.configure_database_name("new.db")
+
+    assert db.db_name == "new.db"
+    assert db._db_path == plugin_dir / "new.db"
+
+    with pytest.raises(ValueError, match="plain filename"):
+        db.configure_database_name("nested/new.db")
+
+
 @pytest.mark.asyncio
 async def test_shared_memory_timeout_bool_and_impl_error_normalization() -> None:
     mem = runtime_memory.MemoryClient(object())

--- a/plugin/tests/unit/server/test_messaging_handlers_additional.py
+++ b/plugin/tests/unit/server/test_messaging_handlers_additional.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from plugin.server.domain.errors import ServerDomainError
@@ -140,3 +142,52 @@ async def test_plugin_config_scope_and_payload_validation(monkeypatch: pytest.Mo
     )
     assert send.calls[-1][2] == {"config": {"k": 1}}
 
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_plugin_config_update_returns_memory_only_payload_before_persistence_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    send = _Recorder()
+    started = asyncio.Event()
+
+    async def _stuck_update(*, plugin_id: str, updates: object) -> dict[str, object]:
+        assert plugin_id == "p1"
+        assert updates == {"feature": {"enabled": True}}
+        started.set()
+        await asyncio.sleep(10)
+        return {"config": {"feature": {"enabled": True}}}
+
+    monkeypatch.setattr(
+        plugin_config_module.config_command_service,
+        "update_plugin_config",
+        _stuck_update,
+    )
+
+    await asyncio.wait_for(
+        plugin_config_module.handle_plugin_config_update(
+            {
+                "from_plugin": "p1",
+                "request_id": "r-timeout",
+                "updates": {"feature": {"enabled": True}},
+                "timeout": 0.05,
+            },
+            send,
+        ),
+        timeout=0.5,
+    )
+
+    assert started.is_set()
+    to_plugin, request_id, result, error, timeout = send.calls[-1]
+    assert to_plugin == "p1"
+    assert request_id == "r-timeout"
+    assert error is None
+    assert timeout == 0.05
+    assert result == {
+        "success": False,
+        "plugin_id": "p1",
+        "config": {"feature": {"enabled": True}},
+        "requires_reload": False,
+        "persisted": False,
+        "message": "Config persistence timed out; update is applied in plugin memory only",
+    }

--- a/plugin/tests/unit/test_plugin_logging_landing.py
+++ b/plugin/tests/unit/test_plugin_logging_landing.py
@@ -38,6 +38,7 @@ def isolated_log_dir(tmp_path, monkeypatch):
     """
     documents = tmp_path / "Documents"
     documents.mkdir()
+    monkeypatch.delenv("NEKO_STORAGE_SELECTED_ROOT", raising=False)
 
     # Each test gets a fresh import of plugin.logging_config so module-level
     # singletons (the brace-compat patch, _root_initialised) don't leak.


### PR DESCRIPTION
## Summary
- refresh SDK store/db/state helpers when effective plugin config becomes available or changes
- make plugin config updates memory-first with bounded host persistence so actions are not blocked by stuck writes
- refresh storage layout env before plugin child process startup so plugin data follows selected_root

## Regression Report
- Impacted area: plugin host configuration/runtime storage helpers only.
- Regression risk checked: config refresh, update_own_config timeout/rollback/cancellation, database rename validation, selected storage root env propagation.
- Verification: uv run python -m pytest plugin/tests -q

## Split Rationale
- Not split: the touched host-layer changes share one root cause, effective plugin config and runtime storage helper state drifting apart.
- Scope is under the project split threshold and tests cover the coupled update path end to end.

## Tests
- uv run python -m pytest plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py plugin/tests/unit/sdk/shared/test_sdk_v2_shared_runtime_storage_transport.py -q
- uv run python -m pytest plugin/tests -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 有效配置变更后自动刷新插件运行时（商店/数据库启用开关、数据库命名与状态后端同步）。
  * 新增“有效配置”缓存与递归深合并（支持删除/替换标记），本地更新先写入乐观配置。
  * 子进程启动前刷新并导出存储布局到环境变量；配置变更同步触发运行时刷新。
  * 支持动态数据库文件名配置并重置相关连接/路径。

* **Bug Fixes**
  * 持久化阶段增加预算；超时仅内存生效并返回结构化失败，拒绝/取消会回滚并刷新同步。

* **Tests**
  * 覆盖有效配置刷新、深合并标记、持久化超时/回滚、环境变量导出与数据库重配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->