### PR TITLE
优化紧凑聊天框工具轮盘的指针反馈：让三角指针落在按钮间隙、加长尖端，并增加滚轮/拖拽时的偏摆回正效果

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -5056,12 +5056,18 @@ describe('App', () => {
       expect(fan).toHaveAttribute('data-compact-tool-wheel-drag-active', 'true');
       expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-screenshot');
       expect(Number.parseFloat(fan.style.getPropertyValue('--compact-tool-wheel-drag-angle'))).toBeCloseTo(15, 1);
+      expect(Number.parseFloat(fan.style.getPropertyValue('--compact-tool-wheel-selection-pointer-deflection-angle'))).toBeGreaterThan(13);
+      expect(Number.parseFloat(fan.style.getPropertyValue('--compact-tool-wheel-selection-pointer-deflection-angle'))).toBeLessThan(15);
+      expect(Number.parseFloat(fan.style.getPropertyValue('--compact-tool-wheel-selection-pointer-deflection-shift'))).toBeGreaterThan(3);
+      expect(Number.parseFloat(fan.style.getPropertyValue('--compact-tool-wheel-selection-pointer-deflection-shift'))).toBeLessThan(5);
 
       fireEvent.pointerUp(fan, { pointerId: 41, ...compactToolWheelPoint(15 * (Math.PI / 180)), buttons: 0, pointerType: 'mouse' });
 
       expect(fan).toHaveAttribute('data-compact-tool-wheel-drag-active', 'false');
       expect(fan.querySelector('[data-compact-tool-wheel-slot="0"]')).toHaveClass('compact-input-tool-item-screenshot');
       expect(fan.style.getPropertyValue('--compact-tool-wheel-drag-angle')).toBe('0deg');
+      expect(fan.style.getPropertyValue('--compact-tool-wheel-selection-pointer-deflection-angle')).toBe('0deg');
+      expect(fan.style.getPropertyValue('--compact-tool-wheel-selection-pointer-deflection-shift')).toBe('0px');
     } finally {
       fanRectSpy.mockRestore();
     }

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -4069,8 +4069,8 @@ function CompactChatApp({
   const rotateCompactInputToolWheelSteps = useCallback((direction: 1 | -1, stepCount: number, options?: { forceFast?: boolean }) => {
     if (stepCount <= 0) return;
     markCompactInputToolWheelMotion(stepCount, options);
-    kickCompactInputToolWheelSelectionPointer(direction);
     for (let step = 0; step < stepCount; step += 1) {
+      kickCompactInputToolWheelSelectionPointer(direction);
       rotateCompactInputToolWheel(direction);
       playCompactToolWheelDetentSound();
     }

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -188,6 +188,10 @@ const COMPACT_TOOL_WHEEL_REBOUND_SOUND_MEDIUM_VOLUME = 0.6;
 const COMPACT_TOOL_WHEEL_REBOUND_SOUND_STRONG_VOLUME = 0.85;
 const COMPACT_TOOL_WHEEL_CHARGE_RELEASE_REBOUND_OVERSHOOT_RATIO = 0.18;
 const COMPACT_TOOL_WHEEL_CHARGE_RELEASE_REBOUND_VISUAL_MS = 120;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_DEFLECTION_DEG = 28;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_SHIFT_PX = 8;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_RATIO = 1;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_MS = 110;
 const COMPACT_TOOL_WHEEL_AUDIO_PRELOAD_RETRY_DELAYS_MS = [120, 300, 700, 1500] as const;
 const COMPACT_TOOL_WHEEL_DEFAULT_DRAG_ANGLE_STEP_DEG = Math.abs(
   compactInputToolWheelDefaultVisibleSlots[2].angleDeg - compactInputToolWheelDefaultVisibleSlots[3].angleDeg,
@@ -1519,6 +1523,7 @@ function CompactChatApp({
   const compactInputToolWheelDragGuardTimerRef = useRef<number | null>(null);
   const compactInputToolWheelFastAnimationTimerRef = useRef<number | null>(null);
   const compactInputToolWheelChargeReleaseTimerRef = useRef<number | null>(null);
+  const compactInputToolWheelSelectionPointerKickTimerRef = useRef<number | null>(null);
   const compactInputToolWheelLastRotationAtRef = useRef(0);
   const compactInputToolWheelChargeRef = useRef<CompactToolWheelChargeState>(createCompactToolWheelChargeState());
   const compactInputToolWheelChargeReleaseActiveRef = useRef(false);
@@ -1615,6 +1620,7 @@ function CompactChatApp({
   const [compactInputToolWheelFastAnimation, setCompactInputToolWheelFastAnimation] = useState(false);
   const [compactInputToolWheelDragActive, setCompactInputToolWheelDragActive] = useState(false);
   const [compactInputToolWheelDragOffsetRatio, setCompactInputToolWheelDragOffsetRatio] = useState(0);
+  const [compactInputToolWheelSelectionPointerKickRatio, setCompactInputToolWheelSelectionPointerKickRatio] = useState(0);
   const [compactInputToolWheelChargeRatio, setCompactInputToolWheelChargeRatio] = useState(0);
   const [compactInputToolWheelChargeDirection, setCompactInputToolWheelChargeDirection] = useState<1 | -1 | null>(null);
   const [compactInputToolWheelChargeReleaseActive, setCompactInputToolWheelChargeReleaseActive] = useState(false);
@@ -3655,6 +3661,17 @@ function CompactChatApp({
     compactInputToolWheelFastAnimationTimerRef.current = null;
   }, []);
 
+  const clearCompactInputToolWheelSelectionPointerKickTimer = useCallback(() => {
+    if (compactInputToolWheelSelectionPointerKickTimerRef.current === null) return;
+    window.clearTimeout(compactInputToolWheelSelectionPointerKickTimerRef.current);
+    compactInputToolWheelSelectionPointerKickTimerRef.current = null;
+  }, []);
+
+  const resetCompactInputToolWheelSelectionPointerKick = useCallback(() => {
+    clearCompactInputToolWheelSelectionPointerKickTimer();
+    setCompactInputToolWheelSelectionPointerKickRatio(0);
+  }, [clearCompactInputToolWheelSelectionPointerKickTimer]);
+
   const clearCompactInputToolWheelChargeReleaseTimer = useCallback(() => {
     if (compactInputToolWheelChargeReleaseTimerRef.current !== null) {
       window.clearTimeout(compactInputToolWheelChargeReleaseTimerRef.current);
@@ -3786,6 +3803,7 @@ function CompactChatApp({
     setCompactInputToolWheelDragOffsetRatio(0);
     dispatchCompactToolWheelDragState(false);
     compactInputToolWheelLastRotationAtRef.current = 0;
+    resetCompactInputToolWheelSelectionPointerKick();
     resetCompactInputToolWheelCharge();
     setCompactInputToolWheelFastAnimation(false);
     setCompactInputToolWheelLayout('default');
@@ -3814,6 +3832,7 @@ function CompactChatApp({
     clearCompactInputToolWheelChargeReleaseTimer,
     dispatchCompactToolWheelDragState,
     dispatchCompactToolFanOpenState,
+    resetCompactInputToolWheelSelectionPointerKick,
     resetCompactInputToolWheelCharge,
     setCompactInputToolFanInteractiveState,
   ]);
@@ -4022,6 +4041,15 @@ function CompactChatApp({
     ));
   }, []);
 
+  const kickCompactInputToolWheelSelectionPointer = useCallback((direction: 1 | -1) => {
+    clearCompactInputToolWheelSelectionPointerKickTimer();
+    setCompactInputToolWheelSelectionPointerKickRatio(direction * COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_RATIO);
+    compactInputToolWheelSelectionPointerKickTimerRef.current = window.setTimeout(() => {
+      compactInputToolWheelSelectionPointerKickTimerRef.current = null;
+      setCompactInputToolWheelSelectionPointerKickRatio(0);
+    }, COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_MS);
+  }, [clearCompactInputToolWheelSelectionPointerKickTimer]);
+
   const markCompactInputToolWheelMotion = useCallback((stepCount: number, options?: { forceFast?: boolean }) => {
     const now = getCompactToolWheelTimestamp();
     const elapsed = compactInputToolWheelLastRotationAtRef.current > 0
@@ -4041,11 +4069,12 @@ function CompactChatApp({
   const rotateCompactInputToolWheelSteps = useCallback((direction: 1 | -1, stepCount: number, options?: { forceFast?: boolean }) => {
     if (stepCount <= 0) return;
     markCompactInputToolWheelMotion(stepCount, options);
+    kickCompactInputToolWheelSelectionPointer(direction);
     for (let step = 0; step < stepCount; step += 1) {
       rotateCompactInputToolWheel(direction);
       playCompactToolWheelDetentSound();
     }
-  }, [markCompactInputToolWheelMotion, rotateCompactInputToolWheel]);
+  }, [kickCompactInputToolWheelSelectionPointer, markCompactInputToolWheelMotion, rotateCompactInputToolWheel]);
 
   const recordCompactInputToolWheelCharge = useCallback((direction: 1 | -1, stepCount: number): CompactToolWheelChargeState => {
     const previous = compactInputToolWheelChargeRef.current;
@@ -4148,6 +4177,7 @@ function CompactChatApp({
 
       completedSteps += 1;
       markCompactInputToolWheelMotion(1, { forceFast: true });
+      kickCompactInputToolWheelSelectionPointer(direction);
       setCompactInputToolWheelChargeReleaseVisualStepOffset(
         normalizeCompactToolWheelStepOffset(
           direction * completedSteps,
@@ -4171,7 +4201,7 @@ function CompactChatApp({
     };
 
     compactInputToolWheelChargeReleaseTimerRef.current = window.setTimeout(runReleaseStep, 0);
-  }, [clearCompactInputToolWheelChargeReleaseTimer, markCompactInputToolWheelMotion]);
+  }, [clearCompactInputToolWheelChargeReleaseTimer, kickCompactInputToolWheelSelectionPointer, markCompactInputToolWheelMotion]);
 
   const getCompactInputToolWheelNormalizedDelta = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
     const rawDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX)
@@ -4389,12 +4419,14 @@ function CompactChatApp({
     clearCompactInputToolFanInteractiveTimer();
     clearCompactInputToolWheelDragGuardTimer();
     clearCompactInputToolWheelFastAnimationTimer();
+    clearCompactInputToolWheelSelectionPointerKickTimer();
     clearCompactInputToolWheelChargeReleaseTimer();
   }, [
     clearCompactInputToolFanCloseTimer,
     clearCompactInputToolFanInteractiveTimer,
     clearCompactInputToolWheelDragGuardTimer,
     clearCompactInputToolWheelFastAnimationTimer,
+    clearCompactInputToolWheelSelectionPointerKickTimer,
     clearCompactInputToolWheelChargeReleaseTimer,
   ]);
 
@@ -5172,12 +5204,14 @@ function CompactChatApp({
     clearCompactInputToolWheelFastAnimationTimer();
     clearCompactInputToolWheelChargeReleaseTimer();
     resetCompactInputToolWheelCharge();
+    resetCompactInputToolWheelSelectionPointerKick();
     setCompactInputToolWheelFastAnimation(false);
     setCompactInputToolWheelIndex(request.index);
   }, [
     clearCompactInputToolWheelChargeReleaseTimer,
     clearCompactInputToolWheelFastAnimationTimer,
     compactToolWheelIndexRequest,
+    resetCompactInputToolWheelSelectionPointerKick,
     resetCompactInputToolWheelCharge,
   ]);
 
@@ -5693,9 +5727,20 @@ function CompactChatApp({
     ? COMPACT_TOOL_WHEEL_VIEWPORT_DRAG_ANGLE_STEP_DEG
     : COMPACT_TOOL_WHEEL_DEFAULT_DRAG_ANGLE_STEP_DEG;
   const compactInputToolWheelDragAngle = compactInputToolWheelDragOffsetRatio * compactInputToolWheelDragAngleStep;
+  const compactInputToolWheelSelectionPointerDeflectionRatio = clamp(
+    compactInputToolWheelDragOffsetRatio + compactInputToolWheelSelectionPointerKickRatio,
+    -1,
+    1,
+  );
+  const compactInputToolWheelSelectionPointerDeflectionAngle = compactInputToolWheelSelectionPointerDeflectionRatio
+    * COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_DEFLECTION_DEG;
+  const compactInputToolWheelSelectionPointerDeflectionShift = compactInputToolWheelSelectionPointerDeflectionRatio
+    * COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_SHIFT_PX;
   const compactInputToolWheelDragStyle = {
     '--compact-tool-wheel-drag-angle': `${compactInputToolWheelDragAngle}deg`,
     '--compact-tool-wheel-drag-counter-angle': `${-compactInputToolWheelDragAngle}deg`,
+    '--compact-tool-wheel-selection-pointer-deflection-angle': `${compactInputToolWheelSelectionPointerDeflectionAngle}deg`,
+    '--compact-tool-wheel-selection-pointer-deflection-shift': `${compactInputToolWheelSelectionPointerDeflectionShift}px`,
   } as CSSProperties;
   const compactToolToggleVisible = isCompactSurface && !composerHidden;
   const compactToolToggleActsAsSubmit = effectiveCompactChatState === 'input' && compactInputHasPayload;

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -128,6 +128,10 @@ const COMPACT_TOOL_WHEEL_REBOUND_SOUND_STRONG_RATIO = 0.7;
 const COMPACT_TOOL_WHEEL_REBOUND_SOUND_SOFT_VOLUME = 0.38;
 const COMPACT_TOOL_WHEEL_REBOUND_SOUND_MEDIUM_VOLUME = 0.6;
 const COMPACT_TOOL_WHEEL_REBOUND_SOUND_STRONG_VOLUME = 0.85;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_DEFLECTION_DEG = 28;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_SHIFT_PX = 8;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_RATIO = 1;
+const COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_MS = 110;
 const COMPACT_TOOL_WHEEL_AUDIO_PRELOAD_RETRY_DELAYS_MS = [120, 300, 700, 1500] as const;
 const COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE = 48;
 const COMPACT_INPUT_TOOL_FAN_INTERACTIVE_DELAY_MS = 220;
@@ -1229,6 +1233,7 @@ export default function FullChatSurface({
   const compactInputToolFanRef = useRef<HTMLDivElement | null>(null);
   const compactInputToolWheelPointerRef = useRef<CompactToolWheelPointerState | null>(null);
   const compactInputToolWheelSuppressClickRef = useRef(false);
+  const compactInputToolWheelSelectionPointerKickTimerRef = useRef<number | null>(null);
   const compactInputToolTogglePointerHandledRef = useRef(false);
   const compactInputToolFanPositionSyncRef = useRef<(() => void) | null>(null);
   const compactInputToolFanCloseTimerRef = useRef<number | null>(null);
@@ -1293,6 +1298,7 @@ export default function FullChatSurface({
   const [compactInputToolWheelIndex, setCompactInputToolWheelIndex] = useState(0);
   const [compactInputToolWheelDragActive, setCompactInputToolWheelDragActive] = useState(false);
   const [compactInputToolWheelDragOffsetRatio, setCompactInputToolWheelDragOffsetRatio] = useState(0);
+  const [compactInputToolWheelSelectionPointerKickRatio, setCompactInputToolWheelSelectionPointerKickRatio] = useState(0);
   const [compactSurfaceResizeWidth, setCompactSurfaceResizeWidth] = useState<number | null>(null);
   const [compactExportHistoryOpen, setCompactExportHistoryOpen] = useState(readPersistedCompactExportHistoryOpen);
   const [compactExportPreviewOpen, setCompactExportPreviewOpen] = useState(false);
@@ -2543,12 +2549,28 @@ export default function FullChatSurface({
     openCompactInputToolFan('click');
   }, [closeCompactInputToolFanFromUserClick, openCompactInputToolFan]);
 
+  const clearCompactInputToolWheelSelectionPointerKickTimer = useCallback(() => {
+    if (compactInputToolWheelSelectionPointerKickTimerRef.current === null) return;
+    window.clearTimeout(compactInputToolWheelSelectionPointerKickTimerRef.current);
+    compactInputToolWheelSelectionPointerKickTimerRef.current = null;
+  }, []);
+
+  const kickCompactInputToolWheelSelectionPointer = useCallback((direction: 1 | -1) => {
+    clearCompactInputToolWheelSelectionPointerKickTimer();
+    setCompactInputToolWheelSelectionPointerKickRatio(direction * COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_RATIO);
+    compactInputToolWheelSelectionPointerKickTimerRef.current = window.setTimeout(() => {
+      compactInputToolWheelSelectionPointerKickTimerRef.current = null;
+      setCompactInputToolWheelSelectionPointerKickRatio(0);
+    }, COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_MS);
+  }, [clearCompactInputToolWheelSelectionPointerKickTimer]);
+
   const rotateCompactInputToolWheel = useCallback((direction: 1 | -1) => {
+    kickCompactInputToolWheelSelectionPointer(direction);
     setCompactInputToolWheelIndex(current => (
       (current + direction + COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT) % COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT
     ));
     playCompactToolWheelDetentSound();
-  }, []);
+  }, [kickCompactInputToolWheelSelectionPointer]);
 
   const getCompactToolWheelDragAngle = useCallback((clientX: number, clientY: number): number | null => {
     if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return null;
@@ -2615,7 +2637,12 @@ export default function FullChatSurface({
   useEffect(() => () => {
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
-  }, [clearCompactInputToolFanCloseTimer, clearCompactInputToolFanInteractiveTimer]);
+    clearCompactInputToolWheelSelectionPointerKickTimer();
+  }, [
+    clearCompactInputToolFanCloseTimer,
+    clearCompactInputToolFanInteractiveTimer,
+    clearCompactInputToolWheelSelectionPointerKickTimer,
+  ]);
 
   useEffect(() => {
     if (!isCompactSurface || effectiveCompactChatState !== 'input') {
@@ -3817,9 +3844,20 @@ export default function FullChatSurface({
     compactInputToolFanActionsDisabled || !isCompactToolWheelActionable(toolIndex)
   );
   const compactInputToolWheelDragAngle = compactInputToolWheelDragOffsetRatio * COMPACT_TOOL_WHEEL_DRAG_ANGLE_STEP_DEG;
+  const compactInputToolWheelSelectionPointerDeflectionRatio = clamp(
+    compactInputToolWheelDragOffsetRatio + compactInputToolWheelSelectionPointerKickRatio,
+    -1,
+    1,
+  );
+  const compactInputToolWheelSelectionPointerDeflectionAngle = compactInputToolWheelSelectionPointerDeflectionRatio
+    * COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_DEFLECTION_DEG;
+  const compactInputToolWheelSelectionPointerDeflectionShift = compactInputToolWheelSelectionPointerDeflectionRatio
+    * COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_SHIFT_PX;
   const compactInputToolWheelDragStyle = {
     '--compact-tool-wheel-drag-angle': `${compactInputToolWheelDragAngle}deg`,
     '--compact-tool-wheel-drag-counter-angle': `${-compactInputToolWheelDragAngle}deg`,
+    '--compact-tool-wheel-selection-pointer-deflection-angle': `${compactInputToolWheelSelectionPointerDeflectionAngle}deg`,
+    '--compact-tool-wheel-selection-pointer-deflection-shift': `${compactInputToolWheelSelectionPointerDeflectionShift}px`,
   } as CSSProperties;
 
   const compactInputToolFanNode = isCompactSurface && effectiveCompactChatState === 'input' ? (

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -128,10 +128,6 @@ const COMPACT_TOOL_WHEEL_REBOUND_SOUND_STRONG_RATIO = 0.7;
 const COMPACT_TOOL_WHEEL_REBOUND_SOUND_SOFT_VOLUME = 0.38;
 const COMPACT_TOOL_WHEEL_REBOUND_SOUND_MEDIUM_VOLUME = 0.6;
 const COMPACT_TOOL_WHEEL_REBOUND_SOUND_STRONG_VOLUME = 0.85;
-const COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_DEFLECTION_DEG = 28;
-const COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_SHIFT_PX = 8;
-const COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_RATIO = 1;
-const COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_MS = 110;
 const COMPACT_TOOL_WHEEL_AUDIO_PRELOAD_RETRY_DELAYS_MS = [120, 300, 700, 1500] as const;
 const COMPACT_INPUT_TOOL_FAN_ORIGIN_CLOSE_SIZE = 48;
 const COMPACT_INPUT_TOOL_FAN_INTERACTIVE_DELAY_MS = 220;
@@ -1233,7 +1229,6 @@ export default function FullChatSurface({
   const compactInputToolFanRef = useRef<HTMLDivElement | null>(null);
   const compactInputToolWheelPointerRef = useRef<CompactToolWheelPointerState | null>(null);
   const compactInputToolWheelSuppressClickRef = useRef(false);
-  const compactInputToolWheelSelectionPointerKickTimerRef = useRef<number | null>(null);
   const compactInputToolTogglePointerHandledRef = useRef(false);
   const compactInputToolFanPositionSyncRef = useRef<(() => void) | null>(null);
   const compactInputToolFanCloseTimerRef = useRef<number | null>(null);
@@ -1298,7 +1293,6 @@ export default function FullChatSurface({
   const [compactInputToolWheelIndex, setCompactInputToolWheelIndex] = useState(0);
   const [compactInputToolWheelDragActive, setCompactInputToolWheelDragActive] = useState(false);
   const [compactInputToolWheelDragOffsetRatio, setCompactInputToolWheelDragOffsetRatio] = useState(0);
-  const [compactInputToolWheelSelectionPointerKickRatio, setCompactInputToolWheelSelectionPointerKickRatio] = useState(0);
   const [compactSurfaceResizeWidth, setCompactSurfaceResizeWidth] = useState<number | null>(null);
   const [compactExportHistoryOpen, setCompactExportHistoryOpen] = useState(readPersistedCompactExportHistoryOpen);
   const [compactExportPreviewOpen, setCompactExportPreviewOpen] = useState(false);
@@ -2549,28 +2543,12 @@ export default function FullChatSurface({
     openCompactInputToolFan('click');
   }, [closeCompactInputToolFanFromUserClick, openCompactInputToolFan]);
 
-  const clearCompactInputToolWheelSelectionPointerKickTimer = useCallback(() => {
-    if (compactInputToolWheelSelectionPointerKickTimerRef.current === null) return;
-    window.clearTimeout(compactInputToolWheelSelectionPointerKickTimerRef.current);
-    compactInputToolWheelSelectionPointerKickTimerRef.current = null;
-  }, []);
-
-  const kickCompactInputToolWheelSelectionPointer = useCallback((direction: 1 | -1) => {
-    clearCompactInputToolWheelSelectionPointerKickTimer();
-    setCompactInputToolWheelSelectionPointerKickRatio(direction * COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_RATIO);
-    compactInputToolWheelSelectionPointerKickTimerRef.current = window.setTimeout(() => {
-      compactInputToolWheelSelectionPointerKickTimerRef.current = null;
-      setCompactInputToolWheelSelectionPointerKickRatio(0);
-    }, COMPACT_TOOL_WHEEL_SELECTION_POINTER_KICK_MS);
-  }, [clearCompactInputToolWheelSelectionPointerKickTimer]);
-
   const rotateCompactInputToolWheel = useCallback((direction: 1 | -1) => {
-    kickCompactInputToolWheelSelectionPointer(direction);
     setCompactInputToolWheelIndex(current => (
       (current + direction + COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT) % COMPACT_INPUT_TOOL_WHEEL_ITEM_COUNT
     ));
     playCompactToolWheelDetentSound();
-  }, [kickCompactInputToolWheelSelectionPointer]);
+  }, []);
 
   const getCompactToolWheelDragAngle = useCallback((clientX: number, clientY: number): number | null => {
     if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return null;
@@ -2637,12 +2615,7 @@ export default function FullChatSurface({
   useEffect(() => () => {
     clearCompactInputToolFanCloseTimer();
     clearCompactInputToolFanInteractiveTimer();
-    clearCompactInputToolWheelSelectionPointerKickTimer();
-  }, [
-    clearCompactInputToolFanCloseTimer,
-    clearCompactInputToolFanInteractiveTimer,
-    clearCompactInputToolWheelSelectionPointerKickTimer,
-  ]);
+  }, [clearCompactInputToolFanCloseTimer, clearCompactInputToolFanInteractiveTimer]);
 
   useEffect(() => {
     if (!isCompactSurface || effectiveCompactChatState !== 'input') {
@@ -3844,20 +3817,9 @@ export default function FullChatSurface({
     compactInputToolFanActionsDisabled || !isCompactToolWheelActionable(toolIndex)
   );
   const compactInputToolWheelDragAngle = compactInputToolWheelDragOffsetRatio * COMPACT_TOOL_WHEEL_DRAG_ANGLE_STEP_DEG;
-  const compactInputToolWheelSelectionPointerDeflectionRatio = clamp(
-    compactInputToolWheelDragOffsetRatio + compactInputToolWheelSelectionPointerKickRatio,
-    -1,
-    1,
-  );
-  const compactInputToolWheelSelectionPointerDeflectionAngle = compactInputToolWheelSelectionPointerDeflectionRatio
-    * COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_DEFLECTION_DEG;
-  const compactInputToolWheelSelectionPointerDeflectionShift = compactInputToolWheelSelectionPointerDeflectionRatio
-    * COMPACT_TOOL_WHEEL_SELECTION_POINTER_MAX_SHIFT_PX;
   const compactInputToolWheelDragStyle = {
     '--compact-tool-wheel-drag-angle': `${compactInputToolWheelDragAngle}deg`,
     '--compact-tool-wheel-drag-counter-angle': `${-compactInputToolWheelDragAngle}deg`,
-    '--compact-tool-wheel-selection-pointer-deflection-angle': `${compactInputToolWheelSelectionPointerDeflectionAngle}deg`,
-    '--compact-tool-wheel-selection-pointer-deflection-shift': `${compactInputToolWheelSelectionPointerDeflectionShift}px`,
   } as CSSProperties;
 
   const compactInputToolFanNode = isCompactSurface && effectiveCompactChatState === 'input' ? (

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3747,7 +3747,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   --compact-tool-wheel-charge-first-angle: 0deg;
   --compact-tool-wheel-charge-second-angle: 0deg;
   --compact-tool-wheel-charge-third-angle: 0deg;
-  --compact-tool-wheel-selection-angle: 45deg;
+  --compact-tool-wheel-selection-angle: 29.59deg;
+  --compact-tool-wheel-selection-pointer-deflection-angle: 0deg;
+  --compact-tool-wheel-selection-pointer-deflection-shift: 0px;
   --compact-tool-preview-fade-left: linear-gradient(99deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.52) 46%, #000 100%);
   --compact-tool-preview-fade-right: linear-gradient(172deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.52) 46%, #000 100%);
   position: absolute;
@@ -3875,7 +3877,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   position: absolute;
   left: var(--compact-tool-wheel-center-x);
   top: var(--compact-tool-wheel-center-y);
-  width: 14px;
+  width: 18px;
   height: 12px;
   border-radius: 2px;
   background:
@@ -3890,9 +3892,13 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transform:
     translate(-1px, -50%)
     rotate(var(--compact-tool-wheel-selection-angle))
-    translateX(48px);
+    translateX(43px)
+    translateY(var(--compact-tool-wheel-selection-pointer-deflection-shift))
+    rotate(var(--compact-tool-wheel-selection-pointer-deflection-angle));
   transform-origin: 1px 50%;
-  transition: opacity 0.16s ease;
+  transition:
+    opacity 0.16s ease,
+    transform 0.08s cubic-bezier(0.18, 0.86, 0.32, 1.24);
   z-index: 4;
 }
 
@@ -4082,6 +4088,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   transition:
     opacity 0.18s ease,
     background 0.15s ease;
+}
+
+.compact-input-tool-fan[data-compact-tool-wheel-drag-active="true"] .compact-input-tool-wheel-selection-pointer {
+  transition: opacity 0.16s ease;
 }
 
 .compact-input-tool-fan[data-compact-input-tool-fan-open="true"]:active {
@@ -4976,7 +4986,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
   /* Only use the phone fallback when the original wheel geometry would overflow the viewport. */
   .compact-input-tool-fan[data-compact-input-tool-fan-open="true"][data-compact-tool-wheel-layout="viewport-fit"] {
-    --compact-tool-wheel-selection-angle: -140deg;
+    --compact-tool-wheel-selection-angle: -125deg;
   }
 
   .compact-input-tool-fan[data-compact-input-tool-fan-open="true"][data-compact-tool-wheel-layout="viewport-fit"] .compact-input-tool-item[data-compact-tool-wheel-slot="-2"],


### PR DESCRIPTION
## 改动概述 / Summary

- 将紧凑聊天框工具轮盘的三角指针从按钮中心线移到按钮间隙，并加长尖端。
- 增加滚轮/拖拽时的指针偏摆与回正反馈。
- 根据 review 反馈，避免修改 frozen legacy `FullChatSurface.tsx`，指针反馈只保留在 active compact `App.tsx` 路径。

## 测试 / Testing

- `npm run typecheck`
- `git diff --check`
- `npm run build`
- 手动浏览器验证：紧凑轮盘指针位于按钮间隙，滚轮/拖拽后会偏摆并回正。

## 回归报告 / Regression Report

不适用。

## 不拆分理由 / Split Rationale

不适用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 紧凑工具轮盘的选择指针新增 kick 摆动冲击效果，提升交互反馈质感

* **Style**
  * 优化选择指针样式与拖拽过渡动画，改进轮盘交互体验

<!-- end of auto-generated comment: release notes by coderabbit.ai -->