### PR TITLE
fix(topic): wait for mature candidate window

### DIFF
--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -42,6 +42,7 @@ DeliveryAvailable = Callable[..., bool]
 _MAX_TEXT_TOKENS = 1000
 _TOKEN_PRECAP_CHARS_PER_TOKEN = 8
 _TRIGGER_RETRY_DELAY_SECONDS = 60.0
+_CANDIDATE_MATURE_SECONDS = 60.0
 _MIN_TOPIC_TRIGGER_GAP_SECONDS = 4 * 60 * 60
 _MAX_DAILY_TOPIC_TRIGGERS = 2
 _USED_TOPIC_RECENT_SECONDS = 48 * 60 * 60
@@ -526,6 +527,9 @@ class TopicHookPool:
             last_turn_at = self._signal_store.last_turn_at(name)
             if last_turn_at is None:
                 self._dirty.discard(name)
+                continue
+            current_time = time.time() if now is None else float(now)
+            if current_time - float(last_turn_at) < _CANDIDATE_MATURE_SECONDS:
                 continue
             try:
                 await self.process_now(name, lang=lang)

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -1560,8 +1560,12 @@ async def test_topic_pool_retries_pending_material_after_delivery_defers():
         ("妮可", "买车像进入新生活阶段", "zh-CN"),
         ("妮可", "买车像进入新生活阶段", "zh-CN"),
     ]
+    task = pool._trigger_tasks.get("妮可")
+    if task is not None:
+        await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
     assert pool.get_ready_materials("妮可") == []
-    assert pool._materials["妮可"][0]["status"] == "used"
+    assert pool._materials["妮可"] == []
+    assert pool._used_topics["妮可"][0]["interest"] == "买车像进入新生活阶段"
 
 
 @pytest.mark.asyncio
@@ -1646,8 +1650,12 @@ async def test_topic_pool_retries_pending_material_after_trigger_exception():
         ("妮可", "买车像进入新生活阶段", "zh-CN"),
         ("妮可", "买车像进入新生活阶段", "zh-CN"),
     ]
+    task = pool._trigger_tasks.get("妮可")
+    if task is not None:
+        await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
     assert pool.get_ready_materials("妮可") == []
-    assert pool._materials["妮可"][0]["status"] == "used"
+    assert pool._materials["妮可"] == []
+    assert pool._used_topics["妮可"][0]["interest"] == "买车像进入新生活阶段"
 
 
 @pytest.mark.asyncio
@@ -1684,8 +1692,12 @@ async def test_topic_pool_does_not_cancel_current_trigger_when_ai_turn_is_record
     await pool.process_now("妮可")
     await asyncio.wait_for(triggered.wait(), timeout=1.0)
 
+    task = pool._trigger_tasks.get("妮可")
+    if task is not None:
+        await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
     assert pool.get_ready_materials("妮可") == []
-    assert pool._materials["妮可"][0]["status"] == "used"
+    assert pool._materials["妮可"] == []
+    assert pool._used_topics["妮可"][0]["interest"] == "买车像进入新生活阶段"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -869,7 +869,7 @@ async def test_topic_pool_release_predicate_reruns_legacy_delivery_gate():
 
 
 @pytest.mark.asyncio
-async def test_topic_pool_process_ready_ignores_legacy_candidate_quiet_window():
+async def test_topic_pool_process_ready_waits_for_mature_window():
     calls = []
 
     async def fake_analyzer(*, lang, **kwargs):
@@ -887,6 +887,10 @@ async def test_topic_pool_process_ready_ignores_legacy_candidate_quiet_window():
     assert last_turn_at is not None
 
     await pool.process_ready_topics(now=last_turn_at + 1, lang="zh-CN")
+    assert calls == []
+    assert pool.get_ready_materials("妮可") == []
+
+    await pool.process_ready_topics(now=last_turn_at + 61, lang="zh-CN")
     assert calls == ["zh-CN"]
     assert pool.get_ready_materials("妮可")[0]["interest"] == "稳定话题"
 
@@ -1132,7 +1136,7 @@ async def test_topic_pool_processes_requested_character_while_privacy_is_enabled
 
     await pool.process_ready_topics(
         lanlan_name="妮可",
-        now=last_turn_at + 30,
+        now=last_turn_at + 61,
         lang="zh-CN",
     )
 
@@ -1284,9 +1288,11 @@ async def test_topic_pool_debounce_retries_after_background_analyzer_failure():
     pool.note_user_message("妮可", "转职这件事我已经反复想了几周，主要怕走错方向")
     pool.note_user_message("妮可", "现在的工作也不是不能做，但我总觉得继续拖会更难")
     pool.note_user_message("妮可", "所以我想聊聊转职的现实风险和机会")
+    last_turn_at = pool._signal_store.last_turn_at("妮可")
+    assert last_turn_at is not None
 
-    await pool.process_ready_topics(lang="zh-CN")
-    await pool.process_ready_topics(lang="zh-CN")
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 61)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 62)
     await asyncio.wait_for(retried.wait(), timeout=1.0)
     materials = pool.get_ready_materials("妮可")
 
@@ -1327,9 +1333,11 @@ async def test_topic_pool_keeps_dirty_when_analyzer_returns_none():
 
     pool.note_user_message("妮可", "我最近一直想换个城市生活，但又怕重新开始太难")
     pool.note_user_message("妮可", "换城市这件事反复想了很久，主要是想改变现在的节奏")
+    last_turn_at = pool._signal_store.last_turn_at("妮可")
+    assert last_turn_at is not None
 
-    await pool.process_ready_topics(lang="zh-CN")
-    await pool.process_ready_topics(lang="zh-CN")
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 61)
+    await pool.process_ready_topics(lang="zh-CN", now=last_turn_at + 62)
     await asyncio.wait_for(retried.wait(), timeout=1.0)
     materials = pool.get_ready_materials("妮可")
 


### PR DESCRIPTION
## 改动概述 / Summary
- 将 topic candidate 的成熟判断对齐为至少 60s quiet window，避免过早分析短窗口。
- 调整 topic pipeline 单测断言，明确 pending/triggered/used 状态边界。
- Relates to #1847

## 回归报告 / Regression Report
- 改动：仅调整 `main_logic/topic/pipeline.py` 的 candidate 成熟时间判断，并更新相关单测。
- 理由与必要性：#1847 后续 deep research 依赖 delivery-time prepare，candidate 阶段需要先稳定收敛，避免 45s 私有节奏过早触发。
- 前后表现：修改前 candidate 可能在较短 quiet window 后进入 pending；修改后需要满足 60s mature window。
- 潜在回归：话题候选出现时间可能比以前稍晚；投递、quota、privacy、research prepare 尚未在本 PR 改动。
- 验证：`uv run ruff check main_logic/topic/pipeline.py tests/unit/test_topic_pipeline.py`；`uv run pytest tests/unit/test_topic_pipeline.py -q`，62 passed。

## 不拆分理由 / Why Not Split
不适用，本 PR 只改 2 个文件。

## 测试 / Testing
- `uv run ruff check main_logic/topic/pipeline.py tests/unit/test_topic_pipeline.py`
- `uv run pytest tests/unit/test_topic_pipeline.py -q`
- `git diff --check project/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 添加候选物料成熟度门控机制，新增 60 秒的成熟期窗口。主题处理现在会等待成熟期窗口完成后再进行后台分析处理，优化处理时序。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->