### PR TITLE
feat(neko_roast): add live event ingestion

### DIFF
--- a/plugin/plugins/neko_roast/core/event_bus.py
+++ b/plugin/plugins/neko_roast/core/event_bus.py
@@ -1,0 +1,103 @@
+"""直播事件中枢的发布 / 订阅骨架（EventBus）。
+
+P2.5 完整版地基：把「谁产出事件」与「谁处理事件」解耦——接入侧（``bili_live_ingest``）只管
+把直播事件包成 ``LiveEvent`` 发布到总线；各 handler 模块在 ``setup`` 里按事件类型订阅，彼此
+互不感知。这是「把插件分发给其他开发者、各写各事件 handler」的核心契约：
+
+    加一个事件族 handler = 写个模块 + 在它的 setup 里
+        self._unsub = ctx.event_bus.subscribe("gift", self._on_gift, owner=self.id)
+    零改外壳、零碰接入层、与其它模块并行无冲突。
+
+三条保证（LIVE 场景可靠性第一）：
+- **隔离**：一个订阅者的 handler 抛错（含其 async 任务抛错）只记 audit，绝不波及其余订阅者
+  或发布方。
+- **归属**：每个订阅带 ``owner``（模块 id）；失败 audit 带 ``owner`` + ``event_type``，能定位
+  是谁炸的。
+- **静默丢弃**：发布到无人订阅的事件类型 = no-op（任意模块子集都能安全运行，见
+  docs/ui-architecture.md §4 层②）。
+
+handler 可同步可异步：同步 handler 内联调用（沿用插件既有「同步回调 + 内部 fire-and-forget」
+节奏，不拖慢弹幕接收循环）；返回协程则调度为隔离后台 task，其异常同样收敛进 audit。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+
+class _Subscription:
+    __slots__ = ("event_type", "handler", "owner")
+
+    def __init__(self, event_type: str, handler: Callable[[Any], Any], owner: str) -> None:
+        self.event_type = event_type
+        self.handler = handler
+        self.owner = owner
+
+
+class EventBus:
+    def __init__(self, audit: Any = None) -> None:
+        self._subs: dict[str, list[_Subscription]] = {}
+        self._audit = audit
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    def subscribe(self, event_type: str, handler: Callable[[Any], Any], *, owner: str = "") -> Callable[[], None]:
+        """订阅某类直播事件。``owner``=归属模块 id（失败 audit 用）。返回取消订阅的句柄。"""
+        sub = _Subscription(str(event_type), handler, str(owner))
+        self._subs.setdefault(sub.event_type, []).append(sub)
+
+        def _unsubscribe() -> None:
+            bucket = self._subs.get(sub.event_type)
+            if bucket and sub in bucket:
+                bucket.remove(sub)
+
+        return _unsubscribe
+
+    def subscriber_count(self, event_type: str) -> int:
+        return len(self._subs.get(str(event_type), []))
+
+    def publish(self, event_type: str, event: Any) -> None:
+        """按类型逐订阅者隔离派发。无订阅者 = 静默丢弃。"""
+        for sub in list(self._subs.get(str(event_type), [])):
+            try:
+                result = sub.handler(event)
+            except Exception as exc:  # noqa: BLE001 — 单订阅者失败隔离，不波及其余
+                self._record_error(sub.owner, str(event_type), exc)
+                continue
+            if asyncio.iscoroutine(result):
+                self._spawn_isolated(result, sub.owner, str(event_type))
+
+    # —— 向后兼容的观测别名（runtime 的 sandbox_result / result 仍走这俩；无订阅者即 no-op）——
+    def on(self, event: str, listener: Callable[[Any], Any]) -> Callable[[], None]:
+        return self.subscribe(event, listener)
+
+    def emit(self, event: str, payload: Any) -> None:
+        self.publish(event, payload)
+
+    def _spawn_isolated(self, coro: Any, owner: str, event_type: str) -> None:
+        async def _runner() -> None:
+            try:
+                await coro
+            except Exception as exc:  # noqa: BLE001 — async handler 失败同样隔离进 audit
+                self._record_error(owner, event_type, exc)
+
+        task = asyncio.create_task(_runner())
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    def _record_error(self, owner: str, event_type: str, exc: Exception) -> None:
+        if self._audit is None:
+            return
+        record = getattr(self._audit, "record", None)
+        if not callable(record):
+            return
+        try:
+            record(
+                "event_handler_failed",
+                f"{owner or '?'} / {event_type}: {type(exc).__name__}",
+                level="warning",
+                detail={"owner": owner, "event_type": event_type},
+            )
+        except Exception:  # noqa: BLE001 — 连记录都失败也不能反过来炸发布方
+            pass

--- a/plugin/plugins/neko_roast/modules/bili_dm_ingest/__init__.py
+++ b/plugin/plugins/neko_roast/modules/bili_dm_ingest/__init__.py
@@ -1,0 +1,3 @@
+"""Reserved Bilibili direct-message ingest module."""
+
+ENABLED = False

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
@@ -139,8 +139,7 @@ class BiliLiveIngestModule(BaseModule):
         同步、非阻塞：``publish`` 只做同步派发（订阅者内部各自 fire-and-forget），不拖慢弹幕
         接收循环。``danmaku_core`` 对 DANMU_MSG/SEND_GIFT/SC/INTERACT_WORD/增强指令都发
         ``on_event``，全部发布到总线；``live_events`` 订阅 danmaku/gift/super_chat/guard
-        ???????????????????????
-        事件族 handler 订阅（见 docs/development.md「直播事件中枢」）。
+        参与窗口择优；其他事件族 handler 可各自订阅（见 docs/development.md「直播事件中枢」）。
         """
         if not self.ctx:
             return

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
@@ -1,0 +1,371 @@
+"""Bilibili live event normalization for v0.1."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+from ...core.contracts import LiveEvent, LiveRoomStatus, ViewerEvent
+from .._base import BaseModule
+
+
+class _ListenerLog:
+    """把 DanmakuListener 的日志收敛到 audit：info/debug 丢弃（避免刷屏+隐私），warning/error 入 audit。"""
+
+    def __init__(self, audit: Any) -> None:
+        self._audit = audit
+
+    def info(self, msg: Any = "", *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def debug(self, msg: Any = "", *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def warning(self, msg: Any = "", *args: Any, **kwargs: Any) -> None:
+        if self._audit is not None:
+            self._audit.record("live_listener", str(msg)[:200], level="warning")
+
+    def error(self, msg: Any = "", *args: Any, **kwargs: Any) -> None:
+        if self._audit is not None:
+            self._audit.record("live_listener", str(msg)[:200], level="error")
+
+
+class BiliLiveIngestModule(BaseModule):
+    id = "bili_live_ingest"
+    title = "B站直播输入"
+
+    def __init__(self) -> None:
+        super().__init__()
+        # 吞并自 plugin/plugins/bilibili_danmaku 的 DanmakuListener（见 live-center 计划）。
+        self._listener: Any = None
+        self._listener_task: "asyncio.Task[Any] | None" = None
+        self._room_id: int = 0
+        # lookup 反 -352：临时 buvid3 缓存 + 房间状态短期缓存（见 _lookup_room_status_sync）
+        self._lookup_buvid3: str = ""
+        self._lookup_buvid3_ts: float = 0.0
+        self._lookup_buvid3_ttl: float = 6 * 3600.0
+        self._room_status_cache: "dict[int, tuple[LiveRoomStatus, float]]" = {}
+        self._room_status_ttl: float = 60.0
+
+    async def teardown(self) -> None:
+        await self.stop_listening()
+        await super().teardown()
+
+    def status(self) -> dict[str, Any]:
+        return {"enabled": self.enabled, "listening": self.is_listening(), "room_id": self._room_id}
+
+    def is_listening(self) -> bool:
+        return self._listener is not None
+
+    def listener_state(self) -> dict[str, Any]:
+        if self._listener is None:
+            return {"state": "disconnected", "room_id": self._room_id, "viewer_count": 0}
+        try:
+            return self._listener.get_connection_state()
+        except Exception:
+            return {"state": "unknown", "room_id": self._room_id, "viewer_count": 0}
+
+    async def start_listening(self, room_id: int) -> bool:
+        """启动真实弹幕监听（匿名只读）。返回是否成功创建监听任务。"""
+        room_id = int(room_id or 0)
+        if room_id <= 0:
+            return False
+        await self.stop_listening()
+        audit = self.ctx.audit if self.ctx else None
+        try:
+            from .danmaku_core import DanmakuListener
+        except Exception as exc:
+            if audit is not None:
+                audit.record("live_listener_import_failed", f"{type(exc).__name__}: {exc}", level="error")
+            return False
+        callbacks = {
+            # 富模型 on_event（带 get_score 打分）→ live_events 中枢窗口择优；不再用轻量
+            # on_danmaku 直连 pipeline，避免同一条弹幕被两条路各锐评一次。
+            "on_event": self._on_live_event,
+            "on_live": self._on_live,
+            "on_preparing": self._on_preparing,
+            "on_error": self._on_error,
+        }
+        self._listener = DanmakuListener(
+            room_id=room_id,
+            # 登录态（若有）让弹幕连接走登录会话，更稳、低风控；未登录=匿名只读（临时 buvid3 绕风控）。
+            credential=getattr(self.ctx, "bili_credential", None) if self.ctx else None,
+            logger=_ListenerLog(audit),
+            callbacks=callbacks,
+        )
+        self._room_id = room_id
+        self._listener_task = asyncio.create_task(self._listener.start())
+        if audit is not None:
+            audit.record("live_listener_started", "danmaku listener started", detail={"room_id": room_id})
+        return True
+
+    async def stop_listening(self) -> None:
+        listener = self._listener
+        task = self._listener_task
+        self._listener = None
+        self._listener_task = None
+        # 先取消监听任务（打断接收循环），再关闭——都加超时，避免 ws close 握手拖慢断开。
+        if task is not None and not task.done():
+            task.cancel()
+        if listener is not None:
+            try:
+                await asyncio.wait_for(listener.stop(), timeout=2.0)
+            except BaseException:
+                pass
+        if task is not None and not task.done():
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except BaseException:
+                pass
+        if self.ctx is not None and listener is not None:
+            self.ctx.audit.record("live_listener_stopped", "danmaku listener stopped", detail={"room_id": self._room_id})
+
+    # 命令名 → LiveEvent.type 路由键（见 core/contracts.LiveEvent）。未列出的命令回落 cmd 小写。
+    _CMD_TO_TYPE = {
+        "DANMU_MSG": "danmaku",
+        "SEND_GIFT": "gift",
+        "SUPER_CHAT_MESSAGE": "super_chat",
+        "GUARD_BUY": "guard",
+        "INTERACT_WORD": "entry",
+    }
+
+    def _on_live_event(self, cmd: str, event: Any) -> None:
+        """富模型直播事件回调 → 包成 ``LiveEvent`` 发布到 ``EventBus``，由订阅者按类型消费。
+
+        同步、非阻塞：``publish`` 只做同步派发（订阅者内部各自 fire-and-forget），不拖慢弹幕
+        接收循环。``danmaku_core`` 对 DANMU_MSG/SEND_GIFT/SC/INTERACT_WORD/增强指令都发
+        ``on_event``，全部发布到总线；``live_events`` 订阅 danmaku/gift/super_chat/guard
+        ???????????????????????
+        事件族 handler 订阅（见 docs/development.md「直播事件中枢」）。
+        """
+        if not self.ctx:
+            return
+        if event is not None and getattr(event, "room_id", 0) in (0, None):
+            try:
+                event.room_id = self._room_id
+            except Exception:
+                pass
+        bus = getattr(self.ctx, "event_bus", None)
+        if bus is None:
+            return
+        live_event = self._to_live_event(cmd, event)
+        bus.publish(live_event.type, live_event)
+
+    def _to_live_event(self, cmd: str, event: Any) -> LiveEvent:
+        """把富模型 + 命令名包成统一信封。``raw`` 保留富模型，供需要完整字段（如
+        ``get_score()``）的 handler（如 ``live_events`` 中枢）解包使用。"""
+        event_type = self._CMD_TO_TYPE.get(str(cmd), str(cmd).lower())
+        uid = str(getattr(event, "uid", "") or "").strip()
+        nickname = str(getattr(event, "nickname", "") or "")
+        text = str(getattr(event, "text", "") or "")
+        payload = {
+            "uid": uid,
+            "username": nickname,
+            "nickname": nickname,
+            "text": text,
+            "event_label": self._event_label(event_type, text),
+            "raw_type": str(cmd),
+            "guard_level": getattr(event, "guard_level", 0),
+            "room_id": getattr(event, "room_id", 0) or self._room_id,
+            "cmd": str(cmd),
+        }
+        return LiveEvent(type=event_type, uid=uid, payload=payload, source="live", ts=time.time(), raw=event)
+
+    @staticmethod
+    def _event_label(event_type: str, text: str) -> str:
+        cleaned = str(text or "").strip()
+        if event_type == "entry":
+            if "关注" in cleaned:
+                return "关注了主播"
+            return "进入直播间"
+        return cleaned
+
+    async def _on_live(self) -> None:
+        if self.ctx is not None:
+            self.ctx.audit.record("live_room_live", "live started", detail={"room_id": self._room_id})
+
+    async def _on_preparing(self) -> None:
+        if self.ctx is not None:
+            self.ctx.audit.record("live_room_preparing", "live ended", detail={"room_id": self._room_id})
+
+    async def _on_error(self, exc: Any) -> None:
+        if self.ctx is not None:
+            self.ctx.audit.record("live_listener_error", str(exc)[:200], level="warning")
+
+    def normalize(self, payload: dict[str, Any]) -> ViewerEvent:
+        uid = str(payload.get("uid") or payload.get("user_id") or "").strip()
+        nickname = str(payload.get("nickname") or payload.get("uname") or payload.get("user_name") or "").strip()
+        avatar_url = str(payload.get("avatar_url") or payload.get("face_url") or payload.get("face") or "").strip()
+        text = str(payload.get("danmaku_text") or payload.get("text") or payload.get("content") or "").strip()
+        target_lanlan = str(payload.get("target_lanlan") or payload.get("lanlan_name") or "").strip()
+        return ViewerEvent(
+            uid=uid,
+            nickname=nickname,
+            avatar_url=avatar_url,
+            danmaku_text=text,
+            target_lanlan=target_lanlan,
+            source="live_danmaku",
+            live_mode=self.ctx.config.live_mode if self.ctx else "co_stream",
+            raw=dict(payload),
+        )
+
+    async def lookup_room_status(self, room_id: int) -> LiveRoomStatus:
+        if room_id <= 0:
+            return LiveRoomStatus(room_id=0, ok=False, message="room_id must be positive")
+        try:
+            return await asyncio.to_thread(self._lookup_room_status_sync, room_id)
+        except Exception as exc:
+            return LiveRoomStatus(
+                room_id=room_id,
+                ok=False,
+                message=f"live room lookup failed: {type(exc).__name__}",
+            )
+
+    # 反 -352：lookup 走的 getInfoByRoom（HTTP）补上临时 buvid3 + 浏览器 headers。
+    # getInfoByRoom 不需要 WBI 签名（弹幕 WS 的 _get_real_room_id 调它也没签）。
+    _BROWSER_HEADERS = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": "zh-CN,zh;q=0.9",
+        "Origin": "https://live.bilibili.com",
+    }
+
+    @staticmethod
+    def _parse_buvid3_from_cookies(set_cookie_lines: "list[str]") -> str:
+        """从 Set-Cookie 行里抽 buvid3 值；没有返回空串。"""
+        for raw in set_cookie_lines or []:
+            for part in str(raw).split(";"):
+                part = part.strip()
+                if part.startswith("buvid3="):
+                    return part[len("buvid3="):]
+        return ""
+
+    def _fetch_buvid3_sync(self) -> str:
+        """访问 B站首页拿临时 buvid3（绕 -352 风控）。失败返回空串。"""
+        try:
+            request = urllib.request.Request(
+                "https://www.bilibili.com",
+                headers={"User-Agent": self._BROWSER_HEADERS["User-Agent"], "Accept": "text/html"},
+            )
+            with urllib.request.urlopen(request, timeout=8) as response:
+                lines = response.headers.get_all("Set-Cookie") or []
+            return self._parse_buvid3_from_cookies(lines)
+        except Exception:
+            return ""
+
+    def _get_buvid3(self, force: bool = False) -> str:
+        now = time.time()
+        if not force and self._lookup_buvid3 and (now - self._lookup_buvid3_ts) < self._lookup_buvid3_ttl:
+            return self._lookup_buvid3
+        fetched = self._fetch_buvid3_sync()
+        if fetched:
+            self._lookup_buvid3 = fetched
+            self._lookup_buvid3_ts = now
+        return self._lookup_buvid3  # 即便本次没拿到也用旧值（可能空）
+
+    def _credential_cookie(self) -> str:
+        """登录态（若有）的完整 Cookie 串；未登录返回空串。用于 lookup 过 -352。"""
+        cred = getattr(self.ctx, "bili_credential", None) if self.ctx else None
+        if cred is None:
+            return ""
+        sessdata = str(getattr(cred, "sessdata", "") or "")
+        if not sessdata:
+            return ""
+        parts = [f"SESSDATA={sessdata}"]
+        for name, attr in (("bili_jct", "bili_jct"), ("DedeUserID", "dedeuserid"), ("buvid3", "buvid3")):
+            value = str(getattr(cred, attr, "") or "")
+            if value:
+                parts.append(f"{name}={value}")
+        return "; ".join(parts)
+
+    def _lookup_room_status_sync(self, room_id: int) -> LiveRoomStatus:
+        now = time.time()
+        cached = self._room_status_cache.get(room_id)
+        if cached and (now - cached[1]) < self._room_status_ttl:
+            return cached[0]
+        status, code = self._do_room_lookup(room_id, self._get_buvid3())
+        if code == -352:
+            # 风控：刷新 buvid3 再试一次（只重试一次，别硬刷加重风控）
+            status, code = self._do_room_lookup(room_id, self._get_buvid3(force=True))
+        if status.ok:
+            self._room_status_cache[room_id] = (status, now)
+        return status
+
+    def _do_room_lookup(self, room_id: int, buvid3: str) -> "tuple[LiveRoomStatus, int]":
+        """单次 getInfoByRoom 请求。返回 (status, B站 code)；网络/解析错误 code=-1。"""
+        url = f"https://api.live.bilibili.com/xlive/web-room/v1/index/getInfoByRoom?room_id={room_id}"
+        headers = dict(self._BROWSER_HEADERS)
+        headers["Referer"] = f"https://live.bilibili.com/{room_id}"
+        # 登录态优先：带完整登录 cookie（过 -352）；未登录回落临时 buvid3（同现状）。
+        cookie = self._credential_cookie() or (f"buvid3={buvid3}" if buvid3 else "")
+        if cookie:
+            headers["Cookie"] = cookie
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=8) as response:
+                payload = json.loads(response.read().decode("utf-8", errors="replace"))
+        except (urllib.error.URLError, TimeoutError) as exc:
+            return LiveRoomStatus(room_id=room_id, ok=False, message=f"network error: {type(exc).__name__}"), -1
+        except json.JSONDecodeError:
+            return LiveRoomStatus(room_id=room_id, ok=False, message="invalid response from Bilibili"), -1
+
+        code = int(payload.get("code") or 0)
+        if code != 0:
+            raw_msg = str(payload.get("message") or payload.get("msg") or "")
+            return LiveRoomStatus(room_id=room_id, ok=False, message=self._friendly_lookup_message(code, raw_msg)), code
+
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+        room_info = data.get("room_info") if isinstance(data.get("room_info"), dict) else {}
+        anchor_info = data.get("anchor_info") if isinstance(data.get("anchor_info"), dict) else {}
+        base_info = anchor_info.get("base_info") if isinstance(anchor_info.get("base_info"), dict) else {}
+        real_room_id = int(room_info.get("room_id") or room_id)
+        live_status = self._normalize_live_status(room_info.get("live_status"))
+        title = str(room_info.get("title") or "").strip()
+        anchor_name = str(base_info.get("uname") or base_info.get("name") or "").strip()
+        message = "live room found"
+        if live_status == "live":
+            message = "live room is streaming"
+        elif live_status == "offline":
+            message = "live room is offline"
+        return LiveRoomStatus(
+            room_id=real_room_id,
+            ok=True,
+            title=title,
+            anchor_name=anchor_name,
+            live_status=live_status,
+            message=message,
+        ), 0
+
+    @staticmethod
+    def _friendly_lookup_message(code: int, raw_message: str) -> str:
+        """把 B站查询失败码翻成人话。最常见的是 -352：匿名请求被反爬风控拦截
+        （查询走的 HTTP 路径没有像弹幕 WS 那样的临时 buvid3 反 -352 措施）。"""
+        raw = (raw_message or "").strip()
+        if code == -352 or raw == "-352":
+            return (
+                "B站风控校验失败（-352）：匿名查询被反爬拦截。"
+                "可稍后重试 / 更换网络 / 登录后再查；直播间监听（弹幕）通常仍可用。"
+            )
+        if code in (1, 19002000) or "不存在" in raw or "未找到" in raw:
+            return f"未找到该直播间（code={code}），请确认房间号是否正确。"
+        if raw:
+            return f"B站查询失败（code={code}）：{raw}"
+        return f"B站查询失败（code={code}）。"
+
+    @staticmethod
+    def _normalize_live_status(value: Any) -> str:
+        try:
+            status = int(value)
+        except (TypeError, ValueError):
+            return "unknown"
+        if status == 1:
+            return "live"
+        if status == 0:
+            return "offline"
+        if status == 2:
+            return "rounding"
+        return "unknown"

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
@@ -114,13 +114,20 @@ class BiliLiveIngestModule(BaseModule):
         if listener is not None:
             try:
                 await asyncio.wait_for(listener.stop(), timeout=2.0)
-            except BaseException:
-                pass
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                if self.ctx is not None:
+                    self.ctx.audit.record("live_listener_stop_failed", str(exc)[:200], level="warning")
         if task is not None and not task.done():
             try:
                 await asyncio.wait_for(task, timeout=2.0)
-            except BaseException:
+            except asyncio.CancelledError:
+                # The task was cancelled above as part of the normal shutdown path.
                 pass
+            except Exception as exc:
+                if self.ctx is not None:
+                    self.ctx.audit.record("live_listener_task_failed", str(exc)[:200], level="warning")
         if self.ctx is not None and listener is not None:
             self.ctx.audit.record("live_listener_stopped", "danmaku listener stopped", detail={"room_id": self._room_id})
 
@@ -129,6 +136,7 @@ class BiliLiveIngestModule(BaseModule):
         "DANMU_MSG": "danmaku",
         "SEND_GIFT": "gift",
         "SUPER_CHAT_MESSAGE": "super_chat",
+        "SUPER_CHAT_MESSAGE_JPN": "super_chat",
         "GUARD_BUY": "guard",
         "INTERACT_WORD": "entry",
     }
@@ -146,8 +154,8 @@ class BiliLiveIngestModule(BaseModule):
         if event is not None and getattr(event, "room_id", 0) in (0, None):
             try:
                 event.room_id = self._room_id
-            except Exception:
-                pass
+            except Exception as exc:
+                self.ctx.audit.record("live_event_room_id_fill_failed", str(exc)[:200], level="warning")
         bus = getattr(self.ctx, "event_bus", None)
         if bus is None:
             return

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
@@ -23,11 +23,6 @@ from datetime import datetime
 from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlencode
 
-# ── 取消检查辅助 ──────────────────────────────────────────────────
-async def _check_cancelled(stop_event: asyncio.Event):
-    """await 此函数可在协程中任意 await 点检查是否应停止"""
-    await asyncio.sleep(0)  # 让出控制权，确保事件状态可被读取
-
 # ── WBI 签名常量 ──────────────────────────────────────────────────
 # 重排映射表（固定不变）
 _MIXIN_KEY_ENC_TAB = [
@@ -79,7 +74,6 @@ class ConnectionState:
 WS_MAIN_URL = "wss://broadcastlv.chat.bilibili.com/sub"
 # 备用地址（按可靠性排序）
 WS_FALLBACK_URLS = [
-    "wss://broadcastlv.chat.bilibili.com/sub",
     "wss://tx-gz-live-comet-01.chat.bilibili.com/sub",
     "wss://live-comet-01.chat.bilibili.com/sub",
     "wss://live-comet-02.chat.bilibili.com/sub",
@@ -111,10 +105,7 @@ def _unpack_header(data: bytes):
     return struct.unpack(">IHHII", data[:HEADER_LEN])
 
 
-# 模块级日志回调（由 DanmakuListener 实例设置，供 _decompress 使用）
-_module_logger = None
-
-def _decompress(data: bytes, proto_ver: int) -> bytes:
+def _decompress(data: bytes, proto_ver: int, log: Callable[[str, str], None] | None = None) -> bytes:
     """解压数据"""
     if proto_ver == PROTOCOL_VERSION_ZLIB:
         return zlib.decompress(data)
@@ -123,8 +114,8 @@ def _decompress(data: bytes, proto_ver: int) -> bytes:
             import brotli
             return brotli.decompress(data)
         except ImportError:
-            if _module_logger:
-                _module_logger("brotli 库未安装，无法解压 brotli 数据包，跳过", "warning")
+            if log:
+                log("brotli 库未安装，无法解压 brotli 数据包，跳过", "warning")
             return b""  # 返回空字节，上层 _split_packets 会返回空列表
     return data
 
@@ -187,11 +178,6 @@ class DanmakuListener:
         self._current_server: str = ""  # 当前连接的服务器地址
         self._viewer_count: int = 0  # 当前观看人数（人气值）
 
-        # 设置模块级日志回调（供 _decompress 使用）
-        global _module_logger
-        if logger:
-            _module_logger = lambda msg, level="info": getattr(logger, level, logger.info)(msg)
-
         # WBI key 缓存（每日更替，缓存12小时足够）
         self._wbi_mixin_key: str = ""
         self._wbi_key_ts: float = 0.0   # 上次获取时间（unix 秒）
@@ -206,7 +192,7 @@ class DanmakuListener:
 
     async def _emit(self, event: str, *args, **kwargs):
         cb = self.callbacks.get(event)
-        self._log(f"_emit: event={event}, cb={'有' if cb else '无'}, callbacks_keys={list(self.callbacks.keys())}", "info")
+        self._log(f"_emit: event={event}, cb={'有' if cb else '无'}, callbacks_keys={list(self.callbacks.keys())}", "debug")
         if cb:
             try:
                 if asyncio.iscoroutinefunction(cb):
@@ -808,7 +794,7 @@ class DanmakuListener:
             if proto_ver in (PROTOCOL_VERSION_ZLIB, PROTOCOL_VERSION_BROTLI):
                 # 解压后递归处理
                 try:
-                    decompressed = _decompress(body, proto_ver)
+                    decompressed = _decompress(body, proto_ver, self._log)
                     for pkt in _split_packets(decompressed):
                         await self._process_packet(pkt)
                 except Exception as e:
@@ -850,6 +836,9 @@ class DanmakuListener:
                 await self._emit("on_error", e)
 
             if self._stop_event.is_set():
+                break
+            if self._live_ended:
+                self._connection_state = ConnectionState.DISCONNECTED
                 break
 
             # 自动重连

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
@@ -18,9 +18,8 @@ import json
 import struct
 import time
 import zlib
-import random
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional
+from typing import Callable, Dict, Optional
 from urllib.parse import urlencode
 
 # ── WBI 签名常量 ──────────────────────────────────────────────────
@@ -636,16 +635,19 @@ class DanmakuListener:
 
     # ── 增强协议指令处理器 ─────────────────────────────────────
 
+    @staticmethod
     def _handle_guard_buy(data: dict):
         """GUARD_BUY — 上舰（大航海）"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_guard_buy(data)
 
