### PR TITLE
fix(proactive): 推歌/推图按素材去重豁免 anti-repeat，修复自发推送频率被压到极低

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1720,6 +1720,17 @@ ANTI_REPEAT_MIN_DRAFT_TOKENS = 12
 - 用途：避免"嗯。"、"好"这种短回复被错杀。
 - 设计依据：~12 个 ngram token 才能形成稳定的 BM25 信号。"""
 
+ANTI_REPEAT_EXEMPT_SOURCE_TAGS = frozenset({"MUSIC"})
+"""主动搭话里豁免 anti-repeat BM25 复读判定的来源标签。
+- 动机：BM25 防的是"话题/措辞复读"，但素材推送类 channel（推歌）的开场白
+  天生模板化（"换首歌 / 这旋律 / 听听看"），台词长一个样、曲目却不同；用
+  台词 BM25 判它属于天生误杀——博士连点几首后，FG 窗被音乐 intro 占满，
+  分数爆表，后续自发推歌全被 drop，表现为"放音乐频率极低"。
+- 语义：这类 channel 的复读应按"素材本身"（曲目）去重，而非台词；因此既
+  跳过出口的 regen/drop 判定，也不把其台词录进 anti-repeat corpus（否则会
+  污染 FG 窗、漂移其它 channel 的复读基线）。
+- 范围：当前仅 MUSIC。MEME 等同样模板化的素材推送 channel 未来可加入。"""
+
 AVATAR_INTERACTION_DEDUPE_MAX_ITEMS = 32
 """_recent_avatar_interaction_ids deque maxlen。
 - 用途：去重已处理的 avatar 交互 ID。
