### PR TITLE
同步紧凑/完整聊天框的主动搭话音乐播放器状态，通过后端 bridge 保证一次只有一个播放器 owner，并让当前使用的聊天框接管播放器显…

### DIFF
--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -55,6 +55,7 @@ _music_player_bridge_events: deque[dict[str, Any]] = deque(maxlen=_MUSIC_PLAYER_
 _music_player_surfaces: dict[str, dict[str, Any]] = {}
 _music_player_busy_until: dict[str, float] = {}
 _music_player_owner: str | None = None
+_music_player_playback_id: str | None = None
 _music_player_latest_state: dict[str, Any] | None = None
 _music_player_latest_state_expire_at = 0.0
 
@@ -87,7 +88,7 @@ def _sanitize_bridge_value(value: Any, *, depth: int = 0) -> Any:
 
 
 def _purge_music_player_bridge(now: float) -> None:
-    global _music_player_owner, _music_player_latest_state, _music_player_latest_state_expire_at
+    global _music_player_owner, _music_player_playback_id, _music_player_latest_state, _music_player_latest_state_expire_at
 
     for sender, surface in list(_music_player_surfaces.items()):
         if float(surface.get("expire_at") or 0) <= now:
@@ -101,6 +102,7 @@ def _purge_music_player_bridge(now: float) -> None:
         _music_player_latest_state = None
         _music_player_latest_state_expire_at = 0.0
         _music_player_owner = None
+        _music_player_playback_id = None
 
     while _music_player_bridge_events and float(_music_player_bridge_events[0].get("expire_at") or 0) <= now:
         _music_player_bridge_events.popleft()
@@ -181,6 +183,10 @@ def _public_music_player_bridge_event(event: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _music_player_playback_matches(playback_id: str) -> bool:
+    return not _music_player_playback_id or bool(playback_id and playback_id == _music_player_playback_id)
+
+
 @router.post("/api/music/player/bridge")
 async def post_music_player_bridge(request: Request):
     """
@@ -215,7 +221,7 @@ async def post_music_player_bridge(request: Request):
     payload = _sanitize_bridge_value(raw_body.get("payload") if isinstance(raw_body.get("payload"), dict) else {})
     surface_payload = raw_body.get("surface") if isinstance(raw_body.get("surface"), dict) else {}
 
-    global _music_player_owner, _music_player_latest_state, _music_player_latest_state_expire_at
+    global _music_player_owner, _music_player_playback_id, _music_player_latest_state, _music_player_latest_state_expire_at
     async with _music_player_bridge_lock:
         now = time.time()
         _purge_music_player_bridge(now)
@@ -226,27 +232,39 @@ async def post_music_player_bridge(request: Request):
 
         if event_type == "coord":
             coord_type = _bridge_string(payload.get("coordType"), max_len=32)
+            playback_id = _bridge_string(payload.get("playbackId"), max_len=512)
             if coord_type == "music_pending":
                 _music_player_busy_until[sender] = now + _MUSIC_PLAYER_PENDING_TTL_SECONDS
             elif coord_type in {"music_started", "music_heartbeat"}:
                 _music_player_busy_until[sender] = now + _MUSIC_PLAYER_ACTIVE_TTL_SECONDS
+                if coord_type == "music_started" and _music_player_owner == sender and playback_id:
+                    _music_player_playback_id = playback_id
             elif coord_type == "music_ended":
-                _music_player_busy_until.pop(sender, None)
-                if _music_player_owner == sender:
+                cleanup_matches = _music_player_owner != sender or _music_player_playback_matches(playback_id)
+                if cleanup_matches:
+                    _music_player_busy_until.pop(sender, None)
+                if _music_player_owner == sender and cleanup_matches:
                     _music_player_latest_state = None
                     _music_player_latest_state_expire_at = 0.0
                     _music_player_owner = None
+                    _music_player_playback_id = None
         elif event_type == "bar_state":
+            playback_id = _bridge_string(payload.get("playbackId"), max_len=512)
             _music_player_owner = sender
+            _music_player_playback_id = playback_id or None
             _music_player_latest_state = payload
             _music_player_latest_state_expire_at = now + _MUSIC_PLAYER_STATE_TTL_SECONDS
             _music_player_busy_until[sender] = now + _MUSIC_PLAYER_STATE_TTL_SECONDS
         elif event_type == "bar_destroyed":
-            _music_player_busy_until.pop(sender, None)
-            if _music_player_owner == sender:
+            playback_id = _bridge_string(payload.get("playbackId"), max_len=512)
+            cleanup_matches = _music_player_owner != sender or _music_player_playback_matches(playback_id)
+            if cleanup_matches:
+                _music_player_busy_until.pop(sender, None)
+            if _music_player_owner == sender and cleanup_matches:
                 _music_player_latest_state = None
                 _music_player_latest_state_expire_at = 0.0
                 _music_player_owner = None
+                _music_player_playback_id = None
 
         seq = _append_music_player_bridge_event(event_type, sender, payload, surface, now)
         return {"success": True, "seq": seq}

--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -25,8 +25,11 @@ enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio
+import time
+from collections import deque
+from typing import Any
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import RedirectResponse, Response, JSONResponse, StreamingResponse
 from cachetools import TTLCache
 import httpx
@@ -38,6 +41,245 @@ from urllib.parse import unquote, urlparse, urljoin
 router = APIRouter()
 
 logger = get_module_logger(__name__, "Music")
+
+_MUSIC_PLAYER_BRIDGE_EVENT_TTL_SECONDS = 90.0
+_MUSIC_PLAYER_BRIDGE_EVENT_LIMIT = 240
+_MUSIC_PLAYER_SURFACE_TTL_SECONDS = 8.0
+_MUSIC_PLAYER_PENDING_TTL_SECONDS = 12.0
+_MUSIC_PLAYER_ACTIVE_TTL_SECONDS = 35.0
+_MUSIC_PLAYER_STATE_TTL_SECONDS = 75.0
+
+_music_player_bridge_lock = asyncio.Lock()
+_music_player_bridge_seq = 0
+_music_player_bridge_events: deque[dict[str, Any]] = deque(maxlen=_MUSIC_PLAYER_BRIDGE_EVENT_LIMIT)
+_music_player_surfaces: dict[str, dict[str, Any]] = {}
+_music_player_busy_until: dict[str, float] = {}
+_music_player_owner: str | None = None
+_music_player_latest_state: dict[str, Any] | None = None
+_music_player_latest_state_expire_at = 0.0
+
+
+def _bridge_string(value: Any, *, max_len: int = 256) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value[:max_len]
+
+
+def _sanitize_bridge_value(value: Any, *, depth: int = 0) -> Any:
+    if depth > 5:
+        return None
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value if abs(value) < 1_000_000_000_000 else 0
+    if isinstance(value, str):
+        return value[:2048]
+    if isinstance(value, list):
+        return [_sanitize_bridge_value(item, depth=depth + 1) for item in value[:24]]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in list(value.items())[:64]:
+            if not isinstance(key, str):
+                continue
+            result[key[:96]] = _sanitize_bridge_value(item, depth=depth + 1)
+        return result
+    return None
+
+
+def _purge_music_player_bridge(now: float) -> None:
+    global _music_player_owner, _music_player_latest_state, _music_player_latest_state_expire_at
+
+    for sender, surface in list(_music_player_surfaces.items()):
+        if float(surface.get("expire_at") or 0) <= now:
+            _music_player_surfaces.pop(sender, None)
+
+    for sender, expire_at in list(_music_player_busy_until.items()):
+        if expire_at <= now:
+            _music_player_busy_until.pop(sender, None)
+
+    if _music_player_latest_state is not None and _music_player_latest_state_expire_at <= now:
+        _music_player_latest_state = None
+        _music_player_latest_state_expire_at = 0.0
+        _music_player_owner = None
+
+    while _music_player_bridge_events and float(_music_player_bridge_events[0].get("expire_at") or 0) <= now:
+        _music_player_bridge_events.popleft()
+
+
+def _normalize_music_surface(sender: str, payload: dict[str, Any], now: float) -> dict[str, Any]:
+    mode = _bridge_string(payload.get("mode") or payload.get("surface") or payload.get("kind"), max_len=32)
+    if mode not in {"compact", "full", "pet", "web", "unknown", "minimized"}:
+        mode = "unknown"
+    active = bool(payload.get("active"))
+    focused = bool(payload.get("focused", active))
+    visible = bool(payload.get("visible", active or focused))
+    return {
+        "sender": sender,
+        "mode": mode,
+        "active": active,
+        "focused": focused,
+        "visible": visible,
+        "reason": _bridge_string(payload.get("reason"), max_len=64),
+        "updated_at": now,
+        "expire_at": now + _MUSIC_PLAYER_SURFACE_TTL_SECONDS,
+    }
+
+
+def _choose_music_player_active_surface(now: float) -> dict[str, Any] | None:
+    _purge_music_player_bridge(now)
+    candidates = [
+        surface for surface in _music_player_surfaces.values()
+        if surface.get("active") or surface.get("focused") or surface.get("visible")
+    ]
+    if not candidates:
+        return None
+
+    mode_weight = {"full": 4, "compact": 3, "web": 2, "pet": 1, "unknown": 0, "minimized": -1}
+
+    def sort_key(surface: dict[str, Any]) -> tuple[int, int, int, float]:
+        active_weight = 2 if surface.get("active") else (1 if surface.get("focused") else 0)
+        visible_weight = 1 if surface.get("visible") else 0
+        return (
+            active_weight,
+            visible_weight,
+            mode_weight.get(str(surface.get("mode") or "unknown"), 0),
+            float(surface.get("updated_at") or 0),
+        )
+
+    selected = max(candidates, key=sort_key)
+    return {
+        key: value for key, value in selected.items()
+        if key not in {"expire_at"}
+    }
+
+
+def _append_music_player_bridge_event(
+    event_type: str,
+    sender: str,
+    payload: dict[str, Any],
+    surface: dict[str, Any],
+    now: float,
+) -> int:
+    global _music_player_bridge_seq
+    _music_player_bridge_seq += 1
+    _music_player_bridge_events.append({
+        "seq": _music_player_bridge_seq,
+        "type": event_type,
+        "sender": sender,
+        "payload": payload,
+        "surface": surface,
+        "ts": int(now * 1000),
+        "expire_at": now + _MUSIC_PLAYER_BRIDGE_EVENT_TTL_SECONDS,
+    })
+    return _music_player_bridge_seq
+
+
+def _public_music_player_bridge_event(event: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in event.items()
+        if key != "expire_at"
+    }
+
+
+@router.post("/api/music/player/bridge")
+async def post_music_player_bridge(request: Request):
+    """
+    Short-lived cross-window music player bridge.
+
+    Electron compact chat and full chat can run in isolated sessions, so browser
+    BroadcastChannel/localStorage are not enough to keep one visible player and
+    one audio owner. This endpoint stores only TTL-bound coordination events.
+    """
+    try:
+        raw_body = await request.json()
+    except Exception:
+        raw_body = {}
+    if not isinstance(raw_body, dict):
+        raw_body = {}
+
+    from .system_router import _validate_local_mutation_request
+
+    validation_error = _validate_local_mutation_request(
+        request,
+        payload=raw_body,
+        error_defaults={"success": False},
+    )
+    if validation_error is not None:
+        return validation_error
+
+    sender = _bridge_string(raw_body.get("sender"), max_len=128)
+    event_type = _bridge_string(raw_body.get("type"), max_len=32)
+    if not sender or event_type not in {"coord", "bar_state", "bar_destroyed", "bar_ctrl", "surface_state"}:
+        return JSONResponse(content={"success": False, "error": "invalid_bridge_event"}, status_code=400)
+
+    payload = _sanitize_bridge_value(raw_body.get("payload") if isinstance(raw_body.get("payload"), dict) else {})
+    surface_payload = raw_body.get("surface") if isinstance(raw_body.get("surface"), dict) else {}
+
+    global _music_player_owner, _music_player_latest_state, _music_player_latest_state_expire_at
+    async with _music_player_bridge_lock:
+        now = time.time()
+        _purge_music_player_bridge(now)
+        surface = _normalize_music_surface(sender, surface_payload, now)
+        if event_type == "surface_state":
+            surface = _normalize_music_surface(sender, payload, now)
+        _music_player_surfaces[sender] = surface
+
+        if event_type == "coord":
+            coord_type = _bridge_string(payload.get("coordType"), max_len=32)
+            if coord_type == "music_pending":
+                _music_player_busy_until[sender] = now + _MUSIC_PLAYER_PENDING_TTL_SECONDS
+            elif coord_type in {"music_started", "music_heartbeat"}:
+                _music_player_busy_until[sender] = now + _MUSIC_PLAYER_ACTIVE_TTL_SECONDS
+            elif coord_type == "music_ended":
+                _music_player_busy_until.pop(sender, None)
+                if _music_player_owner == sender:
+                    _music_player_latest_state = None
+                    _music_player_latest_state_expire_at = 0.0
+                    _music_player_owner = None
+        elif event_type == "bar_state":
+            _music_player_owner = sender
+            _music_player_latest_state = payload
+            _music_player_latest_state_expire_at = now + _MUSIC_PLAYER_STATE_TTL_SECONDS
+            _music_player_busy_until[sender] = now + _MUSIC_PLAYER_STATE_TTL_SECONDS
+        elif event_type == "bar_destroyed":
+            _music_player_busy_until.pop(sender, None)
+            if _music_player_owner == sender:
+                _music_player_latest_state = None
+                _music_player_latest_state_expire_at = 0.0
+                _music_player_owner = None
+
+        seq = _append_music_player_bridge_event(event_type, sender, payload, surface, now)
+        return {"success": True, "seq": seq}
+
+
+@router.get("/api/music/player/bridge")
+async def get_music_player_bridge(
+    sender: str = Query(default="", max_length=128),
+    since: int = Query(default=0, ge=0),
+):
+    sender = _bridge_string(sender, max_len=128)
+    async with _music_player_bridge_lock:
+        now = time.time()
+        _purge_music_player_bridge(now)
+        events = [
+            _public_music_player_bridge_event(event)
+            for event in _music_player_bridge_events
+            if int(event.get("seq") or 0) > since and event.get("sender") != sender
+        ]
+        latest_state = _music_player_latest_state if _music_player_latest_state_expire_at > now else None
+        owner = _music_player_owner if latest_state is not None else None
+        return {
+            "success": True,
+            "seq": _music_player_bridge_seq,
+            "events": events[-80:],
+            "active_surface": _choose_music_player_active_surface(now),
+            "owner": owner,
+            "latest_state": latest_state,
+            "remote_music_active": any(
+                peer != sender and expire_at > now
+                for peer, expire_at in _music_player_busy_until.items()
+            ),
+        }
 
 # ---------------------------------------------------------------------------
 #  pyncm_async compat patch — 1.8.2 uses Python 3.12+ f-string syntax in

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -45,12 +45,24 @@
 
     const PROACTIVE_SELF_ID = (Date.now().toString(36) + Math.random().toString(36).slice(2, 10));
 
+    function _isElectronFullChatHost(path) {
+        const normalizedPath = path || '';
+        if (normalizedPath !== '/chat_full' && normalizedPath !== '/chat_full/') return false;
+        const body = document.body;
+        return !!(
+            body &&
+            body.classList &&
+            body.classList.contains('neko-electron-runtime') &&
+            body.getAttribute('data-chat-host-kind') === 'full'
+        );
+    }
+
     function _computeSelfRank() {
         try {
             const path = (window.location && window.location.pathname) || '';
-            // chat_full.html 使用独立 Electron session，BroadcastChannel 看不到 Pet/compact。
-            // 它只显示/控制同步过来的聊天与播放器，不参与 proactive 调度，避免自封 leader。
-            if (path === '/chat_full') return 99;
+            // Electron full chat 使用独立 session，只显示/控制同步过来的聊天与播放器。
+            // Web /chat_full 没有 neko-electron-runtime，仍需参与 proactive leader 选举。
+            if (_isElectronFullChatHost(path)) return 99;
             // chat.html 浮窗 → 从节点
             if (path === '/chat') return 1;
             // 不参与 proactive 的页面（model_manager / jukebox / subtitle / agenthud / toast / cookies_login 等）

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -48,6 +48,9 @@
     function _computeSelfRank() {
         try {
             const path = (window.location && window.location.pathname) || '';
+            // chat_full.html 使用独立 Electron session，BroadcastChannel 看不到 Pet/compact。
+            // 它只显示/控制同步过来的聊天与播放器，不参与 proactive 调度，避免自封 leader。
+            if (path === '/chat_full') return 99;
             // chat.html 浮窗 → 从节点
             if (path === '/chat') return 1;
             // 不参与 proactive 的页面（model_manager / jukebox / subtitle / agenthud / toast / cookies_login 等）
@@ -627,6 +630,12 @@
             S.proactiveChatTimer = null;
         }
 
+        // 明确不参与的页面不挂 recheck；/chat_full 独立 session 下会一直自封失败。
+        if (PROACTIVE_SELF_RANK === 99) {
+            console.log('[Proactive] 当前页面不参与 proactive 调度，跳过');
+            return;
+        }
+
         // 主备协调：非 leader 不调度，只挂一个轻量的 recheck，
         // 一旦 leader 失联（peer 过期）就自动接班。
         if (!isProactiveLeader()) {
@@ -1068,9 +1077,12 @@
             console.log('[ProactiveChat] 检查音乐模式: proactiveMusicEnabled=' + S.proactiveMusicEnabled + ', proactiveChatEnabled=' + S.proactiveChatEnabled);
             if (S.proactiveMusicEnabled && S.proactiveChatEnabled) {
                 var musicPlaying = (typeof window.isMusicPlaying === 'function') && window.isMusicPlaying();
+                var musicPending = (typeof window.isMusicPending === 'function') && window.isMusicPending();
+                var remoteMusicActive = (typeof window.isRemoteMusicActive === 'function') && window.isRemoteMusicActive();
+                var musicRateLimited = (typeof window.isMusicRecommendRateLimited === 'function') && window.isMusicRecommendRateLimited();
                 var musicCooldown = (typeof window.isMusicCooldown === 'function') && window.isMusicCooldown();
-                if (musicPlaying || musicCooldown) {
-                    console.log('[ProactiveChat] 音乐模式跳过: playing=' + musicPlaying + ', cooldown=' + musicCooldown);
+                if (musicPlaying || musicPending || remoteMusicActive || musicRateLimited || musicCooldown) {
+                    console.log('[ProactiveChat] 音乐模式跳过: playing=' + musicPlaying + ', pending=' + musicPending + ', remote=' + remoteMusicActive + ', rateLimited=' + musicRateLimited + ', cooldown=' + musicCooldown);
                 } else {
                     console.log('[ProactiveChat] 音乐模式已启用');
                     availableModes.push('music');
@@ -1189,8 +1201,11 @@
                 // 音乐搭话（重新检查冷却状态，await 期间可能变化）
                 if (S.proactiveMusicEnabled && S.proactiveChatEnabled) {
                     var musicPlayingNow = (typeof window.isMusicPlaying === 'function') && window.isMusicPlaying();
+                    var musicPendingNow = (typeof window.isMusicPending === 'function') && window.isMusicPending();
+                    var remoteMusicActiveNow = (typeof window.isRemoteMusicActive === 'function') && window.isRemoteMusicActive();
+                    var musicRateLimitedNow = (typeof window.isMusicRecommendRateLimited === 'function') && window.isMusicRecommendRateLimited();
                     var musicCooldownNow = (typeof window.isMusicCooldown === 'function') && window.isMusicCooldown();
-                    if (!musicPlayingNow && !musicCooldownNow) {
+                    if (!musicPlayingNow && !musicPendingNow && !remoteMusicActiveNow && !musicRateLimitedNow && !musicCooldownNow) {
                         latestModes.push('music');
                     }
                 }
@@ -1365,12 +1380,25 @@
                                 url: musicLink.url,
                                 cover: musicLink.cover
                             };
-                            console.log('[ProactiveChat] 发送音乐消息:', track);
-                            var dispatchResult = await window.dispatchMusicPlay(track, { source: 'proactive' });
+                            await new Promise(function (resolve) {
+                                setTimeout(resolve, 50 + Math.floor(Math.random() * 120));
+                            });
+                            var musicBusyBeforeDispatch =
+                                ((typeof window.isMusicPlaying === 'function') && window.isMusicPlaying()) ||
+                                ((typeof window.isMusicPending === 'function') && window.isMusicPending()) ||
+                                ((typeof window.isRemoteMusicActive === 'function') && window.isRemoteMusicActive()) ||
+                                ((typeof window.isMusicRecommendRateLimited === 'function') && window.isMusicRecommendRateLimited()) ||
+                                ((typeof window.isMusicCooldown === 'function') && window.isMusicCooldown());
+                            if (musicBusyBeforeDispatch) {
+                                console.log('[ProactiveChat] 音乐 dispatch 前检测到播放器已占用，跳过本次音乐链接');
+                            } else {
+                                console.log('[ProactiveChat] 发送音乐消息:', track);
+                                var dispatchResult = await window.dispatchMusicPlay(track, { source: 'proactive' });
 
-                            // 仅在明确成功派发时标记；'queued' 仍是等待态，不应提前隐藏链接
-                            if (dispatchResult === true) {
-                                dispatchedTrackUrl = musicLink.url;
+                                // 仅在明确成功派发时标记；'queued' 仍是等待态，不应提前隐藏链接
+                                if (dispatchResult === true) {
+                                    dispatchedTrackUrl = musicLink.url;
+                                }
                             }
                         } else if (musicLink) {
                             console.warn('[ProactiveChat] 音乐链接缺少URL:', musicLink);

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -501,10 +501,11 @@
         if (mount.getAttribute('data-compact-music-player-visibility') === 'closed') return true;
         try {
             const style = window.getComputedStyle ? window.getComputedStyle(mount) : null;
-            const emptyCompactMount = mount.getAttribute('data-music-player-mount') === 'compact-surface'
+            // React hides empty full/compact mounts with :empty; they are still valid targets.
+            const emptyChatMusicMount = mount.id === 'music-player-mount'
                 && !mount.firstElementChild;
             return !!(style && (
-                (style.display === 'none' && !emptyCompactMount)
+                (style.display === 'none' && !emptyChatMusicMount)
                 || style.visibility === 'hidden'
                 || style.visibility === 'collapse'
             ));
@@ -1006,7 +1007,8 @@
     }
 
     const renderMirrorBar = (state) => {
-        if (!state) return;
+        if (!state) return false;
+        ensureMusicMountObserver();
         if (mirrorBarDestroyTimer) { clearTimeout(mirrorBarDestroyTimer); mirrorBarDestroyTimer = null; }
         mirrorBarLastState = state;
 
@@ -1017,18 +1019,18 @@
         const firstRender = !musicBar;
 
         // 已存在但属于本窗口的 owner bar（非 mirror）：说明 leader 是自己，不应覆盖
-        if (musicBar && musicBar.dataset.mirror !== 'true') return;
+        if (musicBar && musicBar.dataset.mirror !== 'true') return false;
 
         if (firstRender) {
             ensureMusicUiCSS();
             const mountTarget = getPreferredMusicMountTarget().mountTarget;
-            if (!mountTarget) return;
+            if (!mountTarget) return false;
 
             musicBar = document.createElement('div');
             musicBar.id = MUSIC_CONFIG.dom.barId;
             musicBar.className = 'music-player-bar';
             musicBar.dataset.mirror = 'true';
-            mountMusicBar(musicBar);
+            if (!mountMusicBar(musicBar) || musicBar.hidden) return false;
 
             const randomColor = MUSIC_CONFIG.themeColors[Math.floor(Math.random() * MUSIC_CONFIG.themeColors.length)];
             musicBar.style.setProperty('--dynamic-random-color', randomColor);
@@ -1071,7 +1073,7 @@
             bindMirrorBarControls(musicBar);
         } else {
             musicBar.classList.remove('fading-out');
-            mountMusicBar(musicBar);
+            if (!mountMusicBar(musicBar) || musicBar.hidden) return false;
         }
 
         // 切歌 / 首次：刷新标题 + 歌手 + 封面
@@ -1140,6 +1142,7 @@
                 else volumeBtn.textContent = '🔊';
             }
         }
+        return true;
     };
 
     const teardownMirrorBar = (fullTeardown) => {
@@ -1247,32 +1250,33 @@
     }
 
     function applyMusicPlayerBridgeEvent(event) {
-        if (!event || typeof event !== 'object') return;
+        if (!event || typeof event !== 'object') return false;
         const sender = event.sender;
-        if (!sender || sender === MUSIC_COORD_SENDER_ID) return;
+        if (!sender || sender === MUSIC_COORD_SENDER_ID) return false;
         const payload = event.payload || {};
         try {
             if (event.type === 'coord') {
                 applyMusicPlayerBridgeCoord(sender, payload.coordType, payload);
             } else if (event.type === 'bar_state') {
-                if (isBarOwner()) return;
+                if (isBarOwner()) return false;
                 setMirrorBarLeader(sender, 'bridge');
-                renderMirrorBar(payload);
+                return renderMirrorBar(payload);
             } else if (event.type === 'bar_destroyed') {
-                if (isBarOwner()) return;
-                if (sender !== mirrorBarLeaderSender) return;
-                if (!isCurrentMirrorPlayback(payload)) return;
+                if (isBarOwner()) return false;
+                if (sender !== mirrorBarLeaderSender) return false;
+                if (!isCurrentMirrorPlayback(payload)) return false;
                 setMirrorBarLeader(null);
                 teardownMirrorBar(!!payload.fullTeardown);
             } else if (event.type === 'bar_ctrl') {
-                if (!isBarOwner()) return;
-                if (payload.target !== MUSIC_COORD_SENDER_ID) return;
-                if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return;
+                if (!isBarOwner()) return false;
+                if (payload.target !== MUSIC_COORD_SENDER_ID) return false;
+                if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return false;
                 handleRemoteBarCtrl(payload.action, payload.value);
             }
         } catch (e) {
             console.warn('[Music UI] music player bridge event failed:', e);
         }
+        return false;
     }
 
     async function pollMusicPlayerBridge() {
@@ -1316,8 +1320,8 @@
             const latestPlaybackId = data.latest_state && data.latest_state.playbackId;
             if (Array.isArray(data.events)) {
                 for (const event of data.events) {
-                    applyMusicPlayerBridgeEvent(event);
-                    if (event && event.type === 'bar_state' && event.sender === data.owner
+                    const renderedEvent = applyMusicPlayerBridgeEvent(event);
+                    if (renderedEvent && event && event.type === 'bar_state' && event.sender === data.owner
                         && (!latestPlaybackId || (event.payload && event.payload.playbackId === latestPlaybackId))) {
                         sawOwnerBarStateEvent = true;
                     }

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -90,8 +90,17 @@
     // dispatchMusicPlay 在 source==='proactive' 时把远程视作"已占用"。 ---
     const MUSIC_COORD_SENDER_ID = (Date.now().toString(36) + Math.random().toString(36).slice(2, 10));
     const REMOTE_MUSIC_TTL_MS = 30 * 1000; // 心跳超时
+    const REMOTE_MUSIC_PENDING_TTL_MS = 12 * 1000;
+    const MUSIC_PLAYER_BRIDGE_ENDPOINT = '/api/music/player/bridge';
+    const MUSIC_PLAYER_BRIDGE_POLL_MS = 900;
+    const MUSIC_PLAYER_BRIDGE_SURFACE_PULSE_MS = 2500;
     // sender_id -> expireAt
     const remoteMusicSenders = new Map();
+    let musicPlayerBridgeSeq = 0;
+    let musicPlayerBridgePollTimer = null;
+    let musicPlayerBridgeSurfacePulseTimer = null;
+    let musicPlayerBridgeRemoteActiveUntil = 0;
+    let musicPlayerBridgeActiveSurface = null;
     let musicCoordChannel = null;
     try {
         if (typeof BroadcastChannel !== 'undefined') {
@@ -103,6 +112,8 @@
                 if (!sid || sid === MUSIC_COORD_SENDER_ID) return;
                 if (data.type === 'music_started' || data.type === 'music_heartbeat') {
                     remoteMusicSenders.set(sid, Date.now() + REMOTE_MUSIC_TTL_MS);
+                } else if (data.type === 'music_pending') {
+                    remoteMusicSenders.set(sid, Date.now() + REMOTE_MUSIC_PENDING_TTL_MS);
                 } else if (data.type === 'music_ended') {
                     remoteMusicSenders.delete(sid);
                 }
@@ -127,10 +138,12 @@
     }
 
     const broadcastMusicCoord = (type) => {
-        if (!musicCoordChannel) return;
-        try {
-            musicCoordChannel.postMessage({ type, sender: MUSIC_COORD_SENDER_ID, ts: Date.now() });
-        } catch (_) { /* ignore */ }
+        if (musicCoordChannel) {
+            try {
+                musicCoordChannel.postMessage({ type, sender: MUSIC_COORD_SENDER_ID, ts: Date.now() });
+            } catch (_) { /* ignore */ }
+        }
+        postMusicPlayerBridgeEvent('coord', { coordType: type });
     };
 
     // 心跳：当本地正在播时定期广播，防止其他窗口误以为对方已退出
@@ -157,8 +170,9 @@
     };
 
     const isRemoteMusicActive = () => {
-        if (remoteMusicSenders.size === 0) return false;
         const now = Date.now();
+        if (musicPlayerBridgeRemoteActiveUntil > now) return true;
+        if (remoteMusicSenders.size === 0) return false;
         // 顺手清理已过期的 sender
         for (const [sid, exp] of remoteMusicSenders) {
             if (now > exp) remoteMusicSenders.delete(sid);
@@ -252,48 +266,77 @@
     // follower 记录当前镜像绑定的 leader sender id。所有 ctrl/destroyed 校验
     // 都要比对这个值，避免 leader 切换重叠时别的 owner 被误触发 pause/close。
     let mirrorBarLeaderSender = null;
+    const processedBarCtrlIds = new Set();
+    const processedBarCtrlOrder = [];
+
+    function shouldSkipProcessedBarCtrl(ctrlId) {
+        if (!ctrlId) return false;
+        if (processedBarCtrlIds.has(ctrlId)) return true;
+        processedBarCtrlIds.add(ctrlId);
+        processedBarCtrlOrder.push(ctrlId);
+        while (processedBarCtrlOrder.length > 120) {
+            processedBarCtrlIds.delete(processedBarCtrlOrder.shift());
+        }
+        return false;
+    }
 
     const isBarOwner = () => !!localPlayer;
 
     const broadcastBarState = (patch) => {
-        if (!musicBarChannel) return;
-        try {
-            musicBarChannel.postMessage(Object.assign({
-                type: 'state',
-                sender: MUSIC_COORD_SENDER_ID,
-                ts: Date.now()
-            }, patch));
-        } catch (_) { /* ignore */ }
+        const message = Object.assign({
+            type: 'state',
+            sender: MUSIC_COORD_SENDER_ID,
+            ts: Date.now()
+        }, patch);
+        if (musicBarChannel) {
+            try {
+                musicBarChannel.postMessage(message);
+            } catch (_) { /* ignore */ }
+        }
+        postMusicPlayerBridgeEvent('bar_state', patch || {});
     };
 
     const broadcastBarDestroyed = (fullTeardown) => {
-        if (!musicBarChannel) return;
-        try {
-            musicBarChannel.postMessage({
-                type: 'destroyed',
-                sender: MUSIC_COORD_SENDER_ID,
-                ts: Date.now(),
-                fullTeardown: !!fullTeardown
-            });
-        } catch (_) { /* ignore */ }
+        const message = {
+            type: 'destroyed',
+            sender: MUSIC_COORD_SENDER_ID,
+            ts: Date.now(),
+            fullTeardown: !!fullTeardown
+        };
+        if (musicBarChannel) {
+            try {
+                musicBarChannel.postMessage(message);
+            } catch (_) { /* ignore */ }
+        }
+        postMusicPlayerBridgeEvent('bar_destroyed', { fullTeardown: !!fullTeardown });
     };
 
     const broadcastBarCtrl = (action, value) => {
-        if (!musicBarChannel) return;
         // 没绑到 leader（镜像 bar 没建或已 teardown）就不发 ctrl
         if (!mirrorBarLeaderSender) return;
-        try {
-            musicBarChannel.postMessage({
-                type: 'ctrl',
-                sender: MUSIC_COORD_SENDER_ID,
-                // target 指明给哪个 leader——owner 侧校验 target 才执行，避免
-                // 非当前绑定的 leader 也一起 pause/seek/close
-                target: mirrorBarLeaderSender,
-                ts: Date.now(),
-                action: action,
-                value: value
-            });
-        } catch (_) { /* ignore */ }
+        const ctrlId = MUSIC_COORD_SENDER_ID + ':' + Date.now().toString(36) + ':' + Math.random().toString(36).slice(2, 8);
+        const message = {
+            type: 'ctrl',
+            sender: MUSIC_COORD_SENDER_ID,
+            // target 指明给哪个 leader——owner 侧校验 target 才执行，避免
+            // 非当前绑定的 leader 也一起 pause/seek/close
+            target: mirrorBarLeaderSender,
+            ts: Date.now(),
+            ctrlId: ctrlId,
+            action: action,
+            value: value
+        };
+        if (musicBarChannel) {
+            try {
+                musicBarChannel.postMessage(message);
+            } catch (_) { /* ignore */ }
+        }
+        postMusicPlayerBridgeEvent('bar_ctrl', {
+            target: mirrorBarLeaderSender,
+            ctrlId: ctrlId,
+            action: action,
+            value: value
+        });
     };
 
     const computeCurrentBarState = () => {
@@ -361,11 +404,142 @@
         return compactMount instanceof Element ? compactMount : null;
     }
 
-    function getPreferredMusicMountTarget() {
-        const compactMount = getCompactMusicMountTarget();
-        if (compactMount) return { mountTarget: compactMount, insertBeforeEl: null };
+    function getFullMusicMountTarget() {
+        const mounts = document.querySelectorAll('#music-player-mount');
+        for (const mount of mounts) {
+            if (mount instanceof Element && mount.getAttribute('data-music-player-mount') !== 'compact-surface') {
+                return mount;
+            }
+        }
+        return null;
+    }
 
-        const reactMount = document.getElementById('music-player-mount');
+    function getChatMusicSurfaceMode() {
+        try {
+            if (typeof window.getNekoChatMusicSurfaceState === 'function') {
+                const state = window.getNekoChatMusicSurfaceState();
+                if (state && state.mode) return String(state.mode);
+            }
+        } catch (_) { /* ignore */ }
+
+        try {
+            const host = window.reactChatWindowHost;
+            if (host && typeof host.getChatSurfaceMode === 'function') {
+                const mode = host.getChatSurfaceMode();
+                if (mode) return String(mode);
+            }
+        } catch (_) { /* ignore */ }
+
+        const shell = document.getElementById('react-chat-window-shell');
+        if (shell && shell.getAttribute) {
+            const mode = shell.getAttribute('data-chat-surface-mode');
+            if (mode) return mode;
+        }
+
+        const body = document.body;
+        if (body && body.getAttribute) {
+            const declaredMode = body.getAttribute('data-initial-chat-surface-mode');
+            if (declaredMode) return declaredMode;
+        }
+
+        try {
+            const path = (window.location && window.location.pathname) || '';
+            if (path === '/chat_full') return 'full';
+            if (path === '/chat') return 'compact';
+        } catch (_) { /* ignore */ }
+
+        if (getCompactMusicMountTarget()) return 'compact';
+        if (getFullMusicMountTarget()) return 'full';
+        return '';
+    }
+
+    function isElementInHiddenTree(element) {
+        let node = element;
+        while (node && node instanceof Element) {
+            if (node.hidden) return true;
+            node = node.parentElement;
+        }
+        return false;
+    }
+
+    function hasUsableLocalChatMusicSurface() {
+        const mode = getChatMusicSurfaceMode();
+        if (mode === 'minimized') return false;
+        const mount = mode === 'compact'
+            ? getCompactMusicMountTarget()
+            : (mode === 'full' ? getFullMusicMountTarget() : (getFullMusicMountTarget() || getCompactMusicMountTarget()));
+        if (!mount || isElementInHiddenTree(mount)) return false;
+
+        const overlay = document.getElementById('react-chat-window-overlay');
+        if (overlay && overlay.hidden) return false;
+        return true;
+    }
+
+    function isLocalChatMusicSurfaceFocused() {
+        if (!hasUsableLocalChatMusicSurface()) return false;
+        try {
+            if (document.visibilityState === 'hidden') return false;
+        } catch (_) { /* ignore */ }
+        try {
+            return typeof document.hasFocus === 'function' ? document.hasFocus() : true;
+        } catch (_) {
+            return true;
+        }
+    }
+
+    function isDedicatedChatMusicSurface() {
+        try {
+            const path = (window.location && window.location.pathname) || '';
+            if (path === '/chat' || path === '/chat_full') return true;
+        } catch (_) { /* ignore */ }
+        const body = document.body;
+        return !!(body && body.classList && body.classList.contains('electron-chat-window'));
+    }
+
+    function getMusicBridgeSurfaceState(reason) {
+        const active = isLocalChatMusicSurfaceFocused();
+        return {
+            mode: getChatMusicSurfaceMode() || 'unknown',
+            active: active,
+            focused: active,
+            visible: hasUsableLocalChatMusicSurface(),
+            reason: reason || ''
+        };
+    }
+
+    function hasBridgeActiveChatMusicSurface() {
+        if (!musicPlayerBridgeActiveSurface) return false;
+        if ((musicPlayerBridgeActiveSurface.expireAt || 0) <= Date.now()) {
+            musicPlayerBridgeActiveSurface = null;
+            return false;
+        }
+        if (musicPlayerBridgeActiveSurface.sender === MUSIC_COORD_SENDER_ID) return false;
+        return !!(
+            musicPlayerBridgeActiveSurface.active ||
+            musicPlayerBridgeActiveSurface.focused ||
+            musicPlayerBridgeActiveSurface.visible
+        );
+    }
+
+    function shouldRenderMusicBarInThisSurface() {
+        if (isLocalChatMusicSurfaceFocused()) return true;
+        if (hasBridgeActiveChatMusicSurface()) return false;
+        if (isDedicatedChatMusicSurface()) return false;
+        return hasUsableLocalChatMusicSurface();
+    }
+
+    function getPreferredMusicMountTarget(options = {}) {
+        const renderHere = shouldRenderMusicBarInThisSurface();
+        const allowInactiveOwner = !!options.allowInactiveOwner;
+        if (!renderHere && !allowInactiveOwner) return { mountTarget: null, insertBeforeEl: null };
+
+        const mode = getChatMusicSurfaceMode();
+        let reactMount = null;
+        if (mode === 'compact') reactMount = getCompactMusicMountTarget();
+        else if (mode === 'full') reactMount = getFullMusicMountTarget();
+
+        if (!reactMount && mode !== 'compact') reactMount = getFullMusicMountTarget();
+        if (!reactMount && mode !== 'full') reactMount = getCompactMusicMountTarget();
         if (reactMount) return { mountTarget: reactMount, insertBeforeEl: null };
 
         const legacyMount = document.getElementById(MUSIC_CONFIG.dom.containerId);
@@ -396,8 +570,15 @@
         ensureMusicMountObserver();
         if (musicBar.dataset) delete musicBar.dataset.skipMountRelocation;
         prepareMusicBarHitRegion(musicBar);
-        const target = getPreferredMusicMountTarget();
-        if (!target || !target.mountTarget) return false;
+        const isMirrorBar = !!(musicBar.dataset && musicBar.dataset.mirror === 'true');
+        const renderHere = shouldRenderMusicBarInThisSurface();
+        const target = getPreferredMusicMountTarget({ allowInactiveOwner: !isMirrorBar });
+        if (!target || !target.mountTarget) {
+            musicBar.hidden = true;
+            requestCompactMusicGeometrySync();
+            return false;
+        }
+        musicBar.hidden = !renderHere;
         if (musicBar.parentNode === target.mountTarget) {
             requestCompactMusicGeometrySync();
             return true;
@@ -500,6 +681,68 @@
                 'style'
             ]
         });
+    }
+
+    async function getMusicPlayerBridgeMutationHeaders() {
+        const headers = { 'Content-Type': 'application/json' };
+        const sec = window.nekoLocalMutationSecurity;
+        if (!sec || typeof sec.getMutationHeaders !== 'function') {
+            return null;
+        }
+        try {
+            Object.assign(headers, await sec.getMutationHeaders());
+        } catch (_) {
+            return null;
+        }
+        return headers;
+    }
+
+    async function isMusicPlayerBridgeCsrfFailure(response) {
+        if (!response || response.status !== 403) return false;
+        try {
+            const cloned = typeof response.clone === 'function' ? response.clone() : response;
+            const data = await cloned.json();
+            return !!(data && data.error_code === 'csrf_validation_failed');
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function postMusicPlayerBridgeEvent(type, payload, options = {}) {
+        const body = {
+            sender: MUSIC_COORD_SENDER_ID,
+            type: type,
+            payload: payload || {},
+            surface: options.surface || getMusicBridgeSurfaceState(type)
+        };
+        (async () => {
+            let headers = await getMusicPlayerBridgeMutationHeaders();
+            if (!headers) return;
+            let response = await fetch(MUSIC_PLAYER_BRIDGE_ENDPOINT, {
+                method: 'POST',
+                headers: headers,
+                body: JSON.stringify(body),
+                keepalive: true,
+                cache: 'no-store'
+            });
+            const sec = window.nekoLocalMutationSecurity;
+            if (await isMusicPlayerBridgeCsrfFailure(response)
+                && sec && typeof sec.refreshToken === 'function') {
+                try { await sec.refreshToken(); } catch (_) { /* ignore */ }
+                headers = await getMusicPlayerBridgeMutationHeaders();
+                if (!headers) return;
+                response = await fetch(MUSIC_PLAYER_BRIDGE_ENDPOINT, {
+                    method: 'POST',
+                    headers: headers,
+                    body: JSON.stringify(body),
+                    keepalive: true,
+                    cache: 'no-store'
+                });
+            }
+            if (response && response.ok) {
+                try { await response.json(); } catch (_) { /* ignore */ }
+            }
+        })().catch(() => { /* bridge unavailable: BroadcastChannel/local owner still works */ });
     }
 
     const bindMirrorBarControls = (musicBar) => {
@@ -889,6 +1132,133 @@
         }
     };
 
+    function applyMusicPlayerBridgeCoord(sender, coordType) {
+        if (!sender || sender === MUSIC_COORD_SENDER_ID) return;
+        if (coordType === 'music_started' || coordType === 'music_heartbeat') {
+            remoteMusicSenders.set(sender, Date.now() + REMOTE_MUSIC_TTL_MS);
+        } else if (coordType === 'music_pending') {
+            remoteMusicSenders.set(sender, Date.now() + REMOTE_MUSIC_PENDING_TTL_MS);
+        } else if (coordType === 'music_ended') {
+            remoteMusicSenders.delete(sender);
+        }
+    }
+
+    function applyMusicPlayerBridgeEvent(event) {
+        if (!event || typeof event !== 'object') return;
+        const sender = event.sender;
+        if (!sender || sender === MUSIC_COORD_SENDER_ID) return;
+        const payload = event.payload || {};
+        try {
+            if (event.type === 'coord') {
+                applyMusicPlayerBridgeCoord(sender, payload.coordType);
+            } else if (event.type === 'bar_state') {
+                if (isBarOwner()) return;
+                mirrorBarLeaderSender = sender;
+                renderMirrorBar(payload);
+            } else if (event.type === 'bar_destroyed') {
+                if (isBarOwner()) return;
+                if (sender !== mirrorBarLeaderSender) return;
+                mirrorBarLeaderSender = null;
+                teardownMirrorBar(!!payload.fullTeardown);
+            } else if (event.type === 'bar_ctrl') {
+                if (!isBarOwner()) return;
+                if (payload.target && payload.target !== MUSIC_COORD_SENDER_ID) return;
+                if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return;
+                handleRemoteBarCtrl(payload.action, payload.value);
+            }
+        } catch (e) {
+            console.warn('[Music UI] music player bridge event failed:', e);
+        }
+    }
+
+    async function pollMusicPlayerBridge() {
+        try {
+            const surface = getMusicBridgeSurfaceState('poll');
+            const params = new URLSearchParams({
+                sender: MUSIC_COORD_SENDER_ID,
+                since: String(musicPlayerBridgeSeq || 0)
+            });
+            const response = await fetch(MUSIC_PLAYER_BRIDGE_ENDPOINT + '?' + params.toString(), {
+                method: 'GET',
+                cache: 'no-store'
+            });
+            if (!response.ok) return;
+            const data = await response.json();
+            if (!data || data.success === false) return;
+
+            if (typeof data.seq === 'number' && data.seq > musicPlayerBridgeSeq) {
+                musicPlayerBridgeSeq = data.seq;
+            }
+
+            if (data.active_surface && data.active_surface.sender) {
+                musicPlayerBridgeActiveSurface = Object.assign({}, data.active_surface, {
+                    expireAt: Date.now() + MUSIC_PLAYER_BRIDGE_SURFACE_PULSE_MS + 1200
+                });
+            } else {
+                musicPlayerBridgeActiveSurface = null;
+            }
+
+            musicPlayerBridgeRemoteActiveUntil = data.remote_music_active
+                ? Date.now() + MUSIC_PLAYER_BRIDGE_POLL_MS + 1400
+                : 0;
+
+            if (Array.isArray(data.events)) {
+                for (const event of data.events) applyMusicPlayerBridgeEvent(event);
+            }
+
+            if (data.owner && data.owner !== MUSIC_COORD_SENDER_ID && data.latest_state && !isBarOwner()) {
+                mirrorBarLeaderSender = data.owner;
+                renderMirrorBar(data.latest_state);
+            } else if (!data.owner && mirrorBarLeaderSender && !isBarOwner()) {
+                mirrorBarLeaderSender = null;
+                teardownMirrorBar(false);
+            }
+
+            if (surface.active || surface.visible) scheduleMusicBarRelocation();
+        } catch (_) {
+            // Bridge is best-effort; BroadcastChannel/local owner remain usable.
+        }
+    }
+
+    function initializeMusicPlayerBridge() {
+        if (musicPlayerBridgePollTimer) return;
+        pollMusicPlayerBridge();
+        musicPlayerBridgePollTimer = window.setInterval(pollMusicPlayerBridge, MUSIC_PLAYER_BRIDGE_POLL_MS);
+        musicPlayerBridgeSurfacePulseTimer = window.setInterval(() => {
+            postMusicPlayerBridgeEvent('surface_state', getMusicBridgeSurfaceState('bridge-pulse'));
+        }, MUSIC_PLAYER_BRIDGE_SURFACE_PULSE_MS);
+        const publishSurfaceState = (reason) => {
+            postMusicPlayerBridgeEvent('surface_state', getMusicBridgeSurfaceState(reason));
+            scheduleMusicBarRelocation();
+        };
+        window.addEventListener('focus', () => publishSurfaceState('focus'));
+        window.addEventListener('blur', () => publishSurfaceState('blur'));
+        window.addEventListener('react-chat-window:chat-surface-mode-change', () => publishSurfaceState('surface-mode'));
+        window.addEventListener('neko:chat-music-surface-change', () => publishSurfaceState('surface-state'));
+        document.addEventListener('visibilitychange', () => publishSurfaceState('visibility'));
+        window.setTimeout(() => publishSurfaceState('init'), 0);
+        window.addEventListener('beforeunload', () => {
+            postMusicPlayerBridgeEvent('surface_state', Object.assign(
+                getMusicBridgeSurfaceState('unload'),
+                { active: false, focused: false, visible: false, reason: 'unload' }
+            ));
+            if (isBarOwner()) {
+                postMusicPlayerBridgeEvent('bar_destroyed', { fullTeardown: true });
+                postMusicPlayerBridgeEvent('coord', { coordType: 'music_ended' });
+            }
+            if (musicPlayerBridgePollTimer) {
+                window.clearInterval(musicPlayerBridgePollTimer);
+                musicPlayerBridgePollTimer = null;
+            }
+            if (musicPlayerBridgeSurfacePulseTimer) {
+                window.clearInterval(musicPlayerBridgeSurfacePulseTimer);
+                musicPlayerBridgeSurfacePulseTimer = null;
+            }
+        });
+    }
+
+    initializeMusicPlayerBridge();
+
     try {
         if (typeof BroadcastChannel !== 'undefined') {
             musicBarChannel = new BroadcastChannel(MUSIC_BAR_CHANNEL_NAME);
@@ -918,6 +1288,7 @@
                         // 被 follower 的指令误触（leader 交接瞬间最容易发生）
                         if (!isBarOwner()) return;
                         if (data.target && data.target !== MUSIC_COORD_SENDER_ID) return;
+                        if (shouldSkipProcessedBarCtrl(data.ctrlId)) return;
                         handleRemoteBarCtrl(data.action, data.value);
                     }
                 } catch (e) {
@@ -1435,7 +1806,7 @@
         // --- 1. DOM 基础架构 ---
         if (isFirstRender) {
             // 优先使用紧凑历史目标，其次 React composer 挂载点，最后回退旧 chat-container。
-            const mountTarget = getPreferredMusicMountTarget().mountTarget;
+            const mountTarget = getPreferredMusicMountTarget({ allowInactiveOwner: true }).mountTarget;
             if (!mountTarget) return;
 
             musicBar = document.createElement('div');
@@ -2027,6 +2398,7 @@
             pendingReleased = true;
             musicDispatchPendingCount = Math.max(0, musicDispatchPendingCount - 1);
         };
+        broadcastMusicCoord('music_pending');
 
         // --- 核心修复：更鲁棒的 URL 预清理 ---
         if (trackInfo.url && typeof trackInfo.url === 'string') {

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -66,6 +66,7 @@
 
     let currentPlayingTrack = null;
     let currentMusicPlaybackId = null;
+    let currentMusicOwnerStartedAt = 0;
     let localPlayer = null;
     let musicCardMessageId = null;
     let aplayerLoadPromise = null;
@@ -309,6 +310,26 @@
 
     const isBarOwner = () => !!localPlayer;
 
+    function getRemoteMusicStateTimestamp(state, eventTs) {
+        const ts = Number(eventTs || (state && state.ts) || 0);
+        return Number.isFinite(ts) ? ts : 0;
+    }
+
+    function acceptRemoteMusicOwnerState(sender, state, eventTs) {
+        if (!isBarOwner()) return true;
+        if (!sender || sender === MUSIC_COORD_SENDER_ID || !state || !state.track) return false;
+
+        const remotePlaybackId = state.playbackId || '';
+        if (remotePlaybackId && remotePlaybackId === getCurrentMusicPlaybackId()) return false;
+
+        const remoteTs = getRemoteMusicStateTimestamp(state, eventTs);
+        if (remoteTs && currentMusicOwnerStartedAt && remoteTs < currentMusicOwnerStartedAt) return false;
+
+        // A newer remote owner wins; remove the local owner bar immediately so a mirror can replace it.
+        destroyMusicPlayer(true, false, true);
+        return true;
+    }
+
     const broadcastBarState = (patch) => {
         const statePayload = Object.assign({}, patch || {});
         if (!statePayload.playbackId) statePayload.playbackId = getCurrentMusicPlaybackId();
@@ -325,8 +346,8 @@
         postMusicPlayerBridgeEvent('bar_state', statePayload);
     };
 
-    const broadcastBarDestroyed = (fullTeardown) => {
-        const playbackId = getCurrentMusicPlaybackId();
+    const broadcastBarDestroyed = (fullTeardown, playbackIdOverride) => {
+        const playbackId = playbackIdOverride || getCurrentMusicPlaybackId();
         const message = {
             type: 'destroyed',
             sender: MUSIC_COORD_SENDER_ID,
@@ -1321,7 +1342,7 @@
                 applyMusicPlayerBridgeCoord(sender, payload.coordType, payload);
                 return true;
             } else if (event.type === 'bar_state') {
-                if (isBarOwner()) return false;
+                if (!acceptRemoteMusicOwnerState(sender, payload, event.ts)) return false;
                 setMirrorBarLeader(sender, 'bridge');
                 const rendered = renderMirrorBar(payload);
                 if (!rendered) scheduleMusicBarRelocation();
@@ -1349,16 +1370,26 @@
     async function pollMusicPlayerBridge() {
         if (musicPlayerBridgePollInFlight) return;
         musicPlayerBridgePollInFlight = true;
+        let abortController = null;
+        let abortTimer = 0;
         try {
+            if (typeof AbortController !== 'undefined') {
+                abortController = new AbortController();
+                abortTimer = window.setTimeout(() => {
+                    try { abortController.abort(); } catch (_) { /* ignore */ }
+                }, MUSIC_PLAYER_BRIDGE_POLL_MS + 2000);
+            }
             const surface = getMusicBridgeSurfaceState('poll');
             const params = new URLSearchParams({
                 sender: MUSIC_COORD_SENDER_ID,
                 since: String(musicPlayerBridgeSeq || 0)
             });
-            const response = await fetch(MUSIC_PLAYER_BRIDGE_ENDPOINT + '?' + params.toString(), {
+            const requestOptions = {
                 method: 'GET',
                 cache: 'no-store'
-            });
+            };
+            if (abortController) requestOptions.signal = abortController.signal;
+            const response = await fetch(MUSIC_PLAYER_BRIDGE_ENDPOINT + '?' + params.toString(), requestOptions);
             if (!response.ok) return;
             const data = await response.json();
             if (!data || data.success === false) return;
@@ -1408,6 +1439,7 @@
         } catch (_) {
             // Bridge is best-effort; BroadcastChannel/local owner remain usable.
         } finally {
+            if (abortTimer) window.clearTimeout(abortTimer);
             musicPlayerBridgePollInFlight = false;
         }
     }
@@ -1461,10 +1493,9 @@
                 if (!data.sender || data.sender === MUSIC_COORD_SENDER_ID) return;
                 try {
                     if (data.type === 'state') {
-                        // 本地是 owner 时忽略来自别人的 state；既防止 race 下
-                        // 另一个窗口的旧 state 覆盖掉自己真实 audio，也让
-                        // leader 切换瞬间不会有两份 bar 互相抢。
-                        if (isBarOwner()) return;
+                        // 如果本地仍是 owner，只接受比本地当前播放更新的远端 owner state，
+                        // 防止旧 state 反杀新播放，也避免两个窗口同时保留 audio。
+                        if (!acceptRemoteMusicOwnerState(data.sender, data, data.ts)) return;
                         // 绑定/切换到当前 leader —— 后续 ctrl 会带 target 指向它，
                         // destroyed 也只接受来自它的那一条，避免多 leader 交接时串窗
                         setMirrorBarLeader(data.sender, 'broadcast');
@@ -1816,6 +1847,7 @@
 
 
     const destroyMusicPlayer = (removeDOM = true, fullTeardown = false, updateToken = false) => {
+        const destroyedPlaybackId = getCurrentMusicPlaybackId();
         // 重要：销毁播放器意味着取消所有正在进行的异步加载令牌
         // 只有在 fullTeardown (手动关闭) 或明确要求时才更新 token
         if (updateToken || fullTeardown) {
@@ -1904,8 +1936,9 @@
 
         // bar 镜像：让 follower 同步摘掉镜像 bar。fullTeardown 传下去
         // 是为了 follower 能走淡出动画而不是硬删。
-        if (removeDOM) broadcastBarDestroyed(fullTeardown);
+        if (removeDOM) broadcastBarDestroyed(fullTeardown, destroyedPlaybackId);
         currentMusicPlaybackId = null;
+        currentMusicOwnerStartedAt = 0;
     };
 
     // --- 查找并替换整个 loadAPlayerLibrary 函数 ---
@@ -2059,7 +2092,9 @@
         const previousCardId = musicCardMessageId;
 
         // --- 2. 原地更新 UI 文本/封面 (始终执行) ---
-        currentMusicPlaybackId = createMusicPlaybackId(trackInfo, currentToken);
+        const playbackIdForRequest = createMusicPlaybackId(trackInfo, currentToken);
+        currentMusicPlaybackId = playbackIdForRequest;
+        currentMusicOwnerStartedAt = Date.now();
         currentPlayingTrack = trackInfo;
         // 广播一次占位 state —— APlayer 还在初始化/切曲，但 follower 现在
         // 就能把 bar 刷新到新 track，避免旧歌信息停留或 bar 空白。
@@ -2187,7 +2222,7 @@
                     // bar，但现在请求被更新的 token 取代，我们不会再发权威
                     // state，得主动广播 destroyed 把占位 bar 摘掉，不然 follower
                     // 会卡在一条假 bar 直到被下一次 state 盖掉。
-                    broadcastBarDestroyed(false);
+                    broadcastBarDestroyed(false, playbackIdForRequest);
                     return;
                 }
 
@@ -2571,7 +2606,7 @@
             if (isFirstRender && musicBar) removeMusicBarWithoutRelocation(musicBar);
             // 回滚：前面已经发过 emitBarInitialState，但 APlayer 没建起来，
             // 后续事件不会广播，follower 会卡着占位 bar，这里补一条 destroyed
-            broadcastBarDestroyed(false);
+            broadcastBarDestroyed(false, playbackIdForRequest);
             showErrorToast('music.playError', '音乐播放加载失败');
         }
     };

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -429,8 +429,11 @@
 
     let musicMountObserver = null;
     let musicMountRelocationFrame = 0;
+    let musicMountRelocationRetryTimer = 0;
+    let musicMountRelocationRetryCount = 0;
     let musicMountGeometryFrame = 0;
     let pendingDetachedMusicBar = null;
+    const MUSIC_MOUNT_RELOCATION_MAX_RETRIES = 6;
 
     function getCompactMusicMountTarget() {
         const compactMount = document.querySelector('[data-music-player-mount="compact-surface"]');
@@ -447,7 +450,35 @@
         return null;
     }
 
+    function getMountSurfaceMode(mount) {
+        if (!(mount instanceof Element)) return '';
+        const surfaceNode = mount.closest && mount.closest('[data-chat-surface-mode]');
+        if (surfaceNode && surfaceNode.getAttribute) {
+            const mode = surfaceNode.getAttribute('data-chat-surface-mode');
+            if (mode === 'compact' || mode === 'full' || mode === 'minimized') return mode;
+        }
+        if (mount.getAttribute('data-music-player-mount') === 'compact-surface') return 'compact';
+        return '';
+    }
+
+    function getRenderedChatMusicSurfaceMode() {
+        const compactMount = getCompactMusicMountTarget();
+        const fullMount = getFullMusicMountTarget();
+        const compactMode = getMountSurfaceMode(compactMount);
+        const fullMode = getMountSurfaceMode(fullMount);
+
+        if (compactMode === 'minimized' || fullMode === 'minimized') return 'minimized';
+        if (fullMode === 'full' && compactMode !== 'compact') return 'full';
+        if (compactMode === 'compact' && fullMode !== 'full') return 'compact';
+        if (fullMount && !compactMount && !fullMode) return 'full';
+        if (compactMount && !fullMount && !compactMode) return 'compact';
+        return '';
+    }
+
     function getChatMusicSurfaceMode() {
+        const renderedMode = getRenderedChatMusicSurfaceMode();
+        if (renderedMode) return renderedMode;
+
         try {
             if (typeof window.getNekoChatMusicSurfaceState === 'function') {
                 const state = window.getNekoChatMusicSurfaceState();
@@ -486,6 +517,10 @@
         return '';
     }
 
+    function isEmptyChatMusicMount(element) {
+        return !!(element && element.id === 'music-player-mount' && !element.firstChild);
+    }
+
     function isElementInHiddenTree(element) {
         let node = element;
         while (node && node instanceof Element) {
@@ -494,7 +529,14 @@
             if (node.getAttribute('data-compact-music-player-visibility') === 'closed') return true;
             try {
                 const style = window.getComputedStyle ? window.getComputedStyle(node) : null;
-                if (style && (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse')) {
+                const emptyMountHiddenByCss = node === element
+                    && isEmptyChatMusicMount(node)
+                    && (!node.style || node.style.display !== 'none');
+                if (style && (
+                    (style.display === 'none' && !emptyMountHiddenByCss)
+                    || style.visibility === 'hidden'
+                    || style.visibility === 'collapse'
+                )) {
                     return true;
                 }
             } catch (_) { /* ignore */ }
@@ -599,6 +641,25 @@
         });
     }
 
+    function clearMusicMountRelocationRetry() {
+        if (musicMountRelocationRetryTimer) {
+            window.clearTimeout(musicMountRelocationRetryTimer);
+            musicMountRelocationRetryTimer = 0;
+        }
+        musicMountRelocationRetryCount = 0;
+    }
+
+    function scheduleMusicBarRelocationRetry() {
+        if (musicMountRelocationRetryTimer) return;
+        if (musicMountRelocationRetryCount >= MUSIC_MOUNT_RELOCATION_MAX_RETRIES) return;
+        musicMountRelocationRetryCount += 1;
+        const delay = Math.min(320, 40 + musicMountRelocationRetryCount * 40);
+        musicMountRelocationRetryTimer = window.setTimeout(() => {
+            musicMountRelocationRetryTimer = 0;
+            scheduleMusicBarRelocation();
+        }, delay);
+    }
+
     function prepareMusicBarHitRegion(musicBar) {
         if (!musicBar) return;
         musicBar.setAttribute('data-compact-hit-region', 'true');
@@ -673,17 +734,33 @@
     }
 
     function scheduleMusicBarRelocation(detachedMusicBar) {
-        if (detachedMusicBar) pendingDetachedMusicBar = detachedMusicBar;
+        if (detachedMusicBar) {
+            pendingDetachedMusicBar = detachedMusicBar;
+            clearMusicMountRelocationRetry();
+        }
         if (musicMountRelocationFrame) return;
         const raf = window.requestAnimationFrame || ((callback) => window.setTimeout(callback, 16));
         musicMountRelocationFrame = raf(() => {
             musicMountRelocationFrame = 0;
             const musicBar = pendingDetachedMusicBar || document.getElementById(MUSIC_CONFIG.dom.barId);
-            pendingDetachedMusicBar = null;
             if (musicBar) {
-                mountMusicBar(musicBar);
+                const mounted = mountMusicBar(musicBar);
+                if (mounted || musicBar.isConnected) {
+                    pendingDetachedMusicBar = null;
+                    clearMusicMountRelocationRetry();
+                } else {
+                    pendingDetachedMusicBar = musicBar;
+                    scheduleMusicBarRelocationRetry();
+                }
             } else if (!isBarOwner() && mirrorBarLastState) {
-                renderMirrorBar(mirrorBarLastState);
+                if (renderMirrorBar(mirrorBarLastState)) {
+                    clearMusicMountRelocationRetry();
+                } else {
+                    scheduleMusicBarRelocationRetry();
+                }
+            } else {
+                pendingDetachedMusicBar = null;
+                clearMusicMountRelocationRetry();
             }
         });
     }
@@ -993,7 +1070,7 @@
     }
 
     const renderMirrorBar = (state) => {
-        if (!state) return;
+        if (!state) return false;
         if (mirrorBarDestroyTimer) { clearTimeout(mirrorBarDestroyTimer); mirrorBarDestroyTimer = null; }
         mirrorBarLastState = state;
 
@@ -1004,18 +1081,18 @@
         const firstRender = !musicBar;
 
         // 已存在但属于本窗口的 owner bar（非 mirror）：说明 leader 是自己，不应覆盖
-        if (musicBar && musicBar.dataset.mirror !== 'true') return;
+        if (musicBar && musicBar.dataset.mirror !== 'true') return false;
 
         if (firstRender) {
             ensureMusicUiCSS();
             const mountTarget = getPreferredMusicMountTarget().mountTarget;
-            if (!mountTarget) return;
+            if (!mountTarget) return false;
 
             musicBar = document.createElement('div');
             musicBar.id = MUSIC_CONFIG.dom.barId;
             musicBar.className = 'music-player-bar';
             musicBar.dataset.mirror = 'true';
-            mountMusicBar(musicBar);
+            if (!mountMusicBar(musicBar)) return false;
 
             const randomColor = MUSIC_CONFIG.themeColors[Math.floor(Math.random() * MUSIC_CONFIG.themeColors.length)];
             musicBar.style.setProperty('--dynamic-random-color', randomColor);
@@ -1058,7 +1135,7 @@
             bindMirrorBarControls(musicBar);
         } else {
             musicBar.classList.remove('fading-out');
-            mountMusicBar(musicBar);
+            if (!mountMusicBar(musicBar)) return false;
         }
 
         // 切歌 / 首次：刷新标题 + 歌手 + 封面
@@ -1127,6 +1204,7 @@
                 else volumeBtn.textContent = '🔊';
             }
         }
+        return true;
     };
 
     const teardownMirrorBar = (fullTeardown) => {
@@ -1234,32 +1312,38 @@
     }
 
     function applyMusicPlayerBridgeEvent(event) {
-        if (!event || typeof event !== 'object') return;
+        if (!event || typeof event !== 'object') return false;
         const sender = event.sender;
-        if (!sender || sender === MUSIC_COORD_SENDER_ID) return;
+        if (!sender || sender === MUSIC_COORD_SENDER_ID) return false;
         const payload = event.payload || {};
         try {
             if (event.type === 'coord') {
                 applyMusicPlayerBridgeCoord(sender, payload.coordType, payload);
+                return true;
             } else if (event.type === 'bar_state') {
-                if (isBarOwner()) return;
+                if (isBarOwner()) return false;
                 setMirrorBarLeader(sender, 'bridge');
-                renderMirrorBar(payload);
+                const rendered = renderMirrorBar(payload);
+                if (!rendered) scheduleMusicBarRelocation();
+                return rendered;
             } else if (event.type === 'bar_destroyed') {
-                if (isBarOwner()) return;
-                if (sender !== mirrorBarLeaderSender) return;
-                if (!isCurrentMirrorPlayback(payload)) return;
+                if (isBarOwner()) return false;
+                if (sender !== mirrorBarLeaderSender) return false;
+                if (!isCurrentMirrorPlayback(payload)) return false;
                 setMirrorBarLeader(null);
                 teardownMirrorBar(!!payload.fullTeardown);
+                return true;
             } else if (event.type === 'bar_ctrl') {
-                if (!isBarOwner()) return;
-                if (payload.target !== MUSIC_COORD_SENDER_ID) return;
-                if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return;
+                if (!isBarOwner()) return false;
+                if (payload.target !== MUSIC_COORD_SENDER_ID) return false;
+                if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return false;
                 handleRemoteBarCtrl(payload.action, payload.value);
+                return true;
             }
         } catch (e) {
             console.warn('[Music UI] music player bridge event failed:', e);
         }
+        return false;
     }
 
     async function pollMusicPlayerBridge() {
@@ -1303,9 +1387,10 @@
             const latestPlaybackId = data.latest_state && data.latest_state.playbackId;
             if (Array.isArray(data.events)) {
                 for (const event of data.events) {
-                    applyMusicPlayerBridgeEvent(event);
+                    const eventRendered = applyMusicPlayerBridgeEvent(event);
                     if (event && event.type === 'bar_state' && event.sender === data.owner
-                        && (!latestPlaybackId || (event.payload && event.payload.playbackId === latestPlaybackId))) {
+                        && (!latestPlaybackId || (event.payload && event.payload.playbackId === latestPlaybackId))
+                        && eventRendered) {
                         sawOwnerBarStateEvent = true;
                     }
                 }
@@ -1313,7 +1398,7 @@
 
             if (data.owner && data.owner !== MUSIC_COORD_SENDER_ID && data.latest_state && !isBarOwner() && !sawOwnerBarStateEvent) {
                 setMirrorBarLeader(data.owner, 'bridge');
-                renderMirrorBar(data.latest_state);
+                if (!renderMirrorBar(data.latest_state)) scheduleMusicBarRelocation();
             } else if (!data.owner && mirrorBarLeaderSender && mirrorBarLeaderSource === 'bridge' && !isBarOwner()) {
                 setMirrorBarLeader(null);
                 teardownMirrorBar(false);
@@ -1383,7 +1468,7 @@
                         // 绑定/切换到当前 leader —— 后续 ctrl 会带 target 指向它，
                         // destroyed 也只接受来自它的那一条，避免多 leader 交接时串窗
                         setMirrorBarLeader(data.sender, 'broadcast');
-                        renderMirrorBar(data);
+                        if (!renderMirrorBar(data)) scheduleMusicBarRelocation();
                     } else if (data.type === 'destroyed') {
                         if (isBarOwner()) return;
                         // 只尊重来自当前绑定 leader 的 destroyed；别的 owner 退出

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -490,17 +490,27 @@
         let node = element;
         while (node && node instanceof Element) {
             if (node.hidden) return true;
-            if (node.getAttribute('aria-hidden') === 'true') return true;
-            if (node.getAttribute('data-compact-music-player-visibility') === 'closed') return true;
-            try {
-                const style = window.getComputedStyle ? window.getComputedStyle(node) : null;
-                if (style && (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse')) {
-                    return true;
-                }
-            } catch (_) { /* ignore */ }
             node = node.parentElement;
         }
         return false;
+    }
+
+    function isMusicMountUnavailable(mount) {
+        if (!mount || isElementInHiddenTree(mount)) return true;
+        if (mount.getAttribute('aria-hidden') === 'true') return true;
+        if (mount.getAttribute('data-compact-music-player-visibility') === 'closed') return true;
+        try {
+            const style = window.getComputedStyle ? window.getComputedStyle(mount) : null;
+            const emptyCompactMount = mount.getAttribute('data-music-player-mount') === 'compact-surface'
+                && !mount.firstElementChild;
+            return !!(style && (
+                (style.display === 'none' && !emptyCompactMount)
+                || style.visibility === 'hidden'
+                || style.visibility === 'collapse'
+            ));
+        } catch (_) {
+            return false;
+        }
     }
 
     function hasUsableLocalChatMusicSurface() {
@@ -509,11 +519,7 @@
         const mount = mode === 'compact'
             ? getCompactMusicMountTarget()
             : (mode === 'full' ? getFullMusicMountTarget() : (getFullMusicMountTarget() || getCompactMusicMountTarget()));
-        if (!mount || isElementInHiddenTree(mount)) return false;
-
-        const overlay = document.getElementById('react-chat-window-overlay');
-        if (overlay && isElementInHiddenTree(overlay)) return false;
-        return true;
+        return !isMusicMountUnavailable(mount);
     }
 
     function isLocalChatMusicSurfaceFocused() {

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -527,6 +527,9 @@
         try {
             if (document.visibilityState === 'hidden') return false;
         } catch (_) { /* ignore */ }
+        if (getChatMusicSurfaceMode() === 'full' && isDedicatedChatMusicSurface()) {
+            return true;
+        }
         try {
             return typeof document.hasFocus === 'function' ? document.hasFocus() : true;
         } catch (_) {
@@ -554,23 +557,27 @@
         };
     }
 
-    function hasBridgeActiveChatMusicSurface() {
+    function getValidBridgeActiveChatMusicSurface() {
         if (!musicPlayerBridgeActiveSurface) return false;
         if ((musicPlayerBridgeActiveSurface.expireAt || 0) <= Date.now()) {
             musicPlayerBridgeActiveSurface = null;
             return false;
         }
-        if (musicPlayerBridgeActiveSurface.sender === MUSIC_COORD_SENDER_ID) return false;
-        return !!(
+        if (!(
             musicPlayerBridgeActiveSurface.active ||
             musicPlayerBridgeActiveSurface.focused ||
             musicPlayerBridgeActiveSurface.visible
-        );
+        )) return false;
+        return musicPlayerBridgeActiveSurface;
     }
 
     function shouldRenderMusicBarInThisSurface() {
-        if (isLocalChatMusicSurfaceFocused()) return true;
-        if (hasBridgeActiveChatMusicSurface()) return false;
+        const bridgeSurface = getValidBridgeActiveChatMusicSurface();
+        const localActive = isLocalChatMusicSurfaceFocused();
+        if (bridgeSurface && bridgeSurface.sender !== MUSIC_COORD_SENDER_ID) {
+            return localActive && getChatMusicSurfaceMode() === 'full';
+        }
+        if (localActive) return true;
         if (isDedicatedChatMusicSurface()) return hasUsableLocalChatMusicSurface();
         return hasUsableLocalChatMusicSurface();
     }

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -65,6 +65,7 @@
     };
 
     let currentPlayingTrack = null;
+    let currentMusicPlaybackId = null;
     let localPlayer = null;
     let musicCardMessageId = null;
     let aplayerLoadPromise = null;
@@ -97,6 +98,7 @@
     // sender_id -> expireAt
     const remoteMusicSenders = new Map();
     let musicPlayerBridgeSeq = 0;
+    let musicPlayerBridgePollInFlight = false;
     let musicPlayerBridgePollTimer = null;
     let musicPlayerBridgeSurfacePulseTimer = null;
     let musicPlayerBridgeRemoteActiveUntil = 0;
@@ -115,6 +117,7 @@
                 } else if (data.type === 'music_pending') {
                     remoteMusicSenders.set(sid, Date.now() + REMOTE_MUSIC_PENDING_TTL_MS);
                 } else if (data.type === 'music_ended') {
+                    if (sid === mirrorBarLeaderSender && !isCurrentMirrorPlayback(data)) return;
                     remoteMusicSenders.delete(sid);
                 }
             };
@@ -125,6 +128,7 @@
                         musicCoordChannel.postMessage({
                             type: 'music_ended',
                             sender: MUSIC_COORD_SENDER_ID,
+                            playbackId: getCurrentMusicPlaybackId(),
                             ts: Date.now()
                         });
                         musicCoordChannel.close();
@@ -138,12 +142,13 @@
     }
 
     const broadcastMusicCoord = (type) => {
+        const playbackId = getCurrentMusicPlaybackId();
         if (musicCoordChannel) {
             try {
-                musicCoordChannel.postMessage({ type, sender: MUSIC_COORD_SENDER_ID, ts: Date.now() });
+                musicCoordChannel.postMessage({ type, sender: MUSIC_COORD_SENDER_ID, playbackId, ts: Date.now() });
             } catch (_) { /* ignore */ }
         }
-        postMusicPlayerBridgeEvent('coord', { coordType: type });
+        postMusicPlayerBridgeEvent('coord', { coordType: type, playbackId });
     };
 
     // 心跳：当本地正在播时定期广播，防止其他窗口误以为对方已退出
@@ -179,6 +184,15 @@
         }
         return remoteMusicSenders.size > 0;
     };
+
+    function createMusicPlaybackId(trackInfo, token) {
+        const trackPart = trackInfo && trackInfo.url ? String(trackInfo.url).slice(0, 256) : 'unknown';
+        return MUSIC_COORD_SENDER_ID + ':' + String(token || Date.now()) + ':' + trackPart;
+    }
+
+    function getCurrentMusicPlaybackId() {
+        return currentMusicPlaybackId || '';
+    }
 
     // --- 跨窗口 React 聊天镜像：把本窗口写入 reactChatWindowHost 的
     // append/update 动作同步广播给其他窗口，解决 PR #780 之后的问题 ——
@@ -266,8 +280,21 @@
     // follower 记录当前镜像绑定的 leader sender id。所有 ctrl/destroyed 校验
     // 都要比对这个值，避免 leader 切换重叠时别的 owner 被误触发 pause/close。
     let mirrorBarLeaderSender = null;
+    let mirrorBarLeaderSource = null;
     const processedBarCtrlIds = new Set();
     const processedBarCtrlOrder = [];
+
+    function setMirrorBarLeader(sender, source) {
+        const leaderChanged = sender !== mirrorBarLeaderSender;
+        mirrorBarLeaderSender = sender || null;
+        if (!sender) {
+            mirrorBarLeaderSource = null;
+            return;
+        }
+        if (source === 'broadcast' || leaderChanged || mirrorBarLeaderSource !== 'broadcast') {
+            mirrorBarLeaderSource = source || null;
+        }
+    }
 
     function shouldSkipProcessedBarCtrl(ctrlId) {
         if (!ctrlId) return false;
@@ -283,24 +310,28 @@
     const isBarOwner = () => !!localPlayer;
 
     const broadcastBarState = (patch) => {
+        const statePayload = Object.assign({}, patch || {});
+        if (!statePayload.playbackId) statePayload.playbackId = getCurrentMusicPlaybackId();
         const message = Object.assign({
             type: 'state',
             sender: MUSIC_COORD_SENDER_ID,
             ts: Date.now()
-        }, patch);
+        }, statePayload);
         if (musicBarChannel) {
             try {
                 musicBarChannel.postMessage(message);
             } catch (_) { /* ignore */ }
         }
-        postMusicPlayerBridgeEvent('bar_state', patch || {});
+        postMusicPlayerBridgeEvent('bar_state', statePayload);
     };
 
     const broadcastBarDestroyed = (fullTeardown) => {
+        const playbackId = getCurrentMusicPlaybackId();
         const message = {
             type: 'destroyed',
             sender: MUSIC_COORD_SENDER_ID,
             ts: Date.now(),
+            playbackId: playbackId,
             fullTeardown: !!fullTeardown
         };
         if (musicBarChannel) {
@@ -308,7 +339,7 @@
                 musicBarChannel.postMessage(message);
             } catch (_) { /* ignore */ }
         }
-        postMusicPlayerBridgeEvent('bar_destroyed', { fullTeardown: !!fullTeardown });
+        postMusicPlayerBridgeEvent('bar_destroyed', { fullTeardown: !!fullTeardown, playbackId: playbackId });
     };
 
     const broadcastBarCtrl = (action, value) => {
@@ -353,7 +384,8 @@
             currentTime: audio ? (audio.currentTime || 0) : 0,
             duration: audio && isFinite(audio.duration) ? (audio.duration || 0) : 0,
             volume: (typeof localPlayer.volume === 'function') ? (localPlayer.volume() || 0) : 0,
-            loadError: !!localPlayer._loadError
+            loadError: !!localPlayer._loadError,
+            playbackId: getCurrentMusicPlaybackId()
         };
     };
 
@@ -390,6 +422,7 @@
             duration: 0,
             volume: MUSIC_CONFIG.defaultVolume,
             loadError: false,
+            playbackId: getCurrentMusicPlaybackId(),
             initial: true
         });
     };
@@ -457,6 +490,14 @@
         let node = element;
         while (node && node instanceof Element) {
             if (node.hidden) return true;
+            if (node.getAttribute('aria-hidden') === 'true') return true;
+            if (node.getAttribute('data-compact-music-player-visibility') === 'closed') return true;
+            try {
+                const style = window.getComputedStyle ? window.getComputedStyle(node) : null;
+                if (style && (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse')) {
+                    return true;
+                }
+            } catch (_) { /* ignore */ }
             node = node.parentElement;
         }
         return false;
@@ -471,7 +512,7 @@
         if (!mount || isElementInHiddenTree(mount)) return false;
 
         const overlay = document.getElementById('react-chat-window-overlay');
-        if (overlay && overlay.hidden) return false;
+        if (overlay && isElementInHiddenTree(overlay)) return false;
         return true;
     }
 
@@ -524,7 +565,7 @@
     function shouldRenderMusicBarInThisSurface() {
         if (isLocalChatMusicSurfaceFocused()) return true;
         if (hasBridgeActiveChatMusicSurface()) return false;
-        if (isDedicatedChatMusicSurface()) return false;
+        if (isDedicatedChatMusicSurface()) return hasUsableLocalChatMusicSurface();
         return hasUsableLocalChatMusicSurface();
     }
 
@@ -611,12 +652,15 @@
     function isMusicMountMutationNode(node) {
         if (!(node instanceof Element)) return false;
         if (node.id === 'music-player-mount' || node.getAttribute('data-music-player-mount') === 'compact-surface') return true;
-        return !!(node.querySelector && node.querySelector('#music-player-mount, [data-music-player-mount="compact-surface"]'));
+        if (node.id === 'react-chat-window-shell' || node.id === 'react-chat-window-overlay') return true;
+        return !!(node.querySelector && node.querySelector('#music-player-mount, [data-music-player-mount="compact-surface"], #react-chat-window-shell, #react-chat-window-overlay'));
     }
 
     function isMusicMountMutationTarget(node) {
         if (!(node instanceof Element)) return false;
         return node.id === 'music-player-mount'
+            || node.id === 'react-chat-window-shell'
+            || node.id === 'react-chat-window-overlay'
             || node.getAttribute('data-music-player-mount') === 'compact-surface';
     }
 
@@ -636,7 +680,11 @@
             musicMountRelocationFrame = 0;
             const musicBar = pendingDetachedMusicBar || document.getElementById(MUSIC_CONFIG.dom.barId);
             pendingDetachedMusicBar = null;
-            mountMusicBar(musicBar);
+            if (musicBar) {
+                mountMusicBar(musicBar);
+            } else if (!isBarOwner() && mirrorBarLastState) {
+                renderMirrorBar(mirrorBarLastState);
+            }
         });
     }
 
@@ -678,6 +726,9 @@
             attributeFilter: [
                 'class',
                 'data-music-player-mount',
+                'data-chat-surface-mode',
+                'aria-hidden',
+                'hidden',
                 'style'
             ]
         });
@@ -695,6 +746,23 @@
             return null;
         }
         return headers;
+    }
+
+    function getMusicPlayerBridgeCachedMutationHeaders(body) {
+        const headers = { 'Content-Type': 'application/json' };
+        const sec = window.nekoLocalMutationSecurity;
+        if (!sec || typeof sec.peekCachedToken !== 'function') {
+            return null;
+        }
+        try {
+            const token = sec.peekCachedToken();
+            if (!token) return null;
+            headers['X-CSRF-Token'] = token;
+            if (body && typeof body === 'object') body._csrf_token = token;
+            return headers;
+        } catch (_) {
+            return null;
+        }
     }
 
     async function isMusicPlayerBridgeCsrfFailure(response) {
@@ -715,6 +783,21 @@
             payload: payload || {},
             surface: options.surface || getMusicBridgeSurfaceState(type)
         };
+        if (options.cachedOnly) {
+            const headers = getMusicPlayerBridgeCachedMutationHeaders(body);
+            if (!headers) return;
+            try {
+                const request = fetch(MUSIC_PLAYER_BRIDGE_ENDPOINT, {
+                    method: 'POST',
+                    headers: headers,
+                    body: JSON.stringify(body),
+                    keepalive: true,
+                    cache: 'no-store'
+                });
+                if (request && typeof request.catch === 'function') request.catch(() => { /* ignore */ });
+            } catch (_) { /* ignore */ }
+            return;
+        }
         (async () => {
             let headers = await getMusicPlayerBridgeMutationHeaders();
             if (!headers) return;
@@ -902,6 +985,12 @@
     };
 
     let mirrorBarLastState = null; // 供 seek UI 计算 currentTime 显示
+
+    function isCurrentMirrorPlayback(payload) {
+        const currentPlaybackId = mirrorBarLastState && mirrorBarLastState.playbackId;
+        if (!currentPlaybackId) return true;
+        return !!(payload && payload.playbackId === currentPlaybackId);
+    }
 
     const renderMirrorBar = (state) => {
         if (!state) return;
@@ -1132,13 +1221,14 @@
         }
     };
 
-    function applyMusicPlayerBridgeCoord(sender, coordType) {
+    function applyMusicPlayerBridgeCoord(sender, coordType, payload) {
         if (!sender || sender === MUSIC_COORD_SENDER_ID) return;
         if (coordType === 'music_started' || coordType === 'music_heartbeat') {
             remoteMusicSenders.set(sender, Date.now() + REMOTE_MUSIC_TTL_MS);
         } else if (coordType === 'music_pending') {
             remoteMusicSenders.set(sender, Date.now() + REMOTE_MUSIC_PENDING_TTL_MS);
         } else if (coordType === 'music_ended') {
+            if (sender === mirrorBarLeaderSender && !isCurrentMirrorPlayback(payload)) return;
             remoteMusicSenders.delete(sender);
         }
     }
@@ -1150,19 +1240,20 @@
         const payload = event.payload || {};
         try {
             if (event.type === 'coord') {
-                applyMusicPlayerBridgeCoord(sender, payload.coordType);
+                applyMusicPlayerBridgeCoord(sender, payload.coordType, payload);
             } else if (event.type === 'bar_state') {
                 if (isBarOwner()) return;
-                mirrorBarLeaderSender = sender;
+                setMirrorBarLeader(sender, 'bridge');
                 renderMirrorBar(payload);
             } else if (event.type === 'bar_destroyed') {
                 if (isBarOwner()) return;
                 if (sender !== mirrorBarLeaderSender) return;
-                mirrorBarLeaderSender = null;
+                if (!isCurrentMirrorPlayback(payload)) return;
+                setMirrorBarLeader(null);
                 teardownMirrorBar(!!payload.fullTeardown);
             } else if (event.type === 'bar_ctrl') {
                 if (!isBarOwner()) return;
-                if (payload.target && payload.target !== MUSIC_COORD_SENDER_ID) return;
+                if (payload.target !== MUSIC_COORD_SENDER_ID) return;
                 if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return;
                 handleRemoteBarCtrl(payload.action, payload.value);
             }
@@ -1172,6 +1263,8 @@
     }
 
     async function pollMusicPlayerBridge() {
+        if (musicPlayerBridgePollInFlight) return;
+        musicPlayerBridgePollInFlight = true;
         try {
             const surface = getMusicBridgeSurfaceState('poll');
             const params = new URLSearchParams({
@@ -1186,8 +1279,12 @@
             const data = await response.json();
             if (!data || data.success === false) return;
 
-            if (typeof data.seq === 'number' && data.seq > musicPlayerBridgeSeq) {
-                musicPlayerBridgeSeq = data.seq;
+            if (typeof data.seq === 'number') {
+                if (data.seq < musicPlayerBridgeSeq) {
+                    musicPlayerBridgeSeq = 0;
+                } else if (data.seq > musicPlayerBridgeSeq) {
+                    musicPlayerBridgeSeq = data.seq;
+                }
             }
 
             if (data.active_surface && data.active_surface.sender) {
@@ -1202,21 +1299,31 @@
                 ? Date.now() + MUSIC_PLAYER_BRIDGE_POLL_MS + 1400
                 : 0;
 
+            let sawOwnerBarStateEvent = false;
+            const latestPlaybackId = data.latest_state && data.latest_state.playbackId;
             if (Array.isArray(data.events)) {
-                for (const event of data.events) applyMusicPlayerBridgeEvent(event);
+                for (const event of data.events) {
+                    applyMusicPlayerBridgeEvent(event);
+                    if (event && event.type === 'bar_state' && event.sender === data.owner
+                        && (!latestPlaybackId || (event.payload && event.payload.playbackId === latestPlaybackId))) {
+                        sawOwnerBarStateEvent = true;
+                    }
+                }
             }
 
-            if (data.owner && data.owner !== MUSIC_COORD_SENDER_ID && data.latest_state && !isBarOwner()) {
-                mirrorBarLeaderSender = data.owner;
+            if (data.owner && data.owner !== MUSIC_COORD_SENDER_ID && data.latest_state && !isBarOwner() && !sawOwnerBarStateEvent) {
+                setMirrorBarLeader(data.owner, 'bridge');
                 renderMirrorBar(data.latest_state);
-            } else if (!data.owner && mirrorBarLeaderSender && !isBarOwner()) {
-                mirrorBarLeaderSender = null;
+            } else if (!data.owner && mirrorBarLeaderSender && mirrorBarLeaderSource === 'bridge' && !isBarOwner()) {
+                setMirrorBarLeader(null);
                 teardownMirrorBar(false);
             }
 
             if (surface.active || surface.visible) scheduleMusicBarRelocation();
         } catch (_) {
             // Bridge is best-effort; BroadcastChannel/local owner remain usable.
+        } finally {
+            musicPlayerBridgePollInFlight = false;
         }
     }
 
@@ -1241,10 +1348,11 @@
             postMusicPlayerBridgeEvent('surface_state', Object.assign(
                 getMusicBridgeSurfaceState('unload'),
                 { active: false, focused: false, visible: false, reason: 'unload' }
-            ));
+            ), { cachedOnly: true });
             if (isBarOwner()) {
-                postMusicPlayerBridgeEvent('bar_destroyed', { fullTeardown: true });
-                postMusicPlayerBridgeEvent('coord', { coordType: 'music_ended' });
+                const playbackId = getCurrentMusicPlaybackId();
+                postMusicPlayerBridgeEvent('bar_destroyed', { fullTeardown: true, playbackId: playbackId }, { cachedOnly: true });
+                postMusicPlayerBridgeEvent('coord', { coordType: 'music_ended', playbackId: playbackId }, { cachedOnly: true });
             }
             if (musicPlayerBridgePollTimer) {
                 window.clearInterval(musicPlayerBridgePollTimer);
@@ -1274,20 +1382,21 @@
                         if (isBarOwner()) return;
                         // 绑定/切换到当前 leader —— 后续 ctrl 会带 target 指向它，
                         // destroyed 也只接受来自它的那一条，避免多 leader 交接时串窗
-                        mirrorBarLeaderSender = data.sender;
+                        setMirrorBarLeader(data.sender, 'broadcast');
                         renderMirrorBar(data);
                     } else if (data.type === 'destroyed') {
                         if (isBarOwner()) return;
                         // 只尊重来自当前绑定 leader 的 destroyed；别的 owner 退出
                         // 不应该把我当前镜像的那条 bar 也一起摘掉
                         if (data.sender !== mirrorBarLeaderSender) return;
-                        mirrorBarLeaderSender = null;
+                        if (!isCurrentMirrorPlayback(data)) return;
+                        setMirrorBarLeader(null);
                         teardownMirrorBar(!!data.fullTeardown);
                     } else if (data.type === 'ctrl') {
                         // owner 只响应明确 target 到自己的 ctrl，避免别的 leader
                         // 被 follower 的指令误触（leader 交接瞬间最容易发生）
                         if (!isBarOwner()) return;
-                        if (data.target && data.target !== MUSIC_COORD_SENDER_ID) return;
+                        if (data.target !== MUSIC_COORD_SENDER_ID) return;
                         if (shouldSkipProcessedBarCtrl(data.ctrlId)) return;
                         handleRemoteBarCtrl(data.action, data.value);
                     }
@@ -1711,6 +1820,7 @@
         // bar 镜像：让 follower 同步摘掉镜像 bar。fullTeardown 传下去
         // 是为了 follower 能走淡出动画而不是硬删。
         if (removeDOM) broadcastBarDestroyed(fullTeardown);
+        currentMusicPlaybackId = null;
     };
 
     // --- 查找并替换整个 loadAPlayerLibrary 函数 ---
@@ -1796,7 +1906,7 @@
             mirrorBarTrackSig = null;
             mirrorBarLastState = null;
             // 自己升成 owner 后就不再持有"绑定到某个 leader"的状态
-            mirrorBarLeaderSender = null;
+            setMirrorBarLeader(null);
         }
 
         const hasCover = trackInfo.cover && trackInfo.cover.length > 0 && isSafeUrl(trackInfo.cover);
@@ -1864,6 +1974,7 @@
         const previousCardId = musicCardMessageId;
 
         // --- 2. 原地更新 UI 文本/封面 (始终执行) ---
+        currentMusicPlaybackId = createMusicPlaybackId(trackInfo, currentToken);
         currentPlayingTrack = trackInfo;
         // 广播一次占位 state —— APlayer 还在初始化/切曲，但 follower 现在
         // 就能把 bar 刷新到新 track，避免旧歌信息停留或 bar 空白。

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -490,28 +490,17 @@
         let node = element;
         while (node && node instanceof Element) {
             if (node.hidden) return true;
+            if (node.getAttribute('aria-hidden') === 'true') return true;
+            if (node.getAttribute('data-compact-music-player-visibility') === 'closed') return true;
+            try {
+                const style = window.getComputedStyle ? window.getComputedStyle(node) : null;
+                if (style && (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse')) {
+                    return true;
+                }
+            } catch (_) { /* ignore */ }
             node = node.parentElement;
         }
         return false;
-    }
-
-    function isMusicMountUnavailable(mount) {
-        if (!mount || isElementInHiddenTree(mount)) return true;
-        if (mount.getAttribute('aria-hidden') === 'true') return true;
-        if (mount.getAttribute('data-compact-music-player-visibility') === 'closed') return true;
-        try {
-            const style = window.getComputedStyle ? window.getComputedStyle(mount) : null;
-            // React hides empty full/compact mounts with :empty; they are still valid targets.
-            const emptyChatMusicMount = mount.id === 'music-player-mount'
-                && !mount.firstElementChild;
-            return !!(style && (
-                (style.display === 'none' && !emptyChatMusicMount)
-                || style.visibility === 'hidden'
-                || style.visibility === 'collapse'
-            ));
-        } catch (_) {
-            return false;
-        }
     }
 
     function hasUsableLocalChatMusicSurface() {
@@ -520,7 +509,11 @@
         const mount = mode === 'compact'
             ? getCompactMusicMountTarget()
             : (mode === 'full' ? getFullMusicMountTarget() : (getFullMusicMountTarget() || getCompactMusicMountTarget()));
-        return !isMusicMountUnavailable(mount);
+        if (!mount || isElementInHiddenTree(mount)) return false;
+
+        const overlay = document.getElementById('react-chat-window-overlay');
+        if (overlay && isElementInHiddenTree(overlay)) return false;
+        return true;
     }
 
     function isLocalChatMusicSurfaceFocused() {
@@ -528,9 +521,6 @@
         try {
             if (document.visibilityState === 'hidden') return false;
         } catch (_) { /* ignore */ }
-        if (getChatMusicSurfaceMode() === 'full' && isDedicatedChatMusicSurface()) {
-            return true;
-        }
         try {
             return typeof document.hasFocus === 'function' ? document.hasFocus() : true;
         } catch (_) {
@@ -558,27 +548,23 @@
         };
     }
 
-    function getValidBridgeActiveChatMusicSurface() {
+    function hasBridgeActiveChatMusicSurface() {
         if (!musicPlayerBridgeActiveSurface) return false;
         if ((musicPlayerBridgeActiveSurface.expireAt || 0) <= Date.now()) {
             musicPlayerBridgeActiveSurface = null;
             return false;
         }
-        if (!(
+        if (musicPlayerBridgeActiveSurface.sender === MUSIC_COORD_SENDER_ID) return false;
+        return !!(
             musicPlayerBridgeActiveSurface.active ||
             musicPlayerBridgeActiveSurface.focused ||
             musicPlayerBridgeActiveSurface.visible
-        )) return false;
-        return musicPlayerBridgeActiveSurface;
+        );
     }
 
     function shouldRenderMusicBarInThisSurface() {
-        const bridgeSurface = getValidBridgeActiveChatMusicSurface();
-        const localActive = isLocalChatMusicSurfaceFocused();
-        if (bridgeSurface && bridgeSurface.sender !== MUSIC_COORD_SENDER_ID) {
-            return localActive && getChatMusicSurfaceMode() === 'full';
-        }
-        if (localActive) return true;
+        if (isLocalChatMusicSurfaceFocused()) return true;
+        if (hasBridgeActiveChatMusicSurface()) return false;
         if (isDedicatedChatMusicSurface()) return hasUsableLocalChatMusicSurface();
         return hasUsableLocalChatMusicSurface();
     }
@@ -1007,8 +993,7 @@
     }
 
     const renderMirrorBar = (state) => {
-        if (!state) return false;
-        ensureMusicMountObserver();
+        if (!state) return;
         if (mirrorBarDestroyTimer) { clearTimeout(mirrorBarDestroyTimer); mirrorBarDestroyTimer = null; }
         mirrorBarLastState = state;
 
@@ -1019,18 +1004,18 @@
         const firstRender = !musicBar;
 
         // 已存在但属于本窗口的 owner bar（非 mirror）：说明 leader 是自己，不应覆盖
-        if (musicBar && musicBar.dataset.mirror !== 'true') return false;
+        if (musicBar && musicBar.dataset.mirror !== 'true') return;
 
         if (firstRender) {
             ensureMusicUiCSS();
             const mountTarget = getPreferredMusicMountTarget().mountTarget;
-            if (!mountTarget) return false;
+            if (!mountTarget) return;
 
             musicBar = document.createElement('div');
             musicBar.id = MUSIC_CONFIG.dom.barId;
             musicBar.className = 'music-player-bar';
             musicBar.dataset.mirror = 'true';
-            if (!mountMusicBar(musicBar) || musicBar.hidden) return false;
+            mountMusicBar(musicBar);
 
             const randomColor = MUSIC_CONFIG.themeColors[Math.floor(Math.random() * MUSIC_CONFIG.themeColors.length)];
             musicBar.style.setProperty('--dynamic-random-color', randomColor);
@@ -1073,7 +1058,7 @@
             bindMirrorBarControls(musicBar);
         } else {
             musicBar.classList.remove('fading-out');
-            if (!mountMusicBar(musicBar) || musicBar.hidden) return false;
+            mountMusicBar(musicBar);
         }
 
         // 切歌 / 首次：刷新标题 + 歌手 + 封面
@@ -1142,7 +1127,6 @@
                 else volumeBtn.textContent = '🔊';
             }
         }
-        return true;
     };
 
     const teardownMirrorBar = (fullTeardown) => {
@@ -1250,33 +1234,32 @@
     }
 
     function applyMusicPlayerBridgeEvent(event) {
-        if (!event || typeof event !== 'object') return false;
+        if (!event || typeof event !== 'object') return;
         const sender = event.sender;
-        if (!sender || sender === MUSIC_COORD_SENDER_ID) return false;
+        if (!sender || sender === MUSIC_COORD_SENDER_ID) return;
         const payload = event.payload || {};
         try {
             if (event.type === 'coord') {
                 applyMusicPlayerBridgeCoord(sender, payload.coordType, payload);
             } else if (event.type === 'bar_state') {
-                if (isBarOwner()) return false;
+                if (isBarOwner()) return;
                 setMirrorBarLeader(sender, 'bridge');
-                return renderMirrorBar(payload);
+                renderMirrorBar(payload);
             } else if (event.type === 'bar_destroyed') {
-                if (isBarOwner()) return false;
-                if (sender !== mirrorBarLeaderSender) return false;
-                if (!isCurrentMirrorPlayback(payload)) return false;
+                if (isBarOwner()) return;
+                if (sender !== mirrorBarLeaderSender) return;
+                if (!isCurrentMirrorPlayback(payload)) return;
                 setMirrorBarLeader(null);
                 teardownMirrorBar(!!payload.fullTeardown);
             } else if (event.type === 'bar_ctrl') {
-                if (!isBarOwner()) return false;
-                if (payload.target !== MUSIC_COORD_SENDER_ID) return false;
-                if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return false;
+                if (!isBarOwner()) return;
+                if (payload.target !== MUSIC_COORD_SENDER_ID) return;
+                if (shouldSkipProcessedBarCtrl(payload.ctrlId)) return;
                 handleRemoteBarCtrl(payload.action, payload.value);
             }
         } catch (e) {
             console.warn('[Music UI] music player bridge event failed:', e);
         }
-        return false;
     }
 
     async function pollMusicPlayerBridge() {
@@ -1320,8 +1303,8 @@
             const latestPlaybackId = data.latest_state && data.latest_state.playbackId;
             if (Array.isArray(data.events)) {
                 for (const event of data.events) {
-                    const renderedEvent = applyMusicPlayerBridgeEvent(event);
-                    if (renderedEvent && event && event.type === 'bar_state' && event.sender === data.owner
+                    applyMusicPlayerBridgeEvent(event);
+                    if (event && event.type === 'bar_state' && event.sender === data.owner
                         && (!latestPlaybackId || (event.payload && event.payload.playbackId === latestPlaybackId))) {
                         sawOwnerBarStateEvent = true;
                     }


### PR DESCRIPTION
## 改动概述 / Summary

同步紧凑/完整聊天框的主动搭话音乐播放器状态，通过后端 bridge 保证一次只有一个播放器 owner，并让当前使用的聊天框接管播放器显示与控制。

## 回归报告 / Regression Report

- 改动内容：在 `main_routers/music_router.py` 新增短 TTL 的音乐播放器 bridge，用于保存当前播放器 owner、最新播放器状态、active chat surface、busy 状态与控制事件队列；前端 `music_ui.js` 通过该 bridge 补足 compact/full 聊天窗口在 Electron 独立 session 下无法互相感知的问题。
- 理由 / 必要性：原逻辑依赖 `BroadcastChannel` / 本地窗口状态，完整聊天框与紧凑聊天框处于不同 Electron session 时无法同步，导致主动搭话音乐可能优先挂到紧凑聊天框、切换后丢失播放器显示，甚至两个聊天框分别触发不同音乐。
- 前后表现对比：修改前 compact/full 可能各自创建播放器并同时播放，切换聊天框后不能稳定继承播放器；修改后真实音频 owner 只保留一份，当前可用聊天框显示镜像播放器，控制事件会回传 owner，主动搭话音乐 dispatch 也会检查 pending/remote busy/rate-limit。
- 潜在回归点：新增轻量轮询和短 TTL 内存态，需关注多窗口数量较多时的请求频率、服务重启后 bridge 状态丢失、owner 异常退出后的 TTL 自愈，以及 `/chat_full` 不再参与 proactive 调度后“只剩完整聊天窗”场景下不会接班触发主动搭话。
- 验证方式：已运行 `node --check .\static\music_ui.js`、`node --check .\static\app-proactive.js`、`uv run python -m py_compile .\main_routers\music_router.py`、`git diff --check -- static\music_ui.js static\app-proactive.js main_routers\music_router.py`；并手动关注主动搭话音乐、compact/full 切换后的播放器显示与控制链路。

## 不拆分理由 / Why Not Split

不适用，计入上限的文件数为 3，未超过 20 个文件阈值。

## 测试 / Testing

- `node --check .\static\music_ui.js`
- `node --check .\static\app-proactive.js`
- `uv run python -m py_compile .\main_routers\music_router.py`
- `git diff --check -- static\music_ui.js static\app-proactive.js main_routers\music_router.py`
- 手动测试音乐搭话与紧凑/完整聊天框切换

## 影响范围

- `main_routers/music_router.py`：新增短 TTL 音乐播放器 bridge。
- `static/music_ui.js`：播放器状态、显示归属、控制事件跨 compact/full 同步。
- `static/app-proactive.js`：`/chat_full` 不再触发主动搭话，音乐 dispatch 增加 busy/pending/remote 拦截。

## 风险

- 有轻量轮询开销：每个加载 `music_ui.js` 的页面约 900ms 一次 GET，2.5s 一次 surface POST。
- bridge 是内存态，服务重启或 owner 异常退出后，状态会丢失或最多短暂残留到 TTL 自愈。
- `/chat_full` 现在不参与 proactive 调度，避免独立 session 自封 leader；代价是如果只剩完整聊天窗，主动搭话不会由它接班触发。
- 播放器显示依赖 focus/visibility/surface mode，极端焦点状态下可能延迟到下一轮 poll 才切换显示位置。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
* 新增跨窗口音乐桥接（HTTP 上报/拉取），基于 TTL 同步 pending/激活曲面、远端忙碌与桥接事件（如曲面/控制销毁等），并引入会话播放标识用于归属校验。

## 改进
* 主动调度：全量聊天界面跳过自身 leader；音乐模式派发改为综合 pending/远端占用/限流/冷却判定，并加入短延迟与二次忙碌校验。
* 镜像音乐条：重构 leader/follower 协议与去重，强化挂载/渲染回填，并与 bridge 轮询/脉冲联动。

## Bug Fixes
* 修正音乐兜底降级分支的重定向返回。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->