### PR TITLE
fix(tutorial): 同步新手教程真实鼠标可见性状态

### DIFF
--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1036,6 +1036,7 @@ class UniversalTutorialManager {
     clearAllTutorialLifecycles(reason = 'destroy') {
         const rawReason = this.normalizeTutorialEndRawReason(reason);
         const director = this.yuiGuideDirector;
+        this.syncPcSystemCursorHidden(false, rawReason);
 
         try {
             this.notifyYuiGuideTutorialEnd(rawReason);
@@ -1102,6 +1103,47 @@ class UniversalTutorialManager {
             finalSteps: finalSteps,
             currentStep: this.currentStep
         });
+    }
+
+    syncPcSystemCursorHidden(hidden, reason = 'tutorial') {
+        let tutorialRunId = '';
+        try {
+            tutorialRunId = window.localStorage
+                ? (window.localStorage.getItem('yuiGuidePcOverlayRunId') || '')
+                : '';
+        } catch (_) {}
+        const message = {
+            action: 'yui_guide_system_cursor_visibility',
+            hidden: hidden === true,
+            tutorialRunId: tutorialRunId,
+            reason: reason,
+            timestamp: Date.now()
+        };
+        try {
+            if (
+                window.nekoTutorialOverlay
+                && typeof window.nekoTutorialOverlay.relayToChat === 'function'
+            ) {
+                window.nekoTutorialOverlay.relayToChat(message);
+            }
+        } catch (_) {}
+        try {
+            if (
+                window.nekoTutorialOverlay
+                && typeof window.nekoTutorialOverlay.relayToPet === 'function'
+            ) {
+                window.nekoTutorialOverlay.relayToPet(message);
+            }
+        } catch (_) {}
+        try {
+            if (
+                window.appInterpage
+                && window.appInterpage.nekoBroadcastChannel
+                && typeof window.appInterpage.nekoBroadcastChannel.postMessage === 'function'
+            ) {
+                window.appInterpage.nekoBroadcastChannel.postMessage(message);
+            }
+        } catch (_) {}
     }
 
     clearPcTutorialGlobalOverlay(reason = 'destroy') {
@@ -3016,6 +3058,7 @@ class UniversalTutorialManager {
 
     emitTutorialStarted(page = this.currentPage, source = this.currentTutorialStartSource) {
         this.clearStartupGreetingRelease('tutorial-started');
+        this.syncPcSystemCursorHidden(true, 'tutorial-started');
         window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
             detail: {
                 page: page,

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1106,44 +1106,12 @@ class UniversalTutorialManager {
     }
 
     syncPcSystemCursorHidden(hidden, reason = 'tutorial') {
-        let tutorialRunId = '';
-        try {
-            tutorialRunId = window.localStorage
-                ? (window.localStorage.getItem('yuiGuidePcOverlayRunId') || '')
-                : '';
-        } catch (_) {}
-        const message = {
-            action: 'yui_guide_system_cursor_visibility',
-            hidden: hidden === true,
-            tutorialRunId: tutorialRunId,
-            reason: reason,
-            timestamp: Date.now()
-        };
-        try {
-            if (
-                window.nekoTutorialOverlay
-                && typeof window.nekoTutorialOverlay.relayToChat === 'function'
-            ) {
-                window.nekoTutorialOverlay.relayToChat(message);
-            }
-        } catch (_) {}
-        try {
-            if (
-                window.nekoTutorialOverlay
-                && typeof window.nekoTutorialOverlay.relayToPet === 'function'
-            ) {
-                window.nekoTutorialOverlay.relayToPet(message);
-            }
-        } catch (_) {}
-        try {
-            if (
-                window.appInterpage
-                && window.appInterpage.nekoBroadcastChannel
-                && typeof window.appInterpage.nekoBroadcastChannel.postMessage === 'function'
-            ) {
-                window.appInterpage.nekoBroadcastChannel.postMessage(message);
-            }
-        } catch (_) {}
+        if (
+            window.YuiGuideCommon
+            && typeof window.YuiGuideCommon.syncPcSystemCursorHidden === 'function'
+        ) {
+            window.YuiGuideCommon.syncPcSystemCursorHidden(hidden === true, reason);
+        }
     }
 
     clearPcTutorialGlobalOverlay(reason = 'destroy') {

--- a/static/tutorial/visual/resistance-controllers.js
+++ b/static/tutorial/visual/resistance-controllers.js
@@ -102,10 +102,16 @@
             const performance = resistanceStep.performance || {};
             const resistanceMessage = this.getResistanceMessage(performance);
             const presentationSnapshot = call(this.callbacks, 'capturePresentationSnapshot', null);
+            let shouldRestoreHiddenCursorAfterResistance = false;
 
             if (!normalizedOptions.suppressCursorReveal) {
                 call(this.callbacks, 'syncSystemCursorHidden', null, false, 'interrupt_resist_light');
-                call(this.callbacks, 'prepareResistanceCursorReveal', null, normalizedOptions);
+                shouldRestoreHiddenCursorAfterResistance = call(
+                    this.callbacks,
+                    'prepareResistanceCursorReveal',
+                    false,
+                    normalizedOptions
+                ) === true;
             }
 
             call(this.callbacks, 'pauseCurrentSceneForResistance', null);
@@ -163,7 +169,9 @@
                 if (this.isStopping()) {
                     return;
                 }
-                call(this.callbacks, 'syncSystemCursorHidden', null, true, 'interrupt_resist_light_done');
+                if (shouldRestoreHiddenCursorAfterResistance) {
+                    call(this.callbacks, 'syncSystemCursorHidden', null, true, 'interrupt_resist_light_done');
+                }
 
                 const didRestorePresentationSnapshot = call(
                     this.callbacks,
@@ -496,10 +504,11 @@
             const performance = resistanceStep.performance || {};
             const resistanceMessage = this.getResistanceMessage(performance);
             const presentationSnapshot = director.captureCurrentGuidePresentationSnapshot();
+            let shouldRestoreHiddenCursorAfterResistance = false;
 
             if (!normalizedOptions.suppressCursorReveal) {
                 this.syncSystemCursorHidden(false, 'interrupt_resist_light');
-                director.prepareResistanceCursorReveal(normalizedOptions);
+                shouldRestoreHiddenCursorAfterResistance = director.prepareResistanceCursorReveal(normalizedOptions);
             }
 
             director.pauseCurrentSceneForResistance();
@@ -546,7 +555,9 @@
                 if (this.isStopping()) {
                     return;
                 }
-                this.syncSystemCursorHidden(true, 'interrupt_resist_light_done');
+                if (shouldRestoreHiddenCursorAfterResistance) {
+                    this.syncSystemCursorHidden(true, 'interrupt_resist_light_done');
+                }
 
                 const didRestorePresentationSnapshot = director.restoreGuidePresentationSnapshot(presentationSnapshot);
                 const narration = director.activeNarration;

--- a/static/tutorial/visual/resistance-controllers.js
+++ b/static/tutorial/visual/resistance-controllers.js
@@ -43,6 +43,8 @@
             const normalizedOptions = options || {};
             this.overlay = normalizedOptions.overlay || null;
             this.cursor = normalizedOptions.cursor || null;
+            // syncSystemCursorHidden: optional callback for PC builds that need
+            // to reveal the real cursor during resistance and angry-exit scenes.
             this.callbacks = normalizedOptions.callbacks || {};
             this.resistanceVoiceKeys = Array.isArray(normalizedOptions.resistanceVoiceKeys)
                 && normalizedOptions.resistanceVoiceKeys.length

--- a/static/tutorial/visual/resistance-controllers.js
+++ b/static/tutorial/visual/resistance-controllers.js
@@ -102,6 +102,7 @@
             const presentationSnapshot = call(this.callbacks, 'capturePresentationSnapshot', null);
 
             if (!normalizedOptions.suppressCursorReveal) {
+                call(this.callbacks, 'syncSystemCursorHidden', null, false, 'interrupt_resist_light');
                 call(this.callbacks, 'prepareResistanceCursorReveal', null, normalizedOptions);
             }
 
@@ -160,6 +161,7 @@
                 if (this.isStopping()) {
                     return;
                 }
+                call(this.callbacks, 'syncSystemCursorHidden', null, true, 'interrupt_resist_light_done');
 
                 const didRestorePresentationSnapshot = call(
                     this.callbacks,
@@ -202,6 +204,7 @@
             call(this.callbacks, 'disableInterrupts', null);
             call(this.callbacks, 'cancelActiveNarration', null);
             call(this.callbacks, 'beginGuideInterruptPresentation', null);
+            call(this.callbacks, 'syncSystemCursorHidden', null, false, 'interrupt_angry_exit');
 
             const angryStep = call(this.callbacks, 'getStep', null, 'interrupt_angry_exit') || {};
             const performance = (angryStep && angryStep.performance) || {};
@@ -493,6 +496,7 @@
             const presentationSnapshot = director.captureCurrentGuidePresentationSnapshot();
 
             if (!normalizedOptions.suppressCursorReveal) {
+                this.syncSystemCursorHidden(false, 'interrupt_resist_light');
                 director.prepareResistanceCursorReveal(normalizedOptions);
             }
 
@@ -540,6 +544,7 @@
                 if (this.isStopping()) {
                     return;
                 }
+                this.syncSystemCursorHidden(true, 'interrupt_resist_light_done');
 
                 const didRestorePresentationSnapshot = director.restoreGuidePresentationSnapshot(presentationSnapshot);
                 const narration = director.activeNarration;
@@ -578,6 +583,7 @@
             director.disableInterrupts();
             director.cancelActiveNarration();
             director.beginGuideInterruptPresentation();
+            this.syncSystemCursorHidden(false, 'interrupt_angry_exit');
 
             const angryStep = director.getStep('interrupt_angry_exit') || {};
             const performance = (angryStep && angryStep.performance) || {};
@@ -648,6 +654,13 @@
         destroy() {
             this.destroyed = true;
             this.lightResistanceActive = false;
+        }
+
+        syncSystemCursorHidden(hidden, reason) {
+            const director = this.director;
+            if (director && typeof director.syncSystemCursorHidden === 'function') {
+                director.syncSystemCursorHidden(hidden, reason);
+            }
         }
     }
 

--- a/static/tutorial/yui-guide/common.js
+++ b/static/tutorial/yui-guide/common.js
@@ -249,6 +249,46 @@
         throw new Error('TutorialVisualRuntime is required before tutorial/yui-guide/common.js');
     }
 
+    function syncPcSystemCursorHidden(hidden, reason = 'tutorial', options) {
+        const normalizedOptions = options || {};
+        const host = normalizedOptions.window || root || {};
+        let tutorialRunId = '';
+        try {
+            const storage = normalizedOptions.localStorage || host.localStorage;
+            tutorialRunId = storage
+                ? (storage.getItem('yuiGuidePcOverlayRunId') || '')
+                : '';
+        } catch (_) {}
+        const message = {
+            action: 'yui_guide_system_cursor_visibility',
+            hidden: hidden === true,
+            tutorialRunId: tutorialRunId,
+            reason: reason,
+            timestamp: Date.now()
+        };
+        const overlay = normalizedOptions.nekoTutorialOverlay || host.nekoTutorialOverlay;
+        try {
+            if (overlay && typeof overlay.relayToChat === 'function') {
+                overlay.relayToChat(message);
+            }
+        } catch (_) {}
+        try {
+            if (overlay && typeof overlay.relayToPet === 'function') {
+                overlay.relayToPet(message);
+            }
+        } catch (_) {}
+        try {
+            const channel = normalizedOptions.channel
+                || (
+                    host.appInterpage
+                    && host.appInterpage.nekoBroadcastChannel
+                );
+            if (channel && typeof channel.postMessage === 'function') {
+                channel.postMessage(message);
+            }
+        } catch (_) {}
+    }
+
     return {
         deepFreeze,
         registerGuide,
@@ -261,6 +301,7 @@
         createTutorialCommandRegistry,
         normalizeTutorialScene,
         createTutorialTimelineEngine,
-        createTutorialVisualRuntime
+        createTutorialVisualRuntime,
+        syncPcSystemCursorHidden
     };
 });

--- a/static/tutorial/yui-guide/common.js
+++ b/static/tutorial/yui-guide/common.js
@@ -252,6 +252,14 @@
     function syncPcSystemCursorHidden(hidden, reason = 'tutorial', options) {
         const normalizedOptions = options || {};
         const host = normalizedOptions.window || root || {};
+        const logger = normalizedOptions.console || host.console || (root && root.console);
+        const warnRelayFailure = (target, error) => {
+            try {
+                if (logger && typeof logger.warn === 'function') {
+                    logger.warn('[YuiGuide] 同步 PC 系统鼠标状态失败:', target, error);
+                }
+            } catch (_) {}
+        };
         let tutorialRunId = '';
         try {
             const storage = normalizedOptions.localStorage || host.localStorage;
@@ -271,12 +279,16 @@
             if (overlay && typeof overlay.relayToChat === 'function') {
                 overlay.relayToChat(message);
             }
-        } catch (_) {}
+        } catch (error) {
+            warnRelayFailure('relayToChat', error);
+        }
         try {
             if (overlay && typeof overlay.relayToPet === 'function') {
                 overlay.relayToPet(message);
             }
-        } catch (_) {}
+        } catch (error) {
+            warnRelayFailure('relayToPet', error);
+        }
         try {
             const channel = normalizedOptions.channel
                 || (
@@ -286,7 +298,9 @@
             if (channel && typeof channel.postMessage === 'function') {
                 channel.postMessage(message);
             }
-        } catch (_) {}
+        } catch (error) {
+            warnRelayFailure('nekoBroadcastChannel', error);
+        }
     }
 
     return {

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -11526,6 +11526,47 @@
             }, 3000);
         }
 
