### PR TITLE
feat(emotion): master 用户情绪画像(valence-arousal) 基建 + 接入凝神，默认开启 FOCUS

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1811,17 +1811,40 @@ PROACTIVE_CHAT_HISTORY_MAX = 10
 - 用途：每个 lanlan 维护的最近主动搭话记录，用于 1h 内去重。
 - 上游：proactive 触发的搭话事件。"""
 
+# ── Master 情绪画像（基建）─────────────────────────────────────────────
+# 用 emotion-tier 小模型即时分析「用户自己说的话」的情绪，产出二维 valence-arousal
+# 瞬时读数（效价 -1~+1、唤醒 0~1）。这是一条独立基建：单一权威源，凝神（FocusScorer
+# 的 emotion 信号）是第一个消费者，后续记忆/UI/主动反应可接同一个 state。绝不复用
+# lanlan 头像那条 outward-emotion 管线（那是角色的脸，不是用户的情绪）。privacy-
+# independent：输入是对话不是屏幕，不受隐私模式门控（同凝神，见 developer-notes 规则 6）。
+MASTER_EMOTION_ENABLED = True
+"""Master 情绪画像总开关（默认开）。
+- 用途：开 = 每条用户消息（节流后）异步跑一次 VA 情绪分析、更新瞬时读数；关掉则
+  不分析、读数恒空，凝神的 emotion 信号自动消失，退回 keyword+cadence。
+- 上游：_note_user_turn 的 fire-and-forget 触发；FocusScorer.emotion 信号的可用性。"""
+
+MASTER_EMOTION_MIN_INTERVAL_SEC = 6.0
+"""两次 VA 分析的最小间隔（秒），节流防连发消息打爆 emotion tier。
+- 用途：MasterEmotionTracker 内部按上次分析时间戳早退。
+- 调小 = 更即时但更费 token；调大 = 更省但读数更陈。"""
+
+MASTER_EMOTION_TIMEOUT_SEC = 8.0
+"""单次 VA 分析的 emotion-tier 调用超时（秒）。
+- 用途：传给 _invoke_emotion_tier 的 timeout；超时则本轮不更新读数、保留上一次。
+- 注意：用的是独立的 emotion tier 模型，不是主对话模型，所以不受 Gemini Live 慢拖累。"""
+
 # ── Focus mode 凝神 (docs/design/focus-truename-mode.md) ───────────────
 # 信号触发、用户无感的「这一轮开思考 + 换强模型」机制，兑现 90/10 产品命题
 # 里的 10% 神明降临。以下全是 A/B 可调旋钮，集中在此便于灰度调参；情绪关键词
 # 这类多语言词表按 i18n 规约放 config/prompts/prompts_focus.py，不在这里。
-FOCUS_MODE_ENABLED = False
-"""凝神总开关（默认关）。
-- 用途：关掉 = FocusScorer 永不评分、SM 永远停在 REGULAR，两条触发路径都退化回
-  常规（proactive 仍 disable_thinking、stream_text 不升档），逐字节零行为变化。
-- 默认关原因：阈值尚未用真实信号分布调过、且 thinking-on 的端到端行为（内联推理
-  文本在流式 content 里的泄露、各 provider 思考开销）未对真模型验证过。先 inert
-  落地，验证 + 调参后再按 provider opt-in 打开。详见 docs/design/focus-truename-mode.md。
+FOCUS_MODE_ENABLED = True
+"""凝神总开关（默认开）。
+- 用途：开 = FocusScorer 正常评分、SM 按累加电荷进入/退出 FOCUS，命中那一轮 inline
+  升档开思考、proactive 路径按情节冷却；关掉则两条触发路径都退化回常规
+  （proactive 仍 disable_thinking、stream_text 不升档），逐字节零行为变化。
+- 历史：曾默认关「先 inert 落地」，因阈值未用真实信号分布调过、且 thinking-on 的
+  端到端行为（内联推理文本在流式 content 里的泄露、各 provider 思考开销）未对真模型
+  验证过。现转默认开，进入真实信号实测 + 调参阶段。详见 docs/design/focus-truename-mode.md。
 - 上游：FocusScorer / SessionStateMachine 入口的早退判定。"""
 
 # ── 累积进入模型（leaky 累加器）─────────────────────────────────────
@@ -1890,14 +1913,19 @@ FOCUS_HARD_CAP_TURNS = 8
 FOCUS_SIGNAL_WEIGHTS: dict[str, float] = {
     "keyword": 0.45,      # 用户消息命中脆弱情绪词
     "cadence": 0.20,      # 回复字数相对基线骤跌
+    "emotion": 0.35,      # master 情绪画像：高唤醒 + 负效价（distress），见 MasterEmotionTracker
 }
 """FocusScorer 各信号的相对权重（仅 inline 路径——评分只看用户自己说的话）。
 - 用途：scorer 对适用信号子集内权重重新归一后加权平均 → 该轮 score（喂给累加器）。
   keyword/cadence 都需要一条真实用户消息；样本不足时 cadence 返回 None、不进分母。
+- emotion：读 master 情绪画像（MasterEmotionTracker）已算好的最近 VA 读数映射成
+  distress 信号（高 arousal × 负 valence）。它是 keyword 脆弱词的「真模型」升级版，
+  但**滞后一拍**——画像异步算，inline 评分拿到的是上一轮的读数；没读数时返回 None、
+  不进分母。MASTER_EMOTION_ENABLED 关或读数缺失时该信号自动消失、退回 keyword+cadence。
 - idle（proactive）路径不评分：它只用 FOCUS_IDLE_SILENT/REPLIED_RETENTION 让 charge
   衰减，绝不抬升，故不在此表里（凝神的进入/维持只由 inline 驱动）。
 - 上游：各子信号各自归一化到 [0,1]。
-- 设计依据：keyword 是最强单信号故权重最高。改这里直接改触发性格，慎调。"""
+- 设计依据：keyword/emotion 是最强的两个情绪信号故权重最高。改这里直接改触发性格，慎调。"""
 
 FOCUS_KEYWORD_SATURATION = 3
 """脆弱情绪关键词命中数的饱和点。

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1923,11 +1923,16 @@ FOCUS_SIGNAL_WEIGHTS: dict[str, float] = {
 }
 """FocusScorer 各信号的相对权重（仅 inline 路径——评分只看用户自己说的话）。
 - 用途：scorer 对适用信号子集内权重重新归一后加权平均 → 该轮 score（喂给累加器）。
-  keyword/cadence 都需要一条真实用户消息；样本不足时 cadence 返回 None、不进分母。
-- emotion：读 master 情绪画像（MasterEmotionTracker）已算好的最近 VA 读数映射成
-  distress 信号（高 arousal × 负 valence）。它是 keyword 脆弱词的「真模型」升级版，
-  但**滞后一拍**——画像异步算，inline 评分拿到的是上一轮的读数；没读数时返回 None、
-  不进分母。MASTER_EMOTION_ENABLED 关或读数缺失时该信号自动消失、退回 keyword+cadence。
+- 信号语义分两类：
+  · keyword / emotion 是「distress 正证据」——无证据时返回 None、不进分母（不投反对
+    票）。于是 keyword 满分 或 emotion 满分**任一都能单轮独立触发**，不会被对方的「0」
+    在分母里互相稀释。这是有意的：emotion 是 keyword 词表的真模型升级，用词不在词表
+    但情绪强烈时应能独立把人拉进 FOCUS。
+  · cadence 是行为信号——它的 0.0（「字数没骤降」）是有信息的、照常进分母；只有样本
+    不足时返回 None。
+- emotion 读 master 情绪画像（MasterEmotionTracker）已算好的最近 VA 读数，映射成
+  distress = arousal × max(0,-valence)。**滞后一拍**（画像异步算，inline 拿上一轮读数）；
+  MASTER_EMOTION_ENABLED 关或无读数/无 distress 时返回 None、自动退回 keyword+cadence。
 - idle（proactive）路径不评分：它只用 FOCUS_IDLE_SILENT/REPLIED_RETENTION 让 charge
   衰减，绝不抬升，故不在此表里（凝神的进入/维持只由 inline 驱动）。
 - 上游：各子信号各自归一化到 [0,1]。

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1839,6 +1839,13 @@ MASTER_EMOTION_MAX_INPUT_CHARS = 500
   （token / 成本 / 输入预算）。
 - 上游：MasterEmotionTracker._invoke 拼 prompt 前截断。"""
 
