### PR TITLE
fix(galgame): compact 选项文字不随背景一起淡出半透明

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2064,11 +2064,6 @@ body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] .composer-g
   border-color: transparent;
 }
 
-body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] .composer-galgame-option-text {
-  -webkit-mask-image: linear-gradient(90deg, #000 0%, #000 78%, transparent 100%);
-  mask-image: linear-gradient(90deg, #000 0%, #000 78%, transparent 100%);
-}
-
 body > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-choice-layer-open="false"] {
   display: none;
 }


### PR DESCRIPTION
compact 模式给 .composer-galgame-option-text 加的 mask-image 渐变会让 文字从 78% 起向右淡出，连同背景一并变透明。删掉该 mask 后背景保留渐变
半透明，文字回落到实色 token（亮色 #1f2329 / 暗色 #e8f3ff）。

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

<!-- 这个 PR 做了什么。若有对应 Issue 可关联（如 Closes #123），非必须。 -->

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->

## 不拆分理由 / Why Not Split

<!--
仅当本 PR 改动计入上限的文件 > 20 个时必填：为什么不拆成多个更小的 PR。
计入上限的文件数 ≤ 20：写「不适用」或删除本节。（新增文件、i18n locale 文件、测试文件不计入这个上限）
-->

## 测试 / Testing

<!-- 怎么验证的：跑了哪些测试、手动验证了哪些场景。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式调整**
  * 移除了紧凑聊天模式中选项文本的遮罩渐隐视觉效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->