### PR TITLE
refactor(focus): idle 路径改为纯冷却——proactive 只衰减凝神、绝不抬升

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1838,15 +1838,21 @@ FOCUS_CHARGE_RETENTION = 0.5
 - 稳态：持续每轮 score=s 时 charge → s/(1-retention)（如 retention=0.5、s=0.5 → 趋近 1.0）。
 - 这是「敏感度」主旋钮。仅用于 inline（用户发声）路径。"""
 
-FOCUS_IDLE_CHARGE_RETENTION = 0.9
-"""idle（proactive 主动搭话）tick 的电荷保留率（须 > FOCUS_CHARGE_RETENTION）。
-- 用途：proactive 那一轮 score 恒 0、只让 charge 以此（较慢）速率衰减：
-  charge = charge × 此值。proactive 绝不抬升 charge——进入/维持凝神只由 inline
-  （用户自己说的话）驱动，idle 仅做「降温」，让凝神在多次主动搭话间缓慢退去。
-- 取 0.9（比 inline 的 0.5 慢）= 主动搭话不会一两轮就把凝神冲没；调低 = 主动搭话
-  冷却更快。⚠️ 与 proactive 触发频率耦合：proactive 越频繁，等效衰减越快；且每个
-  idle tick 也占 FOCUS_HARD_CAP_TURNS 一轮，硬顶可能先到。
-- 上游：SM.update_focus 的 retention_override（仅 idle 路径传）。"""
+# idle（proactive 主动搭话）冷却分两档——proactive 绝不抬升 charge，只衰减；进入/
+# 维持凝神只由 inline（用户自己说的话）驱动。衰减快慢取决于这一轮 proactive 到底
+# 有没有开口：开口了（消耗了这份专注）衰减快，只是安静守着（几乎没消耗）衰减慢。
+# 故凝神的持续由「她开口次数」主导而非单纯时间流逝。两者都须 > 0、< 1，且 silent > replied。
+FOCUS_IDLE_SILENT_RETENTION = 0.95
+"""proactive 本轮没开口（action != chat：被 guard/接管挡下、内容空、pass）时的电荷保留率。
+- 用途：charge = charge × 此值。0.95 ≈ 几乎不衰减——她只是安静守着，凝神留得久。
+- 调低 = 沉默等待也更快冷却。"""
+
+FOCUS_IDLE_REPLIED_RETENTION = 0.6
+"""proactive 本轮真开口了（action == chat：投递了主动搭话）时的电荷保留率。
+- 用途：charge = charge × 此值。0.6 = 每开口一次明显消耗——cap=1.0 起约 3 次主动
+  搭话漏到 EXIT(0.3) 以下退出（「她降临后追一两句就放下」）。
+- 须 < FOCUS_IDLE_SILENT_RETENTION：开口比沉默消耗更多。调低 = 开口后退得更快。
+- 上游：SM.update_focus 的 retention_override（idle 收尾按 action 选这两档之一）。"""
 
 FOCUS_CHARGE_ENTER = 1.0
 """进入凝神的电荷阈值。
@@ -1873,8 +1879,8 @@ FOCUS_SIGNAL_WEIGHTS: dict[str, float] = {
 """FocusScorer 各信号的相对权重（仅 inline 路径——评分只看用户自己说的话）。
 - 用途：scorer 对适用信号子集内权重重新归一后加权平均 → 该轮 score（喂给累加器）。
   keyword/cadence 都需要一条真实用户消息；样本不足时 cadence 返回 None、不进分母。
-- idle（proactive）路径不评分：它只用 FOCUS_IDLE_CHARGE_RETENTION 让 charge 衰减，
-  绝不抬升，故不在此表里（凝神的进入/维持只由 inline 驱动）。
+- idle（proactive）路径不评分：它只用 FOCUS_IDLE_SILENT/REPLIED_RETENTION 让 charge
+  衰减，绝不抬升，故不在此表里（凝神的进入/维持只由 inline 驱动）。
 - 上游：各子信号各自归一化到 [0,1]。
 - 设计依据：keyword 是最强单信号故权重最高。改这里直接改触发性格，慎调。"""
 
@@ -1902,7 +1908,7 @@ FOCUS_CADENCE_DROP_RATIO = 0.4
 - 上游：当前消息长度与基线中位数之比。"""
 
 # NOTE: silence / open_thread 信号已移除——idle（proactive）路径不再评分，改为只用
-# FOCUS_IDLE_CHARGE_RETENTION 让 charge 缓慢衰减（凝神进入/维持只由 inline 驱动）。
+# FOCUS_IDLE_SILENT/REPLIED_RETENTION 让 charge 衰减（凝神进入/维持只由 inline 驱动）。
 # 故 FOCUS_SILENCE_MIN_SECONDS / FOCUS_SILENCE_FULL_SECONDS 一并退役，避免死配置。
 
 # NOTE: FOCUS_IDLE_THRESHOLD_MULTIPLIER（凝神态下调低 idle 触发阈值「她降临一次后

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1836,7 +1836,17 @@ FOCUS_CHARGE_RETENTION = 0.5
 - 调高（如 0.7/0.8）= 记性更长、零散信号更易累积进入、进去后更黏；
   调低（如 0.3）= 漏得快、难累积、退得利落。
 - 稳态：持续每轮 score=s 时 charge → s/(1-retention)（如 retention=0.5、s=0.5 → 趋近 1.0）。
-- 这是「敏感度」主旋钮。"""
+- 这是「敏感度」主旋钮。仅用于 inline（用户发声）路径。"""
+
+FOCUS_IDLE_CHARGE_RETENTION = 0.9
+"""idle（proactive 主动搭话）tick 的电荷保留率（须 > FOCUS_CHARGE_RETENTION）。
+- 用途：proactive 那一轮 score 恒 0、只让 charge 以此（较慢）速率衰减：
+  charge = charge × 此值。proactive 绝不抬升 charge——进入/维持凝神只由 inline
+  （用户自己说的话）驱动，idle 仅做「降温」，让凝神在多次主动搭话间缓慢退去。
+- 取 0.9（比 inline 的 0.5 慢）= 主动搭话不会一两轮就把凝神冲没；调低 = 主动搭话
+  冷却更快。⚠️ 与 proactive 触发频率耦合：proactive 越频繁，等效衰减越快；且每个
+  idle tick 也占 FOCUS_HARD_CAP_TURNS 一轮，硬顶可能先到。
+- 上游：SM.update_focus 的 retention_override（仅 idle 路径传）。"""
 
 FOCUS_CHARGE_ENTER = 1.0
 """进入凝神的电荷阈值。
@@ -1857,20 +1867,16 @@ FOCUS_HARD_CAP_TURNS = 8
 - 上游：SM 的 focus_turn_count 计数器。"""
 
 FOCUS_SIGNAL_WEIGHTS: dict[str, float] = {
-    "keyword": 0.45,      # 用户消息命中脆弱情绪词（inline 路径专属）
-    "cadence": 0.20,      # 回复字数相对基线骤跌（inline 路径专属）
-    "silence": 0.20,      # 静默时长（idle 路径专属）
-    "open_thread": 0.15,  # 存在未收尾话题 / 到点的 followup（idle 路径专属）
+    "keyword": 0.45,      # 用户消息命中脆弱情绪词
+    "cadence": 0.20,      # 回复字数相对基线骤跌
 }
-"""FocusScorer 各信号的相对权重。
-- 用途：scorer 按当前路径取「适用」信号子集，对子集内权重重新归一后加权平均
-  → 该轮 score（再喂给累加器）。inline（有新消息）适用 keyword+cadence；idle
-  （无新消息）适用 silence+open_thread。不适用的信号返回 None、不进归一化分母。
-- ⚠️ open_thread 仅 idle 适用：inline 路径上 on_user_message 已先清掉 unfinished_thread，
-  再读只会得结构性 0 拉低均值；用户脆弱回复由 keyword 捕获。故 inline 实际分母是
-  keyword+cadence（0.45+0.20），不含 open_thread。
+"""FocusScorer 各信号的相对权重（仅 inline 路径——评分只看用户自己说的话）。
+- 用途：scorer 对适用信号子集内权重重新归一后加权平均 → 该轮 score（喂给累加器）。
+  keyword/cadence 都需要一条真实用户消息；样本不足时 cadence 返回 None、不进分母。
+- idle（proactive）路径不评分：它只用 FOCUS_IDLE_CHARGE_RETENTION 让 charge 衰减，
+  绝不抬升，故不在此表里（凝神的进入/维持只由 inline 驱动）。
 - 上游：各子信号各自归一化到 [0,1]。
-- 设计依据：keyword 是 inline 最强单信号故权重最高。改这里直接改触发性格，慎调。"""
+- 设计依据：keyword 是最强单信号故权重最高。改这里直接改触发性格，慎调。"""
 
 FOCUS_KEYWORD_SATURATION = 3
 """脆弱情绪关键词命中数的饱和点。
@@ -1895,15 +1901,9 @@ FOCUS_CADENCE_DROP_RATIO = 0.4
   中间线性。例：基线 30 字、ratio 0.4，则 ≤12 字（「嗯。」「知道了。」）算满格。
 - 上游：当前消息长度与基线中位数之比。"""
 
-FOCUS_SILENCE_MIN_SECONDS = 300
-"""silence 子信号的起跳静默秒数。
-- 用途：seconds_since_user_msg < 此值 → silence 子信号 = 0（日常停顿不算）。
-- 上游：ActivitySnapshot.seconds_since_user_msg。"""
-
-FOCUS_SILENCE_FULL_SECONDS = 1800
-"""silence 子信号满格的静默秒数。
-- 用途：seconds_since_user_msg ≥ 此值 → silence = 1.0；MIN~FULL 间线性。
-- 上游：ActivitySnapshot.seconds_since_user_msg。"""
+# NOTE: silence / open_thread 信号已移除——idle（proactive）路径不再评分，改为只用
+# FOCUS_IDLE_CHARGE_RETENTION 让 charge 缓慢衰减（凝神进入/维持只由 inline 驱动）。
+# 故 FOCUS_SILENCE_MIN_SECONDS / FOCUS_SILENCE_FULL_SECONDS 一并退役，避免死配置。
 
 # NOTE: FOCUS_IDLE_THRESHOLD_MULTIPLIER（凝神态下调低 idle 触发阈值「她降临一次后
 # 主动追一两轮」）属 Path B 的 idle-threshold-drop 子特性，该特性尚未接线，故旋钮

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1854,6 +1854,16 @@ FOCUS_IDLE_REPLIED_RETENTION = 0.6
 - 须 < FOCUS_IDLE_SILENT_RETENTION：开口比沉默消耗更多。调低 = 开口后退得更快。
 - 上游：SM.update_focus 的 retention_override（idle 收尾按 action 选这两档之一）。"""
 
+# 调参护栏：把两档冷却的注释约定变成 fail-fast 的硬校验，避免后续误配把语义反转——
+# >= 1.0 会让 idle tick 不降反升（破坏「绝不抬升」），silent <= replied 会让「开口」
+# 比「沉默」消耗更少（快慢档颠倒）。模块加载即校验，配错直接报错而非静默跑坏。
+if not (0.0 < FOCUS_IDLE_REPLIED_RETENTION < FOCUS_IDLE_SILENT_RETENTION < 1.0):
+    raise ValueError(
+        "Focus idle retentions must satisfy 0 < replied < silent < 1 "
+        f"(got replied={FOCUS_IDLE_REPLIED_RETENTION}, "
+        f"silent={FOCUS_IDLE_SILENT_RETENTION})"
+    )
+
 FOCUS_CHARGE_ENTER = 1.0
 """进入凝神的电荷阈值。
 - 用途：charge ≥ 此值 → REGULAR→FOCUS。

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1840,12 +1840,17 @@ FOCUS_CHARGE_RETENTION = 0.5
 
 # idle（proactive 主动搭话）冷却分两档——proactive 绝不抬升 charge，只衰减；进入/
 # 维持凝神只由 inline（用户自己说的话）驱动。衰减快慢取决于这一轮 proactive 到底
-# 有没有开口：开口了（消耗了这份专注）衰减快，只是安静守着（几乎没消耗）衰减慢。
-# 故凝神的持续由「她开口次数」主导而非单纯时间流逝。两者都须 > 0、< 1，且 silent > replied。
-FOCUS_IDLE_SILENT_RETENTION = 0.95
-"""proactive 本轮没开口（action != chat：被 guard/接管挡下、内容空、pass）时的电荷保留率。
-- 用途：charge = charge × 此值。0.95 ≈ 几乎不衰减——她只是安静守着，凝神留得久。
-- 调低 = 沉默等待也更快冷却。"""
+# 有没有把话说出来：开口了（消耗了这份专注）衰减快，没说出话（守着没开口，或思考
+# 超时/异常没接住）衰减略慢。故凝神的持续由「她开口次数」主导而非单纯时间流逝。
+# 两者都须 > 0、< 1，且 silent > replied。
+FOCUS_IDLE_SILENT_RETENTION = 0.7
+"""proactive 本轮没把话说出来时的电荷保留率。
+- 涵盖：action != chat（被 guard/接管挡下、内容空、[PASS]），以及 Phase 2 思考
+  超时 / 流式异常导致 aborted（最终也归 action=pass）——开了思考模式却没能在限时内
+  接住，同样按此档降温。
+- 用途：charge = charge × 此值。0.7 = 每轮明显降温——没说出话（含思考超时）就别
+  一直占着凝神，但仍比开口（replied）退得慢一点。
+- 调低 = 沉默 / 超时也更快冷却。"""
 
 FOCUS_IDLE_REPLIED_RETENTION = 0.6
 """proactive 本轮真开口了（action == chat：投递了主动搭话）时的电荷保留率。

--- a/docs/design/focus-truename-mode.md
+++ b/docs/design/focus-truename-mode.md
@@ -33,8 +33,14 @@ inert until `FOCUS_MODE_ENABLED` is turned on):
   no LLM rebuild.
 * `main_routers/system_router.py` — proactive Phase-2 generate sites (main
   stream / format-fix / BM25 regen) take `disable_thinking=not
-  _focus_idle_thinking()`; the cooldown decay runs once at the unified exit
-  `_end_proactive`, keyed on whether the turn delivered (`action=="chat"`).
+  _focus_idle_thinking()`. The cooldown decay runs at the unified exit
+  `_end_proactive`, but ONLY for turns that reached the Phase-2 idle decision
+  (short-circuit replies — mini-game invite / break-reminder — never spend
+  Focus), keyed on whether the turn delivered (`action=="chat"`). It decays
+  with `count_turn=False` (a cooldown tick never spends a hard-cap turn slot)
+  and is pinned to the episode the thinking decision observed (a stale tick
+  won't decay a freshly inline-entered episode). Voice nudges never run a
+  Focus reply, so they don't cool down either.
 * `tests/unit/test_focus_mode.py` — focus unit tests (hysteresis / scorer /
   SM / lexicon / `thinking_on` threading / idle cooldown) + SM regression.
 
@@ -195,7 +201,7 @@ where the user opens up** — which flows through `stream_text`, *not*
 | Path | Scenario | Entry point | Mounting site |
 |---|---|---|---|
 | **A: Inline focus** | user sends a message → score it → if over the bar, upgrade *this* reply | lightweight scorer before `stream_text` generation | `main_logic/core.py` `stream_text` entry (near the `last_user_activity_time` / USER_INPUT fire) |
-| **B: Idle cooldown** | a proactive turn fires while in focus → keep it thinking-on, but decay the charge afterwards (never raise it) | thinking read before Phase-2 generate; decay at the proactive unified exit | `main_routers/system_router.py` — three Phase-2 sites take `disable_thinking = not _focus_idle_thinking()` (suppressed under vision); `_end_proactive` calls `_focus_idle_cooldown(replied=action=="chat")` |
+| **B: Idle cooldown** | a Phase-2 proactive turn fires while in focus → keep it thinking-on, but decay the charge afterwards (never raise it) | thinking read before Phase-2 generate; decay at the proactive unified exit, gated to Phase-2 turns | `main_routers/system_router.py` — three Phase-2 sites take `disable_thinking = not _focus_idle_thinking()` (suppressed under vision); `_end_proactive` calls `_focus_idle_cooldown(replied=action=="chat", episode_token=...)` only when the Phase-2 idle decision was reached (count_turn=False, episode-pinned) |
 
 ### Path coupling — this is the key to "she lingers"
 

--- a/docs/design/focus-truename-mode.md
+++ b/docs/design/focus-truename-mode.md
@@ -21,30 +21,34 @@ inert until `FOCUS_MODE_ENABLED` is turned on):
 * `main_logic/activity/focus_scorer.py` — `FocusScorer` (**inline-only**:
   keyword + cadence; idle silence/open-thread signals were removed).
 * `main_logic/core.py` — `FocusScorer` instance + `_focus_inline_decision`
-  (Path A) and `_focus_idle_decision` (Path B) helpers. The inline path
-  scores each user message and passes `thinking_on` into `stream_text`. The
-  idle path does **not** score — a proactive turn never raises the charge;
-  it only cools an active episode down via `FOCUS_IDLE_CHARGE_RETENTION`
-  (slower than the inline retention). Entry/sustain is inline-only.
+  (Path A), and the split idle helpers `_focus_idle_thinking` (read-only:
+  is the session in Focus → thinking_on) + `_focus_idle_cooldown(replied)`
+  (post-turn charge decay). The inline path scores each user message and
+  passes `thinking_on` into `stream_text`. The idle path does **not** score —
+  a proactive turn never raises the charge; it only cools an active episode
+  down, faster when it spoke (`FOCUS_IDLE_REPLIED_RETENTION`) than when it
+  stayed silent (`FOCUS_IDLE_SILENT_RETENTION`). Entry/sustain is inline-only.
 * `main_logic/omni_offline_client.py` — `stream_text(..., thinking_on=...)`
   threads `extra_body=None` (per-call thinking-on override) into `astream`;
   no LLM rebuild.
 * `main_routers/system_router.py` — proactive Phase-2 generate sites (main
   stream / format-fix / BM25 regen) take `disable_thinking=not
