### PR TITLE
为 next-session 上下文缓存与去重记账本加失步自检

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1486,7 +1486,35 @@ class LLMSessionManager:
                 payload.get("_durable_cached")
                 or self._context_append_durable_cache_seen(payload)
             )
-            if durable_cache_remembered and self._context_append_durable_cache_contains(payload):
+            # 去重记账本（_context_append_durable_cache_*）与真缓存
+            # （next_session_context_messages）是两套独立结构：前者记“这条已写过”，
+            # 后者存实际内容，而后者会被 session-swap 的 _consume_next_session_context_messages
+            # 异步消费/清空。下面用 remembered（记账本）与 present（真缓存）双重核对决定是否
+            # 重写，本身能兜住失步、不丢上下文；但两者一旦失步是静默的，故在此显式自检并告警，
+            # 把“隐蔽失步”变成日志里可观测的信号（见 _consume_next_session_context_messages
+            # 不同步清记账本的设计债）。
+            durable_cache_present = self._context_append_durable_cache_contains(payload)
+            if durable_cache_remembered and not durable_cache_present:
+                # 记账本说写过、内容却没了：通常是 swap 消费了缓存而记账本（TTL 内）未清。
+                # 当前靠下方 present 核对兜底重写、不会丢；但若后续有人移除该核对、只信记账本，
+                # 这条上下文就会被误判“已写过”而静默丢失。出现此日志即代表两者已失步。
+                logger.warning(
+                    "[%s] durable context cache desync: dedup record present but content "
+                    "missing from next-session cache; re-appending (source=%s request_id=%s)",
+                    self.lanlan_name,
+                    payload.get("source"),
+                    payload.get("request_id"),
+                )
+            elif durable_cache_present and not durable_cache_remembered:
+                # 内容在、记账本却没记：这条会被当作首次写而重复入库，下个 session 可能看到两遍。
+                logger.warning(
+                    "[%s] durable context cache desync: content present but dedup record "
+                    "missing; may duplicate in next session (source=%s request_id=%s)",
+                    self.lanlan_name,
+                    payload.get("source"),
+                    payload.get("request_id"),
+                )
+            if durable_cache_remembered and durable_cache_present:
                 targets.append("new_session_cache")
             elif self._append_context_to_new_session_cache(role, content):
                 payload["_durable_cached"] = True

--- a/tests/unit/test_context_append_manager.py
+++ b/tests/unit/test_context_append_manager.py
@@ -1192,3 +1192,84 @@ async def test_append_context_applies_token_budget(monkeypatch):
     assert result.appended is True
     assert truncate_calls == 1
     assert history[0].content == "__sentinel_truncated_context__"
