### PR TITLE
fix: translate icebreaker assistant subtitles

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -269,7 +269,7 @@
     function readGalgameModePreference() {
         try {
             var raw = localStorage.getItem(GALGAME_STORAGE_KEY);
-            if (raw === null) return true; // legacy default ON unless new-user tutorial seeds OFF
+            if (raw === null) return true; // default ON per spec
             return raw === 'true';
         } catch (_) {
             return true;
@@ -280,20 +280,6 @@
         try {
             localStorage.setItem(GALGAME_STORAGE_KEY, enabled ? 'true' : 'false');
         } catch (_) {}
-    }
-
-    function hasGalgameModePreference() {
-        try {
-            return localStorage.getItem(GALGAME_STORAGE_KEY) !== null;
-        } catch (_) {
-            return true;
-        }
-    }
-
-    function ensureNewUserGalgameModeDefaultOff() {
-        if (state.galgameModeEnabled) return;
-        if (hasGalgameModePreference()) return;
-        persistGalgameModePreference(false);
     }
 
     // composer 隐藏（请她离开）时强制视为 OFF：保留 state.galgameModeEnabled，
@@ -3428,7 +3414,6 @@
         state.galgameTemporarilyDisabled = next;
 
         if (next) {
-            ensureNewUserGalgameModeDefaultOff();
             setGalgameModeEnabled(false, { persist: false });
         } else if (changed) {
             setGalgameModeEnabled(readGalgameModePreference(), {
@@ -6648,7 +6633,6 @@
         // setGalgameModeEnabled idempotently syncs state + body class + fires
         // the change event when the resolved pref differs from the safe default.
         if (isHomeTutorialInteractionLocked()) {
-            ensureNewUserGalgameModeDefaultOff();
             setGalgameModeTemporarilyDisabled(true);
         } else {
             setGalgameModeEnabled(readGalgameModePreference(), { persist: false });

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -269,7 +269,7 @@
     function readGalgameModePreference() {
         try {
             var raw = localStorage.getItem(GALGAME_STORAGE_KEY);
-            if (raw === null) return true; // default ON per spec
+            if (raw === null) return true; // legacy default ON unless new-user tutorial seeds OFF
             return raw === 'true';
         } catch (_) {
             return true;
@@ -280,6 +280,20 @@
         try {
             localStorage.setItem(GALGAME_STORAGE_KEY, enabled ? 'true' : 'false');
         } catch (_) {}
+    }
+
+    function hasGalgameModePreference() {
+        try {
+            return localStorage.getItem(GALGAME_STORAGE_KEY) !== null;
+        } catch (_) {
+            return true;
+        }
+    }
+
+    function ensureNewUserGalgameModeDefaultOff() {
+        if (state.galgameModeEnabled) return;
+        if (hasGalgameModePreference()) return;
+        persistGalgameModePreference(false);
     }
 
     // composer 隐藏（请她离开）时强制视为 OFF：保留 state.galgameModeEnabled，
@@ -3235,6 +3249,65 @@
         }
     }
 
+    function setTranslateEnabled(enabled, options) {
+        var requestOptions = options || {};
+        var next = !!enabled;
+        if (requestOptions.syncBridge !== false) {
+            try {
+                var bridge = window.subtitleBridge;
+                if (bridge && typeof bridge.setSubtitleEnabled === 'function') {
+                    bridge.setSubtitleEnabled(next);
+                } else {
+                    throw new Error('subtitleBridge.setSubtitleEnabled unavailable');
+                }
+            } catch (err) {
+                console.warn('[ReactChatWindow] bridge set enabled failed, using fallback:', err);
+                var appSt = window.appState;
+                var subtitleStore = window.nekoSubtitleShared;
+                if (appSt) appSt.subtitleEnabled = next;
+                var synced = false;
+                if (subtitleStore && typeof subtitleStore.updateSettings === 'function') {
+                    try {
+                        subtitleStore.updateSettings({
+                            subtitleEnabled: next
+                        }, {
+                            source: 'react-chat-fallback-set-enabled'
+                        });
+                        synced = true;
+                    } catch (storeErr) {
+                        console.warn('[ReactChatWindow] subtitle shared update failed:', storeErr);
+                    }
+                }
+                if (!synced) {
+                    try {
+                        localStorage.setItem('subtitleEnabled', String(next));
+                    } catch (storageErr) {
+                        console.warn('[ReactChatWindow] localStorage subtitleEnabled persist failed:', storageErr);
+                    }
+                }
+            }
+        }
+
+        if (requestOptions.persist !== false
+            && window.appSettings
+            && typeof window.appSettings.saveSettings === 'function') {
+            try {
+                window.appSettings.saveSettings();
+            } catch (saveErr) {
+                console.warn('[ReactChatWindow] appSettings.saveSettings failed:', saveErr);
+            }
+        }
+
+        state.viewProps = Object.assign({}, ensureViewProps(), { translateEnabled: next });
+        syncSubtitleWindowFromTranslateToggle(next);
+        renderWindow();
+
+        if (requestOptions.suppressHostEvent !== true) {
+            dispatchHostEvent('translate-toggle', { enabled: next });
+        }
+        return next;
+    }
+
     function handleTranslateToggle() {
         var bridge = window.subtitleBridge;
         var next;
@@ -3355,6 +3428,7 @@
         state.galgameTemporarilyDisabled = next;
 
         if (next) {
+            ensureNewUserGalgameModeDefaultOff();
             setGalgameModeEnabled(false, { persist: false });
         } else if (changed) {
             setGalgameModeEnabled(readGalgameModePreference(), {
@@ -6485,25 +6559,25 @@
         window.addEventListener('neko:tutorial-completed', function (event) {
             var detail = event && event.detail ? event.detail : {};
             if (detail.page !== 'home') return;
-            setGalgameModeTemporarilyDisabled(false);
             setHomeTutorialInputLocked(false, 'tutorial-completed');
             setHomeTutorialInteractionLocked(false, 'tutorial-completed');
+            setGalgameModeTemporarilyDisabled(false);
         });
 
         window.addEventListener('neko:tutorial-skipped', function (event) {
             var detail = event && event.detail ? event.detail : {};
             if (detail.page !== 'home') return;
-            setGalgameModeTemporarilyDisabled(false);
             setHomeTutorialInputLocked(false, 'tutorial-skipped');
             setHomeTutorialInteractionLocked(false, 'tutorial-skipped');
+            setGalgameModeTemporarilyDisabled(false);
         });
 
         window.addEventListener('neko:tutorial-ended-without-completion', function (event) {
             var detail = event && event.detail ? event.detail : {};
             if (detail.page !== 'home') return;
-            setGalgameModeTemporarilyDisabled(false);
             setHomeTutorialInputLocked(false, 'tutorial-ended-without-completion');
             setHomeTutorialInteractionLocked(false, 'tutorial-ended-without-completion');
+            setGalgameModeTemporarilyDisabled(false);
         });
 
         // Refresh option list whenever an assistant turn finishes streaming.
@@ -6574,6 +6648,7 @@
         // setGalgameModeEnabled idempotently syncs state + body class + fires
         // the change event when the resolved pref differs from the safe default.
         if (isHomeTutorialInteractionLocked()) {
+            ensureNewUserGalgameModeDefaultOff();
             setGalgameModeTemporarilyDisabled(true);
         } else {
             setGalgameModeEnabled(readGalgameModePreference(), { persist: false });
@@ -6895,6 +6970,9 @@
         syncGoodbyeComposerHidden: syncGoodbyeComposerHidden,
         setGalgameModeEnabled: function (enabled, options) {
             setGalgameModeEnabled(enabled, options || {});
+        },
+        setTranslateEnabled: function (enabled, options) {
+            return setTranslateEnabled(enabled, options || {});
         },
         isGalgameModeEnabled: function () { return !!state.galgameModeEnabled; },
         getChatSurfaceMode: function () { return getCurrentChatSurfaceMode(); },

--- a/static/tutorial/core/app-prompt.js
+++ b/static/tutorial/core/app-prompt.js
@@ -150,10 +150,35 @@
         return window.reactChatWindowHost || null;
     }
 
+    function shouldUseNewUserGalgameDefaultOff() {
+        return !!(
+            isHomePage()
+            && !state.homeTutorialCompleted
+            && !state.manualHomeTutorialViewed
+            && !isHomeTutorialSeen()
+        );
+    }
+
+    function hasStoredGalgamePreference() {
+        try {
+            return localStorage.getItem('neko.reactChatWindow.galgameMode') !== null;
+        } catch (_) {
+            return true;
+        }
+    }
+
+    function ensureNewUserGalgameDefaultOffPreference() {
+        if (!shouldUseNewUserGalgameDefaultOff()) return;
+        if (hasStoredGalgamePreference()) return;
+        try {
+            localStorage.setItem('neko.reactChatWindow.galgameMode', 'false');
+        } catch (_) {}
+    }
+
     function getStoredGalgamePreference() {
         try {
             const raw = localStorage.getItem('neko.reactChatWindow.galgameMode');
-            if (raw === null) return true;
+            if (raw === null) return shouldUseNewUserGalgameDefaultOff() ? false : true;
             return raw === 'true';
         } catch (_) {
             return true;
@@ -161,6 +186,9 @@
     }
 
     function snapshotGalgameState() {
+        if (shouldUseNewUserGalgameDefaultOff() && !hasStoredGalgamePreference()) {
+            return false;
+        }
         const host = getReactChatWindowHost();
         if (host && typeof host.isGalgameModeEnabled === 'function') {
             try {
@@ -169,6 +197,8 @@
         }
         return getStoredGalgamePreference();
     }
+
+    ensureNewUserGalgameDefaultOffPreference();
 
     function setGalgameState(enabled, options) {
         const requestOptions = options || {};

--- a/static/tutorial/core/app-prompt.js
+++ b/static/tutorial/core/app-prompt.js
@@ -150,35 +150,10 @@
         return window.reactChatWindowHost || null;
     }
 
-    function shouldUseNewUserGalgameDefaultOff() {
-        return !!(
-            isHomePage()
-            && !state.homeTutorialCompleted
-            && !state.manualHomeTutorialViewed
-            && !isHomeTutorialSeen()
-        );
-    }
-
-    function hasStoredGalgamePreference() {
-        try {
-            return localStorage.getItem('neko.reactChatWindow.galgameMode') !== null;
-        } catch (_) {
-            return true;
-        }
-    }
-
-    function ensureNewUserGalgameDefaultOffPreference() {
-        if (!shouldUseNewUserGalgameDefaultOff()) return;
-        if (hasStoredGalgamePreference()) return;
-        try {
-            localStorage.setItem('neko.reactChatWindow.galgameMode', 'false');
-        } catch (_) {}
-    }
-
     function getStoredGalgamePreference() {
         try {
             const raw = localStorage.getItem('neko.reactChatWindow.galgameMode');
-            if (raw === null) return shouldUseNewUserGalgameDefaultOff() ? false : true;
+            if (raw === null) return true;
             return raw === 'true';
         } catch (_) {
             return true;
@@ -186,9 +161,6 @@
     }
 
     function snapshotGalgameState() {
-        if (shouldUseNewUserGalgameDefaultOff() && !hasStoredGalgamePreference()) {
-            return false;
-        }
         const host = getReactChatWindowHost();
         if (host && typeof host.isGalgameModeEnabled === 'function') {
             try {
@@ -197,8 +169,6 @@
         }
         return getStoredGalgamePreference();
     }
-
-    ensureNewUserGalgameDefaultOffPreference();
 
     function setGalgameState(enabled, options) {
         const requestOptions = options || {};

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -17,6 +17,7 @@
     var localePromises = Object.create(null);
     var icebreakerSortKeySeq = 0;
     var icebreakerBridgeTimestampSeq = 0;
+    var icebreakerSubtitlePanelOpenedSessionId = '';
     var contextAppendPromise = Promise.resolve();
 
     function safeJsonParse(raw, fallback) {
@@ -145,6 +146,28 @@
         return postIcebreakerRoute('/route/start', session, {
             source: SOURCE
         });
+    }
+
+    function openSubtitleTranslationForIcebreakerAssistantMessage() {
+        try {
+            var bridge = window.subtitleBridge;
+            if (bridge && typeof bridge.setSubtitleEnabled === 'function') {
+                bridge.setSubtitleEnabled(true);
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] subtitle bridge open failed:', error);
+        }
+        try {
+            var host = window.reactChatWindowHost;
+            if (host && typeof host.setTranslateEnabled === 'function') {
+                host.setTranslateEnabled(true, {
+                    syncBridge: false,
+                    suppressHostEvent: true
+                });
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] subtitle host translation open failed:', error);
+        }
     }
 
     function clearPendingStartDay(dayKey) {
@@ -436,6 +459,21 @@
         }
     }
 
+    function shouldOpenIcebreakerSubtitlePanelOnce() {
+        var sessionId = activeSession && activeSession.sessionId ? activeSession.sessionId : '';
+        if (!sessionId || icebreakerSubtitlePanelOpenedSessionId === sessionId) return false;
+        icebreakerSubtitlePanelOpenedSessionId = sessionId;
+        return true;
+    }
+
+    function syncIcebreakerAssistantSubtitle(role, contextOk, text) {
+        if (role !== 'assistant' || contextOk !== true) return;
+        if (shouldOpenIcebreakerSubtitlePanelOnce()) {
+            openSubtitleTranslationForIcebreakerAssistantMessage();
+        }
+        finalizeIcebreakerAssistantSubtitle(text);
+    }
+
     function appendChatMessage(role, text, meta) {
         var messageText = String(text || '').trim();
         if (!messageText) return Promise.resolve(null);
@@ -455,10 +493,8 @@
         };
         broadcastIcebreakerAppendMessage(message);
         return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {
-            if (role === 'assistant' && contextOk === true) {
-                finalizeIcebreakerAssistantSubtitle(messageText);
-            }
             if (!shouldRenderIcebreakerOnLocalChatHost()) {
+                syncIcebreakerAssistantSubtitle(role, contextOk, messageText);
                 return message;
             }
             return waitForChatHost(30000).then(function (host) {
@@ -466,6 +502,9 @@
                     host.openWindow();
                 }
                 return host.appendMessage(message);
+            }).then(function (result) {
+                syncIcebreakerAssistantSubtitle(role, contextOk, messageText);
+                return result;
             });
         }).catch(function (error) {
             console.warn('[NewUserIcebreaker] append message failed:', error);

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -411,52 +411,6 @@ def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal
     assert "finalizeIcebreakerAssistantSubtitle(text);" in sync_block
 
 
-def test_new_user_tutorial_seeds_galgame_default_off_without_changing_legacy_default():
-    chat_host = CHAT_HOST_PATH.read_text(encoding="utf-8")
-    app_prompt = APP_PROMPT_PATH.read_text(encoding="utf-8")
-    preference_block = chat_host.split("function readGalgameModePreference()", 1)[1].split(
-        "function persistGalgameModePreference",
-        1,
-    )[0]
-    seed_block = chat_host.split("function ensureNewUserGalgameModeDefaultOff()", 1)[1].split(
-        "function getEffectiveComposerHidden",
-        1,
-    )[0]
-    temp_disable_block = chat_host.split("function setGalgameModeTemporarilyDisabled(disabled)", 1)[1].split(
-        "function setGalgameModeEnabled",
-        1,
-    )[0]
-    init_block = chat_host.split("Resolve the persisted GalGame preference", 1)[1].split(
-        "} else {",
-        1,
-    )[0]
-
-    assert "if (raw === null) return true; // legacy default ON unless new-user tutorial seeds OFF" in preference_block
-    assert "return true;" in preference_block
-    assert "if (state.galgameModeEnabled) return;" in seed_block
-    assert "if (hasGalgameModePreference()) return;" in seed_block
-    assert "persistGalgameModePreference(false);" in seed_block
-    assert "if (next) {" in temp_disable_block
-    assert "ensureNewUserGalgameModeDefaultOff();" in temp_disable_block
-    assert "ensureNewUserGalgameModeDefaultOff();" in init_block
-
-    prompt_preference_block = app_prompt.split("function getStoredGalgamePreference()", 1)[1].split(
-        "function snapshotGalgameState",
-        1,
-    )[0]
-    assert "if (raw === null) return shouldUseNewUserGalgameDefaultOff() ? false : true;" in prompt_preference_block
-    prompt_snapshot_block = app_prompt.split("function snapshotGalgameState()", 1)[1].split(
-        "function setGalgameState",
-        1,
-    )[0]
-    assert "function ensureNewUserGalgameDefaultOffPreference()" in app_prompt
-    assert "ensureNewUserGalgameDefaultOffPreference();" in app_prompt
-    assert "localStorage.setItem('neko.reactChatWindow.galgameMode', 'false');" in app_prompt
-    assert prompt_snapshot_block.index("shouldUseNewUserGalgameDefaultOff()") < prompt_snapshot_block.index(
-        "const host = getReactChatWindowHost();"
-    )
-
-
 def test_icebreaker_assistant_message_auto_opens_subtitle_translation_panel():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
     chat_host = CHAT_HOST_PATH.read_text(encoding="utf-8")

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -13,6 +13,7 @@ LOCALES_DIR = ROOT / "static" / "tutorial" / "icebreaker" / "locales"
 CHAT_HOST_PATH = ROOT / "static" / "app-react-chat-window.js"
 APP_WEBSOCKET_PATH = ROOT / "static" / "app-websocket.js"
 APP_PROACTIVE_PATH = ROOT / "static" / "app-proactive.js"
+APP_PROMPT_PATH = ROOT / "static" / "tutorial" / "core" / "app-prompt.js"
 UNIVERSAL_TUTORIAL_MANAGER_PATH = ROOT / "static" / "tutorial" / "core" / "universal-manager.js"
 INDEX_TEMPLATE_PATH = ROOT / "templates" / "index.html"
 WEBSOCKET_ROUTER_PATH = ROOT / "main_routers" / "websocket_router.py"
@@ -358,7 +359,7 @@ def test_icebreaker_context_appends_are_serialized_before_chat_progression():
 def test_icebreaker_context_append_requires_successful_json_payload():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
     append_context_block = runtime.split("function appendLlmContext(role, text, meta)", 1)[1].split(
-        "function appendChatMessage(role, text, meta)",
+        "function finalizeIcebreakerAssistantSubtitle(text)",
         1,
     )[0]
 
@@ -401,15 +402,125 @@ def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal
     assert "options && options.latch === false" in begin_turn_block
     assert "turnBoundaryLatched = !skipLatch;" in begin_turn_block
 
+    sync_block = runtime.split("function syncIcebreakerAssistantSubtitle(role, contextOk, text)", 1)[1].split(
+        "function appendChatMessage(role, text, meta)",
+        1,
+    )[0]
+    assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
+    assert "openSubtitleTranslationForIcebreakerAssistantMessage();" in sync_block
+    assert "finalizeIcebreakerAssistantSubtitle(text);" in sync_block
+
+
+def test_new_user_tutorial_seeds_galgame_default_off_without_changing_legacy_default():
+    chat_host = CHAT_HOST_PATH.read_text(encoding="utf-8")
+    app_prompt = APP_PROMPT_PATH.read_text(encoding="utf-8")
+    preference_block = chat_host.split("function readGalgameModePreference()", 1)[1].split(
+        "function persistGalgameModePreference",
+        1,
+    )[0]
+    seed_block = chat_host.split("function ensureNewUserGalgameModeDefaultOff()", 1)[1].split(
+        "function getEffectiveComposerHidden",
+        1,
+    )[0]
+    temp_disable_block = chat_host.split("function setGalgameModeTemporarilyDisabled(disabled)", 1)[1].split(
+        "function setGalgameModeEnabled",
+        1,
+    )[0]
+    init_block = chat_host.split("Resolve the persisted GalGame preference", 1)[1].split(
+        "} else {",
+        1,
+    )[0]
+
+    assert "if (raw === null) return true; // legacy default ON unless new-user tutorial seeds OFF" in preference_block
+    assert "return true;" in preference_block
+    assert "if (state.galgameModeEnabled) return;" in seed_block
+    assert "if (hasGalgameModePreference()) return;" in seed_block
+    assert "persistGalgameModePreference(false);" in seed_block
+    assert "if (next) {" in temp_disable_block
+    assert "ensureNewUserGalgameModeDefaultOff();" in temp_disable_block
+    assert "ensureNewUserGalgameModeDefaultOff();" in init_block
+
+    prompt_preference_block = app_prompt.split("function getStoredGalgamePreference()", 1)[1].split(
+        "function snapshotGalgameState",
+        1,
+    )[0]
+    assert "if (raw === null) return shouldUseNewUserGalgameDefaultOff() ? false : true;" in prompt_preference_block
+    prompt_snapshot_block = app_prompt.split("function snapshotGalgameState()", 1)[1].split(
+        "function setGalgameState",
+        1,
+    )[0]
+    assert "function ensureNewUserGalgameDefaultOffPreference()" in app_prompt
+    assert "ensureNewUserGalgameDefaultOffPreference();" in app_prompt
+    assert "localStorage.setItem('neko.reactChatWindow.galgameMode', 'false');" in app_prompt
+    assert prompt_snapshot_block.index("shouldUseNewUserGalgameDefaultOff()") < prompt_snapshot_block.index(
+        "const host = getReactChatWindowHost();"
+    )
+
+
+def test_icebreaker_assistant_message_auto_opens_subtitle_translation_panel():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    chat_host = CHAT_HOST_PATH.read_text(encoding="utf-8")
+
+    assert "function openSubtitleTranslationForIcebreakerAssistantMessage()" in runtime
+    open_block = runtime.split("function openSubtitleTranslationForIcebreakerAssistantMessage()", 1)[1].split(
+        "function startIcebreakerRoute(session)",
+        1,
+    )[0]
+    assert "window.subtitleBridge" in open_block
+    assert "bridge.setSubtitleEnabled(true)" in open_block
+    assert "window.reactChatWindowHost" in open_block
+    assert "host.setTranslateEnabled(true" in open_block
+    assert "console.warn('[NewUserIcebreaker] subtitle bridge open failed:'" in open_block
+    assert "console.warn('[NewUserIcebreaker] subtitle host translation open failed:'" in open_block
+
+    start_block = runtime.split("return startIcebreakerRoute(nextSession).then(function (started)", 1)[1].split(
+        "activeSession = nextSession;",
+        1,
+    )[0]
+    assert "openSubtitleTranslationForIcebreakerAssistantMessage();" not in start_block
+
+    sync_block = runtime.split("function syncIcebreakerAssistantSubtitle(role, contextOk, text)", 1)[1].split(
+        "function appendChatMessage(role, text, meta)",
+        1,
+    )[0]
+    assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
+    assert "if (shouldOpenIcebreakerSubtitlePanelOnce()) {" in sync_block
+    assert "openSubtitleTranslationForIcebreakerAssistantMessage();" in sync_block
+    assert sync_block.index("openSubtitleTranslationForIcebreakerAssistantMessage();") < sync_block.index(
+        "finalizeIcebreakerAssistantSubtitle(text);"
+    )
+    open_once_block = runtime.split("function shouldOpenIcebreakerSubtitlePanelOnce()", 1)[1].split(
+        "function syncIcebreakerAssistantSubtitle",
+        1,
+    )[0]
+    assert "icebreakerSubtitlePanelOpenedSessionId === sessionId" in open_once_block
+    assert "icebreakerSubtitlePanelOpenedSessionId = sessionId;" in open_once_block
+
     append_message_block = runtime.split("function appendChatMessage(role, text, meta)", 1)[1].split(
         "function speakViaProjectTts",
         1,
     )[0]
-    assert "then(function (contextOk) {" in append_message_block
-    assert "if (role === 'assistant' && contextOk === true) {" in append_message_block
-    assert "finalizeIcebreakerAssistantSubtitle(messageText);" in append_message_block
-    assert append_message_block.index("return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {") < append_message_block.index(
-        "finalizeIcebreakerAssistantSubtitle(messageText);"
+    assert "return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {" in append_message_block
+    assert "return host.appendMessage(message);" in append_message_block
+    assert "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);" in append_message_block
+    assert append_message_block.index("return host.appendMessage(message);") < append_message_block.rindex(
+        "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);"
+    )
+
+    assert "setTranslateEnabled: function (enabled, options)" in chat_host
+    set_translate_block = chat_host.split("function setTranslateEnabled(enabled, options)", 1)[1].split(
+        "function handleTranslateToggle()",
+        1,
+    )[0]
+    assert "var synced = false;" in set_translate_block
+    assert "console.warn('[ReactChatWindow] subtitle shared update failed:'" in set_translate_block
+    assert "console.warn('[ReactChatWindow] localStorage subtitleEnabled persist failed:'" in set_translate_block
+    assert "console.warn('[ReactChatWindow] appSettings.saveSettings failed:'" in set_translate_block
+    assert set_translate_block.index("window.appSettings.saveSettings();") > set_translate_block.index(
+        "} catch (err) {"
+    )
+    assert set_translate_block.index("window.appSettings.saveSettings();") < set_translate_block.index(
+        "state.viewProps = Object.assign"
     )
 
 


### PR DESCRIPTION
## 改动概述 / Summary
- 破冰流程里的 assistant 文案成功接入普通聊天框后，自动打开翻译框。
- 破冰 assistant 文案复用普通聊天的字幕翻译收尾逻辑，避免只显示原文或翻译状态不同步。
- React Chat host 新增 `setTranslateEnabled`，供破冰流程只在需要时同步翻译框开关。
- 不改变 GalGame 默认偏好；默认值仍沿用既有行为，教程期间的临时隐藏逻辑保持在教程锁范围内。

## 回归报告 / Regression Report
不适用：本 PR 未改动 `app/`、`main_logic/`、`memory/` 后端核心逻辑。风险集中在前端静态破冰流程、React Chat host 翻译开关同步、字幕翻译状态同步。

已验证破冰 assistant 消息只在聊天框写入成功后打开翻译框并 finalize 字幕翻译；同时确认本 PR 不再保留新用户 GalGame 默认关闭的 seeding 逻辑。

## 不拆分理由 / Why Not Split
不适用：改动集中在破冰字幕接入与对应前端契约测试，范围较小。

## 测试 / Testing
- `uv run pytest tests/unit/test_new_user_icebreaker_static_contracts.py::test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal_chat tests/unit/test_new_user_icebreaker_static_contracts.py::test_icebreaker_assistant_message_auto_opens_subtitle_translation_panel -q`
- `node --check static/app-react-chat-window.js && node --check static/tutorial/icebreaker/new-user-icebreaker.js && node --check static/tutorial/core/app-prompt.js && git diff --check`
- `rg -n "shouldUseNewUserGalgameDefaultOff|ensureNewUserGalgameDefaultOff|ensureNewUserGalgameDefaultOffPreference|localStorage\\.setItem\\('neko\\.reactChatWindow\\.galgameMode', 'false'\\)" static/app-react-chat-window.js static/tutorial/core/app-prompt.js tests/unit/test_new_user_icebreaker_static_contracts.py || true`