+        syncSystemCursorHidden(hidden, reason = 'tutorial') {
+            let tutorialRunId = '';
+            try {
+                tutorialRunId = window.localStorage
+                    ? (window.localStorage.getItem('yuiGuidePcOverlayRunId') || '')
+                    : '';
+            } catch (_) {}
+            const message = {
+                action: 'yui_guide_system_cursor_visibility',
+                hidden: hidden === true,
+                tutorialRunId: tutorialRunId,
+                reason: reason,
+                timestamp: Date.now()
+            };
+            try {
+                if (
+                    window.nekoTutorialOverlay
+                    && typeof window.nekoTutorialOverlay.relayToChat === 'function'
+                ) {
+                    window.nekoTutorialOverlay.relayToChat(message);
+                }
+            } catch (_) {}
+            try {
+                if (
+                    window.nekoTutorialOverlay
+                    && typeof window.nekoTutorialOverlay.relayToPet === 'function'
+                ) {
+                    window.nekoTutorialOverlay.relayToPet(message);
+                }
+            } catch (_) {}
+            try {
+                if (
+                    window.appInterpage
+                    && window.appInterpage.nekoBroadcastChannel
+                    && typeof window.appInterpage.nekoBroadcastChannel.postMessage === 'function'
+                ) {
+                    window.appInterpage.nekoBroadcastChannel.postMessage(message);
+                }
+            } catch (_) {}
+        }
+
         playLightResistance(x, y, options) {
             return this.resistanceController.playLightResistance(x, y, options);
         }
