### PR TITLE
fix: translate icebreaker assistant subtitles

### DIFF
--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -1035,9 +1035,10 @@ function resetSubtitleTurnState() {
  *   isCurrentTurnFinalized=true 会把本轮首个 chunk / 单 chunk 回复的
  *   流式写入全部吞掉。
  */
-function beginSubtitleTurn() {
+function beginSubtitleTurn(options) {
     resetSubtitleTurnState();
-    turnBoundaryLatched = true;
+    const skipLatch = !!(options && options.latch === false);
+    turnBoundaryLatched = !skipLatch;
 }
 
 /**

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -423,7 +423,7 @@
                 return;
             }
             if (typeof bridge.beginTurn === 'function') {
-                bridge.beginTurn();
+                bridge.beginTurn({ latch: false });
             }
             var result = bridge.finalizeTurnWithTranslation(line);
             if (result && typeof result.catch === 'function') {
@@ -454,8 +454,8 @@
             icebreaker: Object.assign({ source: SOURCE }, meta || {})
         };
         broadcastIcebreakerAppendMessage(message);
-        return appendLlmContext(role, messageText, meta || {}).then(function () {
-            if (role === 'assistant') {
+        return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {
+            if (role === 'assistant' && contextOk === true) {
                 finalizeIcebreakerAssistantSubtitle(messageText);
             }
             if (!shouldRenderIcebreakerOnLocalChatHost()) {

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -414,6 +414,28 @@
         return contextAppendPromise;
     }
 
+    function finalizeIcebreakerAssistantSubtitle(text) {
+        var line = String(text || '').trim();
+        if (!line) return;
+        try {
+            var bridge = window.subtitleBridge;
+            if (!bridge || typeof bridge.finalizeTurnWithTranslation !== 'function') {
+                return;
+            }
+            if (typeof bridge.beginTurn === 'function') {
+                bridge.beginTurn();
+            }
+            var result = bridge.finalizeTurnWithTranslation(line);
+            if (result && typeof result.catch === 'function') {
+                result.catch(function (error) {
+                    console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
+                });
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
+        }
+    }
+
     function appendChatMessage(role, text, meta) {
         var messageText = String(text || '').trim();
         if (!messageText) return Promise.resolve(null);
@@ -433,6 +455,9 @@
         };
         broadcastIcebreakerAppendMessage(message);
         return appendLlmContext(role, messageText, meta || {}).then(function () {
+            if (role === 'assistant') {
+                finalizeIcebreakerAssistantSubtitle(messageText);
+            }
             if (!shouldRenderIcebreakerOnLocalChatHost()) {
                 return message;
             }

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -18,6 +18,7 @@ INDEX_TEMPLATE_PATH = ROOT / "templates" / "index.html"
 WEBSOCKET_ROUTER_PATH = ROOT / "main_routers" / "websocket_router.py"
 GAME_ROUTER_PATH = ROOT / "main_routers" / "game_router.py"
 LIVE2D_CORE_PATH = ROOT / "static" / "live2d-core.js"
+SUBTITLE_PATH = ROOT / "static" / "subtitle.js"
 
 
 def assert_icebreaker_script_has_voice_keys_for_every_spoken_line(day_key: str):
@@ -343,12 +344,13 @@ def test_icebreaker_context_appends_are_serialized_before_chat_progression():
         "function speakViaProjectTts",
         1,
     )[0]
-    assert "return appendLlmContext(role, messageText, meta || {}).then(function () {" in append_message_block
+    context_then = "return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {"
+    assert context_then in append_message_block
     assert "broadcastIcebreakerAppendMessage(message);" in append_message_block
     assert append_message_block.index("broadcastIcebreakerAppendMessage(message);") < append_message_block.index(
-        "return appendLlmContext(role, messageText, meta || {}).then(function () {"
+        context_then
     )
-    assert append_message_block.index("return appendLlmContext(role, messageText, meta || {}).then(function () {") < append_message_block.index(
+    assert append_message_block.index(context_then) < append_message_block.index(
         "return waitForChatHost(30000).then(function (host) {"
     )
 
@@ -380,6 +382,7 @@ def test_icebreaker_context_append_requires_successful_json_payload():
 
 def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal_chat():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    subtitle_runtime = SUBTITLE_PATH.read_text(encoding="utf-8")
 
     assert "function finalizeIcebreakerAssistantSubtitle(text)" in runtime
     subtitle_block = runtime.split("function finalizeIcebreakerAssistantSubtitle(text)", 1)[1].split(
@@ -387,17 +390,25 @@ def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal
         1,
     )[0]
     assert "window.subtitleBridge" in subtitle_block
-    assert "bridge.beginTurn()" in subtitle_block
+    assert "bridge.beginTurn({ latch: false })" in subtitle_block
+    assert "bridge.beginTurn()" not in subtitle_block
     assert "bridge.finalizeTurnWithTranslation(line)" in subtitle_block
     assert "console.warn('[NewUserIcebreaker] subtitle translation failed:'" in subtitle_block
+    begin_turn_block = subtitle_runtime.split("function beginSubtitleTurn(", 1)[1].split(
+        "function onAssistantTurnStart()",
+        1,
+    )[0]
+    assert "options && options.latch === false" in begin_turn_block
+    assert "turnBoundaryLatched = !skipLatch;" in begin_turn_block
 
     append_message_block = runtime.split("function appendChatMessage(role, text, meta)", 1)[1].split(
         "function speakViaProjectTts",
         1,
     )[0]
-    assert "if (role === 'assistant') {" in append_message_block
+    assert "then(function (contextOk) {" in append_message_block
+    assert "if (role === 'assistant' && contextOk === true) {" in append_message_block
     assert "finalizeIcebreakerAssistantSubtitle(messageText);" in append_message_block
-    assert append_message_block.index("return appendLlmContext(role, messageText, meta || {}).then(function () {") < append_message_block.index(
+    assert append_message_block.index("return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {") < append_message_block.index(
         "finalizeIcebreakerAssistantSubtitle(messageText);"
     )
 

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -378,6 +378,30 @@ def test_icebreaker_context_append_requires_successful_json_payload():
     assert "return true;" not in append_context_block
 
 
+def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal_chat():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+
+    assert "function finalizeIcebreakerAssistantSubtitle(text)" in runtime
+    subtitle_block = runtime.split("function finalizeIcebreakerAssistantSubtitle(text)", 1)[1].split(
+        "function appendChatMessage(role, text, meta)",
+        1,
+    )[0]
+    assert "window.subtitleBridge" in subtitle_block
+    assert "bridge.beginTurn()" in subtitle_block
+    assert "bridge.finalizeTurnWithTranslation(line)" in subtitle_block
+    assert "console.warn('[NewUserIcebreaker] subtitle translation failed:'" in subtitle_block
+
+    append_message_block = runtime.split("function appendChatMessage(role, text, meta)", 1)[1].split(
+        "function speakViaProjectTts",
+        1,
+    )[0]
+    assert "if (role === 'assistant') {" in append_message_block
+    assert "finalizeIcebreakerAssistantSubtitle(messageText);" in append_message_block
+    assert append_message_block.index("return appendLlmContext(role, messageText, meta || {}).then(function () {") < append_message_block.index(
+        "finalizeIcebreakerAssistantSubtitle(messageText);"
+    )
+
+
 def test_icebreaker_choice_submission_is_mutexed_and_restores_prompt_on_failure():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
     handle_choice_block = runtime.split("function handleChoice(detail)", 1)[1].split(


### PR DESCRIPTION
## 改动概述 / Summary
- 将新用户破冰助手的 assistant 文案接入现有 subtitleBridge 翻译链路，表现与普通聊天回复一致。
- 仅在 LLM 上下文写入明确成功后触发字幕翻译，避免失败上下文仍显示翻译。
- 为完整破冰文案使用无 latch 的字幕 turn 复位，避免污染下一轮普通聊天的 turn-start 状态。
- 补充静态契约测试覆盖破冰 assistant 消息调用翻译桥接与上下文成功门控。

## 回归报告 / Regression Report
不适用：本次只调整前端运行时与对应静态/前端契约测试，未改动 app/main_logic/memory 核心模块。

## 不拆分理由 / Why Not Split
不适用：单一小范围修复。

## 测试 / Testing
- `node --check static/tutorial/icebreaker/new-user-icebreaker.js`
- `node --check static/subtitle.js`
- `.venv/bin/pytest tests/unit/test_new_user_icebreaker_static_contracts.py -k 'subtitle_translation or runtime_wires_choice_prompt or home_tutorial_release_events or context_append' -q`
- `.venv/bin/pytest -q tests/frontend/test_subtitle_incremental.py::test_subtitle_empty_turn_does_not_request_translation_or_show_original_text`
- 使用 fresh PC profile 启动验证教程链路触发，破冰文案走 `/api/translate` 翻译框链路。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化入门冰破游戏中助手消息字幕翻译：在上下文追加成功后再触发字幕收尾，并在翻译失败时进行告警记录。
* **改进**
  * 允许字幕回合开始时通过可选参数控制“轮次边界闸门”（支持在需要时跳过以影响后续事件处理）。
* **测试**
  * 新增单元测试，覆盖助手字幕收尾流程、失败告警与调用时序；并调整相关断言以验证先后顺序。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->