### PR TITLE
perf(activity): activity_guess 签名剔除 idle 桶，纯挂机/闲置不再空烧 LLM

### DIFF
--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -1167,17 +1167,23 @@ class UserActivityTracker:
                     continue
 
                 # State signature: which "kind of activity" the rule
-                # machine sees right now, plus whether the user has
-                # said something new. Quantize idle to coarse buckets
-                # so minor jitter doesn't trigger recompute.
-                idle_bucket = int((rule_snap.system_idle_seconds or 0) // 30)
+                # machine sees right now. Deliberately does NOT include the
+                # idle-seconds bucket: idle time grows monotonically while a
+                # user is AFK, so bucketing it (idle // 30) flips the signature
+                # every ~30s even when nothing about "what the user is doing"
+                # changed — defeating dedup and burning one emotion-tier call
+                # every ~40s during pure idle. The activity narration describes
+                # *what* the user is doing, and the only idle transitions worth
+                # re-narrating (active → idle → away) already show up in
+                # ``state`` (away itself bails above). Finer idle gradations add
+                # no narration value, so excluding the bucket lets a stable
+                # state + window + no-new-turn settle into a permanent skip.
                 sig = (
                     rule_snap.state,
                     (rule_snap.active_window.canonical
                         if rule_snap.active_window else None),
                     (rule_snap.active_window.subcategory
                         if rule_snap.active_window else None),
-                    idle_bucket,
                 )
                 if sig == self._activity_guess_state_sig and self._conv_seq == last_conv_seq:
                     continue

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1007,12 +1007,14 @@ def test_activity_guess_loop_skips_llm_when_narration_suppressed():
 
 
 def test_activity_guess_signature_excludes_idle_bucket():
-    """idle 秒数单调增长不应翻动 dedup 签名。
+    """idle seconds growing must not flip the dedup signature.
 
-    挂机时 system_idle_seconds 一直涨，旧实现把 idle//30 塞进 signature，
-    导致签名每 ~30s 翻一次、dedup 永久失效、纯闲置每 ~40s 空烧一次
-    emotion-tier LLM。signature 现在只按「在做什么」（state + 窗口 + 子类）
-    构成；idle→away 跃迁仍由 state 捕捉（away 本就 bail）。
+    While AFK, system_idle_seconds keeps climbing; the old code folded
+    idle//30 into the signature, flipping it every ~30s, defeating dedup
+    and burning one emotion-tier LLM call every ~40s during pure idle.
+    The signature now keys only on "what the user is doing" (state +
+    window + subcategory); the active->idle->away transition is still
+    caught by state (away bails anyway).
     """
     from main_logic.activity.tracker import UserActivityTracker
 

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1006,6 +1006,24 @@ def test_activity_guess_loop_skips_llm_when_narration_suppressed():
     )
 
 
+def test_activity_guess_signature_excludes_idle_bucket():
+    """idle 秒数单调增长不应翻动 dedup 签名。
+
+    挂机时 system_idle_seconds 一直涨，旧实现把 idle//30 塞进 signature，
+    导致签名每 ~30s 翻一次、dedup 永久失效、纯闲置每 ~40s 空烧一次
+    emotion-tier LLM。signature 现在只按「在做什么」（state + 窗口 + 子类）
+    构成；idle→away 跃迁仍由 state 捕捉（away 本就 bail）。
+    """
+    from main_logic.activity.tracker import UserActivityTracker
+
+    source = inspect.getsource(UserActivityTracker._activity_guess_loop)
+    assert "idle_bucket" not in source
+    # idle 秒数只应出现在喂 LLM 的 signals 里（_snapshot_signals_for_llm，
+    # 独立方法），不应再进入 _activity_guess_loop 的签名计算。
+    assert "system_idle_seconds" not in source
+    assert "sig = (" in source
+
+
 def test_conversation_turn_dispatcher_does_not_purge_topic_signals_for_redacted_turns():
     from main_logic.conversation_turns import ConversationTurnDispatcher, TopicHookTurnSink
 

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1017,10 +1017,11 @@ def test_activity_guess_signature_excludes_idle_bucket():
     from main_logic.activity.tracker import UserActivityTracker
 
     source = inspect.getsource(UserActivityTracker._activity_guess_loop)
+    # idle_bucket 是旧签名里按 idle 秒数分桶的那个变量名（空烧根因），断言它
+    # 不回归即精准守住该行为。不断言 "system_idle_seconds" not in source：那比
+    # 约束目标更宽，会误伤将来 loop 里对 idle 秒数的其它无害引用（喂 LLM 的
+    # signals 仍在 _snapshot_signals_for_llm 这个独立方法里用到它）。
     assert "idle_bucket" not in source
-    # idle 秒数只应出现在喂 LLM 的 signals 里（_snapshot_signals_for_llm，
-    # 独立方法），不应再进入 _activity_guess_loop 的签名计算。
-    assert "system_idle_seconds" not in source
     assert "sig = (" in source
 
 


### PR DESCRIPTION
#1922 的后续。#1922（goodbye_silent 门控）已合并，但它只覆盖「会话已结束、narration 无消费方」；本 PR 补另一条正交的空烧路径：**会话健康、但用户完全没新内容时仍每 ~40s 烧一次 LLM**。

## 问题

`_activity_guess_loop` 的 dedup 签名原本含 `idle_bucket = system_idle_seconds // 30`：

```python
sig = (state, 窗口 canonical, 子类, idle_bucket)
```

挂机时用户不动键鼠，`system_idle_seconds` 单调增长 → `idle_bucket` 每 ~30s 翻一格 → 签名「假性变化」→ dedup 永久失效 → **即使 state/窗口都没变、也没新对话，纯闲置场景仍每 ~40s 空烧一次 emotion-tier `call_activity_guess`**。这条路径 `goodbye_silent` 没触发（会话健康），所以 #1922 的 gate 兜不到。

## 修复

签名改为只按「在做什么」构成：

```python
sig = (state, 窗口 canonical, 子类)
```

idle 时间细分不带来 narration 价值；真正有意义的 active→idle→away 跃迁仍由 `state` 捕捉（away 本就 bail），跟猫说话由 `conv_seq` 捕捉。改后「state+窗口稳定 + 无新对话」即可永久 skip，纯挂机/闲置零 LLM。

## 回归报告

**改动**：`_activity_guess_loop` 的 dedup 签名剔除 `idle_bucket`，让纯闲置稳定 dedup。仅涉及 `main_logic/activity/tracker.py`。

**必要性**：自 PR #1845 把 activity 心跳全员化后，开着主动搭话的用户在「会话健康但闷头不动/挂机」时仍每 ~40s 空烧一次没人读的 emotion LLM；#1922 的 goodbye_silent gate 只覆盖会话已结束的情况，这条会话健康路径需单独治。

**前后行为**：
- 前：纯闲置（idle 桶每 30s 抖动）时，心跳每 ~40s 调一次 `call_activity_guess`。
- 后：state+窗口稳定、无新对话即永久 skip；用户切窗口 / active→idle→away 跃迁 / 说话后自然恢复 narration。

**潜在回归与缓解**：
- *剔除 idle 桶后漏刷 narration*：active→idle→away 跃迁由 `state` 捕捉、说话由 `conv_seq` 捕捉，仅损失「idle 30s vs 90s」纯时间细分，对「在干嘛」的描述无差异。
- *误伤规则心跳*：只动 activity_guess 的 LLM dedup，位于 `_tick_break_reminders` / 情境弹窗 drain / topic 候选之后；已加源码断言测试守住签名不含 idle。

## 测试

新增 1 个单测（断言签名不含 idle 桶）；`tests/test_activity_tracker_followup.py` + `tests/unit/test_topic_pipeline.py` 共 156 passed。

> 注：后端运行时行为，未在 worktree 实测；建议合并前在主仓库挂机复现确认纯闲置时那条周期请求消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能改进**
  * 优化活动追踪的去重签名：不再将“系统待机时长分桶”纳入签名计算，避免仅因空闲时间增长而触发重复重算，提升空闲场景下的响应效率。
* **测试**
  * 新增回归测试，确认活动签名去重逻辑不包含空闲分桶相关标识，并保持签名生成结构一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->