+MASTER_EMOTION_READING_TTL_SEC = 120.0
+"""情绪读数的有效期（秒），超期视为过期、latest 返回 None。
+- 用途：emotion 信号能单轮独立触发凝神，若读数无限有效，长停顿后一条中性消息
+  会读到几分钟前的旧 distress 读数、误重入/维持 Focus。TTL 让陈旧读数失效，
+  正常对话（turn 间隔几秒~几十秒）不受影响。
+- 设 0 关闭老化。上游：MasterEmotionTracker.latest。"""
+
 # ── Focus mode 凝神 (docs/design/focus-truename-mode.md) ───────────────
 # 信号触发、用户无感的「这一轮开思考 + 换强模型」机制，兑现 90/10 产品命题
 # 里的 10% 神明降临。以下全是 A/B 可调旋钮，集中在此便于灰度调参；情绪关键词

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1833,6 +1833,12 @@ MASTER_EMOTION_TIMEOUT_SEC = 8.0
 - 用途：传给 _invoke_emotion_tier 的 timeout；超时则本轮不更新读数、保留上一次。
 - 注意：用的是独立的 emotion tier 模型，不是主对话模型，所以不受 Gemini Live 慢拖累。"""
 
+MASTER_EMOTION_MAX_INPUT_CHARS = 500
+"""送进 VA 分析的用户文本上限（字符），超出截断。
+- 用途：情绪判断只需开头一段；截断防用户粘贴长文时把整段塞进 emotion tier
+  （token / 成本 / 输入预算）。
+- 上游：MasterEmotionTracker._invoke 拼 prompt 前截断。"""
+
 # ── Focus mode 凝神 (docs/design/focus-truename-mode.md) ───────────────
 # 信号触发、用户无感的「这一轮开思考 + 换强模型」机制，兑现 90/10 产品命题
 # 里的 10% 神明降临。以下全是 A/B 可调旋钮，集中在此便于灰度调参；情绪关键词

--- a/config/prompts/prompts_emotion.py
+++ b/config/prompts/prompts_emotion.py
@@ -178,6 +178,124 @@ outward_emotion_analysis_prompt = OUTWARD_EMOTION_ANALYSIS_PROMPT['zh']
 
 
 # ============================================================================
+# Master（用户）情绪画像：二维 valence-arousal 分析 prompt
+# ============================================================================
+# 与上面的 OUTWARD（驱动角色头像表情）严格分开：这里分析的是「对话里说话者
+# （用户）自己」的情绪，产出连续的 valence（效价）/ arousal（唤醒度）二维读数，
+# 供凝神等后端基建消费。module-agnostic，不绑定任何具体角色 / 场景。
+MASTER_EMOTION_VA_PROMPT = {
+    'zh': """你是一个情感分析专家。请分析下面这段对话中说话者流露出的情绪状态，用二维连续值表示，并只返回 JSON：{"valence": 效价, "arousal": 唤醒度, "confidence": 置信度}。
+
+维度定义：
+- valence（效价）：-1 到 1 之间的小数。-1 = 强烈负面（痛苦、难过、愤怒、绝望），0 = 中性，+1 = 强烈正面（开心、满足、兴奋、温暖）。
+- arousal（唤醒度）：0 到 1 之间的小数。0 = 平静、低能量、放松，1 = 高度激动、强烈、能量很高（无论正负）。
+- confidence（置信度）：0 到 1 之间的小数，表示你对本次判断的把握。
+
+判断规则：
+1. 只依据这段文本本身流露的情绪，不要脑补未给出的背景。
+2. valence 与 arousal 相互独立：愤怒是负效价＋高唤醒；平静的难过是负效价＋低唤醒；满足是正效价＋低唤醒；兴奋是正效价＋高唤醒。
+3. 语气助词、口癖、拟声词这类风格词本身不代表情绪，不能单独作为判断依据。
+4. 文本平铺直叙、情绪很弱时，valence 取接近 0，arousal 取较低值。
+
+只返回 JSON，不要附加任何解释文本。""",
+
+    'en': """你是一个情感分析专家。Analyze the emotional state the speaker reveals in the conversation text below, expressed as two continuous values, and return JSON only: {"valence": valence, "arousal": arousal, "confidence": confidence}.
+
+Dimensions:
+- valence: a number between -1 and 1. -1 = strongly negative (distress, sadness, anger, despair), 0 = neutral, +1 = strongly positive (joy, contentment, excitement, warmth).
+- arousal: a number between 0 and 1. 0 = calm, low energy, relaxed; 1 = highly activated, intense, high energy (regardless of sign).
+- confidence: a number between 0 and 1 indicating your certainty.
+
+Rules:
+1. Judge only from the emotion this text reveals; do not invent unstated context.
+2. valence and arousal are independent: anger is negative valence + high arousal; quiet sadness is negative valence + low arousal; contentment is positive valence + low arousal; excitement is positive valence + high arousal.
+3. Catchphrases, verbal tics, and sound effects are style markers, not emotions by themselves.
+4. When the text is flat with weak emotion, set valence near 0 and arousal low.
+
+Return JSON only, with no explanation.""",
+
+    'ja': """你是一个情感分析专家。次の会話文で話し手がにじませている感情の状態を、2つの連続値で表し、JSONのみで返してください：{"valence": valence, "arousal": arousal, "confidence": confidence}。
+
+各次元の定義：
+- valence（感情価）：-1〜1 の数値。-1 = 強い負（つらさ・悲しみ・怒り・絶望）、0 = 中立、+1 = 強い正（喜び・満足・高揚・あたたかさ）。
+- arousal（覚醒度）：0〜1 の数値。0 = 落ち着き・低エネルギー・リラックス、1 = 強い興奮・激しさ・高エネルギー（正負を問わず）。
+- confidence（確信度）：0〜1 の数値で、今回の判断の確かさ。
+
+判断ルール：
+1. この文章がにじませる感情だけで判断し、書かれていない背景を補わない。
+2. valence と arousal は独立：怒りは負の感情価＋高い覚醒、静かな悲しみは負の感情価＋低い覚醒、満足は正の感情価＋低い覚醒、高揚は正の感情価＋高い覚醒。
+3. 語尾、口ぐせ、擬音などの言い回しは、それ自体では感情の根拠にならない。
+4. 平坦で感情が弱い文章では、valence は 0 付近、arousal は低めにする。
+
+JSONのみを返し、説明文は付けないでください。""",
+
+    'ko': """你是一个情感分析专家。아래 대화문에서 말하는 사람이 드러내는 감정 상태를 두 개의 연속 값으로 나타내고 JSON만 반환하세요: {"valence": valence, "arousal": arousal, "confidence": confidence}.
+
+차원 정의:
+- valence(정서가): -1~1 사이 숫자. -1 = 강한 부정(괴로움, 슬픔, 분노, 절망), 0 = 중립, +1 = 강한 긍정(기쁨, 만족, 들뜸, 따뜻함).
+- arousal(각성도): 0~1 사이 숫자. 0 = 차분함, 낮은 에너지, 이완; 1 = 강한 흥분, 격렬함, 높은 에너지(긍·부정 무관).
+- confidence(확신도): 0~1 사이 숫자로 이번 판단에 대한 확신.
+
+판단 규칙:
+1. 이 문장이 드러내는 감정만으로 판단하고, 주어지지 않은 배경을 지어내지 마세요.
+2. valence 와 arousal 은 서로 독립적입니다: 분노는 부정 정서가＋높은 각성, 조용한 슬픔은 부정 정서가＋낮은 각성, 만족은 긍정 정서가＋낮은 각성, 들뜸은 긍정 정서가＋높은 각성.
+3. 말버릇, 어미, 의성어 같은 표현은 그 자체로 감정 근거가 되지 않습니다.
+4. 문장이 밋밋하고 감정이 약하면 valence 는 0 근처, arousal 은 낮게 설정하세요.
+
+설명 없이 JSON만 반환하세요.""",
+
+    'ru': """你是一个情感分析专家。Проанализируйте эмоциональное состояние, которое говорящий выражает в приведённом ниже тексте разговора, представьте его двумя непрерывными значениями и верните только JSON: {"valence": valence, "arousal": arousal, "confidence": confidence}.
+
+Измерения:
+- valence (валентность): число от -1 до 1. -1 = сильно негативное (боль, грусть, гнев, отчаяние), 0 = нейтрально, +1 = сильно позитивное (радость, удовлетворение, воодушевление, теплота).
+- arousal (возбуждение): число от 0 до 1. 0 = спокойствие, низкая энергия, расслабленность; 1 = сильное возбуждение, интенсивность, высокая энергия (независимо от знака).
+- confidence (уверенность): число от 0 до 1, отражающее вашу уверенность.
+
+Правила:
+1. Судите только по эмоции, выраженной в этом тексте; не домысливайте неуказанный контекст.
+2. valence и arousal независимы: гнев — негативная валентность + высокое возбуждение; тихая грусть — негативная валентность + низкое возбуждение; удовлетворение — позитивная валентность + низкое возбуждение; воодушевление — позитивная валентность + высокое возбуждение.
+3. Слова-паразиты, повторяющиеся словечки и звукоподражания сами по себе не являются признаком эмоции.
+4. Если текст ровный и эмоция слабая, ставьте valence около 0 и низкий arousal.
+
+Верните только JSON без пояснений.""",
+
+    'es': """你是一个情感分析专家。Analiza el estado emocional que revela quien habla en el texto de conversación siguiente, exprésalo con dos valores continuos y devuelve solo JSON: {"valence": valence, "arousal": arousal, "confidence": confidence}.
+
+Dimensiones:
+- valence (valencia): un número entre -1 y 1. -1 = fuertemente negativo (dolor, tristeza, ira, desesperación), 0 = neutral, +1 = fuertemente positivo (alegría, satisfacción, entusiasmo, calidez).
+- arousal (activación): un número entre 0 y 1. 0 = calma, baja energía, relajación; 1 = muy activado, intenso, alta energía (sin importar el signo).
+- confidence (confianza): un número entre 0 y 1 que indica tu seguridad.
+
+Reglas:
+1. Juzga solo por la emoción que revela este texto; no inventes contexto no dado.
+2. valence y arousal son independientes: la ira es valencia negativa + activación alta; la tristeza tranquila es valencia negativa + activación baja; la satisfacción es valencia positiva + activación baja; el entusiasmo es valencia positiva + activación alta.
+3. Las muletillas, los tics verbales y los efectos de sonido son marcadores de estilo, no emociones por sí mismos.
+4. Cuando el texto sea plano y con emoción débil, pon valence cerca de 0 y arousal bajo.
+
+Devuelve solo JSON, sin explicación.""",
+
+    'pt': """你是一个情感分析专家。Analise o estado emocional que o falante revela no texto de conversa abaixo, expresso por dois valores contínuos, e retorne apenas JSON: {"valence": valence, "arousal": arousal, "confidence": confidence}.
+
+Dimensões:
+- valence (valência): um número entre -1 e 1. -1 = fortemente negativo (sofrimento, tristeza, raiva, desespero), 0 = neutro, +1 = fortemente positivo (alegria, satisfação, empolgação, calor).
+- arousal (ativação): um número entre 0 e 1. 0 = calmo, baixa energia, relaxado; 1 = muito ativado, intenso, alta energia (independente do sinal).
+- confidence (confiança): um número entre 0 e 1 indicando sua certeza.
+
+Regras:
+1. Julgue apenas pela emoção que este texto revela; não invente contexto não fornecido.
+2. valence e arousal são independentes: raiva é valência negativa + ativação alta; tristeza quieta é valência negativa + ativação baixa; satisfação é valência positiva + ativação baixa; empolgação é valência positiva + ativação alta.
+3. Bordões, tiques verbais e efeitos sonoros são marcadores de estilo, não emoções por si só.
+4. Quando o texto for plano e com emoção fraca, defina valence perto de 0 e arousal baixo.
+
+Retorne apenas JSON, sem explicação.""",
+}
+
+
+def get_master_emotion_va_prompt(lang: str = 'zh') -> str:
+    return _loc(MASTER_EMOTION_VA_PROMPT, lang)
+
+
+# ============================================================================
 # 启发式情感分类的 i18n 关键词表
 # ============================================================================
 # 以下为按语种组织的关键词字典；system_router._infer_emotion_from_text 会通过

--- a/main_logic/activity/__init__.py
+++ b/main_logic/activity/__init__.py
@@ -46,6 +46,10 @@ from main_logic.activity.system_signals import (
 )
 from main_logic.activity.tracker import UserActivityTracker
 from main_logic.activity.focus_scorer import FocusScore, FocusScorer
+from main_logic.activity.master_emotion import (
+    MasterEmotionReading,
+    MasterEmotionTracker,
+)
 
 __all__ = [
     'UserActivityTracker',
@@ -54,4 +58,5 @@ __all__ = [
     'format_activity_state_section', 'state_to_propensity',
     'SystemSignalCollector', 'SystemSnapshot', 'get_system_signal_collector',
     'FocusScore', 'FocusScorer',
+    'MasterEmotionReading', 'MasterEmotionTracker',
 ]

--- a/main_logic/activity/focus_scorer.py
+++ b/main_logic/activity/focus_scorer.py
@@ -153,11 +153,13 @@ class FocusScorer:
             arousal = float(arousal)
         except (TypeError, ValueError):
             return None
-        # arousal ∈ [0,1] = intensity; (1 - valence)/2 maps valence -1→1, 0→0.5,
-        # +1→0. So strong-negative & high-arousal (distress) ≈ 1; calm or happy
-        # ≈ low. Excitement (positive + high arousal) intentionally does NOT
-        # trigger Focus — Focus is for vulnerability / distress, not elation.
-        negativity = (1.0 - valence) / 2.0
+        # arousal ∈ [0,1] = intensity; negativity = max(0, -valence) fires ONLY
+        # in the negative-valence half (valence -1→1, 0→0, +1→0). So distress =
+        # arousal × negativity ≈ 1 for strong-negative & high-arousal, and 0 for
+        # neutral OR positive affect — neither calm, mere intensity, nor elation
+        # triggers Focus, matching the "high arousal + NEGATIVE valence" def.
+        # Focus is for vulnerability / distress.
+        negativity = max(0.0, -valence)
         return max(0.0, min(1.0, arousal * negativity))
 
 

--- a/main_logic/activity/focus_scorer.py
+++ b/main_logic/activity/focus_scorer.py
@@ -93,8 +93,15 @@ class FocusScorer:
         so the score is language-agnostic.
         """
         kw = self._signal_keyword(user_text)
