### PR TITLE
fix: 重建悬浮按钮时摘除孤儿锁图标 ticker，修复每帧 CPU 泄漏

### DIFF
--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -4956,6 +4956,15 @@ const AvatarButtonMixin = {
                 this._returnButtonDragHandlers = null;
             }
 
+            // 移除自身锁图标 ticker —— 下方会把旧锁图标 DOM 一并删掉，但 _removeFloatingButtonsElement
+            // 只调用 el.remove() 不会摘除 ticker。若不在此处摘除，旧 ticker 会变成孤儿，继续每帧 mutate
+            // 已脱离文档的节点（CPU 泄漏，跨 goodbye/return、模型切换循环累积）。镜像 setupHTMLLockIcon /
+            // cleanupFloatingButtons 的拆除逻辑；全新锁图标会在 setupHTMLLockIcon 里重新 add ticker。
+            if (this._lockIconTicker && this.pixi_app && this.pixi_app.ticker) {
+                try { this.pixi_app.ticker.remove(this._lockIconTicker); } catch (_) {}
+                this._lockIconTicker = null;
+            }
+
             // 清理旧 DOM（自身类型）—— 先清理旧容器上的入场动画状态，避免定时器残留
             document.querySelectorAll(`#${options.containerElementId}, #${options.lockIconId}, #${options.returnContainerId}`)
                 .forEach(el => {

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -5927,6 +5927,19 @@ const AvatarButtonMixin = {
                 this._uiUpdateLoopId = null;
             }
 
+            // 摘除浮动按钮 / 锁图标 ticker —— 下方会删掉它们的 DOM，但 _removeFloatingButtonsElement
+            // 只调 el.remove() 不会摘 ticker；与 setupFloatingButtonsBase 同病：不在此处摘除，旧 ticker 会
+            // 变成孤儿继续每帧 mutate 已脱离文档的节点（CPU 泄漏）。换模型时本方法被用于清理“切出去”的旧
+            // manager（见 setupFloatingButtonsBase 的 otherPrefixes 分支、card_maker 等），正是该泄漏的真实触发点。
+            if (this._lockIconTicker && this.pixi_app && this.pixi_app.ticker) {
+                try { this.pixi_app.ticker.remove(this._lockIconTicker); } catch (_) {}
+                this._lockIconTicker = null;
+            }
+            if (this._floatingButtonsTicker && this.pixi_app && this.pixi_app.ticker) {
+                try { this.pixi_app.ticker.remove(this._floatingButtonsTicker); } catch (_) {}
+                this._floatingButtonsTicker = null;
+            }
+
             // 移除 DOM 元素（先清理自己的入场动画状态）
             document.querySelectorAll(`#${opts.containerElementId}, #${opts.lockIconId}, #${opts.returnContainerId}`)
                 .forEach(el => _removeFloatingButtonsElement(el));


### PR DESCRIPTION
## 问题

`Live2DManager.setupFloatingButtonsBase`(`static/avatar-ui-buttons.js`)在**重新调用却不重建锁图标**的路径下(如 showLive2d 重建路径、告别/返回的返回球重建路径),会经 `_removeFloatingButtonsElement` 删掉旧的 `#live2d-lock-icon` DOM —— 但该函数只调用 `el.remove()`,**不会**把 `this._lockIconTicker` 从 `this.pixi_app.ticker` 摘除。

锁图标 ticker 此前只在 `setupHTMLLockIcon`(`static/live2d-ui-buttons.js`)或 `cleanupFloatingButtons`(`static/live2d-model.js`)里才被拆除。于是旧 ticker 变成孤儿,继续每帧 mutate 一个已脱离文档节点的 `left/top`,直到下一次完整 teardown。视觉无感(节点已 detached),但是真实的**每帧 CPU 泄漏**,会跨告别/返回、模型切换循环不断累积。

## 修复

在 `setupFloatingButtonsBase` 删除自身锁图标 DOM **之前**,镜像 `setupHTMLLockIcon` / `cleanupFloatingButtons` 的拆除逻辑,从 `pixi_app.ticker` 摘除 `_lockIconTicker` 并置 `null`:

```js
if (this._lockIconTicker && this.pixi_app && this.pixi_app.ticker) {
    try { this.pixi_app.ticker.remove(this._lockIconTicker); } catch (_) {}
    this._lockIconTicker = null;
}
```

## 验证

- `node --check` 语法通过。
- **无重复移除**:置 `null` 后任何后续拆除路径(`setupHTMLLockIcon` 的 existingLockIcon 分支、`cleanupFloatingButtons`、`app-interpage.js`)都会跳过;PIXI 的 `ticker.remove()` 本身幂等。
- **新锁图标仍注册 ticker**:`setupHTMLLockIcon` 在 base 之后单独运行,无条件重新创建图标并 `ticker.add(tick)`。
- **对其他模型类型安全**:`this._lockIconTicker && this.pixi_app && this.pixi_app.ticker` 守卫,对没有该字段的 VRM/MMD/PNGTuber manager 是空操作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **错误修复**
  * 优化了浮动按钮组件的清理流程：在卸载/切换时移除与浮动按钮相关的动画更新器，避免旧锁图标或按钮动画在切换后持续逐帧更新，从而降低异常行为与资源占用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->