### PR TITLE
fix(proactive): Phase 2 音乐 gate 钉到 selected_music_link 保证 [MUSIC] 必可转译

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6391,9 +6391,13 @@ async def proactive_chat(request: Request):
                         selected_music_topic_key = picked_key
                         phase1_topics.append(('music', music_topic))
                 else:
-                    logger.debug(f"[{lanlan_name}] Phase 1 音乐话题已添加 (topic_len={len(music_topic)})")
-                    print(f"[{lanlan_name}] Phase 1 音乐话题: {music_topic[:100]}")
-                    phase1_topics.append(('music', music_topic))
+                    # formatted_content 非空时 _format_music_content 必已输出至少一条
+                    # 曲目，所以这里实际不可达；保留为防御兜底，并与上面 picked_track
+                    # is None 路径对偶：没有可播曲目就不进 active_channels，守住
+                    # "music ∈ active_channels ⟺ selected_music_link 非空" 这条不变量，
+                    # 避免 Phase 2 出现音乐素材却无歌可投（发了 [MUSIC] 转译不出）。
+                    logger.debug(f"[{lanlan_name}] Phase 1 音乐 formatted_content 非空但无曲目数据，跳过音乐通道")
+                    music_content = None
 
         # ============================================================
         # 表情包话题组装（遍历候选 → 去重 → 限1张）
@@ -6555,9 +6559,12 @@ async def proactive_chat(request: Request):
             external_section = f"{el}\n{web_topic}\n{ef}"
         
         music_section = ""
-        # 如果正在放歌或处于冷却期，强行屏蔽音乐素材推荐，避免 AI 误触
-        # （冷却期时 music_content 已在上游被清空，music_topic 必为 None，此分支不会命中）
-        if music_topic and not is_playing_music and not music_cooldown:
+        # gate 钉在 selected_music_link（本轮真选中、可播的曲目）而非 music_topic：
+        # 保证 Phase 2 prompt 一旦出现音乐素材 / output-format 列出 [MUSIC]，下游必有
+        # 歌可投递，不会"发了 [MUSIC] 却转译不出"。selected_music_link 非空时
+        # music_topic 必非空（同生于 Phase 1 选曲）。正在放歌 / 冷却期时
+        # music_content / selected_music_link 已在上游清空，此分支自然不命中。
+        if selected_music_link and not is_playing_music and not music_cooldown:
             # 【优化】使用独立的标识符，防止模型将音乐素材误认为普通的外部 WEB 话题
             msh = _loc(MUSIC_SECTION_HEADER, proactive_lang)
             msf = _loc(MUSIC_SECTION_FOOTER, proactive_lang)
@@ -6665,7 +6672,8 @@ async def proactive_chat(request: Request):
             output_format_section=output_format_section,
         )
         dynamic_context_for_phase2 = ""
-        if music_topic:
+        # 同 music_section：[MUSIC] tag 强制指令只在真有可播曲目时注入。
+        if selected_music_link:
             dynamic_context_for_phase2 += PROACTIVE_MUSIC_TAG_INSTRUCTIONS.get(
                 proactive_lang,
                 PROACTIVE_MUSIC_TAG_INSTRUCTIONS.get('en', PROACTIVE_MUSIC_TAG_INSTRUCTIONS['zh']),

--- a/tests/unit/test_proactive_phase1_pass.py
+++ b/tests/unit/test_proactive_phase1_pass.py
@@ -5,6 +5,7 @@ from collections import deque
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
 from main_routers import system_router as sr
+from config.prompts.prompts_proactive import get_proactive_format_sections
 
 
 def test_parse_unified_phase1_marks_explicit_music_and_meme_pass():
@@ -151,6 +152,36 @@ def test_recent_proactive_similarity_blocks_at_90_percent():
 
     assert is_duplicate is True
     assert score >= 0.90
+
+
+def test_format_sections_omit_music_tag_without_playable_track():
+    # 没有可播曲目时（Phase 1 链接去重清空 / 无 track），上游不会构造 music_section，
+    # has_music=False。output-format 必须不暴露 [MUSIC] 选项——从模型视角等同"用户
+    # 没碰过音乐分享"，杜绝模型在无歌可投时仍押 [MUSIC]（发了 [MUSIC] 转译不出）。
+    _src, fmt = get_proactive_format_sections(
+        has_screen=False, has_web=True, has_music=False, has_meme=False, lang="zh",
+    )
+    assert "[MUSIC]" not in fmt
+    assert "[WEB]" in fmt  # 其它有副作用通道仍正常列出
+
+
+def test_format_sections_expose_music_tag_with_playable_track():
+    # 有可播曲目（selected_music_link 非空 → music_section 非空 → has_music=True）时，
+    # output-format 才列出 [MUSIC] 选项。
+    _src, fmt = get_proactive_format_sections(
+        has_screen=False, has_web=False, has_music=True, has_meme=False, lang="zh",
+    )
+    assert "[MUSIC]" in fmt
+
+
+def test_format_sections_no_side_effect_tags_is_tagless():
+    # 完全没有副作用素材时走 _of_none：纯文本无 tag，更不会出现 [MUSIC]。
+    _src, fmt = get_proactive_format_sections(
+        has_screen=True, has_web=False, has_music=False, has_meme=False, lang="zh",
+    )
+    assert "[MUSIC]" not in fmt
+    assert "[WEB]" not in fmt
+    assert "[MEME]" not in fmt
 
 
 def test_recent_proactive_similarity_ignores_expired_history():

--- a/tests/unit/test_proactive_phase1_pass.py
+++ b/tests/unit/test_proactive_phase1_pass.py
@@ -162,6 +162,7 @@ def test_format_sections_omit_music_tag_without_playable_track():
         has_screen=False, has_web=True, has_music=False, has_meme=False, lang="zh",
     )
     assert "[MUSIC]" not in fmt