-        cadence = self._signal_cadence(user_text)
         emotion = self._signal_emotion(emotion_reading)
+        cadence = self._signal_cadence(user_text)
+        # cadence amplifies distress evidence; it is NOT a trigger on its own.
+        # With keyword/emotion using positive-evidence-only (None) semantics, a
+        # lone cadence signal would renormalise to a full 1.0 — so an ordinary
+        # short reply ("ok") could enter Focus with no distress evidence at all.
+        # Gate it: when neither keyword nor emotion is present, drop cadence too.
+        if kw is None and emotion is None:
+            cadence = None
 
         signals = {"keyword": kw, "cadence": cadence, "emotion": emotion}
         score = _weighted_average(signals, config.FOCUS_SIGNAL_WEIGHTS)

--- a/main_logic/activity/focus_scorer.py
+++ b/main_logic/activity/focus_scorer.py
@@ -17,7 +17,9 @@
 Produces the single [0, 1] score that ``SessionStateMachine.update_focus``
 feeds into its hysteresis. Scoring is **inline-only**: it reads what the
 user just typed (``stream_text``), never the screen. The applicable
-signals are keyword + cadence — both need a real user message.
+signals are keyword + cadence + emotion — keyword/cadence read the message
+directly, emotion reads the latest master-emotion VA reading the caller hands
+in (no I/O in the scorer). All need a real user message / reading.
 
 The idle (``proactive_chat``) path does NOT score: a proactive turn never
 raises the Focus charge. Entering and sustaining Focus is driven solely by
@@ -71,13 +73,20 @@ class FocusScorer:
         )
 
     # ── public API ──────────────────────────────────────────────────
-    def score(self, *, user_text: str) -> FocusScore:
-        """Score one inline turn from the user's message (keyword + cadence).
+    def score(self, *, user_text: str, emotion_reading=None) -> FocusScore:
+        """Score one inline turn from the user's message (keyword + cadence + emotion).
 
         Side effect: when ``user_text`` is a real (non-empty) message, its
         length is appended to the cadence baseline buffer **after** the
         cadence signal is computed (so cadence always compares the current
         message against *prior* messages).
+
+        ``emotion_reading`` is the latest ``MasterEmotionReading`` (duck-typed:
+        any object with ``valence``/``arousal`` floats) from the master emotion
+        tracker, or ``None`` when unavailable. Stays I/O-free — the caller hands
+        in an already-computed reading, the scorer never analyzes. The reading
+        lags one turn (it is produced async) — by design, the same way cadence
+        compares against prior messages.
 
         No ``lang`` argument: the keyword signal scans every locale's
         vulnerability table in parallel (mixed-language speech is common),
@@ -85,8 +94,9 @@ class FocusScorer:
         """
         kw = self._signal_keyword(user_text)
         cadence = self._signal_cadence(user_text)
+        emotion = self._signal_emotion(emotion_reading)
 
-        signals = {"keyword": kw, "cadence": cadence}
+        signals = {"keyword": kw, "cadence": cadence, "emotion": emotion}
         score = _weighted_average(signals, config.FOCUS_SIGNAL_WEIGHTS)
 
         # Update the cadence baseline for this inline message.
@@ -122,6 +132,33 @@ class FocusScorer:
             return 1.0
         # linear ramp between the drop floor and the baseline
         return (baseline - cur) / (baseline - lo)
+
+    def _signal_emotion(self, emotion_reading) -> Optional[float]:
+        """Distress signal from the master emotion VA reading.
+
+        High arousal × negative valence → distress, the strongest Focus cue
+        (the model-grade upgrade of the vulnerability-keyword signal). Returns
+        ``None`` when no reading is available (master emotion off / not yet
+        analyzed), so it drops out of the weighted average instead of dragging
+        it toward zero.
+        """
+        if emotion_reading is None:
+            return None
+        valence = getattr(emotion_reading, "valence", None)
+        arousal = getattr(emotion_reading, "arousal", None)
+        if valence is None or arousal is None:
+            return None
+        try:
+            valence = float(valence)
+            arousal = float(arousal)
+        except (TypeError, ValueError):
+            return None
+        # arousal ∈ [0,1] = intensity; (1 - valence)/2 maps valence -1→1, 0→0.5,
+        # +1→0. So strong-negative & high-arousal (distress) ≈ 1; calm or happy
+        # ≈ low. Excitement (positive + high arousal) intentionally does NOT
+        # trigger Focus — Focus is for vulnerability / distress, not elation.
+        negativity = (1.0 - valence) / 2.0
+        return max(0.0, min(1.0, arousal * negativity))
 
 
 def _weighted_average(signals: dict, weights: dict) -> float:

--- a/main_logic/activity/focus_scorer.py
+++ b/main_logic/activity/focus_scorer.py
@@ -109,9 +109,16 @@ class FocusScorer:
         """Drop the cadence baseline (call on session teardown / hot-swap)."""
         self._recent_lengths.clear()
 
-    # ── sub-signals (keyword → [0, 1]; cadence → [0, 1] or None) ─────
-    def _signal_keyword(self, user_text: str) -> float:
+    # ── sub-signals ──────────────────────────────────────────────────
+    # keyword / emotion are *positive distress evidence*: they return None (not
+    # 0.0) when absent, so an empty one never dilutes the other in the weighted
+    # average — a saturated keyword OR a saturated emotion reading can each
+    # trigger Focus on its own. cadence is a behavioural signal whose 0.0
+    # ("message length normal") is informative, so it keeps 0.0 in the denom.
+    def _signal_keyword(self, user_text: str) -> Optional[float]:
         count = scan_vulnerability_keywords(user_text)
+        if count <= 0:
+            return None  # no vulnerability keyword → no signal, not "evidence against"
         sat = max(1, int(config.FOCUS_KEYWORD_SATURATION))
         return min(count / sat, 1.0)
 
@@ -136,11 +143,11 @@ class FocusScorer:
     def _signal_emotion(self, emotion_reading) -> Optional[float]:
         """Distress signal from the master emotion VA reading.
 
