### PR TITLE
fix(session): 修复 proactive 自起 text 会话与用户点语音的跨模式竞态

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -640,11 +640,13 @@ IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS = 60
 FRONTEND_START_SESSION_TIMEOUT_SECONDS = 15.0
 
 # 跨模式重启时「等 in-flight 落定」的等待上限。必须明显短于前端超时：等完之后
-# 还要花几秒真正起目标模式会话，若把整个 15s 都耗在等待上，重启发出的
-# session_started 会晚于前端 deadline，前端照样超时、甚至 reset 后才收到 ack 起孤儿
-# 会话（Codex P2）。给重启留 ~1/3 余量，in-flight 没在这窗口内落定就放弃（回落
-# baseline：前端超时，无孤儿）。in-flight（text）正常 1~3s 落定，远在窗口内。
-CROSS_MODE_RESTART_WAIT_SECONDS = FRONTEND_START_SESSION_TIMEOUT_SECONDS * 2 / 3
+# 还要花几秒真正起目标模式会话（含最坏 ~12s 的 TTS 就绪等待），若把大半个 15s 都
+# 耗在等待上，重启发出的 session_started 会晚于前端 deadline，前端照样超时、甚至
+# reset 后才收到 ack 起孤儿会话（Codex P2）。取前端超时的一半，给重启留 ~7.5s 余量；
+# in-flight 没在这窗口内落定就放弃（回落 baseline：前端超时、无孤儿）。in-flight
+# （text）正常 1~3s 落定，远在窗口内。注：TTS 冷启动叠加 in-flight 贴线落定的双重
+# 最坏情形仍可能溢出 15s，此时由 start_session 末尾的连接/放弃校验与重启侧守卫兜底。
+CROSS_MODE_RESTART_WAIT_SECONDS = FRONTEND_START_SESSION_TIMEOUT_SECONDS / 2
 
 # 主动搭话（proactive）调用 prompt_ephemeral 时设置的 sid 期望值。
 # 目的：prompt_ephemeral 内部通过 on_text_delta=handle_text_data 回调 enqueue TTS，
@@ -5508,11 +5510,23 @@ class LLMSessionManager:
                     logger.warning("⚠️ 跨模式等待 in-flight 启动超时（%.1fs，留余量给重启），放弃改起 %s", _waited, input_mode)
                 elif self._user_session_abandon_epoch != _abandon_epoch:
                     logger.warning("⚠️ 跨模式等待期间用户主动结束了启动（已放弃），不再改起 %s", input_mode)
+                elif not (self.websocket is websocket and self._has_connected_websocket()):
+                    # 等待期间浏览器刷新/断连：disconnect cleanup 走 cleanup→end_session
+                    # (by_server=True)，不会 bump abandon epoch，但此刻 self.websocket 已被
+                    # 换成新连接或清空。用这把 stale ws 递归起会话，其 session_started 无处
+                    # 可送 → 孤儿活动会话（Codex P2）。要求"当前 ws 仍是本请求那把且仍连接"
+                    # 才重启。
+                    logger.warning("⚠️ 跨模式等待期间 websocket 已失效/被替换，不再改起 %s", input_mode)
                 else:
-                    # in-flight 干净落定：递归重入起目标模式。重入禁用跨模式重启
-                    # （_allow_cross_mode_restart=False），把递归深度封到 1——若重入
-                    # 时又撞上新的并发启动，回落静默 return 而非无界递归（greptile P2）。
-                    # guard 检查（5431）前无 await，count==0 的判定到重入是原子的。
+                    # in-flight 干净落定且连接仍在：递归重入起目标模式。
+                    # 先清熔断：用户显式请求按 websocket_router 语义本应清，但当时
+                    # _starting_session_count>0 让它没清；若 in-flight 失败把熔断跳了闸，
+                    # 递归会在熔断检查（5427）处静默 return、不发 session_failed → 前端干等
+                    # 15s。这里替它清，让重启真正起来或走正常失败上报（Codex P2）。
+                    # 重入禁用跨模式重启（_allow_cross_mode_restart=False）把递归深度封到 1，
+                    # 二次并发撞车回落静默 return 而非无界递归（greptile P2）。guard 检查
+                    # （5431）前无 await，count==0 的判定到重入是原子的。
+                    self.reset_session_start_circuit()
                     await self.start_session(websocket, new, input_mode,
                                              user_initiated=True, _allow_cross_mode_restart=False)
             else:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5399,7 +5399,14 @@ class LLMSessionManager:
         except Exception as e:
             logger.debug("[%s] 活动心跳 kick 失败: %s", self.lanlan_name, e)
 
-    async def start_session(self, websocket: WebSocket, new=False, input_mode='audio'):
+    async def start_session(self, websocket: WebSocket, new=False, input_mode='audio',
+                            *, user_initiated=False, _allow_cross_mode_restart=True):
+        # user_initiated：True 仅由 websocket_router 的 start_session action 传入，
+        # 标记"用户显式点击启动"。跨模式撞车时只有用户显式请求才会等 in-flight
+        # 落定后改起目标模式；后台 proactive / greeting 的 auto-start 跨模式撞车
+        # 仍走静默 return（保持原行为，避免后台 text 启动反过来顶掉用户的语音会话）。
+        # _allow_cross_mode_restart：跨模式重启重入时置 False，把递归深度封到 1，
+        # 二次并发撞车回落静默 return 而非无界递归。
         # 之前每次 start_session 都无脑用 get_global_language() 覆盖 user_language，
         # 想"语言变更即时生效"，但实际效果是把 ws greeting_check 已经推上来的
         # 前端 i18n 真值（例如 Steam=zh / 系统=en 时正确的 'zh-CN'）一律打回错的
@@ -5460,28 +5467,41 @@ class LLMSessionManager:
                 # 失败路径已通知前端，过早发 failed 会被前端当终态打断本会成功的启动。
                 if self._starting_session_count == 0 and self.session and self.is_active:
                     await self.send_session_started(input_mode)
-            else:
-                # 跨模式撞车：典型是 proactive（主动搭话 / greeting）自起的 text 会话
-                # 还在飞，而用户此刻显式点了"开始语音对话"（audio）。早期实现静默
-                # return，但用户的 audio 请求是显式意图：静默丢弃会让前端干等 15s
-                # ack 超时，且超时时发的 end_session 还会把正在建立的 proactive text
-                # 会话一并撕掉（proactive 语音也播不出）。改为：等 in-flight 那次启动
-                # 落定（_starting_session_count 归 0）后，递归重入起一个本模式的新
-                # 会话——它会按上面 5588 行的旧 session 清理逻辑替换掉刚建好的旧模式
-                # 会话。不复用 in-flight 的 ack（跨模式复用会按错模式切 UI，见上）。
+            elif user_initiated and _allow_cross_mode_restart:
+                # 跨模式撞车，且这是用户显式启动：典型是 proactive（主动搭话 /
+                # greeting）自起的 text 会话还在飞，而用户此刻点了"开始语音对话"
+                # （audio）。早期实现静默 return，但用户的 audio 请求是显式意图：
+                # 静默丢弃会让前端干等 15s ack 超时，且超时时发的 end_session 还会把
+                # 正在建立的 proactive text 会话一并撕掉（proactive 语音也播不出）。
+                # 改为：等 in-flight 那次启动落定（_starting_session_count 归 0）后，
+                # 递归重入起一个本模式的新会话——它会按 5588 行的旧 session 清理逻辑
+                # 替换掉刚建好的旧模式会话。不复用 in-flight 的 ack（跨模式复用会按
+                # 错模式切 UI，见上）。
                 logger.warning("⚠️ Session正在启动中（跨模式），等 in-flight 落定后改起 %s 会话", input_mode)
