### PR TITLE
修复紧凑聊天框工具轮盘中已开启按钮在 hover/focus 选中时背景短暂闪烁的问题

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -4129,6 +4129,14 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   box-shadow: var(--compact-tool-button-active-shadow);
 }
 
+.compact-input-tool-fan button.compact-input-tool-item[data-compact-tool-active="true"]:not(:disabled)[data-compact-tool-pointer-hovered="true"]::after,
+.compact-input-tool-fan button.compact-input-tool-item[data-compact-tool-active="true"]:not(:disabled):focus-within::after,
+.compact-input-tool-fan .compact-input-tool-item-avatar[data-compact-tool-active="true"][data-compact-tool-pointer-hovered="true"]:has(> .composer-emoji-btn:not(:disabled))::after,
+.compact-input-tool-fan .compact-input-tool-item-avatar[data-compact-tool-active="true"]:has(> .composer-emoji-btn:not(:disabled)):focus-within::after {
+  background: var(--compact-tool-button-active-fill);
+  box-shadow: var(--compact-tool-button-active-shadow);
+}
+
 .compact-input-tool-fan .compact-input-tool-item[data-compact-tool-active="true"]::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复紧凑聊天框工具轮盘中已开启按钮在 hover/focus 选中时背景短暂闪烁的问题

## 测试 / Testing

手动测试轮盘按钮


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **风格优化**
  * 改进了紧凑输入工具轮盘在激活、获焦与悬停状态下的视觉反馈效果，包括高亮色彩与阴影渲染。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->