-        High arousal × negative valence → distress, the strongest Focus cue
-        (the model-grade upgrade of the vulnerability-keyword signal). Returns
-        ``None`` when no reading is available (master emotion off / not yet
-        analyzed), so it drops out of the weighted average instead of dragging
-        it toward zero.
+        High arousal × negative valence → distress, the model-grade upgrade of
+        the vulnerability-keyword signal. Returns ``None`` (drops out of the
+        weighted average) when there is no reading OR no distress — a stale
+        neutral/positive reading must not dilute a current keyword-positive
+        turn, same "positive evidence only" rule as ``_signal_keyword``.
         """
         if emotion_reading is None:
             return None
@@ -160,7 +167,9 @@ class FocusScorer:
         # triggers Focus, matching the "high arousal + NEGATIVE valence" def.
         # Focus is for vulnerability / distress.
         negativity = max(0.0, -valence)
-        return max(0.0, min(1.0, arousal * negativity))
+        distress = max(0.0, min(1.0, arousal * negativity))
+        # No distress (neutral / positive / stale) → None, not 0.0 (see above).
+        return distress if distress > 0.0 else None
 
 
 def _weighted_average(signals: dict, weights: dict) -> float:

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -111,15 +111,26 @@ class MasterEmotionTracker:
     # ── public API ──────────────────────────────────────────────────
     @property
     def latest(self) -> Optional[MasterEmotionReading]:
-        """The most recent reading, or ``None`` if never analyzed / reset / disabled.
+        """The most recent reading, or ``None`` if never analyzed / reset / disabled / expired.
 
         Honors the master switch: flipping ``MASTER_EMOTION_ENABLED`` off makes
         the reading disappear immediately (consumers fall back) instead of
         serving a stale reading until the next analyze.
+
+        Also age-gated by ``MASTER_EMOTION_READING_TTL_SEC``: the emotion signal
+        can trigger Focus on its own, so an indefinitely-served old distress
+        reading would mis-enter Focus on an unrelated neutral message after a
+        long pause. Normal turn cadence (seconds) stays well within the TTL.
         """
         if not bool(getattr(config, "MASTER_EMOTION_ENABLED", True)):
             return None