+                # 快照拆除计数：仅在 end_session（前端 15s 超时会发 end_session）里
+                # 递增。in-flight 真正落定时 count 由其自身 finally 归 0、epoch 不变；
+                # 而前端超时的 end_session 也会把 count 清 0 但 epoch 会变。只在
+                # 「count 归 0 且 epoch 未变」时重启——区分真落定与"用户已放弃 +
+                # 被 end_session 清零"，避免在 UI 已 reject 后凭空起一个孤儿会话
+                # （Codex P2）。epoch 因别的清理误增时回落"不重启"（安全侧）。
+                _teardown_epoch = self._audio_stream_epoch
                 _waited = 0.0
                 while self._starting_session_count > 0 and _waited < FRONTEND_START_SESSION_TIMEOUT_SECONDS:
                     await asyncio.sleep(0.05)
                     _waited += 0.05
-                if self._starting_session_count == 0:
-                    # in-flight 已落定，count 归 0：递归重入会穿过本 guard 走正常启动
-                    # 路径并自行发 session_started。guard 检查（5431）前无 await，重入
-                    # 是原子的；若期间又有别的启动抢入，递归调用会再次落到本等待分支，
-                    # 由 FRONTEND_START_SESSION_TIMEOUT_SECONDS 兜底防失控递归。
-                    await self.start_session(websocket, new, input_mode)
-                else:
+                if self._starting_session_count != 0:
                     logger.warning("⚠️ 跨模式等待 in-flight 启动超时（%.1fs），放弃改起 %s", _waited, input_mode)
+                elif self._audio_stream_epoch != _teardown_epoch:
+                    logger.warning("⚠️ 跨模式等待期间发生 end_session（用户已放弃 / in-flight 被拆），不再改起 %s", input_mode)
+                else:
+                    # in-flight 干净落定：递归重入起目标模式。重入禁用跨模式重启
+                    # （_allow_cross_mode_restart=False），把递归深度封到 1——若重入
+                    # 时又撞上新的并发启动，回落静默 return 而非无界递归（greptile P2）。
+                    # guard 检查（5431）前无 await，count==0 的判定到重入是原子的。
+                    await self.start_session(websocket, new, input_mode,
+                                             user_initiated=True, _allow_cross_mode_restart=False)
+            else:
+                logger.warning("⚠️ Session正在启动中（跨模式重复请求），忽略")
             return
 
         # 标记正在启动（使用计数器，避免并发 start_session 的 finally 互相覆盖）

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -639,6 +639,13 @@ IDLE_SESSION_RESET_CHECK_INTERVAL_SECONDS = 60
 # 已无意义（前端早已 reject 并发 end_session），故以它为有意义窗口的天然上界。
 FRONTEND_START_SESSION_TIMEOUT_SECONDS = 15.0
 
+# 跨模式重启时「等 in-flight 落定」的等待上限。必须明显短于前端超时：等完之后
+# 还要花几秒真正起目标模式会话，若把整个 15s 都耗在等待上，重启发出的
+# session_started 会晚于前端 deadline，前端照样超时、甚至 reset 后才收到 ack 起孤儿
+# 会话（Codex P2）。给重启留 ~1/3 余量，in-flight 没在这窗口内落定就放弃（回落
+# baseline：前端超时，无孤儿）。in-flight（text）正常 1~3s 落定，远在窗口内。
+CROSS_MODE_RESTART_WAIT_SECONDS = FRONTEND_START_SESSION_TIMEOUT_SECONDS * 2 / 3
+
 # 主动搭话（proactive）调用 prompt_ephemeral 时设置的 sid 期望值。
 # 目的：prompt_ephemeral 内部通过 on_text_delta=handle_text_data 回调 enqueue TTS，
 # 中间可能被用户输入抢占（user stream_text 清 queue + 换 current_speech_id）。
@@ -839,6 +846,12 @@ class LLMSessionManager:
         self._audio_stream_worker_task: Optional[asyncio.Task] = None
         self._audio_stream_dropped_total = 0
         self._audio_stream_epoch = 0