+
+
+@pytest.mark.asyncio
+async def test_durable_cache_desync_warns_and_reappends_when_swap_consumed_cache(monkeypatch):
+    # 失步窗口：when_ready 的 durable 上下文先入 next-session 缓存并记账，session swap
+    # 期间 _consume_next_session_context_messages 把内容消费走，但去重记账本（TTL 内）未清。
+    # readiness flush 重走 _append_context_to_targets 时应：(1) 自检告警两套结构失步，
+    # (2) 靠 present 二次核对兜底重写、不丢上下文。
+    mgr = _make_manager()
+    mgr.session_ready = False
+
+    warnings_seen = []
+    monkeypatch.setattr(
+        core_module.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warnings_seen.append(msg % args if args else msg),
+    )
+
+    queued = await mgr.append_context(
+        source="game.icebreaker",
+        role="assistant",
+        text="durable setup",
+        timing="when_ready",
+        lifetime="next_session",
+        request_id="durable-request",
+    )
+    assert queued.targets == ("pending_ready",)
+    assert mgr.next_session_context_messages == [{"role": "Lan", "text": "durable setup"}]
+    assert len(mgr.pending_context_appends) == 1
+
+    # 模拟 session swap 消费缓存（记账本不动）。
+    mgr._consume_next_session_context_messages(len(mgr.next_session_context_messages))
+    assert mgr.next_session_context_messages == []
+
+    mgr.session_ready = True
+    flushed = await mgr._flush_pending_context_appends()
+
+    assert flushed == 1
+    assert any("durable context cache desync" in str(msg) for msg in warnings_seen)
+    assert "content missing from next-session cache" in " ".join(str(m) for m in warnings_seen)
+    # 兜底重写，上下文没丢。
+    assert mgr.next_session_context_messages == [{"role": "Lan", "text": "durable setup"}]
+
+
+@pytest.mark.asyncio
+async def test_durable_cache_desync_warns_when_content_present_but_record_missing(monkeypatch):
+    # 反向失步：内容已在 next-session 缓存，但去重记账本没有对应记录（例如记账被清/未写成功）。
+    # 这条会被当作首次写而重复入库，应在重写前自检告警。
+    mgr = _make_manager()
+    mgr.next_session_context_messages = [{"role": "Lan", "text": "dup line"}]
+
+    warnings_seen = []
+    monkeypatch.setattr(
+        core_module.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warnings_seen.append(msg % args if args else msg),
+    )
+
+    payload = {
+        "source": "game.icebreaker",
+        "role": "assistant",
+        "text": "dup line",
+        "audience": "model",
+        "timing": "now",
+        "lifetime": "next_session",
+        "request_id": "dup-request",
+        "ordering_key": "",
+        "metadata": {},
+    }
+    result = await mgr._append_context_to_targets(payload)
+
+    assert result.appended is True
+    assert "new_session_cache" in result.targets
+    assert any(
+        "content present but dedup record" in str(msg) for msg in warnings_seen
+    )
+    # 记账缺失导致重复入库。
+    assert mgr.next_session_context_messages == [
+        {"role": "Lan", "text": "dup line"},
+        {"role": "Lan", "text": "dup line"},
+    ]


### PR DESCRIPTION
## 背景

#1877 引入的 durable 上下文去重用了**两套独立结构**：

- 去重记账本 `_context_append_durable_cache_*`：只记「这条 request_id 已写过」+ TTL
- 真缓存 `next_session_context_messages`：存实际要喂给下个 session 的内容

而真缓存会被 session-swap 的 `_consume_next_session_context_messages` 异步消费/清空，消费时**不同步清记账本**。两者一旦失步是**静默**的：记账本说「写过」、内容却已被消费 → 当前靠 `_append_context_to_targets` 里 `remembered + present` 的双重核对兜底重写、不丢；但若后续有人移除该核对、只信记账本，被误判「已写过」的上下文会**静默丢失**。

## 改动

在 `_append_context_to_targets` 的双重核对处加**双向失步自检**并 `logger.warning`，把隐蔽失步变成可观测信号。**纯加观测**：把 `contains` 求值提为一次无副作用调用，`if/elif` 分支逻辑不变。补两个测试覆盖两个失步方向。

## 回归报告

- **变更与必要性**：#1877 把 durable 上下文去重做成记账本 + 真缓存两套独立结构，消费真缓存时不同步清记账本，失步只能靠双重核对兜底、无任何信号。本 PR 加自检让失步可观测，为后续封装重构（`DurableContextCache`，让 consume 同步清去重）留日志验证网。
- **前后行为**：之前——失步发生时无日志、靠 `remembered && present` 双重核对兜底重写；之后——失步时记 `warning`（记账有/内容无、内容有/记账无两个方向），双重核对兜底逻辑**完全不变**。
- **潜在回归**：纯加观测层。把 `contains()` 求值从短路条件提为一次独立调用——`contains` 无副作用，故无功能差异；`remembered=false` 时多算一次 `contains`（扫描 next_session 缓存，体量极小可忽略）；失步时多两条 warning 日志。无行为回归，已由新增的两个失步方向测试 + 既有 39 个 manager 合约测试覆盖。

## 后续

根治方案是把真缓存 + 记账本 + TTL 封装成 `DurableContextCache`，让 `consume` 内部同步清去重，从结构上消除失步——作为 follow-up，本 PR 先上观测兜底。

## 测试
- `uv run pytest tests/unit/test_context_append_manager.py -q` → 39 passed（含新增 2）
- 回归套件 `test_new_user_icebreaker_context / test_game_router / test_topic_delivery / test_proactive_sm_integration / test_voice_session / test_game_llm_static_contracts` → 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)