### PR TITLE
fix(game): 给小游戏开局上下文输入补水印

### DIFF
--- a/config/prompts/prompts_game.py
+++ b/config/prompts/prompts_game.py
@@ -117,6 +117,11 @@ free-ball, startle-direct, startle-graze, zoneout
 }}
 """
 
+# 开局上下文输入水印：pregame 的近期记录 + 启动参数走独立 HumanMessage（裸 JSON），
+# 用收尾水印标出数据块边界，让模型分清上面那块是注入输入而非指令。逐 locale 保留中文
+# （与 prompts_game_route.py 的成对水印对齐），内部禁冒号破折号。
+PREGAME_CONTEXT_INPUT_WATERMARK = "======以上为开局近期记录与启动参数======"
+
 SOCCER_PREGAME_CONTEXT_PROMPT = """\
 你是足球小游戏开局上下文分析器。只输出 JSON，不要 Markdown，不要解释。
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -50,6 +50,7 @@ _SSML_TAG_PATTERN = re.compile(
 from fastapi import APIRouter, HTTPException, Request
 
 from config.prompts.prompts_game import (
+    PREGAME_CONTEXT_INPUT_WATERMARK,
     get_badminton_pregame_context_formatter_labels,
     get_badminton_pregame_context_prompt,
     get_badminton_quick_lines_prompt,
@@ -1907,7 +1908,9 @@ async def _run_pregame_context_ai(
         async with llm:
             result = await llm.ainvoke([  # noqa: LLM_INPUT_BUDGET  # game-session-scoped input (snapshot / history / archive / config), bounded by a single finite game; not external free-text. Deeper per-field truncation tracked as a game-domain follow-up.
                 SystemMessage(content=prompt_template),
-                HumanMessage(content=json.dumps(user_payload, ensure_ascii=False)),
+                HumanMessage(
+                    content=f"{json.dumps(user_payload, ensure_ascii=False)}\n{PREGAME_CONTEXT_INPUT_WATERMARK}"
+                ),
             ])
         raw = _strip_json_fence(str(result.content or ""))
         parsed = robust_json_loads(raw)

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -3037,6 +3037,55 @@ async def test_game_chat_event_user_turn_keeps_watermark(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_pregame_context_ai_human_message_keeps_watermark(monkeypatch):
+    from config.prompts.prompts_game import PREGAME_CONTEXT_INPUT_WATERMARK
+
+    captured = {}
+
+    class FakeResult:
+        content = '{"launchIntent": "unknown"}'
+
+    class FakeLLM:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def ainvoke(self, messages):
+            captured["messages"] = messages
+            return FakeResult()
+
+    async def fake_create(*_args, **_kwargs):
+        return FakeLLM()
+
+    monkeypatch.setattr("utils.llm_client.create_chat_llm_async", fake_create)
+    monkeypatch.setattr(
+        game_router,
+        "_get_character_info",
+        lambda _name: {"model": "m", "base_url": "u", "api_key": "k"},
+    )
+
+    await game_router._run_pregame_context_ai(
+        lanlan_name="Lan",
+        master_name="玩家",
+        lanlan_prompt="人设摘录",
+        recent_history="昨天一起聊了很久",
+        neko_initiated=True,
+        neko_invite_text="一起踢球吗",
+        prompt_template="开局上下文分析器系统提示",
+        extra_payload={"gameType": "soccer"},
+    )
+
+    human_message = captured["messages"][1]
+    # 收尾水印必须在 human message 末尾，且把近期记录原文包在水印之上。
+    assert human_message.content.endswith(PREGAME_CONTEXT_INPUT_WATERMARK)
+    assert "昨天一起聊了很久" in human_message.content
+    assert PREGAME_CONTEXT_INPUT_WATERMARK.startswith("======以上为")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_run_game_chat_sends_filtered_llm_visible_event(monkeypatch):
     class FakeSession:
         def __init__(self):

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -3081,7 +3081,6 @@ async def test_pregame_context_ai_human_message_keeps_watermark(monkeypatch):
     # 收尾水印必须在 human message 末尾，且把近期记录原文包在水印之上。
     assert human_message.content.endswith(PREGAME_CONTEXT_INPUT_WATERMARK)
     assert "昨天一起聊了很久" in human_message.content
-    assert PREGAME_CONTEXT_INPUT_WATERMARK.startswith("======以上为")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 背景

排查小游戏（`game_router.py`）所有实际喂进模型的 prompt 是否带安全水印（`======以下/以上为...======` 成对中文分隔，用于让模型分清哪段是注入数据、哪段是指令）。

5 个端点里，3 个已带水印：
- 局内上下文整理 organizer
- 赛后记忆筛选 archive highlighter
- 游戏事件实时回应 stream

`quick_lines` 不注入外部自由文本（user 段是固定指令、角色设定拼进 system），不需要水印。

唯一缺口：**开局上下文（足球/羽毛球 pregame）** —— `_run_pregame_context_ai` 把 payload 直接 `json.dumps` 当 HumanMessage 喂进去，两侧都没水印。而 payload 里偏偏含 `recentHistory`（memory server 拉来的近期对话原文，外部自由文本）和 `characterPromptExcerpt` 等最该隔离的内容，破了和其它端点的对偶性。

## 改动

在 pregame HumanMessage 末尾补收尾水印：

```
======以上为开局近期记录与启动参数======
```

- 措辞镜像 system prompt 的「根据**近期记录**和**启动参数**判断开局基调」，模型一看就知道上面那块是注入输入。
- 逐 locale 保留中文、内部无冒号/破折号，符合水印约定。
- 常量 `PREGAME_CONTEXT_INPUT_WATERMARK` 定义在 `prompts_game.py`（与 pregame prompt 同文件，便于审计）。
- soccer / badminton 共用 `_run_pregame_context_ai`，一处覆盖两条路径。
- 不动 system prompt（避免触发 `test_pregame_prompt_must_not_be_format_called` 守门），不破坏 prompt 结构。

## 回归报告

**改了什么**：`main_routers/game_router.py` 的 `_run_pregame_context_ai` 在喂给模型的 `HumanMessage` 末尾拼接收尾水印常量 `PREGAME_CONTEXT_INPUT_WATERMARK`；常量定义在 `config/prompts/prompts_game.py`。soccer / badminton pregame 共用这一处，两条路径一并覆盖。

**为什么必要**：pregame 是小游戏唯一一个把外部自由文本（`recentHistory` 对话原文）直接 `json.dumps` 当 user 输入、且两侧都无水印边界的端点。其它同类「喂数据→出 JSON」的端点（organizer、archive highlighter）都用 `======...======` 把注入数据框起来，pregame 破了这个对偶性，存在注入内容被模型当指令的风险。

**前后行为对比**：
- 前：`HumanMessage(content=json.dumps(user_payload))` —— 裸 JSON，无边界。
- 后：`HumanMessage(content=f"{json.dumps(user_payload)}\n======以上为开局近期记录与启动参数======")` —— JSON 后追加一行收尾水印。
- system prompt（`SystemMessage`）不变；模型输出的 schema 与解析路径（`_strip_json_fence` + `robust_json_loads` 作用于**模型输出**，非本 HumanMessage）完全不受影响。

**潜在回归**：
- 水印只加在送进模型的 prompt 末尾，不参与对模型输出的解析，故 JSON 解析/兜底逻辑无变化。
- 输入 token 每次调用增加约一行（极小）。
- 行为上仅给模型多一个明确的数据边界，降低而非增加混淆；现有 pregame 相关测试（`test_build_pregame_context_*`、i18n、static contract）全绿，另加 `test_pregame_context_ai_human_message_keeps_watermark` 断言实际喂进去的 HumanMessage 以水印收尾且含 recentHistory 原文。

## 测试

`test_game_router.py` 水印/pregame 相关 + `test_game_route_prompts_i18n.py` + `test_game_llm_static_contracts.py`，本地全通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)