### PR TITLE
修复 app-interpage.js 资源版本归属冲突（react_chat vs static）

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -67,7 +67,6 @@ _YUI_GUIDE_ASSET_VERSION_PATHS = (
     _PROJECT_ROOT / "static/app-ui.js",
     _PROJECT_ROOT / "static/common_ui.js",
     _PROJECT_ROOT / "static/common-ui-hud.js",
-    _PROJECT_ROOT / "static/i18n-i18next.js",
     _PROJECT_ROOT / "static/app-react-chat-window.js",
     _PROJECT_ROOT / "static/app-chat-export.js",
     _PROJECT_ROOT / "static/avatar-ui-buttons.js",

--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -65,7 +65,6 @@ _YUI_GUIDE_ASSET_VERSION_PATHS = (
     _PROJECT_ROOT / "static/i18n-i18next.js",
     _PROJECT_ROOT / "static/app-auto-goodbye.js",
     _PROJECT_ROOT / "static/app-ui.js",
-    _PROJECT_ROOT / "static/app-interpage.js",
     _PROJECT_ROOT / "static/common_ui.js",
     _PROJECT_ROOT / "static/common-ui-hud.js",
     _PROJECT_ROOT / "static/i18n-i18next.js",

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -2210,7 +2210,7 @@ def test_cat1_minimized_ball_inside_cat_finishes_without_side_retarget_jitter():
 
 
 def test_return_button_idle_tier_assets_are_version_tracked():
-    for path in (APP_UI_PATH, APP_INTERPAGE_PATH, COMMON_UI_HUD_PATH,
+    for path in (APP_UI_PATH, COMMON_UI_HUD_PATH,
                  APP_REACT_CHAT_WINDOW_PATH,
                  CAT1_ASSET_PATH, CAT1_CLICK_ASSET_PATH,
                  CAT2_ASSET_PATH, CAT2_CLICK_ASSET_PATH,
@@ -2230,6 +2230,12 @@ def test_return_button_idle_tier_assets_are_version_tracked():
                  *THOUGHT_BUBBLE_ITEM_ASSET_PATHS):
         assert path in pages_router._YUI_GUIDE_ASSET_VERSION_PATHS
         assert path.is_file()
+
+    # app-interpage.js 归 react_chat 版本体系：index/chat.html 用 react_chat_asset_version
+    # 给它打版本，其缓存失效由 _REACT_CHAT_ASSET_VERSION_PATHS 追踪，不再列入 static 来源清单
+    # （_YUI_GUIDE_ASSET_VERSION_PATHS），避免改动它无谓 bump 所有 static 资源版本。
+    assert APP_INTERPAGE_PATH in pages_router._REACT_CHAT_ASSET_VERSION_PATHS
+    assert APP_INTERPAGE_PATH.is_file()
 
 
 def test_sleep_sound_assets_match_current_tier_assignment():


### PR DESCRIPTION
## 背景

`main` 上单测 `test_react_chat_assets_use_react_chat_cache_version` 一直是红的，根因是 **两个静态契约测试互相矛盾**，没有纯代码修法：

- **react_chat 测试**（test_new_user_icebreaker_static_contracts.py:803,807）：index/chat.html 里 `app-interpage.js` 必须用 `react_chat_asset_version` 打版本（模板现状如此），且它在 `pages_router.py` 只能出现 **1 次**。
- **version_tracked 测试**（test_avatar_return_button_idle_tiers_static.py:2212）：`app-interpage.js` 必须在 `_YUI_GUIDE_ASSET_VERSION_PATHS`（该常量名有误导，实际产出 `static_asset_version`）里。

模板用 react_chat 版本 ⇒ 它必须进 `_REACT_CHAT` 清单（否则改它不刷新版本 = 真 cache bug）；version_tracked 又要它进 `_YUI_GUIDE` 清单；两个都进就出现 2 次，违反 count==1。**三者不可同时成立。** 这是 #1817「增强伴学图片题解答链路」引入的不一致。

## 改动

按「`app-interpage.js` 归 react_chat 版本体系」（顺应模板现状）消除冲突：

- 从 `_YUI_GUIDE_ASSET_VERSION_PATHS` 删除 `app-interpage.js`，使其只在 `_REACT_CHAT_ASSET_VERSION_PATHS` 出现一次。
- version_tracked 测试改为断言 `app-interpage.js` 在 `_REACT_CHAT_ASSET_VERSION_PATHS` 被追踪。
- 顺带删除 `_YUI_GUIDE_ASSET_VERSION_PATHS` 里 `i18n-i18next.js` 的重复项（dead duplicate，Greptile P2 标出）。

## 回归报告

- **变更与必要性**：#1817 把 `app-interpage.js` 加进 static 来源清单并新增 version_tracked 断言，与既有 react_chat 契约冲突，导致 main 上静态契约测试长期红、且无纯代码解。必须按版本归属（已选 react_chat，顺应模板事实）消歧。
- **前后行为**：之前——`app-interpage.js` 在 static + react_chat 两个版本清单各列一次，改动它会无谓 bump `static_asset_version`（连累所有 static 资源 cache-bust）；之后——只在 react_chat 清单，`static_asset_version` 不再被它影响，模板仍用 `react_chat_asset_version` 给它打版本（不变）。
- **潜在回归**：`app-interpage.js` 的 cache-bust 仍由 `react_chat_asset_version` 正确驱动（与模板一致），功能无损。`static_asset_version` 少算一个文件的 mtime——`static_asset_version` 取 `max(mtime)`，仅当该文件恰为 static 清单中最新时版本数值会变一次，不影响 cache 正确性（它已不属 static 资源）。i18n 重复项删除同理无功能影响（max 对重复不敏感）。已由两个曾冲突的测试转绿 + 相关 asset-version 测试组零净新增失败覆盖。

## 测试
- `test_new_user_icebreaker_static_contracts.py` + `test_return_button_idle_tier_assets_are_version_tracked` → 55 passed（两个曾冲突的测试现都绿）
- 相关 asset-version 静态测试组对比 baseline：零净新增失败，原本红的 `test_react_chat_assets_use_react_chat_cache_version` 转绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)