-  _focus_phase2_thinking`, driven by the idle-path focus decision.
-* `tests/unit/test_focus_mode.py` — 26 tests (hysteresis / scorer / SM /
-  lexicon / `thinking_on` threading); + 86 proactive/SM regression green.
+  _focus_idle_thinking()`; the cooldown decay runs once at the unified exit
+  `_end_proactive`, keyed on whether the turn delivered (`action=="chat"`).
+* `tests/unit/test_focus_mode.py` — focus unit tests (hysteresis / scorer /
+  SM / lexicon / `thinking_on` threading / idle cooldown) + SM regression.
 
 Pending: the `FOCUS_EXIT` memory subscriber (cross-process: a new
 `memory_server` endpoint POSTed from a main-process `FOCUS_EXIT`
 subscriber) and the frontend focus indicator.
 
 Known tuning interaction: both paths tick the SAME leaky accumulator, but
-only the inline path adds charge. Idle (proactive) ticks only decay it by
-`FOCUS_IDLE_CHARGE_RETENTION`. Because proactive fires on a schedule, a
-long silence runs several cooldown ticks — so the effective decay rate is
-coupled to the proactive cadence (and each idle tick also consumes one
-`FOCUS_HARD_CAP_TURNS` slot). Watch this when tuning the retentions.
+only the inline path adds charge. Idle (proactive) ticks only decay it —
+faster when the turn spoke (`FOCUS_IDLE_REPLIED_RETENTION`) than when it
+stayed silent (`FOCUS_IDLE_SILENT_RETENTION`), so persistence is driven by
+how often she speaks, not raw time. Because proactive fires on a schedule
+and a turn that *speaks* also consumes one `FOCUS_HARD_CAP_TURNS` slot,
+watch the cadence × retention interaction when tuning.
 
 Naming: the user-facing fantasy terms are **凝神 (Focus)** and **真名
 (True-Name)**. Internal identifiers use the English `focus` / `true_name`
@@ -191,14 +195,17 @@ where the user opens up** — which flows through `stream_text`, *not*
 | Path | Scenario | Entry point | Mounting site |
 |---|---|---|---|
 | **A: Inline focus** | user sends a message → score it → if over the bar, upgrade *this* reply | lightweight scorer before `stream_text` generation | `main_logic/core.py` `stream_text` entry (near the `last_user_activity_time` / USER_INPUT fire) |