@@ -2379,6 +2390,7 @@ __all__ = [
     'ANTI_REPEAT_BM25_K1',
     'ANTI_REPEAT_BM25_B',
     'ANTI_REPEAT_MIN_DRAFT_TOKENS',
+    'ANTI_REPEAT_EXEMPT_SOURCE_TAGS',
     'AVATAR_INTERACTION_DEDUPE_MAX_ITEMS',
     'AVATAR_INTERACTION_DEDUPE_WINDOW_MS',
     'AVATAR_INTERACTION_CONTEXT_MAX_TOKENS',

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1720,16 +1720,20 @@ ANTI_REPEAT_MIN_DRAFT_TOKENS = 12
 - 用途：避免"嗯。"、"好"这种短回复被错杀。
 - 设计依据：~12 个 ngram token 才能形成稳定的 BM25 信号。"""
 
-ANTI_REPEAT_EXEMPT_SOURCE_TAGS = frozenset({"MUSIC"})
-"""主动搭话里豁免 anti-repeat BM25 复读判定的来源标签。
-- 动机：BM25 防的是"话题/措辞复读"，但素材推送类 channel（推歌）的开场白
-  天生模板化（"换首歌 / 这旋律 / 听听看"），台词长一个样、曲目却不同；用
-  台词 BM25 判它属于天生误杀——博士连点几首后，FG 窗被音乐 intro 占满，
-  分数爆表，后续自发推歌全被 drop，表现为"放音乐频率极低"。
-- 语义：这类 channel 的复读应按"素材本身"（曲目）去重，而非台词；因此既
-  跳过出口的 regen/drop 判定，也不把其台词录进 anti-repeat corpus（否则会
-  污染 FG 窗、漂移其它 channel 的复读基线）。
-- 范围：当前仅 MUSIC。MEME 等同样模板化的素材推送 channel 未来可加入。"""
+ANTI_REPEAT_EXEMPT_SOURCE_TAGS = frozenset({"MUSIC", "MEME"})
+"""主动搭话里"复读判定从台词切到素材维度"的来源标签。
+- 动机：BM25 防的是"话题/措辞复读"，但素材推送类 channel 的开场白天生模板
+  化（推歌"换首歌 / 这旋律 / 听听看"、表情包"看这个 / 笑死"），台词长一个
+  样、而推送的素材（曲目 / 表情包搜索关键词）却不同；用台词 BM25 判它属于
+  天生误杀——博士连点几首后 FG 窗被音乐 intro 占满，分数爆表，后续自发推
+  歌全被 drop，表现为"放音乐频率极低"。
+- 语义：这类 channel 的复读按"素材本身"去重——MUSIC 看曲目、MEME 看搜索
+  关键词（不是图片）。本轮素材与近期不雷同时，豁免台词级硬拦截（字面相似
+  度 + BM25 regen/drop）直接放行；素材雷同（反复推同一曲目 / 同一关键词）
+  才回落到正常台词判定，台词没雷同则依然能发。
+- 另：这类 channel 的台词不录进 anti-repeat corpus（见 finish_proactive_
+  delivery），免得模板化 intro 污染 FG 窗、漂移其它 channel 的复读基线；
+  素材标识的近期去重走 system_router 的 _proactive_material_history。"""
 
 AVATAR_INTERACTION_DEDUPE_MAX_ITEMS = 32
 """_recent_avatar_interaction_ids deque maxlen。

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -74,6 +74,7 @@ from config import (
     SESSION_TURN_THRESHOLD,
     AVATAR_INTERACTION_DEDUPE_MAX_ITEMS,
     HIDE_DIRTY_VOICE_TRANSCRIPTS,
+    ANTI_REPEAT_EXEMPT_SOURCE_TAGS,
 )
 # FOCUS_MODE_ENABLED is read live with a function-local ``from config import
 # FOCUS_MODE_ENABLED`` at each gate (re-imported per call → picks up a runtime
@@ -6629,6 +6630,7 @@ class LLMSessionManager:
         full_text: str,
         expected_speech_id: str | None = None,
         action_note: str | None = None,
+        source_tag: str | None = None,
     ) -> bool:
         """Wrap-up after streaming completes: deliver the full text in one shot + record history + TTS/turn end signals.
 
@@ -6692,14 +6694,18 @@ class LLMSessionManager:
                         history_text = f"{full_text}\n{note}" if full_text else note
                 self.session._conversation_history.append(AIMessage(content=history_text))
                 # 防复读 corpus：只录"被说出口的"那段（full_text），action_note 是
-                # LLM 给自己的元数据备忘，不算复读对象。
-                try:
-                    from memory.anti_repeat import get_anti_repeat_corpus
-                    get_anti_repeat_corpus().record_output(
-                        self.lanlan_name, full_text, is_proactive=True,
-                    )
-                except Exception as _exc:  # pragma: no cover
-                    logger.debug("[AntiRepeat] record proactive skipped: %s", _exc)
+                # LLM 给自己的元数据备忘，不算复读对象。素材推送类 channel（推歌）
+                # 的台词天生模板化，录进 corpus 会污染 FG 窗、漂移其它 channel 的
+                # 复读基线，故按 ANTI_REPEAT_EXEMPT_SOURCE_TAGS 豁免（与出口的
+                # BM25 评分豁免对偶）。
+                if source_tag not in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
+                    try:
+                        from memory.anti_repeat import get_anti_repeat_corpus
+                        get_anti_repeat_corpus().record_output(
+                            self.lanlan_name, full_text, is_proactive=True,
+                        )
+                    except Exception as _exc:  # pragma: no cover
+                        logger.debug("[AntiRepeat] record proactive skipped: %s", _exc)
 
             if self.use_tts and self.tts_thread and self.tts_thread.is_alive() and not self._tts_done_queued_for_turn:
                 try:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -7324,7 +7324,22 @@ async def proactive_chat(request: Request):
             music_already_appended = any(link.get('source') == '音乐推荐' for link in source_links)
             if not music_already_appended:
                 _append_music_recommendations(source_links, music_content)
-        
+
+        # anti-repeat / 素材去重按"真实投递的 channel"归类，而非模型原始 source_tag：
+        # Phase 1 只有音乐时模型可能合法出 [CHAT]，随后 should_try_music_fallback 仍
+        # 追加曲目并置 is_music_used=True——此时实际投递的是音乐。若仍按 CHAT 记录，
+        # finish_proactive_delivery 会把模板化 intro 录进 BM25 corpus、且曲目 key 不
+        # 记，恰好重新引入本 PR 要消除的 fallback 推歌污染（Codex P2）。曲目优先取
+        # selected_music_link；regen 把 tag 降级 CHAT 时它已被清空，则从已追加的
+        # source_links（source=='音乐推荐'）里取首条。
+        _delivered_tag = 'MUSIC' if (is_music_used and source_tag != 'MUSIC') else source_tag
+        _delivered_music_link = selected_music_link
+        if _delivered_tag == 'MUSIC' and not _delivered_music_link:
+            _delivered_music_link = next(
+                (l for l in (source_links or []) if isinstance(l, dict) and l.get('source') == '音乐推荐'),
+                None,
+            )
+
         # 一次性投递完整文本 + 记录历史 + TTS end + turn end
         # 传 proactive_sid：若 Phase 2 流结束到这里之间用户已打断（换了 sid），
         # finish 内部会跳过所有写入，避免 proactive 文本污染用户当前轮次。
@@ -7344,7 +7359,7 @@ async def proactive_chat(request: Request):
                 response_text,
                 expected_speech_id=proactive_sid,
                 action_note=action_note,
-                source_tag=source_tag,
+                source_tag=_delivered_tag,
             )
         except Exception as exc:
             logger.warning("[%s] buffered proactive delivery failed: %s", lanlan_name, exc)
@@ -7376,12 +7391,12 @@ async def proactive_chat(request: Request):
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)
         # 记录本轮实际投递的"素材标识"（曲目 / 搜索关键词），供下次同 channel 的
-        # 素材级去重。按最终 source_tag/selected_music_link 重算——regen 可能已把
-        # MUSIC 降级成 CHAT 并清掉 selected_music_link，此时 key 为空不记录。
+        # 素材级去重。按"真实投递 channel"_delivered_tag/_delivered_music_link 归类
+        # （含模型出 CHAT 但 fallback 追加了曲目的情形），key 为空则不记录。
         _record_proactive_material(
             lanlan_name,
-            source_tag,
-            _proactive_material_key(source_tag, selected_music_link, meme_content),
+            _delivered_tag,
+            _proactive_material_key(_delivered_tag, _delivered_music_link, meme_content),
         )
         # Mini-game 邀请冷却 counter 推进：spec 是"被回应后再 10 次搭话才解禁"，
         # 任何 channel 的成功投递都算一次，pending 期间（responded_at=None）函数

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -96,6 +96,7 @@ from config import (
     ANTI_REPEAT_DROP_THRESHOLD,
     ANTI_REPEAT_INJECT_TOP_K,
     ANTI_REPEAT_REGEN_THRESHOLD,
+    ANTI_REPEAT_EXEMPT_SOURCE_TAGS,
     MINI_GAME_INVITE_ENABLED,
     MINI_GAME_INVITE_FORCE_GAME_TYPE,
     MINI_GAME_INVITE_TRIGGER_PROBABILITY,
@@ -6972,14 +6973,23 @@ async def proactive_chat(request: Request):
         # ``PROACTIVE_PHASE2_GENERATE_MAX_TOKENS`` / ``render_regen_avoid_instruction``）；
         # 这里 try 仅包 corpus 单例与评分本身——若把常量 import 也塞进 try，
         # except 后下面的 ``>= ANTI_REPEAT_DROP_THRESHOLD`` 会 NameError（codex P1）。
-        try:
-            from memory.anti_repeat import get_anti_repeat_corpus
-            _ar_corpus = get_anti_repeat_corpus()
-            _bm25_total, _bm25_terms = _ar_corpus.score_draft(lanlan_name, response_text)
-        except Exception as _ar_exc:  # pragma: no cover - defensive
-            logger.debug("[AntiRepeat] BM25 score skipped: %s", _ar_exc)
+        # 素材推送类 channel（推歌）的开场白天生模板化、台词长一个样而曲目不
+        # 同，用台词 BM25 判复读属于天生误杀（博士连点几首后 FG 窗被音乐 intro
+        # 占满，分数爆表，后续自发推歌全被 drop → "放音乐频率极低"）。这类
+        # channel 的复读按曲目去重而非台词，故整段评分 + regen/drop 直接跳过；
+        # 录入 corpus 时同样豁免（见 finish_proactive_delivery），免得污染 FG 窗。
+        if source_tag in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
             _bm25_total, _bm25_terms = 0.0, {}
             _ar_corpus = None
+        else:
+            try:
+                from memory.anti_repeat import get_anti_repeat_corpus
+                _ar_corpus = get_anti_repeat_corpus()
+                _bm25_total, _bm25_terms = _ar_corpus.score_draft(lanlan_name, response_text)
+            except Exception as _ar_exc:  # pragma: no cover - defensive
+                logger.debug("[AntiRepeat] BM25 score skipped: %s", _ar_exc)
+                _bm25_total, _bm25_terms = 0.0, {}
+                _ar_corpus = None
 
         # ANTI_REPEAT_DROP_THRESHOLD 仅在 regen 之后才生效：初稿超 DROP 也得
         # 给 LLM 一次纠正机会，跑完再用同阈值二判。之前的版本初稿 ≥ DROP
@@ -7249,6 +7259,7 @@ async def proactive_chat(request: Request):
                 response_text,
                 expected_speech_id=proactive_sid,
                 action_note=action_note,
+                source_tag=source_tag,
             )
         except Exception as exc:
             logger.warning("[%s] buffered proactive delivery failed: %s", lanlan_name, exc)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -7009,15 +7009,36 @@ async def proactive_chat(request: Request):
         # 下面的 BM25 regen/drop）一律豁免，免得模板化 intro 被误判为复读、把自
         # 发推歌/推图压到极低频。素材雷同（反复推同一曲目 / 同一关键词）才回落
         # 到正常台词判定。一次算清，下面两道门共用。
-        _material_key = _proactive_material_key(source_tag, selected_music_link, meme_content)
+        #
+        # 归类按"真实投递 channel"而非模型原始 source_tag——gate 在
+        # build_proactive_response 之前，用 Phase-1 已定的 selected_*/active_channels
+        # 预测最终投递（Codex P2）：
+        # - music-only 且已选中曲目 → 无论模型出 [CHAT] 还是 [MUSIC]，下面的
+        #   should_try_music_fallback 都会挂上曲目，本轮等于一次音乐投递，fresh
+        #   曲目不该被 CHAT 文案的字面相似度 / BM25 连带 drop/regen。
+        # - 模型出 [MEME] 但没选中表情包（selected_meme_link 为空）→ 最终
+        #   build_proactive_response 回退 web/vision/plain、meme 没真发出，按非豁免
+        #   走正常台词判定（不能凭模型 tag 就豁免）。
+        _music_only_pending = (
+            'music' in active_channels and selected_music_link is not None
+            and not is_playing_music and not music_cooldown
+            and not any(ch in ('vision', 'web', 'meme') for ch in active_channels)
+        )
+        if _music_only_pending and source_tag != 'MUSIC':
+            _dedup_tag = 'MUSIC'
+        elif source_tag == 'MEME' and selected_meme_link is None:
+            _dedup_tag = 'CHAT'
+        else:
+            _dedup_tag = source_tag
+        _material_key = _proactive_material_key(_dedup_tag, selected_music_link, meme_content)
         _exempt_text_dedup = (
-            source_tag in ANTI_REPEAT_EXEMPT_SOURCE_TAGS
-            and not _is_recent_proactive_material(lanlan_name, source_tag, _material_key)
+            _dedup_tag in ANTI_REPEAT_EXEMPT_SOURCE_TAGS
+            and not _is_recent_proactive_material(lanlan_name, _dedup_tag, _material_key)
         )
         if _exempt_text_dedup:
             logger.info(
-                "[%s] proactive text-dedup exempt: tag=%s material=%r (fresh material, skip similarity+BM25)",
-                lanlan_name, source_tag, _material_key or "(none)",
+                "[%s] proactive text-dedup exempt: tag=%s (model_tag=%s) material=%r (fresh material, skip similarity+BM25)",
+                lanlan_name, _dedup_tag, source_tag, _material_key or "(none)",
             )
 
         is_duplicate, similarity_score = (False, 0.0)
@@ -7325,14 +7346,26 @@ async def proactive_chat(request: Request):
             if not music_already_appended:
                 _append_music_recommendations(source_links, music_content)
 
-        # anti-repeat / 素材去重按"真实投递的 channel"归类，而非模型原始 source_tag：
-        # Phase 1 只有音乐时模型可能合法出 [CHAT]，随后 should_try_music_fallback 仍
-        # 追加曲目并置 is_music_used=True——此时实际投递的是音乐。若仍按 CHAT 记录，
-        # finish_proactive_delivery 会把模板化 intro 录进 BM25 corpus、且曲目 key 不
-        # 记，恰好重新引入本 PR 要消除的 fallback 推歌污染（Codex P2）。曲目优先取
-        # selected_music_link；regen 把 tag 降级 CHAT 时它已被清空，则从已追加的
-        # source_links（source=='音乐推荐'）里取首条。
-        _delivered_tag = 'MUSIC' if (is_music_used and source_tag != 'MUSIC') else source_tag
+        # anti-repeat / 素材去重按"真实投递的 channel"归类，而非模型原始 source_tag
+        # （此处 primary_channel 已由 build_proactive_response 按实际 source_links 定下，
+        # 比 gate 的 Phase-1 预测更准）（Codex P2）：
+        # - is_music_used（含模型出 [CHAT] 但 should_try_music_fallback 追加了曲目）
+        #   或 primary_channel=='music' → 实际投递音乐 → MUSIC：否则模板 intro 会被
+        #   按 CHAT 录进 BM25 corpus、且曲目 key 不记，重新引入 fallback 推歌污染。
+        # - 仅当 primary_channel=='meme' 且确有表情包链接（selected_meme_link 非空，
+        #   build_proactive_response 此时才真 append 图）才算 MEME 投递；模型出 [MEME]
+        #   但选空时它已回退别的 channel（甚至 primary 仍是 'meme' 但无链接），不能按
+        #   MEME 记——否则模板文案漏录 corpus，且把没发出的关键词记成已投递，害得之后
+        #   同关键词的真表情包被当复读跳过。
+        # - 其余落到非豁免 CHAT（WEB/vision 同样非豁免，对 anti-repeat 等价）。
+        if is_music_used or primary_channel == 'music':
+            _delivered_tag = 'MUSIC'
+        elif primary_channel == 'meme' and selected_meme_link is not None:
+            _delivered_tag = 'MEME'
+        else:
+            _delivered_tag = 'CHAT'
+        # 曲目优先取 selected_music_link；regen 把 tag 降级 CHAT 时它已被清空，则从已
+        # 追加的 source_links（source=='音乐推荐'）里取首条。
         _delivered_music_link = selected_music_link
         if _delivered_tag == 'MUSIC' and not _delivered_music_link:
             _delivered_music_link = next(

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1299,6 +1299,15 @@ async def get_changelog(since: str = "", lang: str = ""):
 # {lanlan_name: deque([(timestamp, message), ...], maxlen=10)}
 _proactive_chat_history: dict[str, deque] = {}
 
+# --- 主动搭话"素材标识"近期去重暂存区（ANTI_REPEAT_EXEMPT_SOURCE_TAGS 用）---
+# {lanlan_name: {source_tag: deque([(timestamp, material_key), ...], maxlen=N)}}
+# 素材推送类 channel（MUSIC/MEME）豁免台词级复读判定，改按"素材本身"去重：
+# MUSIC 看曲目（title|artist），MEME 看搜索关键词。本轮素材与近期不雷同就放行；
+# 雷同才回落到台词判定。进程内、重启清零——短期复读保护，与 _proactive_chat_
+# history / _mini_game_invite_state 同样是内存态即可。
+_proactive_material_history: dict[str, dict[str, deque]] = {}
+_PROACTIVE_MATERIAL_HISTORY_MAX = 10
+
 # --- Mini-game 邀请短路状态（每角色独立）---
 # {lanlan_name: {'delivered_at': float|None,
 #                'responded_at': float|None,
@@ -1934,6 +1943,62 @@ def _record_proactive_chat(lanlan_name: str, message: str, channel: str = ''):
     except Exception:
         # 埋点失败不能影响主动搭话投递
         pass
+
+
+def _normalize_material_key(raw: str) -> str:
+    """Normalize a material identity string for exact-match dedup (lowercase + collapse whitespace)."""
+    s = (raw or "").strip().lower()
+    return re.sub(r'\s+', ' ', s)
+
+
+def _proactive_material_key(
+    source_tag: str | None,
+    selected_music_link: dict | None,
+    meme_content: dict | None,
+) -> str:
+    """Compute the dedup identity of the material this round pushes.
+
+    - MUSIC → the picked track (title|artist); two different songs never collide
+    - MEME → the **search keyword** (not the image): same keyword reused soon is a
+      repeat, a fresh keyword is not. Random hot-word fallback has an empty keyword
+      → empty key → treated as "never a repeat" (each random fetch is varied)
+
+    Empty/unknown → "" (caller treats as non-repeat, i.e. always exempt).
+    """
+    if source_tag == 'MUSIC' and selected_music_link:
+        title = (selected_music_link.get('title') or '').strip()
+        artist = (selected_music_link.get('artist') or '').strip()
+        return _normalize_material_key(f"{title}|{artist}") if (title or artist) else ""
+    if source_tag == 'MEME' and meme_content:
+        return _normalize_material_key(meme_content.get('keyword') or '')
+    return ""
+
+
+def _is_recent_proactive_material(lanlan_name: str, source_tag: str, key: str) -> bool:
+    """Whether *key* was pushed for *source_tag* within the recent window (exact match).
+
+    Empty key → never a repeat (no material identity to compare on).
+    """
+    if not key:
+        return False
+    bucket = _proactive_material_history.get(lanlan_name, {}).get(source_tag)
+    if not bucket:
+        return False
+    now = time.time()
+    return any(
+        k == key and now - ts < _RECENT_CHAT_MAX_AGE_SECONDS
+        for ts, k in bucket
+    )
+
+
+def _record_proactive_material(lanlan_name: str, source_tag: str, key: str) -> None:
+    """Record one successfully delivered material identity (skip empty keys)."""
+    if not key:
+        return
+    per_tag = _proactive_material_history.setdefault(lanlan_name, {})
+    if source_tag not in per_tag:
+        per_tag[source_tag] = deque(maxlen=_PROACTIVE_MATERIAL_HISTORY_MAX)
+    per_tag[source_tag].append((time.time(), key))
 
 
 def _open_threads_for_activity_state(activity_snapshot, fresh_open_threads) -> list[str]:
@@ -6939,7 +7004,25 @@ async def proactive_chat(request: Request):
         logger.debug(f"[{lanlan_name}] Phase 2 流式完成 (vision={phase2_use_vision}, len={len(response_text)} chars)")
         print(f"\n[PROACTIVE-DEBUG] Phase 2 STREAM output: {response_text[:200]}...\n")
 
-        is_duplicate, similarity_score = _is_similar_to_recent_proactive_chat(lanlan_name, response_text)
+        # 素材推送类 channel（MUSIC/MEME）的复读按"素材本身"去重而非台词：本轮
+        # 素材（曲目 / 搜索关键词）与近期不雷同时，台词级硬拦截（字面相似度 +
+        # 下面的 BM25 regen/drop）一律豁免，免得模板化 intro 被误判为复读、把自
+        # 发推歌/推图压到极低频。素材雷同（反复推同一曲目 / 同一关键词）才回落
+        # 到正常台词判定。一次算清，下面两道门共用。
+        _material_key = _proactive_material_key(source_tag, selected_music_link, meme_content)
+        _exempt_text_dedup = (
+            source_tag in ANTI_REPEAT_EXEMPT_SOURCE_TAGS
+            and not _is_recent_proactive_material(lanlan_name, source_tag, _material_key)
+        )
+        if _exempt_text_dedup:
+            logger.info(
+                "[%s] proactive text-dedup exempt: tag=%s material=%r (fresh material, skip similarity+BM25)",
+                lanlan_name, source_tag, _material_key or "(none)",
+            )
+
+        is_duplicate, similarity_score = (False, 0.0)
+        if not _exempt_text_dedup:
+            is_duplicate, similarity_score = _is_similar_to_recent_proactive_chat(lanlan_name, response_text)
         if is_duplicate:
             logger.info(
                 "[%s] proactive repeat guard blocked Phase 2 output (similarity=%.3f threshold=%.2f)",
@@ -6973,12 +7056,14 @@ async def proactive_chat(request: Request):
         # ``PROACTIVE_PHASE2_GENERATE_MAX_TOKENS`` / ``render_regen_avoid_instruction``）；
         # 这里 try 仅包 corpus 单例与评分本身——若把常量 import 也塞进 try，
         # except 后下面的 ``>= ANTI_REPEAT_DROP_THRESHOLD`` 会 NameError（codex P1）。
-        # 素材推送类 channel（推歌）的开场白天生模板化、台词长一个样而曲目不
-        # 同，用台词 BM25 判复读属于天生误杀（博士连点几首后 FG 窗被音乐 intro
-        # 占满，分数爆表，后续自发推歌全被 drop → "放音乐频率极低"）。这类
-        # channel 的复读按曲目去重而非台词，故整段评分 + regen/drop 直接跳过；
-        # 录入 corpus 时同样豁免（见 finish_proactive_delivery），免得污染 FG 窗。
-        if source_tag in ANTI_REPEAT_EXEMPT_SOURCE_TAGS:
+        # 素材推送类 channel（推歌/推图）的开场白天生模板化、台词长一个样而素材
+        # （曲目 / 搜索关键词）却不同，用台词 BM25 判复读属于天生误杀（博士连点几
+        # 首后 FG 窗被音乐 intro 占满，分数爆表，后续自发推歌全被 drop → "放音乐
+        # 频率极低"）。本轮素材与近期不雷同时（_exempt_text_dedup，已在上方字面
+        # 相似度门一并算好）跳过整段评分 + regen/drop；录入 corpus 时也豁免（见
+        # finish_proactive_delivery），免得模板化 intro 污染 FG 窗。素材雷同时
+        # 回落到正常台词 BM25（台词没雷同仍可发）。
+        if _exempt_text_dedup:
             _bm25_total, _bm25_terms = 0.0, {}
             _ar_corpus = None
         else:
@@ -7290,6 +7375,14 @@ async def proactive_chat(request: Request):
 
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)
+        # 记录本轮实际投递的"素材标识"（曲目 / 搜索关键词），供下次同 channel 的
+        # 素材级去重。按最终 source_tag/selected_music_link 重算——regen 可能已把
+        # MUSIC 降级成 CHAT 并清掉 selected_music_link，此时 key 为空不记录。
+        _record_proactive_material(
+            lanlan_name,
+            source_tag,
+            _proactive_material_key(source_tag, selected_music_link, meme_content),
+        )
         # Mini-game 邀请冷却 counter 推进：spec 是"被回应后再 10 次搭话才解禁"，
         # 任何 channel 的成功投递都算一次，pending 期间（responded_at=None）函数
         # 内部自然 no-op，不靠"邀请自身"提前耗 counter。

--- a/tests/unit/test_proactive_material_dedup.py
+++ b/tests/unit/test_proactive_material_dedup.py
@@ -1,0 +1,105 @@
+"""主动搭话"素材级去重"契约（ANTI_REPEAT_EXEMPT_SOURCE_TAGS 用）。
+
+素材推送类 channel（MUSIC/MEME）豁免台词级复读判定，改按"素材本身"去重：
+MUSIC 看曲目（title|artist），MEME 看搜索关键词（不是图片）。覆盖：
+
+1. _proactive_material_key：MUSIC 取曲目、MEME 取搜索关键词、非素材 channel /
+   空素材 → 空 key；归一化（大小写 + 折叠空白）。
+2. _is_recent_proactive_material：同素材近期算雷同、异素材不算、空 key 永不算。
+3. 近期窗口按 _RECENT_CHAT_MAX_AGE_SECONDS 过期。
+4. _record_proactive_material：空 key 不记录；按 source_tag 分桶互不串。
+"""
+import os
+import sys
+import time
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from main_routers import system_router as sr
+
+
+def _clear(name="测试角色"):
+    sr._proactive_material_history.pop(name, None)
+
+
+# ── 1. material key 计算 ─────────────────────────────────────
+
+
+def test_material_key_music_is_title_artist():
+    key = sr._proactive_material_key("MUSIC", {"title": "Bong Hoa", "artist": "Dat Nguyen"}, None)
+    assert key == "bong hoa|dat nguyen"
+
+
+def test_material_key_meme_is_search_keyword_not_image():
+    # MEME 取搜索关键词，与 url/title 无关
+    key = sr._proactive_material_key(
+        "MEME", None, {"keyword": "Disaster Girl", "url": "http://x/y.png"}
+    )
+    assert key == "disaster girl"
+
+
+def test_material_key_normalizes_whitespace_and_case():
+    a = sr._proactive_material_key("MEME", None, {"keyword": "  猫   可爱 "})
+    b = sr._proactive_material_key("MEME", None, {"keyword": "猫 可爱"})
+    assert a == b == "猫 可爱"
+
+
+def test_material_key_empty_for_non_material_channels():
+    assert sr._proactive_material_key("CHAT", None, None) == ""
+    assert sr._proactive_material_key("WEB", {"title": "x"}, None) == ""
+
+
+def test_material_key_empty_when_no_material():
+    # 随机热词 fallback 的 MEME（空关键词）→ 空 key
+    assert sr._proactive_material_key("MEME", None, {"keyword": ""}) == ""
+    # MUSIC 但没选中曲目 → 空 key
+    assert sr._proactive_material_key("MUSIC", None, None) == ""
+
+
+# ── 2. 近期素材去重判定 ──────────────────────────────────────
+
+
+def test_recent_material_same_is_repeat_different_is_not():
+    name = "测试角色"
+    _clear(name)
+    sr._record_proactive_material(name, "MUSIC", "bong hoa|dat nguyen")
+    assert sr._is_recent_proactive_material(name, "MUSIC", "bong hoa|dat nguyen") is True
+    assert sr._is_recent_proactive_material(name, "MUSIC", "other song|x") is False
+
+
+def test_empty_key_never_repeat():
+    name = "测试角色"
+    _clear(name)
+    assert sr._is_recent_proactive_material(name, "MEME", "") is False
+
+
+def test_record_skips_empty_key():
+    name = "测试角色"
+    _clear(name)
+    sr._record_proactive_material(name, "MEME", "")
+    assert name not in sr._proactive_material_history or not sr._proactive_material_history[name].get("MEME")
+
+
+def test_tags_are_separate_buckets():
+    name = "测试角色"
+    _clear(name)
+    sr._record_proactive_material(name, "MUSIC", "lofi cat")
+    # 同字串落在 MEME 桶时不应命中 MUSIC 桶记录
+    assert sr._is_recent_proactive_material(name, "MEME", "lofi cat") is False
+    assert sr._is_recent_proactive_material(name, "MUSIC", "lofi cat") is True
+
+
+# ── 3. 近期窗口过期 ──────────────────────────────────────────
+
+
+def test_recent_material_expires_after_window():
+    name = "测试角色"
+    _clear(name)
+    from collections import deque
+
+    # 手动塞一条"很久以前"的记录，超出 _RECENT_CHAT_MAX_AGE_SECONDS
+    stale_ts = time.time() - sr._RECENT_CHAT_MAX_AGE_SECONDS - 10
+    sr._proactive_material_history[name] = {
+        "MUSIC": deque([(stale_ts, "old song|x")], maxlen=sr._PROACTIVE_MATERIAL_HISTORY_MAX)
+    }
+    assert sr._is_recent_proactive_material(name, "MUSIC", "old song|x") is False

--- a/tests/unit/test_proactive_material_dedup.py
+++ b/tests/unit/test_proactive_material_dedup.py
@@ -1,13 +1,16 @@
-"""主动搭话"素材级去重"契约（ANTI_REPEAT_EXEMPT_SOURCE_TAGS 用）。
+"""Material-level dedup contract for proactive chat (ANTI_REPEAT_EXEMPT_SOURCE_TAGS).
 
-素材推送类 channel（MUSIC/MEME）豁免台词级复读判定，改按"素材本身"去重：
-MUSIC 看曲目（title|artist），MEME 看搜索关键词（不是图片）。覆盖：
+Material-push channels (MUSIC/MEME) are exempt from caption-level repeat checks and
+deduped on the material itself: MUSIC keys on the track, MEME on the search keyword
+(not the image). Coverage:
 
-1. _proactive_material_key：MUSIC 取曲目、MEME 取搜索关键词、非素材 channel /
-   空素材 → 空 key；归一化（大小写 + 折叠空白）。
-2. _is_recent_proactive_material：同素材近期算雷同、异素材不算、空 key 永不算。
-3. 近期窗口按 _RECENT_CHAT_MAX_AGE_SECONDS 过期。
-4. _record_proactive_material：空 key 不记录；按 source_tag 分桶互不串。
+1. _proactive_material_key: MUSIC -> track, MEME -> search keyword, non-material
+   channel / empty material -> empty key; normalized (lowercase + collapsed space).
+2. _is_recent_proactive_material: same material recently = repeat, different = not,
+   empty key = never a repeat.
+3. Recent window expires after _RECENT_CHAT_MAX_AGE_SECONDS.
+4. _record_proactive_material: empty key not recorded; per-source_tag buckets stay
+   separate.
 """
 import os
 import sys