-        return self._latest
+        r = self._latest
+        if r is None:
+            return None
+        ttl = float(getattr(config, "MASTER_EMOTION_READING_TTL_SEC", 120.0))
+        if ttl > 0 and (time.time() - r.updated_at) > ttl:
+            return None
+        return r
 
     def reset(self) -> None:
         """Drop the current reading (call on session teardown / hot-swap)."""

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -1,0 +1,209 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Master (user) emotion tracker — instantaneous valence-arousal reading.
+
+The single source of truth for "how the user feels right now". One instance
+per session, owned alongside ``UserActivityTracker`` / ``FocusScorer``.
+
+  * Fed asynchronously from each real user turn (``_note_user_turn``),
+    throttled by ``MASTER_EMOTION_MIN_INTERVAL_SEC`` so rapid messages don't
+    hammer the emotion-tier model.
+  * Produces a two-dimensional reading — ``valence`` (negative ↔ positive) and
+    ``arousal`` (calm ↔ activated) — via the small ``emotion`` model tier,
+    reusing ``llm_enrichment._invoke_emotion_tier``.
+  * Consumed first by ``FocusScorer``'s ``emotion`` signal (distress = high
+    arousal × negative valence); later by memory / UI / proactive reactions.
+
+Hard boundaries:
+  * This is NOT the ``OUTWARD_EMOTION_ANALYSIS`` pipeline that drives lanlan's
+    avatar face — that analyzes the *character's* reply. This analyzes the
+    *user's* own utterance and never touches the avatar channel.
+  * Privacy-independent BY CONSTRUCTION: the input is what the user said, not
+    screen / app state. So it is NOT gated on privacy mode (see
+    ``docs/contributing/developer-notes.md`` rule 6), mirroring Focus.
+
+Only the latest reading is kept — long-term aggregation (dominant emotion /
+volatility / triggers) is a deferred extension; ``to_profile_sample`` is the
+hook a future memory consumer pulls from.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import config
+
+logger = logging.getLogger(__name__)
+
+# ```json ... ``` fence the emotion tier (e.g. Gemini) may wrap the JSON in.
+# Mirrors system_router.emotion_analysis's stripping before robust_json_loads.
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.+?)\s*```", flags=re.S)
+
+
+@dataclass(frozen=True)
+class MasterEmotionReading:
+    """One instantaneous read of the user's emotional state.
+
+    ``valence`` ∈ [-1, 1] (negative → positive), ``arousal`` ∈ [0, 1]
+    (calm → activated), ``confidence`` ∈ [0, 1]. ``source_excerpt`` keeps a
+    short prefix of the analyzed text for diagnostics only.
+    """
+
+    valence: float
+    arousal: float
+    confidence: float
+    updated_at: float
+    source_excerpt: str = ""
+
+
+def _clamp(value, lo: float, hi: float, default: float) -> float:
+    """Coerce ``value`` to a float in [lo, hi]; return ``default`` on junk/NaN."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return default
+    if v != v:  # NaN
+        return default
+    return max(lo, min(hi, v))
+
+
+class MasterEmotionTracker:
+    """Per-session instantaneous master-emotion state. Async-fed, throttled."""
+
+    def __init__(self, lanlan_name: str) -> None:
+        self.lanlan_name = lanlan_name
+        self._latest: Optional[MasterEmotionReading] = None
+        self._last_attempt_at: float = 0.0
+
+    # ── public API ──────────────────────────────────────────────────
+    @property
+    def latest(self) -> Optional[MasterEmotionReading]:
+        """The most recent reading, or ``None`` if never analyzed / reset."""
+        return self._latest
+
+    def reset(self) -> None:
+        """Drop the current reading (call on session teardown / hot-swap)."""
+        self._latest = None
+        self._last_attempt_at = 0.0
+
+    async def analyze(
+        self, text: Optional[str], *, now: Optional[float] = None,
+    ) -> Optional[MasterEmotionReading]:
+        """Analyze one user utterance → update the latest VA reading.
+
+        Throttled by ``MASTER_EMOTION_MIN_INTERVAL_SEC`` and gated by
+        ``MASTER_EMOTION_ENABLED``. Best-effort: any failure (tier disabled,
+        bad JSON, timeout) leaves the previous reading intact and returns
+        ``None``. Returns the new reading on success.
+        """
+        if now is None:
+            now = time.time()
+        cleaned = (text or "").strip()
+        if not cleaned:
+            return None
+        if self._should_skip(now):
+            return None
+        # Reserve the throttle slot up-front (before the await) so concurrent
+        # turns inside the same interval don't all fire a model call.
+        self._last_attempt_at = now
+
+        raw = await self._invoke(cleaned)
+        if not raw:
+            return None
+        reading = self._parse(raw, now=now, source=cleaned)
+        if reading is None:
+            return None
+        self._latest = reading
+        logger.info(
+            "[%s] master emotion: valence=%.2f arousal=%.2f conf=%.2f",
+            self.lanlan_name, reading.valence, reading.arousal, reading.confidence,
+        )
+        return reading
+
+    def to_profile_sample(self) -> Optional[dict]:
+        """Future long-term-profile hook: one sample = the latest reading.
+
+        Long-term aggregation is deferred; this lets a memory / reflection
+        consumer pull the current sample without reaching into private state.
+        """
+        r = self._latest
+        if r is None:
+            return None
+        return {
+            "valence": r.valence,
+            "arousal": r.arousal,
+            "confidence": r.confidence,
+            "at": r.updated_at,
+        }
+
+    # ── internals ────────────────────────────────────────────────────
+    def _should_skip(self, now: float) -> bool:
+        if not bool(getattr(config, "MASTER_EMOTION_ENABLED", True)):
+            return True
+        interval = float(getattr(config, "MASTER_EMOTION_MIN_INTERVAL_SEC", 6.0))
+        return (now - self._last_attempt_at) < interval
+
+    async def _invoke(self, text: str) -> Optional[str]:
+        # Reuse the package-internal emotion-tier call (same small model the
+        # activity enrichment uses). Telemetry currently attributes these to
+        # the shared ``activity_enrichment`` call type.
+        from config.prompts.prompts_emotion import get_master_emotion_va_prompt
+        from main_logic.activity.llm_enrichment import _invoke_emotion_tier
+
+        lang = self._resolve_lang(text)
+        # The VA prompt already says "the speaker in the conversation below",
+        # so the user's utterance follows directly — no extra delimiter needed.
+        prompt = get_master_emotion_va_prompt(lang) + "\n\n" + text
+        timeout = float(getattr(config, "MASTER_EMOTION_TIMEOUT_SEC", 8.0))
+        return await _invoke_emotion_tier(prompt, timeout=timeout, label="master_emotion")
+
+    @staticmethod
+    def _resolve_lang(text: str) -> str:
+        # Prompt language follows the language the user spoke in.
+        try:
+            from utils.language_utils import detect_language, normalize_language_code
+            return normalize_language_code(detect_language(text), format="short")
+        except Exception:
+            return "zh"
+
+    @staticmethod
+    def _parse(
+        raw: str, *, now: float, source: str,
+    ) -> Optional[MasterEmotionReading]:
+        from utils.file_utils import robust_json_loads
+
+        text = (raw or "").strip()
+        fence = _JSON_FENCE_RE.search(text)
+        if fence:
+            text = fence.group(1).strip()
+        try:
+            data = robust_json_loads(text)
+        except Exception:
+            return None
+        if not isinstance(data, dict):
+            return None
+        # Require at least one of the two axes; a dict with neither is junk.
+        if "valence" not in data and "arousal" not in data:
+            return None
+        return MasterEmotionReading(
+            valence=_clamp(data.get("valence"), -1.0, 1.0, 0.0),
+            arousal=_clamp(data.get("arousal"), 0.0, 1.0, 0.0),
+            confidence=_clamp(data.get("confidence"), 0.0, 1.0, 0.5),
+            updated_at=now,
+            source_excerpt=source[:80],
+        )

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -41,6 +41,7 @@ hook a future memory consumer pulls from.
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
 from dataclasses import dataclass
@@ -52,7 +53,8 @@ logger = logging.getLogger(__name__)
 
 # ```json ... ``` fence the emotion tier (e.g. Gemini) may wrap the JSON in.
 # Mirrors system_router.emotion_analysis's stripping before robust_json_loads.
-_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.+?)\s*```", flags=re.S)
+# Case-insensitive: models also emit ```JSON / ```Json.
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.+?)\s*```", flags=re.S | re.I)
 
 
 @dataclass(frozen=True)
@@ -77,9 +79,24 @@ def _clamp(value, lo: float, hi: float, default: float) -> float:
         v = float(value)
     except (TypeError, ValueError):
         return default
-    if v != v:  # NaN
+    if math.isnan(v):
         return default
     return max(lo, min(hi, v))
+
+
+def _coerce_axis(value) -> Optional[float]:
+    """Coerce a VA axis to float, or ``None`` if missing / non-numeric / NaN.
+
+    Unlike ``_clamp``, this distinguishes "absent" from a real value so a
+    partial response can be rejected rather than silently defaulted to 0.
+    """
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(v):
+        return None
+    return v
 
 
 class MasterEmotionTracker:
@@ -89,17 +106,26 @@ class MasterEmotionTracker:
         self.lanlan_name = lanlan_name
         self._latest: Optional[MasterEmotionReading] = None
         self._last_attempt_at: float = 0.0
+        self._seq: int = 0
 
     # ── public API ──────────────────────────────────────────────────
     @property
     def latest(self) -> Optional[MasterEmotionReading]:
-        """The most recent reading, or ``None`` if never analyzed / reset."""
+        """The most recent reading, or ``None`` if never analyzed / reset / disabled.
+
+        Honors the master switch: flipping ``MASTER_EMOTION_ENABLED`` off makes
+        the reading disappear immediately (consumers fall back) instead of
+        serving a stale reading until the next analyze.
+        """
+        if not bool(getattr(config, "MASTER_EMOTION_ENABLED", True)):
+            return None
         return self._latest
 
     def reset(self) -> None:
         """Drop the current reading (call on session teardown / hot-swap)."""
         self._latest = None
         self._last_attempt_at = 0.0
+        self._seq += 1
 
     async def analyze(
         self, text: Optional[str], *, now: Optional[float] = None,
@@ -119,14 +145,23 @@ class MasterEmotionTracker:
         if self._should_skip(now):
             return None
         # Reserve the throttle slot up-front (before the await) so concurrent
-        # turns inside the same interval don't all fire a model call.
+        # turns inside the same interval don't all fire a model call. ``_seq``
+        # tags this analysis so an out-of-order completion can't clobber a newer
+        # turn's reading (see the stale-result guard below).
         self._last_attempt_at = now
+        self._seq += 1
+        my_seq = self._seq
 
         raw = await self._invoke(cleaned)
         if not raw:
             return None
         reading = self._parse(raw, now=now, source=cleaned)
         if reading is None:
+            return None
+        # Stale-result guard: if a newer analysis (or a reset) was kicked off
+        # while this one awaited — possible under a slow tier — the newer turn
+        # wins; never let this older turn's reading overwrite it.
+        if my_seq != self._seq:
             return None
         self._latest = reading
         logger.info(
@@ -165,10 +200,14 @@ class MasterEmotionTracker:
         from config.prompts.prompts_emotion import get_master_emotion_va_prompt
         from main_logic.activity.llm_enrichment import _invoke_emotion_tier
 
-        lang = self._resolve_lang(text)
+        # Bound the input: emotion is judgeable from the opening; truncating
+        # stops a pasted wall of text from going to the emotion tier whole.
+        max_chars = max(1, int(getattr(config, "MASTER_EMOTION_MAX_INPUT_CHARS", 500)))
+        bounded = text[:max_chars]
+        lang = self._resolve_lang(bounded)
         # The VA prompt already says "the speaker in the conversation below",
         # so the user's utterance follows directly — no extra delimiter needed.
-        prompt = get_master_emotion_va_prompt(lang) + "\n\n" + text
+        prompt = get_master_emotion_va_prompt(lang) + "\n\n" + bounded
         timeout = float(getattr(config, "MASTER_EMOTION_TIMEOUT_SEC", 8.0))
         return await _invoke_emotion_tier(prompt, timeout=timeout, label="master_emotion")
 
@@ -197,12 +236,17 @@ class MasterEmotionTracker:
             return None
         if not isinstance(data, dict):
             return None
-        # Require at least one of the two axes; a dict with neither is junk.
-        if "valence" not in data and "arousal" not in data:
+        # A complete reading needs BOTH axes as real numbers. A partial response
+        # (e.g. only ``valence``) must NOT be filled with 0 — a missing arousal
+        # would zero the distress signal (distress ∝ arousal) and silently
+        # misread strong negative affect as calm. Reject → keep the last reading.
+        valence = _coerce_axis(data.get("valence"))
+        arousal = _coerce_axis(data.get("arousal"))
+        if valence is None or arousal is None:
             return None
         return MasterEmotionReading(
-            valence=_clamp(data.get("valence"), -1.0, 1.0, 0.0),
-            arousal=_clamp(data.get("arousal"), 0.0, 1.0, 0.0),
+            valence=max(-1.0, min(1.0, valence)),
+            arousal=max(0.0, min(1.0, arousal)),
             confidence=_clamp(data.get("confidence"), 0.0, 1.0, 0.5),
             updated_at=now,
             source_excerpt=source[:80],

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -175,8 +175,9 @@ class MasterEmotionTracker:
 
         Long-term aggregation is deferred; this lets a memory / reflection
         consumer pull the current sample without reaching into private state.
+        Reads via ``self.latest`` so it honors the MASTER_EMOTION_ENABLED gate.
         """
-        r = self._latest
+        r = self.latest
         if r is None:
             return None
         return {

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1042,7 +1042,7 @@ class LLMSessionManager:
         # 用户活动 tracker：把窗口/进程/CPU/idle/语音/对话信号聚合成结构化
         # ActivitySnapshot，供 proactive_chat Phase 1/2 决策搭话倾向。
         # 详见 docs/design/user-activity-tracker.md。
-        from main_logic.activity import FocusScorer, UserActivityTracker
+        from main_logic.activity import FocusScorer, MasterEmotionTracker, UserActivityTracker
         from main_logic.conversation_turns import create_default_turn_dispatcher
         self._activity_tracker = UserActivityTracker(lanlan_name)
         self._turn_dispatcher = create_default_turn_dispatcher(
@@ -1056,6 +1056,12 @@ class LLMSessionManager:
         # cadence 基线滚动 buffer。两条触发路径（inline stream_text / idle
         # proactive）共用同一个 scorer，保证行为不分裂。
         self._focus_scorer = FocusScorer(lanlan_name)
+
+        # Master 情绪画像（基建，docs 见 config MASTER_EMOTION_*）：异步分析「用户
+        # 说的话」的 valence-arousal，单一权威源。凝神是第一个消费者（_focus_scorer
+        # 的 emotion 信号读它的最近读数）。绝不复用 lanlan 头像 outward-emotion 管线。
+        # privacy-independent（输入是对话不是屏幕），不受隐私门控。
+        self._master_emotion = MasterEmotionTracker(lanlan_name)
 
         # 进入游戏/娱乐 或 进入专注工作时，给前端推一次性情境信号——前端（每会话每类
         # 一次）据此弹窗问要不要开/关主动搭话里的屏幕分享来源。后端只检测「进入」那一刻
@@ -2350,7 +2356,14 @@ class LLMSessionManager:
             # they typed is core to an AI companion. Privacy mode governs only
             # SCREEN / app-state visibility (see docs/contributing/
             # developer-notes.md rule 6). Hence no snapshot fetch here.
-            scored = self._focus_scorer.score(user_text=user_text)
+            # emotion 信号读 master 情绪画像的最近读数（异步算、滞后一拍，与
+            # cadence 用历史一脉相承）。画像关 / 还没算过时 latest 为 None，
+            # FocusScorer 让 emotion 信号自动退出加权、退回 keyword+cadence。
+            _me = getattr(self, '_master_emotion', None)
+            emotion_reading = getattr(_me, 'latest', None)
+            scored = self._focus_scorer.score(
+                user_text=user_text, emotion_reading=emotion_reading,
+            )
             topic_changed = detect_topic_switch(user_text)
             mode = await self.state.update_focus(
                 scored.score, topic_changed=topic_changed,
@@ -2656,6 +2669,15 @@ class LLMSessionManager:
             dispatcher.set_language(language)
 
     def _note_user_turn(self, *, text: str | None = None, now: float | None = None) -> None:
+        # Master 情绪画像：异步分析用户这轮说的话（节流 + 开关都在 tracker 内部）。
+        # 语音转写 / 文本输入两条路径的对偶 chokepoint。fire-and-forget、best-effort，
+        # 绝不阻塞 turn 记录、不让分析异常冒泡。凝神 inline 评分读它的最近读数。
+        if text and text.strip() and getattr(self, '_master_emotion', None) is not None:
+            try:
+                self._fire_task(self._master_emotion.analyze(text, now=now))
+            except Exception as _me_err:
+                logger.debug("[%s] master emotion fire failed: %s", self.lanlan_name, _me_err)
+
         dispatcher = getattr(self, '_turn_dispatcher', None)
         if dispatcher is not None:
             dispatcher.note_user_message(text=text, now=now)
@@ -4113,6 +4135,7 @@ class LLMSessionManager:
             try:
                 await self.state.clear_focus()
                 self._focus_scorer.reset()
+                self._master_emotion.reset()
             except Exception as _focus_err:
                 logger.debug(f"[{self.lanlan_name}] focus reset on repetition failed: {_focus_err}")
 
@@ -4641,8 +4664,9 @@ class LLMSessionManager:
         # auto-start 不被误清），但 end_session 语义就是整轮收尾，必须强制清场。
         await self.state.reset(force=True)
         # 对偶 SM.reset 清 focus 态：scorer 的 cadence 基线也按会话隔离，新会话
-        # 不继承上一会话的消息长度基线。
+        # 不继承上一会话的消息长度基线。master 情绪画像同样按会话隔离。
         self._focus_scorer.reset()
+        self._master_emotion.reset()
 
     def _realtime_base_url(self) -> str:
         """Read the realtime route's base_url, for the native voice routing host remap

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1062,6 +1062,9 @@ class LLMSessionManager:
         # 的 emotion 信号读它的最近读数）。绝不复用 lanlan 头像 outward-emotion 管线。
         # privacy-independent（输入是对话不是屏幕），不受隐私门控。
         self._master_emotion = MasterEmotionTracker(lanlan_name)
+        # 凝神 inline 评分用的 emotion 读数快照：每个 user turn 在 _note_user_turn 里
+        # 于「本轮 analyze 启动前」刷新，保证 emotion 信号确定性滞后一拍。
+        self._focus_emotion_reading = None
 
         # 进入游戏/娱乐 或 进入专注工作时，给前端推一次性情境信号——前端（每会话每类
         # 一次）据此弹窗问要不要开/关主动搭话里的屏幕分享来源。后端只检测「进入」那一刻
@@ -2359,8 +2362,11 @@ class LLMSessionManager:
             # emotion 信号读 master 情绪画像的最近读数（异步算、滞后一拍，与
             # cadence 用历史一脉相承）。画像关 / 还没算过时 latest 为 None，
             # FocusScorer 让 emotion 信号自动退出加权、退回 keyword+cadence。
-            _me = getattr(self, '_master_emotion', None)
-            emotion_reading = getattr(_me, 'latest', None)
+            # 读 _note_user_turn 在「本轮 analyze 启动前」存的快照，保证 emotion
+            # 信号确定性地滞后一拍——当前 turn 不消费它自己即将算出的读数（否则快
+            # tier / 中途 await 让 fire-and-forget analyze 抢先更新 latest，同一条
+            # 消息会时而读旧读数时而读自己的，违反 scorer 的 lag-one-turn 契约）。
+            emotion_reading = getattr(self, '_focus_emotion_reading', None)
             scored = self._focus_scorer.score(
                 user_text=user_text, emotion_reading=emotion_reading,
             )
@@ -2671,10 +2677,16 @@ class LLMSessionManager:
     def _note_user_turn(self, *, text: str | None = None, now: float | None = None) -> None:
         # Master 情绪画像：异步分析用户这轮说的话（节流 + 开关都在 tracker 内部）。
         # 语音转写 / 文本输入两条路径的对偶 chokepoint。fire-and-forget、best-effort，
-        # 绝不阻塞 turn 记录、不让分析异常冒泡。凝神 inline 评分读它的最近读数。
-        if text and text.strip() and getattr(self, '_master_emotion', None) is not None:
+        # 绝不阻塞 turn 记录、不让分析异常冒泡。
+        _me = getattr(self, '_master_emotion', None)
+        if _me is not None:
+            # 先 snapshot「本轮 analyze 启动前」的读数，供 _focus_inline_decision 用，
+            # 保证 emotion 信号滞后一拍（当前 turn 不消费下面这次 analyze 的结果）。
+            # 读 .latest 已含 TTL / 开关 gate。
+            self._focus_emotion_reading = _me.latest
+        if text and text.strip() and _me is not None:
             try:
-                self._fire_task(self._master_emotion.analyze(text, now=now))
+                self._fire_task(_me.analyze(text, now=now))
             except Exception as _me_err:
                 logger.debug("[%s] master emotion fire failed: %s", self.lanlan_name, _me_err)
 

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -190,8 +190,10 @@ def test_scorer_cadence_drop_after_baseline():
     # Feed long messages to build a baseline (each call appends after scoring).
     for _ in range(4):
         s.score(user_text="这是一段比较长的正常聊天消息内容大概三十个字符以上")
-    res = s.score(user_text="嗯。")
-    assert res.signals["cadence"] is not None and res.signals["cadence"] > 0.5
+    # Query the cadence sub-signal directly: score() gates cadence out when no
+    # distress evidence (keyword/emotion) is present, so going through score()
+    # here would mask the cadence computation this test is about.
+    assert s._signal_cadence("嗯。") is not None and s._signal_cadence("嗯。") > 0.5
 
 
 def test_scorer_cadence_none_without_baseline():

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -179,8 +179,9 @@ def test_scorer_keyword_inline():
 def test_scorer_no_signal_is_zero():
     s = FocusScorer("x")
     res = s.score(user_text="嗯，那个文件我改好了发你了")
-    # No vulnerability keyword; cadence not enough samples.
-    assert res.signals["keyword"] == 0.0
+    # No vulnerability keyword → None (positive-evidence-only); cadence not enough
+    # samples → None. All signals absent → score 0.0.
+    assert res.signals["keyword"] is None
     assert res.score == 0.0
 
 

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -275,9 +275,12 @@ def test_input_is_bounded(monkeypatch):
     assert ("x" * 11) not in captured["prompt"]
 
 
-def test_to_profile_sample():
+def test_to_profile_sample(monkeypatch):
     t = MasterEmotionTracker("t")
     assert t.to_profile_sample() is None
     t._latest = _reading(-0.4, 0.6)
     sample = t.to_profile_sample()
     assert sample == {"valence": -0.4, "arousal": 0.6, "confidence": 0.9, "at": 0.0}
+    # honors the switch (reads via self.latest), same as latest
+    monkeypatch.setattr(config, "MASTER_EMOTION_ENABLED", False)
+    assert t.to_profile_sample() is None

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -1,0 +1,219 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the master (user) emotion tracker and its Focus signal."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import config
+from main_logic.activity import (
+    FocusScorer,
+    MasterEmotionReading,
+    MasterEmotionTracker,
+)
+from main_logic.activity.master_emotion import _clamp
+
+
+# ── _clamp ───────────────────────────────────────────────────────────
+def test_clamp_bounds_and_junk():
+    assert _clamp(0.5, -1.0, 1.0, 0.0) == 0.5
+    assert _clamp(5, -1.0, 1.0, 0.0) == 1.0       # over → hi
+    assert _clamp(-9, -1.0, 1.0, 0.0) == -1.0      # under → lo
+    assert _clamp("nope", 0.0, 1.0, 0.5) == 0.5    # non-numeric → default
+    assert _clamp(None, 0.0, 1.0, 0.5) == 0.5
+    assert _clamp(float("nan"), 0.0, 1.0, 0.5) == 0.5  # NaN → default
+
+
+# ── FocusScorer.emotion signal mapping ───────────────────────────────
+def _reading(valence, arousal):
+    return MasterEmotionReading(
+        valence=valence, arousal=arousal, confidence=0.9, updated_at=0.0,
+    )
+
+
+def test_emotion_signal_distress_is_max():
+    s = FocusScorer("t")
+    assert s._signal_emotion(_reading(-1.0, 1.0)) == 1.0
+
+
+def test_emotion_signal_happy_is_zero():
+    s = FocusScorer("t")
+    # positive valence + high arousal (excitement) must NOT trigger Focus
+    assert s._signal_emotion(_reading(1.0, 1.0)) == 0.0
+
+
+def test_emotion_signal_neutral_high_arousal_is_half():
+    s = FocusScorer("t")
+    assert abs(s._signal_emotion(_reading(0.0, 1.0)) - 0.5) < 1e-9
+
+
+def test_emotion_signal_calm_negative_is_low():
+    s = FocusScorer("t")
+    # negative but low arousal → weak signal
+    assert abs(s._signal_emotion(_reading(-1.0, 0.1)) - 0.1) < 1e-9
+
+
+def test_emotion_signal_none_when_no_reading():
+    s = FocusScorer("t")
+    assert s._signal_emotion(None) is None
+
+
+def test_emotion_signal_none_when_axis_missing():
+    s = FocusScorer("t")
+    # duck-typed object missing arousal → drops out (None), never crashes
+    assert s._signal_emotion(SimpleNamespace(valence=-0.5, arousal=None)) is None
+
+
+def test_score_includes_emotion_and_drops_when_absent():
+    s = FocusScorer("t")
+    with_reading = s.score(user_text="嗯。", emotion_reading=_reading(-0.8, 0.7))
+    assert with_reading.signals["emotion"] is not None
+    # No reading → emotion signal is None and excluded from the weighted average.
+    s2 = FocusScorer("t")
+    without = s2.score(user_text="嗯。")
+    assert without.signals["emotion"] is None
+
+
+# ── MasterEmotionTracker._parse robustness ───────────────────────────
+def test_parse_valid_json():
+    r = MasterEmotionTracker._parse(
+        '{"valence": -0.6, "arousal": 0.8, "confidence": 0.7}',
+        now=123.0, source="撑不住了",
+    )
+    assert r is not None
+    assert r.valence == -0.6 and r.arousal == 0.8 and r.confidence == 0.7
+    assert r.updated_at == 123.0
+
+
+def test_parse_markdown_wrapped_json():
+    # robust_json_loads tolerates ```json fences the emotion tier may emit.
+    r = MasterEmotionTracker._parse(
+        '```json\n{"valence": 0.2, "arousal": 0.3}\n```',
+        now=1.0, source="x",
+    )
+    assert r is not None
+    assert r.valence == 0.2 and r.arousal == 0.3
+    assert r.confidence == 0.5  # default when omitted
+
+
+def test_parse_out_of_range_is_clamped():
+    r = MasterEmotionTracker._parse(
+        '{"valence": -5, "arousal": 9, "confidence": 2}', now=1.0, source="x",
+    )
+    assert r.valence == -1.0 and r.arousal == 1.0 and r.confidence == 1.0
+
+
+def test_parse_rejects_garbage():
+    assert MasterEmotionTracker._parse("not json at all", now=1.0, source="x") is None
+    assert MasterEmotionTracker._parse("[1, 2, 3]", now=1.0, source="x") is None  # not a dict
+    assert MasterEmotionTracker._parse('{"mood": "sad"}', now=1.0, source="x") is None  # neither axis
+
+
+# ── MasterEmotionTracker.analyze (async, throttle, gating) ───────────
+def _fake_tier(payload):
+    """Build an async stand-in for ``_invoke_emotion_tier`` returning ``payload``
+    and counting calls. Patch onto the llm_enrichment module."""
+    calls = {"n": 0}
+
+    async def fake(prompt, *, timeout, label):
+        calls["n"] += 1
+        return payload
+
+    return fake, calls
+
+
+def _patch_tier(monkeypatch, fake):
+    import main_logic.activity.llm_enrichment as le
+    monkeypatch.setattr(le, "_invoke_emotion_tier", fake)
+
+
+def test_analyze_updates_latest(monkeypatch):
+    fake, calls = _fake_tier('{"valence": -0.7, "arousal": 0.6, "confidence": 0.8}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("t")
+    r = asyncio.run(t.analyze("我今天很难过", now=100.0))
+    assert r is not None and t.latest is r
+    assert calls["n"] == 1
+    assert t.latest.valence == -0.7
+
+
+def test_analyze_throttled_within_interval(monkeypatch):
+    fake, calls = _fake_tier('{"valence": -0.5, "arousal": 0.5}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("t")
+    asyncio.run(t.analyze("a", now=100.0))
+    # within MASTER_EMOTION_MIN_INTERVAL_SEC → skipped, no model call
+    r2 = asyncio.run(t.analyze("b", now=100.0 + config.MASTER_EMOTION_MIN_INTERVAL_SEC - 0.5))
+    assert r2 is None
+    assert calls["n"] == 1
+    # past the interval → fires again
+    r3 = asyncio.run(t.analyze("c", now=100.0 + config.MASTER_EMOTION_MIN_INTERVAL_SEC + 0.1))
+    assert r3 is not None
+    assert calls["n"] == 2
+
+
+def test_analyze_disabled_is_noop(monkeypatch):
+    fake, calls = _fake_tier('{"valence": -0.5, "arousal": 0.5}')
+    _patch_tier(monkeypatch, fake)
+    monkeypatch.setattr(config, "MASTER_EMOTION_ENABLED", False)
+    t = MasterEmotionTracker("t")
+    assert asyncio.run(t.analyze("我很难过", now=100.0)) is None
+    assert calls["n"] == 0
+    assert t.latest is None
+
+
+def test_analyze_empty_text_is_noop(monkeypatch):
+    fake, calls = _fake_tier('{"valence": 0, "arousal": 0}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("t")
+    assert asyncio.run(t.analyze("   ", now=100.0)) is None
+    assert calls["n"] == 0
+
+
+def test_analyze_bad_response_keeps_previous(monkeypatch):
+    fake_ok, _ = _fake_tier('{"valence": -0.9, "arousal": 0.9}')
+    _patch_tier(monkeypatch, fake_ok)
+    t = MasterEmotionTracker("t")
+    asyncio.run(t.analyze("难过", now=100.0))
+    prev = t.latest
+    assert prev is not None
+    # next call returns junk → latest must stay the previous good reading
+    fake_bad, _ = _fake_tier("garbage not json")
+    _patch_tier(monkeypatch, fake_bad)
+    r = asyncio.run(t.analyze("再说点", now=200.0))
+    assert r is None
+    assert t.latest is prev
+
+
+def test_reset_clears_state(monkeypatch):
+    fake, _ = _fake_tier('{"valence": -0.5, "arousal": 0.5}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("t")
+    asyncio.run(t.analyze("难过", now=100.0))
+    assert t.latest is not None
+    t.reset()
+    assert t.latest is None
+    # after reset the throttle is cleared too → an immediate call fires
+    r = asyncio.run(t.analyze("难过", now=101.0))
+    assert r is not None
+
+
+def test_to_profile_sample():
+    t = MasterEmotionTracker("t")
+    assert t.to_profile_sample() is None
+    t._latest = _reading(-0.4, 0.6)
+    sample = t.to_profile_sample()
+    assert sample == {"valence": -0.4, "arousal": 0.6, "confidence": 0.9, "at": 0.0}

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 import config
 from main_logic.activity import (
     FocusScorer,
@@ -25,6 +27,14 @@ from main_logic.activity import (
     MasterEmotionTracker,
 )
 from main_logic.activity.master_emotion import _clamp
+
+
+@pytest.fixture(autouse=True)
+def _disable_reading_ttl(monkeypatch):
+    # Most tests pin a fixed epoch-ish now=100.0 for throttle/seq determinism;
+    # the real-time TTL gate (time.time() - updated_at) would treat that as long
+    # expired. Disable aging by default — the TTL test re-enables it explicitly.
+    monkeypatch.setattr(config, "MASTER_EMOTION_READING_TTL_SEC", 0)
 
 
 # ── _clamp ───────────────────────────────────────────────────────────
@@ -114,6 +124,39 @@ def test_stale_neutral_emotion_does_not_dilute_keyword():
     assert res.signals["emotion"] is None
     assert res.signals["keyword"] is not None and res.signals["keyword"] > 0
     assert res.score == res.signals["keyword"]  # not diluted by the stale 0
+
+
+def test_cadence_alone_does_not_trigger():
+    # cadence amplifies distress evidence, not a trigger: a built baseline + a
+    # short neutral reply ("嗯。") with no keyword/emotion must gate cadence out
+    # and score 0, not renormalise cadence to a full 1.0.
+    s = FocusScorer("t")
+    for _ in range(4):
+        s.score(user_text="这是一段比较长的正常聊天消息内容大概三十个字符以上")
+    res = s.score(user_text="嗯。")
+    assert res.signals["cadence"] is None  # gated: no distress evidence present
+    assert res.score == 0.0
+
+
+def test_cadence_counts_when_distress_present():
+    # with a distress signal present, cadence is NOT gated and amplifies it.
+    s = FocusScorer("t")
+    for _ in range(4):
+        s.score(user_text="这是一段比较长的正常聊天消息内容大概三十个字符以上")
+    res = s.score(user_text="嗯。", emotion_reading=_reading(-0.9, 0.9))
+    assert res.signals["cadence"] is not None and res.signals["cadence"] > 0.5
+    assert res.signals["emotion"] is not None
+
+
+def test_reading_expires_after_ttl(monkeypatch):
+    fake, _ = _fake_tier('{"valence": -0.9, "arousal": 0.9}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("t")
+    asyncio.run(t.analyze("难过", now=100.0))  # updated_at=100.0 (ancient epoch)
+    monkeypatch.setattr(config, "MASTER_EMOTION_READING_TTL_SEC", 120.0)
+    assert t.latest is None  # ancient updated_at vs real now → expired
+    monkeypatch.setattr(config, "MASTER_EMOTION_READING_TTL_SEC", 0)
+    assert t.latest is not None  # aging disabled → served again
 
 
 # ── MasterEmotionTracker._parse robustness ───────────────────────────

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -49,21 +49,22 @@ def test_emotion_signal_distress_is_max():
     assert s._signal_emotion(_reading(-1.0, 1.0)) == 1.0
 
 
-def test_emotion_signal_happy_is_zero():
+def test_emotion_signal_happy_is_none():
     s = FocusScorer("t")
-    # positive valence + high arousal (excitement) must NOT trigger Focus
-    assert s._signal_emotion(_reading(1.0, 1.0)) == 0.0
+    # positive valence + high arousal (excitement) → no distress → None (drops
+    # out of the weighted average, never counts as evidence against Focus)
+    assert s._signal_emotion(_reading(1.0, 1.0)) is None
 
 
-def test_emotion_signal_neutral_high_arousal_is_zero():
+def test_emotion_signal_neutral_high_arousal_is_none():
     s = FocusScorer("t")
     # neutral valence → no distress even at high arousal (intensity ≠ distress)
-    assert s._signal_emotion(_reading(0.0, 1.0)) == 0.0
+    assert s._signal_emotion(_reading(0.0, 1.0)) is None
 
 
-def test_emotion_signal_positive_high_arousal_is_zero():
+def test_emotion_signal_positive_high_arousal_is_none():
     s = FocusScorer("t")
-    assert s._signal_emotion(_reading(0.5, 1.0)) == 0.0
+    assert s._signal_emotion(_reading(0.5, 1.0)) is None
 
 
 def test_emotion_signal_calm_negative_is_low():
@@ -91,6 +92,28 @@ def test_score_includes_emotion_and_drops_when_absent():
     s2 = FocusScorer("t")
     without = s2.score(user_text="嗯。")
     assert without.signals["emotion"] is None
+
+
+def test_emotion_alone_can_saturate_score():
+    # #2: a saturated distress reading with no keyword/cadence still scores 1.0
+    # (keyword None drops out of the denominator), so emotion triggers Focus
+    # independently of the vulnerability lexicon.
+    s = FocusScorer("t")
+    res = s.score(user_text="嗯", emotion_reading=_reading(-1.0, 1.0))
+    assert res.signals["keyword"] is None
+    assert res.signals["emotion"] == 1.0
+    assert res.score == 1.0
+
+
+def test_stale_neutral_emotion_does_not_dilute_keyword():
+    # #1: a keyword-positive turn with a stale neutral reading scores on keyword
+    # alone (emotion None drops out), preserving the single-turn entry that
+    # keyword-only scoring used to give.
+    s = FocusScorer("t")
+    res = s.score(user_text="今天好累，感觉一个人撑不住了", emotion_reading=_reading(0.0, 1.0))
+    assert res.signals["emotion"] is None
+    assert res.signals["keyword"] is not None and res.signals["keyword"] > 0
+    assert res.score == res.signals["keyword"]  # not diluted by the stale 0
 
 
 # ── MasterEmotionTracker._parse robustness ───────────────────────────

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -55,9 +55,15 @@ def test_emotion_signal_happy_is_zero():
     assert s._signal_emotion(_reading(1.0, 1.0)) == 0.0
 
 
-def test_emotion_signal_neutral_high_arousal_is_half():
+def test_emotion_signal_neutral_high_arousal_is_zero():
     s = FocusScorer("t")
-    assert abs(s._signal_emotion(_reading(0.0, 1.0)) - 0.5) < 1e-9
+    # neutral valence → no distress even at high arousal (intensity ≠ distress)
+    assert s._signal_emotion(_reading(0.0, 1.0)) == 0.0
+
+
+def test_emotion_signal_positive_high_arousal_is_zero():
+    s = FocusScorer("t")
+    assert s._signal_emotion(_reading(0.5, 1.0)) == 0.0
 
 
 def test_emotion_signal_calm_negative_is_low():
@@ -107,6 +113,11 @@ def test_parse_markdown_wrapped_json():
     assert r is not None
     assert r.valence == 0.2 and r.arousal == 0.3
     assert r.confidence == 0.5  # default when omitted
+    # uppercase fence label (```JSON) is tolerated too
+    r2 = MasterEmotionTracker._parse(
+        '```JSON\n{"valence": -0.1, "arousal": 0.4}\n```', now=1.0, source="x",
+    )
+    assert r2 is not None and r2.arousal == 0.4
 
 
 def test_parse_out_of_range_is_clamped():
@@ -120,6 +131,19 @@ def test_parse_rejects_garbage():
     assert MasterEmotionTracker._parse("not json at all", now=1.0, source="x") is None
     assert MasterEmotionTracker._parse("[1, 2, 3]", now=1.0, source="x") is None  # not a dict
     assert MasterEmotionTracker._parse('{"mood": "sad"}', now=1.0, source="x") is None  # neither axis
+
+
+def test_parse_rejects_partial_reading():
+    # A partial response must be rejected, NOT defaulted to 0 — a missing arousal
+    # would zero the distress signal and misread strong negative affect as calm.
+    assert MasterEmotionTracker._parse('{"valence": -0.9}', now=1.0, source="x") is None
+    assert MasterEmotionTracker._parse('{"arousal": 0.8}', now=1.0, source="x") is None
+    # axis present but null / non-numeric is also incomplete
+    assert MasterEmotionTracker._parse('{"valence": -0.9, "arousal": null}', now=1.0, source="x") is None
+    assert MasterEmotionTracker._parse('{"valence": "bad", "arousal": 0.5}', now=1.0, source="x") is None
+    # both axes present → confidence may still be omitted (defaults)
+    ok = MasterEmotionTracker._parse('{"valence": -0.9, "arousal": 0.8}', now=1.0, source="x")
+    assert ok is not None and ok.confidence == 0.5
 
 
 # ── MasterEmotionTracker.analyze (async, throttle, gating) ───────────
@@ -209,6 +233,46 @@ def test_reset_clears_state(monkeypatch):
     # after reset the throttle is cleared too → an immediate call fires
     r = asyncio.run(t.analyze("难过", now=101.0))
     assert r is not None
+
+
+def test_analyze_drops_stale_out_of_order(monkeypatch):
+    # Simulate a newer analysis (or reset) bumping _seq while this call awaits
+    # the slow tier → the older result must be dropped, not written to latest.
+    t = MasterEmotionTracker("t")
+
+    async def fake(prompt, *, timeout, label):
+        t._seq += 1  # a newer turn kicked off during the await
+        return '{"valence": -0.5, "arousal": 0.5}'
+
+    _patch_tier(monkeypatch, fake)
+    assert asyncio.run(t.analyze("x", now=100.0)) is None
+    assert t.latest is None
+
+
+def test_latest_hidden_when_switch_off(monkeypatch):
+    fake, _ = _fake_tier('{"valence": -0.5, "arousal": 0.5}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("t")
+    asyncio.run(t.analyze("难过", now=100.0))
+    assert t.latest is not None
+    # flip the switch off after a reading exists → latest disappears
+    monkeypatch.setattr(config, "MASTER_EMOTION_ENABLED", False)
+    assert t.latest is None
+
+
+def test_input_is_bounded(monkeypatch):
+    captured = {}
+
+    async def fake(prompt, *, timeout, label):
+        captured["prompt"] = prompt
+        return '{"valence": 0, "arousal": 0}'
+
+    _patch_tier(monkeypatch, fake)
+    monkeypatch.setattr(config, "MASTER_EMOTION_MAX_INPUT_CHARS", 10)
+    t = MasterEmotionTracker("t")
+    asyncio.run(t.analyze("x" * 100, now=100.0))
+    assert captured["prompt"].endswith("x" * 10)
+    assert ("x" * 11) not in captured["prompt"]
 
 
 def test_to_profile_sample():


### PR DESCRIPTION
## 背景

之前 emotion analysis 只追踪 **lanlan（角色）的外显情绪**（`OUTWARD_EMOTION_ANALYSIS`）驱动头像表情。本 PR 新增对 **master（用户）情绪** 的即时追踪，作为一条独立后端基建。

## 设计

- **情绪画像基建**：用 emotion-tier 小模型分析「用户说的话」，产出二维 **valence（效价 -1~+1）/ arousal（唤醒 0~1）** 瞬时读数。单一权威源，只存最近一次读数（长期聚合留 `to_profile_sample` 钩子，后续做）。
- **凝神是第一个消费者**：`FocusScorer` 新增 `emotion` 信号（高 arousal × 负 valence = distress），读画像最近读数。滞后一拍（画像异步算），与 cadence 用历史一脉相承；画像关 / 无读数时该信号自动退出加权，退回 keyword+cadence。
- **边界**：绝不复用 lanlan 头像 outward 管线；privacy-independent（输入是对话不是屏幕），不受隐私门控（同凝神，developer-notes 规则 6）。

## 默认开关

- `MASTER_EMOTION_ENABLED` 默认 **开**。
- `FOCUS_MODE_ENABLED` 从「inert 默认关」翻为默认 **开** —— 进入真实信号实测 + 调参阶段（端到端 thinking-on 行为此前未在真模型验证过，随本 PR 一并实测）。

## 改动

- `config`：翻两个开关；`FOCUS_SIGNAL_WEIGHTS` 加 `emotion: 0.35`；新增 `MASTER_EMOTION_*` 旋钮（开关 / 节流 6s / 超时 8s）。
- `config/prompts/prompts_emotion.py`：新增 `MASTER_EMOTION_VA_PROMPT`（7 locale，module-agnostic + 中性称呼，与 outward 严格分开）。
- `main_logic/activity/master_emotion.py`（新）：`MasterEmotionTracker` 瞬时读数 + 节流 + best-effort 解析。
- `FocusScorer`：加 `emotion` 信号 + duck-typed 读数。
- `core`：`_note_user_turn`（语音/文本对偶 chokepoint）fire-and-forget 触发；`_focus_inline_decision` 喂读数；会话 teardown reset。

## 回归报告

- **改动**：新增 master 用户情绪画像基建（VA 瞬时读数）+ 接入凝神 emotion 信号；翻开 `FOCUS_MODE_ENABLED` / `MASTER_EMOTION_ENABLED` 默认值。
- **必要性**：此前用户侧情绪无任何信号，凝神只靠脆弱关键词、缺真模型情绪信号。
- **改动前后**：改前 emotion 只分析角色回复驱动头像、凝神 score = keyword+cadence、FOCUS 默认关；改后每条用户消息异步算 VA 画像、凝神多一个 emotion 信号、两个开关默认开。
- **潜在回归**：
  1. FOCUS 默认开 → 命中阈值的轮会真 thinking-on + 升模型（此前未端到端验证）。缓解：信号未达阈值零行为变化，可 config 关回。
  2. 每条用户消息多一次 emotion-tier 异步调用（节流 6s）。缓解：fire-and-forget 不阻塞对话；tier 未配置时静默 no-op。
  3. emotion 信号改变凝神触发性格（权重 0.35）。缓解：缺读数自动退出加权、退回原 keyword+cadence；阈值/权重可调。
- **测试**：`test_master_emotion` 19 例 + `test_focus_mode` 43 例 + emotion/enrichment 103 例全过。

## 验收注意

需配置好 `emotion` 模型 tier，否则 master emotion 静默 no-op、emotion 信号缺失、凝神退回 keyword+cadence。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 默认启用“焦点模式（凝神）”，凝神评分支持引入“主情绪画像”（基于效价/唤醒度等连续读数）。
* **设置更新**
  * “焦点模式（凝神）”总开关默认改为启用。
  * 新增主情绪画像配置：节流间隔、单次超时、输入截断上限与读数有效期（过期后不参与）。
* **评分改进**
  * 关键线索缺失时不再以 0 参与加权；情绪/关键词均无有效证据时自动收紧信号参与。
* **测试**
  * 新增主情绪画像与凝神评分相关单测，并更新焦点模式断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->