### PR TITLE
[codex] 优化羽毛球对拉提示和触网反馈

### DIFF
--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -3862,7 +3862,7 @@
     return normalized <= 1;
   }
   function canPlayerReturnIncomingShuttle() {
-    return isPlayerReceivingReturn() && !game.ball.resolved && isIncomingPlayerShuttleInReach(game.ball);
+    return isPlayerReceivingReturn() && !game.ball.resolved && !game.ball.hitNet && isIncomingPlayerShuttleInReach(game.ball);
   }
   function shouldDrawHeldShuttle() {
     return game.heldShuttleVisible && !game.ball && !game.pendingSwing && game.state === 'ready' && isPlayerTurn();
@@ -4069,17 +4069,26 @@
       direction: ball && ball.direction === -1 ? -1 : 1
     });
     if (netContactEffects.length > 5) netContactEffects = netContactEffects.slice(netContactEffects.length - 5);
-    window.__badmintonNetEffectDebug = {
-      count: netContactEffects.length,
-      x: contactX,
-      y: contactY,
-      strength: strength,
-      startedAt: now
-    };
+    if (debugMode) {
+      window.__badmintonNetEffectDebug = {
+        count: netContactEffects.length,
+        x: contactX,
+        y: contactY,
+        strength: strength,
+        startedAt: now
+      };
+    }
   }
   function resetGame() {
     clearTimeout(resultTimer);
     resultTimer = 0;
+    netContactEffects = [];
+    if (debugMode && window.__badmintonNetEffectDebug) {
+      window.__badmintonNetEffectDebug = {
+        count: 0,
+        clearedAt: performance.now()
+      };
+    }
     var shouldRestartRoute = endedRoute || routeActive || heartbeatTimer || drainTimer;
     if (shouldRestartRoute) {
       if (!endedRoute) endRoute(false);
@@ -4573,6 +4582,7 @@
   }
   function maybePlayerReceiveIncomingShuttle(ball) {
     if (!isDuelMode() || !ball || ball.resolved || game.pendingSwing) return false;
+    if (ball.hitNet) return false;
     if (ball.shooter !== 'neko' || ball.direction !== -1 || ball.awaitingReturnBy) return false;
     var shuttleCourtY = getShuttleCourtY(ball, false);
     var shuttleZ = getShuttleCourtZ(ball, false);

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -831,8 +831,8 @@
   var NET_BALL_FRICTION = 0.018;
   var NET_BALL_RADIUS = BALL_R + 6;
   var NET_CONTACT_RADIUS = 42;
-  var NET_CONTACT_IMPULSE = 240;
-  var NET_CONTACT_HOLD_MS = 180;
+  var NET_CONTACT_IMPULSE = 320;
+  var NET_CONTACT_HOLD_MS = 230;
   var PLAYER_MOVE_SPEED = 1040;
   var PLAYER_JUMP_SPEED = 430;
   var PLAYER_JUMP_GRAVITY = 1350;
@@ -863,6 +863,7 @@
   try { modeParams = new URLSearchParams(window.location.search); } catch (_) { modeParams = null; }
   var debugMode = modeParams ? modeParams.get('debug') === '1' : false;
   var currentMode = 'duel';
+  var netContactEffects = [];
   var DUEL_DIFFICULTY = [
     { name: 'max', skillBase: 0.88, growth: 0.010, pressure: 0.07, angleVar: 0.6, powerVar: 1.2, windupMs: 200, reactionMs: 300 },
     { name: 'lv2', skillBase: 0.78, growth: 0.007, pressure: 0.05, angleVar: 1.5, powerVar: 2.5, windupMs: 450, reactionMs: 550 },
@@ -3429,8 +3430,9 @@
   }
   function canPlayerJump() {
     if (!game.playerJump) return false;
-    if (game.state !== 'ready' || game.pendingSwing || !isPlayerTurn()) return false;
-    if (isPositionTransitioning) return false;
+    if (isBadmintonLoadingActive()) return false;
+    if (game.pendingSwing && game.pendingSwing.shooter === 'player') return false;
+    if (!canPlayerMoveCourt()) return false;
     if (game.playerJump.active || getPlayerJumpOffset() > 0) return false;
     return performance.now() >= (game.playerJump.cooldownUntil || 0);
   }
@@ -4026,7 +4028,7 @@
     var incomingSpeed = typeof ball.speed === 'function'
       ? ball.speed()
       : Math.sqrt((ball.vx || 0) * (ball.vx || 0) + (ball.vy || 0) * (ball.vy || 0));
-    var impact = clamp(incomingSpeed / 360, 0.55, 1.35);
+    var impact = clamp(incomingSpeed / 330, 0.68, 1.55);
     var centerCol = Math.floor(NET_COLS / 2);
     for (var col = 0; col < NET_COLS; col++) {
       var colSpread = centerCol > 0 ? (col - centerCol) / centerCol : 0;
@@ -4041,14 +4043,39 @@
         if (falloff <= 0) continue;
         var rowT = getNetSpanT(row, NET_ROWS);
         var weight = falloff * columnFalloff * (0.72 + Math.sin(rowT * Math.PI) * 0.28);
-        var recoilX = (direction * 0.14 + colSpread * 0.035) * NET_CONTACT_IMPULSE * impact * weight;
-        var rippleY = (rowT - 0.5) * 0.12 * NET_CONTACT_IMPULSE * impact * weight;
+        var recoilX = (direction * 0.18 + colSpread * 0.045) * NET_CONTACT_IMPULSE * impact * weight;
+        var rippleY = (rowT - 0.5) * 0.16 * NET_CONTACT_IMPULSE * impact * weight;
         node.vx += recoilX;
         node.vy += rippleY;
-        node.x += (direction * 0.9 + colSpread * 0.35) * weight;
-        node.y += (rowT - 0.5) * 0.55 * weight;
+        node.x += (direction * 1.7 + colSpread * 0.52) * weight * impact;
+        node.y += (rowT - 0.5) * 0.9 * weight * impact;
       }
     }
+  }
+  function spawnNetContactEffect(ball, crossing) {
+    var contactX = crossing && Number.isFinite(crossing.screenX) ? crossing.screenX : (ball ? ball.x : BADMINTON.netX);
+    var contactY = crossing && Number.isFinite(crossing.screenY) ? crossing.screenY : (ball ? ball.y : BADMINTON.netTop);
+    var speed = ball && typeof ball.speed === 'function'
+      ? ball.speed()
+      : Math.sqrt(Math.pow(ball && ball.vx || 0, 2) + Math.pow(ball && ball.vy || 0, 2));
+    var strength = clamp(speed / 430, 0.56, 1.24);
+    var now = performance.now();
+    netContactEffects.push({
+      x: contactX,
+      y: contactY,
+      startAt: now,
+      duration: 560,
+      strength: strength,
+      direction: ball && ball.direction === -1 ? -1 : 1
+    });
+    if (netContactEffects.length > 5) netContactEffects = netContactEffects.slice(netContactEffects.length - 5);
+    window.__badmintonNetEffectDebug = {
+      count: netContactEffects.length,
+      x: contactX,
+      y: contactY,
+      strength: strength,
+      startedAt: now
+    };
   }
   function resetGame() {
     clearTimeout(resultTimer);
@@ -4469,8 +4496,9 @@
     ball.netContactAt = performance.now();
     ball.netContactHoldUntil = ball.netContactAt + NET_CONTACT_HOLD_MS;
     applyNetContactImpulse(ball, crossing);
-    ball.vx = direction * clamp(Math.abs(ball.vx || 0) * 0.22, 32, 130);
-    ball.vy = Math.max(Math.abs(ball.vy || 0) * 0.18 + 115, 115);
+    spawnNetContactEffect(ball, crossing);
+    ball.vx = direction * clamp(Math.abs(ball.vx || 0) * 0.14, 24, 88);
+    ball.vy = Math.max(Math.abs(ball.vy || 0) * 0.10 + 132, 132);
     syncShuttleCourtCoordinates(ball);
   }
   function checkShuttleLanding(ball) {
@@ -4492,8 +4520,8 @@
       var targetRight = direction > 0 ? BADMINTON.courtRight : BADMINTON.netX - ballRadius * 0.5;
       var inTargetX = ball.x >= targetLeft && ball.x <= targetRight;
       var inTargetY = ball.y >= BADMINTON.targetTop && ball.y <= BADMINTON.courtBottom + ballRadius;
-      var scored = ball.crossedNet && inTargetX && inTargetY;
-      var shotType = ball.crossedNet ? 'out' : 'net';
+      var scored = !ball.hitNet && ball.crossedNet && inTargetX && inTargetY;
+      var shotType = ball.hitNet ? 'net' : (ball.crossedNet ? 'out' : 'net');
       if (scored) {
         var nearBaseline = direction > 0 ? ball.x > targetRight - 34 : ball.x < targetLeft + 34;
         var nearNet = direction > 0 ? ball.x < targetLeft + 34 : ball.x > targetRight - 34;
@@ -6015,6 +6043,58 @@
     ctx.lineTo(bottomRight.x, bottomRight.y);
     ctx.stroke();
     ctx.restore();
+    drawNetContactEffects();
+  }
+
+  function drawNetContactEffects() {
+    if (!netContactEffects.length) return;
+    var now = performance.now();
+    netContactEffects = netContactEffects.filter(function (effect) {
+      return now - effect.startAt < effect.duration;
+    });
+    if (!netContactEffects.length) return;
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    for (var i = 0; i < netContactEffects.length; i++) {
+      var effect = netContactEffects[i];
+      var age = clamp((now - effect.startAt) / effect.duration, 0, 1);
+      var alpha = (1 - age) * effect.strength;
+      var spread = 8 + age * 54 * effect.strength;
+      var lift = Math.sin(age * Math.PI) * 8 * effect.strength;
+      var x = clamp(effect.x, BADMINTON.netX - 34, BADMINTON.netX + 34);
+      var y = clamp(effect.y - lift, NET_TOP - 18, NET_BOTTOM + 24);
+
+      ctx.shadowColor = 'rgba(255,244,190,' + (0.26 * alpha).toFixed(3) + ')';
+      ctx.shadowBlur = 7 + 8 * alpha;
+      ctx.strokeStyle = 'rgba(255,245,204,' + (0.22 * alpha).toFixed(3) + ')';
+      ctx.lineWidth = 5.8 * alpha;
+      ctx.beginPath();
+      ctx.moveTo(x - 3, y - spread * 0.55);
+      ctx.quadraticCurveTo(x + effect.direction * (5 + spread * 0.08), y, x - 2, y + spread * 0.55);
+      ctx.stroke();
+
+      ctx.shadowBlur = 3 + 6 * alpha;
+      ctx.strokeStyle = 'rgba(236,255,248,' + (0.46 * alpha).toFixed(3) + ')';
+      ctx.lineWidth = Math.max(0.65, 1.45 * alpha);
+      ctx.beginPath();
+      ctx.moveTo(x, y - spread);
+      ctx.quadraticCurveTo(x + effect.direction * (4 + spread * 0.10), y, x, y + spread);
+      ctx.stroke();
+
+      ctx.fillStyle = 'rgba(255,236,170,' + (0.42 * alpha).toFixed(3) + ')';
+      for (var spark = 0; spark < 4; spark++) {
+        var sparkPhase = spark * 1.7 + age * 2.6;
+        var sparkX = x + effect.direction * (6 + spark * 4 + age * 18) + Math.sin(sparkPhase) * 3;
+        var sparkY = y + (spark - 1.5) * 9 - age * (8 + spark * 2);
+        var sparkR = Math.max(0.7, (1.9 - spark * 0.2) * alpha);
+        ctx.beginPath();
+        ctx.arc(sparkX, sparkY, sparkR, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+    ctx.restore();
   }
 
   function drawNetCord() {
@@ -6681,6 +6761,89 @@
   }
   function drawAiming() {
     aimingCtx.clearRect(0, 0, BASE_W, BASE_H);
+    drawPlayerReturnHitCue();
+  }
+  function drawPlayerReturnHitCue() {
+    if (!isPlayerReceivingReturn() || !canPlayerReturnIncomingShuttle()) return;
+    var ball = game.ball;
+    var contact = getRacketContactPoint('player');
+    var yui = getYuiShotOrigin();
+    if (!ball || !contact || !yui) return;
+    var dx = yui.x - contact.x;
+    var dy = yui.y - contact.y;
+    var len = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+    var ux = dx / len;
+    var uy = dy / len;
+    var nx = -uy;
+    var ny = ux;
+    var now = performance.now();
+    var pulse = 0.5 + 0.5 * Math.sin(now / 118);
+    var shimmer = 0.5 + 0.5 * Math.sin(now / 96);
+    var radius = ball.radius || BALL_R;
+    var startX = ball.x - ux * 32 + nx * 10;
+    var startY = ball.y - uy * 32 + ny * 10;
+    var controlX = ball.x + ux * 2 + nx * 24;
+    var controlY = ball.y + uy * 2 + ny * 24;
+    var endX = ball.x + ux * 38 + nx * 7;
+    var endY = ball.y + uy * 38 + ny * 7;
+
+    aimingCtx.save();
+    aimingCtx.globalCompositeOperation = 'lighter';
+    aimingCtx.shadowColor = 'rgba(255,221,122,.26)';
+    aimingCtx.shadowBlur = 5 + pulse * 3;
+    aimingCtx.strokeStyle = 'rgba(255,236,168,.075)';
+    aimingCtx.lineWidth = 7 + pulse * 1.5;
+    aimingCtx.lineCap = 'round';
+    aimingCtx.beginPath();
+    aimingCtx.moveTo(startX, startY);
+    aimingCtx.quadraticCurveTo(controlX, controlY, endX, endY);
+    aimingCtx.stroke();
+
+    var cueGradient = aimingCtx.createLinearGradient(startX, startY, endX, endY);
+    cueGradient.addColorStop(0, 'rgba(255,255,255,0)');
+    cueGradient.addColorStop(0.42, 'rgba(255,246,190,.16)');
+    cueGradient.addColorStop(1, 'rgba(255,210,96,.30)');
+    aimingCtx.shadowBlur = 3 + pulse * 2;
+    aimingCtx.strokeStyle = cueGradient;
+    aimingCtx.lineWidth = 1.8 + pulse * 0.55;
+    aimingCtx.beginPath();
+    aimingCtx.moveTo(startX, startY);
+    aimingCtx.quadraticCurveTo(controlX, controlY, endX, endY);
+    aimingCtx.stroke();
+
+    var tangentX = endX - controlX;
+    var tangentY = endY - controlY;
+    var tangentLen = Math.max(1, Math.sqrt(tangentX * tangentX + tangentY * tangentY));
+    tangentX /= tangentLen;
+    tangentY /= tangentLen;
+    var sideX = -tangentY;
+    var sideY = tangentX;
+    var head = 6 + shimmer * 1.5;
+    aimingCtx.fillStyle = 'rgba(255,218,102,.24)';
+    aimingCtx.shadowBlur = 3;
+    aimingCtx.beginPath();
+    aimingCtx.moveTo(endX + tangentX * 4, endY + tangentY * 4);
+    aimingCtx.lineTo(endX - tangentX * head + sideX * head * 0.32, endY - tangentY * head + sideY * head * 0.32);
+    aimingCtx.lineTo(endX - tangentX * head - sideX * head * 0.22, endY - tangentY * head - sideY * head * 0.22);
+    aimingCtx.closePath();
+    aimingCtx.fill();
+
+    var glowRadius = radius + 3 + pulse * 2;
+    var glow = aimingCtx.createRadialGradient(ball.x, ball.y, Math.max(2, radius * 0.4), ball.x, ball.y, glowRadius + 7);
+    glow.addColorStop(0, 'rgba(255,255,255,.055)');
+    glow.addColorStop(0.45, 'rgba(255,232,150,.085)');
+    glow.addColorStop(1, 'rgba(255,216,94,0)');
+    aimingCtx.fillStyle = glow;
+    aimingCtx.beginPath();
+    aimingCtx.arc(ball.x, ball.y, glowRadius + 7, 0, Math.PI * 2);
+    aimingCtx.fill();
+    aimingCtx.strokeStyle = 'rgba(255,242,183,.18)';
+    aimingCtx.lineWidth = 0.9;
+    aimingCtx.shadowBlur = 2;
+    aimingCtx.beginPath();
+    aimingCtx.arc(ball.x, ball.y, glowRadius, 0, Math.PI * 2);
+    aimingCtx.stroke();
+    aimingCtx.restore();
   }
   function drawBall() {
     if (!game.ball) return;

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -5139,8 +5139,10 @@
         b.prevZ = getShuttleCourtZ(b, false);
         stepBallPhysics(b, subDt);
         checkShuttleLanding(b);
-        if (maybeYuiReturnIncomingShuttle(b)) break;
-        if (maybePlayerReceiveIncomingShuttle(b)) break;
+        if (!b.hitNet) {
+          if (maybeYuiReturnIncomingShuttle(b)) break;
+          if (maybePlayerReceiveIncomingShuttle(b)) break;
+        }
         updateNetPhysics(subDt);
         b.trail.push({ x: b.x, y: b.y });
         if (b.trail.length > 20) b.trail.shift();

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -31,7 +31,13 @@ def _install_badminton_test_hooks(page: Page) -> None:
     )
 
 
-def _goto_badminton(page: Page, running_server: str, mode: str) -> None:
+def _goto_badminton(
+    page: Page,
+    running_server: str,
+    mode: str,
+    debug: bool = True,
+    wait_loading: bool = True,
+) -> None:
     _install_badminton_test_hooks(page)
     lanlan_name = "e2e-yui"
     session_id = f"e2e-badminton-{mode}"
@@ -40,12 +46,15 @@ def _goto_badminton(page: Page, running_server: str, mode: str) -> None:
     state["responded_at"] = time.time()
     state["pending_session_id"] = session_id
     state["last_game_type"] = "badminton"
+    debug_query = "&debug=1" if debug else ""
     page.goto(
         f"{running_server}/badminton_demo"
-        f"?mode={mode}&lanlan_name={lanlan_name}&session_id={session_id}&debug=1"
+        f"?mode={mode}&lanlan_name={lanlan_name}&session_id={session_id}{debug_query}"
     )
     expect(page.locator("#game")).to_be_attached(timeout=15000)
     page.wait_for_function("window.BadmintonDemo && window.BadmintonDemo.getState")
+    if not wait_loading:
+        return
     page.wait_for_function(
         """() => {
           const loading = document.getElementById('badminton-loading');
@@ -572,7 +581,9 @@ def test_badminton_yui_awaiting_return_still_hits_midcourt_net(mock_page: Page, 
           window.__bdYuiAwaitingNetSample = {
             hitNet: state.currentShuttle.hitNet,
             crossedNet: state.currentShuttle.crossedNet,
+            receivingReturn: state.receivingReturn,
             incomingReturnInReach: state.incomingReturnInReach,
+            canControlShot: state.canControlShot,
             attemptsResultsLength: state.attemptsResults.length,
             netEffect: window.__badmintonNetEffectDebug || null,
             vx: state.currentShuttle.vx,
@@ -585,7 +596,9 @@ def test_badminton_yui_awaiting_return_still_hits_midcourt_net(mock_page: Page, 
     netted = page.evaluate("window.__bdYuiAwaitingNetSample")
     assert netted["hitNet"] is True
     assert netted["crossedNet"] is True
+    assert netted["receivingReturn"] is True
     assert netted["incomingReturnInReach"] is False
+    assert netted["canControlShot"] is False
     assert netted["attemptsResultsLength"] == 0
     assert netted["netEffect"] is not None
     assert netted["netEffect"]["count"] >= 1
@@ -614,6 +627,61 @@ def test_badminton_yui_awaiting_return_still_hits_midcourt_net(mock_page: Page, 
     assert resolved["duel"]["neko_score"] == 0
     assert resolved["duel"]["neko_misses"] == 1
     assert resolved["duel"]["player_misses"] == 0
+
+    page.evaluate("window.BadmintonDemo.resetGame()")
+    page.wait_for_function(
+        """() => {
+          return window.__badmintonNetEffectDebug
+            && window.__badmintonNetEffectDebug.count === 0;
+        }"""
+    )
+
+
+@pytest.mark.e2e
+def test_badminton_net_effect_debug_global_stays_debug_only(mock_page: Page, running_server: str):
+    page = mock_page
+    _goto_badminton(page, running_server, "duel", debug=False, wait_loading=False)
+
+    page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    page.evaluate(
+        """() => {
+          window.BadmintonDemo._debugSetAwaitingPlayerReturnBall({
+            id: 904,
+            x: 466,
+            y: 330,
+            prevX: 470,
+            prevY: 330,
+            courtY: 466,
+            prevCourtY: 470,
+            z: 120,
+            prevZ: 120,
+            vx: -360,
+            vy: 0,
+            vCourtY: -360,
+            vz: 0,
+            radius: 18,
+            shooter: 'neko',
+            direction: -1,
+            crossedNet: false,
+            resolved: false,
+            awaitingReturnBy: 'player',
+            returnDeadlineAt: performance.now() + 2400,
+            groundedReturnAt: 0,
+            angle: 43,
+            power: 52,
+            trail: []
+          });
+        }"""
+    )
+
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          return state && state.currentShuttle && state.currentShuttle.hitNet;
+        }""",
+        timeout=2000,
+    )
+    assert page.evaluate("typeof window.__badmintonNetEffectDebug") == "undefined"
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -574,6 +574,7 @@ def test_badminton_yui_awaiting_return_still_hits_midcourt_net(mock_page: Page, 
             crossedNet: state.currentShuttle.crossedNet,
             incomingReturnInReach: state.incomingReturnInReach,
             attemptsResultsLength: state.attemptsResults.length,
+            netEffect: window.__badmintonNetEffectDebug || null,
             vx: state.currentShuttle.vx,
             vy: state.currentShuttle.vy
           };
@@ -586,6 +587,9 @@ def test_badminton_yui_awaiting_return_still_hits_midcourt_net(mock_page: Page, 
     assert netted["crossedNet"] is True
     assert netted["incomingReturnInReach"] is False
     assert netted["attemptsResultsLength"] == 0
+    assert netted["netEffect"] is not None
+    assert netted["netEffect"]["count"] >= 1
+    assert netted["netEffect"]["strength"] > 0
     assert abs(netted["vx"]) < 360
     assert netted["vy"] > 0
 
@@ -604,7 +608,12 @@ def test_badminton_yui_awaiting_return_still_hits_midcourt_net(mock_page: Page, 
     )
     resolved = page.evaluate("window.BadmintonDemo.getState()")
     assert resolved["attemptsResults"][-1]["shooter"] == "neko"
-    assert resolved["attemptsResults"][-1]["shot_type"] in ("net_touch", "net", "out")
+    assert resolved["attemptsResults"][-1]["shot_type"] == "net"
+    assert resolved["attemptsResults"][-1]["point_winner"] == "player"
+    assert resolved["duel"]["player_score"] == 1
+    assert resolved["duel"]["neko_score"] == 0
+    assert resolved["duel"]["neko_misses"] == 1
+    assert resolved["duel"]["player_misses"] == 0
 
 
 @pytest.mark.e2e
@@ -734,6 +743,63 @@ def test_badminton_player_return_requires_shuttle_to_enter_character_reach(mock_
 
 
 @pytest.mark.e2e
+def test_badminton_player_return_hit_cue_only_draws_inside_reach(mock_page: Page, running_server: str):
+    page = mock_page
+    _goto_badminton(page, running_server, "duel")
+
+    count_cue_pixels = """
+      () => {
+        const canvas = document.getElementById('aiming-canvas');
+        if (!canvas) return 0;
+        const ctx = canvas.getContext('2d');
+        const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+        let lit = 0;
+        for (let i = 3; i < data.length; i += 4) {
+          if (data[i] > 20) lit++;
+        }
+        return lit;
+      }
+    """
+
+    page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    page.evaluate(
+        """() => {
+          const state = window.BadmintonDemo.getState();
+          const contact = state.playerRacketContact || { x: state.playerCourt.x + 42, y: state.playerCourt.y - 76 };
+          window.BadmintonDemo._debugSetAwaitingPlayerReturnBall({
+            x: contact.x + 180,
+            y: contact.y - 180,
+            prevX: contact.x + 184,
+            prevY: contact.y - 180,
+            vx: 0,
+            vy: 0,
+            returnDeadlineAt: performance.now() + 5000
+          });
+        }"""
+    )
+    page.wait_for_timeout(80)
+    assert page.evaluate(count_cue_pixels) == 0
+
+    page.evaluate(
+        """() => {
+          const state = window.BadmintonDemo.getState();
+          const contact = state.playerRacketContact || { x: state.playerCourt.x + 42, y: state.playerCourt.y - 76 };
+          window.BadmintonDemo._debugSetAwaitingPlayerReturnBall({
+            x: contact.x,
+            y: contact.y,
+            prevX: contact.x + 4,
+            prevY: contact.y,
+            vx: -360,
+            vy: -80,
+            returnDeadlineAt: performance.now() + 5000
+          });
+        }"""
+    )
+    page.wait_for_function(f"({count_cue_pixels})() > 12", timeout=2000)
+    assert page.evaluate("window.BadmintonDemo.getState().incomingReturnInReach") is True
+
+
+@pytest.mark.e2e
 def test_badminton_vrm_overlay_does_not_block_player_swing(mock_page: Page, running_server: str):
     page = mock_page
     _goto_badminton(page, running_server, "duel")
@@ -758,7 +824,7 @@ def test_badminton_vrm_overlay_does_not_block_player_swing(mock_page: Page, runn
 
 
 @pytest.mark.e2e
-def test_badminton_allows_player_movement_but_blocks_shot_during_yui_turn(mock_page: Page, running_server: str):
+def test_badminton_allows_player_movement_and_jump_but_blocks_shot_during_yui_turn(mock_page: Page, running_server: str):
     page = mock_page
     _goto_badminton(page, running_server, "duel")
 
@@ -774,6 +840,25 @@ def test_badminton_allows_player_movement_but_blocks_shot_during_yui_turn(mock_p
 
     viewport = page.viewport_size or {"width": 1280, "height": 720}
     page.mouse.move(viewport["width"] - 8, 12)
+    page.evaluate(
+        """() => {
+          window.dispatchEvent(new KeyboardEvent('keydown', {
+            key: ' ',
+            code: 'Space',
+            bubbles: true,
+            cancelable: true
+          }));
+        }"""
+    )
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          if (!state || !state.playerJump || !state.playerJump.active || state.playerJump.offset <= 0) return false;
+          window.__bdYuiTurnJumpSnapshot = state.playerJump;
+          return true;
+        }""",
+        timeout=2000,
+    )
     page.mouse.down()
     page.mouse.up()
     page.evaluate("window.BadmintonDemo.shoot()")
@@ -788,6 +873,9 @@ def test_badminton_allows_player_movement_but_blocks_shot_during_yui_turn(mock_p
     )
 
     state = page.evaluate("window.BadmintonDemo.getState()")
+    jump = page.evaluate("window.__bdYuiTurnJumpSnapshot")
+    assert jump["active"] is True
+    assert jump["offset"] > 0
     assert state["playerCourt"]["targetX"] > before_move["targetX"]
     assert state["playerCourt"]["x"] > before_move["x"]
     assert state["charging"] is False


### PR DESCRIPTION
## 改动概述

本次调整羽毛球对拉体验，解决玩家接 Yui 回球时缺少可击时机反馈、Yui 触网计分归属错误、Yui 回合玩家无法跳跃，以及中场网触网反馈偏弱的问题。

实现上复用现有击球判定，只在提示层绘制弱化的挥拍光轨和羽毛球轻提示；触网结算排除已触网球的成功落点，避免 Yui 挂网后仍判 Yui 得分；跳跃权限与防守移动窗口对齐，保持 Yui 回合不能出拍；中场网触网反馈增加局部拉扯、回弹、吃球下坠和短生命周期接触效果。

## 风险与边界

改动集中在羽毛球 demo 模板和对应 e2e 覆盖，不涉及 neko-pc，不触碰 app、main_logic、memory 等核心运行目录。

本轮不调整基础击球判定、对拉 AI 策略、排行榜接口和游戏 LLM 流程。主要回归风险在羽毛球触网动画观感、Yui 回合输入窗口，以及触网/越网边界判定；对应路径已补充端到端覆盖。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增触网特效：在触网点按来球速度生成发光与火花脉冲，并随时间衰减展示。
  * 新增回击提示：当回球可达时显示动态脉冲曲线与发光箭头指引。

* **改进**
  * 触网物理与反馈效果增强，回弹/形变表现更贴近预期。
  * 落地判定与回球可行性更清晰地区分挂网/出界；命中网后不进入回球流程。

* **测试**
  * 加强网特效与回击提示的端到端校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->