@@ -33,7 +36,7 @@ def test_material_key_music_is_title_artist():
 def test_material_key_meme_is_search_keyword_not_image():
     # MEME 取搜索关键词，与 url/title 无关
     key = sr._proactive_material_key(
-        "MEME", None, {"keyword": "Disaster Girl", "url": "http://x/y.png"}
+        "MEME", None, {"keyword": "Disaster Girl", "url": "https://x/y.png"}
     )
     assert key == "disaster girl"
 


### PR DESCRIPTION
## 问题

主动搭话的 anti-repeat BM25 是为「话题/措辞复读」设计的，但素材推送类 channel（推歌、推表情包）的开场白天生模板化（推歌「换首歌/这旋律/听听看」、推图「看这个/笑死」），台词长一个样、而推送的素材（曲目 / 搜索关键词）却不同。博士连点几首歌后，FG 窗被音乐 intro 占满，BM25 爆表（线上实测 60~95，远超 DROP=16），后续**自发**推歌连 regen 都救不回、整轮 drop，表现为「放音乐频率极低」。（用户主动点歌走 user-initiated 路径不过这套 dedup，所以点了能放，被压制的全是她自己想起来推的。）

## 改动

把复读判定从**台词**切到**素材维度**：

- `ANTI_REPEAT_EXEMPT_SOURCE_TAGS = {MUSIC, MEME}`
- 豁免是**条件式**的：本轮素材（MUSIC=曲目 `title|artist`，MEME=**搜索关键词**，不是图片）与近期不雷同时，豁免台词级硬拦截（字面相似度 90% + BM25 regen/drop）直接放行；素材雷同（反复推同一曲目 / 同一关键词）才回落到正常台词判定，台词没雷同则依然能发。
- 新增进程内 `_proactive_material_history`（按 `source_tag` 分桶、1h 窗口）记录已投递的素材标识；投递成功后按最终 tag 重算 key 记录（regen 把 MUSIC 降级成 CHAT 时 key 为空不记录）。
- 这类 channel 的台词不再录进 anti-repeat corpus（`finish_proactive_delivery` 加 `source_tag` 参数），免得模板化 intro 污染 FG 窗、漂移其它 channel 的复读基线。
- 随机热词 fallback 的 MEME（空关键词）→ 空 key → 视作永不雷同，照常放行。
- soft 信号保留：台词仍进 `_proactive_chat_history`（喂 prompt 的「最近自发发言」块做软提示去重），只是移除硬拦截。