+    @staticmethod
     def _handle_entry_effect(data: dict):
         """ENTRY_EFFECT — 高能用户进场特效"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_entry_effect(data)
 
+    @staticmethod
     def _handle_combo_send(data: dict):
         """COMBO_SEND — 礼物连击"""
         from .livedanmaku import LiveDanmaku as _LD, GiftInfo, MessageType, MedalInfo
@@ -670,36 +672,43 @@ class DanmakuListener:
             ) if d.get("medal_info") else None,
         )
 
+    @staticmethod
     def _handle_like(data: dict):
         """LIKE_INFO_V3_CLICK — 点赞"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_like(data)
 
+    @staticmethod
     def _handle_online_rank(data: dict):
         """ONLINE_RANK_V2 / ONLINE_RANK_TOP3 — 高能榜"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_online_rank(data)
 
+    @staticmethod
     def _handle_notice(data: dict):
         """NOTICE_MSG — 公告"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_notice(data)
 
+    @staticmethod
     def _handle_anchor_lot(data: dict):
         """ANCHOR_LOT_START / ANCHOR_LOT_END — 天选抽奖"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_anchor_lot(data)
 
+    @staticmethod
     def _handle_block(data: dict):
         """ROOM_BLOCK_MSG — 禁言"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_block(data)
 
