### PR TITLE
[codex] 整理 #1619 的 study companion 感知与语音监督

### DIFF
--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from collections.abc import Mapping
+from dataclasses import replace
 from datetime import datetime
 import json
 import math
@@ -20,8 +21,10 @@ from plugin.sdk.plugin import (
     Err,
     NekoPluginBase,
     Ok,
+    OsActivitySnapshot,
     SdkError,
     custom_event,
+    get_os_activity_snapshot,
     lifecycle,
     neko_plugin,
     plugin_entry,
@@ -43,12 +46,13 @@ from .awareness_buffer import ActivityBuffer
 from .checkin_manager import CheckinManager
 from ._event_bus import StudyEvent, StudyEventBus
 from .pomodoro_timer import PomodoroTimer
-from .screen_classifier import classify_screen_from_ocr
+from .screen_classifier import classify_app_from_title, classify_screen_from_ocr
 from .models import (
     MODE_CONCEPT_EXPLAIN,
     STATUS_ERROR,
     STATUS_READY,
     STATUS_STOPPED,
+    ActivitySnapshot,
     ActivitySummary,
     StudyConfig,
     StudyState,
@@ -84,7 +88,22 @@ from .tutor_llm_agent import diagnostic_code_for_exception
 from .ui_api import build_open_ui_payload
 from .ui_api import build_contribution_settings_payload, build_knowledge_map_payload
 from .ui_api import build_habit_dashboard_payload, build_pomodoro_status_payload
+from .voice_contracts import (
+    VOICE_TRANSCRIPT_EVENT_ID,
+    VOICE_TRANSCRIPT_EVENT_TYPE,
+    voice_transcript_cancel_response,
+    voice_transcript_noop,
+    voice_transcript_prime_context,
+)
 from .voice_filter import VoiceFilter, _derive_subject, build_context_for_catgirl
+
+
+_OS_CATEGORY_TO_APP_TYPE: dict[str, str] = {
+    "gaming": "game",
+    "work": "work",
+    "entertainment": "entertainment",
+    "communication": "communication",
+}
 
 
 def _voice_session_key(lanlan_name: str, metadata: Mapping[str, Any] | None) -> str:
@@ -252,7 +271,8 @@ class StudyCompanionPlugin(
         self._awareness_task: asyncio.Task[None] | None = None
         self._last_awareness_push_at = 0.0
         self._awareness_idle_ticks = 0
-        self._voice_filter = VoiceFilter()
+        self._consecutive_os_read_failures = 0
+        self._voice_filter = VoiceFilter(logger=self.logger)
         self._review_due_task: asyncio.Task[None] | None = None
         self._review_due_payload_future: asyncio.Future[dict[str, Any]] | None = None
         self._command_queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
@@ -270,7 +290,8 @@ class StudyCompanionPlugin(
             raw = await self.config.dump(timeout=5.0)
             self._cfg = build_config(raw if isinstance(raw, dict) else {})
             self._voice_filter = VoiceFilter(
-                plugin_config=raw if isinstance(raw, dict) else {}
+                plugin_config=raw if isinstance(raw, dict) else {},
+                logger=self.logger,
             )
             await asyncio.to_thread(self._store.open)
             self._cfg = await asyncio.to_thread(self._store.load_config, self._cfg)
@@ -501,6 +522,7 @@ class StudyCompanionPlugin(
         )
         self._last_awareness_push_at = 0.0
         self._awareness_idle_ticks = 0
+        self._consecutive_os_read_failures = 0
         self._awareness_task = asyncio.create_task(self._run_awareness_loop())
         self._awareness_task.add_done_callback(self._on_awareness_task_done)
 
@@ -509,6 +531,7 @@ class StudyCompanionPlugin(
         self._buffer = None
         self._last_awareness_push_at = 0.0
         self._awareness_idle_ticks = 0
+        self._consecutive_os_read_failures = 0
         if task is not None and not task.done():
             task.cancel()
 
@@ -525,7 +548,8 @@ class StudyCompanionPlugin(
             self.logger.warning("study awareness task cleanup failed: {}", exc)
 
     def is_awareness_active(self) -> bool:
-        return self._buffer is not None
+        task = self._awareness_task
+        return self._buffer is not None and task is not None and not task.done()
 
     def _start_command_worker(self) -> None:
         if self._event_bus is None:
@@ -742,31 +766,156 @@ class StudyCompanionPlugin(
             return max(base, 15.0)
         return base
 
+    async def _read_awareness_activity_snapshot(
+        self,
+        *,
+        now: float,
+    ) -> OsActivitySnapshot | None:
+        if not self._cfg.awareness.os_signals_enabled:
+            return None
+        return await get_os_activity_snapshot(self.plugin_id, now=now)
+
+    async def _read_awareness_os_activity(self, *, now: float):
+        activity_snap = None
+        foreground_category = None
+        os_signals_available = False
+        if not self._cfg.awareness.os_signals_enabled:
+            return activity_snap, foreground_category, os_signals_available
+        try:
+            activity_snap = await self._read_awareness_activity_snapshot(now=now)
+            os_signals_available = activity_snap is not None and activity_snap.os_signals_available
+            if os_signals_available:
+                foreground_category = activity_snap.foreground_category
+        except Exception:
+            fails = self._consecutive_os_read_failures + 1
+            self._consecutive_os_read_failures = fails
+            log = self.logger.warning if fails <= 3 else self.logger.error
+            log(
+                "study awareness activity snapshot failed (consecutive={})",
+                fails,
+                exc_info=True,
+            )
+        else:
+            self._consecutive_os_read_failures = 0
+        return activity_snap, foreground_category, os_signals_available
+
+    async def _record_private_awareness_activity(
+        self,
+        buffer: ActivityBuffer,
+        *,
+        timestamp: float,
+    ) -> None:
+        await buffer.add(
+            ActivitySnapshot(
+                timestamp=timestamp,
+                first_seen_at=timestamp,
+                app_type="private",
+                activity_type="private",
+                classify_method="os_signal",
+                ocr_text_snippet="",
+                window_title="",
+                has_content_change=False,
+            )
+        )
+        self._awareness_idle_ticks += 1
+
+    async def _capture_awareness_lightweight(self, pipeline: Any):
+        try:
+            return await asyncio.to_thread(pipeline.capture_lightweight)
+        except Exception:
+            self.logger.warning("awareness_tick capture failed", exc_info=True)
+            return None
+
+    @staticmethod
+    def _classify_awareness_snapshot(snapshot: Any, foreground_category: str | None):
+        if not hasattr(snapshot, "app_type"):
+            return snapshot
+        mapped = _OS_CATEGORY_TO_APP_TYPE.get(str(foreground_category or ""))
+        if mapped is not None:
+            return replace(snapshot, app_type=mapped)
+        if getattr(snapshot, "app_type", "") != "unknown":
+            return snapshot
+        return replace(
+            snapshot,
+            app_type=classify_app_from_title(
+                getattr(snapshot, "window_title", ""),
+                default="unknown",
+            ),
+        )
+
+    def _observe_awareness_supervision(
+        self,
+        snapshot: Any,
+        *,
+        activity_snap: Any | None,
+        os_signals_available: bool,
+        foreground_category: str | None,
+    ) -> None:
+        if self._supervision is None:
+            return
+        supervision_category = foreground_category
+        if supervision_category == "own_app" or not self._cfg.awareness.distraction_detection:
+            supervision_category = None
+        self._supervision.observe_activity(
+            ocr_text=getattr(snapshot, "ocr_text_snippet", ""),
+            sensor_available=getattr(snapshot, "status", "") in {"ok", "empty"},
+            idle_seconds=(
+                getattr(activity_snap, "system_idle_seconds", None)
+                if activity_snap is not None and os_signals_available
+                else None
+            ),
+            foreground_category=supervision_category,
+        )
+
+    async def _record_awareness_snapshot(
+        self,
+        buffer: ActivityBuffer,
+        snapshot: Any,
+    ) -> None:
+        activity = snapshot.to_activity_snapshot()
+        if activity is None:
+            self._awareness_idle_ticks += 1
+            return
+        await buffer.add(activity)
+        if activity.app_type in ("other", "unknown") and activity.activity_type in (
+            "idle",
+            "",
+        ):
+            self._awareness_idle_ticks += 1
+        else:
+            self._awareness_idle_ticks = 0
+
     async def awareness_tick(self) -> None:
         buffer = self._buffer
         pipeline = self._ocr_pipeline
         if buffer is None or pipeline is None:
             return
-        try:
-            snapshot = await asyncio.to_thread(pipeline.capture_lightweight)
-        except Exception:
-            self._awareness_idle_ticks += 1
-            self.logger.warning("awareness_tick capture failed", exc_info=True)
+
+        ts = time.time()
+        activity_snap, foreground_category, os_signals_available = (
+            await self._read_awareness_os_activity(now=ts)
+        )
+        if activity_snap is not None and (
+            getattr(activity_snap, "privacy_state", "") == "private"
+            or foreground_category == "private"
+        ):
+            await self._record_private_awareness_activity(buffer, timestamp=ts)
             return
+
+        snapshot = await self._capture_awareness_lightweight(pipeline)
 
         if snapshot is None or snapshot.status == "capture_failed":
             self._awareness_idle_ticks += 1
             return
 
-        activity = snapshot.to_activity_snapshot()
-        if activity is not None:
-            await buffer.add(activity)
-            if activity.app_type == "other" and activity.activity_type in ("idle", ""):
-                self._awareness_idle_ticks += 1
-            else:
-                self._awareness_idle_ticks = 0
-        else:
-            self._awareness_idle_ticks += 1
+        snapshot = self._classify_awareness_snapshot(snapshot, foreground_category)
+        self._observe_awareness_supervision(
+            snapshot,
+            activity_snap=activity_snap,
+            os_signals_available=os_signals_available,
+            foreground_category=foreground_category,
+        )
+        await self._record_awareness_snapshot(buffer, snapshot)
 
         if self._should_push_context():
             summary = await buffer.summarize()
@@ -781,22 +930,29 @@ class StudyCompanionPlugin(
 
     async def _push_awareness_context(self, summary: ActivitySummary) -> None:
         mode = self._cfg.awareness.push_to_llm_mode
+        try:
+            self.push_message(
+                visibility=[],
+                ai_behavior="read" if mode == "read" else "respond",
+                parts=[
+                    {
+                        "type": "text",
+                        "text": (
+                            "[环境感知] "
+                            + json.dumps(
+                                self._summary_for_llm(summary),
+                                ensure_ascii=False,
+                            )
+                        ),
+                    }
+                ],
+                source="awareness",
+                priority=0,
+            )
+        except Exception:
+            self.logger.warning("study awareness context push failed", exc_info=True)
+            return
         self._last_awareness_push_at = time.monotonic()
-        self.push_message(
-            visibility=[],
-            ai_behavior="read" if mode == "read" else "respond",
-            parts=[
-                {
-                    "type": "text",
-                    "text": (
-                        "[环境感知] "
-                        + json.dumps(self._summary_for_llm(summary), ensure_ascii=False)
-                    ),
-                }
-            ],
-            source="awareness",
-            priority=0,
-        )
 
     @staticmethod
     def _summary_for_llm(
@@ -966,8 +1122,8 @@ class StudyCompanionPlugin(
         return dict(self._state.last_screen_classification)
 
     @custom_event(
-        event_type="voice_transcript",
-        id="handle_transcript",
+        event_type=VOICE_TRANSCRIPT_EVENT_TYPE,
+        id=VOICE_TRANSCRIPT_EVENT_ID,
         name="Handle study voice transcript",
         description="Filter realtime study voice transcripts and return a voice-session action.",
         input_schema={
@@ -994,7 +1150,12 @@ class StudyCompanionPlugin(
             if original_method and original_method != reason:
                 filter_payload["source_method"] = original_method
             filter_payload["method"] = reason
-            return Ok({"action": "noop", "reason": reason, "filter": filter_payload})
+            return Ok(
+                voice_transcript_noop(
+                    reason,
+                    filter=filter_payload,
+                )
+            )
 
         text = str(transcript or "").strip()
         if not text:
@@ -1038,7 +1199,11 @@ class StudyCompanionPlugin(
         if filter_result is None:
             return voice_noop("not_matched")
         if not bool(filter_result.get("should_relay")):
-            return Ok({"action": "cancel_response", "filter": dict(filter_result)})
+            return Ok(
+                voice_transcript_cancel_response(
+                    filter_payload=filter_result,
+                )
+            )
 
         state_snapshot = SimpleNamespace(**state_snapshot_payload)
         context_text = build_context_for_catgirl(
@@ -1050,13 +1215,12 @@ class StudyCompanionPlugin(
         if not context_text:
             return voice_noop("empty_context", filter_result)
         return Ok(
-            {
-                "action": "prime_context",
-                "context": context_text,
-                "skipped": True,
-                "filter": dict(filter_result),
-                "lanlan_name": str(lanlan_name or ""),
-            }
+            voice_transcript_prime_context(
+                context_text,
+                skipped=True,
+                filter_payload=filter_result,
+                lanlan_name=str(lanlan_name or ""),
+            )
         )
 
     async def _update_screen_classification(

--- a/plugin/plugins/study_companion/awareness_buffer.py
+++ b/plugin/plugins/study_companion/awareness_buffer.py
@@ -110,7 +110,7 @@ class ActivityBuffer:
             for snapshot in reversed(self.snapshots):
                 if snapshot.timestamp < recent_threshold:
                     return False
-                if snapshot.app_type not in ("other", "unknown") and snapshot.activity_type not in (
+                if snapshot.app_type not in ("other", "unknown", "private") and snapshot.activity_type not in (
                     "idle",
                     "",
                 ):

--- a/plugin/plugins/study_companion/awareness_buffer.py
+++ b/plugin/plugins/study_companion/awareness_buffer.py
@@ -80,7 +80,7 @@ class ActivityBuffer:
             window_start = current.timestamp - self.window_seconds
             active_seconds = 0.0
             for snapshot in self.snapshots:
-                if snapshot.app_type in ("other",) or snapshot.activity_type in (
+                if snapshot.app_type in ("other", "unknown", "private") or snapshot.activity_type in (
                     "idle",
                     "",
                 ):
@@ -110,7 +110,7 @@ class ActivityBuffer:
             for snapshot in reversed(self.snapshots):
                 if snapshot.timestamp < recent_threshold:
                     return False
-                if snapshot.app_type not in ("other",) and snapshot.activity_type not in (
+                if snapshot.app_type not in ("other", "unknown") and snapshot.activity_type not in (
                     "idle",
                     "",
                 ):

--- a/plugin/plugins/study_companion/models.py
+++ b/plugin/plugins/study_companion/models.py
@@ -205,6 +205,7 @@ class SupervisionConfig:
     enabled: bool = True
     remind_interval_minutes: int = 10
     inactivity_timeout_minutes: int = 5
+    idle_away_seconds: int = 900
     allow_disable_by_chat: bool = True
 
     def __post_init__(self) -> None:
@@ -214,6 +215,9 @@ class SupervisionConfig:
         )
         self.inactivity_timeout_minutes = _range_or_default(
             self.inactivity_timeout_minutes, 1, 30, 5
+        )
+        self.idle_away_seconds = _range_or_default(
+            self.idle_away_seconds, 60, 3600, 900
         )
         self.allow_disable_by_chat = bool(self.allow_disable_by_chat)
 
@@ -253,9 +257,11 @@ class AwarenessConfig:
     snapshot_interval_seconds: int = 5
     context_window_minutes: int = 5
     classify_mode: str = "title_first"
-    image_max_bytes: int = 204800
-    push_to_llm_interval_seconds: int = 30
+    image_max_bytes: int = 65_536
+    push_to_llm_interval_seconds: int = 300
     push_to_llm_mode: str = "read"
+    os_signals_enabled: bool = True
+    distraction_detection: bool = True
 
     def __post_init__(self) -> None:
         self.enabled = bool(self.enabled)
@@ -274,10 +280,10 @@ class AwarenessConfig:
             classify_mode = "title_first"
         self.classify_mode = classify_mode
         self.image_max_bytes = _clamp_int_or_default(
-            self.image_max_bytes, 10240, 1_048_576, 204800
+            self.image_max_bytes, 10240, 512_000, 65_536
         )
         self.push_to_llm_interval_seconds = _clamp_int_or_default(
-            self.push_to_llm_interval_seconds, 5, 300, 30
+            self.push_to_llm_interval_seconds, 30, 300, 300
         )
         push_mode = str(self.push_to_llm_mode or "read").strip()
         if push_mode not in {"read", "blind", "respond"}:
@@ -287,6 +293,8 @@ class AwarenessConfig:
             )
             push_mode = "read"
         self.push_to_llm_mode = push_mode
+        self.os_signals_enabled = bool(self.os_signals_enabled)
+        self.distraction_detection = bool(self.distraction_detection)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -773,6 +781,12 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
                 5,
                 "supervision_inactivity_timeout_minutes",
             ),
+            idle_away_seconds=_int(
+                supervision,
+                "idle_away_seconds",
+                900,
+                "supervision_idle_away_seconds",
+            ),
             allow_disable_by_chat=_bool(
                 supervision,
                 "allow_disable_by_chat",
@@ -825,13 +839,13 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
             image_max_bytes=_int(
                 awareness,
                 "image_max_bytes",
-                204800,
+                65_536,
                 "awareness_image_max_bytes",
             ),
             push_to_llm_interval_seconds=_int(
                 awareness,
                 "push_to_llm_interval_seconds",
-                30,
+                300,
                 "awareness_push_to_llm_interval_seconds",
             ),
             push_to_llm_mode=_str(
@@ -839,6 +853,18 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
                 "push_to_llm_mode",
                 "read",
                 "awareness_push_to_llm_mode",
+            ),
+            os_signals_enabled=_bool(
+                awareness,
+                "os_signals_enabled",
+                True,
+                "awareness_os_signals_enabled",
+            ),
+            distraction_detection=_bool(
+                awareness,
+                "distraction_detection",
+                True,
+                "awareness_distraction_detection",
             ),
         ),
     )

--- a/plugin/plugins/study_companion/plugin.toml
+++ b/plugin/plugins/study_companion/plugin.toml
@@ -46,6 +46,7 @@ allow_custom_duration = true
 enabled = true
 remind_interval_minutes = 10
 inactivity_timeout_minutes = 5
+idle_away_seconds = 900
 allow_disable_by_chat = true
 
 [study.checkin]
@@ -58,9 +59,11 @@ enabled = false
 snapshot_interval_seconds = 5
 context_window_minutes = 5
 classify_mode = "title_first"
-image_max_bytes = 204800
-push_to_llm_interval_seconds = 30
+image_max_bytes = 65536
+push_to_llm_interval_seconds = 300
 push_to_llm_mode = "read"
+os_signals_enabled = true
+distraction_detection = true
 
 [study_companion.communication]
 enabled = true

--- a/plugin/plugins/study_companion/supervision.py
+++ b/plugin/plugins/study_companion/supervision.py
@@ -115,29 +115,30 @@ class SupervisionController:
             and self._focus_active
             and foreground in _DISTRACTION_FOREGROUND_CATEGORIES
         )
+        away_detected = (
+            self._enabled
+            and self._focus_active
+            and idle_value is not None
+            and idle_value >= away_seconds
+        )
         text = str(ocr_text or "")
         if text != self._last_ocr_text or active_from_idle:
             self._last_ocr_text = text
             self._last_activity_at = current
             if self._reminder_level != "active":
                 self._reminder_level = "active"
+        if away_detected:
+            self._reminder_level = "away"
+            return _result(
+                inactivity_detected=True,
+                suggested_action="pause_or_switch",
+            )
         if distraction_detected:
             self._reminder_level = "distraction"
             return _result(
                 inactivity_detected=False,
                 suggested_action="return_to_focus",
                 distraction_detected=True,
-            )
-        if (
-            self._enabled
-            and self._focus_active
-            and idle_value is not None
-            and idle_value >= away_seconds
-        ):
-            self._reminder_level = "away"
-            return _result(
-                inactivity_detected=True,
-                suggested_action="pause_or_switch",
             )
         inactive = (
             self._enabled
@@ -146,6 +147,8 @@ class SupervisionController:
         )
         if inactive:
             self._reminder_level = "inactivity"
+        elif self._reminder_level == "distraction":
+            self._reminder_level = "active"
         return _result(
             inactivity_detected=bool(inactive),
             suggested_action="pause_or_switch" if inactive else "",

--- a/plugin/plugins/study_companion/supervision.py
+++ b/plugin/plugins/study_companion/supervision.py
@@ -6,6 +6,9 @@ from typing import Any, Callable
 from .models import SupervisionConfig
 
 
+_DISTRACTION_FOREGROUND_CATEGORIES = frozenset({"gaming", "entertainment"})
+
+
 class SupervisionController:
     def __init__(
         self,
@@ -72,40 +75,81 @@ class SupervisionController:
         *,
         ocr_text: str,
         sensor_available: bool,
+        idle_seconds: float | None = None,
+        foreground_category: str | None = None,
         now: float | None = None,
     ) -> dict[str, Any]:
         current = self._clock() if now is None else float(now)
         self._sensor_available = bool(sensor_available)
-        if not self._sensor_available:
-            return {
+        try:
+            idle_value = None if idle_seconds is None else max(0.0, float(idle_seconds))
+        except (TypeError, ValueError, OverflowError):
+            idle_value = None
+        foreground = str(foreground_category or "").strip().lower()
+
+        def _result(
+            *,
+            inactivity_detected: bool,
+            suggested_action: str,
+            distraction_detected: bool = False,
+        ) -> dict[str, Any]:
+            result = {
                 **self.status(now=current),
-                "inactivity_detected": False,
-                "suggested_action": "",
+                "inactivity_detected": bool(inactivity_detected),
+                "suggested_action": suggested_action,
             }
+            if idle_value is not None:
+                result["idle_seconds"] = idle_value
+            if foreground:
+                result["foreground_category"] = foreground
+                result["distraction_detected"] = bool(distraction_detected)
+            return result
+
+        if not self._sensor_available:
+            return _result(inactivity_detected=False, suggested_action="")
+        timeout_seconds = self.config.inactivity_timeout_minutes * 60
+        away_seconds = self.config.idle_away_seconds
+        active_from_idle = idle_value is not None and idle_value < timeout_seconds
+        distraction_detected = (
+            self._enabled
+            and self._focus_active
+            and foreground in _DISTRACTION_FOREGROUND_CATEGORIES
+        )
         text = str(ocr_text or "")
-        if text != self._last_ocr_text:
+        if text != self._last_ocr_text or active_from_idle:
             self._last_ocr_text = text
             self._last_activity_at = current
-            if self._reminder_level == "inactivity":
+            if self._reminder_level != "active":
                 self._reminder_level = "active"
-            return {
-                **self.status(now=current),
-                "inactivity_detected": False,
-                "suggested_action": "",
-            }
+        if distraction_detected:
+            self._reminder_level = "distraction"
+            return _result(
+                inactivity_detected=False,
+                suggested_action="return_to_focus",
+                distraction_detected=True,
+            )
+        if (
+            self._enabled
+            and self._focus_active
+            and idle_value is not None
+            and idle_value >= away_seconds
+        ):
+            self._reminder_level = "away"
+            return _result(
+                inactivity_detected=True,
+                suggested_action="pause_or_switch",
+            )
         inactive = (
             self._enabled
             and self._focus_active
-            and current - self._last_activity_at
-            >= self.config.inactivity_timeout_minutes * 60
+            and current - self._last_activity_at >= timeout_seconds
         )
         if inactive:
             self._reminder_level = "inactivity"
-        return {
-            **self.status(now=current),
-            "inactivity_detected": bool(inactive),
-            "suggested_action": "pause_or_switch" if inactive else "",
-        }
+        return _result(
+            inactivity_detected=bool(inactive),
+            suggested_action="pause_or_switch" if inactive else "",
+        )
 
     def status(self, *, now: float | None = None) -> dict[str, Any]:
         return {

--- a/plugin/plugins/study_companion/voice_contracts.py
+++ b/plugin/plugins/study_companion/voice_contracts.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+VOICE_TRANSCRIPT_EVENT_TYPE = "voice_transcript"
+VOICE_TRANSCRIPT_EVENT_ID = "handle_transcript"
+
+VOICE_TRANSCRIPT_ACTION_NOOP = "noop"
+VOICE_TRANSCRIPT_ACTION_CANCEL_RESPONSE = "cancel_response"
+VOICE_TRANSCRIPT_ACTION_PRIME_CONTEXT = "prime_context"
+VOICE_TRANSCRIPT_ACTIONS = {
+    VOICE_TRANSCRIPT_ACTION_NOOP,
+    VOICE_TRANSCRIPT_ACTION_CANCEL_RESPONSE,
+    VOICE_TRANSCRIPT_ACTION_PRIME_CONTEXT,
+}
+VOICE_TRANSCRIPT_ACTION_RANK = {
+    VOICE_TRANSCRIPT_ACTION_NOOP: 0,
+    VOICE_TRANSCRIPT_ACTION_PRIME_CONTEXT: 1,
+    VOICE_TRANSCRIPT_ACTION_CANCEL_RESPONSE: 2,
+}
+
+
+def voice_transcript_noop(reason: str, **extra: object) -> dict[str, object]:
+    payload = dict(extra)
+    payload.update(
+        {
+            "action": VOICE_TRANSCRIPT_ACTION_NOOP,
+            "reason": str(reason or "noop"),
+        }
+    )
+    return payload
+
+
+def voice_transcript_cancel_response(
+    *,
+    filter_payload: Mapping[str, object] | None = None,
+    **extra: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = dict(extra)
+    payload["action"] = VOICE_TRANSCRIPT_ACTION_CANCEL_RESPONSE
+    if filter_payload is not None:
+        payload["filter"] = dict(filter_payload)
+    return payload
+
+
+def voice_transcript_prime_context(
+    context: str,
+    *,
+    skipped: bool = False,
+    filter_payload: Mapping[str, object] | None = None,
+    **extra: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = dict(extra)
+    payload.update(
+        {
+            "action": VOICE_TRANSCRIPT_ACTION_PRIME_CONTEXT,
+            "context": str(context or "").strip(),
+            "skipped": bool(skipped),
+        }
+    )
+    if filter_payload is not None:
+        payload["filter"] = dict(filter_payload)
+    return payload
+
+
+def _coerce_priority(value: object) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        priority = float(value)
+        return priority if math.isfinite(priority) else 0.0
+    if isinstance(value, str):
+        try:
+            priority = float(value.strip())
+        except ValueError:
+            return 0.0
+        return priority if math.isfinite(priority) else 0.0
+    return 0.0
+
+
+def _normalize_voice_transcript_candidate(
+    item: Mapping[str, object],
+    *,
+    fallback_reason: str = "",
+) -> dict[str, Any] | None:
+    if not bool(item.get("success")):
+        return None
+    raw_result = item.get("result")
+    if not isinstance(raw_result, Mapping):
+        return None
+
+    candidate = dict(raw_result)
+    action = str(candidate.get("action") or VOICE_TRANSCRIPT_ACTION_NOOP).strip()
+    if action not in VOICE_TRANSCRIPT_ACTIONS:
+        action = VOICE_TRANSCRIPT_ACTION_NOOP
+        fallback_reason = "invalid_action"
+
+    priority = _coerce_priority(candidate.get("priority", 0))
+    reason = str(candidate.get("reason") or fallback_reason)
+    skipped = bool(candidate.get("skipped", False))
+    plugin_id = str(item.get("plugin_id") or "").strip()
+
+    if action == VOICE_TRANSCRIPT_ACTION_PRIME_CONTEXT:
+        context_text = str(candidate.get("context") or "").strip()
+        if not context_text:
+            action = VOICE_TRANSCRIPT_ACTION_NOOP
+            reason = "empty_context"
+        else:
+            candidate["context"] = context_text
+
+    candidate["action"] = action
+    candidate["priority"] = priority
+    candidate["reason"] = reason
+    candidate["skipped"] = skipped
+    if plugin_id:
+        candidate["source_plugin"] = plugin_id
+    event_id = str(item.get("event_id") or "").strip()
+    if event_id:
+        candidate.setdefault("source_event_id", event_id)
+    return candidate
+
+
+def arbitrate_voice_transcript_results(dispatch_results: object) -> dict[str, Any]:
+    if not isinstance(dispatch_results, list) or not dispatch_results:
+        return voice_transcript_noop(
+            "no_subscribers",
+            priority=0.0,
+            skipped=False,
+        )
+
+    selected: tuple[int, float, int, dict[str, Any]] | None = None
+    noop_count = 0
+    failure_count = 0
+    for index, item in enumerate(dispatch_results):
+        if not isinstance(item, Mapping):
+            continue
+        if not bool(item.get("success")):
+            failure_count += 1
+            continue
+        candidate = _normalize_voice_transcript_candidate(item)
+        if candidate is None:
+            continue
+        action = str(candidate.get("action") or VOICE_TRANSCRIPT_ACTION_NOOP)
+        if action == VOICE_TRANSCRIPT_ACTION_NOOP:
+            noop_count += 1
+            continue
+        priority = _coerce_priority(candidate.get("priority", 0))
+        rank = VOICE_TRANSCRIPT_ACTION_RANK.get(action, 0)
+        contender = (rank, priority, -index, candidate)
+        if selected is None or contender[:3] > selected[:3]:
+            selected = contender
+
+    if selected is not None:
+        return selected[3]
+    if noop_count:
+        return voice_transcript_noop(
+            "all_noop",
+            priority=0.0,
+            skipped=False,
+            handlers=noop_count,
+            failures=failure_count,
+        )
+    return voice_transcript_noop(
+        "no_handler_result",
+        priority=0.0,
+        skipped=False,
+        failures=failure_count,
+    )
+
+
+__all__ = [
+    "VOICE_TRANSCRIPT_ACTION_CANCEL_RESPONSE",
+    "VOICE_TRANSCRIPT_ACTION_NOOP",
+    "VOICE_TRANSCRIPT_ACTION_PRIME_CONTEXT",
+    "VOICE_TRANSCRIPT_EVENT_ID",
+    "VOICE_TRANSCRIPT_EVENT_TYPE",
+    "arbitrate_voice_transcript_results",
+    "voice_transcript_cancel_response",
+    "voice_transcript_noop",
+    "voice_transcript_prime_context",
+]

--- a/plugin/plugins/study_companion/voice_filter.py
+++ b/plugin/plugins/study_companion/voice_filter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime, timezone
 import re
@@ -80,13 +81,16 @@ class VoiceFilter:
         config_manager: Any | None = None,
         plugin_config: Mapping[str, Any] | None = None,
         clock: Callable[[], float] | None = None,
+        logger: Any | None = None,
     ) -> None:
         self._clock = clock or time.monotonic
+        self._logger = logger
         self._last_name_call_times: dict[str, float] = {}
         self._names = self._load_names(
             names,
             config_manager=config_manager,
             plugin_config=plugin_config,
+            logger=logger,
         )
 
     @property
@@ -179,11 +183,15 @@ class VoiceFilter:
         *,
         config_manager: Any | None,
         plugin_config: Mapping[str, Any] | None,
+        logger: Any | None,
     ) -> list[str]:
         candidates: list[str] = []
         _extend_names(candidates, names)
         if not candidates:
-            _extend_names(candidates, _names_from_config_manager(config_manager))
+            _extend_names(
+                candidates,
+                _names_from_config_manager(config_manager, logger=logger),
+            )
         if not candidates:
             voice_filter = (
                 plugin_config.get("voice_filter")
@@ -219,12 +227,19 @@ def _extend_names(target: list[str], values: Any) -> None:
             seen.add(key)
 
 
-def _names_from_config_manager(config_manager: Any | None) -> list[str]:
+def _names_from_config_manager(
+    config_manager: Any | None,
+    *,
+    logger: Any | None = None,
+) -> list[str]:
     if config_manager is None or not hasattr(config_manager, "get_character_data"):
         return []
     try:
         data = config_manager.get_character_data()
-    except Exception:
+    except Exception as exc:
+        warning = getattr(logger, "warning", None)
+        if callable(warning):
+            warning("voice filter failed to read configured names: {}", exc)
         return []
     if not isinstance(data, tuple) or len(data) < 4:
         return []
@@ -440,10 +455,12 @@ def _ocr_is_stale(value: Any, *, max_age_seconds: float = 5.0) -> bool:
             datetime.now(timezone.utc) - captured.astimezone(timezone.utc)
         ).total_seconds() > max_age_seconds
     except Exception:
-        return False
+        return True
 
 
 def _is_safe_cancel_exception(exc: Exception) -> bool:
+    if isinstance(exc, asyncio.InvalidStateError):
+        return True
     safe_names = {"ResourceNotFound", "InvalidState", "InvalidStateError"}
     if type(exc).__name__ in safe_names:
         return True

--- a/plugin/sdk/plugin/__init__.py
+++ b/plugin/sdk/plugin/__init__.py
@@ -13,6 +13,7 @@ from . import decorators as _decorators
 # 避免 `from . import llm_tool as _llm_tool` 在 importlib.reload 时被外部 `llm_tool` 函数名
 # 遮蔽（第一次加载后本模块的 `llm_tool` 属性变成函数，导致下次 `from . import llm_tool` 拿回函数而非子模块）喵
 _llm_tool = _sys.modules.get("plugin.sdk.plugin.llm_tool") or _import_module("plugin.sdk.plugin.llm_tool")
+from . import activity as _activity
 from . import runtime as _runtime
 from . import settings as _settings
 from . import ui as ui
@@ -44,6 +45,10 @@ quick_action = _decorators.quick_action
 # --- LLM tool ---
 llm_tool = _llm_tool.llm_tool
 LlmToolMeta = _llm_tool.LlmToolMeta
+
+# --- Activity ---
+OsActivitySnapshot = _activity.OsActivitySnapshot
+get_os_activity_snapshot = _activity.get_os_activity_snapshot
 
 # --- Result ---
 Ok = _runtime.Ok
@@ -97,6 +102,9 @@ __all__ = [
     # LLM tool
     "llm_tool",
     "LlmToolMeta",
+    # Activity
+    "OsActivitySnapshot",
+    "get_os_activity_snapshot",
     "PluginI18n",
     "tr",
     # Result

--- a/plugin/sdk/plugin/activity.py
+++ b/plugin/sdk/plugin/activity.py
@@ -1,0 +1,83 @@
+"""Plugin-facing activity snapshot helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+PrivacyState = Literal["visible", "private", "unavailable"]
+
+
+@dataclass(frozen=True, slots=True)
+class OsActivitySnapshot:
+    """Narrow OS activity view exposed to plugins."""
+
+    os_signals_available: bool
+    foreground_category: str | None = None
+    system_idle_seconds: float | None = None
+    privacy_state: PrivacyState = "unavailable"
+
+
+_ACTIVITY_TRACKERS: dict[str, Any] = {}
+
+
+def _tracker_for_source(source: str) -> Any:
+    source_key = str(source or "").strip() or "plugin"
+    tracker = _ACTIVITY_TRACKERS.get(source_key)
+    if tracker is None:
+        from main_logic.activity import UserActivityTracker
+
+        tracker = UserActivityTracker(source_key)
+        _ACTIVITY_TRACKERS[source_key] = tracker
+    return tracker
+
+
+def _coerce_idle_seconds(value: Any) -> float | None:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return max(0.0, seconds)
+
+
+def _privacy_state(core_snapshot: Any, foreground_category: str | None) -> PrivacyState:
+    if not bool(getattr(core_snapshot, "os_signals_available", True)):
+        return "unavailable"
+    if getattr(core_snapshot, "state", "") == "private" or foreground_category == "private":
+        return "private"
+    return "visible"
+
+
+async def get_os_activity_snapshot(
+    source: str,
+    *,
+    now: float | None = None,
+) -> OsActivitySnapshot:
+    """Return the OS-only activity signals plugins are allowed to consume."""
+
+    core_snapshot = await _tracker_for_source(source).get_snapshot(now=now)
+    os_signals_available = bool(getattr(core_snapshot, "os_signals_available", True))
+    active_window = getattr(core_snapshot, "active_window", None)
+    foreground_category = (
+        str(getattr(active_window, "category", "") or "").strip() or None
+        if os_signals_available and active_window is not None
+        else None
+    )
+    idle_seconds = (
+        _coerce_idle_seconds(getattr(core_snapshot, "system_idle_seconds", None))
+        if os_signals_available
+        else None
+    )
+    return OsActivitySnapshot(
+        os_signals_available=os_signals_available,
+        foreground_category=foreground_category,
+        system_idle_seconds=idle_seconds,
+        privacy_state=_privacy_state(core_snapshot, foreground_category),
+    )
+
+
+__all__ = [
+    "OsActivitySnapshot",
+    "PrivacyState",
+    "get_os_activity_snapshot",
+]

--- a/plugin/sdk/plugin/activity.py
+++ b/plugin/sdk/plugin/activity.py
@@ -18,18 +18,16 @@ class OsActivitySnapshot:
     privacy_state: PrivacyState = "unavailable"
 
 
-_ACTIVITY_TRACKERS: dict[str, Any] = {}
+def _read_system_signal_snapshot() -> Any:
+    from main_logic.activity import get_system_signal_collector
+
+    return get_system_signal_collector().snapshot()
 
 
-def _tracker_for_source(source: str) -> Any:
-    source_key = str(source or "").strip() or "plugin"
-    tracker = _ACTIVITY_TRACKERS.get(source_key)
-    if tracker is None:
-        from main_logic.activity import UserActivityTracker
+def _active_window_from_system_snapshot(system_snapshot: Any) -> Any | None:
+    from main_logic.activity.state_machine import observation_from_system
 
-        tracker = UserActivityTracker(source_key)
-        _ACTIVITY_TRACKERS[source_key] = tracker
-    return tracker
+    return observation_from_system(system_snapshot)
 
 
 def _coerce_idle_seconds(value: Any) -> float | None:
@@ -55,16 +53,21 @@ async def get_os_activity_snapshot(
 ) -> OsActivitySnapshot:
     """Return the OS-only activity signals plugins are allowed to consume."""
 
-    core_snapshot = await _tracker_for_source(source).get_snapshot(now=now)
-    os_signals_available = bool(getattr(core_snapshot, "os_signals_available", True))
-    active_window = getattr(core_snapshot, "active_window", None)
+    _ = (source, now)
+    system_snapshot = _read_system_signal_snapshot()
+    os_signals_available = bool(getattr(system_snapshot, "os_signals_available", True))
+    active_window = (
+        _active_window_from_system_snapshot(system_snapshot)
+        if os_signals_available
+        else None
+    )
     foreground_category = (
         str(getattr(active_window, "category", "") or "").strip().lower() or None
-        if os_signals_available and active_window is not None
+        if active_window is not None
         else None
     )
     idle_seconds = (
-        _coerce_idle_seconds(getattr(core_snapshot, "system_idle_seconds", None))
+        _coerce_idle_seconds(getattr(system_snapshot, "idle_seconds", None))
         if os_signals_available
         else None
     )
@@ -72,7 +75,7 @@ async def get_os_activity_snapshot(
         os_signals_available=os_signals_available,
         foreground_category=foreground_category,
         system_idle_seconds=idle_seconds,
-        privacy_state=_privacy_state(core_snapshot, foreground_category),
+        privacy_state=_privacy_state(system_snapshot, foreground_category),
     )
 
 

--- a/plugin/sdk/plugin/activity.py
+++ b/plugin/sdk/plugin/activity.py
@@ -59,7 +59,7 @@ async def get_os_activity_snapshot(
     os_signals_available = bool(getattr(core_snapshot, "os_signals_available", True))
     active_window = getattr(core_snapshot, "active_window", None)
     foreground_category = (
-        str(getattr(active_window, "category", "") or "").strip() or None
+        str(getattr(active_window, "category", "") or "").strip().lower() or None
         if os_signals_available and active_window is not None
         else None
     )

--- a/plugin/tests/unit/plugins/test_awareness_buffer.py
+++ b/plugin/tests/unit/plugins/test_awareness_buffer.py
@@ -158,6 +158,9 @@ async def test_activity_buffer_is_active_states(monkeypatch: pytest.MonkeyPatch)
     await buffer.add(_snapshot(9, app_type="other", activity_type="idle"))
     assert await buffer.is_active() is False
 
+    await buffer.add(_snapshot(10, app_type="private", activity_type="private"))
+    assert await buffer.is_active() is False
+
     await buffer.add(_snapshot(10, app_type="code_editor", activity_type="question"))
     assert await buffer.is_active() is True
 

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -122,7 +122,7 @@ from plugin.plugins.study_companion.ui_api import (
     build_open_ui_payload,
 )
 from plugin.server.application.plugins.ui_query_service import _build_surfaces_sync
-from plugin.sdk.plugin import Err, Ok
+from plugin.sdk.plugin import Err, Ok, OsActivitySnapshot
 from plugin.sdk.shared.constants import EVENT_META_ATTR
 
 
@@ -441,6 +441,7 @@ async def test_start_awareness_loop_runs_async_tick_and_pushes_context(
             enabled=True,
             snapshot_interval_seconds=60,
             push_to_llm_mode="read",
+            os_signals_enabled=False,
         )
     )
     plugin._ocr_pipeline = _FakeAwarenessPipeline()
@@ -487,13 +488,191 @@ async def test_awareness_tick_counts_unusable_snapshot_as_idle(tmp_path: Path) -
             return _NoActivitySnapshot()
 
     plugin = StudyCompanionPlugin(_Ctx(tmp_path, {"study": {"language": "en", "auto_open_ui": False}}))
-    plugin._cfg = StudyConfig(awareness=AwarenessConfig(push_to_llm_mode="blind"))
+    plugin._cfg = StudyConfig(
+        awareness=AwarenessConfig(
+            push_to_llm_mode="blind",
+            os_signals_enabled=False,
+        )
+    )
     plugin._buffer = ActivityBuffer()
     plugin._ocr_pipeline = _FakeAwarenessPipeline()
 
     await plugin.awareness_tick()
 
     assert plugin._awareness_idle_ticks == 1
+
+
+@pytest.mark.asyncio
+async def test_awareness_tick_private_activity_tracker_skips_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _CaptureShouldNotRun:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def capture_lightweight(self):
+            self.calls += 1
+            raise AssertionError("private activity must not capture the screen")
+
+    async def _activity_snapshot(source: str, *, now: float | None = None):
+        assert source == "study_companion"
+        assert now is not None
+        return OsActivitySnapshot(
+            os_signals_available=True,
+            foreground_category=None,
+            system_idle_seconds=12.0,
+            privacy_state="private",
+        )
+
+    plugin = StudyCompanionPlugin(
+        _Ctx(tmp_path, {"study": {"language": "en", "auto_open_ui": False}})
+    )
+    plugin._cfg = StudyConfig(awareness=AwarenessConfig(push_to_llm_mode="blind"))
+    plugin._buffer = ActivityBuffer()
+    pipeline = _CaptureShouldNotRun()
+    plugin._ocr_pipeline = pipeline
+    monkeypatch.setattr(
+        study_companion_module,
+        "get_os_activity_snapshot",
+        _activity_snapshot,
+    )
+
+    await plugin.awareness_tick()
+
+    assert pipeline.calls == 0
+    assert plugin._awareness_idle_ticks == 1
+    summary = await plugin._buffer.summarize()
+    assert summary["current_app"] == "private"
+    assert summary["current_activity"] == "private"
+
+
+@pytest.mark.asyncio
+async def test_awareness_tick_uses_activity_tracker_foreground_category(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeAwarenessPipeline:
+        def capture_lightweight(self) -> LightweightSnapshot:
+            return LightweightSnapshot(
+                status="ok",
+                captured_at="2026-06-01T00:00:00Z",
+                window_title="Quiz - Google Chrome",
+                app_type="unknown",
+                activity_type="question",
+                ocr_text_snippet="Question: Why?",
+                has_content_change=True,
+                thumbnail_phash="1" * 16,
+            )
+
+    async def _activity_snapshot(source: str, *, now: float | None = None):
+        assert source == "study_companion"
+        assert now is not None
+        return OsActivitySnapshot(
+            os_signals_available=True,
+            foreground_category="gaming",
+            system_idle_seconds=42.0,
+            privacy_state="visible",
+        )
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def observe_activity(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            return {}
+
+    plugin = StudyCompanionPlugin(
+        _Ctx(tmp_path, {"study": {"language": "en", "auto_open_ui": False}})
+    )
+    plugin._cfg = StudyConfig(awareness=AwarenessConfig(push_to_llm_mode="blind"))
+    plugin._buffer = ActivityBuffer()
+    plugin._ocr_pipeline = _FakeAwarenessPipeline()
+    monkeypatch.setattr(
+        study_companion_module,
+        "get_os_activity_snapshot",
+        _activity_snapshot,
+    )
+    supervision = _Supervision()
+    plugin._supervision = supervision
+
+    await plugin.awareness_tick()
+
+    summary = await plugin._buffer.summarize()
+    assert summary["current_app"] == "game"
+    assert supervision.calls == [
+        {
+            "ocr_text": "Question: Why?",
+            "sensor_available": True,
+            "idle_seconds": 42.0,
+            "foreground_category": "gaming",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_awareness_tick_ignores_unavailable_os_signals_for_supervision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeAwarenessPipeline:
+        def capture_lightweight(self) -> LightweightSnapshot:
+            return LightweightSnapshot(
+                status="ok",
+                captured_at="2026-06-01T00:00:00Z",
+                window_title="Quiz - Google Chrome",
+                app_type="unknown",
+                activity_type="question",
+                ocr_text_snippet="Question: Why?",
+                has_content_change=True,
+                thumbnail_phash="2" * 16,
+            )
+
+    async def _activity_snapshot(source: str, *, now: float | None = None):
+        assert source == "study_companion"
+        assert now is not None
+        return OsActivitySnapshot(
+            os_signals_available=False,
+            foreground_category=None,
+            system_idle_seconds=None,
+            privacy_state="unavailable",
+        )
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def observe_activity(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            return {}
+
+    plugin = StudyCompanionPlugin(
+        _Ctx(tmp_path, {"study": {"language": "en", "auto_open_ui": False}})
+    )
+    plugin._cfg = StudyConfig(awareness=AwarenessConfig(push_to_llm_mode="blind"))
+    plugin._buffer = ActivityBuffer()
+    plugin._ocr_pipeline = _FakeAwarenessPipeline()
+    monkeypatch.setattr(
+        study_companion_module,
+        "get_os_activity_snapshot",
+        _activity_snapshot,
+    )
+    supervision = _Supervision()
+    plugin._supervision = supervision
+
+    await plugin.awareness_tick()
+
+    summary = await plugin._buffer.summarize()
+    assert summary["current_app"] == "web_page"
+    assert supervision.calls == [
+        {
+            "ocr_text": "Question: Why?",
+            "sensor_available": True,
+            "idle_seconds": None,
+            "foreground_category": None,
+        }
+    ]
 
 
 class _FakeOcrBackend:

--- a/plugin/tests/unit/plugins/test_study_companion_voice_contracts.py
+++ b/plugin/tests/unit/plugins/test_study_companion_voice_contracts.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pytest
+
+from plugin.plugins.study_companion.voice_contracts import (
+    arbitrate_voice_transcript_results,
+)
+
+pytestmark = pytest.mark.plugin_unit
+
+
+def test_voice_transcript_arbitration_prefers_cancel_response() -> None:
+    result = arbitrate_voice_transcript_results(
+        [
+            {
+                "plugin_id": "math_helper",
+                "event_id": "voice_math",
+                "success": True,
+                "result": {
+                    "action": "prime_context",
+                    "context": "explain this",
+                    "priority": 100,
+                },
+            },
+            {
+                "plugin_id": "study_companion",
+                "event_id": "handle_transcript",
+                "success": True,
+                "result": {
+                    "action": "cancel_response",
+                    "reason": "ocr_overlap",
+                    "priority": -10,
+                },
+            },
+        ]
+    )
+
+    assert result["action"] == "cancel_response"
+    assert result["reason"] == "ocr_overlap"
+    assert result["priority"] == -10.0
+    assert result["skipped"] is False
+    assert result["source_plugin"] == "study_companion"
+    assert result["source_event_id"] == "handle_transcript"
+
+
+def test_voice_transcript_arbitration_orders_prime_context_by_priority() -> None:
+    result = arbitrate_voice_transcript_results(
+        [
+            {
+                "plugin_id": "low",
+                "event_id": "low_handler",
+                "success": True,
+                "result": {
+                    "action": "prime_context",
+                    "context": "low context",
+                    "priority": 1,
+                },
+            },
+            {
+                "plugin_id": "high",
+                "event_id": "high_handler",
+                "success": True,
+                "result": {
+                    "action": "prime_context",
+                    "context": "high context",
+                    "priority": "5",
+                    "skipped": True,
+                },
+            },
+        ]
+    )
+
+    assert result["action"] == "prime_context"
+    assert result["context"] == "high context"
+    assert result["priority"] == 5.0
+    assert result["skipped"] is True
+    assert result["source_plugin"] == "high"
+    assert result["source_event_id"] == "high_handler"
+
+
+def test_voice_transcript_arbitration_all_noop_continues_ordinary_flow() -> None:
+    result = arbitrate_voice_transcript_results(
+        [
+            {
+                "plugin_id": "alpha",
+                "event_id": "a",
+                "success": True,
+                "result": {"action": "noop", "reason": "not_matched"},
+            },
+            {
+                "plugin_id": "beta",
+                "event_id": "b",
+                "success": False,
+                "error": "timeout",
+            },
+        ]
+    )
+
+    assert result == {
+        "action": "noop",
+        "reason": "all_noop",
+        "priority": 0.0,
+        "skipped": False,
+        "handlers": 1,
+        "failures": 1,
+    }

--- a/plugin/tests/unit/plugins/test_study_companion_voice_filter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_voice_filter.py
@@ -14,6 +14,7 @@ from plugin.plugins.study_companion.voice_filter import (
     _derive_subject,
     _find_earliest_name,
     _has_question_intent,
+    _ocr_is_stale,
     _number_sequence_match,
     _text_overlap_ratio,
     build_context_for_catgirl,
@@ -42,6 +43,28 @@ def test_voice_filter_loads_current_catgirl_name_and_nicknames_from_config_manag
     voice_filter = VoiceFilter(config_manager=ConfigManager())
 
     assert voice_filter.names == ("Mika", "米卡", "小M", "Sensei")
+
+
+def test_voice_filter_logs_config_manager_failures() -> None:
+    class ConfigManager:
+        def get_character_data(self) -> tuple[object, ...]:
+            raise RuntimeError("config damaged")
+
+    class Logger:
+        def __init__(self) -> None:
+            self.warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def warning(self, *args: object, **kwargs: object) -> None:
+            self.warnings.append((args, kwargs))
+
+    logger = Logger()
+    voice_filter = VoiceFilter(config_manager=ConfigManager(), logger=logger)
+
+    assert voice_filter.names == CATGIRL_NAMES
+    assert any(
+        "voice filter failed to read configured names" in str(args[0])
+        for args, _kwargs in logger.warnings
+    )
 
 
 def test_find_earliest_name_is_case_insensitive_and_uses_first_position() -> None:
@@ -227,6 +250,10 @@ def test_unknown_non_overlapping_transcript_relays_by_returning_none() -> None:
     )
 
     assert result is None
+
+
+def test_ocr_is_stale_treats_invalid_timestamps_as_stale() -> None:
+    assert _ocr_is_stale("not-a-timestamp") is True
 
 
 def test_question_intent_relays_before_ocr_overlap() -> None:

--- a/plugin/tests/unit/plugins/test_supervision.py
+++ b/plugin/tests/unit/plugins/test_supervision.py
@@ -145,3 +145,61 @@ def test_supervision_flags_foreground_distraction_during_focus() -> None:
     assert result["foreground_category"] == "gaming"
     assert result["suggested_action"] == "return_to_focus"
     assert result["reminder_level"] == "distraction"
+
+
+def test_supervision_idle_away_takes_priority_over_distraction() -> None:
+    controller = SupervisionController(
+        SupervisionConfig(
+            enabled=True,
+            remind_interval_minutes=10,
+            inactivity_timeout_minutes=5,
+            idle_away_seconds=120,
+        ),
+        clock=lambda: 0.0,
+    )
+    controller.on_focus_start(goal={}, planned_minutes=25, now=0.0)
+
+    result = controller.observe_activity(
+        ocr_text="same text",
+        sensor_available=True,
+        idle_seconds=121.0,
+        foreground_category="gaming",
+        now=121.0,
+    )
+
+    assert result["inactivity_detected"] is True
+    assert result["suggested_action"] == "pause_or_switch"
+    assert result["reminder_level"] == "away"
+    assert result["foreground_category"] == "gaming"
+    assert result["distraction_detected"] is False
+
+
+def test_supervision_clears_distraction_level_after_foreground_changes() -> None:
+    controller = SupervisionController(
+        SupervisionConfig(
+            enabled=True,
+            remind_interval_minutes=10,
+            inactivity_timeout_minutes=5,
+        ),
+        clock=lambda: 0.0,
+    )
+    controller.on_focus_start(goal={}, planned_minutes=25, now=0.0)
+
+    distracted = controller.observe_activity(
+        ocr_text="same text",
+        sensor_available=True,
+        idle_seconds=1.0,
+        foreground_category="gaming",
+        now=60.0,
+    )
+    recovered = controller.observe_activity(
+        ocr_text="same text",
+        sensor_available=True,
+        now=61.0,
+    )
+
+    assert distracted["reminder_level"] == "distraction"
+    assert recovered["inactivity_detected"] is False
+    assert recovered["suggested_action"] == ""
+    assert recovered["reminder_level"] == "active"
+    assert "distraction_detected" not in recovered

--- a/plugin/tests/unit/plugins/test_supervision.py
+++ b/plugin/tests/unit/plugins/test_supervision.py
@@ -64,3 +64,84 @@ def test_supervision_inactivity_degrades_when_sensor_unavailable() -> None:
     assert inactive["suggested_action"] == "pause_or_switch"
     assert changed["inactivity_detected"] is False
     assert changed["reminder_level"] != "inactivity"
+
+
+def test_supervision_uses_idle_signal_as_activity_when_screen_is_static() -> None:
+    controller = SupervisionController(
+        SupervisionConfig(
+            enabled=True,
+            remind_interval_minutes=10,
+            inactivity_timeout_minutes=5,
+        ),
+        clock=lambda: 0.0,
+    )
+    controller.on_focus_start(goal={}, planned_minutes=25, now=0.0)
+
+    controller.observe_activity(
+        ocr_text="same text",
+        sensor_available=True,
+        idle_seconds=1.0,
+        now=60.0,
+    )
+    active = controller.observe_activity(
+        ocr_text="same text",
+        sensor_available=True,
+        idle_seconds=2.0,
+        now=421.0,
+    )
+
+    assert active["inactivity_detected"] is False
+    assert active["suggested_action"] == ""
+    assert active["reminder_level"] != "inactivity"
+    assert active["idle_seconds"] == 2.0
+
+
+def test_supervision_idle_away_detected() -> None:
+    controller = SupervisionController(
+        SupervisionConfig(
+            enabled=True,
+            remind_interval_minutes=10,
+            inactivity_timeout_minutes=5,
+            idle_away_seconds=120,
+        ),
+        clock=lambda: 0.0,
+    )
+    controller.on_focus_start(goal={}, planned_minutes=25, now=0.0)
+
+    away = controller.observe_activity(
+        ocr_text="same text",
+        sensor_available=True,
+        idle_seconds=121.0,
+        now=121.0,
+    )
+
+    assert away["inactivity_detected"] is True
+    assert away["suggested_action"] == "pause_or_switch"
+    assert away["reminder_level"] == "away"
+    assert away["idle_seconds"] == 121.0
+
+
+def test_supervision_flags_foreground_distraction_during_focus() -> None:
+    controller = SupervisionController(
+        SupervisionConfig(
+            enabled=True,
+            remind_interval_minutes=10,
+            inactivity_timeout_minutes=5,
+        ),
+        clock=lambda: 0.0,
+    )
+    controller.on_focus_start(goal={}, planned_minutes=25, now=0.0)
+
+    result = controller.observe_activity(
+        ocr_text="same text",
+        sensor_available=True,
+        idle_seconds=1.0,
+        foreground_category="gaming",
+        now=60.0,
+    )
+
+    assert result["inactivity_detected"] is False
+    assert result["distraction_detected"] is True
+    assert result["foreground_category"] == "gaming"
+    assert result["suggested_action"] == "return_to_focus"
+    assert result["reminder_level"] == "distraction"

--- a/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
+++ b/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_base.py
@@ -581,6 +581,8 @@ def test_plugin_init_all_contains_expected_symbols(plugin_api_module) -> None:
         "neko_plugin",
         "plugin_entry",
         "plugin",
+        "OsActivitySnapshot",
+        "get_os_activity_snapshot",
         "PluginConfig",
         "Plugins",
         "PluginRouter",

--- a/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_runtime.py
+++ b/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_runtime.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import fields
+from types import SimpleNamespace
 
 import pytest
 
+import plugin.sdk.plugin.activity as activity_api
 from plugin.sdk.plugin import runtime as rt
 from plugin.sdk.shared.models.errors import ErrorCode
 from plugin.sdk.shared.models.exceptions import TransportError, ValidationError
@@ -100,6 +102,61 @@ def test_hook_executor_mixin_not_implemented() -> None:
     mixin = object.__new__(rt.HookExecutorMixin)
     with pytest.raises(NotImplementedError):
         mixin.__init_hook_executor__()
+
+
+@pytest.mark.asyncio
+async def test_os_activity_snapshot_narrows_core_tracker_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Tracker:
+        async def get_snapshot(self, *, now: float | None = None):
+            assert now == 12.5
+            return SimpleNamespace(
+                state="focused_work",
+                active_window=SimpleNamespace(category="gaming"),
+                system_idle_seconds="42.25",
+                os_signals_available=True,
+            )
+
+    monkeypatch.setattr(activity_api, "_tracker_for_source", lambda source: _Tracker())
+
+    snapshot = await activity_api.get_os_activity_snapshot("study_companion", now=12.5)
+
+    assert snapshot.os_signals_available is True
+    assert snapshot.foreground_category == "gaming"
+    assert snapshot.system_idle_seconds == 42.25
+    assert snapshot.privacy_state == "visible"
+
+
+@pytest.mark.asyncio
+async def test_os_activity_snapshot_privacy_and_unavailable_states(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _PrivateTracker:
+        async def get_snapshot(self, *, now: float | None = None):
+            return SimpleNamespace(
+                state="private",
+                active_window=SimpleNamespace(category="private"),
+                system_idle_seconds=7,
+                os_signals_available=True,
+            )
+
+    monkeypatch.setattr(activity_api, "_tracker_for_source", lambda source: _PrivateTracker())
+    private_snapshot = await activity_api.get_os_activity_snapshot("study_companion")
+    assert private_snapshot.privacy_state == "private"
+    assert private_snapshot.foreground_category == "private"
+
+    class _UnavailableTracker:
+        async def get_snapshot(self, *, now: float | None = None):
+            return SimpleNamespace(
+                state="idle",
+                active_window=SimpleNamespace(category="gaming"),
+                system_idle_seconds=7,
+                os_signals_available=False,
+            )
+
+    monkeypatch.setattr(activity_api, "_tracker_for_source", lambda source: _UnavailableTracker())
+    unavailable_snapshot = await activity_api.get_os_activity_snapshot("study_companion")
+    assert unavailable_snapshot.os_signals_available is False
+    assert unavailable_snapshot.foreground_category is None
+    assert unavailable_snapshot.system_idle_seconds is None
+    assert unavailable_snapshot.privacy_state == "unavailable"
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_runtime.py
+++ b/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_runtime.py
@@ -105,18 +105,18 @@ def test_hook_executor_mixin_not_implemented() -> None:
 
 
 @pytest.mark.asyncio
-async def test_os_activity_snapshot_narrows_core_tracker_payload(monkeypatch: pytest.MonkeyPatch) -> None:
-    class _Tracker:
-        async def get_snapshot(self, *, now: float | None = None):
-            assert now == 12.5
-            return SimpleNamespace(
-                state="focused_work",
-                active_window=SimpleNamespace(category="Gaming"),
-                system_idle_seconds="42.25",
-                os_signals_available=True,
-            )
+async def test_os_activity_snapshot_narrows_system_signal_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    system_snapshot = SimpleNamespace(
+        idle_seconds="42.25",
+        os_signals_available=True,
+    )
 
-    monkeypatch.setattr(activity_api, "_tracker_for_source", lambda source: _Tracker())
+    monkeypatch.setattr(activity_api, "_read_system_signal_snapshot", lambda: system_snapshot)
+    monkeypatch.setattr(
+        activity_api,
+        "_active_window_from_system_snapshot",
+        lambda snapshot: SimpleNamespace(category="Gaming"),
+    )
 
     snapshot = await activity_api.get_os_activity_snapshot("study_companion", now=12.5)
 
@@ -128,30 +128,31 @@ async def test_os_activity_snapshot_narrows_core_tracker_payload(monkeypatch: py
 
 @pytest.mark.asyncio
 async def test_os_activity_snapshot_privacy_and_unavailable_states(monkeypatch: pytest.MonkeyPatch) -> None:
-    class _PrivateTracker:
-        async def get_snapshot(self, *, now: float | None = None):
-            return SimpleNamespace(
-                state="private",
-                active_window=SimpleNamespace(category="private"),
-                system_idle_seconds=7,
-                os_signals_available=True,
-            )
+    private_snapshot_raw = SimpleNamespace(
+        idle_seconds=7,
+        os_signals_available=True,
+    )
 
-    monkeypatch.setattr(activity_api, "_tracker_for_source", lambda source: _PrivateTracker())
+    monkeypatch.setattr(
+        activity_api, "_read_system_signal_snapshot", lambda: private_snapshot_raw
+    )
+    monkeypatch.setattr(
+        activity_api,
+        "_active_window_from_system_snapshot",
+        lambda snapshot: SimpleNamespace(category="private"),
+    )
     private_snapshot = await activity_api.get_os_activity_snapshot("study_companion")
     assert private_snapshot.privacy_state == "private"
     assert private_snapshot.foreground_category == "private"
 
-    class _UnavailableTracker:
-        async def get_snapshot(self, *, now: float | None = None):
-            return SimpleNamespace(
-                state="idle",
-                active_window=SimpleNamespace(category="gaming"),
-                system_idle_seconds=7,
-                os_signals_available=False,
-            )
+    unavailable_snapshot_raw = SimpleNamespace(
+        idle_seconds=7,
+        os_signals_available=False,
+    )
 
-    monkeypatch.setattr(activity_api, "_tracker_for_source", lambda source: _UnavailableTracker())
+    monkeypatch.setattr(
+        activity_api, "_read_system_signal_snapshot", lambda: unavailable_snapshot_raw
+    )
     unavailable_snapshot = await activity_api.get_os_activity_snapshot("study_companion")
     assert unavailable_snapshot.os_signals_available is False
     assert unavailable_snapshot.foreground_category is None

--- a/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_runtime.py
+++ b/plugin/tests/unit/sdk/plugin/test_sdk_v2_plugin_runtime.py
@@ -111,7 +111,7 @@ async def test_os_activity_snapshot_narrows_core_tracker_payload(monkeypatch: py
             assert now == 12.5
             return SimpleNamespace(
                 state="focused_work",
-                active_window=SimpleNamespace(category="gaming"),
+                active_window=SimpleNamespace(category="Gaming"),
                 system_idle_seconds="42.25",
                 os_signals_available=True,
             )


### PR DESCRIPTION
## 改动概述

本 PR 是对已关闭 #1619 的重整：基于最新 `upstream/main` 去掉已被 #1793 吸收/改写的 notebook 内容和已清理的 deskpet 内容，只保留还需要继续推进的 study companion OS awareness、voice transcript 与 supervision 能力。

## 回归报告 / Regression Report

改动内容：新增插件 SDK 的 OS activity 窄接口，study companion 通过该接口消费 `os_signals_available`、`foreground_category`、`system_idle_seconds`、`privacy_state`；awareness 循环使用 OS 信号处理隐私跳过、前台分类映射和监督观察；voice transcript 返回结构收敛为 `noop`、`cancel_response`、`prime_context` 契约；supervision 增加 idle-away 和前台娱乐/游戏分心判断；同步相关配置与单元测试。

理由/必要性：#1619 的原始改动混入 notebook、deskpet、依赖和 study companion 多条路径，其中 notebook 已由 #1793 处理。这里重新梳理剩余可推进部分，避免把过期实现和不必要依赖带回，同时把插件对 `UserActivityTracker` 的直接依赖收敛为 SDK 窄接口，符合插件边界。

前后表现：study companion awareness 不再直接实例化 core activity tracker，而是通过 SDK 获取 OS 活动摘要；隐私状态下跳过截图并只记录 private 活动；OS 前台分类可辅助把游戏/工作/娱乐/通信映射到学习伴侣活动类型；监督逻辑能区分静态屏幕但用户仍活跃、长时间离开以及焦点期间打开娱乐/游戏应用；语音转录处理返回结构更稳定。

潜在回归点：SDK OS activity facade 与 core activity snapshot 的字段适配、awareness 循环的隐私跳过与截图恢复、supervision 的 idle/distraction 阈值、voice transcript action 仲裁、配置默认值变化对既有 study companion 行为的影响。

## 不拆分理由 / Why Not Split

本 PR 文件数未超过 20，且改动都围绕 #1619 剩余的 study companion 感知、语音和监督路径。SDK 窄接口、插件消费侧、voice contract、supervision 行为和对应测试需要一起落地，否则会出现插件边界调整完成但业务路径或测试合同不一致的状态。因此保留为一个整理 PR。

## 风险与边界

本 PR 不带回 #1619 中已由 #1793 覆盖的 notebook 批量改动，不包含 deskpet，不修改依赖文件，也不引入 `jieba` 依赖。新增 SDK 接口只公开 OS activity 的窄摘要，不公开 `UserActivityTracker` 本体，也不修改 core activity 实现。后续同类插件应继续通过 SDK 窄接口消费 OS 信号；如果需要更多字段，应先扩展 SDK 契约，而不是直接依赖 `main_logic` 内部实现。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 OS 活动快照感知，用于隐私状态判断与前台类别分类，并在私密场景下避免触发屏幕采集。
  * 增强干扰检测：识别指定前台“干扰”类别，提示“回到专注”。

* **功能改进**
  * 焦点统计与活动判定更严格：`private/unknown/other` 不再计入有效专注时间，`unknown` 将不再触发活跃状态。
  * 语音转录事件裁决与响应构造更一致，异常处理更稳健。

* **配置更新**
  * 新增 `idle_away_seconds=900`。
  * 默认图像上限与 LLM 推送间隔调整为 65,536 字节与 300 秒；默认开启 OS 信号与干扰检测。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
