### PR TITLE
移除打开模型管理时自动隐藏主页面模型的逻辑。模型管理窗口不再发送 hide_main_ui/show_main_ui，主页面侧边入口也不再…

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -3025,12 +3025,6 @@
                         }
                         break;
                     }
-                    case 'hide_main_ui':
-                        handleHideMainUI();
-                        break;
-                    case 'show_main_ui':
-                        handleShowMainUI();
-                        break;
                     case 'memory_edited':
                         await handleMemoryEdited(event.data.catgirl_name);
                         break;

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -769,26 +769,6 @@ function createCharacterSettingsSidePanel(manager, prefix) {
 /**
  * 创建侧边面板菜单项
  */
-// 跟踪所有已打开的模型管理子窗口，只有全部关闭后才恢复主页渲染
-const _activeManagerWindows = new Set();
-let _managerWindowCheckTimer = null;
-
-function _startManagerWindowWatcher() {
-    if (_managerWindowCheckTimer) return;
-    _managerWindowCheckTimer = setInterval(() => {
-        for (const win of _activeManagerWindows) {
-            if (win.closed) _activeManagerWindows.delete(win);
-        }
-        if (_activeManagerWindows.size === 0) {
-            clearInterval(_managerWindowCheckTimer);
-            _managerWindowCheckTimer = null;
-            if (typeof window.handleShowMainUI === 'function') {
-                window.handleShowMainUI();
-            }
-        }
-    }, 1000);
-}
-
 function createSidePanelMenuItem(manager, prefix, item) {
     const menuItem = document.createElement('div');
     menuItem.id = `${prefix}-sidepanel-${item.id}`;
@@ -849,21 +829,15 @@ function createSidePanelMenuItem(manager, prefix, item) {
 
     let isOpening = false;
 
-    // 打开子窗口并暂停主页渲染，所有管理窗口关闭后自动恢复
-    function openAndPauseMainUI(url, name, feat) {
+    // 打开模型管理子窗口，主页面模型保持原样显示。
+    function openModelManagerWindow(url, name, feat) {
         let childWin;
         if (typeof window.openOrFocusWindow === 'function') {
             childWin = window.openOrFocusWindow(url, name, feat);
         } else {
             childWin = window.open(url, name, feat);
         }
-        // 弹窗被拦截或打开失败时不隐藏主页，避免无法恢复
-        if (!childWin) return;
-        if (typeof window.handleHideMainUI === 'function') {
-            window.handleHideMainUI();
-        }
-        _activeManagerWindows.add(childWin);
-        _startManagerWindowWatcher();
+        return childWin;
     }
 
     menuItem.addEventListener('click', (e) => {
@@ -881,7 +855,7 @@ function createSidePanelMenuItem(manager, prefix, item) {
                 isOpening = true;
                 windowName = `neko_${item.id}_${encodeURIComponent(lanlanName || 'default')}`;
                 features = buildAvatarFullscreenWindowFeatures();
-                openAndPauseMainUI(finalUrl, windowName, features);
+                openModelManagerWindow(finalUrl, windowName, features);
                 setTimeout(() => { isOpening = false; }, 500);
             } else if (item.id === 'voice-clone' && item.url) {
                 const lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -541,6 +541,10 @@ function sendMessageToMainPage(action, payload = {}) {
 
 
 
+function isModelManagerPopupWindow() {
+    return window.opener !== null;
+}
+
 // 全局变量：跟踪未保存的更改
 window.hasUnsavedChanges = false;
 window._modelManagerParameterEditedSinceSave = false;
@@ -2752,7 +2756,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             textSpan = document.getElementById('back-text');
         }
 
-        const isPopupWindow = window.opener !== null;
+        const isPopupWindow = isModelManagerPopupWindow();
         if (textSpan) {
             let text;
             if (isPopupWindow) {
@@ -2838,12 +2842,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             DropdownManager.updateAllButtonText();
             refreshLocalizedInteractiveTexts();
         });
-    }
-
-    // 页面加载时发送消息隐藏主界面（仅在弹出窗口模式下）
-    const isPopupWindow = window.opener !== null;
-    if (isPopupWindow) {
-        sendMessageToMainPage('hide_main_ui');
     }
 
     // 翻译辅助函数：简化翻译调用并处理错误
@@ -8745,6 +8743,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         // 根据窗口类型执行不同的操作
+        const isPopupWindow = isModelManagerPopupWindow();
         if (isPopupWindow) {
             // 如果是弹出窗口：只有在本页确实保存过设置时才刷新主界面模型
             // 否则不触发重载，避免“退出即复位/回默认模型”
@@ -10567,7 +10566,6 @@ window.addEventListener('beforeunload', (e) => {
         if (window._modelManagerHasSaved && window._modelManagerLanlanName && window._modelManagerLanlanName.trim() !== '') {
             sendMessageToMainPage('reload_model', { lanlan_name: window._modelManagerLanlanName });
         }
-        sendMessageToMainPage('show_main_ui');
     }
 
 });

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -10569,8 +10569,3 @@ window.addEventListener('beforeunload', (e) => {
     }
 
 });
-
-// 确保在页面关闭时也恢复主界面
-window.addEventListener('unload', () => {
-    // 页面卸载时不需要再次发送消息
-});

--- a/static/tutorial/yui-guide/page-handoff.js
+++ b/static/tutorial/yui-guide/page-handoff.js
@@ -1303,7 +1303,8 @@
         return openPage(
             url,
             windowName,
-            buildFullscreenWindowFeatures()
+            buildFullscreenWindowFeatures(),
+            { keepMainUIVisible: true }
         );
     }
 

--- a/tests/unit/test_model_manager_window_features.py
+++ b/tests/unit/test_model_manager_window_features.py
@@ -24,6 +24,16 @@ def test_yui_model_manager_handoff_opens_fullscreen():
     assert "{ keepMainUIVisible: true }" in model_manager_block
 
 
+def test_model_manager_hide_show_cross_page_messages_are_removed():
+    model_manager_source = Path("static/js/model_manager.js").read_text(encoding="utf-8")
+    interpage_source = Path("static/app-interpage.js").read_text(encoding="utf-8")
+
+    assert "hide_main_ui" not in model_manager_source
+    assert "show_main_ui" not in model_manager_source
+    assert "case 'hide_main_ui':" not in interpage_source
+    assert "case 'show_main_ui':" not in interpage_source
+
+
 def test_voice_clone_api_settings_uses_shared_named_window():
     source = Path("static/js/voice_clone.js").read_text(encoding="utf-8")
     common_source = Path("static/common_dialogs.js").read_text(encoding="utf-8")

--- a/tests/unit/test_model_manager_window_features.py
+++ b/tests/unit/test_model_manager_window_features.py
@@ -19,7 +19,9 @@ def test_yui_model_manager_handoff_opens_fullscreen():
     assert "function isModelManagerPageUrl(openUrl)" in source
     assert "if (isModelManagerPageUrl(openUrl))" in source
     assert "return buildFullscreenWindowFeatures();" in source
-    assert "buildFullscreenWindowFeatures()" in source[source.index("function openModelManagerPage("):]
+    model_manager_block = source[source.index("function openModelManagerPage("):source.index("function triggerGoodbye(")]
+    assert "buildFullscreenWindowFeatures()" in model_manager_block
+    assert "{ keepMainUIVisible: true }" in model_manager_block
 
 
 def test_voice_clone_api_settings_uses_shared_named_window():

--- a/tests/unit/test_model_manager_window_features.py
+++ b/tests/unit/test_model_manager_window_features.py
@@ -8,7 +8,8 @@ def test_avatar_model_manager_popup_opens_fullscreen():
     assert "screenRef.availWidth || screenRef.width" in source
     assert "screenRef.availHeight || screenRef.height" in source
     assert "features = buildAvatarFullscreenWindowFeatures();" in source
-    assert "openAndPauseMainUI(finalUrl, windowName, features);" in source
+    assert "openModelManagerWindow(finalUrl, windowName, features);" in source
+    assert "window.handleHideMainUI()" not in source
 
 
 def test_yui_model_manager_handoff_opens_fullscreen():

--- a/tests/unit/test_model_manager_window_features.py
+++ b/tests/unit/test_model_manager_window_features.py
@@ -19,7 +19,9 @@ def test_yui_model_manager_handoff_opens_fullscreen():
     assert "function isModelManagerPageUrl(openUrl)" in source
     assert "if (isModelManagerPageUrl(openUrl))" in source
     assert "return buildFullscreenWindowFeatures();" in source
-    model_manager_block = source[source.index("function openModelManagerPage("):source.index("function triggerGoodbye(")]
+    start = source.index("function openModelManagerPage(")
+    end = source.index("\n    function ", start + len("function openModelManagerPage("))
+    model_manager_block = source[start:end]
     assert "buildFullscreenWindowFeatures()" in model_manager_block
     assert "{ keepMainUIVisible: true }" in model_manager_block
 

--- a/tests/unit/test_model_manager_window_features.py
+++ b/tests/unit/test_model_manager_window_features.py
@@ -32,8 +32,8 @@ def test_model_manager_hide_show_cross_page_messages_are_removed():
 
     assert "hide_main_ui" not in model_manager_source
     assert "show_main_ui" not in model_manager_source
-    assert "case 'hide_main_ui':" not in interpage_source
-    assert "case 'show_main_ui':" not in interpage_source
+    assert "hide_main_ui" not in interpage_source
+    assert "show_main_ui" not in interpage_source
 
 
 def test_voice_clone_api_settings_uses_shared_named_window():


### PR DESCRIPTION
…暂停/恢复主 UI；保留保存后通知主页面重载模型的行为，并修复弹窗模式判断变量作用域问题

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

移除打开模型管理时自动隐藏主页面模型的逻辑

## 测试 / Testing

手动打开模型管理测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 简化模型管理器弹窗的打开、返回与关闭处理，移除“暂停/恢复主页渲染”的窗口跟踪与相关跨页协同。
  * 统一弹窗/主页面判断逻辑，并调整退出场景下的跨页分发行为。
* **新功能**
  * 教程的模型管理页交接流程中，打开模型管理页时可显式保持主页可见性。
* **Bug Fixes**
  * 移除跨页面 `hide_main_ui/show_main_ui` 相关消息分支与兜底发送。
* **测试**
  * 更新并加强模型管理器单元测试的断言与负向校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->