### PR TITLE
feat(focus): 凝神指示灯 + 流式 <think> 剥离 + i18n（#1815 follow-up 3/4/6）

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -2130,6 +2130,7 @@ from config.providers import (  # noqa: E402, F401
     get_extra_body,
     get_agent_extra_body,
     focus_extra_body,
+    leaks_thinking_in_content,
 )
 
 
@@ -2176,6 +2177,7 @@ __all__ = [
     'get_extra_body',
     'get_agent_extra_body',
     'focus_extra_body',
+    'leaks_thinking_in_content',
     'EXTRA_BODY_OPENAI',
     'EXTRA_BODY_CLAUDE',
     'EXTRA_BODY_GEMINI',

--- a/config/providers.py
+++ b/config/providers.py
@@ -150,6 +150,23 @@ def focus_extra_body(model: str) -> dict | None:
     return kept or None
 
 
+def leaks_thinking_in_content(model: str) -> bool:
+    """True for models that stream chain-of-thought into ``content`` (not the
+    separate ``reasoning_content`` field), which a Focus (thinking-on) turn
+    would otherwise speak aloud.
+
+    Only the Qwen3.5/3.6/3.7 *hybrid* models do this — they emit the whole CoT
+    into ``content`` terminated by a lone ``</think>`` (see the leak note in
+    ``utils.llm_client``). The ``qwen3-vl-*`` vision models route reasoning to
+    ``reasoning_content`` and stay clean, so they are excluded. Used to gate
+    ``utils.llm_client.ThinkingStreamStripper`` onto the streaming path so clean
+    providers keep streaming untouched."""
+    m = (model or "").lower()
+    if "vl" in m:
+        return False
+    return any(tag in m for tag in ("qwen3.5", "qwen3.6", "qwen3.7"))
+
+
 # ────────────────────────────────────────────────────────────────
 # Cache Provider 配置（原 tests/test_cco_capacity.py PROVIDER_CACHE_CONFIG）
 # ────────────────────────────────────────────────────────────────

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1620,6 +1620,10 @@ function CompactChatApp({
   const [compactInputToolWheelChargeReleaseActive, setCompactInputToolWheelChargeReleaseActive] = useState(false);
   const [compactInputToolWheelChargeReleaseVisualStepOffset, setCompactInputToolWheelChargeReleaseVisualStepOffset] = useState(0);
   const [compactSurfaceResizeWidth, setCompactSurfaceResizeWidth] = useState<number | null>(null);
+  // Focus 凝神: subtle cognition indicator. Driven by the backend `focus_state`
+  // ws message (app-websocket.js → 'neko-focus-state' CustomEvent). Inert by
+  // default — the backend only emits it when FOCUS_MODE_ENABLED.
+  const [focusActive, setFocusActive] = useState(false);
   const [compactHistorySlotHeight, setCompactHistorySlotHeight] = useState<number | null>(readPersistedCompactHistorySlotHeight);
   const [compactHistoryResizeActive, setCompactHistoryResizeActive] = useState(false);
   const [compactHistoryResizeContentLocked, setCompactHistoryResizeContentLocked] = useState(false);
@@ -2573,6 +2577,19 @@ function CompactChatApp({
       window.removeEventListener('neko-assistant-turn-ending', handleAssistantTurnBoundary);
       window.removeEventListener('neko-assistant-turn-end', handleAssistantTurnBoundary);
       window.removeEventListener('neko-compact-caption-update', handleCompactCaptionUpdate);
+    };
+  }, []);
+
+  // Focus 凝神 indicator: reflect backend enter/exit. The bridge in
+  // app-websocket.js translates the `focus_state` ws message into this event.
+  useEffect(() => {
+    const handleFocusState = (event: Event) => {
+      const detail = (event as CustomEvent<{ active?: boolean }>).detail;
+      setFocusActive(Boolean(detail && detail.active));
+    };
+    window.addEventListener('neko-focus-state', handleFocusState);
+    return () => {
+      window.removeEventListener('neko-focus-state', handleFocusState);
     };
   }, []);
 
@@ -6490,7 +6507,20 @@ function CompactChatApp({
       data-compact-export-selected-count={isCompactSurface ? compactExportSelectedCount : 0}
       data-compact-export-auto-scroll={isCompactSurface && compactExportAutoScrollToBottom ? 'true' : 'false'}
       data-compact-tool-layer-open={isCompactSurface && compactInputToolFanOpen ? 'true' : 'false'}
+      data-focus-active={focusActive ? 'true' : 'false'}
     >
+      {focusActive ? (
+        <div
+          className="chat-surface-focus-indicator"
+          role="status"
+          aria-live="polite"
+          title={i18n('chat.focusIndicator', '凝神中')}
+        >
+          <span className="chat-surface-focus-indicator-label">
+            {i18n('chat.focusIndicator', '凝神中')}
+          </span>
+        </div>
+      ) : null}
       {compactExportHistoryNode}
       {compactHistoryVisibilityHandleNode}
       {compactMusicPlayerMountNode}

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -417,7 +417,7 @@ svg {
   margin: -1px;
   padding: 0;
   overflow: hidden;
-  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -388,6 +388,40 @@ svg {
   background: transparent;
 }
 
+/* Focus 凝神: 极隐"思考微光". A faint, slow-breathing inset glow on the chat
+   surface while the backend is in Focus (thinking-on). Deliberately subtle —
+   see docs/design/focus-truename-mode.md. Inset (not an outer box-shadow) so it
+   renders inside the surface in BOTH compact (overflow:visible) and full
+   (overflow:hidden) modes without being clipped. The .chat-window has no
+   box-shadow of its own in any mode, so nothing is stomped. Inert by default —
+   the backend only emits focus_state when FOCUS_MODE_ENABLED. */
+.app-shell[data-focus-active="true"] .chat-window {
+  animation: chat-surface-focus-breathe 4.2s ease-in-out infinite;
+}
+@keyframes chat-surface-focus-breathe {
+  0%, 100% { box-shadow: inset 0 0 0 0 rgba(150, 190, 255, 0); }
+  50% { box-shadow: inset 0 0 16px rgba(150, 190, 255, 0.28); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .app-shell[data-focus-active="true"] .chat-window {
+    animation: none;
+    box-shadow: inset 0 0 12px rgba(150, 190, 255, 0.2);
+  }
+}
+/* SR-only — gives assistive tech the "in Focus" tell without any visual text
+   (the glow above is the visual cue). */
+.chat-surface-focus-indicator {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .window-topbar {
   display: flex;
   align-items: center;

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2332,6 +2332,10 @@ class LLMSessionManager:
             # unrelated mild cue enter on stale evidence once re-enabled.
             # update_focus self-clears when the switch is off (idempotent).
             await self.state.update_focus(0.0)
+            # Reconcile AGAIN after the self-clear: if the switch was flipped off
+            # mid-episode, the clear above is silent (no FOCUS_EXIT), so clear the
+            # badge this turn rather than waiting for the next one.
+            await self._reconcile_focus_indicator()
             return False
         if not (user_text and user_text.strip()):
             return False
@@ -2486,6 +2490,9 @@ class LLMSessionManager:
             if not FOCUS_MODE_ENABLED:
                 # Master switch off → update_focus self-clears any residue.
                 await self.state.update_focus(0.0)
+                # Same-turn badge clear on a mid-episode switch-off (symmetric
+                # with the inline path); the self-clear emits no FOCUS_EXIT.
+                await self._reconcile_focus_indicator()
                 return
             # User took over an UNDELIVERED turn: the user spoke during the
             # proactive request (USER_INPUT flipped owner→USER) and aborted it

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1101,9 +1101,17 @@ class LLMSessionManager:
         self.state = SessionStateMachine(lanlan_name=lanlan_name)
         # Focus 凝神: mirror enter/exit to the frontend as a subtle cognition
         # indicator (极隐微光 badge — see react-neko-chat). Inert by default: the
-        # SM only emits FOCUS_ENTER / FOCUS_EXIT when FOCUS_MODE_ENABLED. The
-        # badge needs only on/off; memory consumes FOCUS_EXIT's episode payload
-        # on a separate (not-yet-wired) path.
+        # SM only enters Focus when FOCUS_MODE_ENABLED. The badge needs only
+        # on/off; memory consumes FOCUS_EXIT's episode payload on a separate
+        # (not-yet-wired) path.
+        #   Two layers keep the badge honest: (1) FOCUS_ENTER/EXIT subscriptions
+        # give immediate updates on the normal hysteresis path; (2) a per-turn
+        # reconcile (_reconcile_focus_indicator) catches Focus states dropped
+        # WITHOUT an event — clear_focus (history wipe) and the master-switch /
+        # privacy self-clear in update_focus — so the badge can't get stuck on.
+        # _push_focus_indicator is idempotent on this cached state so the two
+        # layers never double-fire.
+        self._focus_indicator_active = False
         self.state.subscribe(SessionEvent.FOCUS_ENTER, self._on_focus_transition)
         self.state.subscribe(SessionEvent.FOCUS_EXIT, self._on_focus_transition)
 
@@ -2311,6 +2319,10 @@ class LLMSessionManager:
         never blocks the user reply. Returns False fast when the master switch
         is off (skips the snapshot cost).
         """
+        # Reconcile the badge first — catches a Focus state cleared since the
+        # last turn without a FOCUS_EXIT event (clear_focus / master-switch
+        # self-clear), even on the early-return path when the switch is now off.
+        await self._reconcile_focus_indicator()
         from config import FOCUS_MODE_ENABLED  # live read (re-imported per call)
         if not FOCUS_MODE_ENABLED:
             # Flag flipped off → clear ALL focus residue unconditionally, not
@@ -2376,16 +2388,30 @@ class LLMSessionManager:
         return self.state.mode is CognitionMode.FOCUS
 
     async def _on_focus_transition(self, event: SessionEvent, payload: dict) -> None:
-        """SM subscriber: mirror a Focus enter/exit to the frontend as an
-        ephemeral cognition indicator (a subtle breathing glow — see
-        react-neko-chat). Registered on FOCUS_ENTER / FOCUS_EXIT only, so it is
-        inert unless FOCUS_MODE_ENABLED (the SM emits these only when the switch
-        is on). Ephemeral UI state: pushed live over the websocket and mirrored
-        to the sync queue for cross-server, but never persisted to history — the
-        badge is not conversation, and memory consumes FOCUS_EXIT's payload on a
-        separate path. Best-effort: a ws failure must never disturb the SM event
-        flow (``_dispatch_subscribers`` also swallows, this is belt-and-braces)."""
-        msg = {"type": "focus_state", "active": event is SessionEvent.FOCUS_ENTER}
+        """SM subscriber for FOCUS_ENTER / FOCUS_EXIT — immediate badge update on
+        the normal hysteresis path. Delegates to the idempotent push."""
+        await self._push_focus_indicator(event is SessionEvent.FOCUS_ENTER)
+
+    async def _reconcile_focus_indicator(self) -> None:
+        """Catch Focus states dropped WITHOUT a FOCUS_EXIT event (clear_focus
+        history-wipe, master-switch / privacy self-clear in update_focus) so the
+        badge can't get stuck on. Called once per turn; idempotent."""
+        await self._push_focus_indicator(self.state.mode is CognitionMode.FOCUS)
+
+    async def _push_focus_indicator(self, active: bool) -> None:
+        """Mirror the cognition indicator (focus_state) to the frontend — a
+        subtle breathing glow (see react-neko-chat). Idempotent on the cached
+        state so the event path and the per-turn reconcile never double-fire.
+        Ephemeral UI state: pushed live over the websocket and mirrored to the
+        sync queue for cross-server, but never persisted to history (the badge
+        is not conversation; memory consumes FOCUS_EXIT's payload separately).
+        Best-effort: a ws failure must never disturb the caller."""
+        # getattr default guards bypass-__init__ constructions (bare test mgrs,
+        # cross-server / unpickled managers) — they simply have no badge to sync.
+        if active == getattr(self, "_focus_indicator_active", False):
+            return
+        self._focus_indicator_active = active
+        msg = {"type": "focus_state", "active": active}
         try:
             self.sync_message_queue.put({"type": "json", "data": msg})
         except Exception as e:
@@ -2448,6 +2474,9 @@ class LLMSessionManager:
         hard-cap turn slot (that bounds inline turns). Pure charge cooldown:
         privacy-independent, no snapshot. Best-effort; never blocks the exit.
         """
+        # Idle-path counterpart to the inline reconcile — keeps the badge honest
+        # on proactive-only stretches (idempotent).
+        await self._reconcile_focus_indicator()
         from config import (  # live read
             FOCUS_MODE_ENABLED,
             FOCUS_IDLE_REPLIED_RETENTION,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1099,7 +1099,14 @@ class LLMSessionManager:
         # handle_new_message / stream_text 入口 / prepare_proactive_delivery /
         # finish_proactive_delivery / system_router.proactive_chat 等处。
         self.state = SessionStateMachine(lanlan_name=lanlan_name)
-        
+        # Focus 凝神: mirror enter/exit to the frontend as a subtle cognition
+        # indicator (极隐微光 badge — see react-neko-chat). Inert by default: the
+        # SM only emits FOCUS_ENTER / FOCUS_EXIT when FOCUS_MODE_ENABLED. The
+        # badge needs only on/off; memory consumes FOCUS_EXIT's episode payload
+        # on a separate (not-yet-wired) path.
+        self.state.subscribe(SessionEvent.FOCUS_ENTER, self._on_focus_transition)
+        self.state.subscribe(SessionEvent.FOCUS_EXIT, self._on_focus_transition)
+
         # 用户语言设置（由 start_session 或前端 set_user_language() 设置，初始为 None）
         self.user_language = None
         self._conversation_turn_language = None
@@ -2367,6 +2374,32 @@ class LLMSessionManager:
         if not FOCUS_MODE_ENABLED:
             return False
         return self.state.mode is CognitionMode.FOCUS
+
+    async def _on_focus_transition(self, event: SessionEvent, payload: dict) -> None:
+        """SM subscriber: mirror a Focus enter/exit to the frontend as an
+        ephemeral cognition indicator (a subtle breathing glow — see
+        react-neko-chat). Registered on FOCUS_ENTER / FOCUS_EXIT only, so it is
+        inert unless FOCUS_MODE_ENABLED (the SM emits these only when the switch
+        is on). Ephemeral UI state: pushed live over the websocket and mirrored
+        to the sync queue for cross-server, but never persisted to history — the
+        badge is not conversation, and memory consumes FOCUS_EXIT's payload on a
+        separate path. Best-effort: a ws failure must never disturb the SM event
+        flow (``_dispatch_subscribers`` also swallows, this is belt-and-braces)."""
+        msg = {"type": "focus_state", "active": event is SessionEvent.FOCUS_ENTER}
+        try:
+            self.sync_message_queue.put({"type": "json", "data": msg})
+        except Exception as e:
+            logger.debug("[%s] focus_state sync-queue push failed: %s", self.lanlan_name, e)
+        try:
+            ws = self.websocket
+            if ws and hasattr(ws, 'client_state') and ws.client_state == ws.client_state.CONNECTED:
+                if self.websocket_lock:
+                    async with self.websocket_lock:
+                        await ws.send_json(msg)
+                else:
+                    await ws.send_json(msg)
+        except Exception as e:
+            logger.debug("[%s] focus_state ws push failed: %s", self.lanlan_name, e)
 
     async def _focus_idle_cooldown(
         self, *, replied: bool, episode_token, turn_token=None,

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -19,7 +19,7 @@ import json
 import re
 import time
 from typing import Optional, Callable, Dict, Any, Awaitable, List
-from utils.llm_client import SystemMessage, HumanMessage, AIMessage, LLMStreamChunk, create_chat_llm, create_chat_llm_async
+from utils.llm_client import SystemMessage, HumanMessage, AIMessage, LLMStreamChunk, ThinkingStreamStripper, create_chat_llm, create_chat_llm_async
 from openai import APIConnectionError, AuthenticationError, InternalServerError, RateLimitError
 from utils.frontend_utils import calculate_text_similarity
 from utils.tokenize import count_tokens, truncate_to_tokens
@@ -2038,6 +2038,17 @@ class OmniOfflineClient:
                         _focus_overrides = self._focus_stream_overrides(
                             thinking_on, self._focus_images_seen, self.model,
                         )
+                        # Focus 凝神: leak-prone models (qwen3.5/3.6/3.7 hybrids)
+                        # stream their chain-of-thought into ``content`` ending in
+                        # a lone ``</think>``; hold + drop it before TTS/UI ever
+                        # see it. Clean providers (reasoning_content path) get no
+                        # stripper, so their streaming stays byte-for-byte untouched.
+                        from config.providers import leaks_thinking_in_content
+                        think_stripper = (
+                            ThinkingStreamStripper()
+                            if thinking_on and leaks_thinking_in_content(self.model)
+                            else None
+                        )
                         async for chunk in self._astream_visible_with_tools(
                             self._conversation_history, **_focus_overrides,
                         ):
@@ -2070,6 +2081,10 @@ class OmniOfflineClient:
                                 pipe_count = 0
                                 prefix_buffer = ""
                                 prefix_checked = not bool(self._prefix_buffer_size)
+                                if think_stripper is not None:
+                                    # New semantic unit after a tool round — the
+                                    # one-shot CoT preamble is behind us; don't hold.
+                                    think_stripper.reset()
                                 # Summary 状态收尾：cutover 之后的 tail 已经 UI-only
                                 # 发出去了，但 TTS 还没听到。tool 边界处不知道
                                 # post-tool 段会有多长，没法走"final < max+slack"
@@ -2108,6 +2123,10 @@ class OmniOfflineClient:
                                 break
 
                             content = chunk.content if hasattr(chunk, 'content') else str(chunk)
+                            if think_stripper is not None and content:
+                                # Holds CoT until the first </think>; returns "" while
+                                # buffering so the empty-content guard below skips it.
+                                content = think_stripper.feed(content)
 
                             if content and content.strip():
                                 truncated_content = content
@@ -2306,6 +2325,14 @@ class OmniOfflineClient:
                             elif content and not content.strip():
                                 logger.debug(f"OmniOfflineClient: 过滤空白内容 - content_repr: {repr(content)[:100]}")
 
+                        # 流结束后：先 flush thinking stripper 的残留。仅漏型
+                        # provider 的 thinking_on 轮挂了它；若整轮没出现 </think>
+                        # （模型本轮没思考），它一直 hold，这里把攒住的正文还回
+                        # prefix_buffer，走下面的通用 emit/guard 路径，避免丢答案。
+                        if think_stripper is not None:
+                            _think_residual = think_stripper.flush()
+                            if _think_residual:
+                                prefix_buffer += _think_residual
                         # 流结束后：flush 未处理的前缀缓冲区（走通用 emit/guard 路径）
                         if prefix_buffer and not prefix_checked:
                             prefix_checked = True

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -2052,10 +2052,15 @@ class OmniOfflineClient:
                         # a lone ``</think>``; hold + drop it before TTS/UI ever
                         # see it. Clean providers (reasoning_content path) get no
                         # stripper, so their streaming stays byte-for-byte untouched.
+                        # Gate on the SAME effective-thinking condition as
+                        # _focus_stream_overrides (``thinking_on and not uses_vision``):
+                        # a vision Focus turn runs thinking-OFF, so no </think> ever
+                        # arrives and a stripper would needlessly hold the stream.
                         from config.providers import leaks_thinking_in_content
                         think_stripper = (
                             ThinkingStreamStripper()
-                            if thinking_on and leaks_thinking_in_content(self.model)
+                            if thinking_on and not self._focus_images_seen
+                            and leaks_thinking_in_content(self.model)
                             else None
                         )
                         async for chunk in self._astream_visible_with_tools(

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -19,7 +19,7 @@ import json
 import re
 import time
 from typing import Optional, Callable, Dict, Any, Awaitable, List
-from utils.llm_client import SystemMessage, HumanMessage, AIMessage, LLMStreamChunk, ThinkingStreamStripper, create_chat_llm, create_chat_llm_async
+from utils.llm_client import SystemMessage, HumanMessage, AIMessage, LLMStreamChunk, ThinkingStreamStripper, strip_thinking_segments, create_chat_llm, create_chat_llm_async
 from openai import APIConnectionError, AuthenticationError, InternalServerError, RateLimitError
 from utils.frontend_utils import calculate_text_similarity
 from utils.tokenize import count_tokens, truncate_to_tokens
@@ -1029,7 +1029,13 @@ class OmniOfflineClient:
                 calls = _ChatOpenAI.collect_tool_calls(deltas_per_chunk)
                 await self._execute_and_append_openai_tool_calls(
                     messages, calls,
-                    assistant_text=streamed_text_buffer,
+                    # Strip any leaked <think> CoT before it lands in history:
+                    # the streaming guard (ThinkingStreamStripper) only protects
+                    # TTS/UI; this assembled pre-tool text is persisted raw to the
+                    # assistant tool-call turn, so a leak-prone Focus turn would
+                    # otherwise carry CoT into the next turn's context. No-op on
+                    # clean replies (no think tag present).
+                    assistant_text=strip_thinking_segments(streamed_text_buffer),
                     assistant_reasoning=streamed_reasoning_buffer,
                 )
                 # 通知上游 ``stream_text``：本轮的 pre-tool text + tool_calls
@@ -1317,7 +1323,10 @@ class OmniOfflineClient:
                 # 会重复前缀或改口，最终持久化历史的顺序也跟真实生成顺序对不上。
                 messages.append({
                     "role": "assistant",
-                    "content": streamed_text_buffer,
+                    # Symmetric with the OpenAI path: strip leaked <think> CoT
+                    # before persisting the pre-tool text to history (no-op on
+                    # clean replies / the genai path, which routes thought out).
+                    "content": strip_thinking_segments(streamed_text_buffer),
                     "tool_calls": tool_calls_dict,
                 })
                 for i, (tc_id, tc_name, tc_args, tc_raw) in enumerate(collected_tool_calls):
@@ -2082,8 +2091,18 @@ class OmniOfflineClient:
                                 prefix_buffer = ""
                                 prefix_checked = not bool(self._prefix_buffer_size)
                                 if think_stripper is not None:
-                                    # New semantic unit after a tool round — the
-                                    # one-shot CoT preamble is behind us; don't hold.
+                                    # Flush before reset: if this pre-tool segment
+                                    # never emitted </think>, the stripper is still
+                                    # holding real answer text it withheld from
+                                    # TTS/UI. The inner generator already persisted
+                                    # that text to history (stripped), so emit it to
+                                    # TTS/UI only here — dropping it (a bare reset)
+                                    # would lose the pre-tool sentence. Then re-arm
+                                    # for the post-tool segment (new semantic unit).
+                                    _pretool_residual = think_stripper.flush()
+                                    if _pretool_residual and _pretool_residual.strip() and self.on_text_delta:
+                                        await self.on_text_delta(_pretool_residual, is_first_chunk)
+                                        is_first_chunk = False
                                     think_stripper.reset()
                                 # Summary 状态收尾：cutover 之后的 tail 已经 UI-only
                                 # 发出去了，但 TTS 还没听到。tool 边界处不知道

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -2333,6 +2333,16 @@ class OmniOfflineClient:
                             _think_residual = think_stripper.flush()
                             if _think_residual:
                                 prefix_buffer += _think_residual
+                                # Force the unified flush below to run on this
+                                # residual. When prefix checking is disabled
+                                # (_prefix_buffer_size == 0) prefix_checked starts
+                                # True, so `and not prefix_checked` would otherwise
+                                # drop the held answer silently. Safe to clear: a
+                                # non-empty residual means no </think> ever arrived,
+                                # which only happens when the stripper held the whole
+                                # stream → prefix_buffer was never filled by the live
+                                # path, so prefix_checked carried no completed state.
+                                prefix_checked = False
                         # 流结束后：flush 未处理的前缀缓冲区（走通用 emit/guard 路径）
                         if prefix_buffer and not prefix_checked:
                             prefix_checked = True

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -55,7 +55,7 @@ from uuid import uuid4
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, Response
 from openai import APIConnectionError, InternalServerError, RateLimitError
-from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm_async
+from utils.llm_client import SystemMessage, HumanMessage, ThinkingStreamStripper, create_chat_llm_async
 from utils.tokenize import count_tokens
 import ssl
 import httpx
@@ -84,6 +84,7 @@ from config import (
     MEMORY_SERVER_PORT,
     get_extra_body,
     focus_extra_body,
+    leaks_thinking_in_content,
     PROACTIVE_PHASE1_FETCH_PER_SOURCE,
     PROACTIVE_PHASE1_TOTAL_TOPICS,
     PROACTIVE_EXTERNAL_PER_ITEM_MAX_TOKENS,
@@ -6717,6 +6718,16 @@ async def proactive_chat(request: Request):
             full_text += text
             return False
         
+        # Focus 凝神: idle/proactive counterpart to OmniOfflineClient's inline
+        # stripper — text-mode Phase-2 also streams thinking-on (disable_thinking
+        # False). Strip leaked <think> CoT before it reaches TTS/UI for leak-prone
+        # models (qwen3.5/3.6/3.7 hybrids). Symmetric with the inline path; None
+        # (no wrapping) for clean providers or thinking-off turns → zero impact.
+        _p2_strip = (
+            ThinkingStreamStripper()
+            if (not phase2_disable_thinking) and leaks_thinking_in_content(conversation_model)
+            else None
+        )
         try:
             async with asyncio.timeout(25.0):
                 # 使用 async with 确保 ChatOpenAI 正确关闭
@@ -6732,9 +6743,13 @@ async def proactive_chat(request: Request):
                             aborted = True
                             break
                         content = chunk.content if hasattr(chunk, 'content') else ''
+                        if _p2_strip is not None and content:
+                            # Holds CoT until the first </think>; returns "" while
+                            # buffering so the skip below drops the held chunk.
+                            content = _p2_strip.feed(content)
                         if not content:
                             continue
-                        
+
                         if not tag_parsed:
                             buffer += content
                             # 缓冲前 ~80 字符，解析 "主动搭话" 前缀和来源标签
@@ -6801,7 +6816,17 @@ async def proactive_chat(request: Request):
             else:
                 await _emit_safe(pass_probe)
         pass_probe = ""
-        
+
+        # Focus: flush the stripper's held answer. Non-empty only when no
+        # </think> ever arrived (the model didn't think this turn) — which means
+        # the tag was never parsed and nothing flowed through pass_probe, so feed
+        # it into `buffer` and let the unparsed-buffer block below tag-parse +
+        # emit it (symmetric with the inline path's prefix_buffer flush).
+        if _p2_strip is not None and not aborted:
+            _p2_residual = _p2_strip.flush()
+            if _p2_residual:
+                buffer += _p2_residual
+
         # --- 流结束后 buffer 未 flush 的兜底处理 ---
         if not tag_parsed and buffer and not aborted:
             cleaned = buffer

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1946,6 +1946,16 @@
                         window.handleCatgirlSwitch(newCatgirl, oldCatgirl);
                     }
 
+                // -------- focus_state (凝神 indicator) --------
+                // Backend mirrors Focus enter/exit (LLMSessionManager
+                // ._on_focus_transition). Re-dispatch as a CustomEvent the React
+                // chat window listens for to toggle its subtle 思考微光 glow.
+                // Inert by default — only emitted when FOCUS_MODE_ENABLED.
+                } else if (response.type === 'focus_state') {
+                    window.dispatchEvent(new CustomEvent('neko-focus-state', {
+                        detail: { active: !!response.active },
+                    }));
+
                 // -------- status --------
                 } else if (response.type === 'status') {
                     var statusCode = null;

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "Failed to mount the chat window",
         "reactWindowLoadFailed": "Failed to load chat window resources",
         "reactWindowAriaLabel": "Neko chat window",
+        "focusIndicator": "In focus",
         "reactWindowInputHint": "Press Enter to send, Shift + Enter for a new line",
         "messageListAriaLabel": "Chat messages",
         "composerToolsAriaLabel": "Composer tools",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "No se pudo montar la ventana de chat",
         "reactWindowLoadFailed": "No se pudieron cargar recursos de la ventana de chat",
         "reactWindowAriaLabel": "Ventana de chat de Neko",
+        "focusIndicator": "Concentrada",
         "reactWindowInputHint": "Presione Enter para enviar, Shift + Enter para una nueva línea",
         "messageListAriaLabel": "mensajes de chat",
         "composerToolsAriaLabel": "Herramientas del compositor",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "チャットウィンドウのマウントに失敗しました",
         "reactWindowLoadFailed": "チャットウィンドウのリソース読み込みに失敗しました",
         "reactWindowAriaLabel": "Neko チャットウィンドウ",
+        "focusIndicator": "集中モード",
         "reactWindowInputHint": "Enter で送信、Shift + Enter で改行",
         "messageListAriaLabel": "チャットメッセージ一覧",
         "composerToolsAriaLabel": "入力ツールバー",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "채팅 창 마운트에 실패했습니다",
         "reactWindowLoadFailed": "채팅 창 리소스를 불러오지 못했습니다",
         "reactWindowAriaLabel": "Neko 채팅 창",
+        "focusIndicator": "집중 모드",
         "reactWindowInputHint": "Enter 로 전송하고 Shift + Enter 로 줄바꿈",
         "messageListAriaLabel": "채팅 메시지 목록",
         "composerToolsAriaLabel": "입력 도구 모음",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "Falha ao montar a janela de bate-papo",
         "reactWindowLoadFailed": "Falha ao carregar recursos da janela de bate-papo",
         "reactWindowAriaLabel": "Janela de bate-papo Neko",
+        "focusIndicator": "Concentrada",
         "reactWindowInputHint": "Pressione Enter para enviar, Shift + Enter para uma nova linha",
         "messageListAriaLabel": "Mensagens de bate-papo",
         "composerToolsAriaLabel": "Ferramentas do compositor",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "Не удалось встроить окно чата",
         "reactWindowLoadFailed": "Не удалось загрузить ресурсы окна чата",
         "reactWindowAriaLabel": "Окно чата Neko",
+        "focusIndicator": "Сосредоточена",
         "reactWindowInputHint": "Enter для отправки, Shift + Enter для новой строки",
         "messageListAriaLabel": "Список сообщений чата",
         "composerToolsAriaLabel": "Инструменты ввода",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "聊天框挂载失败",
         "reactWindowLoadFailed": "聊天框资源加载失败",
         "reactWindowAriaLabel": "Neko 聊天窗口",
+        "focusIndicator": "凝神中",
         "reactWindowInputHint": "Enter 发送，Shift + Enter 换行",
         "messageListAriaLabel": "聊天消息列表",
         "composerToolsAriaLabel": "输入工具栏",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -768,6 +768,7 @@
         "reactWindowMountFailed": "聊天框掛載失敗",
         "reactWindowLoadFailed": "聊天框資源加載失敗",
         "reactWindowAriaLabel": "Neko 聊天視窗",
+        "focusIndicator": "凝神中",
         "reactWindowInputHint": "Enter 發送，Shift + Enter 換行",
         "messageListAriaLabel": "聊天訊息列表",
         "composerToolsAriaLabel": "輸入工具列",

--- a/tests/unit/test_focus_indicator_bridge.py
+++ b/tests/unit/test_focus_indicator_bridge.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 """Focus (thinking-on) -> frontend indicator bridge.
 
-``LLMSessionManager._on_focus_transition`` is the SM subscriber that mirrors a
-Focus enter/exit to the frontend as an ephemeral ``focus_state`` message (the
-subtle breathing badge). It pushes on/off only — no episode payload — and must
-not raise even with no live websocket.
+The cognition badge is driven by ``LLMSessionManager._push_focus_indicator``
+(idempotent on a cached on/off state). Two layers feed it: the
+``FOCUS_ENTER``/``FOCUS_EXIT`` subscription (``_on_focus_transition``, immediate)
+and a per-turn ``_reconcile_focus_indicator`` that mirrors ``state.mode`` so a
+silent clear (clear_focus / master-switch self-clear, which emit no FOCUS_EXIT)
+can't leave the badge stuck on. It pushes on/off only — no episode payload — and
+must not raise with no live websocket.
 """
 import asyncio
 import os
@@ -14,7 +17,7 @@ import types
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
 from main_logic.core import LLMSessionManager
-from main_logic.session_state import SessionEvent
+from main_logic.session_state import CognitionMode, SessionEvent
 
 
 class _RecordingQueue:
@@ -25,33 +28,72 @@ class _RecordingQueue:
         self.items.append(item)
 
 
-def _bound_handler():
+def _stub(mode=CognitionMode.REGULAR):
     stub = types.SimpleNamespace(
         sync_message_queue=_RecordingQueue(),
         websocket=None,            # no live ws → ws branch is skipped, never raises
         websocket_lock=None,
         lanlan_name="测试娘",
+        _focus_indicator_active=False,
+        state=types.SimpleNamespace(mode=mode),
     )
-    return stub, LLMSessionManager._on_focus_transition.__get__(stub, LLMSessionManager)
+    # _on_focus_transition / _reconcile delegate to _push_focus_indicator via
+    # self — attach it so the delegation resolves on the bare stub.
+    stub._push_focus_indicator = LLMSessionManager._push_focus_indicator.__get__(
+        stub, LLMSessionManager
+    )
+    return stub
+
+
+def _bind(stub, name):
+    return getattr(LLMSessionManager, name).__get__(stub, LLMSessionManager)
+
+
+def _pushed(stub):
+    return [m["data"] for m in stub.sync_message_queue.items if m.get("type") == "json"]
 
 
 def test_enter_then_exit_pushes_active_on_off():
-    stub, handler = _bound_handler()
+    stub = _stub()
+    handler = _bind(stub, "_on_focus_transition")
     asyncio.run(handler(SessionEvent.FOCUS_ENTER, {"episode_id": "e1", "score": 0.9}))
     asyncio.run(handler(SessionEvent.FOCUS_EXIT, {"episode_id": "e1", "reason": "topic_switch"}))
-
-    datas = [m["data"] for m in stub.sync_message_queue.items if m.get("type") == "json"]
-    assert datas == [
+    assert _pushed(stub) == [
         {"type": "focus_state", "active": True},
         {"type": "focus_state", "active": False},
     ]
 
 
 def test_payload_is_ignored_only_on_off_carried():
-    # The badge needs on/off only; the episode payload (used by memory) must not
-    # leak into the frontend message.
-    stub, handler = _bound_handler()
+    stub = _stub()
+    handler = _bind(stub, "_on_focus_transition")
     asyncio.run(handler(SessionEvent.FOCUS_ENTER, {"episode_id": "secret", "charge": 1.4}))
     msg = stub.sync_message_queue.items[0]["data"]
     assert set(msg.keys()) == {"type", "active"}
     assert msg["active"] is True
+
+
+def test_push_is_idempotent_on_cached_state():
+    stub = _stub()
+    push = _bind(stub, "_push_focus_indicator")
+    asyncio.run(push(True))
+    asyncio.run(push(True))   # no change → no second push
+    asyncio.run(push(False))
+    asyncio.run(push(False))  # no change → no second push
+    assert _pushed(stub) == [
+        {"type": "focus_state", "active": True},
+        {"type": "focus_state", "active": False},
+    ]
+
+
+def test_reconcile_clears_badge_after_silent_focus_drop():
+    # Badge is on; a silent clear (clear_focus) drops state.mode to REGULAR
+    # without a FOCUS_EXIT event. The per-turn reconcile must push it off.
+    stub = _stub(mode=CognitionMode.FOCUS)
+    stub._focus_indicator_active = True
+    reconcile = _bind(stub, "_reconcile_focus_indicator")
+    asyncio.run(reconcile())                      # mode still FOCUS → no-op
+    assert _pushed(stub) == []
+    stub.state.mode = CognitionMode.REGULAR       # silent clear happened
+    asyncio.run(reconcile())
+    assert _pushed(stub) == [{"type": "focus_state", "active": False}]

--- a/tests/unit/test_focus_indicator_bridge.py
+++ b/tests/unit/test_focus_indicator_bridge.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Focus (thinking-on) -> frontend indicator bridge.
+
+``LLMSessionManager._on_focus_transition`` is the SM subscriber that mirrors a
+Focus enter/exit to the frontend as an ephemeral ``focus_state`` message (the
+subtle breathing badge). It pushes on/off only — no episode payload — and must
+not raise even with no live websocket.
+"""
+import asyncio
+import os
+import sys
+import types
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from main_logic.core import LLMSessionManager
+from main_logic.session_state import SessionEvent
+
+
+class _RecordingQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+def _bound_handler():
+    stub = types.SimpleNamespace(
+        sync_message_queue=_RecordingQueue(),
+        websocket=None,            # no live ws → ws branch is skipped, never raises
+        websocket_lock=None,
+        lanlan_name="测试娘",
+    )
+    return stub, LLMSessionManager._on_focus_transition.__get__(stub, LLMSessionManager)
+
+
+def test_enter_then_exit_pushes_active_on_off():
+    stub, handler = _bound_handler()
+    asyncio.run(handler(SessionEvent.FOCUS_ENTER, {"episode_id": "e1", "score": 0.9}))
+    asyncio.run(handler(SessionEvent.FOCUS_EXIT, {"episode_id": "e1", "reason": "topic_switch"}))
+
+    datas = [m["data"] for m in stub.sync_message_queue.items if m.get("type") == "json"]
+    assert datas == [
+        {"type": "focus_state", "active": True},
+        {"type": "focus_state", "active": False},
+    ]
+
+
+def test_payload_is_ignored_only_on_off_carried():
+    # The badge needs on/off only; the episode payload (used by memory) must not
+    # leak into the frontend message.
+    stub, handler = _bound_handler()
+    asyncio.run(handler(SessionEvent.FOCUS_ENTER, {"episode_id": "secret", "charge": 1.4}))
+    msg = stub.sync_message_queue.items[0]["data"]
+    assert set(msg.keys()) == {"type", "active"}
+    assert msg["active"] is True

--- a/tests/unit/test_thinking_stream_stripper.py
+++ b/tests/unit/test_thinking_stream_stripper.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""``ThinkingStreamStripper`` — streaming-safe sibling of
+``strip_thinking_segments``.
+
+Focus (thinking-on) turns stream token-by-token straight into TTS + UI, so the
+Qwen3.5/3.6/3.7 hybrid leak (whole chain-of-thought dumped into ``content``
+ending in a lone ``</think>``) can't wait for the non-streaming cleanup. The
+stripper holds content until the first close tag, drops everything up to and
+including it, then passes the real answer through. Clean providers route
+reasoning to ``reasoning_content`` and never get a stripper (see
+``leaks_thinking_in_content``).
+"""
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from config.providers import leaks_thinking_in_content
+from utils.llm_client import ThinkingStreamStripper
+
+
+def _drain(chunks):
+    """Feed ``chunks`` through a fresh stripper, return (emitted_text, residual)."""
+    s = ThinkingStreamStripper()
+    out = "".join(s.feed(c) for c in chunks)
+    return out, s.flush()
+
+
+def test_dangling_leak_split_across_chunks_drops_cot():
+    # CoT arrives in pieces (each held → ""), then </think>, then the answer.
+    out, residual = _drain(["用户让我描述", "图片。草稿2更准确。\n", "</think>\n\n", "这张图片包含一个红色矩形。"])
+    assert out == "\n\n这张图片包含一个红色矩形。"
+    assert residual == ""
+
+
+def test_paired_block_streamed():
+    out, residual = _drain(["<think>", "reason here", "</think>", "final answer"])
+    assert out == "final answer"
+    assert residual == ""
+
+
+def test_close_tag_split_across_chunk_boundary():
+    # The close tag itself straddles two chunks — buffer must accumulate.
+    out, residual = _drain(["cot here</thi", "nk>answer"])
+    assert out == "answer"
+    assert residual == ""
+
+
+def test_answer_on_same_chunk_as_close_tag():
+    out, residual = _drain(["reasoning</think>the answer"])
+    assert out == "the answer"
+    assert residual == ""
+
+
+def test_clean_content_no_close_tag_held_until_flush():
+    # Leak-prone model that didn't actually think this turn: no </think> ever
+    # arrives, so content is held and returned intact at flush (never lost).
+    out, residual = _drain(["你好", "呀，", "今天怎么样？"])
+    assert out == ""
+    assert residual == "你好呀，今天怎么样？"
+
+
+def test_passthrough_is_verbatim_after_close():
+    s = ThinkingStreamStripper()
+    assert s.feed("cot</think>") == ""
+    # Everything after the close streams through byte-for-byte, no stripping.
+    assert s.feed("first ") == "first "
+    assert s.feed("second") == "second"
+    assert s.flush() == ""
+
+
+def test_reset_rearms_for_next_segment():
+    s = ThinkingStreamStripper()
+    s.feed("cot</think>answer")
+    s.reset()
+    # After reset it buffers again until the next close tag.
+    assert s.feed("more reasoning") == ""
+    assert s.feed("</think>done") == "done"
+
+
+def test_empty_feed_is_noop():
+    s = ThinkingStreamStripper()
+    assert s.feed("") == ""
+    assert s.flush() == ""
+
+
+def test_classifier_flags_qwen_hybrids_only():
+    for leaky in ("qwen3.5-plus", "qwen3.6-flash", "qwen3.7-plus-2026-05-26",
+                  "Qwen/Qwen3.5-397B-A17B", "qwen/qwen3.5-9b"):
+        assert leaks_thinking_in_content(leaky) is True, leaky
+    for clean in ("qwen3-vl-plus", "qwen3-vl-flash", "gpt-4o", "claude-opus-4-8",
+                  "step-2-mini", "", None):
+        assert leaks_thinking_in_content(clean) is False, clean

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -79,6 +79,67 @@ def strip_thinking_segments(text: str | None) -> str:
     return s.strip()
 
 
+class ThinkingStreamStripper:
+    """Streaming-safe sibling of :func:`strip_thinking_segments`.
+
+    ``strip_thinking_segments`` only runs on a *whole* non-streaming reply.
+    Focus (thinking-on) turns stream token-by-token straight into TTS + the UI, so a
+    provider that leaks chain-of-thought into ``content`` would speak its
+    reasoning aloud. Only the Qwen3.5/3.6/3.7 hybrids do this: they dump the
+    whole CoT into ``content`` terminated by a lone ``</think>`` (clean
+    providers route reasoning to the separate ``reasoning_content`` field,
+    which the streaming loop already withholds). So this holds **all** content
+    until the first ``</think>`` (or a paired ``<think>...</think>``) is seen —
+    dropping everything up to and including it — then passes the real answer
+    through untouched, chunk by chunk.
+
+    Engage it ONLY for ``thinking_on`` turns on a leak-prone model
+    (``config.providers.leaks_thinking_in_content``): for clean providers the
+    close tag never arrives, so holding-until-``</think>`` would withhold the
+    whole answer until ``flush``. If a leak-prone model didn't think this turn
+    (no close tag), ``flush`` returns the held buffer intact so nothing is lost.
+    Split tags across chunks are safe — the buffer accumulates until matched.
+    """
+
+    def __init__(self) -> None:
+        self._buf = ""
+        self._passthrough = False
+
+    def feed(self, text: str) -> str:
+        """Return the emittable slice of ``text`` (``""`` while still buffering)."""
+        if self._passthrough:
+            return text
+        if not text:
+            return ""
+        self._buf += text
+        m = _THINK_ANY_CLOSE_RE.search(self._buf)
+        if m:
+            # Everything up to and including the first close tag is the leaked
+            # CoT (covers both the dangling shape and a paired <think>...</think>,
+            # whose opening tag sits earlier in the buffer). Release the tail and
+            # stream freely from here on.
+            tail = self._buf[m.end():]
+            self._buf = ""
+            self._passthrough = True
+            return tail
+        return ""
+
+    def flush(self) -> str:
+        """Drain any held content at stream end (no close tag ever arrived)."""
+        if self._passthrough:
+            return ""
+        residual = self._buf
+        self._buf = ""
+        return residual
+
+    def reset(self) -> None:
+        """Forget held state — used at a tool-round boundary, where the next
+        segment is a fresh semantic unit and the one-shot CoT preamble (if any)
+        is already behind us."""
+        self._buf = ""
+        self._passthrough = False
+
+
 # ────────────────────────────────────────────────────────────────
 # Active-character context — used by ChatOpenAI._params to substitute
 # ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders that originated from


### PR DESCRIPTION
PR #1815「凝神模式 v1」剩余 follow-up 里的 **3①/4/6** 三项（后端骨架此前已落，这次补「打开开关前的安全闸」+「前端可见化」）。默认 `FOCUS_MODE_ENABLED=False`，整条特性仍 inert。

## 做了什么

### 3① 流式 `<think>` 剥离（安全前置）
凝神开 `thinking_on` 后，qwen3.5/3.6/3.7 hybrid 会把 CoT 塞进 `content`、尾随一个 dangling `</think>`，原 `strip_thinking_segments` 只在非流式跑 → 流式 chunk 会把推理文本流给 TTS/前端。
- 新增 `utils/llm_client.ThinkingStreamStripper`：缓冲到首个 `</think>` 丢弃 CoT 段、再放行正文，跨 chunk 分割安全；流末 `flush` 兜底（本轮没思考时原样还回，不丢答案）。
- 仅对**会在 content 里漏**的 provider 挂（`config.providers.leaks_thinking_in_content`：qwen3.5/3.6/3.7 非 vl）+ `thinking_on`。干净 provider（reasoning_content 路径）直接 passthrough，**已验证的主流 TTS 链路零回归**。
- 接入点：`OmniOfflineClient.stream_text` 流式咽喉（content 派生处 feed、tool-round 重置、流末 flush）。

### 4 前端凝神指示灯（极隐微光）
凝神态此前没有任何推前端的通道。
- `SessionStateMachine` 订阅 `FOCUS_ENTER/EXIT` → `LLMSessionManager._on_focus_transition` 推 `focus_state` ws（瞬时 UI 态，不进 history）。
- `app-websocket.js` 转成 `neko-focus-state` CustomEvent → `react-neko-chat` 渲一个**极隐"呼吸微光"** badge：`.chat-window` 的 `inset box-shadow` 慢呼吸（inset 故 compact `overflow:visible` / full `overflow:hidden` 都不被裁），三上下文共用，`prefers-reduced-motion` 退化静态微光。
- `FOCUS_MODE_ENABLED` 默认关 = 不显示。

### 6 i18n
`chat.focusIndicator` 八语言（极隐微光无可见文字，仅 aria-label/tooltip）。

## 不在本 PR 的
- 3② provider extras 保留：此前已落。
- 评分器 LLM 化（1）：在另一分支推进中。
- memory `FOCUS_EXIT` 联动（5）、True-Name v2（8）：未含。

## 回归报告

**必要性**：3① 是打开任一 thinking provider 前的安全闸（不剥会把推理链念给 TTS）；4/6 让凝神态对用户/无障碍可感，补齐 v1 的前端缺口。

**改动前 → 改动后**：
- `OmniOfflineClient.stream_text` 流式路径：改前所有 content chunk 裸流给 TTS/UI；改后**仅当** `thinking_on=True` 且 model 命中 `leaks_thinking_in_content`（qwen3.5/3.6/3.7 非 vl）时，chunk 先过 `ThinkingStreamStripper`。其余所有情况 `think_stripper is None`，走原路径、逐字节不变。
- `LLMSessionManager.__init__` 新增两个 SM 订阅；`SessionStateMachine` 自身行为不变（只是多了订阅者）。
- 前端新增 `focus_state` ws 分支 + 一个 React 监听 + 一个条件渲染元素，默认不触发。

**回归面与缓解**：
- 已验证的非凝神 TTS 流式链路：`think_stripper is None`，无任何包裹，零影响。
- 凝神链路（默认关、inert）：跨-chunk 分割、dangling/paired、passthrough、flush 兜底均有单测覆盖（`test_thinking_stream_stripper`）。
- tool-round 边界：stripper 随 prefix_buffer 一起 reset，避免跨段误吞。
- 前端：221 vitest 全过；vite dev 实测 on/off 后 DOM/动画/阴影全清、SR 元素 1×1px 零布局影响。
- `FOCUS_MODE_ENABLED=False` 默认关，整条特性 inert。

## 验证
- 后端：`ThinkingStreamStripper` 流式/跨-chunk/dangling/passthrough/classifier、`focus_state` 桥 on/off；既有 `test_focus_mode` 43 全过。
- 前端：221 vitest 全过；vite dev 实测 compact 上下文。
- `check_i18n_sync` / `check_i18n` / `check_docstring_no_cjk` 均过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新增功能**
  - 新增“凝神模式”状态提示：界面显示“凝神中”，并随专注进入/退出实时更新；支持多语言文案与无障碍提示。
  - 凝神模式聊天窗口新增呼吸光晕动画，并兼容“减少动态效果”偏好。
- **Bug 修复**
  - 改善焦点指示的自动对齐与自清，避免切换后徽章卡住。
  - 对在内容中可能泄露思维段的流式输出进行剥离，减少可展示内容污染。
- **测试**
  - 新增凝神状态桥接与思维剥离器覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->