## 测试

- 新增 `tests/unit/test_proactive_material_dedup.py`（10 项）锁 helper 契约：素材 key 计算 / 归一化 / 分桶 / 1h 过期 / 空 key 永不雷同。
- 回归：`test_anti_repeat` / `test_proactive_*` / `test_game_router_concurrency` 全过。
- 注：`test_game_router.py::test_badminton_template_contract` 为存量失败（base 同样红，读 badminton_demo.html 模板，与本 PR 无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 为主动搭话新增“素材级”精确去重豁免：音乐与表情包类素材不再按台词相似度误判重复。
  * 记录与后续去重现在支持按素材来源标识进行衔接。
* **Bug Fixes**
  * 改进主动搭话拦截：命中豁免时跳过相似度比对及后续重生成/丢弃流程。
* **Tests**
  * 新增单元测试覆盖素材键生成、归一化与近期重复判定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 回归报告

**改动**：`main_logic/core.py` `finish_proactive_delivery` 加 `source_tag` 参数（豁免 tag 的台词不录进 anti-repeat corpus）；`main_routers/system_router.py` 新增素材级去重（`_proactive_material_history` + helpers），把 MUSIC/MEME 主动搭话的复读判定从台词切到素材维度，gate 与记录两侧均按「真实投递 channel」归类。

