### PR TITLE
修复app-interpage.js 初始化中断问题，恢复“请她离开/回来”时聊天框进入再见状态，并补充 goodbye bridge 初始化…

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -32,6 +32,114 @@
     var _processedMsgKeys = {};
     var CROSS_WINDOW_IDLE_ACTIVITY_MIN_INTERVAL_MS = 250;
     var _lastCrossWindowIdleActivityAt = 0;
+    var YUI_GUIDE_CHAT_BRIDGE_QUEUE_KEY = 'neko_yui_guide_chat_bridge_queue_v1';
+    var ICEBREAKER_BRIDGE_STORAGE_KEY = 'neko_new_user_icebreaker_bridge_event';
+    var yuiGuideBridgeCommandBus = null;
+
+    function createAppInterpageScopedResources() {
+        if (
+            window.YuiGuideCommon
+            && typeof window.YuiGuideCommon.createScopedTutorialResources === 'function'
+        ) {
+            try {
+                return window.YuiGuideCommon.createScopedTutorialResources({ window: window });
+            } catch (error) {
+                console.warn('[YuiGuide] scoped resource helper unavailable; using local fallback:', error);
+            }
+        }
+
+        var destroyed = false;
+        var timers = [];
+        var intervals = [];
+        var listeners = [];
+
+        function removeFrom(list, value) {
+            var index = list.indexOf(value);
+            if (index !== -1) {
+                list.splice(index, 1);
+            }
+        }
+
+        function addEventListener(target, type, handler, options) {
+            if (destroyed || !target || typeof target.addEventListener !== 'function') {
+                return null;
+            }
+            target.addEventListener(type, handler, options);
+            listeners.push({
+                target: target,
+                type: type,
+                handler: handler,
+                options: options
+            });
+            return handler;
+        }
+
+        function setScopedTimeout(callback, delayMs) {
+            if (destroyed || typeof window.setTimeout !== 'function') {
+                return 0;
+            }
+            var timerId = window.setTimeout(function scopedTimeoutCallback() {
+                removeFrom(timers, timerId);
+                if (typeof callback === 'function') {
+                    callback();
+                }
+            }, delayMs);
+            timers.push(timerId);
+            return timerId;
+        }
+
+        function clearScopedTimeout(timerId) {
+            if (!timerId || typeof window.clearTimeout !== 'function') {
+                return;
+            }
+            removeFrom(timers, timerId);
+            window.clearTimeout(timerId);
+        }
+
+        function setScopedInterval(callback, delayMs) {
+            if (destroyed || typeof window.setInterval !== 'function') {
+                return 0;
+            }
+            var intervalId = window.setInterval(function scopedIntervalCallback() {
+                if (typeof callback === 'function') {
+                    callback();
+                }
+            }, delayMs);
+            intervals.push(intervalId);
+            return intervalId;
+        }
+
+        function clearScopedInterval(intervalId) {
+            if (!intervalId || typeof window.clearInterval !== 'function') {
+                return;
+            }
+            removeFrom(intervals, intervalId);
+            window.clearInterval(intervalId);
+        }
+
+        function destroy() {
+            destroyed = true;
+            timers.slice().forEach(clearScopedTimeout);
+            intervals.slice().forEach(clearScopedInterval);
+            listeners.splice(0).forEach(function (entry) {
+                try {
+                    entry.target.removeEventListener(entry.type, entry.handler, entry.options);
+                } catch (_) {}
+            });
+        }
+
+        return {
+            addEventListener: addEventListener,
+            setTimeout: setScopedTimeout,
+            clearTimeout: clearScopedTimeout,
+            setInterval: setScopedInterval,
+            clearInterval: clearScopedInterval,
+            destroy: destroy,
+            isDestroyed: function () { return destroyed; }
+        };
+    }
+
+    var yuiGuideInterpageResources = createAppInterpageScopedResources();
 
     /**
      * Returns true if this action+timestamp was already processed (duplicate).

--- a/tests/unit/test_app_auto_goodbye_phase1.py
+++ b/tests/unit/test_app_auto_goodbye_phase1.py
@@ -772,6 +772,109 @@ def test_goodbye_composer_hidden_syncs_to_chat_window():
     assert "postGoodbyeChatComposerHiddenState(false, 'return-click')" in app_ui_source
 
 
+def test_app_interpage_initializes_goodbye_bridge_exports_with_tutorial_bridge_fallback():
+    script = textwrap.dedent(
+        """
+        const fs = require('node:fs');
+        const vm = require('node:vm');
+        const source = fs.readFileSync(__APP_INTERPAGE_PATH__, 'utf8');
+        const listeners = {};
+        const storage = {
+          getItem() { return null; },
+          setItem() {},
+          removeItem() {}
+        };
+        const quietConsole = {
+          log() {},
+          warn() {},
+          error() {}
+        };
+        const windowStub = {
+          appState: { lanlan_name: 'Yui' },
+          appConst: {},
+          lanlan_config: { lanlan_name: 'Yui' },
+          location: { origin: 'http://localhost', pathname: '/chat' },
+          addEventListener(type, handler) { (listeners[type] ||= []).push(handler); },
+          removeEventListener() {},
+          dispatchEvent() {},
+          setTimeout,
+          clearTimeout,
+          setInterval,
+          clearInterval,
+          localStorage: storage,
+          console: quietConsole
+        };
+        windowStub.window = windowStub;
+
+        const documentStub = {
+          hidden: false,
+          body: { classList: { toggle() {}, add() {}, remove() {}, contains() { return false; } } },
+          head: { appendChild() {} },
+          documentElement: { appendChild() {} },
+          createElement() {
+            return {
+              hidden: false,
+              style: {},
+              classList: { add() {}, remove() {} },
+              setAttribute() {},
+              appendChild() {}
+            };
+          },
+          getElementById() { return null; },
+          querySelector() { return null; },
+          querySelectorAll() { return []; },
+          addEventListener(type, handler) { (listeners[`document:${type}`] ||= []).push(handler); },
+          removeEventListener() {}
+        };
+
+        class CustomEvent {
+          constructor(type, init) {
+            this.type = type;
+            this.detail = init && init.detail;
+          }
+        }
+        class BroadcastChannel {
+          constructor(name) { this.name = name; }
+          postMessage() {}
+          close() {}
+        }
+
+        const context = {
+          window: windowStub,
+          document: documentStub,
+          localStorage: storage,
+          console: quietConsole,
+          setTimeout,
+          clearTimeout,
+          setInterval,
+          clearInterval,
+          CustomEvent,
+          BroadcastChannel,
+          URL,
+          location: windowStub.location
+        };
+
+        try {
+          vm.runInNewContext(source, context, { filename: 'static/app-interpage.js' });
+        } catch (error) {
+          console.error(error && (error.stack || error.message) || error);
+          process.exit(1);
+        }
+
+        if (!windowStub.appInterpage || typeof windowStub.postGoodbyeChatComposerHiddenState !== 'function') {
+          process.exit(2);
+        }
+        windowStub.postGoodbyeChatComposerHiddenState(true, 'harness-goodbye');
+        if (!windowStub.__nekoGoodbyeChatComposerHidden || windowStub.__nekoGoodbyeChatComposerHidden.hidden !== true) {
+          process.exit(3);
+        }
+        """
+    ).replace("__APP_INTERPAGE_PATH__", json.dumps(str(APP_INTERPAGE_PATH)))
+
+    result = _run_node_harness(script)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
 def test_app_interpage_relays_idle_chat_minimized_state_to_pet_window():
     source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
…回归测试

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复请她回来按钮无法像以前一样让聊天框进入再见状态的问题

## 测试 / Testing

手动请她离开测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 新增跨页通信机制的测试用例，验证了桥接模块的初始化和回退路径

* **Chores**
  * 改进了跨页资源管理机制，增强了系统级通信的健壮性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->