### PR TITLE
fix: translate icebreaker assistant subtitles

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3235,6 +3235,71 @@
         }
     }
 
+    function setTranslateEnabled(enabled, options) {
+        var requestOptions = options || {};
+        var next = !!enabled;
+        var shouldPersist = requestOptions.persist !== false;
+        var syncSource = requestOptions.source || 'react-chat-host-set-enabled';
+        if (requestOptions.syncBridge !== false) {
+            try {
+                var bridge = window.subtitleBridge;
+                if (bridge && typeof bridge.setSubtitleEnabled === 'function') {
+                    bridge.setSubtitleEnabled(next, {
+                        persist: shouldPersist,
+                        source: syncSource
+                    });
+                } else {
+                    throw new Error('subtitleBridge.setSubtitleEnabled unavailable');
+                }
+            } catch (err) {
+                console.warn('[ReactChatWindow] bridge set enabled failed, using fallback:', err);
+                var appSt = window.appState;
+                var subtitleStore = window.nekoSubtitleShared;
+                if (appSt) appSt.subtitleEnabled = next;
+                var synced = false;
+                if (subtitleStore && typeof subtitleStore.updateSettings === 'function') {
+                    try {
+                        subtitleStore.updateSettings({
+                            subtitleEnabled: next
+                        }, {
+                            persist: shouldPersist,
+                            source: syncSource
+                        });
+                        synced = true;
+                    } catch (storeErr) {
+                        console.warn('[ReactChatWindow] subtitle shared update failed:', storeErr);
+                    }
+                }
+                if (!synced && shouldPersist) {
+                    try {
+                        localStorage.setItem('subtitleEnabled', String(next));
+                    } catch (storageErr) {
+                        console.warn('[ReactChatWindow] localStorage subtitleEnabled persist failed:', storageErr);
+                    }
+                }
+            }
+        }
+
+        if (shouldPersist
+            && window.appSettings
+            && typeof window.appSettings.saveSettings === 'function') {
+            try {
+                window.appSettings.saveSettings();
+            } catch (saveErr) {
+                console.warn('[ReactChatWindow] appSettings.saveSettings failed:', saveErr);
+            }
+        }
+
+        state.viewProps = Object.assign({}, ensureViewProps(), { translateEnabled: next });
+        syncSubtitleWindowFromTranslateToggle(next);
+        renderWindow();
+
+        if (requestOptions.suppressHostEvent !== true) {
+            dispatchHostEvent('translate-toggle', { enabled: next });
+        }
+        return next;
+    }
+
     function handleTranslateToggle() {
         var bridge = window.subtitleBridge;
         var next;
@@ -6895,6 +6960,9 @@
         syncGoodbyeComposerHidden: syncGoodbyeComposerHidden,
         setGalgameModeEnabled: function (enabled, options) {
             setGalgameModeEnabled(enabled, options || {});
+        },
+        setTranslateEnabled: function (enabled, options) {
+            return setTranslateEnabled(enabled, options || {});
         },
         isGalgameModeEnabled: function () { return !!state.galgameModeEnabled; },
         getChatSurfaceMode: function () { return getCurrentChatSurfaceMode(); },

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -1264,12 +1264,14 @@ window.subtitleBridge = {
         return isCurrentTurnFinalized;
     },
     /** 同步开启状态并执行显示/隐藏副作用（用于服务器设置回灌和窗口控制） */
-    setSubtitleEnabled: function(enabled) {
+    setSubtitleEnabled: function(enabled, options) {
+        var requestOptions = options || {};
         subtitleEnabled = !!enabled;
         applySharedSubtitleSettings({
             subtitleEnabled: subtitleEnabled
         }, {
-            source: 'subtitle-bridge-set-enabled'
+            persist: requestOptions.persist !== false,
+            source: requestOptions.source || 'subtitle-bridge-set-enabled'
         });
 
         if (subtitleEnabled) {
@@ -1279,7 +1281,7 @@ window.subtitleBridge = {
             hideSubtitle();
         }
         syncSettingsPanel();
-        syncSubtitleRenderState('subtitle-bridge-set-enabled');
+        syncSubtitleRenderState(requestOptions.source || 'subtitle-bridge-set-enabled');
     },
     /** 完整切换：翻转开关 + 执行运行时副作用（隐藏/补显字幕，并在开启时翻译当前文本） */
     toggle: function() {

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -17,6 +17,7 @@
     var localePromises = Object.create(null);
     var icebreakerSortKeySeq = 0;
     var icebreakerBridgeTimestampSeq = 0;
+    var icebreakerSubtitlePanelOpenedSessionId = '';
     var contextAppendPromise = Promise.resolve();
 
     function safeJsonParse(raw, fallback) {
@@ -145,6 +146,32 @@
         return postIcebreakerRoute('/route/start', session, {
             source: SOURCE
         });
+    }
+
+    function openSubtitleTranslationForIcebreakerAssistantMessage() {
+        try {
+            var bridge = window.subtitleBridge;
+            if (bridge && typeof bridge.setSubtitleEnabled === 'function') {
+                bridge.setSubtitleEnabled(true, {
+                    persist: false,
+                    source: 'new-user-icebreaker-auto-open'
+                });
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] subtitle bridge open failed:', error);
+        }
+        try {
+            var host = window.reactChatWindowHost;
+            if (host && typeof host.setTranslateEnabled === 'function') {
+                host.setTranslateEnabled(true, {
+                    syncBridge: false,
+                    suppressHostEvent: true,
+                    persist: false
+                });
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] subtitle host translation open failed:', error);
+        }
     }
 
     function clearPendingStartDay(dayKey) {
@@ -436,6 +463,21 @@
         }
     }
 
+    function shouldOpenIcebreakerSubtitlePanelOnce() {
+        var sessionId = activeSession && activeSession.sessionId ? activeSession.sessionId : '';
+        if (!sessionId || icebreakerSubtitlePanelOpenedSessionId === sessionId) return false;
+        icebreakerSubtitlePanelOpenedSessionId = sessionId;
+        return true;
+    }
+
+    function syncIcebreakerAssistantSubtitle(role, contextOk, text) {
+        if (role !== 'assistant' || contextOk !== true) return;
+        if (shouldOpenIcebreakerSubtitlePanelOnce()) {
+            openSubtitleTranslationForIcebreakerAssistantMessage();
+        }
+        finalizeIcebreakerAssistantSubtitle(text);
+    }
+
     function appendChatMessage(role, text, meta) {
         var messageText = String(text || '').trim();
         if (!messageText) return Promise.resolve(null);
@@ -455,10 +497,8 @@
         };
         broadcastIcebreakerAppendMessage(message);
         return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {
-            if (role === 'assistant' && contextOk === true) {
-                finalizeIcebreakerAssistantSubtitle(messageText);
-            }
             if (!shouldRenderIcebreakerOnLocalChatHost()) {
+                syncIcebreakerAssistantSubtitle(role, contextOk, messageText);
                 return message;
             }
             return waitForChatHost(30000).then(function (host) {
@@ -466,6 +506,9 @@
                     host.openWindow();
                 }
                 return host.appendMessage(message);
+            }).then(function (result) {
+                syncIcebreakerAssistantSubtitle(role, contextOk, messageText);
+                return result;
             });
         }).catch(function (error) {
             console.warn('[NewUserIcebreaker] append message failed:', error);

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -358,7 +358,7 @@ def test_icebreaker_context_appends_are_serialized_before_chat_progression():
 def test_icebreaker_context_append_requires_successful_json_payload():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
     append_context_block = runtime.split("function appendLlmContext(role, text, meta)", 1)[1].split(
-        "function appendChatMessage(role, text, meta)",
+        "function finalizeIcebreakerAssistantSubtitle(text)",
         1,
     )[0]
 
@@ -401,15 +401,85 @@ def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal
     assert "options && options.latch === false" in begin_turn_block
     assert "turnBoundaryLatched = !skipLatch;" in begin_turn_block
 
+    sync_block = runtime.split("function syncIcebreakerAssistantSubtitle(role, contextOk, text)", 1)[1].split(
+        "function appendChatMessage(role, text, meta)",
+        1,
+    )[0]
+    assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
+    assert "openSubtitleTranslationForIcebreakerAssistantMessage();" in sync_block
+    assert "finalizeIcebreakerAssistantSubtitle(text);" in sync_block
+
+
+def test_icebreaker_assistant_message_auto_opens_subtitle_translation_panel():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    chat_host = CHAT_HOST_PATH.read_text(encoding="utf-8")
+
+    assert "function openSubtitleTranslationForIcebreakerAssistantMessage()" in runtime
+    open_block = runtime.split("function openSubtitleTranslationForIcebreakerAssistantMessage()", 1)[1].split(
+        "function startIcebreakerRoute(session)",
+        1,
+    )[0]
+    assert "window.subtitleBridge" in open_block
+    assert "bridge.setSubtitleEnabled(true, {" in open_block
+    assert "persist: false" in open_block
+    assert "window.reactChatWindowHost" in open_block
+    assert "host.setTranslateEnabled(true" in open_block
+    assert "console.warn('[NewUserIcebreaker] subtitle bridge open failed:'" in open_block
+    assert "console.warn('[NewUserIcebreaker] subtitle host translation open failed:'" in open_block
+
+    start_block = runtime.split("return startIcebreakerRoute(nextSession).then(function (started)", 1)[1].split(
+        "activeSession = nextSession;",
+        1,
+    )[0]
+    assert "openSubtitleTranslationForIcebreakerAssistantMessage();" not in start_block
+
+    sync_block = runtime.split("function syncIcebreakerAssistantSubtitle(role, contextOk, text)", 1)[1].split(
+        "function appendChatMessage(role, text, meta)",
+        1,
+    )[0]
+    assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
+    assert "if (shouldOpenIcebreakerSubtitlePanelOnce()) {" in sync_block
+    assert "openSubtitleTranslationForIcebreakerAssistantMessage();" in sync_block
+    assert sync_block.index("openSubtitleTranslationForIcebreakerAssistantMessage();") < sync_block.index(
+        "finalizeIcebreakerAssistantSubtitle(text);"
+    )
+    open_once_block = runtime.split("function shouldOpenIcebreakerSubtitlePanelOnce()", 1)[1].split(
+        "function syncIcebreakerAssistantSubtitle",
+        1,
+    )[0]
+    assert "icebreakerSubtitlePanelOpenedSessionId === sessionId" in open_once_block
+    assert "icebreakerSubtitlePanelOpenedSessionId = sessionId;" in open_once_block
+
     append_message_block = runtime.split("function appendChatMessage(role, text, meta)", 1)[1].split(
         "function speakViaProjectTts",
         1,
     )[0]
-    assert "then(function (contextOk) {" in append_message_block
-    assert "if (role === 'assistant' && contextOk === true) {" in append_message_block
-    assert "finalizeIcebreakerAssistantSubtitle(messageText);" in append_message_block
-    assert append_message_block.index("return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {") < append_message_block.index(
-        "finalizeIcebreakerAssistantSubtitle(messageText);"
+    assert "return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {" in append_message_block
+    assert "return host.appendMessage(message);" in append_message_block
+    assert "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);" in append_message_block
+    assert append_message_block.index("return host.appendMessage(message);") < append_message_block.rindex(
+        "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);"
+    )
+
+    assert "setTranslateEnabled: function (enabled, options)" in chat_host
+    set_translate_block = chat_host.split("function setTranslateEnabled(enabled, options)", 1)[1].split(
+        "function handleTranslateToggle()",
+        1,
+    )[0]
+    assert "var shouldPersist = requestOptions.persist !== false;" in set_translate_block
+    assert "bridge.setSubtitleEnabled(next, {" in set_translate_block
+    assert "persist: shouldPersist" in set_translate_block
+    assert "source: syncSource" in set_translate_block
+    assert "var synced = false;" in set_translate_block
+    assert "if (!synced && shouldPersist) {" in set_translate_block
+    assert "console.warn('[ReactChatWindow] subtitle shared update failed:'" in set_translate_block
+    assert "console.warn('[ReactChatWindow] localStorage subtitleEnabled persist failed:'" in set_translate_block
+    assert "console.warn('[ReactChatWindow] appSettings.saveSettings failed:'" in set_translate_block
+    assert set_translate_block.index("window.appSettings.saveSettings();") > set_translate_block.index(
+        "} catch (err) {"
+    )
+    assert set_translate_block.index("window.appSettings.saveSettings();") < set_translate_block.index(
+        "state.viewProps = Object.assign"
     )
 
 


### PR DESCRIPTION
## 改动概述 / Summary
- 破冰流程里的 assistant 文案成功接入普通聊天框后，自动打开翻译框。
- 破冰 assistant 文案复用普通聊天的字幕翻译收尾逻辑，避免只显示原文或翻译状态不同步。
- React Chat host 新增 `setTranslateEnabled`，供破冰流程只在需要时同步翻译框开关。
- 破冰自动打开翻译框使用非持久化开关，不把 onboarding 的自动打开写成用户长期字幕偏好。
- 不改变 GalGame 默认偏好或教程结束恢复顺序。

## 回归报告 / Regression Report
不适用：本 PR 未改动 `app/`、`main_logic/`、`memory/` 后端核心逻辑。风险集中在前端静态破冰流程、React Chat host 翻译开关同步、字幕翻译状态同步。

已验证破冰 assistant 消息只在聊天框写入成功后打开翻译框并 finalize 字幕翻译；同时确认本 PR 不包含新用户 GalGame 默认关闭的 seeding 逻辑，也不夹带 GalGame 教程结束顺序调整。

## 不拆分理由 / Why Not Split
不适用：改动集中在破冰字幕接入与对应前端契约测试，范围较小。

## 测试 / Testing
- `uv run pytest tests/unit/test_new_user_icebreaker_static_contracts.py::test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal_chat tests/unit/test_new_user_icebreaker_static_contracts.py::test_icebreaker_assistant_message_auto_opens_subtitle_translation_panel -q`
- `node --check static/app-react-chat-window.js && node --check static/tutorial/icebreaker/new-user-icebreaker.js && node --check static/subtitle.js && node --check static/tutorial/core/app-prompt.js && git diff --check project/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增字幕/翻译切换入口 `setTranslateEnabled(enabled, options)`，支持同步、持久化，并可选择抑制宿主事件；字幕桥接 `setSubtitleEnabled(enabled, options)` 支持 `options.persist/source`。
  * 冰花助手会话内自动打开字幕/翻译面板，且同一 session 仅触发一次。
* **改进**
  * 统一字幕最终化与面板打开时机；同步失败时按预期降级并给出告警。
* **测试**
  * 更新并增强单测：门控条件、去重逻辑、时序顺序与失败告警分支。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->