**必要性**：推歌/推图的开场白天生模板化、台词雷同，原 anti-repeat 台词 BM25 把自发推送误判为复读并 drop，导致放音乐频率被压到极低（线上实测 BM25 60~95，远超 DROP=16）。

**前后行为**：
- 前：MUSIC/MEME 自发推送的模板 intro 进 corpus + 走台词 BM25 → 连点几首后 FG 窗被占满、分数爆表、后续整轮 drop。
- 后：素材（曲目 / 搜索关键词）与近期不雷同 → 豁免台词级硬拦截（字面相似度 + BM25）直接放行；素材雷同才回落正常台词判定（台词没雷同仍发）。模板 intro 不再进 corpus；台词仍进 `_proactive_chat_history` 供 prompt 软提示（软去重保留、只去硬杀）。用户主动点歌路径（user-initiated）不受影响。

**潜在回归**：
- 豁免范围限定 `ANTI_REPEAT_EXEMPT_SOURCE_TAGS={MUSIC,MEME}`，CHAT/WEB 等台词判定完全不变。
- 素材去重为进程内态（`_proactive_material_history`，1h 窗、按 tag 分桶），重启清零——短期复读保护，与既有 `_proactive_chat_history`/`_mini_game_invite_state` 同级，无持久化依赖。
- 归类按真实投递（gate 用 Phase-1 预测、记录用 primary_channel + selected_meme_link），覆盖「模型出 CHAT 但 music fallback 追加曲目」「[MEME] 选空回退」两个边界，避免误录/漏录 corpus。
- 既有 anti_repeat / proactive / game_router 单测全过；新增 `test_proactive_material_dedup.py` 锁 helper 契约。