-| **B: Idle cooldown** | a proactive turn fires while in focus → keep it thinking-on, but decay the charge a notch (never raise it) | `proactive_chat` Phase-2 generate (after PHASE2 fired) | `main_routers/system_router.py` — the three Phase-2 generate sites take `disable_thinking = not _focus_idle_decision()`, suppressed under vision |
+| **B: Idle cooldown** | a proactive turn fires while in focus → keep it thinking-on, but decay the charge afterwards (never raise it) | thinking read before Phase-2 generate; decay at the proactive unified exit | `main_routers/system_router.py` — three Phase-2 sites take `disable_thinking = not _focus_idle_thinking()` (suppressed under vision); `_end_proactive` calls `_focus_idle_cooldown(replied=action=="chat")` |
 
 ### Path coupling — this is the key to "she lingers"
 
 A focus episode is entered and re-charged ONLY by the inline path (the
 user's own messages). A proactive turn that fires mid-episode does not
 re-score or prop the charge up — it runs thinking-on (she's still in it)
-and decays the charge by the slower `FOCUS_IDLE_CHARGE_RETENTION`.
+and, once the turn finishes, decays the charge: faster if she actually
+spoke (`FOCUS_IDLE_REPLIED_RETENTION`), slower if she stayed silent
+(`FOCUS_IDLE_SILENT_RETENTION`). So how long she lingers is driven by how
+often she *speaks*, not raw elapsed time.
 
 This produces the loop *"after she arrives once, she follows up a turn or
 two before letting go"* via the **decay rate**, not a more-sensitive idle
@@ -343,8 +350,9 @@ later, not a reason to build an inverse table up front.
 5. `main_routers/system_router.py` — Path B: replace the hard-coded
    `disable_thinking=True` at the proactive **Phase-2** generate sites
    (main stream / format-fix regen / BM25 regen) with `not
-   _focus_idle_decision()` (a cooldown tick, suppressed under a vision
-   model). The idle path never raises the charge.
+   _focus_idle_thinking()` (read-only, suppressed under a vision model), and
+   decay the charge once at `_end_proactive` via `_focus_idle_cooldown`. The
+   idle path never raises the charge.
 6. `app/memory_server.py` (+ memory stations) — subscribe to
    `EmotionalEpisodeFinished`; route the episode slice into
    `synthesize_reflections` / `resolve_corrections` / facts / ban-list
@@ -361,9 +369,10 @@ later, not a reason to build an inverse table up front.
   collect data, loosen later for under-triggered users. Magic-dilution vs
   magic-burial is a tuning curve, not a one-shot choice.
 * `T_out`, `M` — exit hysteresis (`FOCUS_CHARGE_EXIT` `0.3`, hard cap `8`).
-* `FOCUS_CHARGE_RETENTION` (inline `0.5`) + `FOCUS_IDLE_CHARGE_RETENTION`
-  (idle cooldown `0.9`, slower) — the latter sets how many proactive turns
-  Focus lingers before fading.
+* `FOCUS_CHARGE_RETENTION` (inline `0.5`) + idle cooldown retentions
+  `FOCUS_IDLE_SILENT_RETENTION` (`0.95`, she just waited) and
+  `FOCUS_IDLE_REPLIED_RETENTION` (`0.6`, she spoke) — these set how many
+  proactive turns Focus lingers, weighted by how often she actually speaks.
 * **Topic-boundary detection** (gates hard-exit + inline ban-list): cheap
   per-turn classifier model vs keyword/syntax heuristic. *Recommendation:
   heuristic for v1 (zero-cost), upgrade to classifier if false exits hurt.*

--- a/docs/design/focus-truename-mode.md
+++ b/docs/design/focus-truename-mode.md
@@ -18,10 +18,14 @@ inert until `FOCUS_MODE_ENABLED` is turned on):
 * `main_logic/session_state.py` — `CognitionMode`, `FocusThresholds`, the
   pure `_focus_decide` hysteresis, `SessionStateMachine.update_focus`,
   `FOCUS_ENTER` / `FOCUS_EXIT` events, reset/snapshot integration.
-* `main_logic/activity/focus_scorer.py` — `FocusScorer`.
+* `main_logic/activity/focus_scorer.py` — `FocusScorer` (**inline-only**:
+  keyword + cadence; idle silence/open-thread signals were removed).
 * `main_logic/core.py` — `FocusScorer` instance + `_focus_inline_decision`
-  (Path A) and `_focus_idle_decision` (Path B) helpers; inline path scores
-  each user message and passes `thinking_on` into `stream_text`.
+  (Path A) and `_focus_idle_decision` (Path B) helpers. The inline path
+  scores each user message and passes `thinking_on` into `stream_text`. The
+  idle path does **not** score — a proactive turn never raises the charge;
+  it only cools an active episode down via `FOCUS_IDLE_CHARGE_RETENTION`
+  (slower than the inline retention). Entry/sustain is inline-only.
 * `main_logic/omni_offline_client.py` — `stream_text(..., thinking_on=...)`
   threads `extra_body=None` (per-call thinking-on override) into `astream`;
   no LLM rebuild.
@@ -35,9 +39,12 @@ Pending: the `FOCUS_EXIT` memory subscriber (cross-process: a new
 `memory_server` endpoint POSTed from a main-process `FOCUS_EXIT`
 subscriber) and the frontend focus indicator.
 
-Known tuning interaction: both paths tick the SAME hysteresis. Because
-proactive fires on a schedule, idle ticks can advance the low-streak exit
-faster than conversational turns — watch this when tuning `T_out` / `K`.
+Known tuning interaction: both paths tick the SAME leaky accumulator, but
+only the inline path adds charge. Idle (proactive) ticks only decay it by
+`FOCUS_IDLE_CHARGE_RETENTION`. Because proactive fires on a schedule, a
+long silence runs several cooldown ticks — so the effective decay rate is
+coupled to the proactive cadence (and each idle tick also consumes one
+`FOCUS_HARD_CAP_TURNS` slot). Watch this when tuning the retentions.
 
 Naming: the user-facing fantasy terms are **凝神 (Focus)** and **真名
 (True-Name)**. Internal identifiers use the English `focus` / `true_name`
@@ -87,10 +94,9 @@ dispatch sub-model tasks, gated behind explicit emotional consent.
    activity snapshot. Privacy mode governs SCREEN / app-state visibility
    only and must never gate Focus (or any other understanding-the-user
    feature) — reading the user's emotional state from what they typed is
-   core to a companion. The idle path's silence/open-thread signals do
-   consume the activity snapshot, so they simply skip a tick when it's
-   absent (and never clear the accumulator on absence). See
-   `docs/contributing/developer-notes.md` rule 6.
+   core to a companion. The idle path does not score and reads no snapshot
+   at all — it is a pure charge cooldown, so it is privacy-independent too.
+   See `docs/contributing/developer-notes.md` rule 6.
 
 ## Mode model
 
@@ -166,8 +172,12 @@ collection needed.
   persona/memory and what I'm now reading about the user?" If yes, it
   does *not* rewrite — it emits a proposal and waits for one-word consent.
 
-A single shared `FocusScorer` produces the score; both trigger paths
-(below) call it so behaviour cannot diverge between inline and idle entry.
+The `FocusScorer` produces the score for the **inline** path only (keyword
++ cadence over the user's message). The **idle** path does not score: a
+proactive turn is a pure cooldown that decays the charge (see below). So
+the silence / open-thread / time-anchored-follow-up signals in Layers 1–2
+above are **not** wired into the trigger — entry and sustain are driven
+solely by what the user actually says.
 
 ## Two trigger paths
 
@@ -181,21 +191,27 @@ where the user opens up** — which flows through `stream_text`, *not*
 | Path | Scenario | Entry point | Mounting site |
 |---|---|---|---|
 | **A: Inline focus** | user sends a message → score it → if over the bar, upgrade *this* reply | lightweight scorer before `stream_text` generation | `main_logic/core.py` `stream_text` entry (near the `last_user_activity_time` / USER_INPUT fire) |
-| **B: Idle focus** | silence window → score over bar → run `proactive_chat` but thinking-on | `proactive_chat` Phase-2 generate (after PHASE2 fired) | `main_routers/system_router.py` — the three Phase-2 generate sites take a score-driven `disable_thinking`, suppressed under vision |
+| **B: Idle cooldown** | a proactive turn fires while in focus → keep it thinking-on, but decay the charge a notch (never raise it) | `proactive_chat` Phase-2 generate (after PHASE2 fired) | `main_routers/system_router.py` — the three Phase-2 generate sites take `disable_thinking = not _focus_idle_decision()`, suppressed under vision |
 
 ### Path coupling — this is the key to "she lingers"
 
-While in focus, **Path B's idle threshold drops**:
-`T_idle = in_focus ? T_base * 0.4 : T_base`.
+A focus episode is entered and re-charged ONLY by the inline path (the
+user's own messages). A proactive turn that fires mid-episode does not
+re-score or prop the charge up — it runs thinking-on (she's still in it)
+and decays the charge by the slower `FOCUS_IDLE_CHARGE_RETENTION`.
 
-Rationale: after the user says something heavy → AI gives a focus reply →
-user goes silent — that silence is *qualitatively different* from
-everyday idle. The idle proactive trigger should fire after a *shorter*
-silence ("she's still thinking about you") rather than the usual N
-minutes. This naturally produces the loop *"after she arrives once, she
-follows up a turn or two before letting go."* Focus's persistence is not
-sticky-by-flag; it is **persistence-via-more-sensitive-idle-trigger**,
-and it ends when the session-level hysteresis (below) decides to exit.
+This produces the loop *"after she arrives once, she follows up a turn or
+two before letting go"* via the **decay rate**, not a more-sensitive idle
+trigger: while the user keeps opening up, inline ticks keep the charge
+above the exit bar; once they go quiet, successive proactive turns cool it
+down until the session-level hysteresis exits. Persistence is the slow
+idle retention, not sticky-by-flag.
+
+(An earlier draft proposed instead *dropping the idle trigger threshold*
+while in focus — `T_idle = in_focus ? T_base * 0.4 : T_base` — so she'd
+re-approach after a shorter silence. That was rejected in favour of the
+cooldown model: the idle path must never make Focus *more* likely, only
+let it fade. The idle-threshold-drop sub-feature is not implemented.)
 
 These two mechanisms are orthogonal: hysteresis decides *when the
 session-level focus mode exits*; path coupling decides *how sensitive the
@@ -326,9 +342,9 @@ later, not a reason to build an inverse table up front.
    on over-bar, build the LLM with thinking-on + stronger model.
 5. `main_routers/system_router.py` — Path B: replace the hard-coded
    `disable_thinking=True` at the proactive **Phase-2** generate sites
-   (main stream / format-fix regen / BM25 regen) with the score-driven
-   choice, suppressed whenever the round uses a vision model. The in-focus
-   idle-threshold drop is a separate deferred sub-feature.
+   (main stream / format-fix regen / BM25 regen) with `not
+   _focus_idle_decision()` (a cooldown tick, suppressed under a vision
+   model). The idle path never raises the charge.
 6. `app/memory_server.py` (+ memory stations) — subscribe to
    `EmotionalEpisodeFinished`; route the episode slice into
    `synthesize_reflections` / `resolve_corrections` / facts / ban-list
@@ -344,8 +360,10 @@ later, not a reason to build an inverse table up front.
 * `T_in` — focus entry water line. **Start tight** ("1–2× / week"),
   collect data, loosen later for under-triggered users. Magic-dilution vs
   magic-burial is a tuning curve, not a one-shot choice.
-* `T_out`, `K`, `M` — exit hysteresis (start `0.3·T_in`, `3`, `8`).
-* `T_base` idle threshold + the `0.4` in-focus multiplier.
+* `T_out`, `M` — exit hysteresis (`FOCUS_CHARGE_EXIT` `0.3`, hard cap `8`).
+* `FOCUS_CHARGE_RETENTION` (inline `0.5`) + `FOCUS_IDLE_CHARGE_RETENTION`
+  (idle cooldown `0.9`, slower) — the latter sets how many proactive turns
+  Focus lingers before fading.
 * **Topic-boundary detection** (gates hard-exit + inline ban-list): cheap
   per-turn classifier model vs keyword/syntax heuristic. *Recommendation:
   heuristic for v1 (zero-cost), upgrade to classifier if false exits hurt.*

--- a/main_logic/activity/focus_scorer.py
+++ b/main_logic/activity/focus_scorer.py
@@ -22,9 +22,9 @@ signals are keyword + cadence — both need a real user message.
 The idle (``proactive_chat``) path does NOT score: a proactive turn never
 raises the Focus charge. Entering and sustaining Focus is driven solely by
 the user's own messages here; proactive turns only let an active episode
-cool down via ``FOCUS_IDLE_CHARGE_RETENTION`` (see
+cool down (faster when she spoke, slower when she stayed silent — see
 ``docs/design/focus-truename-mode.md`` and ``LLMSessionManager.
-_focus_idle_decision``).
+_focus_idle_cooldown``).
 
 The score is a weighted average over the *applicable* signals
 (``FOCUS_SIGNAL_WEIGHTS`` renormalised to the present subset), so an

--- a/main_logic/activity/focus_scorer.py
+++ b/main_logic/activity/focus_scorer.py
@@ -89,8 +89,8 @@ class FocusScorer:
         signals = {"keyword": kw, "cadence": cadence}
         score = _weighted_average(signals, config.FOCUS_SIGNAL_WEIGHTS)
 
-        # Update the cadence baseline only for real inline messages.
-        if user_text is not None and user_text.strip():
+        # Update the cadence baseline for this inline message.
+        if user_text.strip():
             self._recent_lengths.append(len(user_text.strip()))
 
         return FocusScore(score=score, signals=signals)
@@ -99,17 +99,13 @@ class FocusScorer:
         """Drop the cadence baseline (call on session teardown / hot-swap)."""
         self._recent_lengths.clear()
 
-    # ── sub-signals (each → [0, 1] or None when not applicable) ──────
-    def _signal_keyword(self, user_text: Optional[str]) -> Optional[float]:
-        if user_text is None:
-            return None
+    # ── sub-signals (keyword → [0, 1]; cadence → [0, 1] or None) ─────
+    def _signal_keyword(self, user_text: str) -> float:
         count = scan_vulnerability_keywords(user_text)
         sat = max(1, int(config.FOCUS_KEYWORD_SATURATION))
         return min(count / sat, 1.0)
 
-    def _signal_cadence(self, user_text: Optional[str]) -> Optional[float]:
-        if user_text is None:
-            return None
+    def _signal_cadence(self, user_text: str) -> Optional[float]:
         text = user_text.strip()
         if not text:
             return None

--- a/main_logic/activity/focus_scorer.py
+++ b/main_logic/activity/focus_scorer.py
@@ -15,29 +15,25 @@
 """Focus-mode signal scorer (the Focus trigger).
 
 Produces the single [0, 1] score that ``SessionStateMachine.update_focus``
-feeds into its hysteresis. The SAME scorer instance serves both trigger
-paths (see ``docs/design/focus-truename-mode.md``) so behaviour can't
-diverge:
+feeds into its hysteresis. Scoring is **inline-only**: it reads what the
+user just typed (``stream_text``), never the screen. The applicable
+signals are keyword + cadence — both need a real user message.
 
-  * **Inline** (`stream_text`): a real user message just arrived. Pass
-    ``user_text=...``; the applicable signals are keyword + cadence +
-    open_thread.
-  * **Idle** (`proactive_chat`): a silence window with no new message.
-    Pass ``user_text=None``; the applicable signals are silence +
-    open_thread.
+The idle (``proactive_chat``) path does NOT score: a proactive turn never
+raises the Focus charge. Entering and sustaining Focus is driven solely by
+the user's own messages here; proactive turns only let an active episode
+cool down via ``FOCUS_IDLE_CHARGE_RETENTION`` (see
+``docs/design/focus-truename-mode.md`` and ``LLMSessionManager.
+_focus_idle_decision``).
 
-Per-path applicability matters: signals that need a fresh message
-(keyword, cadence) are ``None`` on the idle path, and the silence signal
-is ``None`` on the inline path (the user just spoke — silence is
-meaningless). The score is a weighted average over only the *applicable*
-signals (``FOCUS_SIGNAL_WEIGHTS`` renormalised to the present subset), so
-an absent signal never silently drags the average toward zero.
+The score is a weighted average over the *applicable* signals
+(``FOCUS_SIGNAL_WEIGHTS`` renormalised to the present subset), so an
+absent signal (e.g. cadence before the baseline has enough samples) never
+silently drags the average toward zero.
 
-The scorer is intentionally thin: all Layer-1/2 raw evidence already
-lives on ``ActivitySnapshot`` (``seconds_since_user_msg`` /
-``unfinished_thread`` / ``open_threads``); the only state the scorer owns
-is a small rolling buffer of recent user-message lengths for the cadence
-signal. One instance per session, owned alongside ``UserActivityTracker``.
+The scorer is intentionally thin: the only state it owns is a small
+rolling buffer of recent user-message lengths for the cadence signal. One
+instance per session, owned alongside ``UserActivityTracker``.
 """
 from __future__ import annotations
 
@@ -75,19 +71,13 @@ class FocusScorer:
         )
 
     # ── public API ──────────────────────────────────────────────────
-    def score(
-        self,
-        snapshot,
-        *,
-        user_text: Optional[str] = None,
-    ) -> FocusScore:
-        """Score the current turn. ``user_text`` non-None ⇒ inline path; None ⇒ idle path.
+    def score(self, *, user_text: str) -> FocusScore:
+        """Score one inline turn from the user's message (keyword + cadence).
 
         Side effect: when ``user_text`` is a real (non-empty) message, its
         length is appended to the cadence baseline buffer **after** the
         cadence signal is computed (so cadence always compares the current
-        message against *prior* messages). Idle calls leave the buffer
-        untouched.
+        message against *prior* messages).
 
         No ``lang`` argument: the keyword signal scans every locale's
         vulnerability table in parallel (mixed-language speech is common),
@@ -95,15 +85,8 @@ class FocusScorer:
         """
         kw = self._signal_keyword(user_text)
         cadence = self._signal_cadence(user_text)
-        silence = self._signal_silence(snapshot, user_text)
-        open_thread = self._signal_open_thread(snapshot, user_text)
 
-        signals = {
-            "keyword": kw,
-            "cadence": cadence,
-            "silence": silence,
-            "open_thread": open_thread,
-        }
+        signals = {"keyword": kw, "cadence": cadence}
         score = _weighted_average(signals, config.FOCUS_SIGNAL_WEIGHTS)
 
         # Update the cadence baseline only for real inline messages.
@@ -143,35 +126,6 @@ class FocusScorer:
             return 1.0
         # linear ramp between the drop floor and the baseline
         return (baseline - cur) / (baseline - lo)
-
-    def _signal_silence(self, snapshot, user_text: Optional[str]) -> Optional[float]:
-        # Silence is only meaningful on the idle path (no fresh message).
-        if user_text is not None:
-            return None
-        secs = getattr(snapshot, "seconds_since_user_msg", None)
-        if secs is None:
-            return None
-        lo = float(config.FOCUS_SILENCE_MIN_SECONDS)
-        hi = float(config.FOCUS_SILENCE_FULL_SECONDS)
-        if secs < lo:
-            return 0.0
-        if secs >= hi or hi <= lo:
-            return 1.0
-        return (secs - lo) / (hi - lo)
-
-    def _signal_open_thread(self, snapshot, user_text: Optional[str]) -> Optional[float]:
-        # Idle-path only. On the inline path the just-arrived message has
-        # already cleared the tracker's unfinished_thread (on_user_message
-        # runs before scoring), so reading it here would be a structural 0
-        # that just dilutes the inline average — and a user replying to an
-        # open question is already captured by the keyword cue. So this is
-        # the anchor for "she comes back to what was left open" only when
-        # there's no fresh message (idle).
-        if user_text is not None:
-            return None
-        has_unfinished = getattr(snapshot, "unfinished_thread", None) is not None
-        has_open = bool(getattr(snapshot, "open_threads", None))
-        return 1.0 if (has_unfinished or has_open) else 0.0
 
 
 def _weighted_average(signals: dict, weights: dict) -> float:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1720,7 +1720,7 @@ class LLMSessionManager:
             # they typed is core to an AI companion. Privacy mode governs only
             # SCREEN / app-state visibility (see docs/contributing/
             # developer-notes.md rule 6). Hence no snapshot fetch here.
-            scored = self._focus_scorer.score(None, user_text=user_text)
+            scored = self._focus_scorer.score(user_text=user_text)
             topic_changed = detect_topic_switch(user_text)
             mode = await self.state.update_focus(
                 scored.score, topic_changed=topic_changed,
@@ -1746,47 +1746,42 @@ class LLMSessionManager:
                              self.lanlan_name, _exit_err)
             return False
 
-    async def _focus_idle_decision(self, snapshot) -> bool:
-        """Path B (idle) Focus gate: score a silence window (no fresh user
-        message) and return whether THIS proactive reply should run thinking-on.
+    async def _focus_idle_decision(self) -> bool:
+        """Path B (idle) Focus COOLDOWN: a proactive turn fired with no fresh
+        user message. Returns whether THIS proactive reply runs thinking-on.
 
-        Idle-path signals are silence + open-thread (keyword/cadence need a
-        message and are N/A). Advances the SAME ``self.state`` hysteresis as
-        the inline path so a focus episode is one shared state regardless of
-        which path drove it. Best-effort; degrades to regular on any failure
-        or when the master switch is off. When no snapshot is available this
-        tick (tracker unavailable / privacy nulls SCREEN data) the idle signals
-        can't be computed, so it simply skips — it does NOT clear the
-        accumulator, since the privacy-independent inline path is still driving
-        the episode and clearing here would wipe a live one.
+        A proactive turn NEVER raises the Focus charge — entering and sustaining
+        Focus is driven solely by the inline path (the user's own messages).
+        This tick only lets an active episode cool down, decaying the charge by
+        the slower idle retention (``config.FOCUS_IDLE_CHARGE_RETENTION`` >
+        the inline retention) so Focus fades gradually across proactive turns
+        instead of being propped up. It is a pure time/charge cooldown:
+        privacy-independent, no snapshot, no screen signals.
 
-        Note (tuning): because proactive fires on a schedule, idle ticks can
-        accumulate toward the low-streak exit faster than conversational turns
-        — the cross-path interaction is a known knob (see
-        docs/design/focus-truename-mode.md).
+        Best-effort; degrades to regular on failure or when the master switch
+        is off (which self-clears the accumulator).
+
+        Note (tuning): proactive fires on a schedule, so a long silence runs
+        several cooldown ticks — the effective decay rate is coupled to the
+        proactive cadence, and each tick also consumes one
+        ``FOCUS_HARD_CAP_TURNS`` slot (see docs/design/focus-truename-mode.md).
         """
-        from config import FOCUS_MODE_ENABLED  # live read (re-imported per call)
+        from config import FOCUS_MODE_ENABLED, FOCUS_IDLE_CHARGE_RETENTION  # live read
         if not FOCUS_MODE_ENABLED:
-            # Clear unconditionally (not just on FOCUS) so a REGULAR charge
-            # frozen under the enter bar can't survive a disabled window —
-            # mirrors the inline disabled gate. update_focus self-clears when
-            # the switch is off.
+            # Master switch off → update_focus self-clears any residue.
             await self.state.update_focus(0.0)
             return False
-        if snapshot is None:
-            # No activity data this idle tick (tracker unavailable / privacy
-            # nulls SCREEN data). Idle signals (silence / open_thread) need it,
-            # so skip scoring — but do NOT touch the accumulator: the
-            # privacy-independent inline path keeps driving the episode, and
-            # clearing here would wipe a legitimate in-progress Focus.
-            return False
         try:
-            scored = self._focus_scorer.score(snapshot, user_text=None)
-            mode = await self.state.update_focus(scored.score)
+            # score=0 + slower idle retention ⇒ charge can only decay (never
+            # cross the enter bar from REGULAR), so this tick can't ENTER Focus,
+            # only let an inline-driven episode cool toward the exit bar.
+            mode = await self.state.update_focus(
+                0.0, retention_override=FOCUS_IDLE_CHARGE_RETENTION,
+            )
             logger.info(
-                "[%s] 凝神 idle: score=%.2f charge=%s mode=%s signals=%s",
-                self.lanlan_name, scored.score,
-                self.state.snapshot().get("focus_charge"), mode.value, scored.signals,
+                "[%s] 凝神 idle(cooldown): charge=%s mode=%s",
+                self.lanlan_name,
+                self.state.snapshot().get("focus_charge"), mode.value,
             )
             return mode is CognitionMode.FOCUS
         except Exception as e:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1761,24 +1761,28 @@ class LLMSessionManager:
             return False
         return self.state.mode is CognitionMode.FOCUS
 
-    async def _focus_idle_cooldown(self, *, replied: bool) -> None:
-        """Path B (idle) Focus COOLDOWN: decay the charge once, after a proactive
-        turn finishes. A proactive turn NEVER raises the charge — entering and
-        sustaining Focus is driven solely by the inline path (the user's own
-        messages). This only lets an active episode cool down.
+    async def _focus_idle_cooldown(self, *, replied: bool, episode_token) -> None:
+        """Path B (idle) Focus COOLDOWN: decay the charge once, after a Phase-2
+        proactive turn finishes. A proactive turn NEVER raises the charge —
+        entering and sustaining Focus is driven solely by the inline path (the
+        user's own messages). This only lets an active episode cool down.
 
         Two-tier decay by whether the turn actually spoke:
-          * ``replied=True`` (action == "chat", a proactive reply was delivered)
-            → faster ``FOCUS_IDLE_REPLIED_RETENTION``: speaking spends more of
-            the episode.
-          * ``replied=False`` (guarded / preempted / empty / pass — she stayed
-            silent) → slower ``FOCUS_IDLE_SILENT_RETENTION``: just waiting barely
-            spends it.
+          * ``replied=True`` (a Phase-2 proactive reply was delivered) → faster
+            ``FOCUS_IDLE_REPLIED_RETENTION``: speaking spends more of the episode.
+          * ``replied=False`` (Phase-2 reached but produced no reply — empty /
+            aborted) → slower ``FOCUS_IDLE_SILENT_RETENTION``: barely spends it.
         So Focus persistence is driven by how often she speaks, not raw time.
 
-        Pure charge cooldown: privacy-independent, no snapshot. Best-effort;
-        never blocks the proactive exit. Called from the proactive unified exit
-        (``_end_proactive``) so every path ticks exactly once.
+        ``episode_token`` is the focus episode id observed when this proactive
+        turn made its thinking decision. If the SM is no longer in that same
+        episode (the inline path exited and/or entered a new one while this
+        proactive request was finishing), the decay is SKIPPED — a stale
+        proactive tick must not decay a fresh, user-driven episode.
+
+        Decays with ``count_turn=False`` so a proactive tick never consumes a
+        hard-cap turn slot (that bounds inline turns). Pure charge cooldown:
+        privacy-independent, no snapshot. Best-effort; never blocks the exit.
         """
         from config import (  # live read
             FOCUS_MODE_ENABLED,
@@ -1790,14 +1794,25 @@ class LLMSessionManager:
                 # Master switch off → update_focus self-clears any residue.
                 await self.state.update_focus(0.0)
                 return
+            # Race guard: only decay the episode this turn actually observed.
+            current_episode = self.state.snapshot().get("focus_episode_id")
+            if current_episode != episode_token:
+                logger.debug(
+                    "[%s] focus idle cooldown skipped: episode changed (%s → %s)",
+                    self.lanlan_name, episode_token, current_episode,
+                )
+                return
             retention = (
                 FOCUS_IDLE_REPLIED_RETENTION if replied
                 else FOCUS_IDLE_SILENT_RETENTION
             )
             # score=0 + retention<1 ⇒ charge can only decay (never cross the
             # enter bar from REGULAR), so this can't ENTER Focus — only cool an
-            # inline-driven episode toward the exit bar.
-            mode = await self.state.update_focus(0.0, retention_override=retention)
+            # inline-driven episode toward the exit bar. count_turn=False keeps
+            # it off the hard-cap turn budget.
+            mode = await self.state.update_focus(
+                0.0, retention_override=retention, count_turn=False,
+            )
             logger.info(
                 "[%s] 凝神 idle(cooldown replied=%s): charge=%s mode=%s",
                 self.lanlan_name, replied,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1746,55 +1746,72 @@ class LLMSessionManager:
                              self.lanlan_name, _exit_err)
             return False
 
-    async def _focus_idle_decision(self) -> bool:
-        """Path B (idle) Focus COOLDOWN: a proactive turn fired with no fresh
-        user message. Returns whether THIS proactive reply runs thinking-on.
+    def _focus_idle_thinking(self) -> bool:
+        """Path B (idle) — does THIS proactive reply run thinking-on?
 
-        A proactive turn NEVER raises the Focus charge — entering and sustaining
-        Focus is driven solely by the inline path (the user's own messages).
-        This tick only lets an active episode cool down, decaying the charge by
-        the slower idle retention (``config.FOCUS_IDLE_CHARGE_RETENTION`` >
-        the inline retention) so Focus fades gradually across proactive turns
-        instead of being propped up. It is a pure time/charge cooldown:
-        privacy-independent, no snapshot, no screen signals.
-
-        Best-effort; degrades to regular on failure or when the master switch
-        is off (which self-clears the accumulator).
-
-        Note (tuning): proactive fires on a schedule, so a long silence runs
-        several cooldown ticks — the effective decay rate is coupled to the
-        proactive cadence, and each tick also consumes one
-        ``FOCUS_HARD_CAP_TURNS`` slot (see docs/design/focus-truename-mode.md).
+        Read-only: returns whether the session is currently in Focus. A
+        proactive turn never raises the charge, so there is nothing to score
+        here. The charge decay happens AFTER the turn, in
+        ``_focus_idle_cooldown`` (it needs to know whether the turn actually
+        spoke). Returns False when the master switch is off. Privacy-independent
+        (no snapshot, no screen signals).
         """
-        from config import FOCUS_MODE_ENABLED, FOCUS_IDLE_CHARGE_RETENTION  # live read
+        from config import FOCUS_MODE_ENABLED  # live read
         if not FOCUS_MODE_ENABLED:
-            # Master switch off → update_focus self-clears any residue.
-            await self.state.update_focus(0.0)
             return False
+        return self.state.mode is CognitionMode.FOCUS
+
+    async def _focus_idle_cooldown(self, *, replied: bool) -> None:
+        """Path B (idle) Focus COOLDOWN: decay the charge once, after a proactive
+        turn finishes. A proactive turn NEVER raises the charge — entering and
+        sustaining Focus is driven solely by the inline path (the user's own
+        messages). This only lets an active episode cool down.
+
+        Two-tier decay by whether the turn actually spoke:
+          * ``replied=True`` (action == "chat", a proactive reply was delivered)
+            → faster ``FOCUS_IDLE_REPLIED_RETENTION``: speaking spends more of
+            the episode.
+          * ``replied=False`` (guarded / preempted / empty / pass — she stayed
+            silent) → slower ``FOCUS_IDLE_SILENT_RETENTION``: just waiting barely
+            spends it.
+        So Focus persistence is driven by how often she speaks, not raw time.
+
+        Pure charge cooldown: privacy-independent, no snapshot. Best-effort;
+        never blocks the proactive exit. Called from the proactive unified exit
+        (``_end_proactive``) so every path ticks exactly once.
+        """
+        from config import (  # live read
+            FOCUS_MODE_ENABLED,
+            FOCUS_IDLE_REPLIED_RETENTION,
+            FOCUS_IDLE_SILENT_RETENTION,
+        )
         try:
-            # score=0 + slower idle retention ⇒ charge can only decay (never
-            # cross the enter bar from REGULAR), so this tick can't ENTER Focus,
-            # only let an inline-driven episode cool toward the exit bar.
-            mode = await self.state.update_focus(
-                0.0, retention_override=FOCUS_IDLE_CHARGE_RETENTION,
+            if not FOCUS_MODE_ENABLED:
+                # Master switch off → update_focus self-clears any residue.
+                await self.state.update_focus(0.0)
+                return
+            retention = (
+                FOCUS_IDLE_REPLIED_RETENTION if replied
+                else FOCUS_IDLE_SILENT_RETENTION
             )
+            # score=0 + retention<1 ⇒ charge can only decay (never cross the
+            # enter bar from REGULAR), so this can't ENTER Focus — only cool an
+            # inline-driven episode toward the exit bar.
+            mode = await self.state.update_focus(0.0, retention_override=retention)
             logger.info(
-                "[%s] 凝神 idle(cooldown): charge=%s mode=%s",
-                self.lanlan_name,
+                "[%s] 凝神 idle(cooldown replied=%s): charge=%s mode=%s",
+                self.lanlan_name, replied,
                 self.state.snapshot().get("focus_charge"), mode.value,
             )
-            return mode is CognitionMode.FOCUS
         except Exception as e:
-            logger.warning("[%s] focus idle decision failed (degrading to regular): %s",
+            logger.warning("[%s] focus idle cooldown failed (degrading to regular): %s",
                            self.lanlan_name, e)
-            # Mirror the inline path: don't leave a stale FOCUS episode on failure.
             try:
                 if self.state.mode is CognitionMode.FOCUS:
                     await self.state.update_focus(0.0, topic_changed=True)
             except Exception as _exit_err:
                 logger.debug("[%s] focus idle fail-exit also failed: %s",
                              self.lanlan_name, _exit_err)
-            return False
 
     async def handle_text_data(
         self,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1761,7 +1761,9 @@ class LLMSessionManager:
             return False
         return self.state.mode is CognitionMode.FOCUS
 
-    async def _focus_idle_cooldown(self, *, replied: bool, episode_token) -> None:
+    async def _focus_idle_cooldown(
+        self, *, replied: bool, episode_token, turn_token=None,
+    ) -> None:
         """Path B (idle) Focus COOLDOWN: decay the charge once, after a Phase-2
         proactive turn finishes. A proactive turn NEVER raises the charge —
         entering and sustaining Focus is driven solely by the inline path (the
@@ -1774,11 +1776,19 @@ class LLMSessionManager:
             aborted) → slower ``FOCUS_IDLE_SILENT_RETENTION``: barely spends it.
         So Focus persistence is driven by how often she speaks, not raw time.
 
-        ``episode_token`` is the focus episode id observed when this proactive
-        turn made its thinking decision. If the SM is no longer in that same
-        episode (the inline path exited and/or entered a new one while this
-        proactive request was finishing), the decay is SKIPPED — a stale
-        proactive tick must not decay a fresh, user-driven episode.
+        ``episode_token`` / ``turn_token`` pin the decay to the exact focus state
+        this proactive turn observed when it made its thinking decision — the
+        episode id and the turn count at Phase 2. The decay is SKIPPED unless the
+        SM is STILL in that same episode AND no inline turn has landed since:
+          * ``episode_token is None`` → the turn observed REGULAR (no active
+            episode). There is nothing to cool, and a proactive tick must not
+            erode the pre-entry accumulator the inline path is building toward
+            ENTER — entering Focus is the inline path's job alone.
+          * episode id changed → the inline path exited and/or entered a new
+            episode while this proactive request was finishing.
+          * turn count changed → the inline path recharged THIS same episode (a
+            user message landed mid-flight). A stale proactive tick must not
+            decay that fresh, user-driven charge.
 
         Decays with ``count_turn=False`` so a proactive tick never consumes a
         hard-cap turn slot (that bounds inline turns). Pure charge cooldown:
@@ -1794,12 +1804,28 @@ class LLMSessionManager:
                 # Master switch off → update_focus self-clears any residue.
                 await self.state.update_focus(0.0)
                 return
-            # Race guard: only decay the episode this turn actually observed.
-            current_episode = self.state.snapshot().get("focus_episode_id")
-            if current_episode != episode_token:
+            # Only cool an episode this turn actually observed — never the
+            # REGULAR pre-entry accumulator (entering Focus is inline-only).
+            if episode_token is None:
                 logger.debug(
-                    "[%s] focus idle cooldown skipped: episode changed (%s → %s)",
+                    "[%s] focus idle cooldown skipped: no active episode observed",
+                    self.lanlan_name,
+                )
+                return
+            # Race guard: skip if the focus state moved since this turn observed
+            # it — a different episode (inline exited / re-entered) or a fresh
+            # inline turn that recharged this same episode (turn count bumped).
+            snap = self.state.snapshot()
+            current_episode = snap.get("focus_episode_id")
+            current_turn = snap.get("focus_turn_count")
+            if current_episode != episode_token or (
+                turn_token is not None and current_turn != turn_token
+            ):
+                logger.debug(
+                    "[%s] focus idle cooldown skipped: focus state changed "
+                    "(episode %s→%s, turn %s→%s)",
                     self.lanlan_name, episode_token, current_episode,
+                    turn_token, current_turn,
                 )
                 return
             retention = (

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any, Awaitable, Callable, Optional, Union
 
@@ -274,16 +274,23 @@ class SessionStateMachine:
     # ── Focus mode 凝神 ─────────────────────────────────────────────
     async def update_focus(
         self, score: float, *, topic_changed: bool = False,
+        retention_override: float | None = None,
     ) -> CognitionMode:
         """Apply one Focus hysteresis tick for a just-scored turn; return the resulting mode.
 
-        Called once per scored turn by BOTH trigger paths (inline
-        ``stream_text`` and idle ``proactive_chat``) after the shared
-        ``FocusScorer`` produces ``score`` ∈ [0, 1]. Drives the
-        ``REGULAR ⇄ FOCUS`` transition with asymmetric thresholds + a hard
-        turn cap (``config.FOCUS_*``). ``topic_changed=True`` forces an
-        immediate exit regardless of score — a clear subject switch ends the
-        emotional episode.
+        Called once per turn by BOTH trigger paths. The INLINE path
+        (``stream_text``, a real user message) feeds the ``FocusScorer`` score
+        ∈ [0, 1] and is the ONLY path that can raise the charge / enter Focus.
+        The IDLE path (``proactive_chat``) feeds ``score=0`` with
+        ``retention_override`` set to the slower idle retention: a proactive
+        turn never props Focus up, it only lets an active episode cool down a
+        notch. Drives the ``REGULAR ⇄ FOCUS`` transition with asymmetric
+        thresholds + a hard turn cap (``config.FOCUS_*``). ``topic_changed=True``
+        forces an immediate exit regardless of score.
+
+        ``retention_override`` (when not None) replaces ``FOCUS_CHARGE_RETENTION``
+        for this tick only — used by the idle cooldown so proactive turns decay
+        the charge more slowly than inline turns.
 
         The transition itself is a pure function (``_focus_decide``); this
         method only wires config thresholds, mutates state under
@@ -297,6 +304,8 @@ class SessionStateMachine:
         docs/design/focus-truename-mode.md).
         """
         th = _focus_thresholds_from_config()
+        if retention_override is not None:
+            th = replace(th, retention=float(retention_override))
         emit_event: Optional[SessionEvent] = None
         emit_payload: dict = {}
         snap_subs: "list[Subscriber]" = []

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -275,6 +275,7 @@ class SessionStateMachine:
     async def update_focus(
         self, score: float, *, topic_changed: bool = False,
         retention_override: float | None = None,
+        count_turn: bool = True,
     ) -> CognitionMode:
         """Apply one Focus hysteresis tick for a just-scored turn; return the resulting mode.
 
@@ -297,6 +298,10 @@ class SessionStateMachine:
         ``_write_lock``, and dispatches ``FOCUS_ENTER`` / ``FOCUS_EXIT``
         outside the lock. Returns the post-tick ``mode`` so the caller can
         immediately build the LLM thinking-on (FOCUS) or off (REGULAR).
+
+        ``count_turn=False`` (idle cooldown) decays the charge without spending
+        a ``FOCUS_HARD_CAP_TURNS`` slot — the cap bounds real inline turns, not
+        proactive cooldown ticks.
 
         ``FOCUS_EXIT`` carries ``episode_id`` + ``episode_started_at`` so a
         future memory-side subscriber can slice the emotional episode out of
@@ -328,6 +333,7 @@ class SessionStateMachine:
                 score=score,
                 topic_changed=topic_changed,
                 th=th,
+                count_turn=count_turn,
             )
             if decision.action is _FocusAction.ENTER:
                 self.mode = CognitionMode.FOCUS
@@ -396,6 +402,7 @@ class SessionStateMachine:
             "mode": self.mode.value,
             "focus_turn_count": self._focus_turn_count,
             "focus_charge": round(self._focus_charge, 3),
+            "focus_episode_id": self._focus_episode_id,
         }
 
     # ── 写路径 ──────────────────────────────────────────────────────
@@ -557,6 +564,7 @@ def _focus_decide(
     score: float,
     topic_changed: bool,
     th: FocusThresholds,
+    count_turn: bool = True,
 ) -> _FocusDecision:
     """Pure leaky-accumulator transition for one scored turn.
 
@@ -599,8 +607,14 @@ def _focus_decide(
             return _FocusDecision(_FocusAction.EXIT, turn_count=0, charge=0.0, reason="hard_cap")
         if new_charge < th.exit:
             return _FocusDecision(_FocusAction.EXIT, turn_count=0, charge=0.0, reason="decayed")
+        # ``count_turn=False`` (idle cooldown) decays the charge WITHOUT spending
+        # a hard-cap turn slot — the cap bounds real inline conversation turns,
+        # not proactive cooldown ticks (a silent scheduler poll must not age the
+        # episode toward the hard cap).
         return _FocusDecision(
-            _FocusAction.STAY, turn_count=focus_turn_count + 1, charge=new_charge,
+            _FocusAction.STAY,
+            turn_count=focus_turn_count + (1 if count_turn else 0),
+            charge=new_charge,
         )
 
     # TRUE_NAME (v2) or any future mode — focus machine does not act.

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4935,12 +4935,22 @@ async def proactive_chat(request: Request):
             # 散落各分支无需各自记；排查"她这轮为什么没主动说话"看这条即可。
             # 占坑前的早退（游戏路由 / voice 与 text 的 409 并发拒绝）不经过
             # 本出口，各自就地补了同前缀（"主动搭话本轮未发起："）的 info。
-            if body.get("action") != "chat":
+            _replied = body.get("action") == "chat"
+            if not _replied:
                 logger.info(
                     "[%s] 主动搭话本轮未发起：%s",
                     lanlan_name,
                     body.get("message") or body.get("error") or "(无原因说明)",
                 )
+            # Idle Focus cooldown: a proactive turn never raises the charge, it
+            # only decays it — faster when she actually spoke (action=="chat":
+            # a reply spends more of the episode) than when she stayed silent
+            # (guard / preempted / empty: barely spent). Entry/sustain stay
+            # inline-only. Runs at this unified exit so every path ticks once.
+            try:
+                await mgr._focus_idle_cooldown(replied=_replied)
+            except Exception as _focus_err:
+                logger.debug("[%s] focus idle cooldown failed: %s", lanlan_name, _focus_err)
             if 'next_schedule_fixed_mode' in body:
                 return resp
             body['next_schedule_fixed_mode'] = _next_schedule_fixed_mode
@@ -6607,11 +6617,13 @@ async def proactive_chat(request: Request):
         await mgr.state.fire(_SE.PROACTIVE_PHASE2)
 
         # Path B (idle) Focus 凝神：this round is now committed to speaking
-        # (PHASE2 fired), so tick the shared hysteresis on the idle-path score
-        # (silence + open-thread) and decide whether Phase-2 generation runs
-        # thinking-on. Dominates all three Phase-2 generate sites below
-        # (main stream / format-fix regen / BM25 anti-repeat regen).
-        _focus_phase2_thinking = await mgr._focus_idle_decision()
+        # (PHASE2 fired). Read-only: does this proactive reply run thinking-on?
+        # (= the session is already in Focus, inline-driven). A proactive turn
+        # never raises the charge; the charge cooldown happens after the turn in
+        # _end_proactive (it needs to know whether we actually spoke). Dominates
+        # all three Phase-2 generate sites below (main stream / format-fix regen
+        # / BM25 anti-repeat regen).
+        _focus_phase2_thinking = mgr._focus_idle_thinking()
 
         # --- 构建 LLM + messages (static/dynamic 分离) ---
         phase2_use_vision = bool(screenshot_b64_for_phase2 and has_vision_model)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4880,6 +4880,10 @@ async def proactive_chat(request: Request):
                 await _increment_proactive_chat_total(lanlan_name)
             else:
                 logger.info("[%s] 主动搭话本轮未发起：语音 nudge 被 guard 跳过", lanlan_name)
+            # No Focus cooldown here: a voice nudge is realtime and never runs a
+            # Focus thinking-on reply, so it is not a Focus proactive turn — the
+            # cooldown is applied only at the text Phase-2 idle path (which is
+            # where _focus_idle_thinking actually gates thinking-on).
             return JSONResponse({
                 "success": True,
                 "action": "chat" if delivered else "pass",
@@ -4907,6 +4911,14 @@ async def proactive_chat(request: Request):
         # screen-only delay block further down and the matching
         # ``S.proactiveFixedScheduleMode`` branch in static/app-proactive.js.
         _next_schedule_fixed_mode = False
+
+        # Focus idle cooldown bookkeeping (read by _end_proactive via closure).
+        # Set only when the flow reaches the Phase-2 idle Focus decision, so
+        # short-circuit replies (mini-game invite, break-reminder, must-fire)
+        # that return before Phase 2 never spend Focus charge. The episode token
+        # pins the decay to the episode the thinking decision observed.
+        _focus_phase2_reached = False
+        _focus_episode_token = None
 
         async def _end_proactive(resp: JSONResponse) -> JSONResponse:
             """Wraps every normal/short-circuit proactive exit: idempotently fires PROACTIVE_DONE.
@@ -4942,15 +4954,19 @@ async def proactive_chat(request: Request):
                     lanlan_name,
                     body.get("message") or body.get("error") or "(无原因说明)",
                 )
-            # Idle Focus cooldown: a proactive turn never raises the charge, it
-            # only decays it — faster when she actually spoke (action=="chat":
-            # a reply spends more of the episode) than when she stayed silent
-            # (guard / preempted / empty: barely spent). Entry/sustain stay
-            # inline-only. Runs at this unified exit so every path ticks once.
-            try:
-                await mgr._focus_idle_cooldown(replied=_replied)
-            except Exception as _focus_err:
-                logger.debug("[%s] focus idle cooldown failed: %s", lanlan_name, _focus_err)
+            # Idle Focus cooldown — only for turns that reached the Phase-2 idle
+            # Focus decision (short-circuit replies never set the flag, so they
+            # don't spend Focus). A proactive turn never raises the charge; it
+            # decays — faster when it delivered a reply (_replied) than when
+            # Phase 2 produced nothing. count_turn=False + episode-token guard
+            # live inside _focus_idle_cooldown.
+            if _focus_phase2_reached:
+                try:
+                    await mgr._focus_idle_cooldown(
+                        replied=_replied, episode_token=_focus_episode_token,
+                    )
+                except Exception as _focus_err:
+                    logger.debug("[%s] focus idle cooldown failed: %s", lanlan_name, _focus_err)
             if 'next_schedule_fixed_mode' in body:
                 return resp
             body['next_schedule_fixed_mode'] = _next_schedule_fixed_mode
@@ -6624,6 +6640,11 @@ async def proactive_chat(request: Request):
         # all three Phase-2 generate sites below (main stream / format-fix regen
         # / BM25 anti-repeat regen).
         _focus_phase2_thinking = mgr._focus_idle_thinking()
+        # Mark that this turn reached the Phase-2 idle Focus decision and pin the
+        # episode it observed — _end_proactive applies the cooldown only for such
+        # turns, and only if still in this same episode (race guard).
+        _focus_phase2_reached = True
+        _focus_episode_token = mgr.state.snapshot().get("focus_episode_id")
 
         # --- 构建 LLM + messages (static/dynamic 分离) ---
         phase2_use_vision = bool(screenshot_b64_for_phase2 and has_vision_model)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4919,6 +4919,7 @@ async def proactive_chat(request: Request):
         # pins the decay to the episode the thinking decision observed.
         _focus_phase2_reached = False
         _focus_episode_token = None
+        _focus_turn_token = None
 
         async def _end_proactive(resp: JSONResponse) -> JSONResponse:
             """Wraps every normal/short-circuit proactive exit: idempotently fires PROACTIVE_DONE.
@@ -4964,6 +4965,7 @@ async def proactive_chat(request: Request):
                 try:
                     await mgr._focus_idle_cooldown(
                         replied=_replied, episode_token=_focus_episode_token,
+                        turn_token=_focus_turn_token,
                     )
                 except Exception as _focus_err:
                     logger.debug("[%s] focus idle cooldown failed: %s", lanlan_name, _focus_err)
@@ -6641,10 +6643,13 @@ async def proactive_chat(request: Request):
         # / BM25 anti-repeat regen).
         _focus_phase2_thinking = mgr._focus_idle_thinking()
         # Mark that this turn reached the Phase-2 idle Focus decision and pin the
-        # episode it observed — _end_proactive applies the cooldown only for such
-        # turns, and only if still in this same episode (race guard).
+        # focus state it observed (episode id + turn count) — _end_proactive
+        # applies the cooldown only for such turns, and only if still in this
+        # exact episode/turn (race guard: a no-op if inline moved it since).
         _focus_phase2_reached = True
-        _focus_episode_token = mgr.state.snapshot().get("focus_episode_id")
+        _focus_phase2_snap = mgr.state.snapshot()
+        _focus_episode_token = _focus_phase2_snap.get("focus_episode_id")
+        _focus_turn_token = _focus_phase2_snap.get("focus_turn_count")
 
         # --- 构建 LLM + messages (static/dynamic 分离) ---
         phase2_use_vision = bool(screenshot_b64_for_phase2 and has_vision_model)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6509,28 +6509,22 @@ async def proactive_chat(request: Request):
         # unfinished_thread）仍取自早期 snapshot，避免 Phase 1 中途 state 变化
         # 导致 gating 决策（restricted_screen_only 收紧 enabled_modes 等）和最终
         # prompt 不一致。
-        # Freshest snapshot to feed the idle Focus decision below — Phase 1
-        # (source fetch + memory + LLM) just elapsed, so silence duration and
-        # open-thread signals moved on. Falls back to the entry snapshot if the
-        # refresh fails / is unavailable.
-        _focus_idle_snapshot = activity_snapshot
+        # Freshest enrichment for the proactive prompt — Phase 1 (source fetch +
+        # memory + LLM) just elapsed, so activity scores / open threads moved on.
+        # Falls back to the entry snapshot if the refresh fails / is unavailable.
+        # (The idle Focus decision no longer consumes a snapshot — it is a pure
+        # charge cooldown — so this block only feeds the prompt now.)
         if activity_snapshot is not None:
             from dataclasses import replace as _dc_replace
             from main_logic.activity import format_activity_state_section
             try:
                 fresh_enrich = await mgr._activity_tracker.get_snapshot()
                 # restricted_screen_only deliberately strips semantic open_threads
-                # so gaming / focused-work prompts stay screen-only. The idle Focus
-                # decision must see the SAME filtered threads the prompt does —
-                # otherwise _signal_open_thread could charge / enter Focus from a
-                # text follow-up signal this workflow just suppressed. Keep
-                # fresh_enrich's silence duration (freshest), only swap open_threads.
+                # so gaming / focused-work prompts stay screen-only — render the
+                # prompt with that filtered set.
                 _filtered_open_threads = _open_threads_for_activity_state(
                     activity_snapshot,
                     fresh_enrich.open_threads,
-                )
-                _focus_idle_snapshot = _dc_replace(
-                    fresh_enrich, open_threads=_filtered_open_threads,
                 )
                 display_snap = _dc_replace(
                     activity_snapshot,
@@ -6617,7 +6611,7 @@ async def proactive_chat(request: Request):
         # (silence + open-thread) and decide whether Phase-2 generation runs
         # thinking-on. Dominates all three Phase-2 generate sites below
         # (main stream / format-fix regen / BM25 anti-repeat regen).
-        _focus_phase2_thinking = await mgr._focus_idle_decision(_focus_idle_snapshot)
+        _focus_phase2_thinking = await mgr._focus_idle_decision()
 
         # --- 构建 LLM + messages (static/dynamic 分离) ---
         phase2_use_vision = bool(screenshot_b64_for_phase2 and has_vision_model)

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -8,10 +8,11 @@ Coverage:
    renormalisation, cadence baseline roll.
 3. ``SessionStateMachine.update_focus``: async enter/exit, FOCUS_EXIT payload,
    retention override, reset clearing, master-switch-off degradation.
-6. Idle cooldown: proactive ticks decay charge (slow retention), never enter.
 4. ``prompts_focus`` lexicon scans: vulnerability count, cross-locale (mixed
    language) scanning, topic-switch anchoring.
 5. ``stream_text`` thinking-on threading (Path A wiring).
+6. Idle cooldown: proactive ticks decay charge (two-tier retention by whether
+   the turn spoke), never enter; thinking read is mode-only.
 """
 import os
 import sys
@@ -197,13 +198,14 @@ def test_scorer_cadence_none_without_baseline():
 
 # ── 3. SessionStateMachine.update_focus (async) ─────────────────────
 def _patch_charge(monkeypatch, *, retention=0.5, enter=1.0, exit=0.3, hard_cap=99,
-                  idle_retention=0.9):
+                  idle_silent=0.95, idle_replied=0.6):
     monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", True)
     monkeypatch.setattr(config, "FOCUS_CHARGE_RETENTION", retention)
     monkeypatch.setattr(config, "FOCUS_CHARGE_ENTER", enter)
     monkeypatch.setattr(config, "FOCUS_CHARGE_EXIT", exit)
     monkeypatch.setattr(config, "FOCUS_HARD_CAP_TURNS", hard_cap)
-    monkeypatch.setattr(config, "FOCUS_IDLE_CHARGE_RETENTION", idle_retention)
+    monkeypatch.setattr(config, "FOCUS_IDLE_SILENT_RETENTION", idle_silent)
+    monkeypatch.setattr(config, "FOCUS_IDLE_REPLIED_RETENTION", idle_replied)
 
 
 async def test_sm_enter_and_exit_cycle(monkeypatch):
@@ -485,44 +487,59 @@ async def test_inline_focus_is_privacy_independent(monkeypatch):
     assert mgr.state.mode is CognitionMode.FOCUS
 
 
-async def test_idle_cooldown_decays_charge_slowly_never_enters(monkeypatch):
-    # A proactive (idle) tick NEVER raises the charge: it applies score=0 with
-    # the slower idle retention, so it can only cool an active episode down —
-    # never enter Focus from REGULAR.
-    _patch_charge(monkeypatch, retention=0.5, enter=1.0, idle_retention=0.9)
+async def test_idle_thinking_is_read_only(monkeypatch):
+    # _focus_idle_thinking reports whether we're in Focus WITHOUT mutating the
+    # charge — the decay is deferred to the post-turn cooldown.
+    _patch_charge(monkeypatch, enter=1.0)
     mgr = _bare_mgr()
-    await mgr.state.update_focus(0.8)  # REGULAR, charge ~0.8 (just under enter)
-    assert mgr.state.mode is CognitionMode.REGULAR
-    # idle tick decays by the slow idle retention (0.8 * 0.9 = 0.72), no enter
-    assert await mgr._focus_idle_decision() is False
-    assert mgr.state.mode is CognitionMode.REGULAR
-    assert abs(mgr.state.snapshot()["focus_charge"] - 0.72) < 1e-9
+    await mgr.state.update_focus(1.0)  # FOCUS
+    charge_before = mgr.state.snapshot()["focus_charge"]
+    assert mgr._focus_idle_thinking() is True
+    assert mgr.state.snapshot()["focus_charge"] == charge_before  # unchanged
+    # disabled → False (and no mutation here either)
+    monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", False)
+    assert mgr._focus_idle_thinking() is False
 
 
-async def test_idle_cooldown_eventually_exits_focus(monkeypatch):
-    # Inline drives entry; repeated idle cooldown ticks decay the charge until
-    # it falls below the exit bar and Focus ends.
-    _patch_charge(monkeypatch, retention=0.5, enter=1.0, exit=0.3, idle_retention=0.9)
+async def test_idle_cooldown_silent_decays_slower_than_replied(monkeypatch):
+    # A proactive turn never raises the charge. Staying silent (replied=False)
+    # decays slower than actually speaking (replied=True), and neither enters.
+    _patch_charge(monkeypatch, enter=1.0, idle_silent=0.95, idle_replied=0.6)
+    silent = _bare_mgr()
+    await silent.state.update_focus(0.8)  # REGULAR, charge 0.8
+    await silent._focus_idle_cooldown(replied=False)
+    assert silent.state.mode is CognitionMode.REGULAR
+    assert abs(silent.state.snapshot()["focus_charge"] - 0.8 * 0.95) < 1e-9
+
+    replied = _bare_mgr()
+    await replied.state.update_focus(0.8)
+    await replied._focus_idle_cooldown(replied=True)
+    assert replied.state.mode is CognitionMode.REGULAR
+    assert abs(replied.state.snapshot()["focus_charge"] - 0.8 * 0.6) < 1e-9
+
+
+async def test_idle_cooldown_replied_exits_focus_faster(monkeypatch):
+    # Inline drives entry; speaking proactive turns (replied=True) cool the
+    # episode down to the exit bar in a few ticks.
+    _patch_charge(monkeypatch, enter=1.0, exit=0.3, idle_replied=0.6)
     mgr = _bare_mgr()
-    await mgr.state.update_focus(1.0)  # inline enter
+    await mgr.state.update_focus(1.0)  # inline enter, charge cap 1.0
     assert mgr.state.mode is CognitionMode.FOCUS
-    # charge starts at cap 1.0; *0.9 per idle tick → crosses 0.3 after ~12 ticks
-    exited = False
-    for _ in range(20):
-        still = await mgr._focus_idle_decision()
-        if not still:
-            exited = True
-            break
-    assert exited and mgr.state.mode is CognitionMode.REGULAR
+    # 1.0 → 0.6 → 0.36 → 0.216 (<0.3) ⇒ exits on the 3rd replied tick
+    for _ in range(2):
+        await mgr._focus_idle_cooldown(replied=True)
+        assert mgr.state.mode is CognitionMode.FOCUS
+    await mgr._focus_idle_cooldown(replied=True)
+    assert mgr.state.mode is CognitionMode.REGULAR
 
 
-async def test_idle_gate_disabled_clears_regular_charge(monkeypatch):
+async def test_idle_cooldown_disabled_clears_regular_charge(monkeypatch):
     _patch_charge(monkeypatch, enter=1.0)
     mgr = _bare_mgr()
     await mgr.state.update_focus(0.6)
     assert mgr.state.snapshot()["focus_charge"] > 0
     monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", False)
-    assert await mgr._focus_idle_decision() is False
+    await mgr._focus_idle_cooldown(replied=False)
     assert mgr.state.snapshot()["focus_charge"] == 0.0
 
 

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -12,7 +12,9 @@ Coverage:
    language) scanning, topic-switch anchoring.
 5. ``stream_text`` thinking-on threading (Path A wiring).
 6. Idle cooldown: proactive ticks decay charge (two-tier retention by whether
-   the turn spoke), never enter; thinking read is mode-only.
+   the turn spoke), never enter; thinking read is mode-only; decay is pinned to
+   the observed episode + turn (skips on no-episode / episode-changed / inline
+   recharge of the same episode).
 """
 import os
 import sys
@@ -507,16 +509,17 @@ async def test_idle_cooldown_replied_exits_focus_faster(monkeypatch):
     _patch_charge(monkeypatch, enter=1.0, exit=0.3, idle_silent=0.95, idle_replied=0.6)
     mgr = _bare_mgr()
     await mgr.state.update_focus(1.0)  # inline enter, charge cap 1.0
-    tok = mgr.state.snapshot()["focus_episode_id"]
+    snap = mgr.state.snapshot()
+    tok, turn = snap["focus_episode_id"], snap["focus_turn_count"]
     assert mgr.state.mode is CognitionMode.FOCUS
     # silent tick barely moves it (×0.95); replied tick spends it (×0.6)
-    await mgr._focus_idle_cooldown(replied=False, episode_token=tok)
+    await mgr._focus_idle_cooldown(replied=False, episode_token=tok, turn_token=turn)
     assert abs(mgr.state.snapshot()["focus_charge"] - 0.95) < 1e-9
     # 0.95 → 0.57 → 0.342 → 0.2052 (<0.3) ⇒ exits on the 3rd replied tick
     for _ in range(2):
-        await mgr._focus_idle_cooldown(replied=True, episode_token=tok)
+        await mgr._focus_idle_cooldown(replied=True, episode_token=tok, turn_token=turn)
         assert mgr.state.mode is CognitionMode.FOCUS
-    await mgr._focus_idle_cooldown(replied=True, episode_token=tok)
+    await mgr._focus_idle_cooldown(replied=True, episode_token=tok, turn_token=turn)
     assert mgr.state.mode is CognitionMode.REGULAR
 
 
@@ -527,9 +530,10 @@ async def test_idle_cooldown_does_not_spend_hard_cap(monkeypatch):
     _patch_charge(monkeypatch, enter=1.0, exit=0.1, hard_cap=2, idle_silent=0.99)
     mgr = _bare_mgr()
     await mgr.state.update_focus(1.0)
-    tok = mgr.state.snapshot()["focus_episode_id"]
+    snap = mgr.state.snapshot()
+    tok, turn = snap["focus_episode_id"], snap["focus_turn_count"]
     for _ in range(5):  # > hard_cap, but cooldown doesn't bump turn_count
-        await mgr._focus_idle_cooldown(replied=False, episode_token=tok)
+        await mgr._focus_idle_cooldown(replied=False, episode_token=tok, turn_token=turn)
     assert mgr.state.mode is CognitionMode.FOCUS  # not force-exited by hard cap
     # entry set turn_count=1; cooldown ticks (count_turn=False) never bumped it
     assert mgr.state.snapshot()["focus_turn_count"] == 1
@@ -544,6 +548,46 @@ async def test_idle_cooldown_skips_when_episode_changed(monkeypatch):
     charge_now = mgr.state.snapshot()["focus_charge"]
     await mgr._focus_idle_cooldown(replied=True, episode_token="stale-other-episode")
     assert mgr.state.snapshot()["focus_charge"] == charge_now  # untouched
+
+
+async def test_idle_cooldown_skips_when_no_episode_observed(monkeypatch):
+    # A proactive turn that ran while REGULAR observes no episode (token=None).
+    # The cooldown must NOT erode the pre-entry accumulator the inline path is
+    # building toward ENTER — entering Focus is the inline path's job alone.
+    _patch_charge(monkeypatch, enter=1.0, idle_silent=0.95, idle_replied=0.6)
+    mgr = _bare_mgr()
+    await mgr.state.update_focus(0.6)  # REGULAR, charge building under the bar
+    assert mgr.state.mode is CognitionMode.REGULAR
+    snap = mgr.state.snapshot()
+    assert snap["focus_episode_id"] is None
+    charge_now = snap["focus_charge"]
+    await mgr._focus_idle_cooldown(
+        replied=True, episode_token=None, turn_token=snap["focus_turn_count"],
+    )
+    assert mgr.state.snapshot()["focus_charge"] == charge_now  # untouched
+    assert mgr.state.mode is CognitionMode.REGULAR
+
+
+async def test_idle_cooldown_skips_when_inline_recharged_same_episode(monkeypatch):
+    # Turn race within ONE episode: a user message lands mid-flight and the
+    # inline path recharges the same episode (turn count bumps). The stale
+    # proactive cooldown must not decay that fresh, user-driven charge — the
+    # turn-count token mismatch makes it a no-op even though the episode id matches.
+    _patch_charge(monkeypatch, retention=0.5, enter=1.0, idle_replied=0.6)
+    mgr = _bare_mgr()
+    await mgr.state.update_focus(1.0)  # FOCUS, episode A, turn_count 1
+    snap = mgr.state.snapshot()
+    ep_tok, turn_tok = snap["focus_episode_id"], snap["focus_turn_count"]
+    # Inline turn recharges the same episode while the proactive turn finishes.
+    await mgr.state.update_focus(0.5)  # same episode A, turn_count -> 2
+    fresh = mgr.state.snapshot()
+    assert fresh["focus_episode_id"] == ep_tok          # same episode
+    assert fresh["focus_turn_count"] != turn_tok        # but turn moved
+    charge_fresh = fresh["focus_charge"]
+    await mgr._focus_idle_cooldown(
+        replied=True, episode_token=ep_tok, turn_token=turn_tok,
+    )
+    assert mgr.state.snapshot()["focus_charge"] == charge_fresh  # not decayed
 
 
 async def test_idle_cooldown_disabled_clears_regular_charge(monkeypatch):

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -4,10 +4,11 @@ Coverage:
 1. ``_focus_decide`` pure leaky-accumulator transition: strong-single enter /
    scattered-cue accumulation / charge cap / decayed exit / noise-doesn't-stick /
    hard-cap exit / topic-switch exit-and-clear.
-2. ``FocusScorer``: keyword/cadence/silence/open_thread sub-signals, inline
-   vs idle path applicability + weight renormalisation, cadence baseline roll.
+2. ``FocusScorer`` (inline-only): keyword + cadence sub-signals, weight
+   renormalisation, cadence baseline roll.
 3. ``SessionStateMachine.update_focus``: async enter/exit, FOCUS_EXIT payload,
-   reset clearing, master-switch-off degradation.
+   retention override, reset clearing, master-switch-off degradation.
+6. Idle cooldown: proactive ticks decay charge (slow retention), never enter.
 4. ``prompts_focus`` lexicon scans: vulnerability count, cross-locale (mixed
    language) scanning, topic-switch anchoring.
 5. ``stream_text`` thinking-on threading (Path A wiring).
@@ -41,14 +42,6 @@ def _th(retention=0.5, enter=1.0, exit=0.3, hard_cap_turns=8, enabled=True):
     )
 
 
-class _Snap:
-    """Minimal ActivitySnapshot stand-in for the scorer (duck-typed)."""
-
-    def __init__(self, *, seconds_since_user_msg=None, unfinished_thread=None,
-                 open_threads=None):
-        self.seconds_since_user_msg = seconds_since_user_msg
-        self.unfinished_thread = unfinished_thread
-        self.open_threads = open_threads or []
 
 
 # ── 1. pure leaky-accumulator transition ───────────────────────────
@@ -170,19 +163,19 @@ def test_decide_hard_cap_yields_exactly_n_focus_turns():
     assert focus_turns == 4
 
 
-# ── 2. FocusScorer ──────────────────────────────────────────────────
+# ── 2. FocusScorer (inline-only: keyword + cadence) ─────────────────
 def test_scorer_keyword_inline():
     s = FocusScorer("x")
-    res = s.score(_Snap(), user_text="今天好累，感觉一个人撑不住了")
+    res = s.score(user_text="今天好累，感觉一个人撑不住了")
     assert res.signals["keyword"] is not None and res.signals["keyword"] > 0
-    assert res.signals["silence"] is None  # inline path: silence N/A
+    assert "silence" not in res.signals  # idle signals removed
     assert res.score > 0
 
 
 def test_scorer_no_signal_is_zero():
     s = FocusScorer("x")
-    res = s.score(_Snap(), user_text="嗯，那个文件我改好了发你了")
-    # No vulnerability keyword, no open thread, cadence not enough samples.
+    res = s.score(user_text="嗯，那个文件我改好了发你了")
+    # No vulnerability keyword; cadence not enough samples.
     assert res.signals["keyword"] == 0.0
     assert res.score == 0.0
 
@@ -191,55 +184,26 @@ def test_scorer_cadence_drop_after_baseline():
     s = FocusScorer("x")
     # Feed long messages to build a baseline (each call appends after scoring).
     for _ in range(4):
-        s.score(_Snap(), user_text="这是一段比较长的正常聊天消息内容大概三十个字符以上")
-    res = s.score(_Snap(), user_text="嗯。")
+        s.score(user_text="这是一段比较长的正常聊天消息内容大概三十个字符以上")
+    res = s.score(user_text="嗯。")
     assert res.signals["cadence"] is not None and res.signals["cadence"] > 0.5
 
 
 def test_scorer_cadence_none_without_baseline():
     s = FocusScorer("x")
-    res = s.score(_Snap(), user_text="嗯。")
+    res = s.score(user_text="嗯。")
     assert res.signals["cadence"] is None  # below FOCUS_CADENCE_MIN_SAMPLES
 
 
-def test_scorer_idle_silence_and_renorm():
-    s = FocusScorer("x")
-    # Idle path (user_text=None): only silence + open_thread apply.
-    res = s.score(_Snap(seconds_since_user_msg=config.FOCUS_SILENCE_FULL_SECONDS + 10),
-                  user_text=None)
-    assert res.signals["keyword"] is None and res.signals["cadence"] is None
-    assert res.signals["silence"] == 1.0
-    # silence weight 0.2 + open_thread 0.15 (=0) → renorm: 1.0*0.2/(0.35)=0.571
-    assert 0.5 < res.score < 0.62
-
-
-def test_scorer_open_thread_lifts_idle_score():
-    s = FocusScorer("x")
-    res = s.score(
-        _Snap(seconds_since_user_msg=config.FOCUS_SILENCE_FULL_SECONDS + 10,
-              open_threads=["上次没聊完的换工作的事"]),
-        user_text=None,
-    )
-    assert res.signals["open_thread"] == 1.0
-    assert res.score == 1.0  # both applicable idle signals saturated
-
-
-def test_scorer_open_thread_idle_only():
-    # On the inline path the just-arrived message has already cleared the
-    # tracker's unfinished_thread, so open_thread is N/A (None) there — it
-    # must not be a structural 0 that dilutes the inline average.
-    s = FocusScorer("x")
-    res = s.score(_Snap(open_threads=["残留的开放话题"]), user_text="今天好累")
-    assert res.signals["open_thread"] is None
-
-
 # ── 3. SessionStateMachine.update_focus (async) ─────────────────────
-def _patch_charge(monkeypatch, *, retention=0.5, enter=1.0, exit=0.3, hard_cap=99):
+def _patch_charge(monkeypatch, *, retention=0.5, enter=1.0, exit=0.3, hard_cap=99,
+                  idle_retention=0.9):
     monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", True)
     monkeypatch.setattr(config, "FOCUS_CHARGE_RETENTION", retention)
     monkeypatch.setattr(config, "FOCUS_CHARGE_ENTER", enter)
     monkeypatch.setattr(config, "FOCUS_CHARGE_EXIT", exit)
     monkeypatch.setattr(config, "FOCUS_HARD_CAP_TURNS", hard_cap)
+    monkeypatch.setattr(config, "FOCUS_IDLE_CHARGE_RETENTION", idle_retention)
 
 
 async def test_sm_enter_and_exit_cycle(monkeypatch):
@@ -521,18 +485,35 @@ async def test_inline_focus_is_privacy_independent(monkeypatch):
     assert mgr.state.mode is CognitionMode.FOCUS
 
 
-async def test_idle_gate_snapshot_none_preserves_charge(monkeypatch):
-    # No snapshot this idle tick (tracker unavailable / privacy nulls SCREEN
-    # data): the idle path skips scoring but must NOT clear the accumulator —
-    # the privacy-independent inline path keeps driving the episode, so
-    # clearing here would wipe a legitimate in-progress Focus.
-    _patch_charge(monkeypatch, enter=1.0)  # leaves FOCUS_MODE_ENABLED True
+async def test_idle_cooldown_decays_charge_slowly_never_enters(monkeypatch):
+    # A proactive (idle) tick NEVER raises the charge: it applies score=0 with
+    # the slower idle retention, so it can only cool an active episode down —
+    # never enter Focus from REGULAR.
+    _patch_charge(monkeypatch, retention=0.5, enter=1.0, idle_retention=0.9)
     mgr = _bare_mgr()
-    await mgr.state.update_focus(0.6)
-    _charge_before = mgr.state.snapshot()["focus_charge"]
-    assert _charge_before > 0
-    assert await mgr._focus_idle_decision(None) is False
-    assert mgr.state.snapshot()["focus_charge"] == _charge_before  # preserved
+    await mgr.state.update_focus(0.8)  # REGULAR, charge ~0.8 (just under enter)
+    assert mgr.state.mode is CognitionMode.REGULAR
+    # idle tick decays by the slow idle retention (0.8 * 0.9 = 0.72), no enter
+    assert await mgr._focus_idle_decision() is False
+    assert mgr.state.mode is CognitionMode.REGULAR
+    assert abs(mgr.state.snapshot()["focus_charge"] - 0.72) < 1e-9
+
+
+async def test_idle_cooldown_eventually_exits_focus(monkeypatch):
+    # Inline drives entry; repeated idle cooldown ticks decay the charge until
+    # it falls below the exit bar and Focus ends.
+    _patch_charge(monkeypatch, retention=0.5, enter=1.0, exit=0.3, idle_retention=0.9)
+    mgr = _bare_mgr()
+    await mgr.state.update_focus(1.0)  # inline enter
+    assert mgr.state.mode is CognitionMode.FOCUS
+    # charge starts at cap 1.0; *0.9 per idle tick → crosses 0.3 after ~12 ticks
+    exited = False
+    for _ in range(20):
+        still = await mgr._focus_idle_decision()
+        if not still:
+            exited = True
+            break
+    assert exited and mgr.state.mode is CognitionMode.REGULAR
 
 
 async def test_idle_gate_disabled_clears_regular_charge(monkeypatch):
@@ -541,5 +522,15 @@ async def test_idle_gate_disabled_clears_regular_charge(monkeypatch):
     await mgr.state.update_focus(0.6)
     assert mgr.state.snapshot()["focus_charge"] > 0
     monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", False)
-    assert await mgr._focus_idle_decision(_Snap(seconds_since_user_msg=300)) is False
+    assert await mgr._focus_idle_decision() is False
     assert mgr.state.snapshot()["focus_charge"] == 0.0
+
+
+async def test_update_focus_retention_override(monkeypatch):
+    # retention_override replaces FOCUS_CHARGE_RETENTION for one tick only.
+    _patch_charge(monkeypatch, retention=0.5, enter=1.0, exit=0.01)
+    sm = SessionStateMachine(lanlan_name="x")
+    await sm.update_focus(1.0)  # FOCUS, charge 1.0
+    # default retention would give 0.5; override 0.9 keeps it higher
+    await sm.update_focus(0.0, retention_override=0.9)
+    assert abs(sm.snapshot()["focus_charge"] - 0.9) < 1e-9

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -501,36 +501,49 @@ async def test_idle_thinking_is_read_only(monkeypatch):
     assert mgr._focus_idle_thinking() is False
 
 
-async def test_idle_cooldown_silent_decays_slower_than_replied(monkeypatch):
-    # A proactive turn never raises the charge. Staying silent (replied=False)
-    # decays slower than actually speaking (replied=True), and neither enters.
-    _patch_charge(monkeypatch, enter=1.0, idle_silent=0.95, idle_replied=0.6)
-    silent = _bare_mgr()
-    await silent.state.update_focus(0.8)  # REGULAR, charge 0.8
-    await silent._focus_idle_cooldown(replied=False)
-    assert silent.state.mode is CognitionMode.REGULAR
-    assert abs(silent.state.snapshot()["focus_charge"] - 0.8 * 0.95) < 1e-9
-
-    replied = _bare_mgr()
-    await replied.state.update_focus(0.8)
-    await replied._focus_idle_cooldown(replied=True)
-    assert replied.state.mode is CognitionMode.REGULAR
-    assert abs(replied.state.snapshot()["focus_charge"] - 0.8 * 0.6) < 1e-9
-
-
 async def test_idle_cooldown_replied_exits_focus_faster(monkeypatch):
     # Inline drives entry; speaking proactive turns (replied=True) cool the
-    # episode down to the exit bar in a few ticks.
-    _patch_charge(monkeypatch, enter=1.0, exit=0.3, idle_replied=0.6)
+    # episode down to the exit bar in a few ticks. Slow (silent) decays less.
+    _patch_charge(monkeypatch, enter=1.0, exit=0.3, idle_silent=0.95, idle_replied=0.6)
     mgr = _bare_mgr()
     await mgr.state.update_focus(1.0)  # inline enter, charge cap 1.0
+    tok = mgr.state.snapshot()["focus_episode_id"]
     assert mgr.state.mode is CognitionMode.FOCUS
-    # 1.0 → 0.6 → 0.36 → 0.216 (<0.3) ⇒ exits on the 3rd replied tick
+    # silent tick barely moves it (×0.95); replied tick spends it (×0.6)
+    await mgr._focus_idle_cooldown(replied=False, episode_token=tok)
+    assert abs(mgr.state.snapshot()["focus_charge"] - 0.95) < 1e-9
+    # 0.95 → 0.57 → 0.342 → 0.2052 (<0.3) ⇒ exits on the 3rd replied tick
     for _ in range(2):
-        await mgr._focus_idle_cooldown(replied=True)
+        await mgr._focus_idle_cooldown(replied=True, episode_token=tok)
         assert mgr.state.mode is CognitionMode.FOCUS
-    await mgr._focus_idle_cooldown(replied=True)
+    await mgr._focus_idle_cooldown(replied=True, episode_token=tok)
     assert mgr.state.mode is CognitionMode.REGULAR
+
+
+async def test_idle_cooldown_does_not_spend_hard_cap(monkeypatch):
+    # Idle cooldown ticks must NOT count toward FOCUS_HARD_CAP_TURNS (that bounds
+    # inline turns). With a tiny hard cap, many silent cooldowns stay in FOCUS as
+    # long as the charge holds, instead of force-exiting after hard_cap polls.
+    _patch_charge(monkeypatch, enter=1.0, exit=0.1, hard_cap=2, idle_silent=0.99)
+    mgr = _bare_mgr()
+    await mgr.state.update_focus(1.0)
+    tok = mgr.state.snapshot()["focus_episode_id"]
+    for _ in range(5):  # > hard_cap, but cooldown doesn't bump turn_count
+        await mgr._focus_idle_cooldown(replied=False, episode_token=tok)
+    assert mgr.state.mode is CognitionMode.FOCUS  # not force-exited by hard cap
+    # entry set turn_count=1; cooldown ticks (count_turn=False) never bumped it
+    assert mgr.state.snapshot()["focus_turn_count"] == 1
+
+
+async def test_idle_cooldown_skips_when_episode_changed(monkeypatch):
+    # Race guard: if the observed episode is no longer current (inline exited /
+    # re-entered while the proactive turn finished), the stale cooldown is a no-op.
+    _patch_charge(monkeypatch, enter=1.0, idle_replied=0.6)
+    mgr = _bare_mgr()
+    await mgr.state.update_focus(1.0)  # FOCUS, episode A
+    charge_now = mgr.state.snapshot()["focus_charge"]
+    await mgr._focus_idle_cooldown(replied=True, episode_token="stale-other-episode")
+    assert mgr.state.snapshot()["focus_charge"] == charge_now  # untouched
 
 
 async def test_idle_cooldown_disabled_clears_regular_charge(monkeypatch):
@@ -539,15 +552,17 @@ async def test_idle_cooldown_disabled_clears_regular_charge(monkeypatch):
     await mgr.state.update_focus(0.6)
     assert mgr.state.snapshot()["focus_charge"] > 0
     monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", False)
-    await mgr._focus_idle_cooldown(replied=False)
+    await mgr._focus_idle_cooldown(replied=False, episode_token=None)
     assert mgr.state.snapshot()["focus_charge"] == 0.0
 
 
-async def test_update_focus_retention_override(monkeypatch):
-    # retention_override replaces FOCUS_CHARGE_RETENTION for one tick only.
+async def test_update_focus_retention_override_and_count_turn(monkeypatch):
+    # retention_override replaces FOCUS_CHARGE_RETENTION for one tick; count_turn
+    # =False decays without bumping the hard-cap turn counter.
     _patch_charge(monkeypatch, retention=0.5, enter=1.0, exit=0.01)
     sm = SessionStateMachine(lanlan_name="x")
-    await sm.update_focus(1.0)  # FOCUS, charge 1.0
-    # default retention would give 0.5; override 0.9 keeps it higher
-    await sm.update_focus(0.0, retention_override=0.9)
-    assert abs(sm.snapshot()["focus_charge"] - 0.9) < 1e-9
+    await sm.update_focus(1.0)  # FOCUS, charge 1.0, turn_count 1
+    tc_before = sm.snapshot()["focus_turn_count"]
+    await sm.update_focus(0.0, retention_override=0.9, count_turn=False)
+    assert abs(sm.snapshot()["focus_charge"] - 0.9) < 1e-9  # override applied
+    assert sm.snapshot()["focus_turn_count"] == tc_before    # not bumped


### PR DESCRIPTION
承 #1815（已合并）。按需求调整凝神 idle 路径的语义。

## 原本 vs 现在
- **原本**：idle（proactive 主动搭话）路径用 `silence` + `open_thread` 作**正向**信号评分，会推高 charge——长沉默时 proactive 反而维持/拉高凝神，且 privacy/快照缺失时直接早退、累加器冻住（既不增也不减）。
- **现在**：proactive **绝不抬升**凝神。idle tick 只让 charge 以较慢的 retention（`FOCUS_IDLE_CHARGE_RETENTION=0.9` > inline 的 `0.5`）衰减。凝神的**进入/维持完全由 inline（用户自己说的话）驱动**，proactive 只做「降温」，让凝神在多次主动搭话间缓慢退去。

## 改动
- **config**：加 `FOCUS_IDLE_CHARGE_RETENTION=0.9`；`FOCUS_SIGNAL_WEIGHTS` 收窄为 `keyword+cadence`；退役 `FOCUS_SILENCE_MIN/FULL_SECONDS`（避免死配置）。
- **session_state.update_focus**：加 `retention_override`，仅 idle 路径传，替换该 tick 的 retention。
- **core._focus_idle_decision**：不再 score、不再吃 snapshot，改为 `update_focus(0.0, retention_override=FOCUS_IDLE_CHARGE_RETENTION)` 纯冷却。`score=0 + 衰减 ⇒` 永不从 REGULAR 进入，只让 inline 起的 episode 冷却到退出。
- **focus_scorer**：删 `_signal_silence` / `_signal_open_thread`，`score()` 去掉 `snapshot` 参数，变 inline-only。
- **system_router**：idle 调用去掉 snapshot 实参；删 `_focus_idle_snapshot`（`display_snap` 渲染仍保留 filtered `open_threads`）。
- **docs/design/focus-truename-mode.md**：蓝图同步——idle=cooldown、「she lingers」机制改为「慢衰减」而非「降低 idle 触发阈值」。

## 回归报告
- `tests/unit/test_focus_mode.py` + `test_session_state.py`：80 passed（删 silence/open_thread/idle-score 测试，新增 idle 冷却衰减 / 永不进入 / `retention_override` 测试）。
- docstring-cjk 守卫通过；语法检查通过。
- 默认仍 `FOCUS_MODE_ENABLED=False`，inert。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

- 优化凝神模式在空闲期间的保留逻辑，根据用户是否有回应调整衰减速率
- 精简凝神模式的触发评分机制
- 调整系统在主动和被动交互间的凝神状态管理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->