+    @staticmethod
     def _handle_watched_change(data: dict):
         """WATCHED_CHANGE — 看过人数变化"""
         from .livedanmaku import LiveDanmaku as _LD
         return _LD.from_watched_change(data)
 
+    @staticmethod
     def _handle_room_update(data: dict):
         """ROOM_REAL_TIME_MESSAGE_UPDATE — 直播间实时数据更新"""
         from .livedanmaku import LiveDanmaku as _LD, MessageType
@@ -713,6 +722,7 @@ class DanmakuListener:
             extra_json=__import__('json').dumps(data, ensure_ascii=False),
         )
 
+    @staticmethod
     def _handle_room_change(data: dict):
         """ROOM_CHANGE — 直播间信息变更"""
         from .livedanmaku import LiveDanmaku as _LD, MessageType
@@ -732,6 +742,7 @@ class DanmakuListener:
             extra_json=__import__('json').dumps(data, ensure_ascii=False),
         )
 
+    @staticmethod
     def _handle_sc_jpn(data: dict):
         """SUPER_CHAT_MESSAGE_JPN — 日文 SC（复用 SC handler）"""
         from .livedanmaku import LiveDanmaku as _LD

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
@@ -1,0 +1,1106 @@
+"""
+Bilibili 弹幕监听核心模块（纯 WebSocket 实现）
+
+不依赖 bilibili_api，直接使用 websockets 库实现 B站弹幕协议，
+规避 NEKO 内置 bilibili_api 版本不兼容问题。
+
+协议参考：
+  - 连接地址：wss://broadcastlv.chat.bilibili.com/sub
+  - 数据包格式：header(16字节) + body
+  - 心跳包：30秒一次，维持连接
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import struct
+import time
+import zlib
+import random
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional
+from urllib.parse import urlencode
+
+# ── 取消检查辅助 ──────────────────────────────────────────────────
+async def _check_cancelled(stop_event: asyncio.Event):
+    """await 此函数可在协程中任意 await 点检查是否应停止"""
+    await asyncio.sleep(0)  # 让出控制权，确保事件状态可被读取
+
+# ── WBI 签名常量 ──────────────────────────────────────────────────
+# 重排映射表（固定不变）
+_MIXIN_KEY_ENC_TAB = [
+    46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
+    27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
+    37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4,
+    22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52,
+]
+
+def _get_mixin_key(img_key: str, sub_key: str) -> str:
+    """将 img_key + sub_key 按 MIXIN_KEY_ENC_TAB 重排后取前32位"""
+    # 两个 key 必须都非空且长度为 32（MD5 hex），否则无法正确重排
+    if not img_key or not sub_key or len(img_key) != 32 or len(sub_key) != 32:
+        return ""
+    raw = img_key + sub_key  # 总长 64
+    return "".join(raw[i] for i in _MIXIN_KEY_ENC_TAB if i < len(raw))[:32]
+
+
+def _wbi_sign(params: dict, mixin_key: str) -> dict:
+    """
+    对参数字典添加 wts，按键名升序 URL 编码后拼 mixin_key 求 MD5，
+    返回追加了 w_rid 和 wts 的新参数字典。
+    """
+    wts = int(time.time())
+    params = dict(params)
+    params["wts"] = wts
+    # 键名升序，过滤掉值中的 !'()*
+    filtered = {
+        k: "".join(c for c in str(v) if c not in "!'()*")
+        for k, v in sorted(params.items())
+    }
+    query = urlencode(filtered)
+    w_rid = hashlib.md5((query + mixin_key).encode()).hexdigest()
+    params["w_rid"] = w_rid
+    return params
+
+
+# ── 连接状态枚举 ─────────────────────────────────────────────────
+class ConnectionState:
+    DISCONNECTED = "disconnected"      # 未连接
+    CONNECTING = "connecting"          # 连接中
+    AUTHENTICATING = "authenticating"   # 认证中
+    RECEIVING = "receiving"             # 接收中（认证成功后进入）
+    RECONNECTING = "reconnecting"       # 重连中
+
+
+# ── WebSocket 弹幕服务器 ──────────────────────────────────────────
+# 最可靠的服务器（始终作为最终保底）
+WS_MAIN_URL = "wss://broadcastlv.chat.bilibili.com/sub"
+# 备用地址（按可靠性排序）
+WS_FALLBACK_URLS = [
+    "wss://broadcastlv.chat.bilibili.com/sub",
+    "wss://tx-gz-live-comet-01.chat.bilibili.com/sub",
+    "wss://live-comet-01.chat.bilibili.com/sub",
+    "wss://live-comet-02.chat.bilibili.com/sub",
+    "wss://broadcastlv.chat.bilibili.com/sub",  # 最终保底
+]
+
+# ── 数据包协议常量 ────────────────────────────────────────────────
+HEADER_LEN = 16
+PROTOCOL_VERSION_JSON       = 0   # JSON
+PROTOCOL_VERSION_HEARTBEAT  = 1   # 心跳/认证
+PROTOCOL_VERSION_ZLIB       = 2   # zlib 压缩
+PROTOCOL_VERSION_BROTLI     = 3   # brotli 压缩
+
+OPERATION_HEARTBEAT         = 2   # 心跳
+OPERATION_HEARTBEAT_REPLY   = 3   # 心跳回包（人气值）
+OPERATION_SEND_MSG          = 5   # 普通消息
+OPERATION_AUTH              = 7   # 认证
+OPERATION_AUTH_REPLY        = 8   # 认证回包
+
+
+def _pack(operation: int, body: bytes, proto_ver: int = PROTOCOL_VERSION_HEARTBEAT) -> bytes:
+    """打包数据包"""
+    total = HEADER_LEN + len(body)
+    return struct.pack(">IHHII", total, HEADER_LEN, proto_ver, operation, 1) + body
+
+
+def _unpack_header(data: bytes):
+    """解包头部，返回 (total_len, header_len, proto_ver, operation, seq)"""
+    return struct.unpack(">IHHII", data[:HEADER_LEN])
+
+
+# 模块级日志回调（由 DanmakuListener 实例设置，供 _decompress 使用）
+_module_logger = None
+
+def _decompress(data: bytes, proto_ver: int) -> bytes:
+    """解压数据"""
+    if proto_ver == PROTOCOL_VERSION_ZLIB:
+        return zlib.decompress(data)
+    if proto_ver == PROTOCOL_VERSION_BROTLI:
+        try:
+            import brotli
+            return brotli.decompress(data)
+        except ImportError:
+            if _module_logger:
+                _module_logger("brotli 库未安装，无法解压 brotli 数据包，跳过", "warning")
+            return b""  # 返回空字节，上层 _split_packets 会返回空列表
+    return data
+
+
+def _split_packets(data: bytes) -> list[bytes]:
+    """拆分多个数据包（zlib/brotli 解压后可能包含多个包）"""
+    packets = []
+    offset = 0
+    while offset < len(data):
+        if len(data) - offset < HEADER_LEN:
+            break
+        total_len = struct.unpack(">I", data[offset:offset + 4])[0]
+        if total_len < HEADER_LEN or offset + total_len > len(data):
+            break
+        packets.append(data[offset:offset + total_len])
+        offset += total_len
+    return packets
+
+
+class DanmakuListener:
+    """
+    B站直播弹幕异步监听器（纯 WebSocket 实现，无 bilibili_api 依赖）
+
+    事件回调：
+    - on_danmaku(data): 普通弹幕
+    - on_gift(data): 礼物
+    - on_sc(data): 超级留言
+    - on_entry(user_name): 进入直播间
+    - on_follow(user_name): 关注主播
+    - on_live(): 开播
+    - on_preparing(): 下播
+    - on_error(e): 连接错误
+    """
+
+    def __init__(
+        self,
+        room_id: int,
+        credential=None,
+        logger=None,
+        callbacks: Dict[str, Callable] = None,
+        danmaku_max_length: int = 20,  # 弹幕最大长度限制（B站限制 20 字符）
+    ):
+        self.room_id = room_id
+        self.real_room_id: int = room_id  # 连接后更新为真实房间号（处理短号）
+        self.credential = credential
+        self.logger = logger
+        self.callbacks = callbacks or {}
+        self.running = False
+        self._stop_event = asyncio.Event()  # 用于在 await 点可靠取消连接
+        self._ws = None
+        self._heartbeat_task: Optional[asyncio.Task] = None
+        self._buvid3_temp: str = ""  # 临时 buvid3，无凭据时从 B站首页获取
+        self._danmaku_max_length = max(1, min(100, danmaku_max_length))  # 限制范围 1-100
+
+        # 连接状态
+        self._connection_state = ConnectionState.DISCONNECTED
+
+        # 直播结束标记：收到 PREPARING 后置位，阻止重连循环
+        self._live_ended: bool = False
+        self._current_server: str = ""  # 当前连接的服务器地址
+        self._viewer_count: int = 0  # 当前观看人数（人气值）
+
+        # 设置模块级日志回调（供 _decompress 使用）
+        global _module_logger
+        if logger:
+            _module_logger = lambda msg, level="info": getattr(logger, level, logger.info)(msg)
+
+        # WBI key 缓存（每日更替，缓存12小时足够）
+        self._wbi_mixin_key: str = ""
+        self._wbi_key_ts: float = 0.0   # 上次获取时间（unix 秒）
+        self._wbi_key_ttl: float = 43200  # 12小时
+        self._real_room_id_cache: dict[int, tuple[int, float]] = {}
+        self._real_room_id_ttl: float = 300
+        self._http_timeout = 8
+
+    def _log(self, msg: str, level: str = "info"):
+        if self.logger:
+            getattr(self.logger, level, self.logger.info)(msg)
+
+    async def _emit(self, event: str, *args, **kwargs):
+        cb = self.callbacks.get(event)
+        self._log(f"_emit: event={event}, cb={'有' if cb else '无'}, callbacks_keys={list(self.callbacks.keys())}", "info")
+        if cb:
+            try:
+                if asyncio.iscoroutinefunction(cb):
+                    await cb(*args, **kwargs)
+                else:
+                    cb(*args, **kwargs)
+            except Exception as e:
+                self._log(f"回调 {event} 异常: {e}", "warning")
+
+    def get_connection_state(self) -> dict:
+        """
+        获取当前连接状态信息。
+
+        Returns:
+            dict: 包含连接状态的字典
+                - state: 连接状态字符串
+                - server: 当前服务器地址
+                - viewer_count: 当前观看人数
+                - room_id: 房间号
+        """
+        return {
+            "state": self._connection_state,
+            "server": self._current_server,
+            "viewer_count": self._viewer_count,
+            "room_id": self.real_room_id if self._connection_state != ConnectionState.DISCONNECTED else self.room_id,
+        }
+
+    async def _request_json(
+        self,
+        url: str,
+        *,
+        headers: Optional[dict] = None,
+        cookies: Optional[dict] = None,
+        params: Optional[dict] = None,
+        allow_redirects: bool = True,
+    ) -> dict:
+        import aiohttp
+
+        timeout = aiohttp.ClientTimeout(total=self._http_timeout)
+        async with aiohttp.ClientSession(cookies=cookies, timeout=timeout) as session:
+            async with session.get(
+                url,
+                headers=headers,
+                params=params,
+                allow_redirects=allow_redirects,
+            ) as resp:
+                return await resp.json()
+
+    async def _get_wbi_mixin_key(self, cookies: dict) -> str:
+        """
+        获取 WBI mixin_key（带12小时缓存）。
+        从 https://api.bilibili.com/x/web-interface/nav 接口的
+        wbi_img.img_url / sub_url 中提取 img_key / sub_key。
+        """
+        now = time.time()
+        if self._wbi_mixin_key and (now - self._wbi_key_ts) < self._wbi_key_ttl:
+            return self._wbi_mixin_key
+
+        try:
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Referer": "https://www.bilibili.com/",
+            }
+            data = await self._request_json(
+                "https://api.bilibili.com/x/web-interface/nav",
+                headers=headers,
+                cookies=cookies,
+            )
+            wbi_img = data.get("data", {}).get("wbi_img", {})
+            img_url = wbi_img.get("img_url", "")
+            sub_url = wbi_img.get("sub_url", "")
+            # 从 URL 中取文件名（去掉扩展名）
+            img_key = img_url.rsplit("/", 1)[-1].split(".")[0] if img_url else ""
+            sub_key = sub_url.rsplit("/", 1)[-1].split(".")[0] if sub_url else ""
+            if img_key and sub_key:
+                mixin_key = _get_mixin_key(img_key, sub_key)
+                if mixin_key:
+                    self._wbi_mixin_key = mixin_key
+                    self._wbi_key_ts = now
+                    self._log(f"WBI key 已更新 (img={img_key[:8]}...)")
+                    return mixin_key
+                else:
+                    self._log(f"WBI key 重排失败: img_key 长度={len(img_key)}, sub_key 长度={len(sub_key)}", "warning")
+            else:
+                self._log(f"WBI key 缺失: img_key={'有' if img_key else '无'}, sub_key={'有' if sub_key else '无'}", "warning")
+        except Exception as e:
+            self._log(f"获取 WBI key 失败: {e}", "warning")
+        return ""
+
+    async def _get_real_room_id(self, room_id: int) -> int:
+        """获取真实房间号（处理短号）"""
+        now = time.time()
+        cached = self._real_room_id_cache.get(room_id)
+        if cached and now - cached[1] < self._real_room_id_ttl:
+            return cached[0]
+        try:
+            url = f"https://api.live.bilibili.com/xlive/web-room/v1/index/getInfoByRoom?room_id={room_id}"
+            headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+            data = await self._request_json(url, headers=headers)
+            if data.get("code") == 0:
+                real_id = data["data"]["room_info"]["room_id"]
+                self._real_room_id_cache[room_id] = (real_id, now)
+                self._log(f"房间号解析: {room_id} -> {real_id}")
+                return real_id
+        except Exception as e:
+            self._log(f"获取真实房间号失败: {e}，使用原始号", "warning")
+        return room_id
+
+    async def _fetch_buvid3(self) -> str:
+        """访问 B站首页获取临时 buvid3（用于绕过 -352 风控）"""
+        try:
+            import aiohttp
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            }
+            timeout = aiohttp.ClientTimeout(total=self._http_timeout)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(
+                    "https://www.bilibili.com/",
+                    headers=headers,
+                    allow_redirects=True,
+                ) as resp:
+                    # 从 Set-Cookie 中提取 buvid3
+                    buvid3 = resp.cookies.get("buvid3")
+                    if buvid3:
+                        val = buvid3.value if hasattr(buvid3, "value") else str(buvid3)
+                        self._log(f"已获取临时 buvid3 (长度={len(val)})")
+                        return val
+                    # 备用：从响应头 raw Set-Cookie 里找
+                    for raw in resp.headers.getall("Set-Cookie", []):
+                        if "buvid3=" in raw:
+                            for part in raw.split(";"):
+                                part = part.strip()
+                                if part.startswith("buvid3="):
+                                    val = part[len("buvid3="):]
+                                    self._log(f"已获取临时 buvid3 (备用, 长度={len(val)})")
+                                    return val
+        except Exception as e:
+            self._log(f"获取临时 buvid3 失败: {e}", "warning")
+        return ""
+
+    async def _get_danmaku_server_info(self, real_room_id: int) -> tuple[list, str]:
+        """
+        获取所有弹幕服务器地址列表和 token（带 WBI 签名）。
+
+        Returns:
+            tuple: ([(ws_url, host, wss_port), ...], token)
+                - ws_url: 完整的 WebSocket URL
+                - host: 服务器域名
+                - wss_port: WSS 端口
+                - token: 认证 token
+        """
+        servers = []
+        token = ""
+
+        try:
+            # 从凭据中取 buvid3
+            buvid3 = ""
+            if self.credential:
+                try:
+                    buvid3 = getattr(self.credential, "buvid3", "") or ""
+                except Exception:
+                    pass
+
+            # buvid3 为空时自动获取临时值，避免 -352 风控
+            if not buvid3:
+                self._log("buvid3 为空，尝试获取临时 buvid3...")
+                buvid3 = await self._fetch_buvid3()
+                # 把获取到的 buvid3 回写到 credential，供认证包使用
+                if buvid3 and self.credential:
+                    try:
+                        self.credential.buvid3 = buvid3
+                    except Exception:
+                        pass
+                # 即使没有 credential 也记下来
+                self._buvid3_temp = buvid3
+
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Referer": f"https://live.bilibili.com/{real_room_id}",
+            }
+
+            # 构建 Cookie
+            cookies = {"buvid3": buvid3} if buvid3 else {}
+            if self.credential:
+                try:
+                    cookies.update({
+                        "SESSDATA": getattr(self.credential, "sessdata", "") or "",
+                        "bili_jct": getattr(self.credential, "bili_jct", "") or "",
+                        "DedeUserID": getattr(self.credential, "dedeuserid", "") or "",
+                    })
+                    # 过滤空值
+                    cookies = {k: v for k, v in cookies.items() if v}
+                except Exception:
+                    pass
+
+            # ── WBI 签名 ────────────────────────────────────────────
+            params = {"id": real_room_id, "type": 0}
+            mixin_key = await self._get_wbi_mixin_key(cookies)
+            if mixin_key:
+                params = _wbi_sign(params, mixin_key)
+                self._log(f"WBI 签名已添加 (w_rid={params.get('w_rid', '')[:8]}...)")
+            else:
+                self._log("WBI key 获取失败，尝试不带签名请求", "warning")
+
+            url = "https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo"
+            data = await self._request_json(url, params=params, headers=headers, cookies=cookies)
+            api_code = data.get("code", -1)
+            self._log(f"getDanmuInfo API: code={api_code}, msg={data.get('message', '')}")
+            if api_code == 0:
+                token = data["data"].get("token", "")
+                hosts = data["data"].get("host_list", [])
+                self._log(f"token长度={len(token)}, 可用服务器数={len(hosts)}")
+                if hosts:
+                    # 构建所有服务器的 URL 列表
+                    for host in hosts:
+                        # B站 API 可能返回 wss_port=0, 此时降级尝试 port 字段或默认 443
+                        wss_port = host.get("wss_port", 0)
+                        if not wss_port:
+                            wss_port = host.get("port", 443)
+                        if not wss_port:
+                            wss_port = 443
+                        ws_url = f"wss://{host['host']}:{wss_port}/sub"
+                        servers.append((ws_url, host['host'], wss_port))
+                    # 始终加入最可靠的 broadcastlv 作为保底（去重）
+                    main_host = "broadcastlv.chat.bilibili.com"
+                    if not any(s[1] == main_host for s in servers):
+                        servers.append((f"wss://{main_host}/sub", main_host, 443))
+                    self._log(f"弹幕服务器列表: {[s[1] + ':' + str(s[2]) for s in servers]}")
+                    return servers, token
+            else:
+                self._log(f"getDanmuInfo 返回错误: {data}", "warning")
+        except Exception as e:
+            self._log(f"获取弹幕服务器信息失败: {e}，使用默认地址", "warning")
+
+        # 回退到所有备用服务器（而非单一地址）
+        fallback_servers = []
+        for url in WS_FALLBACK_URLS:
+            # 解析 wss://host:port/sub 格式
+            try:
+                from urllib.parse import urlparse
+                parsed = urlparse(url)
+                host = parsed.hostname or ""
+                port = parsed.port or 443
+                fallback_servers.append((url, host, port))
+            except Exception:
+                fallback_servers.append((url, url.split("//")[1].split(":")[0] if "//" in url else "", 443))
+        return fallback_servers, token
+
+    def _build_auth_body(self, real_room_id: int, token: str) -> bytes:
+        """构建认证包 body"""
+        uid = 0
+        buvid3 = ""
+        if self.credential:
+            try:
+                uid = int(getattr(self.credential, "dedeuserid", 0) or 0)
+            except Exception:
+                uid = 0
+            try:
+                buvid3 = getattr(self.credential, "buvid3", "") or ""
+            except Exception:
+                buvid3 = ""
+
+        # credential 里没有 buvid3 时，用临时获取的
+        if not buvid3:
+            buvid3 = self._buvid3_temp
+
+        body = {
+            "uid": uid,
+            "roomid": real_room_id,
+            "protover": 2,  # zlib 压缩，兼容性最好
+            "platform": "web",
+            "type": 2,
+            "key": token,
+        }
+        # buvid3 有值时加入认证包（同时兼容新旧字段名）
+        if buvid3:
+            body["buvid"] = buvid3
+            body["buvid3"] = buvid3  # 新版 B站 协议需要
+
+        self._log(
+            f"认证包信息: uid={uid}, room={real_room_id}, "
+            f"buvid3={'有' if buvid3 else '⚠️无'}, "
+            f"token={'有(' + str(len(token)) + '字节)' if token else '⚠️无(空token)'}"
+        )
+        return json.dumps(body, separators=(",", ":")).encode("utf-8")
+
+    async def _heartbeat_loop(self):
+        """每 30 秒发一次心跳，可被 stop() 中断"""
+        try:
+            while self.running and self._ws:
+                try:
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=30)
+                    # _stop_event 被 set，停止心跳
+                    break
+                except asyncio.TimeoutError:
+                    # 30秒超时正常，发送心跳
+                    pass
+                if self.running and self._ws:
+                    try:
+                        await self._ws.send(_pack(OPERATION_HEARTBEAT, b"[object Object]"))
+                    except Exception:
+                        break
+        except asyncio.CancelledError:
+            pass
+
+    async def _dispatch_message(self, cmd: str, data: dict):
+        """根据 cmd 分发事件"""
+        self._log(f"_dispatch_message: cmd={cmd}", "debug")
+        try:
+            if cmd == "DANMU_MSG":
+                info = data.get("info", [])
+                if not isinstance(info, list) or len(info) < 2:
+                    return
+                content = str(info[1]) if info[1] is not None else ""
+
+                user_info = info[2] if len(info) > 2 else []
+                if isinstance(user_info, list):
+                    user_id = user_info[0] if len(user_info) > 0 else 0
+                    user_name = str(user_info[1]) if len(user_info) > 1 else "未知"
+                else:
+                    user_id, user_name = 0, "未知"
+
+                user_level = 0
+                if len(info) > 4 and isinstance(info[4], list) and len(info[4]) > 0:
+                    try:
+                        user_level = int(info[4][0])
+                    except (ValueError, TypeError):
+                        user_level = 0
+
+                try:
+                    ts = info[0][4] / 1000 if isinstance(info[0], list) and len(info[0]) > 4 else None
+                    time_str = datetime.fromtimestamp(ts).strftime("%H:%M:%S") if ts else datetime.now().strftime("%H:%M:%S")
+                except Exception:
+                    time_str = datetime.now().strftime("%H:%M:%S")
+
+                medal_text = ""
+                medal_level = 0
+                medal_name = ""
+                if len(info) > 3 and isinstance(info[3], list) and len(info[3]) >= 2:
+                    try:
+                        medal_level = int(info[3][0])
+                        medal_name = str(info[3][1])
+                        medal_text = f"[{medal_name}{medal_level}]"
+                    except Exception:
+                        pass
+
+                await self._emit("on_danmaku", {
+                    "time": time_str,
+                    "content": content,
+                    "user_id": user_id,
+                    "user_name": user_name,
+                    "user_level": user_level,
+                    "medal_text": medal_text,
+                    "medal_level": medal_level,
+                    "medal_name": medal_name,
+                })
+
+                # LiveDanmaku 事件（增强协议）
+                try:
+                    from .livedanmaku import LiveDanmaku as _LD
+                    ld = _LD.from_danmaku(data)
+                    if ld.text:
+                        await self._emit("on_event", "DANMU_MSG", ld)
+                except Exception:
+                    pass
+
+            elif cmd == "SEND_GIFT":
+                inner = data.get("data", {})
+                await self._emit("on_gift", {
+                    "user_name": inner.get("uname", "未知"),
+                    "user_id": inner.get("uid", 0),
+                    "gift_name": inner.get("giftName", "未知礼物"),
+                    "num": inner.get("num", 1),
+                    "coin_type": inner.get("coin_type", "silver"),
+                    "total_coin": inner.get("total_coin", 0),
+                    "price": inner.get("price", 0),
+                })
+
+                try:
+                    from .livedanmaku import LiveDanmaku as _LD
+                    ld = _LD.from_gift(data)
+                    await self._emit("on_event", "SEND_GIFT", ld)
+                except Exception:
+                    pass
+
+            elif cmd == "SUPER_CHAT_MESSAGE":
+                inner = data.get("data", {})
+                user_info = inner.get("user_info", {})
+                await self._emit("on_sc", {
+                    "user_name": user_info.get("uname", "未知"),
+                    "user_id": inner.get("uid", 0),
+                    "message": inner.get("message", ""),
+                    "price": inner.get("price", 0),
+                    "start_time": inner.get("start_time", 0),
+                })
+
+                try:
+                    from .livedanmaku import LiveDanmaku as _LD
+                    ld = _LD.from_sc(data)
+                    await self._emit("on_event", "SUPER_CHAT_MESSAGE", ld)
+                except Exception:
+                    pass
+
+            elif cmd == "INTERACT_WORD":
+                inner = data.get("data", {})
+                user_name = inner.get("uname", "未知")
+                msg_type = inner.get("msg_type", 0)
+                if msg_type == 1:
+                    await self._emit("on_entry", user_name)
+                elif msg_type == 2:
+                    await self._emit("on_follow", user_name)
+
+                try:
+                    from .livedanmaku import LiveDanmaku as _LD
+                    ld = _LD.from_interact(data)
+                    await self._emit("on_event", "INTERACT_WORD", ld)
+                except Exception:
+                    pass
+
+            elif cmd == "LIVE":
+                await self._emit("on_live")
+
+            elif cmd == "PREPARING":
+                self._live_ended = True
+                await self._emit("on_preparing")
+
+            # ── 新增协议指令（MagicalDanmaku 增强） ────────────────────────
+            elif cmd in self._CMD_HANDLERS:
+                handler = self._CMD_HANDLERS[cmd]
+                try:
+                    ld = handler(data)
+                    if ld:
+                        await self._emit("on_event", cmd, ld)
+                except Exception as e:
+                    self._log(f"增强协议处理 {cmd} 异常: {e}", "debug")
+
+        except Exception as e:
+            self._log(f"分发消息 {cmd} 异常: {e}", "debug")
+
+    # ── 增强协议指令处理器 ─────────────────────────────────────
+
+    def _handle_guard_buy(data: dict):
+        """GUARD_BUY — 上舰（大航海）"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_guard_buy(data)
+
+    def _handle_entry_effect(data: dict):
+        """ENTRY_EFFECT — 高能用户进场特效"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_entry_effect(data)
+
+    def _handle_combo_send(data: dict):
+        """COMBO_SEND — 礼物连击"""
+        from .livedanmaku import LiveDanmaku as _LD, GiftInfo, MessageType, MedalInfo
+        d = data.get("data", {})
+        return _LD(
+            msg_type=MessageType.MSG_GIFT,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("uname", "")),
+            text=f"连击 {d.get('combo_num', 1)} 个 {d.get('gift_name', '礼物')}",
+            room_id=int(data.get("room_id", 0)),
+            guard_level=int(d.get("guard_level", 0)),
+            user_level=int(d.get("level", 0)),
+            gift=GiftInfo(
+                gift_id=int(d.get("gift_id", 0)),
+                gift_name=str(d.get("gift_name", "礼物")),
+                num=int(d.get("combo_num", 1)),
+                total_coin=int(d.get("total_coin", 0)),
+            ),
+            medal=MedalInfo(
+                name=str(d.get("medal_info", {}).get("medal_name", "")),
+                level=int(d.get("medal_info", {}).get("medal_level", 0)),
+            ) if d.get("medal_info") else None,
+        )
+
+    def _handle_like(data: dict):
+        """LIKE_INFO_V3_CLICK — 点赞"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_like(data)
+
+    def _handle_online_rank(data: dict):
+        """ONLINE_RANK_V2 / ONLINE_RANK_TOP3 — 高能榜"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_online_rank(data)
+
+    def _handle_notice(data: dict):
+        """NOTICE_MSG — 公告"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_notice(data)
+
+    def _handle_anchor_lot(data: dict):
+        """ANCHOR_LOT_START / ANCHOR_LOT_END — 天选抽奖"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_anchor_lot(data)
+
+    def _handle_block(data: dict):
+        """ROOM_BLOCK_MSG — 禁言"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_block(data)
+
+    def _handle_watched_change(data: dict):
+        """WATCHED_CHANGE — 看过人数变化"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_watched_change(data)
+
+    def _handle_room_update(data: dict):
+        """ROOM_REAL_TIME_MESSAGE_UPDATE — 直播间实时数据更新"""
+        from .livedanmaku import LiveDanmaku as _LD, MessageType
+        d = data.get("data", {})
+        return _LD(
+            msg_type=MessageType.MSG_EXTRA,
+            uid=0,
+            nickname="",
+            text=f"直播间实时更新: {d.get('fans', 0)}粉丝, {d.get('room_id', '?')}",
+            room_id=int(data.get("room_id", 0)),
+            extra_json=__import__('json').dumps(data, ensure_ascii=False),
+        )
+
+    def _handle_room_change(data: dict):
+        """ROOM_CHANGE — 直播间信息变更"""
+        from .livedanmaku import LiveDanmaku as _LD, MessageType
+        d = data.get("data", {})
+        changes = []
+        if "title" in d:
+            changes.append(f"标题: {d['title']}")
+        if "area_name" in d:
+            changes.append(f"分区: {d['area_name']}")
+        text = "直播间变更: " + "; ".join(changes) if changes else "直播间信息更新"
+        return _LD(
+            msg_type=MessageType.MSG_EXTRA,
+            uid=0,
+            nickname="",
+            text=text,
+            room_id=int(data.get("room_id", 0)),
+            extra_json=__import__('json').dumps(data, ensure_ascii=False),
+        )
+
+    def _handle_sc_jpn(data: dict):
+        """SUPER_CHAT_MESSAGE_JPN — 日文 SC（复用 SC handler）"""
+        from .livedanmaku import LiveDanmaku as _LD
+        return _LD.from_sc(data)
+
+    # ── CMD 分发字典 ──────────────────────────────────────────
+    _CMD_HANDLERS = {
+        "GUARD_BUY": _handle_guard_buy,
+        "ENTRY_EFFECT": _handle_entry_effect,
+        "COMBO_SEND": _handle_combo_send,
+        "LIKE_INFO_V3_CLICK": _handle_like,
+        "ONLINE_RANK_V2": _handle_online_rank,
+        "ONLINE_RANK_TOP3": _handle_online_rank,
+        "NOTICE_MSG": _handle_notice,
+        "ANCHOR_LOT_START": _handle_anchor_lot,
+        "ANCHOR_LOT_END": _handle_anchor_lot,
+        "ROOM_BLOCK_MSG": _handle_block,
+        "WATCHED_CHANGE": _handle_watched_change,
+        "ROOM_REAL_TIME_MESSAGE_UPDATE": _handle_room_update,
+        "ROOM_CHANGE": _handle_room_change,
+        "SUPER_CHAT_MESSAGE_JPN": _handle_sc_jpn,
+    }
+
+    async def _process_packet(self, raw: bytes):
+        """处理单个数据包"""
+        if len(raw) < HEADER_LEN:
+            return
+        total_len, header_len, proto_ver, operation, seq = _unpack_header(raw)
+        body = raw[header_len:total_len]
+
+        if operation == OPERATION_HEARTBEAT_REPLY:
+            # 解析人气值（心跳回复前4字节是大端序int）
+            try:
+                if len(body) >= 4:
+                    viewer_count = struct.unpack(">I", body[:4])[0]
+                    if viewer_count != self._viewer_count:
+                        self._viewer_count = viewer_count
+                        self._log(f"📊 人气值: {viewer_count:,}")
+                    # 可选：触发人气值变化回调
+                    await self._emit("on_viewer_count", viewer_count)
+            except Exception:
+                pass
+
+        elif operation == OPERATION_AUTH_REPLY:
+            try:
+                result = json.loads(body.decode("utf-8"))
+                code = result.get("code", -1)
+                if code == 0:
+                    self._connection_state = ConnectionState.RECEIVING
+                    self._log(f"✅ 认证成功，开始接收弹幕 [{self._current_server}]")
+                else:
+                    self._connection_state = ConnectionState.DISCONNECTED
+                    self._log(f"❌ 认证失败: code={code} msg={result}", "warning")
+                    # 认证失败，停止监听
+                    self.running = False
+                    self._stop_event.set()
+            except Exception as ex:
+                self._log(f"解析认证回包异常: {ex}", "debug")
+
+        elif operation == OPERATION_SEND_MSG:
+            if proto_ver in (PROTOCOL_VERSION_ZLIB, PROTOCOL_VERSION_BROTLI):
+                # 解压后递归处理
+                try:
+                    decompressed = _decompress(body, proto_ver)
+                    for pkt in _split_packets(decompressed):
+                        await self._process_packet(pkt)
+                except Exception as e:
+                    self._log(f"解压失败: {e}", "warning")
+            else:
+                # 直接解析 JSON
+                try:
+                    msg = json.loads(body.decode("utf-8"))
+                    cmd = msg.get("cmd", "")
+                    # 有些 cmd 带 : 后缀，取前部分
+                    cmd = cmd.split(":")[0]
+                    if cmd == "DANMU_MSG":
+                        self._log(f"📨 收到弹幕包 cmd=DANMU_MSG")
+                    await self._dispatch_message(cmd, msg)
+                except Exception as e:
+                    self._log(f"解析消息失败: {e}", "warning")
+
+    async def start(self):
+        """启动监听（带自动重连，直到 stop() 被调用）"""
+        import websockets
+
+        # 重置停止事件和直播结束标记
+        self._stop_event.clear()
+        self._live_ended = False
+        self.running = True
+        self._connection_state = ConnectionState.CONNECTING
+
+        retry_count = 0
+        max_retries = 10
+        retry_delay = 5  # 初始重试间隔（秒）
+
+        while True:
+            if self._stop_event.is_set():
+                break
+            try:
+                await self._connect_once()
+            except Exception as e:
+                self._log(f"连接过程异常: {e}", "error")
+                await self._emit("on_error", e)
+
+            if self._stop_event.is_set():
+                break
+
+            # 自动重连
+            retry_count += 1
+            if retry_count > max_retries:
+                self._log(f"重连次数超过 {max_retries} 次，停止重连", "error")
+                self._connection_state = ConnectionState.DISCONNECTED
+                break
+
+            self._connection_state = ConnectionState.RECONNECTING
+            wait = min(retry_delay * retry_count, 60)
+            # 前3次打印重连日志，之后静默
+            if retry_count <= 3:
+                self._log(f"🔄 {wait}s 后自动重连 (第{retry_count}次)...")
+            elif retry_count == 4:
+                self._log(f"🔄 持续重连中，后续重连不再打印日志（共最多{max_retries}次）")
+
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=wait)
+                # _stop_event 被 set，退出重连循环
+                break
+            except asyncio.TimeoutError:
+                # 超时正常，继续重连
+                pass
+
+        self.running = False
+        self._log("弹幕监听已停止")
+
+    async def _connect_once(self):
+        """单次 WebSocket 连接（尝试所有服务器，内部）"""
+        import websockets
+
+        # 连接前检查是否已被 stop
+        if self._stop_event.is_set():
+            return
+
+        # 1. 获取真实房间号
+        real_room_id = await self._get_real_room_id(self.room_id)
+        if self._stop_event.is_set():
+            return
+        # 保存真实房间号供 send_danmaku 等接口使用
+        self.real_room_id = real_room_id
+
+        # 2. 获取所有服务器和 token
+        servers, token = await self._get_danmaku_server_info(real_room_id)
+        if self._stop_event.is_set():
+            return
+
+        if not servers:
+            self._log("没有可用的弹幕服务器", "error")
+            return
+
+        # 3. 构建认证包
+        auth_body = self._build_auth_body(real_room_id, token)
+
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "Origin": "https://live.bilibili.com",
+        }
+
+        # websockets 新版用 additional_headers，旧版用 extra_headers，做兼容
+        try:
+            import inspect
+            _ws_ver = getattr(websockets, "__version__", "unknown")
+            _ws_connect_sig = inspect.signature(websockets.connect)
+            if "additional_headers" in _ws_connect_sig.parameters:
+                _ws_kwargs = {"additional_headers": headers}
+            else:
+                _ws_kwargs = {"extra_headers": headers}
+            self._log(f"websockets 版本={_ws_ver}, 使用参数={list(_ws_kwargs.keys())[0]}")
+        except Exception:
+            _ws_kwargs = {"extra_headers": headers}
+
+        # 遍历所有服务器尝试连接
+        last_error = None
+        for ws_url, host, port in servers:
+            if self._stop_event.is_set():
+                return
+
+            self._connection_state = ConnectionState.CONNECTING
+            self._current_server = f"{host}:{port}"
+            self._log(f"正在连接弹幕服务器 [{host}:{port}]...")
+
+            # 标记是否曾成功建立连接（用于区分"从未连上"和"连上后正常断开"）
+            had_authenticated = False
+
+            try:
+                async with websockets.connect(ws_url, ping_interval=None, **_ws_kwargs) as ws:
+                    self._ws = ws
+
+                    # 发送认证包
+                    self._connection_state = ConnectionState.AUTHENTICATING
+                    await ws.send(_pack(OPERATION_AUTH, auth_body))
+                    self._log("认证包已发送，等待服务器回复...")
+
+                    # 启动心跳（心跳会在收到 AUTH_REPLY 成功后自动开始计时）
+                    self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+                    async for message in ws:
+                        if self._stop_event.is_set():
+                            break
+                        try:
+                            if isinstance(message, bytes):
+                                # 认证成功会在这里设置 RECEIVING 状态
+                                await self._process_packet(message)
+                            # str 消息忽略
+                        except Exception as e:
+                            self._log(f"处理消息异常: {e}", "debug")
+
+                    # 正常退出循环（可能是 stop() 调用或服务器断开）
+                    had_authenticated = self._connection_state == ConnectionState.RECEIVING
+
+                    # 如果是被 stop() 打断，跳出不再尝试其他服务器
+                    if self._stop_event.is_set():
+                        break
+
+                    # 直播结束：收到 PREPARING 后不再重连
+                    if self._live_ended:
+                        self._log(f"直播已结束，停止重连", "info")
+                        break
+
+                    # 否则是服务器正常断开，继续尝试下一个服务器
+                    if had_authenticated:
+                        self._log(f"服务器 [{host}:{port}] 连接已正常关闭，尝试下一个...", "info")
+                    continue
+
+            except Exception as e:
+                err_str = str(e)
+                last_error = e
+                # "no close frame" 是服务器直接断 TCP 的正常情况，降级为 warning
+                if "no close frame" in err_str or "connection closed" in err_str.lower():
+                    self._log(f"服务器 [{host}:{port}] 连接已断开，尝试下一个...", "warning")
+                else:
+                    self._log(f"服务器 [{host}:{port}] 连接异常: {err_str}，尝试下一个...", "warning")
+                continue
+
+            finally:
+                if self._heartbeat_task and not self._heartbeat_task.done():
+                    self._heartbeat_task.cancel()
+                self._ws = None
+                self._log(f"弹幕连接 [{host}:{port}] 已断开")
+
+        # 只有在从未成功认证过的情况下才报"所有服务器失败"
+        # 如果有任意服务器曾成功连接并断开，说明是直播结束，不是故障
+        if not self._stop_event.is_set() and self._connection_state != ConnectionState.RECEIVING:
+            self._connection_state = ConnectionState.DISCONNECTED
+            self._current_server = ""
+            if last_error:
+                self._log(f"所有 {len(servers)} 个服务器连接失败: {last_error}", "error")
+                raise last_error
+
+    async def send_danmaku(
+        self,
+        message: str,
+        room_id: int,
+        credential=None,
+        danmaku_max_length: int = 20,
+    ) -> dict:
+        """
+        发送弹幕到 B站直播间。
+
+        Args:
+            message: 弹幕文本
+            room_id: 直播间真实房间号
+            credential: _BiliCredential 实例（需要 bili_jct + SESSDATA）
+            danmaku_max_length: 弹幕最大长度限制（默认 20，B站限制 20 字符/秒）
+
+        Returns:
+            dict: {"success": bool, "message": str}
+        """
+        if not credential:
+            return {"success": False, "message": "未登录，无法发送弹幕"}
+
+        bili_jct = getattr(credential, "bili_jct", "")
+        sessdata = getattr(credential, "sessdata", "")
+        dedeuserid = getattr(credential, "dedeuserid", "")
+
+        if not bili_jct:
+            return {"success": False, "message": "缺少 bili_jct，无法发送弹幕"}
+
+        message = str(message).strip()
+        if not message:
+            return {"success": False, "message": "弹幕内容不能为空"}
+        max_len = danmaku_max_length or self._danmaku_max_length or 20
+        if len(message) > max_len:
+            message = message[:max_len]
+
+        try:
+            import aiohttp
+
+            url = "https://api.live.bilibili.com/msg/send"
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Referer": f"https://live.bilibili.com/{room_id}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            }
+            cookies = {
+                "SESSDATA": sessdata,
+                "bili_jct": bili_jct,
+                "DedeUserID": dedeuserid,
+            }
+            # 过滤空值
+            cookies = {k: v for k, v in cookies.items() if v}
+
+            payload = {
+                "bubble": "0",
+                "msg": message,
+                "color": "16777215",
+                "mode": "1",
+                "fontsize": "25",
+                "rnd": int(time.time() * 1000000),
+                "roomid": room_id,
+                "csrf": bili_jct,
+                "csrf_token": bili_jct,
+            }
+
+            async with aiohttp.ClientSession(cookies=cookies, timeout=aiohttp.ClientTimeout(total=self._http_timeout)) as session:
+                async with session.post(
+                    url,
+                    data=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=self._http_timeout),
+                ) as resp:
+                    data = await resp.json()
+                    code = data.get("code", -1)
+                    if code == 0:
+                        self._log(f"✅ 弹幕发送成功: {message[:30]}...")
+                        return {"success": True, "message": f"弹幕发送成功: {message}"}
+                    else:
+                        msg = data.get("message", "未知错误")
+                        self._log(f"❌ 弹幕发送失败: code={code} msg={msg}", "warning")
+                        return {"success": False, "message": f"发送失败: {msg} (code={code})"}
+        except Exception as e:
+            self._log(f"❌ 弹幕发送异常: {e}", "error")
+            return {"success": False, "message": f"发送异常: {e}"}
+
+    async def stop(self):
+        """断开连接（可在任意时刻安全调用，包括连接建立过程中）"""
+        self.running = False
+        self._connection_state = ConnectionState.DISCONNECTED
+        self._current_server = ""
+        self._viewer_count = 0  # 清空人气值
+        self._stop_event.set()  # 唤醒所有等待此事件的协程
+        if self._heartbeat_task and not self._heartbeat_task.done():
+            self._heartbeat_task.cancel()
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        self._ws = None
+
+    def is_running(self) -> bool:
+        return self.running

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/danmaku_core.py
@@ -354,8 +354,8 @@ class DanmakuListener:
             if self.credential:
                 try:
                     buvid3 = getattr(self.credential, "buvid3", "") or ""
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._log(f"credential cookie extraction failed: {e}", "debug")
 
             # buvid3 为空时自动获取临时值，避免 -352 风控
             if not buvid3:
@@ -365,8 +365,8 @@ class DanmakuListener:
                 if buvid3 and self.credential:
                     try:
                         self.credential.buvid3 = buvid3
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        self._log(f"credential buvid3 writeback failed: {e}", "debug")
                 # 即使没有 credential 也记下来
                 self._buvid3_temp = buvid3
 
@@ -386,8 +386,8 @@ class DanmakuListener:
                     })
                     # 过滤空值
                     cookies = {k: v for k, v in cookies.items() if v}
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._log(f"credential cookie extraction failed: {e}", "debug")
 
             # ── WBI 签名 ────────────────────────────────────────────
             params = {"id": real_room_id, "type": 0}
@@ -494,10 +494,11 @@ class DanmakuListener:
                 if self.running and self._ws:
                     try:
                         await self._ws.send(_pack(OPERATION_HEARTBEAT, b"[object Object]"))
-                    except Exception:
+                    except Exception as e:
+                        self._log(f"heartbeat send failed: {e}", "debug")
                         break
         except asyncio.CancelledError:
-            pass
+            self._log("heartbeat loop cancelled", "debug")
 
     async def _dispatch_message(self, cmd: str, data: dict):
         """根据 cmd 分发事件"""
@@ -537,8 +538,8 @@ class DanmakuListener:
                         medal_level = int(info[3][0])
                         medal_name = str(info[3][1])
                         medal_text = f"[{medal_name}{medal_level}]"
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        self._log(f"fans medal parse failed: {e}", "debug")
 
                 await self._emit("on_danmaku", {
                     "time": time_str,
@@ -557,8 +558,8 @@ class DanmakuListener:
                     ld = _LD.from_danmaku(data)
                     if ld.text:
                         await self._emit("on_event", "DANMU_MSG", ld)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._log(f"LiveDanmaku DANMU_MSG parse failed: {e}", "debug")
 
             elif cmd == "SEND_GIFT":
                 inner = data.get("data", {})
@@ -576,8 +577,8 @@ class DanmakuListener:
                     from .livedanmaku import LiveDanmaku as _LD
                     ld = _LD.from_gift(data)
                     await self._emit("on_event", "SEND_GIFT", ld)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._log(f"LiveDanmaku SEND_GIFT parse failed: {e}", "debug")
 
             elif cmd == "SUPER_CHAT_MESSAGE":
                 inner = data.get("data", {})
@@ -594,8 +595,8 @@ class DanmakuListener:
                     from .livedanmaku import LiveDanmaku as _LD
                     ld = _LD.from_sc(data)
                     await self._emit("on_event", "SUPER_CHAT_MESSAGE", ld)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._log(f"LiveDanmaku SUPER_CHAT_MESSAGE parse failed: {e}", "debug")
 
             elif cmd == "INTERACT_WORD":
                 inner = data.get("data", {})
@@ -610,8 +611,8 @@ class DanmakuListener:
                     from .livedanmaku import LiveDanmaku as _LD
                     ld = _LD.from_interact(data)
                     await self._emit("on_event", "INTERACT_WORD", ld)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._log(f"LiveDanmaku INTERACT_WORD parse failed: {e}", "debug")
 
             elif cmd == "LIVE":
                 await self._emit("on_live")
@@ -771,8 +772,8 @@ class DanmakuListener:
                         self._log(f"📊 人气值: {viewer_count:,}")
                     # 可选：触发人气值变化回调
                     await self._emit("on_viewer_count", viewer_count)
-            except Exception:
-                pass
+            except Exception as e:
+                self._log(f"viewer count callback failed: {e}", "debug")
 
         elif operation == OPERATION_AUTH_REPLY:
             try:
@@ -1087,8 +1088,8 @@ class DanmakuListener:
         if self._ws:
             try:
                 await self._ws.close()
-            except Exception:
-                pass
+            except Exception as e:
+                self._log(f"WebSocket close failed: {e}", "debug")
         self._ws = None
 
     def is_running(self) -> bool:

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/livedanmaku.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/livedanmaku.py
@@ -15,7 +15,7 @@ import json
 import time
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Any, Optional
+from typing import Optional
 
 
 # ── 消息类型枚举 ─────────────────────────────────────────────────
@@ -188,9 +188,9 @@ class LiveDanmaku:
                 medal = MedalInfo(
                     name=str(medal_info[1] or ""),
                     level=int(medal_info[0]),
-                    up_name=str(medal_info[3] or ""),
-                    color=int(medal_info[2]) if len(medal_info) > 2 else 0,
-                    anchor_roomid=int(medal_info[5]) if len(medal_info) > 5 else 0,
+                    up_name=str(medal_info[2] or "") if len(medal_info) > 2 else "",
+                    anchor_roomid=int(medal_info[3]) if len(medal_info) > 3 else 0,
+                    color=int(medal_info[4]) if len(medal_info) > 4 else 0,
                 )
             except (TypeError, ValueError):
                 medal = None

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/livedanmaku.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/livedanmaku.py
@@ -1,0 +1,531 @@
+"""
+MagicalDanmaku LiveDanmaku 数据模型（Python 移植版）
+
+功能：
+- MessageType 枚举（15种 B站消息类型）
+- LiveDanmaku dataclass（30+ 字段）
+- 工厂方法：从各种 B站 WS 消息体解析
+- get_score() 打分（guard > admin > medal > user level > text length）
+- to_dict() 序列化
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any, Optional
+
+
+# ── 消息类型枚举 ─────────────────────────────────────────────────
+
+
+class MessageType(IntEnum):
+    """B站直播 WS 消息类型"""
+    MSG_DANMAKU = 1
+    MSG_GIFT = 2
+    MSG_WELCOME = 3
+    MSG_GUARD_BUY = 5
+    MSG_WELCOME_GUARD = 6
+    MSG_FANS = 7
+    MSG_ATTENTION = 8
+    MSG_BLOCK = 9
+    MSG_MSG = 10
+    MSG_SHARE = 11
+    MSG_SUPER_CHAT = 13
+    MSG_EXTRA = 14
+
+
+# ── 嵌套数据类 ──────────────────────────────────────────────────
+
+
+@dataclass
+class MedalInfo:
+    """粉丝牌信息"""
+    name: str = ""
+    level: int = 0
+    up_name: str = ""           # 主播名称（牌子的主播）
+    color: int = 0
+    anchor_roomid: int = 0
+
+
+@dataclass
+class GiftInfo:
+    """礼物信息"""
+    gift_id: int = 0
+    gift_name: str = ""
+    num: int = 1
+    coin_type: str = "silver"   # silver/gold
+    total_coin: int = 0
+    price: int = 0               # 单价（金瓜子）
+
+
+@dataclass
+class UserInfo:
+    """用户信息"""
+    uid: int = 0
+    nickname: str = ""
+    face_url: str = ""
+    user_level: int = 0
+    admin: bool = False          # 是否房管
+    guard_level: int = 0         # 0=无, 1=总督, 2=提督, 3=舰长
+    vip: bool = False
+    svip: bool = False
+
+
+# ── LiveDanmaku 主类 ────────────────────────────────────────────
+
+
+@dataclass
+class LiveDanmaku:
+    """
+    LiveDanmaku — 单条 B站直播消息
+
+    覆盖 30+ 字段，包含完整的用户/礼物/粉丝牌/房间信息。
+    通过工厂方法从不同 WS 指令解析。
+    """
+    # 基础字段
+    msg_type: MessageType = MessageType.MSG_DANMAKU
+    uid: int = 0
+    nickname: str = ""
+    text: str = ""
+    timeline: float = field(default_factory=time.time)
+    room_id: int = 0
+
+    # 标记位
+    admin: bool = False
+    guard_level: int = 0          # 0=无, 1=总督, 2=提督, 3=舰长
+    vip: bool = False
+    svip: bool = False
+
+    # 粉丝牌
+    medal: Optional[MedalInfo] = None
+
+    # 用户等级
+    user_level: int = 0
+
+    # 礼物信息
+    gift: Optional[GiftInfo] = None
+
+    # 粉丝数据
+    fans_medal_name: str = ""
+    fans_medal_level: int = 0
+
+    # 关注状态
+    attention: int = 0            # 0=未关注, 1=已关注
+
+    # 用户头像
+    face_url: str = ""
+
+    # 原始 JSON（调试用）
+    extra_json: str = ""
+
+    # ── 工厂方法 ─────────────────────────────────────────────
+
+    @classmethod
+    def from_danmaku(cls, data: dict) -> "LiveDanmaku":
+        """从 DANMU_MSG 解析弹幕消息。
+
+        B站 ``DANMU_MSG.info`` 真实结构（仅取本类用到的字段）：
+
+        - ``info[1]`` 弹幕文本。
+        - ``info[2]`` 用户数组 ``[uid, uname, is_admin, is_vip, is_svip, ...]``。
+        - ``info[3]`` 粉丝牌数组 ``[level, name, up_name, room_id, color, ...]``（可为空）。
+        - ``info[4]`` 用户等级数组 ``[user_level, ...]``。
+        - ``info[7]`` 大航海等级（**普通 int**：0 无 / 1 总督 / 2 提督 / 3 舰长）。
+
+        历史 bug：旧实现把 ``info[7]`` 当作可下标的列表（``info[7][3]`` / ``info[7][1]``），
+        但它实际是 int —— 任意一条正常弹幕都会在 ``len(info[7])`` 处抛 ``TypeError``，被
+        ``_dispatch_message`` 的 ``except`` 吞掉，导致 ``on_event("DANMU_MSG")`` 永不触发
+        （计数恒为 0）。同时 ``admin`` 只判了外层 ``len(info) > 2``、未判内层长度，短 ``info[2]``
+        会 ``IndexError``。此处按真实结构重写并补齐内层长度 / 类型守卫。
+        """
+        info = data.get("info", [])
+        user_info = info[2] if len(info) > 2 and isinstance(info[2], list) else []
+        medal_info = info[3] if len(info) > 3 and isinstance(info[3], list) else []
+        user_level_info = info[4] if len(info) > 4 and isinstance(info[4], list) else []
+
+        uid = 0
+        nickname = ""
+        admin = False
+        vip = False
+        svip = False
+        if len(user_info) >= 2:
+            uid = user_info[0]
+            nickname = str(user_info[1] or "")
+        if len(user_info) > 2:
+            admin = bool(user_info[2])
+        if len(user_info) > 3:
+            vip = bool(user_info[3])
+        if len(user_info) > 4:
+            svip = bool(user_info[4])
+
+        text = str(info[1]) if len(info) > 1 and info[1] is not None else ""
+
+        # info[7] 是 int（大航海等级）；偶有实现返回列表，做一次兜底。
+        guard_level = 0
+        if len(info) > 7:
+            guard_raw = info[7]
+            try:
+                if isinstance(guard_raw, list):
+                    guard_level = int(guard_raw[0]) if guard_raw else 0
+                else:
+                    guard_level = int(guard_raw or 0)
+            except (TypeError, ValueError):
+                guard_level = 0
+
+        user_level = 0
+        if user_level_info:
+            try:
+                user_level = int(user_level_info[0])
+            except (TypeError, ValueError):
+                user_level = 0
+
+        medal = None
+        if len(medal_info) >= 4:
+            try:
+                medal = MedalInfo(
+                    name=str(medal_info[1] or ""),
+                    level=int(medal_info[0]),
+                    up_name=str(medal_info[3] or ""),
+                    color=int(medal_info[2]) if len(medal_info) > 2 else 0,
+                    anchor_roomid=int(medal_info[5]) if len(medal_info) > 5 else 0,
+                )
+            except (TypeError, ValueError):
+                medal = None
+
+        fans_medal_name = ""
+        fans_medal_level = 0
+        if len(medal_info) >= 2:
+            fans_medal_name = str(medal_info[1] or "")
+            try:
+                fans_medal_level = int(medal_info[0])
+            except (TypeError, ValueError):
+                fans_medal_level = 0
+
+        return cls(
+            msg_type=MessageType.MSG_DANMAKU,
+            uid=uid,
+            nickname=nickname,
+            text=text,
+            room_id=data.get("room_id", 0),
+            admin=admin,
+            guard_level=guard_level,
+            vip=vip,
+            svip=svip,
+            medal=medal,
+            user_level=user_level,
+            fans_medal_name=fans_medal_name,
+            fans_medal_level=fans_medal_level,
+            # 弹幕 payload 不含头像 URL，头像由下游 bili_identity 按 UID 抓取。
+            face_url="",
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_gift(cls, data: dict) -> "LiveDanmaku":
+        """从 SEND_GIFT 解析礼物消息"""
+        d = data.get("data", {})
+        return cls(
+            msg_type=MessageType.MSG_GIFT,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("uname", "")),
+            text=f"赠送 {d.get('num', 1)} 个 {d.get('giftName', '礼物')}",
+            room_id=int(d.get("room_id") or d.get("ruid", 0)),
+            medal=MedalInfo(
+                name=str(d.get("medal_info", {}).get("medal_name", "")),
+                level=int(d.get("medal_info", {}).get("medal_level", 0)),
+                up_name=str(d.get("medal_info", {}).get("medal_up_name", "")),
+            ) if d.get("medal_info") else None,
+            gift=GiftInfo(
+                gift_id=int(d.get("giftId", 0)),
+                gift_name=str(d.get("giftName", "礼物")),
+                num=int(d.get("num", 1)),
+                coin_type=str(d.get("coin_type", "silver")),
+                total_coin=int(d.get("total_coin", 0)),
+                price=int(d.get("price", 0)),
+            ),
+            user_level=int(d.get("level", 0)),
+            face_url=str(d.get("face", "")),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_sc(cls, data: dict) -> "LiveDanmaku":
+        """从 SUPER_CHAT_MESSAGE 解析 SC"""
+        d = data.get("data", {})
+        return cls(
+            msg_type=MessageType.MSG_SUPER_CHAT,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("user_info", {}).get("uname", "")),
+            text=str(d.get("message", "")),
+            room_id=int(d.get("room_id", 0)),
+            admin=bool(d.get("user_info", {}).get("admin", False)),
+            medal=MedalInfo(
+                name=str(d.get("medal_info", {}).get("medal_name", "")),
+                level=int(d.get("medal_info", {}).get("medal_level", 0)),
+            ) if d.get("medal_info") else None,
+            gift=GiftInfo(
+                gift_name="Super Chat",
+                total_coin=int(d.get("price", 0)) * 1000,
+                price=int(d.get("price", 0)) * 1000,
+            ),
+            user_level=int(d.get("user_info", {}).get("user_level", 0)),
+            face_url=str(d.get("user_info", {}).get("face", "")),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_interact(cls, data: dict) -> "LiveDanmaku":
+        """从 INTERACT_WORD 解析互动消息（进场/关注）"""
+        d = data.get("data", {})
+        msg_type_val = int(d.get("msg_type", 0))
+        return cls(
+            msg_type=MessageType.MSG_WELCOME if msg_type_val in (1, 3) else MessageType.MSG_ATTENTION if msg_type_val == 2 else MessageType.MSG_EXTRA,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("uname", "")),
+            text=str(d.get("uname", "")) + (" 进入直播间" if msg_type_val in (1, 3) else " 关注了主播"),
+            room_id=int(d.get("room_id", 0)),
+            medal=MedalInfo(
+                name=str(d.get("medal_info", {}).get("medal_name", "")),
+                level=int(d.get("medal_info", {}).get("medal_level", 0)),
+                up_name=str(d.get("medal_info", {}).get("medal_up_name", "")),
+            ) if d.get("medal_info") else None,
+            guard_level=int(d.get("guard_level", 0)),
+            user_level=int(d.get("level", 0)),
+            attention=int(d.get("attention", 0)),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_guard_buy(cls, data: dict) -> "LiveDanmaku":
+        """从 GUARD_BUY 解析上舰消息"""
+        d = data.get("data", {})
+        guard_level = int(d.get("guard_level", 0))
+        guard_names = {1: "总督", 2: "提督", 3: "舰长"}
+        guard_name = guard_names.get(guard_level, f"等级{guard_level}")
+        return cls(
+            msg_type=MessageType.MSG_GUARD_BUY,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("username", "")),
+            text=f"购买了 {guard_name}",
+            room_id=int(d.get("room_id", 0)),
+            guard_level=guard_level,
+            gift=GiftInfo(
+                gift_id=int(d.get("gift_id", 0)),
+                gift_name=guard_name,
+                num=int(d.get("num", 1)),
+                total_coin=int(d.get("price", 0)),
+                price=int(d.get("price", 0)),
+            ),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_entry_effect(cls, data: dict) -> "LiveDanmaku":
+        """从 ENTRY_EFFECT 解析高能用户进场"""
+        d = data.get("data", {})
+        return cls(
+            msg_type=MessageType.MSG_WELCOME_GUARD,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("copy_writing", "")).split(" ")[0] if d.get("copy_writing") else str(d.get("uname", "")),
+            text=str(d.get("copy_writing", "高能用户进场")),
+            room_id=int(d.get("room_id", 0)),
+            guard_level=3,  # ENTRY_EFFECT 通常为舰长以上
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_like(cls, data: dict) -> "LiveDanmaku":
+        """从 LIKE_INFO_V3_CLICK 解析点赞"""
+        d = data.get("data", {})
+        return cls(
+            msg_type=MessageType.MSG_EXTRA,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("uname", "")),
+            text="点赞了直播间",
+            room_id=int(d.get("room_id", 0)),
+            user_level=int(d.get("level", 0)),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_online_rank(cls, data: dict) -> "LiveDanmaku":
+        """从 ONLINE_RANK_V2 / ONLINE_RANK_TOP3 解析高能榜"""
+        d = data.get("data", {})
+        names = []
+        if "list" in d:
+            for item in d["list"][:3]:
+                names.append(str(item.get("name", "")))
+        elif "name" in d:
+            names = [str(d.get("name", ""))]
+        text = "高能榜: " + ", ".join(names) if names else "高能榜更新"
+        return cls(
+            msg_type=MessageType.MSG_EXTRA,
+            uid=0,
+            nickname="",
+            text=text,
+            room_id=int(data.get("room_id", 0)),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_anchor_lot(cls, data: dict) -> "LiveDanmaku":
+        """从 ANCHOR_LOT_START / ANCHOR_LOT_END 解析天选抽奖"""
+        d = data.get("data", {})
+        is_start = data.get("cmd", "").endswith("_START")
+        return cls(
+            msg_type=MessageType.MSG_EXTRA,
+            uid=0,
+            nickname="",
+            text="天选时刻开始啦！快去参与抽奖！" if is_start else "天选时刻已结束",
+            room_id=int(d.get("room_id", 0)),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_block(cls, data: dict) -> "LiveDanmaku":
+        """从 ROOM_BLOCK_MSG 解析禁言"""
+        d = data.get("data", {})
+        return cls(
+            msg_type=MessageType.MSG_BLOCK,
+            uid=int(d.get("uid", 0)),
+            nickname=str(d.get("uname", "")),
+            text=f"{d.get('uname', '用户')} 被禁言",
+            room_id=int(data.get("room_id", 0)),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_watched_change(cls, data: dict) -> "LiveDanmaku":
+        """从 WATCHED_CHANGE 解析看过人数变化"""
+        d = data.get("data", {})
+        num = int(d.get("num", 0))
+        text_small = d.get("text_small", "")
+        return cls(
+            msg_type=MessageType.MSG_EXTRA,
+            uid=0,
+            nickname="",
+            text=f"累计看过: {text_small or num}",
+            room_id=int(data.get("room_id", 0)),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_notice(cls, data: dict) -> "LiveDanmaku":
+        """从 NOTICE_MSG 解析公告"""
+        d = data.get("data", {})
+        notice_text = ""
+        if isinstance(d, dict):
+            notice_text = str(d.get("real_room_notice", "") or d.get("msg", "") or "")
+        full_cmd = data.get("cmd", "")
+        if not notice_text and "full" in data:
+            notice_text = str(data.get("full", ""))
+        return cls(
+            msg_type=MessageType.MSG_MSG,
+            uid=0,
+            nickname="",
+            text=notice_text or f"公告: {full_cmd}",
+            room_id=int(data.get("room_id", 0) or (d.get("room_id", 0) if isinstance(d, dict) else 0)),
+            extra_json=json.dumps(data, ensure_ascii=False),
+        )
+
+    @classmethod
+    def from_raw_json(cls, raw: str) -> Optional["LiveDanmaku"]:
+        """从原始 JSON 字符串解析（兜底方法）"""
+        try:
+            data = json.loads(raw) if isinstance(raw, str) else raw
+        except json.JSONDecodeError:
+            return None
+        cmd = data.get("cmd", "")
+        if "DANMU_MSG" in cmd:
+            return cls.from_danmaku(data)
+        elif cmd == "SEND_GIFT":
+            return cls.from_gift(data)
+        elif "SUPER_CHAT_MESSAGE" in cmd:
+            return cls.from_sc(data)
+        elif cmd == "INTERACT_WORD":
+            return cls.from_interact(data)
+        elif cmd == "GUARD_BUY":
+            return cls.from_guard_buy(data)
+        elif cmd == "ENTRY_EFFECT":
+            return cls.from_entry_effect(data)
+        elif cmd == "LIKE_INFO_V3_CLICK":
+            return cls.from_like(data)
+        elif cmd in ("ONLINE_RANK_V2", "ONLINE_RANK_TOP3"):
+            return cls.from_online_rank(data)
+        elif cmd in ("ANCHOR_LOT_START", "ANCHOR_LOT_END"):
+            return cls.from_anchor_lot(data)
+        elif cmd == "ROOM_BLOCK_MSG":
+            return cls.from_block(data)
+        elif cmd == "WATCHED_CHANGE":
+            return cls.from_watched_change(data)
+        elif cmd == "NOTICE_MSG":
+            return cls.from_notice(data)
+        return None
+
+    # ── 方法 ─────────────────────────────────────────────────
+
+    def get_score(self) -> float:
+        """
+        计算弹幕的综合评分
+        用于降级模式下的优选/排序
+        """
+        score = 0.0
+        _guard_score = {1: 3000, 2: 2000, 3: 1000}
+        score += _guard_score.get(self.guard_level, 0)
+        if self.admin:
+            score += 500
+        if self.vip:
+            score += 100
+        if self.svip:
+            score += 200
+        if self.medal:
+            score += self.medal.level * 10
+        score += self.user_level * 2
+        text_len = len(self.text.strip())
+        score += min(text_len, 100)
+
+        # 高价值内容额外加分
+        if self.msg_type == MessageType.MSG_SUPER_CHAT:
+            score += 5000  # SC 优先
+        elif self.msg_type == MessageType.MSG_GIFT:
+            if self.gift:
+                score += min(self.gift.total_coin / 100, 1000)  # 高价值礼物
+        elif self.msg_type == MessageType.MSG_GUARD_BUY:
+            score += 3000  # 上舰
+
+        return score
+
+    def to_dict(self) -> dict:
+        """序列化为字典"""
+        return {
+            "msg_type": int(self.msg_type),
+            "uid": self.uid,
+            "nickname": self.nickname,
+            "text": self.text,
+            "timeline": self.timeline,
+            "room_id": self.room_id,
+            "admin": self.admin,
+            "guard_level": self.guard_level,
+            "vip": self.vip,
+            "svip": self.svip,
+            "medal": {
+                "name": self.medal.name,
+                "level": self.medal.level,
+                "up_name": self.medal.up_name,
+                "color": self.medal.color,
+            } if self.medal else None,
+            "user_level": self.user_level,
+            "gift": {
+                "gift_id": self.gift.gift_id,
+                "gift_name": self.gift.gift_name,
+                "num": self.gift.num,
+                "coin_type": self.gift.coin_type,
+                "total_coin": self.gift.total_coin,
+                "price": self.gift.price,
+            } if self.gift else None,
+            "face_url": self.face_url,
+            "attention": self.attention,
+        }

--- a/plugin/plugins/neko_roast/tests/test_event_bus.py
+++ b/plugin/plugins/neko_roast/tests/test_event_bus.py
@@ -1,0 +1,113 @@
+"""EventBus 真订阅分发骨架单测（P2.5 完整版地基 / 分发给其他开发者的核心契约）。
+
+锁住：① subscribe/publish 按 type 路由；② 无订阅者静默丢弃（不抛不记）；③ 单订阅者 handler
+抛错被隔离——其余订阅者照常收到 + 记 ``event_handler_failed`` audit（带 owner/event_type）；
+④ async handler 返回的协程被调度为隔离 task，其异常同样进 audit；⑤ unsubscribe 生效；
+⑥ subscriber_count；⑦ emit/on 向后兼容别名；⑧ LiveEvent 信封 to_dict 不含 raw。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from plugin.plugins.neko_roast.core.contracts import LiveEvent
+from plugin.plugins.neko_roast.core.event_bus import EventBus
+
+
+class _Audit:
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+
+    def record(self, op, message="", level="info", detail=None) -> None:
+        self.records.append({"op": op, "message": message, "level": level, "detail": detail or {}})
+
+
+def test_publish_routes_only_to_subscribers_of_that_type():
+    bus = EventBus()
+    got: list = []
+    bus.subscribe("danmaku", lambda e: got.append(("d", e)), owner="a")
+    bus.subscribe("gift", lambda e: got.append(("g", e)), owner="b")
+
+    bus.publish("danmaku", {"x": 1})
+    assert got == [("d", {"x": 1})]
+    assert bus.subscriber_count("danmaku") == 1
+
+
+def test_publish_to_unsubscribed_type_is_silent_noop():
+    bus = EventBus()
+    bus.publish("gift", {"x": 1})  # 无订阅者：不抛、不记
+    assert bus.subscriber_count("gift") == 0
+
+
+def test_sync_handler_failure_is_isolated_and_audited():
+    audit = _Audit()
+    bus = EventBus(audit)
+    seen: list = []
+
+    def boom(_e):
+        raise RuntimeError("boom")
+
+    bus.subscribe("danmaku", boom, owner="bad")
+    bus.subscribe("danmaku", lambda e: seen.append(e), owner="good")
+
+    bus.publish("danmaku", {"x": 1})
+
+    assert seen == [{"x": 1}]  # 坏订阅者不波及好订阅者
+    rec = [r for r in audit.records if r["op"] == "event_handler_failed"]
+    assert rec and rec[0]["detail"]["owner"] == "bad" and rec[0]["detail"]["event_type"] == "danmaku"
+
+
+async def test_async_handler_runs_in_isolated_task():
+    bus = EventBus()
+    done: list = []
+
+    async def handler(e):
+        done.append(e)
+
+    bus.subscribe("gift", handler, owner="g")
+    bus.publish("gift", {"x": 1})
+    await asyncio.gather(*list(bus._tasks))
+    assert done == [{"x": 1}]
+
+
+async def test_async_handler_failure_is_isolated_and_audited():
+    audit = _Audit()
+    bus = EventBus(audit)
+
+    async def boom(_e):
+        raise RuntimeError("async-boom")
+
+    bus.subscribe("gift", boom, owner="gift_mod")
+    bus.publish("gift", {"x": 1})
+    await asyncio.gather(*list(bus._tasks))
+
+    rec = [r for r in audit.records if r["op"] == "event_handler_failed"]
+    assert rec and rec[0]["detail"]["owner"] == "gift_mod" and rec[0]["detail"]["event_type"] == "gift"
+
+
+def test_unsubscribe_stops_delivery():
+    bus = EventBus()
+    got: list = []
+    unsub = bus.subscribe("danmaku", lambda e: got.append(e), owner="a")
+    bus.publish("danmaku", 1)
+    unsub()
+    bus.publish("danmaku", 2)
+    assert got == [1]
+    assert bus.subscriber_count("danmaku") == 0
+
+
+def test_emit_and_on_aliases_still_work_for_observability():
+    bus = EventBus()
+    got: list = []
+    bus.on("result", lambda p: got.append(p))
+    bus.emit("result", {"ok": True})
+    assert got == [{"ok": True}]
+
+
+def test_live_event_to_dict_excludes_raw():
+    ev = LiveEvent(type="danmaku", uid="42", payload={"text": "hi"}, raw=object())
+    data = ev.to_dict()
+    assert data["type"] == "danmaku"
+    assert data["uid"] == "42"
+    assert data["payload"] == {"text": "hi"}
+    assert "raw" not in data

--- a/plugin/plugins/neko_roast/tests/test_event_bus.py
+++ b/plugin/plugins/neko_roast/tests/test_event_bus.py
@@ -9,9 +9,11 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 from plugin.plugins.neko_roast.core.contracts import LiveEvent
 from plugin.plugins.neko_roast.core.event_bus import EventBus
+from plugin.plugins.neko_roast.modules.bili_live_ingest import BiliLiveIngestModule
 
 
 class _Audit:
@@ -111,3 +113,14 @@ def test_live_event_to_dict_excludes_raw():
     assert data["uid"] == "42"
     assert data["payload"] == {"text": "hi"}
     assert "raw" not in data
+
+
+def test_super_chat_jpn_routes_to_super_chat_bus_key():
+    module = BiliLiveIngestModule()
+    event = SimpleNamespace(uid=42, nickname="SCUser", text="こんにちは", room_id=100, guard_level=0)
+
+    live_event = module._to_live_event("SUPER_CHAT_MESSAGE_JPN", event)
+
+    assert live_event.type == "super_chat"
+    assert live_event.uid == "42"
+    assert live_event.payload["raw_type"] == "SUPER_CHAT_MESSAGE_JPN"

--- a/plugin/plugins/neko_roast/tests/test_livedanmaku.py
+++ b/plugin/plugins/neko_roast/tests/test_livedanmaku.py
@@ -8,8 +8,17 @@ except 吞掉，导致 on_event("DANMU_MSG") 永不触发（计数恒为 0）。
 
 from __future__ import annotations
 
+import asyncio
 import json
+import sys
 
+from plugin.plugins.neko_roast.modules.bili_live_ingest.danmaku_core import (
+    PROTOCOL_VERSION_BROTLI,
+    DanmakuListener,
+    WS_FALLBACK_URLS,
+    WS_MAIN_URL,
+    _decompress,
+)
 from plugin.plugins.neko_roast.modules.bili_live_ingest.livedanmaku import (
     LiveDanmaku,
     MessageType,
@@ -198,3 +207,33 @@ def test_from_danmaku_score_reflects_guard_and_admin():
     assert captain.get_score() > plain.get_score()
     assert captain.guard_level == 3
     assert captain.admin is True
+
+
+def test_fallback_urls_only_repeat_main_as_final_fallback():
+    """Main WebSocket URL should only appear once in the fallback list."""
+    assert WS_FALLBACK_URLS.count(WS_MAIN_URL) == 1
+    assert WS_FALLBACK_URLS[-1] == WS_MAIN_URL
+
+
+def test_preparing_marks_live_ended():
+    """PREPARING should stop outer reconnect attempts after the room goes offline."""
+    seen: list[str] = []
+    listener = DanmakuListener(
+        room_id=1,
+        callbacks={"on_preparing": lambda: seen.append("preparing")},
+    )
+
+    asyncio.run(listener._dispatch_message("PREPARING", {"cmd": "PREPARING"}))
+
+    assert listener._live_ended is True
+    assert seen == ["preparing"]
+
+
+def test_brotli_missing_uses_supplied_log_callback(monkeypatch):
+    """Decompression logging must be scoped to the listener/callback, not module state."""
+    monkeypatch.setitem(sys.modules, "brotli", None)
+    logs: list[tuple[str, str]] = []
+
+    assert _decompress(b"", PROTOCOL_VERSION_BROTLI, lambda msg, level: logs.append((msg, level))) == b""
+
+    assert logs == [("brotli 库未安装，无法解压 brotli 数据包，跳过", "warning")]

--- a/plugin/plugins/neko_roast/tests/test_livedanmaku.py
+++ b/plugin/plugins/neko_roast/tests/test_livedanmaku.py
@@ -1,0 +1,200 @@
+"""Tests for LiveDanmaku.from_danmaku DANMU_MSG parsing.
+
+回归保护：历史 bug 把 ``info[7]``（大航海等级，普通 int）当作可下标列表，
+任意一条正常弹幕都会在 ``len(info[7])`` 抛 TypeError 并被 _dispatch_message 的
+except 吞掉，导致 on_event("DANMU_MSG") 永不触发（计数恒为 0）。同时 admin 只判了
+外层 len、未判内层长度，短 info[2] 会 IndexError。这些测试锁住真实结构解析。
+"""
+
+from __future__ import annotations
+
+import json
+
+from plugin.plugins.neko_roast.modules.bili_live_ingest.livedanmaku import (
+    LiveDanmaku,
+    MessageType,
+)
+
+
+def _danmu(info: list, room_id: int = 81004) -> dict:
+    return {"cmd": "DANMU_MSG", "room_id": room_id, "info": info}
+
+
+def test_from_danmaku_full_payload_parses_without_error():
+    """完整正常弹幕（info[7] 为 int 大航海等级）不再抛 TypeError，且字段正确。"""
+    ld = LiveDanmaku.from_danmaku(
+        _danmu(
+            [
+                [0, 1, 25, 16777215, 1700000000000, 0, 0, "", 0, 0, 0],
+                "great stream!",
+                # 用户数组：admin=1, vip=0, svip=0
+                [123456, "CaptainUser", 1, 0, 0, 10000, 1, "#ff0000"],
+                # 粉丝牌：level, name, color, up_name, ?, anchor_roomid
+                [21, "MyMedal", 6126494, "UpName", 0, 22333],
+                [25],  # user_level
+                ["", ""],
+                0,
+                3,  # info[7] = guard_level (int) = 舰长
+                {"ts": 1700000000},
+            ]
+        )
+    )
+    assert ld.msg_type == MessageType.MSG_DANMAKU
+    assert ld.text == "great stream!"
+    assert ld.uid == 123456
+    assert ld.nickname == "CaptainUser"
+    assert ld.admin is True
+    assert ld.vip is False
+    assert ld.svip is False
+    assert ld.guard_level == 3
+    assert ld.user_level == 25
+    assert ld.medal is not None
+    assert ld.medal.name == "MyMedal"
+    assert ld.medal.level == 21
+    assert ld.fans_medal_name == "MyMedal"
+    assert ld.fans_medal_level == 21
+
+
+def test_from_danmaku_guard_level_is_plain_int():
+    """info[7] 是普通 int（大航海等级），不能当作列表下标。"""
+    for guard in (0, 1, 2, 3):
+        ld = LiveDanmaku.from_danmaku(
+            _danmu(
+                [
+                    [0, 1, 25],
+                    "hi",
+                    [111, "U", 0, 0, 0],
+                    [],
+                    [10],
+                    ["", ""],
+                    0,
+                    guard,
+                ]
+            )
+        )
+        assert ld.guard_level == guard
+
+
+def test_from_danmaku_short_user_array_no_index_error():
+    """短 info[2]（仅 uid+uname，无 admin 位）不应 IndexError，admin 安全降级 False。"""
+    ld = LiveDanmaku.from_danmaku(
+        _danmu(
+            [
+                [0, 1, 25, 16777215, 1700000000000],
+                "short danmaku",
+                [654321, "ShortUser"],  # 只有 2 个元素
+                [],
+                [25, 0, 0, 0, 0],
+                ["", ""],
+                0,
+                0,
+            ]
+        )
+    )
+    assert ld.text == "short danmaku"
+    assert ld.uid == 654321
+    assert ld.nickname == "ShortUser"
+    assert ld.admin is False
+    assert ld.guard_level == 0
+
+
+def test_from_danmaku_missing_index7_defaults_guard_zero():
+    """缺少 info[7]（稀疏 payload）时 guard_level 默认 0，不抛异常。"""
+    ld = LiveDanmaku.from_danmaku(
+        _danmu(
+            [
+                [0, 1, 25],
+                "no index7",
+                [777, "NoSeven", 0],
+            ]
+        )
+    )
+    assert ld.text == "no index7"
+    assert ld.uid == 777
+    assert ld.guard_level == 0
+    assert ld.admin is False
+
+
+def test_from_danmaku_vip_svip_from_user_array():
+    """vip/svip 来自用户数组 info[2][3]/[4]，而非 info[7]。"""
+    ld = LiveDanmaku.from_danmaku(
+        _danmu(
+            [
+                [0, 1, 25],
+                "vip msg",
+                [222, "VipUser", 0, 1, 1],  # vip=1, svip=1
+                [],
+                [30],
+                ["", ""],
+                0,
+                0,
+            ]
+        )
+    )
+    assert ld.vip is True
+    assert ld.svip is True
+    assert ld.admin is False
+
+
+def test_from_danmaku_face_url_empty():
+    """弹幕 payload 不携带头像 URL，face_url 必须为空（头像由 bili_identity 按 UID 抓取）。"""
+    ld = LiveDanmaku.from_danmaku(
+        _danmu(
+            [
+                [0, 1, 25],
+                "msg",
+                [333, "User", 0, 0, 0, 1, 1, "#abcdef"],
+                [],
+                [5],
+                ["", ""],
+                0,
+                0,
+            ]
+        )
+    )
+    assert ld.face_url == ""
+
+
+def test_from_raw_json_routes_danmu_msg():
+    """from_raw_json 兜底入口能正确路由 DANMU_MSG 到 from_danmaku。"""
+    raw = json.dumps(
+        _danmu(
+            [
+                [0, 1, 25],
+                "routed",
+                [444, "RoutedUser", 0, 0, 0],
+                [],
+                [12],
+                ["", ""],
+                0,
+                1,
+            ]
+        )
+    )
+    ld = LiveDanmaku.from_raw_json(raw)
+    assert ld is not None
+    assert ld.text == "routed"
+    assert ld.uid == 444
+    assert ld.guard_level == 1
+
+
+def test_from_danmaku_empty_info_is_safe():
+    """空 info 不抛异常，产出空文本的弹幕对象。"""
+    ld = LiveDanmaku.from_danmaku({"cmd": "DANMU_MSG", "info": []})
+    assert ld.text == ""
+    assert ld.uid == 0
+    assert ld.guard_level == 0
+
+
+def test_from_danmaku_score_reflects_guard_and_admin():
+    """get_score 应反映正确解析出的 guard_level 与 admin（验证字段确实进了打分）。"""
+    captain = LiveDanmaku.from_danmaku(
+        _danmu([[0, 1, 25], "x", [1, "Cap", 1, 0, 0], [], [50], ["", ""], 0, 3])
+    )
+    plain = LiveDanmaku.from_danmaku(
+        _danmu([[0, 1, 25], "x", [2, "Plain", 0, 0, 0], [], [1], ["", ""], 0, 0])
+    )
+    # 舰长(1000) + admin(500) + 高用户等级 应远高于普通观众
+    assert captain.get_score() > plain.get_score()
+    assert captain.guard_level == 3
+    assert captain.admin is True

--- a/plugin/plugins/neko_roast/tests/test_livedanmaku.py
+++ b/plugin/plugins/neko_roast/tests/test_livedanmaku.py
@@ -234,6 +234,7 @@ def test_brotli_missing_uses_supplied_log_callback(monkeypatch):
     monkeypatch.setitem(sys.modules, "brotli", None)
     logs: list[tuple[str, str]] = []
 
-    assert _decompress(b"", PROTOCOL_VERSION_BROTLI, lambda msg, level: logs.append((msg, level))) == b""
+    result = _decompress(b"", PROTOCOL_VERSION_BROTLI, lambda msg, level: logs.append((msg, level)))
 
+    assert result == b""
     assert logs == [("brotli 库未安装，无法解压 brotli 数据包，跳过", "warning")]

--- a/plugin/plugins/neko_roast/tests/test_livedanmaku.py
+++ b/plugin/plugins/neko_roast/tests/test_livedanmaku.py
@@ -38,8 +38,8 @@ def test_from_danmaku_full_payload_parses_without_error():
                 "great stream!",
                 # 用户数组：admin=1, vip=0, svip=0
                 [123456, "CaptainUser", 1, 0, 0, 10000, 1, "#ff0000"],
-                # 粉丝牌：level, name, color, up_name, ?, anchor_roomid
-                [21, "MyMedal", 6126494, "UpName", 0, 22333],
+                # 粉丝牌：level, name, up_name, anchor_roomid, color
+                [21, "MyMedal", "UpName", 22333, 6126494],
                 [25],  # user_level
                 ["", ""],
                 0,
@@ -60,6 +60,9 @@ def test_from_danmaku_full_payload_parses_without_error():
     assert ld.medal is not None
     assert ld.medal.name == "MyMedal"
     assert ld.medal.level == 21
+    assert ld.medal.up_name == "UpName"
+    assert ld.medal.anchor_roomid == 22333
+    assert ld.medal.color == 6126494
     assert ld.fans_medal_name == "MyMedal"
     assert ld.fans_medal_level == 21
 
@@ -227,6 +230,18 @@ def test_preparing_marks_live_ended():
 
     assert listener._live_ended is True
     assert seen == ["preparing"]
+
+
+def test_enhanced_cmd_handler_table_keeps_static_handlers_callable():
+    """Class-level enhanced handlers should stay callable from _CMD_HANDLERS."""
+    handler = DanmakuListener._CMD_HANDLERS["SUPER_CHAT_MESSAGE_JPN"]
+
+    ld = handler({"cmd": "SUPER_CHAT_MESSAGE_JPN", "data": {"uid": 9, "user_info": {"uname": "JP"}, "message": "hi"}})
+
+    assert ld.msg_type == MessageType.MSG_SUPER_CHAT
+    assert ld.uid == 9
+    assert ld.nickname == "JP"
+    assert ld.text == "hi"
 
 
 def test_brotli_missing_uses_supplied_log_callback(monkeypatch):


### PR DESCRIPTION
﻿## Depends on

https://github.com/Project-N-E-K-O/N.E.K.O/pull/1904

## Module added

Adds the live event ingestion layer:

- LiveEvent dispatch through EventBus
- Bilibili live ingest module
- danmaku core listener wrapper
- rich Bilibili live event model/parser
- reserved DM ingest placeholder
- EventBus and live parser tests

## Out of scope

- No event selection/cooldown window
- No roast pipeline/runtime wiring
- No monitor, skip reason, recent_results recap
- No entry welcome, gift thanks, SC readout, or guard welcome handlers

## File count

7 files.

## Validation

Stack-level validation was run on the final dependent branch:

- uv run pytest plugin/plugins/neko_roast/tests -q -> 41 passed
- uv run python -m plugin.neko_plugin_cli.cli check plugin/plugins/neko_roast -> 0 errors, 6 warnings
- git diff --check upstream/main..HEAD -> no output

This PR is draft and should be reviewed after PR #1904.

## Regression report

No output behavior is introduced here. This only adds the ingestion and event envelope layer used by later selection/pipeline PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明
* **新功能**
  * 新增直播事件发布/订阅总线：按事件类型分发，支持取消订阅与订阅统计；订阅处理异常隔离并写入审计记录；提供 `on/emit` 别名。
  * 新增哔哩哔哩直播摄取：统一弹幕/礼物/超级聊天等事件模型、解析与综合打分；支持 WebSocket 监听与直播间状态查询。
  * 新增直连消息摄取模块配置开关，默认未启用。
* **测试**
  * 补全事件总线与弹幕解析/连接/解压等回归用例，覆盖多种边界与失败场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->