### PR TITLE
fix(focus): 用户接管本轮时跳过 idle cooldown（#1887 Codex P2 follow-up）

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -53,7 +53,7 @@ from main_logic.tool_calling import (
     ToolResult,
 )
 from utils.llm_client import AIMessage, HumanMessage
-from main_logic.session_state import SessionStateMachine, SessionEvent, ProactivePhase, CognitionMode
+from main_logic.session_state import SessionStateMachine, SessionEvent, ProactivePhase, CognitionMode, TurnOwner
 from main_logic.lifecycle_bus import LifecycleEventBus
 from main_logic.proactive_delivery import (
     DELIVERY_RETRACTED_KEY,
@@ -2387,6 +2387,15 @@ class LLMSessionManager:
         this proactive turn observed when it made its thinking decision — the
         episode id and the turn count at Phase 2. The decay is SKIPPED unless the
         SM is STILL in that same episode AND no inline turn has landed since:
+          * the user already took over this turn (``owner is USER``) → the user
+            spoke during the proactive turn and aborted it. The inline path
+            marks USER_INPUT (owner→USER) the moment they speak, but its focus
+            update lands LATER (after mini-game / agent-callback handling), so
+            the episode + turn token still match here. This aborted proactive
+            tick must not decay the charge before the user's own message is
+            scored — that (user-driven) episode is the inline path's to update.
+            owner stays USER through PROACTIVE_DONE (which only clears a
+            PROACTIVE owner), so it is still observable at this point.
           * ``episode_token is None`` → the turn observed REGULAR (no active
             episode). There is nothing to cool, and a proactive tick must not
             erode the pre-entry accumulator the inline path is building toward
@@ -2410,6 +2419,17 @@ class LLMSessionManager:
             if not FOCUS_MODE_ENABLED:
                 # Master switch off → update_focus self-clears any residue.
                 await self.state.update_focus(0.0)
+                return
+            # User already took over this turn: they spoke during the proactive
+            # request (USER_INPUT flipped owner→USER) and aborted it, but their
+            # inline focus update has not landed yet, so the episode/turn token
+            # below would still match. Hand the charge to the imminent inline
+            # turn instead of decaying it with this aborted proactive tick.
+            if self.state.owner is TurnOwner.USER:
+                logger.debug(
+                    "[%s] focus idle cooldown skipped: user took over the turn",
+                    self.lanlan_name,
+                )
                 return
             # Only cool an episode this turn actually observed — never the
             # REGULAR pre-entry accumulator (entering Focus is inline-only).

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2387,15 +2387,20 @@ class LLMSessionManager:
         this proactive turn observed when it made its thinking decision — the
         episode id and the turn count at Phase 2. The decay is SKIPPED unless the
         SM is STILL in that same episode AND no inline turn has landed since:
-          * the user already took over this turn (``owner is USER``) → the user
-            spoke during the proactive turn and aborted it. The inline path
-            marks USER_INPUT (owner→USER) the moment they speak, but its focus
-            update lands LATER (after mini-game / agent-callback handling), so
-            the episode + turn token still match here. This aborted proactive
-            tick must not decay the charge before the user's own message is
-            scored — that (user-driven) episode is the inline path's to update.
-            owner stays USER through PROACTIVE_DONE (which only clears a
-            PROACTIVE owner), so it is still observable at this point.
+          * ``not replied`` AND the user already took over (``owner is USER``) →
+            the user spoke during an UNDELIVERED proactive turn and aborted it
+            before it said anything. The inline path marks USER_INPUT
+            (owner→USER) the moment they speak, but its focus update lands LATER
+            (after mini-game / agent-callback handling), so the episode + turn
+            token still match here. This aborted proactive tick must not decay
+            the charge before the user's own message is scored — that
+            (user-driven) episode is the inline path's to update. owner stays
+            USER through PROACTIVE_DONE (which only clears a PROACTIVE owner), so
+            it is still observable at this point. A turn that DID reply
+            (``replied=True``) genuinely spent the episode and still takes the
+            replied retention even if the user fired back fast enough to flip the
+            owner first; once the inline update actually lands the turn-token
+            guard below takes over.
           * ``episode_token is None`` → the turn observed REGULAR (no active
             episode). There is nothing to cool, and a proactive tick must not
             erode the pre-entry accumulator the inline path is building toward
@@ -2420,14 +2425,22 @@ class LLMSessionManager:
                 # Master switch off → update_focus self-clears any residue.
                 await self.state.update_focus(0.0)
                 return
-            # User already took over this turn: they spoke during the proactive
-            # request (USER_INPUT flipped owner→USER) and aborted it, but their
-            # inline focus update has not landed yet, so the episode/turn token
-            # below would still match. Hand the charge to the imminent inline
-            # turn instead of decaying it with this aborted proactive tick.
-            if self.state.owner is TurnOwner.USER:
+            # User took over an UNDELIVERED turn: the user spoke during the
+            # proactive request (USER_INPUT flipped owner→USER) and aborted it
+            # before it said anything, but their inline focus update has not
+            # landed yet, so the episode/turn token below would still match.
+            # Hand the charge to the imminent inline turn instead of decaying it
+            # with this aborted proactive tick.
+            #   Gated on ``not replied``: a turn that DID commit a reply
+            # (``replied=True``) genuinely spent the episode and must still take
+            # the replied retention even if the user fired back fast enough to
+            # flip the owner before this cooldown ran — owner==USER alone would
+            # wrongly let quick replies after a successful proactive chat skip
+            # their decay. (Once the inline focus update actually lands, the
+            # episode/turn-token guard below takes over.)
+            if not replied and self.state.owner is TurnOwner.USER:
                 logger.debug(
-                    "[%s] focus idle cooldown skipped: user took over the turn",
+                    "[%s] focus idle cooldown skipped: user took over an undelivered turn",
                     self.lanlan_name,
                 )
                 return

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -14,7 +14,7 @@ Coverage:
 6. Idle cooldown: proactive ticks decay charge (two-tier retention by whether
    the turn spoke), never enter; thinking read is mode-only; decay is pinned to
    the observed episode + turn (skips on no-episode / episode-changed / inline
-   recharge of the same episode).
+   recharge of the same episode / user takeover mid-turn).
 """
 import os
 import sys
@@ -32,6 +32,7 @@ from main_logic.session_state import (
     FocusThresholds,
     SessionEvent,
     SessionStateMachine,
+    TurnOwner,
     _focus_decide,
     _FocusAction,
 )
@@ -588,6 +589,26 @@ async def test_idle_cooldown_skips_when_inline_recharged_same_episode(monkeypatc
         replied=True, episode_token=ep_tok, turn_token=turn_tok,
     )
     assert mgr.state.snapshot()["focus_charge"] == charge_fresh  # not decayed
+
+
+async def test_idle_cooldown_skips_after_user_takeover(monkeypatch):
+    # User typed during the proactive turn: USER_INPUT flips owner→USER and
+    # aborts the turn, but the inline focus update lands LATER (after mini-game /
+    # agent-callback handling), so the episode + turn token still match when the
+    # aborted proactive turn runs its cooldown. That stale tick must not decay
+    # the charge before the user's own message is scored — owner==USER gates it.
+    _patch_charge(monkeypatch, enter=1.0, idle_silent=0.7, idle_replied=0.6)
+    mgr = _bare_mgr()
+    await mgr.state.update_focus(1.0)  # FOCUS, episode A, turn token unchanged
+    snap = mgr.state.snapshot()
+    ep_tok, turn_tok = snap["focus_episode_id"], snap["focus_turn_count"]
+    charge_now = snap["focus_charge"]
+    mgr.state.owner = TurnOwner.USER  # user took over mid-turn (USER_INPUT)
+    await mgr._focus_idle_cooldown(
+        replied=False, episode_token=ep_tok, turn_token=turn_tok,
+    )
+    assert mgr.state.snapshot()["focus_charge"] == charge_now  # not decayed
+    assert mgr.state.mode is CognitionMode.FOCUS
 
 
 async def test_idle_cooldown_disabled_clears_regular_charge(monkeypatch):

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -611,6 +611,24 @@ async def test_idle_cooldown_skips_after_user_takeover(monkeypatch):
     assert mgr.state.mode is CognitionMode.FOCUS
 
 
+async def test_idle_cooldown_replied_decays_even_when_owner_user(monkeypatch):
+    # A proactive turn that DID commit a reply (replied=True) genuinely spent the
+    # episode. Even if the user fired back fast enough to flip owner→USER before
+    # the cooldown ran (and the inline focus update hasn't landed yet, so the
+    # token still matches), the replied retention must STILL apply — the
+    # owner==USER shortcut is only for UNDELIVERED (replied=False) turns.
+    _patch_charge(monkeypatch, enter=1.0, idle_silent=0.7, idle_replied=0.6)
+    mgr = _bare_mgr()
+    await mgr.state.update_focus(1.0)  # FOCUS, charge 1.0
+    snap = mgr.state.snapshot()
+    ep_tok, turn_tok = snap["focus_episode_id"], snap["focus_turn_count"]
+    mgr.state.owner = TurnOwner.USER  # user fired back after the reply committed
+    await mgr._focus_idle_cooldown(
+        replied=True, episode_token=ep_tok, turn_token=turn_tok,
+    )
+    assert abs(mgr.state.snapshot()["focus_charge"] - 0.6) < 1e-9  # still decayed ×0.6
+
+
 async def test_idle_cooldown_disabled_clears_regular_charge(monkeypatch):
     _patch_charge(monkeypatch, enter=1.0)
     mgr = _bare_mgr()


### PR DESCRIPTION
承 #1887（已合并）。修 Codex 在 #1887 上留的最后一条 P2——idle cooldown 的 race guard 漏掉了「用户中途接管」这个窗口。

## 原本 vs 现在
- **原本**：用户在 Phase-2 proactive 进行中打字 → `stream_text` 先 `mark_user_input_preempt()` + fire `USER_INPUT`（`owner→USER`），proactive 被 abort。但 inline 的 focus 评分（`_focus_inline_decision`）发生在**更晚**（mini-game / agent-callback 处理之后）。所以走到 `_end_proactive` 调 cooldown 时，episode id 和 turn count **还没被 inline 改**，现有的 episode/turn-token guard 拦不住 → 这个被用户打断、作废的 proactive tick 仍然把 Focus charge 砍一道（×0.7），抢在用户自己那句话被评分之前。
- **现在**：cooldown 多一道 `owner is USER` 的 guard。会话已被用户接管 ⇒ 这一拍 proactive 是被用户打断作废的 ⇒ 把 charge 交给紧随其后的 inline turn 去处理，不用 stale 的 proactive tick 去衰减。

## 为什么 owner 在此刻可靠
`PROACTIVE_DONE` 只在 `owner is PROACTIVE` 时把 owner 翻回 `NONE`；被 `USER_INPUT` 抢占的话 owner 早已是 `USER` 并保持。所以即便 `_preempted` sticky flag 已被 `PROACTIVE_DONE` 清掉，`owner==USER` 在 cooldown 执行点依然是「本轮被用户接管」的可靠信号。正常 pass（无抢占）时 owner 是 `NONE`，不会误伤。

## 改动
- `main_logic/core.py`：`_focus_idle_cooldown` 在 episode/turn guard 之前加 `owner is USER` 跳过；import `TurnOwner`；docstring 同步。
- `tests/unit/test_focus_mode.py`：新增 `test_idle_cooldown_skips_after_user_takeover`。

## 回归报告
- `tests/unit/test_focus_mode.py` + `test_session_state.py`：**85 passed**（新增 1 个用户接管跳过测试）。
- docstring-cjk 守卫通过；`py_compile` 通过。
- 默认仍 `FOCUS_MODE_ENABLED=False`，inert。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了焦点模式的空闲冷却逻辑，当用户主动接管对话时，系统现在能准确保留焦点状态，避免焦点值被不必要地消耗。

* **Tests**
  * 新增单元测试以验证用户接管时焦点状态的正确保留。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->