+    assert "[MEME]" not in fmt
     assert "[WEB]" in fmt  # 其它有副作用通道仍正常列出
 
 
@@ -172,6 +173,8 @@ def test_format_sections_expose_music_tag_with_playable_track():
         has_screen=False, has_web=False, has_music=True, has_meme=False, lang="zh",
     )
     assert "[MUSIC]" in fmt
+    assert "[WEB]" not in fmt
+    assert "[MEME]" not in fmt
 
 
 def test_format_sections_no_side_effect_tags_is_tagless():
@@ -182,6 +185,7 @@ def test_format_sections_no_side_effect_tags_is_tagless():
     assert "[MUSIC]" not in fmt
     assert "[WEB]" not in fmt
     assert "[MEME]" not in fmt
+    assert "[CHAT]" not in fmt
 
 
 def test_recent_proactive_similarity_ignores_expired_history():


### PR DESCRIPTION
## 背景

排查"猫娘发了 `[MUSIC]` 但实际没有转译成音乐推送"的问题，深挖 Phase 1/2 音乐链路后定性：

- **Phase 2 音乐"去重"按曲目（`曲名|歌手` 归一化精确相等，1h 窗口）判定**，且它只决定"豁不豁免台词复读检查"，不决定推不推；链接（URL）只在 Phase 1 选曲的衰减 skip 里用。
- 真正决定"能不能转译"的是 Phase 1 备好的 `selected_music_link`。但 Phase 2 prompt 里的音乐段、`[MUSIC]` 标签指令、output-format 选项此前都 gate 在 `music_topic`（话题文本）这个**中间变量**上，而非 `selected_music_link`。
- 两者此前靠"`music_topic` 与 `selected_music_link` 同生"维持一致——但这是**隐式且脆弱**的，依赖一条 dead `else` 分支恰好不可达。

## 改动

把音乐 prompt 的 gate 统一收紧到 `selected_music_link`（本轮真选中、可播的曲目），建立硬不变量：

> Phase 2 出现音乐素材 / output-format 列出 `[MUSIC]`  ⟺  `selected_music_link` 非空  ⟺  下游必有歌可投

- `music_section` / `dynamic_context` 的 `[MUSIC]` 强制指令 gate 改为 `selected_music_link`
- Phase 1 选曲那条 dead `else`（`formatted_content` 非空但无 track）改为防御兜底：清空 `music_content`、不进 `active_channels`，与上面 `picked_track is None` 路径对偶，也与 meme 组装对齐（meme 进 `phase1_topics` ⟺ `selected_meme_link` 非空）
- 新增 `get_proactive_format_sections` 契约测试，钉住无可播曲目时 output-format 不暴露 `[MUSIC]`，从模型视角等同"用户没碰过音乐分享"

## 回归报告

**改动内容**
`main_routers/system_router.py` 的 `proactive_chat`：①Phase 1 音乐选曲 `if music_tracks:` 的 `else` 分支由"append music topic"改为"清空 `music_content`、不进 `active_channels`"；②Phase 2 `music_section` 的 gate 条件由 `music_topic` 改为 `selected_music_link`；③`dynamic_context_for_phase2` 注入 `[MUSIC]` 指令的 gate 由 `music_topic` 改为 `selected_music_link`。`tests/unit/test_proactive_phase1_pass.py` 新增 3 个 `get_proactive_format_sections` 契约测试。

**理由 / 必要性**
原本音乐相关的 prompt 注入（音乐素材段、`[MUSIC]` 强制指令、output-format 是否列出 `[MUSIC]`）都 gate 在中间变量 `music_topic` 上，而真正决定"能否把 `[MUSIC]` 转译成实际投递"的是 `selected_music_link`。两者一致是隐式的、依赖一条 dead `else` 不可达，脆弱且易 regression。收紧 gate 建立"出现音乐 prompt ⟺ 有可播曲目"的显式硬不变量。

**前后行为对比**
运行时行为**基本不变**：那条 `else` 本就是 dead code（`_format_music_content` 在无 track 时返回 `""`，进不到该分支），且 `music_topic` 与 `selected_music_link` 此前已同生同灭。本 PR 是把隐式保证显式化 + 测试锁定，不改变任何已知可达路径的输出。

**潜在回归**
- 若未来有人修改 Phase 1 选曲逻辑、让 `selected_music_link` 与 `music_topic` 不再同生，新 gate 会以 `selected_music_link` 为准（更安全：宁可不给音乐 prompt）。
- `music_section` body 仍引用 `music_topic` 文本：`selected_music_link` 非空时 `music_topic` 必非空，无空段风险。
- 覆盖：`get_proactive_format_sections` 契约测试 + 现有 proactive/music/mini_game 套件 `-k "proactive or music or mini_game"` → 435 passed / 1 skipped。
- 不在范围：模型在 prompt 完全无音乐时仍**幻觉**押 `[MUSIC]`（下游已兜底不投、`[MUSIC]` 字面被 `_strip_proactive_screen_tag_leak` 清掉），按需求方约定不处理。

## 测试

`tests/unit/test_proactive_phase1_pass.py`、`tests/unit/test_proactive_material_dedup.py` 全绿；`-k "proactive or music or mini_game"` 共 435 passed / 1 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了音乐素材注入逻辑，防止出现音乐区段存在但无可播曲目的不一致状态
  * 优化了音乐指令注入条件，确保仅在真实可播曲目存在时才注入相关指令

* **Tests**
  * 新增单元测试验证不同素材可用性条件下的格式标签包含行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->