### PR TITLE
fix(react-neko-chat): 提高 compact galgame 选项渐变背景不透明度

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2044,9 +2044,9 @@ body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] .composer-g
   background:
     linear-gradient(
       90deg,
-      rgba(206, 229, 252, 0.68) 0%,
-      rgba(232, 244, 255, 0.46) 52%,
-      rgba(247, 252, 255, 0.14) 82%,
+      rgba(206, 229, 252, 0.78) 0%,
+      rgba(232, 244, 255, 0.58) 52%,
+      rgba(247, 252, 255, 0.24) 82%,
       rgba(255, 255, 255, 0) 100%
     );
   box-shadow: none;
@@ -2056,9 +2056,9 @@ body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] .composer-g
   background:
     linear-gradient(
       90deg,
-      rgba(190, 220, 249, 0.76) 0%,
-      rgba(224, 240, 255, 0.54) 52%,
-      rgba(244, 250, 255, 0.18) 82%,
+      rgba(190, 220, 249, 0.86) 0%,
+      rgba(224, 240, 255, 0.66) 52%,
+      rgba(244, 250, 255, 0.28) 82%,
       rgba(255, 255, 255, 0) 100%
     );
   border-color: transparent;
@@ -5479,9 +5479,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background:
     linear-gradient(
       90deg,
-      rgba(55, 113, 164, 0.58) 0%,
-      rgba(43, 83, 124, 0.38) 52%,
-      rgba(25, 54, 84, 0.14) 82%,
+      rgba(55, 113, 164, 0.70) 0%,
+      rgba(43, 83, 124, 0.50) 52%,
+      rgba(25, 54, 84, 0.24) 82%,
       rgba(8, 17, 30, 0) 100%
     );
   border-color: transparent;
@@ -5492,9 +5492,9 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   background:
     linear-gradient(
       90deg,
-      rgba(66, 132, 188, 0.66) 0%,
-      rgba(50, 98, 145, 0.46) 52%,
-      rgba(30, 65, 100, 0.18) 82%,
+      rgba(66, 132, 188, 0.78) 0%,
+      rgba(50, 98, 145, 0.58) 52%,
+      rgba(30, 65, 100, 0.28) 82%,
       rgba(8, 17, 30, 0) 100%
     );
   border-color: transparent;


### PR DESCRIPTION
## 背景

有人反馈 galgame mode 在 react-neko-chat 的 compact 模式下那条渐变背景挺好看，但整体不透明度偏低，有时看不清字。

## 改动

compact 模式 galgame 选项（A/B/C）的背景是一条从左到右淡出的蓝色渐变。文字叠在桌面背景之上，中右段 alpha 偏低（如 0.46 / 0.14）时字会糊。

把四处渐变定义（浅色/深色 × 默认/hover）前三个色标的 alpha 各上调约 +0.1，**最右端仍保留全透明** `rgba(...,0)`，所以渐变的淡出观感、圆角、文字 `mask-image` 都不变，只是中段/右段更实、字更清楚。

| 位置 | 色标 alpha 变化 |
|---|---|
| 浅色 默认 | 0.68/0.46/0.14 → 0.78/0.58/0.24 |
| 浅色 hover | 0.76/0.54/0.18 → 0.86/0.66/0.28 |
| 深色 默认 | 0.58/0.38/0.14 → 0.70/0.50/0.24 |
| 深色 hover | 0.66/0.46/0.18 → 0.78/0.58/0.28 |

纯 CSS 调参，无逻辑改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式更新**
  * 优化了紧凑模式下选项的背景渐变配色，调整透明度参数，增强视觉高亮强度
  * 为亮色与暗色主题分别调整了默认态和悬停态的背景效果

<!-- end of auto-generated comment: release notes by coderabbit.ai -->