@@ -11557,6 +11598,7 @@
 
             this.destroyed = true;
             this.terminationRequested = true;
+            this.syncSystemCursorHidden(false, 'destroy');
             this.setHomePcCursorOutputSuppressedForExternalizedChat(false);
             this.restoreDay1TakeoverAgentSwitches('destroy').catch((error) => {
                 console.warn('[YuiGuide] 销毁时恢复 Day1 Agent 开关失败:', error);

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -11478,6 +11478,7 @@
             document.documentElement.classList.add('yui-resistance-cursor-reveal');
             document.body.classList.add('yui-user-cursor-revealed');
             document.body.classList.add('yui-resistance-cursor-reveal');
+            this.syncSystemCursorHidden(false, 'user_cursor_revealed');
         }
 
         clearUserCursorReveal(resetCursor) {
@@ -11509,7 +11510,7 @@
         prepareResistanceCursorReveal() {
             if (this.userCursorRevealed) {
                 this.revealUserCursor();
-                return;
+                return false;
             }
 
             if (this.resistanceCursorTimer) {
@@ -11524,6 +11525,7 @@
                 document.body.classList.remove('yui-resistance-cursor-reveal');
                 this.restoreHiddenCursorAfterResistance = false;
             }, 3000);
+            return true;
         }
 
         syncSystemCursorHidden(hidden, reason = 'tutorial') {

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -11527,44 +11527,12 @@
         }
 
         syncSystemCursorHidden(hidden, reason = 'tutorial') {
-            let tutorialRunId = '';
-            try {
-                tutorialRunId = window.localStorage
-                    ? (window.localStorage.getItem('yuiGuidePcOverlayRunId') || '')
-                    : '';
-            } catch (_) {}
-            const message = {
-                action: 'yui_guide_system_cursor_visibility',
-                hidden: hidden === true,
-                tutorialRunId: tutorialRunId,
-                reason: reason,
-                timestamp: Date.now()
-            };
-            try {
-                if (
-                    window.nekoTutorialOverlay
-                    && typeof window.nekoTutorialOverlay.relayToChat === 'function'
-                ) {
-                    window.nekoTutorialOverlay.relayToChat(message);
-                }
-            } catch (_) {}
-            try {
-                if (
-                    window.nekoTutorialOverlay
-                    && typeof window.nekoTutorialOverlay.relayToPet === 'function'
-                ) {
-                    window.nekoTutorialOverlay.relayToPet(message);
-                }
-            } catch (_) {}
-            try {
-                if (
-                    window.appInterpage
-                    && window.appInterpage.nekoBroadcastChannel
-                    && typeof window.appInterpage.nekoBroadcastChannel.postMessage === 'function'
-                ) {
-                    window.appInterpage.nekoBroadcastChannel.postMessage(message);
-                }
-            } catch (_) {}
+            if (
+                window.YuiGuideCommon
+                && typeof window.YuiGuideCommon.syncPcSystemCursorHidden === 'function'
+            ) {
+                window.YuiGuideCommon.syncPcSystemCursorHidden(hidden === true, reason);
+            }
         }
 
         playLightResistance(x, y, options) {

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -45,6 +45,86 @@ test('common guide helpers freeze config, register guides, and create locale aud
     });
 });
 