+        # 只在「用户/前端主动结束启动」时递增（end_session 的 not by_server +
+        # reset_starting_count 路径），用于跨模式重启守卫区分"用户已放弃"与
+        # "内部 cleanup / in-flight 启动失败"。不能复用 _audio_stream_epoch——
+        # 它在所有 end_session cleanup（含 by_server=True 的 in-flight 失败收口）
+        # 里都会涨，会把用户仍在等待的 audio 请求误判为已放弃（CodeRabbit）。
+        self._user_session_abandon_epoch = 0
         self._last_audio_stream_backlog_log_time = 0.0
         self.emoji_pattern = re.compile(r'[^\w\u4e00-\u9fff\s>][^\w\u4e00-\u9fff\s]{2,}[^\w\u4e00-\u9fff\s<]', flags=re.UNICODE)
         self.emoji_pattern2 = re.compile("["
@@ -5478,21 +5491,23 @@ class LLMSessionManager:
                 # 替换掉刚建好的旧模式会话。不复用 in-flight 的 ack（跨模式复用会按
                 # 错模式切 UI，见上）。
                 logger.warning("⚠️ Session正在启动中（跨模式），等 in-flight 落定后改起 %s 会话", input_mode)
-                # 快照拆除计数：仅在 end_session（前端 15s 超时会发 end_session）里
-                # 递增。in-flight 真正落定时 count 由其自身 finally 归 0、epoch 不变；
-                # 而前端超时的 end_session 也会把 count 清 0 但 epoch 会变。只在
-                # 「count 归 0 且 epoch 未变」时重启——区分真落定与"用户已放弃 +
-                # 被 end_session 清零"，避免在 UI 已 reject 后凭空起一个孤儿会话
-                # （Codex P2）。epoch 因别的清理误增时回落"不重启"（安全侧）。
-                _teardown_epoch = self._audio_stream_epoch
+                # 快照"用户放弃"计数：仅在前端/用户主动 end_session 时递增（见
+                # end_session 顶部）。in-flight 真正落定时 count 由其自身 finally 归 0、
+                # abandon epoch 不变；而前端 15s 超时发的 end_session 会把 count 清 0
+                # 且 abandon epoch +1。只在「count 归 0 且 abandon epoch 未变」时重启——
+                # 区分"真落定"与"用户已放弃 + 被 end_session 清零"，避免在 UI 已 reject
+                # 后凭空起孤儿会话（Codex P2）。关键：不能用 _audio_stream_epoch——它在
+                # in-flight 启动失败的 by_server cleanup 里也会涨，会把用户仍在等待的
+                # audio 误判成放弃、回到 15s 干等（CodeRabbit）。
+                _abandon_epoch = self._user_session_abandon_epoch
                 _waited = 0.0
-                while self._starting_session_count > 0 and _waited < FRONTEND_START_SESSION_TIMEOUT_SECONDS:
+                while self._starting_session_count > 0 and _waited < CROSS_MODE_RESTART_WAIT_SECONDS:
                     await asyncio.sleep(0.05)
                     _waited += 0.05
                 if self._starting_session_count != 0:
-                    logger.warning("⚠️ 跨模式等待 in-flight 启动超时（%.1fs），放弃改起 %s", _waited, input_mode)
-                elif self._audio_stream_epoch != _teardown_epoch:
-                    logger.warning("⚠️ 跨模式等待期间发生 end_session（用户已放弃 / in-flight 被拆），不再改起 %s", input_mode)
+                    logger.warning("⚠️ 跨模式等待 in-flight 启动超时（%.1fs，留余量给重启），放弃改起 %s", _waited, input_mode)
+                elif self._user_session_abandon_epoch != _abandon_epoch:
+                    logger.warning("⚠️ 跨模式等待期间用户主动结束了启动（已放弃），不再改起 %s", input_mode)
                 else:
                     # in-flight 干净落定：递归重入起目标模式。重入禁用跨模式重启
                     # （_allow_cross_mode_restart=False），把递归深度封到 1——若重入
@@ -9426,6 +9441,14 @@ class LLMSessionManager:
             await self.send_status(json.dumps({"code": "API_UNKNOWN_ERROR", "details": {"msg": error_message}}))
 
     async def end_session(self, by_server=False, *, expected_session=None, reset_starting_count=True):  # 与Core API断开连接
+        # 「用户/前端主动结束启动」信号：只有前端发来的 end_session / pause_session
+        # （by_server=False 且 reset_starting_count=True，见 websocket_router）才计。
+        # 内部 recovery（reset_starting_count=False）与各类 by_server=True cleanup
+        # 不算，避免把 in-flight 启动失败误判成"用户放弃"而误杀跨模式重启
+        # （见 start_session 跨模式分支的 _user_session_abandon_epoch 守卫）。放在所有
+        # 早退之前，确保 in-flight（尚未 active）期间前端 end_session 也能计上。
+        if not by_server and reset_starting_count:
+            self._user_session_abandon_epoch += 1
         # Pre-check: no-side-effect guard before _init_renew_status which mutates
         # pending/prewarm state.  A stale callback must not nuke preparation state.
         _inactive_early = False

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5438,8 +5438,7 @@ class LLMSessionManager:
             # 仅对**同模式**的去重请求补发 ack：in-flight 启的是它自己的模式，
             # 跨模式（如 greeting 拉 text、另一路同刻请求 audio）若复用 in-flight 的
             # session_started(text)，前端会按 text 切 UI、收口 promise，而用户要的
-            # audio 会话根本没起（CodeRabbit）。跨模式时维持原静默 return（与改动前
-            # 完全一致，不更差）。
+            # audio 会话根本没起（CodeRabbit）。
             if (self._starting_input_mode or input_mode) == input_mode:
                 logger.warning("⚠️ Session正在启动中，等 in-flight 启动落定后给本请求补发 session_started")
                 # 等 in-flight 那次启动**自己落定**（_starting_session_count 归 0）。
@@ -5462,7 +5461,27 @@ class LLMSessionManager:
                 if self._starting_session_count == 0 and self.session and self.is_active:
                     await self.send_session_started(input_mode)
             else:
-                logger.warning("⚠️ Session正在启动中（跨模式重复请求），忽略")
+                # 跨模式撞车：典型是 proactive（主动搭话 / greeting）自起的 text 会话
+                # 还在飞，而用户此刻显式点了"开始语音对话"（audio）。早期实现静默
+                # return，但用户的 audio 请求是显式意图：静默丢弃会让前端干等 15s
+                # ack 超时，且超时时发的 end_session 还会把正在建立的 proactive text
+                # 会话一并撕掉（proactive 语音也播不出）。改为：等 in-flight 那次启动
+                # 落定（_starting_session_count 归 0）后，递归重入起一个本模式的新
+                # 会话——它会按上面 5588 行的旧 session 清理逻辑替换掉刚建好的旧模式
+                # 会话。不复用 in-flight 的 ack（跨模式复用会按错模式切 UI，见上）。
+                logger.warning("⚠️ Session正在启动中（跨模式），等 in-flight 落定后改起 %s 会话", input_mode)
+                _waited = 0.0
+                while self._starting_session_count > 0 and _waited < FRONTEND_START_SESSION_TIMEOUT_SECONDS:
+                    await asyncio.sleep(0.05)
+                    _waited += 0.05
+                if self._starting_session_count == 0:
+                    # in-flight 已落定，count 归 0：递归重入会穿过本 guard 走正常启动
+                    # 路径并自行发 session_started。guard 检查（5431）前无 await，重入
+                    # 是原子的；若期间又有别的启动抢入，递归调用会再次落到本等待分支，
+                    # 由 FRONTEND_START_SESSION_TIMEOUT_SECONDS 兜底防失控递归。
+                    await self.start_session(websocket, new, input_mode)
+                else:
+                    logger.warning("⚠️ 跨模式等待 in-flight 启动超时（%.1fs），放弃改起 %s", _waited, input_mode)
             return
 
         # 标记正在启动（使用计数器，避免并发 start_session 的 finally 互相覆盖）

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5265,7 +5265,12 @@ class LLMSessionManager:
 
         # 必须在 cleanup 之前发送，因为 cleanup 会清空 websocket 引用
         await self.send_session_failed(input_mode)
-        await self.cleanup()
+        # reset_starting_count=False：本函数从失败的 start_session 的 except 里调用，
+        # 那次 start_session 的 finally 才是 _starting_session_count guard 的唯一所有者
+        # 并会在最后递减它。若让这里的 cleanup 提前把 count 清 0，会开出一个"失败任务
+        # 尚未完全收尾、但 count 已 0"的窗口，等待中的跨模式重启会据此重入，随后被
+        # 失败任务残余的 cleanup（清 websocket）和 finally（减 guard）clobber（Codex P2）。
+        await self.cleanup(reset_starting_count=False)
 
     @property
     def is_starting(self) -> bool:
@@ -9625,23 +9630,34 @@ class LLMSessionManager:
             await self.send_status(json.dumps({"code": "CHARACTER_LEFT", "details": {"name": self.lanlan_name}}))
             logger.info("End Session: Resources cleaned up.")
 
-    async def cleanup(self, expected_websocket=None, *, expected_session=None):
+    async def cleanup(self, expected_websocket=None, *, expected_session=None, reset_starting_count=True):
         """
         Clean up session resources.
-        
+
         Args:
             expected_websocket: optional, the expected websocket instance.
                                If provided and it doesn't match the current websocket, skip cleanup.
                                Prevents an old connection from wrongly cleaning up a new connection's resources (race protection).
             expected_session: optional, the expected session instance.
                              Session-level guard from lifecycle callbacks, passed through to end_session.
+            reset_starting_count: forwarded to end_session. Pass False when the
+                             caller is itself a start_session that owns the
+                             _starting_session_count guard and will decrement it
+                             in its own finally — letting cleanup reset it to 0
+                             early opens a premature-0 window where a concurrent
+                             start (e.g. the cross-mode restart wait) sees the
+                             guard freed before the failing start has fully
+                             unwound, then gets its websocket/guard clobbered by
+                             the still-running teardown (Codex P2). Same rationale
+                             as the in-start old-session cleanup at line ~5610.
         """
         if expected_websocket is not None and self.websocket is not None:
             if self.websocket != expected_websocket:
                 logger.info("⏭️ cleanup 跳过：当前 websocket 已被新连接替换")
                 return
-        
-        await self.end_session(by_server=True, expected_session=expected_session)
+
+        await self.end_session(by_server=True, expected_session=expected_session,
+                               reset_starting_count=reset_starting_count)
         # 清理websocket引用，防止保留失效的连接
         # 使用共享锁保护websocket操作，防止与initialize_character_data()中的restore竞争
         if self.websocket_lock:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5506,17 +5506,29 @@ class LLMSessionManager:
                 while self._starting_session_count > 0 and _waited < CROSS_MODE_RESTART_WAIT_SECONDS:
                     await asyncio.sleep(0.05)
                     _waited += 0.05
+                # 重启前的连接校验，两个条件都要满足：
+                #   1) 本请求那把 ws（param）仍连接。in-flight 失败时
+                #      _handle_session_start_exception→cleanup() 会把 self.websocket 清成
+                #      None，但浏览器连接其实还开着——这种必须能重启，否则用户 audio 干等
+                #      15s（Codex P2）。判据用 param ws 的连接态，不看 self.websocket：浏览器
+                #      真刷新/断连时这把 param ws 会变 DISCONNECTED。
+                #   2) self.websocket 仍是这把或已被清空（None）。若已被换成另一条新连接，
+                #      说明发生了重连，别用旧 ws 重启去和新连接打架（Codex P2 stale ws）。
+                try:
+                    _param_ws_connected = (
+                        websocket is not None
+                        and hasattr(websocket, 'client_state')
+                        and websocket.client_state == websocket.client_state.CONNECTED
+                    )
+                except Exception:  # noqa: BLE001
+                    _param_ws_connected = False
+                _self_ws_ok = self.websocket is websocket or self.websocket is None
                 if self._starting_session_count != 0:
                     logger.warning("⚠️ 跨模式等待 in-flight 启动超时（%.1fs，留余量给重启），放弃改起 %s", _waited, input_mode)
                 elif self._user_session_abandon_epoch != _abandon_epoch:
                     logger.warning("⚠️ 跨模式等待期间用户主动结束了启动（已放弃），不再改起 %s", input_mode)
-                elif not (self.websocket is websocket and self._has_connected_websocket()):
-                    # 等待期间浏览器刷新/断连：disconnect cleanup 走 cleanup→end_session
-                    # (by_server=True)，不会 bump abandon epoch，但此刻 self.websocket 已被
-                    # 换成新连接或清空。用这把 stale ws 递归起会话，其 session_started 无处
-                    # 可送 → 孤儿活动会话（Codex P2）。要求"当前 ws 仍是本请求那把且仍连接"
-                    # 才重启。
-                    logger.warning("⚠️ 跨模式等待期间 websocket 已失效/被替换，不再改起 %s", input_mode)
+                elif not (_param_ws_connected and _self_ws_ok):
+                    logger.warning("⚠️ 跨模式等待期间 websocket 已断连/被新连接替换，不再改起 %s", input_mode)
                 else:
                     # in-flight 干净落定且连接仍在：递归重入起目标模式。
                     # 先清熔断：用户显式请求按 websocket_router 语义本应清，但当时

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5271,6 +5271,17 @@ class LLMSessionManager:
         # 尚未完全收尾、但 count 已 0"的窗口，等待中的跨模式重启会据此重入，随后被
         # 失败任务残余的 cleanup（清 websocket）和 finally（减 guard）clobber（Codex P2）。
         await self.cleanup(reset_starting_count=False)
+        # 但 reset_starting_count=False 会让 end_session 的 inactive-early 路径跳过
+        # pending_input_data.clear()（那块与 guard 释放耦合），导致本次失败启动期间缓存的
+        # 输入残留、被下次成功启动的 _flush_pending_input_data() 误注入（Codex P2）。
+        # 这里显式补清本次失败 start 自己的输入：此刻 count 仍被本次 finally 持有(>0)，
+        # 没有并发 start 穿过、缓存里只可能是本次失败 start 的输入，清理安全。
+        # 不走 end_session 的 gating 改动，rebuild 路径(同样 reset_starting_count=False 但
+        # 需要保留输入回放)语义不受影响。
+        async with self.input_cache_lock:
+            self.session_ready = False
+            self.pending_input_data.clear()
+            self._clear_pending_context_appends()
 
     @property
     def is_starting(self) -> bool:

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -321,7 +321,7 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                             if session_manager[lanlan_name]._starting_session_count == 0:
                                 session_manager[lanlan_name].reset_session_start_circuit()
                             _fire_task(route_external_stream_message(lanlan_name, {"input_type": "audio", "stt_provider": "realtime"}))
-                            _fire_task(session_manager[lanlan_name].start_session(websocket, message.get("new_session", False), "audio"))
+                            _fire_task(session_manager[lanlan_name].start_session(websocket, message.get("new_session", False), "audio", user_initiated=True))
                             continue
                     # 传递input_mode参数，告知session manager使用何种模式
                     # 注意：音频模块由 main_server 后台预加载，Python import lock 会自动等待首次导入完成
@@ -334,7 +334,7 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                     # _starting_session_count > 0 的早退拦掉。
                     if session_manager[lanlan_name]._starting_session_count == 0:
                         session_manager[lanlan_name].reset_session_start_circuit()
-                    _fire_task(session_manager[lanlan_name].start_session(websocket, message.get("new_session", False), mode))
+                    _fire_task(session_manager[lanlan_name].start_session(websocket, message.get("new_session", False), mode, user_initiated=True))
                 else:
                     await session_manager[lanlan_name].send_status(json.dumps({"code": "INVALID_INPUT_TYPE", "details": {"input_type": input_type}}))
 

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2018,6 +2018,7 @@
                 var sessionStartPromise = new Promise(function (resolve, reject) {
                     S.sessionStartedResolver = resolve;
                     S.sessionStartedRejecter = reject;
+                    S._pendingSessionStartMode = 'audio';
 
                     if (window.sessionTimeoutId) {
                         clearTimeout(window.sessionTimeoutId);
@@ -2380,6 +2381,7 @@
                 var sessionStartPromise = new Promise(function (resolve, reject) {
                     S.sessionStartedResolver = resolve;
                     S.sessionStartedRejecter = reject;
+                    S._pendingSessionStartMode = 'text';
 
                     if (window.sessionTimeoutId) {
                         clearTimeout(window.sessionTimeoutId);
@@ -2609,6 +2611,7 @@
                             var sessionStartPromise = new Promise(function (resolve, reject) {
                                 S.sessionStartedResolver = resolve;
                                 S.sessionStartedRejecter = reject;
+                                S._pendingSessionStartMode = 'text';
                                 mod._textSessionStartRejecter = reject;
 
                                 if (window.sessionTimeoutId) {

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2040,6 +2040,7 @@
                         var rejecter = S.sessionStartedRejecter;
                         S.sessionStartedResolver = null;
                         S.sessionStartedRejecter = null;
+                        S._pendingSessionStartMode = null;
                         window.sessionTimeoutId = null;
 
                         if (S.socket && S.socket.readyState === WebSocket.OPEN) {
@@ -2128,6 +2129,7 @@
                 rejectPendingTextSessionStart(error);
                 S.sessionStartedResolver = null;
                 S.sessionStartedRejecter = null;
+                S._pendingSessionStartMode = null;
 
                 if (!isVoiceStartCancelled && !(error && error.voiceConfigSwitchTimedOut) && S.socket && S.socket.readyState === WebSocket.OPEN) {
                     S.socket.send(JSON.stringify({ action: 'end_session' }));
@@ -2393,6 +2395,7 @@
                             var rejecter = S.sessionStartedRejecter;
                             S.sessionStartedResolver = null;
                             S.sessionStartedRejecter = null;
+                            S._pendingSessionStartMode = null;
                             window.sessionTimeoutId = null;
 
                             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
@@ -2633,6 +2636,7 @@
                                     var rejecter = S.sessionStartedRejecter;
                                     S.sessionStartedResolver = null;
                                     S.sessionStartedRejecter = null;
+                                    S._pendingSessionStartMode = null;
                                     mod._textSessionStartRejecter = null;
                                     window.sessionTimeoutId = null;
 

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -111,6 +111,11 @@
         isSwitchingMode: false,
         sessionStartedResolver: null,
         sessionStartedRejecter: null,
+        // 本次正在 await session_started 的启动请求模式（'audio' / 'text'）。
+        // session_started 处理用它校验到达的 input_mode 是否与用户请求的一致：
+        // 不一致（典型是 proactive/greeting 并发自起的 text 会话发来的 ack）时
+        // 忽略，避免错误模式的 ack 收口用户的启动 promise / 翻转会话状态。
+        _pendingSessionStartMode: null,
         voiceSessionStartEpoch: 0,
         assistantTurnId: null,
         assistantTurnStartedAt: 0,

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -237,6 +237,7 @@
         }
         S.sessionStartedResolver = null;
         S.sessionStartedRejecter = null;
+        S._pendingSessionStartMode = null;
     };
 
     // ======================== 工具函数 ========================

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2747,6 +2747,15 @@
                         window.syncVoiceChatComposerHidden(_shouldHide);
                     }
 
+                    // 立即清掉启动超时：匹配的 ack 已到（已过上方 mode 守卫），若拖到下面
+                    // 500ms 后才清，贴近 15s deadline 的 ack（如 14.8s，尤其跨模式等待+重启
+                    // 链路）会被先一步触发的超时误 reject + end_session，把后端已接受的会话
+                    // 打断（Codex P2）。resolve 仍延后做（留时间收尾 UI），但超时此刻就拆。
+                    if (S.sessionStartedResolver && window.sessionTimeoutId) {
+                        clearTimeout(window.sessionTimeoutId);
+                        window.sessionTimeoutId = null;
+                    }
+
                     setTimeout(function () {
                         if (typeof window.hideVoicePreparingToast === 'function') window.hideVoicePreparingToast();
                         if (S.sessionStartedResolver) {

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2820,6 +2820,7 @@
                     }
                     S.sessionStartedResolver = null;
                     S.sessionStartedRejecter = null;
+                    S._pendingSessionStartMode = null;
 
                 // -------- session_ended_by_server --------
                 } else if (response.type === 'session_ended_by_server') {
@@ -2835,6 +2836,7 @@
                     }
                     S.sessionStartedResolver = null;
                     S.sessionStartedRejecter = null;
+                    S._pendingSessionStartMode = null;
 
                     if (window.sessionTimeoutId) {
                         clearTimeout(window.sessionTimeoutId);

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2133,6 +2133,7 @@
                                     var sessionStartPromise = new Promise(function (resolve, reject) {
                                         S.sessionStartedResolver = resolve;
                                         S.sessionStartedRejecter = reject;
+                                        S._pendingSessionStartMode = 'audio';
                                         if (window.sessionTimeoutId) {
                                             clearTimeout(window.sessionTimeoutId);
                                             window.sessionTimeoutId = null;
@@ -2696,6 +2697,24 @@
                         }
                         return;
                     }
+                    // 跨模式 ack 守卫：用户点的麦/文本启动正在 await session_started 时
+                    // （resolver 还在 + _pendingSessionStartMode 记着请求模式），若到达的
+                    // input_mode 与用户请求的不一致，这条 ack 属于并发的后台会话——典型是
+                    // proactive / greeting 自起的 text 会话（它也是一次正常 start_session，
+                    // 完成时会发 session_started(text)）。绝不能用它去 resolve 用户的 audio
+                    // 启动 promise 或翻转 voiceChatActive/isTextSessionActive，否则用户点了
+                    // 语音却被 text ack 收口 → 开麦但后端是 text 会话、UI 错配。直接忽略，
+                    // 用户那次启动的真正 ack（后端跨模式撞车会等 in-flight 落定后改起本模式
+                    // 会话再发，见 core.py start_session）随后到达时按下方正常流程收口。
+                    // 注意要求 resolver 仍在：无 pending 启动时（如 chat.html 子窗口纯靠
+                    // session_started 同步 hide 自己的输入框）不拦，维持多窗口原行为。
+                    if (S._pendingSessionStartMode
+                            && S.sessionStartedResolver
+                            && response.input_mode !== S._pendingSessionStartMode) {
+                        console.log('[App] ignore cross-mode session_started', response.input_mode,
+                            'while pending', S._pendingSessionStartMode);
+                        return;
+                    }
                     console.log(window.t('console.sessionStartedReceived'), response.input_mode);
                     S.isTextSessionActive = response.input_mode === 'text';
                     S.voiceChatActive = response.input_mode !== 'text';
@@ -2738,6 +2757,7 @@
                             S.sessionStartedResolver(response.input_mode);
                             S.sessionStartedResolver = null;
                             S.sessionStartedRejecter = null;
+                            S._pendingSessionStartMode = null;
                         }
                     }, 500);
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2778,6 +2778,20 @@
                 // -------- session_failed --------
                 } else if (response.type === 'session_failed') {
                     console.log(window.t('console.sessionFailedReceived'), response.input_mode);
+                    // 跨模式 fail 守卫（与上方 session_started 守卫对偶）：用户的启动正在
+                    // await 时，并发的后台会话（如 proactive 自起的 text）若启动失败会发
+                    // session_failed(text)。它不该 reject 用户那次 audio 启动——后端跨模式
+                    // 撞车会等 in-flight 落定后改起 audio（见 core.py start_session），用户的
+                    // 真正 ack 随后到达。模式不一致就忽略这条 fail。session_failed 一定带
+                    // input_mode（见后端 send_session_failed），故 mismatch 判定可靠。
+                    if (S._pendingSessionStartMode
+                            && S.sessionStartedRejecter
+                            && response.input_mode
+                            && response.input_mode !== S._pendingSessionStartMode) {
+                        console.log('[App] ignore cross-mode session_failed', response.input_mode,
+                            'while pending', S._pendingSessionStartMode);
+                        return;
+                    }
                     if (typeof window.hideVoicePreparingToast === 'function') window.hideVoicePreparingToast();
                     S.voiceChatActive = false;
                     S.voiceStartPending = false;

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -110,9 +110,11 @@ def _make_starting_manager(*, starting_input_mode):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
-    """用户点语音(audio)时撞上 proactive 自起的 text 会话(在飞)：旧实现静默
-    丢弃 audio 请求 → 前端干等超时。新实现应等 in-flight text 落定后递归
-    重入起一个 audio 会话（而非复用 text 的 ack）。"""
+    """User-initiated audio start colliding with an in-flight proactive text
+    session: the old code silently dropped the audio request (frontend hung
+    until timeout). The new code should wait for the in-flight text to settle,
+    then re-enter start_session in the requested (audio) mode rather than
+    reusing the text ack."""
     mgr = _make_starting_manager(starting_input_mode="text")
     # 递归重入会走 self.start_session(...)；用实例属性 mock 截住，断言它被
     # 以请求模式再调一次，而不真正跑完整启动路径。
@@ -138,8 +140,9 @@ async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_cross_mode_start_gives_up_when_inflight_never_settles(monkeypatch):
-    """in-flight 启动一直不落定（count 不归 0）时，跨模式分支等到上限后放弃，
-    不递归重入（避免在 in-flight 仍卡着时叠起第二个会话）。"""
+    """When the in-flight start never settles (count never drops to 0), the
+    cross-mode branch gives up at the timeout and does not re-enter (avoids
+    stacking a second session while the in-flight one is still stuck)."""
     monkeypatch.setattr("main_logic.core.FRONTEND_START_SESSION_TIMEOUT_SECONDS", 0.2)
     mgr = _make_starting_manager(starting_input_mode="text")
     restart_mock = AsyncMock()
@@ -154,9 +157,10 @@ async def test_cross_mode_start_gives_up_when_inflight_never_settles(monkeypatch
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_cross_mode_background_start_does_not_restart():
-    """后台 proactive/greeting 的跨模式 auto-start（user_initiated=False）撞车时
-    维持原静默 return，绝不等待+重启——否则后台 text 启动会反过来顶掉用户
-    正在飞的语音会话。"""
+    """A background proactive/greeting cross-mode auto-start
+    (user_initiated=False) keeps the original silent return and never
+    waits+restarts — otherwise a background text start would tear down the
+    user's in-flight voice session."""
     mgr = _make_starting_manager(starting_input_mode="audio")
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
@@ -171,9 +175,10 @@ async def test_cross_mode_background_start_does_not_restart():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_cross_mode_start_skips_restart_when_torn_down_during_wait():
-    """等待期间发生 end_session（前端 15s 超时会发，_audio_stream_epoch 递增、
-    且把 count 清 0）时，不重启——区分真落定与"用户已放弃 + 被清零"，避免起
-    一个 UI 已 reject 的孤儿会话。"""
+    """When an end_session happens during the wait (the frontend 15s timeout
+    sends one, which bumps _audio_stream_epoch and zeroes the count), do NOT
+    restart — this distinguishes a genuine settle from "user gave up + count
+    was zeroed", avoiding an orphan session whose UI was already rejected."""
     mgr = _make_starting_manager(starting_input_mode="text")
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -89,6 +89,18 @@ async def test_inactive_end_session_does_not_clear_next_start_pending_input():
     assert mgr.pending_input_data == [{"input_type": "text", "data": "new"}]
 
 
+class _ConnectedState:
+    """Stand-in for starlette WebSocketState.CONNECTED that satisfies the
+    codebase pattern ``ws.client_state == ws.client_state.CONNECTED``."""
+    @property
+    def CONNECTED(self):
+        return self
+
+
+class _FakeConnectedWS:
+    client_state = _ConnectedState()
+
+
 def _make_starting_manager(*, starting_input_mode):
     """Manager pre-positioned at the start_session 'already starting' guard:
     an in-flight start of ``starting_input_mode`` is occupying the count.
@@ -106,6 +118,9 @@ def _make_starting_manager(*, starting_input_mode):
     mgr.is_active = True
     mgr._audio_stream_epoch = 0
     mgr._user_session_abandon_epoch = 0
+    # 跨模式重启前会校验"当前 ws 仍是本请求那把且仍连接"，并清熔断。
+    mgr.websocket = _FakeConnectedWS()
+    mgr.reset_session_start_circuit = lambda: None
     return mgr
 
 
@@ -123,7 +138,7 @@ async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
 
-    ws = object()
+    ws = mgr.websocket  # 重启前会校验 self.websocket is websocket 且连接
     start_task = asyncio.create_task(
         LLMSessionManager.start_session(mgr, ws, False, "audio", user_initiated=True)
     )
@@ -211,7 +226,7 @@ async def test_cross_mode_start_restarts_even_if_inflight_failed_internally():
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
 
-    ws = object()
+    ws = mgr.websocket
     start_task = asyncio.create_task(
         LLMSessionManager.start_session(mgr, ws, False, "audio", user_initiated=True)
     )
@@ -225,3 +240,29 @@ async def test_cross_mode_start_restarts_even_if_inflight_failed_internally():
     restart_mock.assert_awaited_once_with(
         ws, False, "audio", user_initiated=True, _allow_cross_mode_restart=False
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cross_mode_start_skips_restart_when_websocket_replaced_during_wait():
+    """If the browser reloads/disconnects during the wait, the disconnect
+    cleanup runs by_server=True (no abandon-epoch bump), but self.websocket is
+    swapped/cleared. Restarting with the stale ws would create a session whose
+    session_started can't be delivered — so skip the restart when the current
+    ws is no longer the one this request came in on."""
+    mgr = _make_starting_manager(starting_input_mode="text")
+    restart_mock = AsyncMock()
+    mgr.start_session = restart_mock
+
+    stale_ws = _FakeConnectedWS()  # the request's original ws
+    # During the wait the connection is replaced (reload): self.websocket now
+    # points at a different live connection, not stale_ws.
+    start_task = asyncio.create_task(
+        LLMSessionManager.start_session(mgr, stale_ws, False, "audio", user_initiated=True)
+    )
+    await asyncio.sleep(0.1)
+    mgr.websocket = _FakeConnectedWS()  # new connection after reload
+    mgr._starting_session_count = 0
+    await start_task
+
+    restart_mock.assert_not_awaited()

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -136,9 +136,7 @@ async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
 async def test_cross_mode_start_gives_up_when_inflight_never_settles(monkeypatch):
     """in-flight 启动一直不落定（count 不归 0）时，跨模式分支等到上限后放弃，
     不递归重入（避免在 in-flight 仍卡着时叠起第二个会话）。"""
-    import main_logic.core as core_mod
-
-    monkeypatch.setattr(core_mod, "FRONTEND_START_SESSION_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr("main_logic.core.FRONTEND_START_SESSION_TIMEOUT_SECONDS", 0.2)
     mgr = _make_starting_manager(starting_input_mode="text")
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -21,6 +21,7 @@ def _make_inactive_manager(*, starting_count=1):
     mgr.tts_request_queue = Queue()
     mgr.tts_response_queue = Queue()
     mgr._audio_stream_epoch = 0
+    mgr._user_session_abandon_epoch = 0
     mgr._reset_tts_retry_state = lambda: None
     mgr._clear_audio_stream_queue = lambda reason: None
     mgr._cancel_audio_stream_worker = lambda reason: None
@@ -104,6 +105,7 @@ def _make_starting_manager(*, starting_input_mode):
     mgr.session = object()
     mgr.is_active = True
     mgr._audio_stream_epoch = 0
+    mgr._user_session_abandon_epoch = 0
     return mgr
 
 
@@ -143,7 +145,7 @@ async def test_cross_mode_start_gives_up_when_inflight_never_settles(monkeypatch
     """When the in-flight start never settles (count never drops to 0), the
     cross-mode branch gives up at the timeout and does not re-enter (avoids
     stacking a second session while the in-flight one is still stuck)."""
-    monkeypatch.setattr("main_logic.core.FRONTEND_START_SESSION_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr("main_logic.core.CROSS_MODE_RESTART_WAIT_SECONDS", 0.2)
     mgr = _make_starting_manager(starting_input_mode="text")
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
@@ -175,10 +177,11 @@ async def test_cross_mode_background_start_does_not_restart():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_cross_mode_start_skips_restart_when_torn_down_during_wait():
-    """When an end_session happens during the wait (the frontend 15s timeout
-    sends one, which bumps _audio_stream_epoch and zeroes the count), do NOT
-    restart — this distinguishes a genuine settle from "user gave up + count
-    was zeroed", avoiding an orphan session whose UI was already rejected."""
+    """When the user actively ends the start during the wait (the frontend 15s
+    timeout sends end_session, which bumps _user_session_abandon_epoch and
+    zeroes the count), do NOT restart — this distinguishes a genuine settle
+    from "user gave up + count was zeroed", avoiding an orphan session whose UI
+    was already rejected."""
     mgr = _make_starting_manager(starting_input_mode="text")
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
@@ -188,9 +191,37 @@ async def test_cross_mode_start_skips_restart_when_torn_down_during_wait():
         LLMSessionManager.start_session(mgr, ws, False, "audio", user_initiated=True)
     )
     await asyncio.sleep(0.1)
-    # 模拟 end_session：清零 count 的同时 bump epoch（与真实 end_session 一致）。
-    mgr._audio_stream_epoch += 1
+    # Simulate a frontend-initiated end_session: zero the count AND bump the
+    # abandon epoch (mirrors end_session's not-by_server path).
+    mgr._user_session_abandon_epoch += 1
     mgr._starting_session_count = 0
     await start_task
 
     restart_mock.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cross_mode_start_restarts_even_if_inflight_failed_internally():
+    """If the in-flight start fails internally (its by_server cleanup bumps
+    _audio_stream_epoch but NOT _user_session_abandon_epoch), the user's
+    explicit audio request should STILL restart — otherwise the user's audio
+    promise gets no ack and hangs the full 15s (the very bug being fixed)."""
+    mgr = _make_starting_manager(starting_input_mode="text")
+    restart_mock = AsyncMock()
+    mgr.start_session = restart_mock
+
+    ws = object()
+    start_task = asyncio.create_task(
+        LLMSessionManager.start_session(mgr, ws, False, "audio", user_initiated=True)
+    )
+    await asyncio.sleep(0.1)
+    # In-flight text start failed → internal by_server cleanup bumps the audio
+    # stream epoch but NOT the user-abandon epoch, and zeroes the count.
+    mgr._audio_stream_epoch += 1
+    mgr._starting_session_count = 0
+    await start_task
+
+    restart_mock.assert_awaited_once_with(
+        ws, False, "audio", user_initiated=True, _allow_cross_mode_restart=False
+    )

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -103,6 +103,7 @@ def _make_starting_manager(*, starting_input_mode):
     mgr._starting_input_mode = starting_input_mode
     mgr.session = object()
     mgr.is_active = True
+    mgr._audio_stream_epoch = 0
     return mgr
 
 
@@ -120,7 +121,7 @@ async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
 
     ws = object()
     start_task = asyncio.create_task(
-        LLMSessionManager.start_session(mgr, ws, False, "audio")
+        LLMSessionManager.start_session(mgr, ws, False, "audio", user_initiated=True)
     )
     # 让它先进入跨模式等待循环，再放行 in-flight 落定。
     await asyncio.sleep(0.1)
@@ -128,7 +129,10 @@ async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
     mgr._starting_session_count = 0
     await start_task
 
-    restart_mock.assert_awaited_once_with(ws, False, "audio")
+    # 重入禁用二次跨模式重启（深度封顶 1）。
+    restart_mock.assert_awaited_once_with(
+        ws, False, "audio", user_initiated=True, _allow_cross_mode_restart=False
+    )
 
 
 @pytest.mark.unit
@@ -141,7 +145,47 @@ async def test_cross_mode_start_gives_up_when_inflight_never_settles(monkeypatch
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
 
-    await LLMSessionManager.start_session(mgr, object(), False, "audio")
+    await LLMSessionManager.start_session(mgr, object(), False, "audio", user_initiated=True)
 
     restart_mock.assert_not_awaited()
     assert mgr._starting_session_count == 1  # in-flight guard 原样保留
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cross_mode_background_start_does_not_restart():
+    """后台 proactive/greeting 的跨模式 auto-start（user_initiated=False）撞车时
+    维持原静默 return，绝不等待+重启——否则后台 text 启动会反过来顶掉用户
+    正在飞的语音会话。"""
+    mgr = _make_starting_manager(starting_input_mode="audio")
+    restart_mock = AsyncMock()
+    mgr.start_session = restart_mock
+
+    # 后台 text 撞上在飞的 audio：默认 user_initiated=False。
+    await LLMSessionManager.start_session(mgr, object(), False, "text")
+
+    restart_mock.assert_not_awaited()
+    assert mgr._starting_session_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cross_mode_start_skips_restart_when_torn_down_during_wait():
+    """等待期间发生 end_session（前端 15s 超时会发，_audio_stream_epoch 递增、
+    且把 count 清 0）时，不重启——区分真落定与"用户已放弃 + 被清零"，避免起
+    一个 UI 已 reject 的孤儿会话。"""
+    mgr = _make_starting_manager(starting_input_mode="text")
+    restart_mock = AsyncMock()
+    mgr.start_session = restart_mock
+
+    ws = object()
+    start_task = asyncio.create_task(
+        LLMSessionManager.start_session(mgr, ws, False, "audio", user_initiated=True)
+    )
+    await asyncio.sleep(0.1)
+    # 模拟 end_session：清零 count 的同时 bump epoch（与真实 end_session 一致）。
+    mgr._audio_stream_epoch += 1
+    mgr._starting_session_count = 0
+    await start_task
+
+    restart_mock.assert_not_awaited()

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -1,5 +1,6 @@
 import asyncio
 from queue import Queue
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -85,3 +86,64 @@ async def test_inactive_end_session_does_not_clear_next_start_pending_input():
     assert mgr._starting_session_count == 1
     assert mgr.session_ready is False
     assert mgr.pending_input_data == [{"input_type": "text", "data": "new"}]
+
+
+def _make_starting_manager(*, starting_input_mode):
+    """Manager pre-positioned at the start_session 'already starting' guard:
+    an in-flight start of ``starting_input_mode`` is occupying the count.
+    Only the attributes touched before the guard need to be real."""
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.user_language = "zh"
+    mgr._conversation_turn_language = "zh-CN"
+    mgr._set_conversation_turn_language = lambda *_a, **_k: None
+    mgr.session_closed_by_server = True
+    mgr.last_audio_send_error_time = 1.0
+    mgr._session_start_circuit_open = False
+    mgr._starting_session_count = 1
+    mgr._starting_input_mode = starting_input_mode
+    mgr.session = object()
+    mgr.is_active = True
+    return mgr
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cross_mode_start_waits_then_restarts_in_requested_mode():
+    """用户点语音(audio)时撞上 proactive 自起的 text 会话(在飞)：旧实现静默
+    丢弃 audio 请求 → 前端干等超时。新实现应等 in-flight text 落定后递归
+    重入起一个 audio 会话（而非复用 text 的 ack）。"""
+    mgr = _make_starting_manager(starting_input_mode="text")
+    # 递归重入会走 self.start_session(...)；用实例属性 mock 截住，断言它被
+    # 以请求模式再调一次，而不真正跑完整启动路径。
+    restart_mock = AsyncMock()
+    mgr.start_session = restart_mock
+
+    ws = object()
+    start_task = asyncio.create_task(
+        LLMSessionManager.start_session(mgr, ws, False, "audio")
+    )
+    # 让它先进入跨模式等待循环，再放行 in-flight 落定。
+    await asyncio.sleep(0.1)
+    assert restart_mock.await_count == 0  # 还在等，不该提前重入
+    mgr._starting_session_count = 0
+    await start_task
+
+    restart_mock.assert_awaited_once_with(ws, False, "audio")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cross_mode_start_gives_up_when_inflight_never_settles(monkeypatch):
+    """in-flight 启动一直不落定（count 不归 0）时，跨模式分支等到上限后放弃，
+    不递归重入（避免在 in-flight 仍卡着时叠起第二个会话）。"""
+    import main_logic.core as core_mod
+
+    monkeypatch.setattr(core_mod, "FRONTEND_START_SESSION_TIMEOUT_SECONDS", 0.2)
+    mgr = _make_starting_manager(starting_input_mode="text")
+    restart_mock = AsyncMock()
+    mgr.start_session = restart_mock
+
+    await LLMSessionManager.start_session(mgr, object(), False, "audio")
+
+    restart_mock.assert_not_awaited()
+    assert mgr._starting_session_count == 1  # in-flight guard 原样保留

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -254,13 +254,16 @@ async def test_cross_mode_start_skips_restart_when_websocket_replaced_during_wai
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
 
-    stale_ws = _FakeConnectedWS()  # the request's original ws
-    # During the wait the connection is replaced (reload): self.websocket now
-    # points at a different live connection, not stale_ws.
+    # The request comes in on the CURRENT ws (must match initially, else the
+    # test would pass trivially without exercising the replacement path).
+    stale_ws = mgr.websocket
     start_task = asyncio.create_task(
         LLMSessionManager.start_session(mgr, stale_ws, False, "audio", user_initiated=True)
     )
     await asyncio.sleep(0.1)
+    # During the wait the connection is replaced (reload): self.websocket now
+    # points at a different live connection, so `self.websocket is websocket`
+    # (the original stale_ws) is False → restart must be skipped.
     mgr.websocket = _FakeConnectedWS()  # new connection after reload
     mgr._starting_session_count = 0
     await start_task

--- a/tests/unit/test_session_start_guard.py
+++ b/tests/unit/test_session_start_guard.py
@@ -218,25 +218,29 @@ async def test_cross_mode_start_skips_restart_when_torn_down_during_wait():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_cross_mode_start_restarts_even_if_inflight_failed_internally():
-    """If the in-flight start fails internally (its by_server cleanup bumps
-    _audio_stream_epoch but NOT _user_session_abandon_epoch), the user's
-    explicit audio request should STILL restart — otherwise the user's audio
-    promise gets no ack and hangs the full 15s (the very bug being fixed)."""
+    """If the in-flight start fails internally, its cleanup() clears
+    self.websocket to None (and bumps _audio_stream_epoch) WITHOUT bumping
+    _user_session_abandon_epoch — yet the browser connection (the request's own
+    ws param) is still open. The user's explicit audio request should STILL
+    restart; otherwise the audio promise gets no ack and hangs the full 15s
+    (the very bug being fixed)."""
     mgr = _make_starting_manager(starting_input_mode="text")
     restart_mock = AsyncMock()
     mgr.start_session = restart_mock
 
-    ws = mgr.websocket
+    ws = mgr.websocket  # the request's ws stays connected throughout
     start_task = asyncio.create_task(
         LLMSessionManager.start_session(mgr, ws, False, "audio", user_initiated=True)
     )
     await asyncio.sleep(0.1)
-    # In-flight text start failed → internal by_server cleanup bumps the audio
-    # stream epoch but NOT the user-abandon epoch, and zeroes the count.
+    # In-flight text start failed → cleanup() clears self.websocket to None and
+    # bumps the audio stream epoch, but NOT the user-abandon epoch; count→0.
     mgr._audio_stream_epoch += 1
+    mgr.websocket = None
     mgr._starting_session_count = 0
     await start_task
 
+    # param ws still connected + self.websocket is None ⇒ restart proceeds.
     restart_mock.assert_awaited_once_with(
         ws, False, "audio", user_initiated=True, _allow_cross_mode_restart=False
     )


### PR DESCRIPTION
## 问题

Electron 下（web 同样存在）猫娘正在发 proactive（如 meme，没有语音会话时后端会**自起一个 text 会话**播 TTS）的同时，用户点了"开始语音对话"(audio)，会出现：

- 语音对话加载直到 **15s 超时**，UI 显示"对话中"但实际没真正开起来；
- proactive 的语音也没播放出来。

## 根因

前后端都不区分 **audio（用户意图）** vs **text（proactive 自起）** 的并发启动：

- **后端** [`start_session`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/main_logic/core.py)：跨模式撞车时**静默 return**，audio 请求的 `session_started` ack 永不到达 → 前端干等 15s 超时；而超时时前端发的 `end_session` 又把正在建立的 proactive text 会话一并撕掉（meme 也播不出）。
- **前端** `session_started` 处理**不校验 mode**：proactive 的 `session_started(text)` 会错误 resolve 用户的 audio 启动 promise → 开麦进"对话中"，但后端其实是 text 会话。

两条路径都在 **web/Electron 共用代码**里，不是 Electron 特有；Electron 因 WSProxy 多一跳 + Pet 模式更频繁触发 proactive，所以更容易撞上。

## 修复

1. **后端（core.py）— 等 text 落定再起 audio**：跨模式撞车不再静默丢弃，而是等 in-flight 启动落定（`_starting_session_count` 归 0）后**递归重入**起一个本模式会话——它按既有旧会话清理逻辑替换掉刚建好的 text 会话，并自行发出匹配模式的 `session_started`。等待上界仍绑 `FRONTEND_START_SESSION_TIMEOUT_SECONDS`，超时则放弃、不叠会话。proactive 的 callbacks 在 session 被换成 audio 后会自动重新入队、延后重试，meme 不丢。
2. **前端（app-state / app-buttons / app-websocket.js）— 校验 mode**：在 4 个启动点记录 `_pendingSessionStartMode`（audio/text），`session_started` 处理新增守卫——当有 pending 启动且到达的 `input_mode` 与请求不一致时忽略该 ack。守卫要求 resolver 仍在，故 chat.html 子窗口靠 `session_started` 同步隐藏输入框的多窗口行为不受影响。

## 验证

- 4 个改动文件语法检查通过；
- `tests/unit/test_session_start_guard.py` 5 个（含新增 2 个：跨模式等待后递归重入 / in-flight 不落定时放弃）+ `tests/unit/test_proactive_sm_integration.py` 66 个全过。

> 这个竞态需要 LLM+TTS 实时时序才能端到端复现，单测覆盖不到时序——建议在主仓库跑 Electron 实测做最终回归确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

- **Bug修复**
  - 提升会话并发启动可靠性：仅在用户显式触发且允许跨模式重启时，在限定时间内等待进行中的启动落定；超时或用户主动结束则放弃并避免无界重试。
  - 强化跨模式 `session_started/session_failed` 应答校验，避免后台会话应答误触发前端状态切换。
- **新功能**
  - 前端新增“等待中的目标启动模式”标记（音频/文本），取消时清理，结束/失败路径同步回收。
- **测试**
  - 补充跨模式等待、超时放弃、后台不重启、用户中止与断线等场景用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 回归报告

**改动面**：仅 `main_logic/core.py` 的 `start_session` 跨模式撞车分支 + `websocket_router` 两处用户启动调用点传 `user_initiated=True` + 前端 `session_started`/`session_failed` 的跨模式守卫。正常单次启动路径（`_starting_session_count==0`，不进 in-flight 分支）、同模式去重分支、以及后台 proactive/greeting 的跨模式 auto-start（维持原静默 return）均零行为变化。

**潜在回退点与防护**：
- 跨模式重启只对 `user_initiated=True`（仅 websocket_router 用户点击路径）生效，后台 text 启动不会顶掉用户在飞的语音会话；
- 重启前用 `_audio_stream_epoch` 快照区分"真落定"与"用户超时后 end_session 清零"，不起孤儿会话；
- 重入禁用二次跨模式重启（`_allow_cross_mode_restart=False`），递归深度封顶 1。

**测试**：`tests/unit/test_session_start_guard.py` 7 个（新增 4 个覆盖跨模式等待后重入 / 超时放弃 / 后台不重启 / 等待期被拆不重启）+ `tests/unit/test_proactive_sm_integration.py` 66 个全过；后端/前端语法检查通过。端到端时序竞态需 LLM+TTS 实时环境，建议在主仓库跑 Electron 实测做最终确认。
