### PR TITLE
fix(llm): 接上 enable_cache_control 的 body 级 cache_control 注入，与 header 路解耦 (#1066)

### DIFF
--- a/config/providers.py
+++ b/config/providers.py
@@ -181,6 +181,11 @@ class CacheProviderConfig:
     base_url_pattern: str           # 用于 substring match
     cache_mode: str                 # "session" | "auto" | "upstream"
     requires_header: bool
+    # 是否需要在请求体里打 body 级缓存标记（Anthropic 风格
+    # cache_control: {"type": "ephemeral"}）。与 requires_header 正交：
+    # provider 可以两个都不要、只要其一、或两个都要。get_cache_kwargs 据此
+    # 决定是否给 ChatOpenAI 传 enable_cache_control=True，由 _params() 消费。
+    requires_body_flag: bool = False
     header_name: str | None = None
     header_value: str | None = None
     min_cache_tokens: int = 1024
@@ -341,16 +346,28 @@ def resolve_cache_provider(base_url: str | None) -> CacheProviderConfig | None:
 def get_cache_kwargs(base_url: str | None) -> dict[str, Any]:
     """Return the cache-related kwargs needed when constructing ChatOpenAI.
 
+    Two *orthogonal* cache-engagement mechanisms, keyed off the resolved
+    provider — a provider may need neither, either, or both:
+
+      - ``requires_header`` → inject the provider's session-cache header
+        (e.g. DashScope ``x-dashscope-session-cache: enable``). Header-only
+        providers (qwen) DO NOT get ``enable_cache_control``; their caching is
+        engaged entirely by the header.
+      - ``requires_body_flag`` → set ``enable_cache_control`` so
+        ``ChatOpenAI._params`` stamps an Anthropic-style
+        ``cache_control: {"type": "ephemeral"}`` marker onto the cache
+        breakpoint message (Anthropic direct / Anthropic-compat gateways).
+
     Returns:
         {"default_headers": dict, "enable_cache_control": bool}
     """
     provider = resolve_cache_provider(base_url)
-    if provider and provider.requires_header:
-        return {
-            "default_headers": {provider.header_name: provider.header_value},
-            "enable_cache_control": True,
-        }
+    if provider is None:
+        return {"default_headers": {}, "enable_cache_control": False}
+    headers: dict[str, str] = {}
+    if provider.requires_header and provider.header_name is not None:
+        headers[provider.header_name] = provider.header_value or ""
     return {
-        "default_headers": {},
-        "enable_cache_control": False,
+        "default_headers": headers,
+        "enable_cache_control": provider.requires_body_flag,
     }

--- a/config/providers.py
+++ b/config/providers.py
@@ -185,6 +185,12 @@ class CacheProviderConfig:
     # cache_control: {"type": "ephemeral"}）。与 requires_header 正交：
     # provider 可以两个都不要、只要其一、或两个都要。get_cache_kwargs 据此
     # 决定是否给 ChatOpenAI 传 enable_cache_control=True，由 _params() 消费。
+    #
+    # ⚠️ 切勿给 Anthropic 自家的 OpenAI 兼容端点（api.anthropic.com 走 OpenAI
+    # SDK，见 utils.llm_client.create_chat_llm 的 anthropic 分支）置 True：该兼容
+    # 层不支持 prompt caching，注入的 cache_control 会被静默忽略，结果是"报告开了
+    # 缓存却零命中"。需要 body 级缓存时，走原生 Messages API，或换一个明确支持该
+    # OpenAI-wire cache_control 形态的网关（Anthropic-compat / OpenRouter 等）再开。
     requires_body_flag: bool = False
     header_name: str | None = None
     header_value: str | None = None

--- a/docs/api_providers_fields.md
+++ b/docs/api_providers_fields.md
@@ -79,8 +79,8 @@
 
 | 字段 | 值 | 说明 |
 |------|-----|------|
-| `default_headers` | `{"x-dashscope-session-cache": "enable"}` | 开启会话级缓存 |
-| `enable_cache_control` | `True` | 启用缓存控制 |
+| `default_headers` | `{"x-dashscope-session-cache": "enable"}` | 开启会话级缓存（DashScope 走 **header 路**，缓存由此 header 启用） |
+| `enable_cache_control` | `False` | body 级 cache_control 标记开关，与 header 正交。DashScope 不需要 body 级标记（它是 OpenAI 兼容端点，不认 Anthropic 风格 `cache_control`），故为 `False`；缓存仍由上面的 header 生效。仅 `requires_body_flag=True` 的 provider（Anthropic 直连 / Anthropic-compat 网关）才置 `True`。 |
 
 ### 遥测字段 (Token Usage)
 

--- a/tests/test_cco_capacity.py
+++ b/tests/test_cco_capacity.py
@@ -138,8 +138,8 @@ def test_cache_hit_rate_scenarios():
 
 
 def test_provider_compatibility():
-    """测试提供商兼容性：enable_cache_control 只跟随 requires_body_flag，
-    与 requires_header 正交。header-only 的 qwen 现在应为 False。"""
+    """enable_cache_control tracks requires_body_flag only, orthogonal to
+    requires_header. Header-only providers (qwen) must now report False."""
     print("\n" + "="*70)
     print("测试: 提供商兼容性检查")
     print("="*70)
@@ -181,11 +181,12 @@ def test_min_cache_tokens_all_providers():
 
 
 def test_session_cache_header():
-    """测试 Session Cache Header (仅 qwen)。
+    """Session Cache Header (qwen only).
 
-    qwen 走 header 路：default_headers 注入 session-cache header，但
-    enable_cache_control 必须为 False —— 它不需要 body 级 cache_control 标记，
-    给 DashScope（OpenAI 兼容端点）打 Anthropic 风格 cache_control 是错的。
+    qwen takes the header path: default_headers carries the session-cache
+    header, but enable_cache_control must be False -- it needs no body-level
+    cache_control marker, and stamping an Anthropic-style cache_control onto
+    DashScope (an OpenAI-compatible endpoint) would be wrong.
     """
     print("\n" + "="*70)
     print("测试: Session Cache Header 配置")
@@ -209,8 +210,9 @@ def test_session_cache_header():
 
 
 def test_body_flag_drives_enable_cache_control():
-    """requires_body_flag=True 的 provider 才会拿到 enable_cache_control=True，
-    且与 requires_header 完全正交（可同时存在）。用临时合成 provider 验证装配。"""
+    """Only a provider with requires_body_flag=True gets enable_cache_control=True,
+    fully orthogonal to requires_header (both can coexist). Verified via a
+    temporary synthetic provider."""
     print("\n" + "="*70)
     print("测试: requires_body_flag 驱动 enable_cache_control")
     print("="*70)
@@ -240,7 +242,8 @@ def test_body_flag_drives_enable_cache_control():
 
 
 def test_inject_cache_control_helper():
-    """_inject_cache_control / _attach_cache_control：选断点、提升字符串、不改原对象。"""
+    """_inject_cache_control / _attach_cache_control: breakpoint selection,
+    string promotion, idempotency, and defensive no-mutation behavior."""
     print("\n" + "="*70)
     print("测试: body 级 cache_control 注入逻辑")
     print("="*70)
@@ -327,8 +330,9 @@ def test_inject_cache_control_helper():
 
 
 def test_params_consumes_enable_cache_control():
-    """端到端：ChatOpenAI._params 真正读取 self.enable_cache_control 并打标，
-    关掉时一字不改 —— 证明字段不再是死的。"""
+    """End-to-end: ChatOpenAI._params actually reads self.enable_cache_control
+    and stamps the marker, and changes nothing when off -- proving the field is
+    no longer dead."""
     print("\n" + "="*70)
     print("测试: _params 消费 enable_cache_control")
     print("="*70)

--- a/tests/test_cco_capacity.py
+++ b/tests/test_cco_capacity.py
@@ -138,28 +138,30 @@ def test_cache_hit_rate_scenarios():
 
 
 def test_provider_compatibility():
-    """测试提供商兼容性"""
+    """测试提供商兼容性：enable_cache_control 只跟随 requires_body_flag，
+    与 requires_header 正交。header-only 的 qwen 现在应为 False。"""
     print("\n" + "="*70)
     print("测试: 提供商兼容性检查")
     print("="*70)
 
     from config.providers import get_cache_kwargs
 
-    results = []
-
     for provider_id, config in PROVIDER_CACHE_CONFIG.items():
         cache_config = get_cache_kwargs(config["base_url"])
 
-        if provider_id in ("qwen", "qwen_intl", "qwen_us"):
-            expected = True
-        else:
-            expected = False
+        # body 级 cache flag 由 requires_body_flag 决定，而非 requires_header。
+        expected = config["requires_body_flag"]
 
         actual = cache_config["enable_cache_control"]
-        passed = actual == expected
         status = "[PASS]" if (actual == expected) else "[FAIL]"
         print(f"  {status} {config['name']}: 缓存控制 = {actual}")
         assert actual == expected, f"{config['name']}: expected {expected}, got {actual}"
+
+    # 没接 body-flag provider 时，全员都应该是 False（header 路不受影响）。
+    assert all(
+        not get_cache_kwargs(c["base_url"])["enable_cache_control"]
+        for c in PROVIDER_CACHE_CONFIG.values()
+    ), "当前没有 provider 需要 body 级 flag，enable_cache_control 应全为 False"
 
 
 def test_min_cache_tokens_all_providers():
@@ -179,7 +181,12 @@ def test_min_cache_tokens_all_providers():
 
 
 def test_session_cache_header():
-    """测试 Session Cache Header (仅 qwen)"""
+    """测试 Session Cache Header (仅 qwen)。
+
+    qwen 走 header 路：default_headers 注入 session-cache header，但
+    enable_cache_control 必须为 False —— 它不需要 body 级 cache_control 标记，
+    给 DashScope（OpenAI 兼容端点）打 Anthropic 风格 cache_control 是错的。
+    """
     print("\n" + "="*70)
     print("测试: Session Cache Header 配置")
     print("="*70)
@@ -193,12 +200,157 @@ def test_session_cache_header():
     print(f"    default_headers: {qwen_config['default_headers']}")
 
     expected_header = {"x-dashscope-session-cache": "enable"}
-    passed = qwen_config["enable_cache_control"] is True and qwen_config["default_headers"] == expected_header
+    passed = qwen_config["enable_cache_control"] is False and qwen_config["default_headers"] == expected_header
 
     status = "[PASS]" if passed else "[FAIL]"
     print(f"\n  {status} Session Cache Header 正确配置")
-    assert qwen_config["enable_cache_control"] is True, "enable_cache_control should be True"
+    assert qwen_config["enable_cache_control"] is False, "header-only provider 不应打 body flag"
     assert qwen_config["default_headers"] == expected_header, f"headers mismatch: {qwen_config['default_headers']}"
+
+
+def test_body_flag_drives_enable_cache_control():
+    """requires_body_flag=True 的 provider 才会拿到 enable_cache_control=True，
+    且与 requires_header 完全正交（可同时存在）。用临时合成 provider 验证装配。"""
+    print("\n" + "="*70)
+    print("测试: requires_body_flag 驱动 enable_cache_control")
+    print("="*70)
+
+    from config.providers import CACHE_PROVIDERS, CacheProviderConfig, get_cache_kwargs
+
+    fake = CacheProviderConfig(
+        provider_id="anthropic_test",
+        name="Anthropic (test)",
+        base_url="https://anthropic-test.example/v1",
+        base_url_pattern="anthropic-test.example",
+        cache_mode="auto",
+        requires_header=True,           # 故意两个都打开，验证正交
+        requires_body_flag=True,
+        header_name="x-test-cache",
+        header_value="on",
+    )
+    CACHE_PROVIDERS["anthropic_test"] = fake
+    try:
+        kw = get_cache_kwargs("https://anthropic-test.example/v1/messages")
+        print(f"  body-flag provider → {kw}")
+        assert kw["enable_cache_control"] is True, "requires_body_flag 应驱动 enable_cache_control"
+        assert kw["default_headers"] == {"x-test-cache": "on"}, "header 与 body flag 正交，应同时注入"
+        print("  [PASS] requires_body_flag 正确驱动 enable_cache_control 且与 header 正交")
+    finally:
+        del CACHE_PROVIDERS["anthropic_test"]
+
+
+def test_inject_cache_control_helper():
+    """_inject_cache_control / _attach_cache_control：选断点、提升字符串、不改原对象。"""
+    print("\n" + "="*70)
+    print("测试: body 级 cache_control 注入逻辑")
+    print("="*70)
+
+    from utils.llm_client import _inject_cache_control
+
+    EPH = {"type": "ephemeral"}
+
+    # 1) 有 system → 标在最后一条 system 上；字符串内容提升为 text part。
+    msgs = [
+        {"role": "system", "content": "you are a cat"},
+        {"role": "user", "content": "hi"},
+    ]
+    out = _inject_cache_control(msgs)
+    assert out[0]["content"] == [{"type": "text", "text": "you are a cat", "cache_control": EPH}]
+    assert out[1] == {"role": "user", "content": "hi"}, "非断点消息不应被改"
+    # 原列表与原 dict 不被 mutate
+    assert msgs[0]["content"] == "you are a cat", "原始消息被 mutate 了"
+    print("  [PASS] system 断点：字符串提升为带 cache_control 的 text part，原对象不变")
+
+    # 2) 没有 system → 标在最后一条消息。
+    msgs2 = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+    ]
+    out2 = _inject_cache_control(msgs2)
+    assert out2[0] == {"role": "user", "content": "a"}
+    assert out2[1]["content"] == [{"type": "text", "text": "b", "cache_control": EPH}]
+    print("  [PASS] 无 system：回退到最后一条消息")
+
+    # 3) content 已是 parts list → 标在最后一个 text part 上。
+    msgs3 = [{
+        "role": "system",
+        "content": [
+            {"type": "text", "text": "p1"},
+            {"type": "image_url", "image_url": {"url": "x"}},
+            {"type": "text", "text": "p2"},
+        ],
+    }]
+    out3 = _inject_cache_control(msgs3)
+    parts = out3[0]["content"]
+    assert parts[2] == {"type": "text", "text": "p2", "cache_control": EPH}
+    assert parts[0] == {"type": "text", "text": "p1"}, "非最后 text part 不应带标记"
+    assert parts[1] == {"type": "image_url", "image_url": {"url": "x"}}, "图片 part 不应带标记"
+    print("  [PASS] parts list：只标最后一个 text part，图片/前置 part 不动")
+
+    # 4) 断点选 leading 连续 system 段的末尾，trailing system（状态/归档提示）
+    #    不许偷走断点 —— 否则只缓存一句废话，长上下文白缓存。
+    msgs4 = [
+        {"role": "system", "content": "BIG STABLE SYSTEM PROMPT"},
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+        {"role": "system", "content": "你已断开连接"},  # trailing 噪声 system
+    ]
+    out4 = _inject_cache_control(msgs4)
+    assert out4[0]["content"] == [{"type": "text", "text": "BIG STABLE SYSTEM PROMPT", "cache_control": EPH}]
+    assert out4[3] == {"role": "system", "content": "你已断开连接"}, "trailing system 不应被标记"
+    print("  [PASS] leading system 段末尾被选中，trailing system 噪声不抢断点")
+
+    # 5) 幂等：对已打标的输出再跑一次，不二次打标、不 clobber 既有 marker。
+    once = _inject_cache_control([{"role": "system", "content": "s"}])
+    twice = _inject_cache_control(once)
+    assert twice is once, "已打标 → 原样返回，幂等"
+    rich = [{"role": "system", "content": [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]}]
+    assert _inject_cache_control(rich) is rich, "已有更丰富的 marker → 不覆盖"
+    print("  [PASS] 幂等：重复调用不二次打标，既有 marker 不被 clobber")
+
+    # 6) 防御分支：非 dict / None content / 纯图片 system / 空列表 / 空字符串。
+    assert _inject_cache_control([]) == []
+    img_only = [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "x"}}]}]
+    assert _inject_cache_control(img_only) is img_only, "无可标记 text → 原样返回"
+    empty_str = [{"role": "system", "content": ""}]
+    assert _inject_cache_control(empty_str) is empty_str, "空字符串 → 不造空 part"
+    none_content = [{"role": "system", "content": None}, {"role": "user", "content": "u"}]
+    # leading system 的 content=None 不可标记 → 整体 no-op（不回退到 user）。
+    assert _inject_cache_control(none_content) is none_content, "system content=None → no-op"
+    sys_img_only = [{"role": "system", "content": [{"type": "image_url", "image_url": {"url": "x"}}]}]
+    assert _inject_cache_control(sys_img_only) is sys_img_only, "纯图片 system → idx 为 None → no-op"
+    with_nondict = [{"role": "system", "content": "s"}, None, {"role": "user", "content": "u"}]
+    out6 = _inject_cache_control(with_nondict)
+    assert out6[0]["content"] == [{"type": "text", "text": "s", "cache_control": EPH}]
+    assert out6[1] is None, "非 dict 成员原样保留，不崩"
+    print("  [PASS] 防御分支：非 dict / None content / 纯图片 system 均安全 no-op 或跳过")
+
+
+def test_params_consumes_enable_cache_control():
+    """端到端：ChatOpenAI._params 真正读取 self.enable_cache_control 并打标，
+    关掉时一字不改 —— 证明字段不再是死的。"""
+    print("\n" + "="*70)
+    print("测试: _params 消费 enable_cache_control")
+    print("="*70)
+
+    from utils.llm_client import ChatOpenAI
+
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+    ]
+
+    on = ChatOpenAI(model="claude-x", base_url="https://x/v1", api_key="k", enable_cache_control=True)
+    p_on = on._params(msgs)
+    assert p_on["messages"][0]["content"] == [
+        {"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}
+    ], "enable_cache_control=True 时应打标"
+    print("  [PASS] enable_cache_control=True：system 消息被打上 cache_control")
+
+    off = ChatOpenAI(model="qwen-x", base_url="https://y/v1", api_key="k", enable_cache_control=False)
+    p_off = off._params(msgs)
+    assert p_off["messages"][0]["content"] == "sys", "关闭时不应改动消息"
+    print("  [PASS] enable_cache_control=False：消息原样下发")
 
 
 def main():
@@ -214,6 +366,9 @@ def main():
         ("提供商兼容性", test_provider_compatibility),
         ("最小缓存限制", test_min_cache_tokens_all_providers),
         ("Session Header", test_session_cache_header),
+        ("body-flag 驱动 enable_cache_control", test_body_flag_drives_enable_cache_control),
+        ("cache_control 注入逻辑", test_inject_cache_control_helper),
+        ("_params 消费 enable_cache_control", test_params_consumes_enable_cache_control),
     ]
 
     results = []

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -288,6 +288,94 @@ def _substitute_character_placeholders(messages: list, master: str, lanlan: str)
         out.append({**m, "content": new_content})
     return out
 
+
+# Anthropic-style ephemeral cache marker. Fresh dict per attach site so two
+# messages never alias the same mutable object.
+_CACHE_CONTROL_EPHEMERAL = {"type": "ephemeral"}
+_TEXT_PART_TYPES = ("text", "input_text", "output_text")
+
+
+def _attach_cache_control(message: dict) -> dict | None:
+    """Return a NEW message dict with ``cache_control: {"type": "ephemeral"}``
+    attached to a text content block, or ``None`` if there's nothing markable.
+
+    Anthropic (and Anthropic-compat gateways speaking OpenAI wire format) carry
+    the cache breakpoint on a content *block*, not on the message itself. A
+    plain-string ``content`` is promoted to a single text part so the marker
+    has somewhere to live; an existing parts list gets the marker on its last
+    text part. Defensive copy throughout — never mutates the input.
+
+    Caveat for whoever flips a provider on: this promotes a string ``system``
+    message into a content-parts array. Native Anthropic and most compat
+    gateways accept that, but a few stricter OpenAI-compatible endpoints only
+    allow array content on the ``user`` role — verify the target gateway, and
+    if needed steer the breakpoint to the last user message for that provider.
+    """
+    content = message.get("content")
+    if isinstance(content, str):
+        if not content:
+            return None
+        part = {"type": "text", "text": content, "cache_control": dict(_CACHE_CONTROL_EPHEMERAL)}
+        return {**message, "content": [part]}
+    if isinstance(content, list):
+        idx = next(
+            (i for i in range(len(content) - 1, -1, -1)
+             if isinstance(content[i], dict) and content[i].get("type") in _TEXT_PART_TYPES),
+            None,
+        )
+        if idx is None:
+            return None
+        # Idempotent: if the breakpoint part already carries a marker, leave it
+        # (and any richer TTL it may hold) untouched rather than clobbering it.
+        if "cache_control" in content[idx]:
+            return None
+        new_parts = list(content)
+        new_parts[idx] = {**new_parts[idx], "cache_control": dict(_CACHE_CONTROL_EPHEMERAL)}
+        return {**message, "content": new_parts}
+    return None
+
+
+def _inject_cache_control(messages: list) -> list:
+    """Return a NEW messages list with a single body-level cache breakpoint
+    marker on the most stable prefix — the END of the leading contiguous run of
+    ``system`` messages, falling back to the last message when there's no
+    leading system message.
+
+    The "leading contiguous" choice (rather than "last system message anywhere")
+    is deliberate: some role-tagged histories in this codebase append a
+    *trailing*, non-instructional system message later in the conversation
+    (status notices, archive markers). Anchoring to the leading system block
+    keeps the breakpoint on the large stable prefix instead of letting a tiny
+    trailing system note steal it and cache almost nothing.
+
+    Used only for providers whose caching needs a request-*body* flag rather
+    than a header (see ``config.providers.CacheProviderConfig.requires_body_flag``
+    / ``ChatOpenAI.enable_cache_control``). Header-based providers (DashScope)
+    never reach here. Defensive copy — the input list and its dicts are left
+    untouched, so repeated calls are idempotent. No-op (returns the input) when
+    the list is empty or the chosen message has no markable text content.
+    """
+    if not messages:
+        return messages
+    target: int | None = None
+    for i, m in enumerate(messages):
+        if isinstance(m, dict) and m.get("role") == "system":
+            target = i
+        else:
+            break
+    if target is None:
+        target = len(messages) - 1
+    chosen = messages[target]
+    if not isinstance(chosen, dict):
+        return messages
+    marked = _attach_cache_control(chosen)
+    if marked is None:
+        return messages
+    out = list(messages)
+    out[target] = marked
+    return out
+
+
 # ────────────────────────────────────────────────────────────────
 # Message classes
 # ────────────────────────────────────────────────────────────────
@@ -539,6 +627,11 @@ class ChatOpenAI:
         self.extra_body: dict = extra_body or {}
         self.max_completion_tokens = max_completion_tokens
         self.max_tokens = max_tokens
+        # When True, _params() stamps a body-level Anthropic-style
+        # cache_control marker onto the cache breakpoint message. Set by
+        # create_chat_llm via config.providers.get_cache_kwargs for providers
+        # with requires_body_flag (Anthropic direct / Anthropic-compat). Header
+        # cache providers (DashScope) leave this False — their header does the job.
         self.enable_cache_control = enable_cache_control
 
         if model_kwargs and "extra_body" in model_kwargs:
@@ -637,6 +730,16 @@ class ChatOpenAI:
                 p["messages"] = _substitute_character_placeholders(
                     p["messages"], master, lanlan
                 )
+
+        # Body-level cache flag: stamp an Anthropic-style cache_control marker
+        # onto the cache breakpoint. Gated on the provider opting in via
+        # requires_body_flag (no live provider does today, so this is a no-op
+        # for current traffic) — header-cache providers leave this False. Runs
+        # after character substitution so the marked text is already resolved,
+        # and before the leak check (which transparently scans list-of-parts
+        # content) so a promoted string still gets audited for placeholder leaks.
+        if self.enable_cache_control:
+            p["messages"] = _inject_cache_control(p["messages"])
 
         # Catch prompt-template leaks: literal {placeholder} that should have
         # been .format()-ed before reaching the wire. See


### PR DESCRIPTION
## 背景

Refs #1066。

`enable_cache_control` 此前是个**死字段**，而且**接错了线**：

- `config/providers.get_cache_kwargs()` 把 `enable_cache_control` 耦合在 `requires_header` 上 —— 即只为走 header 的 DashScope/qwen 置 `True`，而它们**恰恰不需要** body 级标记（header `x-dashscope-session-cache: enable` 已经搞定缓存）；
- `ChatOpenAI._params()` **从不读取** `self.enable_cache_control`。

结果：任何需要 body 级 `cache_control: {"type":"ephemeral"}` 的 provider（Anthropic 直连 / Anthropic-compat 网关）都拿不到隐式缓存标记，命中率拿不到预期效果。

## 改动

按 issue 自己列的三点方案，把机制真正接上：

1. **`config/providers.py`** —— `CacheProviderConfig` 新增 `requires_body_flag`，与 `requires_header` **正交**（一个 provider 可两个都不要 / 只要其一 / 两个都要）。`get_cache_kwargs` 解耦：header 按 `requires_header` 注入，`enable_cache_control` 改由 `requires_body_flag` 驱动。**qwen 现在正确返回 `enable_cache_control=False`，header 仍注入，缓存路径不受影响**。
2. **`utils/llm_client.py`** —— 新增 `_inject_cache_control` / `_attach_cache_control`：防御性拷贝（绝不 mutate 调用方的 messages），在缓存断点打上 ephemeral 标记。
   - 断点选 **leading 连续 system 段的末尾**（而非"最后一条 system"），避免会话里 trailing 的非指令 system 消息（状态/归档提示）偷走断点、只缓存一句废话；无 leading system 时回退到末条消息。
   - 字符串内容提升为 text part；已有 `cache_control` marker **幂等不覆盖**。
   - `_params()` 在 `self.enable_cache_control` 时消费它 —— 在字符替换之后、leak check 之前（leak check 透明支持 list-of-parts，提升后的 system 文本仍会被审计）。
3. **`tests/test_cco_capacity.py`** —— 更新 2 个用例适配新语义（qwen `enable_cache_control` 现为 False）；新增 3 个：正交装配、注入逻辑边界（leading/trailing system、幂等、非 dict/None content、纯图片 system）、`_params` 端到端消费证明字段不再是死的。

## 设计取舍

当前**无任何 provider 置 `requires_body_flag=True`**，因此对线上流量是 **no-op** —— 严格遵循 issue "先把轨道铺好、等遇到具体需要 body 级 flag 的 provider 接入时再翻"的意图。轨道铺好、可用、且有测试覆盖；要启用某个 provider（如给 Anthropic 直连加一条 `CACHE_PROVIDERS` 配置并置 `requires_body_flag=True`）时直接翻开关即可。

## 验证

- `python3 -m pytest tests/test_cco_capacity.py` → **10 passed**
- 对改动做了一轮多 agent 对抗式 review（正确性 / wire-format / 边界三个 lens + 逐条对抗验证），核心修复经独立确认无误（死字段端到端打通、运行期 mutation-safety、顺序与 leak-check 兼容），review 提出的硬化点（断点选 leading-contiguous、幂等不覆盖、防御分支补测）已在本 PR 一并落地。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增缓存提供商配置项 `requires_body_flag`，实现请求头/请求体缓存控制的正交生效。
  * 启用请求体缓存时，在被审计的消息内容结构中注入缓存断点标记，并保持幂等；系统消息前导位置与回退逻辑已更新。

* **测试**
  * 调整并新增 CCO 相关用例：基于 `requires_body_flag` 推导 `enable_cache_control`、会话头约束，以及端到端校验消息标记注入/不注入。

* **文档**
  * 更新 DashScope/Context Cache 字段说明，澄清其不使用 body 级 `cache_control`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