+test('common helper relays PC system cursor visibility and logs relay failures', () => {
+    const chatRelays = [];
+    const petRelays = [];
+    const channelMessages = [];
+    const warnings = [];
+    const storage = new Map([['yuiGuidePcOverlayRunId', 'run-cursor']]);
+    const localStorage = {
+        getItem(key) {
+            return storage.get(key) || null;
+        }
+    };
+    const consoleApi = {
+        warn(...args) {
+            warnings.push(args);
+        }
+    };
+
+    common.syncPcSystemCursorHidden(true, 'tutorial-started', {
+        localStorage,
+        nekoTutorialOverlay: {
+            relayToChat(message) {
+                chatRelays.push(message);
+            },
+            relayToPet(message) {
+                petRelays.push(message);
+            }
+        },
+        channel: {
+            postMessage(message) {
+                channelMessages.push(message);
+            }
+        },
+        console: consoleApi
+    });
+
+    assert.equal(chatRelays.length, 1);
+    assert.equal(petRelays.length, 1);
+    assert.equal(channelMessages.length, 1);
+    assert.deepEqual(chatRelays[0], petRelays[0]);
+    assert.deepEqual(chatRelays[0], channelMessages[0]);
+    assert.equal(chatRelays[0].action, 'yui_guide_system_cursor_visibility');
+    assert.equal(chatRelays[0].hidden, true);
+    assert.equal(chatRelays[0].tutorialRunId, 'run-cursor');
+    assert.equal(chatRelays[0].reason, 'tutorial-started');
+    assert.equal(typeof chatRelays[0].timestamp, 'number');
+    assert.equal(warnings.length, 0);
+
+    const relayError = new Error('relay failed');
+    const petError = new Error('pet failed');
+    const channelError = new Error('channel failed');
+    common.syncPcSystemCursorHidden(false, 'destroy', {
+        localStorage,
+        nekoTutorialOverlay: {
+            relayToChat() {
+                throw relayError;
+            },
+            relayToPet() {
+                throw petError;
+            }
+        },
+        channel: {
+            postMessage() {
+                throw channelError;
+            }
+        },
+        console: consoleApi
+    });
+
+    assert.deepEqual(warnings.map((entry) => entry[1]), [
+        'relayToChat',
+        'relayToPet',
+        'nekoBroadcastChannel'
+    ]);
+    assert.deepEqual(warnings.map((entry) => entry[2]), [
+        relayError,
+        petError,
+        channelError
+    ]);
+});
+
 test('guide helpers are exported from a standalone module and re-exported by common', () => {
     const helpersSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/core/guide-helpers.js'), 'utf8');
     const commonSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/yui-guide/common.js'), 'utf8');

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -50,6 +50,7 @@ test('common helper relays PC system cursor visibility and logs relay failures',
     const petRelays = [];
     const channelMessages = [];
     const warnings = [];
+    const nativeCursorCalls = [];
     const storage = new Map([['yuiGuidePcOverlayRunId', 'run-cursor']]);
     const localStorage = {
         getItem(key) {
@@ -60,6 +61,12 @@ test('common helper relays PC system cursor visibility and logs relay failures',
         warn(...args) {
             warnings.push(args);
         }
+    };
+    const consumeCursorVisibilityMessage = (message) => {
+        if (!message || message.action !== 'yui_guide_system_cursor_visibility') {
+            return;
+        }
+        nativeCursorCalls.push(message.hidden === true ? 'hideNativeCursor' : 'restoreNativeCursor');
     };
 
     common.syncPcSystemCursorHidden(true, 'tutorial-started', {
@@ -90,6 +97,34 @@ test('common helper relays PC system cursor visibility and logs relay failures',
     assert.equal(chatRelays[0].tutorialRunId, 'run-cursor');
     assert.equal(chatRelays[0].reason, 'tutorial-started');
     assert.equal(typeof chatRelays[0].timestamp, 'number');
+    assert.equal(warnings.length, 0);
+    consumeCursorVisibilityMessage(chatRelays[0]);
+
+    common.syncPcSystemCursorHidden(false, 'destroy', {
+        localStorage,
+        nekoTutorialOverlay: {
+            relayToChat(message) {
+                chatRelays.push(message);
+            },
+            relayToPet(message) {
+                petRelays.push(message);
+            }
+        },
+        channel: {
+            postMessage(message) {
+                channelMessages.push(message);
+            }
+        },
+        console: consoleApi
+    });
+
+    assert.equal(chatRelays[1].hidden, false);
+    assert.equal(chatRelays[1].reason, 'destroy');
+    consumeCursorVisibilityMessage(chatRelays[1]);
+    assert.deepEqual(nativeCursorCalls, [
+        'hideNativeCursor',
+        'restoreNativeCursor'
+    ]);
     assert.equal(warnings.length, 0);
 
     const relayError = new Error('relay failed');

--- a/tests/unit/test_yui_guide_director_static.py
+++ b/tests/unit/test_yui_guide_director_static.py
@@ -159,11 +159,17 @@ def test_day6_plugin_dashboard_handoff_closes_at_narration_boundary():
     assert "await this.waitForPluginDashboardPerformance(pluginDashboardWindow" not in side_panel_block
 
 
-def test_avatar_floating_guides_keep_real_cursor_visible():
+def test_avatar_floating_guides_delegate_real_cursor_visibility_to_pc():
     guide_css = YUI_GUIDE_CSS_PATH.read_text(encoding="utf-8")
     overlay_source = YUI_GUIDE_OVERLAY_PATH.read_text(encoding="utf-8")
     director_source = _read_director()
     plugin_runtime_source = PLUGIN_YUI_GUIDE_RUNTIME_PATH.read_text(encoding="utf-8")
+    manager_source = (Path(__file__).resolve().parents[2] / "static" / "tutorial/core/universal-manager.js").read_text(
+        encoding="utf-8"
+    )
+    resistance_source = (
+        Path(__file__).resolve().parents[2] / "static" / "tutorial/visual/resistance-controllers.js"
+    ).read_text(encoding="utf-8")
 
     assert not re.search(r"cursor\s*:\s*none\b", guide_css)
     assert not re.search(r"cursor\s*:\s*none\b", plugin_runtime_source)
@@ -181,6 +187,16 @@ def test_avatar_floating_guides_keep_real_cursor_visible():
     )[0]
     assert "style.cursor = 'none';" not in resistance_block
     assert "this.restoreHiddenCursorAfterResistance = false;" in resistance_block
+
+    assert "syncPcSystemCursorHidden(hidden, reason = 'tutorial')" in manager_source
+    assert "action: 'yui_guide_system_cursor_visibility'" in manager_source
+    assert "this.syncPcSystemCursorHidden(true, 'tutorial-started');" in manager_source
+    assert "this.syncPcSystemCursorHidden(false, rawReason);" in manager_source
+    assert "syncSystemCursorHidden(hidden, reason = 'tutorial')" in director_source
+    assert "this.syncSystemCursorHidden(false, 'interrupt_resist_light');" in resistance_source
+    assert "this.syncSystemCursorHidden(true, 'interrupt_resist_light_done');" in resistance_source
+    assert "this.syncSystemCursorHidden(false, 'interrupt_angry_exit');" in resistance_source
+    assert "this.syncSystemCursorHidden(false, 'destroy');" in director_source
 
 
 def test_day1_intro_activation_copy_matches_auto_advance_behavior():

--- a/tests/unit/test_yui_guide_director_static.py
+++ b/tests/unit/test_yui_guide_director_static.py
@@ -188,7 +188,15 @@ def test_avatar_floating_guides_delegate_real_cursor_visibility_to_pc():
         1,
     )[0]
     assert "style.cursor = 'none';" not in resistance_block
+    assert "return false;" in resistance_block
+    assert "return true;" in resistance_block
     assert "this.restoreHiddenCursorAfterResistance = false;" in resistance_block
+
+    reveal_block = director_source.split("        revealUserCursor() {", 1)[1].split(
+        "        clearUserCursorReveal(resetCursor) {",
+        1,
+    )[0]
+    assert "this.syncSystemCursorHidden(false, 'user_cursor_revealed');" in reveal_block
 
     assert "syncPcSystemCursorHidden(hidden, reason = 'tutorial')" in manager_source
     assert "syncPcSystemCursorHidden(hidden === true, reason);" in manager_source
@@ -201,7 +209,12 @@ def test_avatar_floating_guides_delegate_real_cursor_visibility_to_pc():
     assert "syncSystemCursorHidden(hidden, reason = 'tutorial')" in director_source
     assert "syncPcSystemCursorHidden(hidden === true, reason);" in director_source
     assert "this.syncSystemCursorHidden(false, 'interrupt_resist_light');" in resistance_source
+    assert "let shouldRestoreHiddenCursorAfterResistance = false;" in resistance_source
+    assert "shouldRestoreHiddenCursorAfterResistance = director.prepareResistanceCursorReveal(normalizedOptions);" in resistance_source
+    assert "if (shouldRestoreHiddenCursorAfterResistance) {" in resistance_source
     assert "this.syncSystemCursorHidden(true, 'interrupt_resist_light_done');" in resistance_source
+    assert "shouldRestoreHiddenCursorAfterResistance = call(" in resistance_source
+    assert "call(this.callbacks, 'syncSystemCursorHidden', null, true, 'interrupt_resist_light_done');" in resistance_source
     assert "this.syncSystemCursorHidden(false, 'interrupt_angry_exit');" in resistance_source
     assert "this.syncSystemCursorHidden(false, 'destroy');" in director_source
     assert "syncSystemCursorHidden: optional callback" in resistance_source

--- a/tests/unit/test_yui_guide_director_static.py
+++ b/tests/unit/test_yui_guide_director_static.py
@@ -12,6 +12,7 @@ SCENE_ORCHESTRATOR_PATH = Path(__file__).resolve().parents[2] / "static" / "tuto
 NEW_USER_ICEBREAKER_PATH = Path(__file__).resolve().parents[2] / "static" / "icebreaker/new-user-icebreaker.js"
 APP_INTERPAGE_PATH = Path(__file__).resolve().parents[2] / "static" / "app-interpage.js"
 PLUGIN_YUI_GUIDE_RUNTIME_PATH = Path(__file__).resolve().parents[2] / "frontend" / "plugin-manager/src/yui-guide-runtime.ts"
+YUI_GUIDE_COMMON_PATH = Path(__file__).resolve().parents[2] / "static" / "tutorial/yui-guide/common.js"
 STATIC_LOCALES_DIR = Path(__file__).resolve().parents[2] / "static" / "locales"
 
 
@@ -164,6 +165,7 @@ def test_avatar_floating_guides_delegate_real_cursor_visibility_to_pc():
     overlay_source = YUI_GUIDE_OVERLAY_PATH.read_text(encoding="utf-8")
     director_source = _read_director()
     plugin_runtime_source = PLUGIN_YUI_GUIDE_RUNTIME_PATH.read_text(encoding="utf-8")
+    common_source = YUI_GUIDE_COMMON_PATH.read_text(encoding="utf-8")
     manager_source = (Path(__file__).resolve().parents[2] / "static" / "tutorial/core/universal-manager.js").read_text(
         encoding="utf-8"
     )
@@ -189,14 +191,20 @@ def test_avatar_floating_guides_delegate_real_cursor_visibility_to_pc():
     assert "this.restoreHiddenCursorAfterResistance = false;" in resistance_block
 
     assert "syncPcSystemCursorHidden(hidden, reason = 'tutorial')" in manager_source
-    assert "action: 'yui_guide_system_cursor_visibility'" in manager_source
+    assert "syncPcSystemCursorHidden(hidden === true, reason);" in manager_source
+    assert "function syncPcSystemCursorHidden(hidden, reason = 'tutorial', options)" in common_source
+    assert "action: 'yui_guide_system_cursor_visibility'" in common_source
+    assert "action: 'yui_guide_system_cursor_visibility'" not in manager_source
+    assert "action: 'yui_guide_system_cursor_visibility'" not in director_source
     assert "this.syncPcSystemCursorHidden(true, 'tutorial-started');" in manager_source
     assert "this.syncPcSystemCursorHidden(false, rawReason);" in manager_source
     assert "syncSystemCursorHidden(hidden, reason = 'tutorial')" in director_source
+    assert "syncPcSystemCursorHidden(hidden === true, reason);" in director_source
     assert "this.syncSystemCursorHidden(false, 'interrupt_resist_light');" in resistance_source
     assert "this.syncSystemCursorHidden(true, 'interrupt_resist_light_done');" in resistance_source
     assert "this.syncSystemCursorHidden(false, 'interrupt_angry_exit');" in resistance_source
     assert "this.syncSystemCursorHidden(false, 'destroy');" in director_source
+    assert "syncSystemCursorHidden: optional callback" in resistance_source
 
 
 def test_day1_intro_activation_copy_matches_auto_advance_behavior():


### PR DESCRIPTION
## 改动概述 / Summary

- 新手教程启动时向 PC 壳层广播真实鼠标隐藏请求。
- 教程正常结束、跳过、销毁时统一广播真实鼠标恢复请求。
- 对抗台词和愤怒退出期间恢复真实鼠标，对抗结束后重新隐藏。
- 补充静态测试覆盖教程侧系统鼠标可见性信号。

> 说明：PC 壳层配套实现位于 N.E.K.O.-PC 的 `cursor_fix` 分支，本次按要求不为 N.E.K.O.-PC 创建 PR。

## 回归报告 / Regression Report

不适用。本 PR 未触碰 `app/`、`main_logic/`、`memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 计入上限的改动文件数不超过 20 个。

## 测试 / Testing

- `uv run pytest tests/unit/test_yui_guide_director_static.py::test_avatar_floating_guides_delegate_real_cursor_visibility_to_pc -q`
- `node --check static/tutorial/core/universal-manager.js && node --check static/tutorial/yui-guide/director.js && node --check static/tutorial/visual/resistance-controllers.js && git diff --check`
- 配套 PC 分支验证：`node --test test/system-cursor-visibility-service.test.js test/main-composition-contract.test.js && node --check src/system-cursor-visibility-service.js && node --check src/main.js && git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在教程启动、抗打断与愤怒退出、以及销毁流程中新增“PC 系统光标隐藏/显示”同步：启动先隐藏；关键阶段按原因同步隐藏/恢复；销毁时恢复可见性。
  * 当 PC 同步能力可用时，会进行委托式转发，并附带原因标识以保持一致性。
* **测试**
  * 更新并重命名教程静态校验用例，补强跨模块同步链路与参数场景验证。
  * 新增对同步转发消息一致性与失败告警记录的单测覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->