### PR TITLE
[codex] Add mini-game session diagnostics

### DIFF
--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -117,6 +117,14 @@ logger = get_module_logger(__name__, "Game")
 router = APIRouter(tags=["game"], prefix="/api/game")
 
 
+def _game_log_payload_flag_is_true(value: Any) -> bool:
+    if value is True:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return False
+
+
 @router.get("/logs")
 async def game_logs(session_id: str = "", game_type: str = "", since: int = 0, limit: int = 300):
     if session_id:
@@ -186,6 +194,17 @@ async def game_log_ingest(request: Request):
     lanlan_name = str(data.get("lanlan_name") or data.get("lanlanName") or "").strip()
     if not session_id:
         return {"ok": False, "reason": "missing_session_id"}
+
+    from .system_router import _validate_local_mutation_request
+
+    validation_error = _validate_local_mutation_request(
+        request,
+        payload=data,
+        error_defaults={"ok": False, "reason": "csrf_validation_failed"},
+    )
+    if validation_error is not None:
+        return validation_error
+
     ignored = {
         "session_id", "sessionId", "game_type", "gameType", "lanlan_name", "lanlanName", "level",
         "category", "event", "type", "source", "message",
@@ -193,8 +212,14 @@ async def game_log_ingest(request: Request):
         "preserve_message", "preserveMessage", "preserve_details", "preserveDetails",
         "no_truncate", "noTruncate",
     }
-    preserve_message = bool(data.get("preserve_message") or data.get("preserveMessage") or data.get("no_truncate") or data.get("noTruncate"))
-    preserve_details = bool(data.get("preserve_details") or data.get("preserveDetails") or data.get("no_truncate") or data.get("noTruncate"))
+    preserve_message = (
+        _game_log_payload_flag_is_true(data.get("preserve_message"))
+        or _game_log_payload_flag_is_true(data.get("preserveMessage"))
+    )
+    preserve_details = (
+        _game_log_payload_flag_is_true(data.get("preserve_details"))
+        or _game_log_payload_flag_is_true(data.get("preserveDetails"))
+    )
     item = _append_game_session_debug_log(
         game_type,
         session_id,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -24,6 +24,7 @@ Currently implemented: soccer. The generic route /{game_type}/chat supports exte
 """
 
 import asyncio
+import html
 import json
 import math
 import random
@@ -48,6 +49,7 @@ _SSML_TAG_PATTERN = re.compile(
 )
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
 
 from config.prompts.prompts_game import (
     get_badminton_pregame_context_formatter_labels,
@@ -98,12 +100,120 @@ from utils.game_route_state import (
     is_game_route_active,
     register_voice_transcript_handler,
 )
+from utils.game_log import (
+    append_game_session_debug_log as _append_game_session_debug_log,
+    find_game_session_debug_log as _find_game_session_debug_log,
+    GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT,
+    list_game_session_debug_log_summaries,
+    mark_game_session_debug_log_active as _mark_game_session_debug_log_active,
+    mark_game_session_debug_log_ended as _mark_game_session_debug_log_ended,
+    public_game_session_debug_log,
+)
 from utils.language_utils import get_global_language, normalize_language_code, is_supported_language_code
 from utils.logger_config import get_module_logger
 
 logger = get_module_logger(__name__, "Game")
 
 router = APIRouter(tags=["game"], prefix="/api/game")
+
+
+@router.get("/logs")
+async def game_logs(session_id: str = "", game_type: str = "", since: int = 0, limit: int = 300):
+    if session_id:
+        entry = _find_game_session_debug_log(session_id, game_type)
+        if not entry:
+            return {"ok": True, "missing": True, "entries": [], "session_id": session_id, "game_type": game_type}
+        return {"ok": True, "log": public_game_session_debug_log(entry, since=since, limit=limit)}
+    return {
+        "ok": True,
+        "sessions": list_game_session_debug_log_summaries(str(game_type or "").strip()),
+        "retention": {
+            "entry_limit": GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT,
+            "ended_session_cleanup": "disabled",
+        },
+    }
+
+
+@router.get("/logs/view", response_class=HTMLResponse)
+async def game_log_view(session_id: str = "", game_type: str = "", limit: int = 300):
+    game_type_s = str(game_type or "").strip()
+    session_id_s = str(session_id or "").strip()
+    entry = _find_game_session_debug_log(session_id_s, game_type_s) if session_id_s else None
+    if entry:
+        payload = public_game_session_debug_log(entry, limit=limit)
+        title = f"{entry.get('game_type') or 'game'} / {session_id_s}"
+        body = json.dumps(payload, ensure_ascii=False, indent=2)
+    else:
+        title = "小游戏诊断日志"
+        body = json.dumps({
+            "ok": True,
+            "message": "请带上 session_id，或查看 sessions 列表。",
+            "sessions": list_game_session_debug_log_summaries(game_type_s),
+        }, ensure_ascii=False, indent=2)
+    safe_title = html.escape(title)
+    safe_body = html.escape(body)
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>{safe_title}</title>
+<style>
+body {{ font-family: ui-monospace, Consolas, monospace; margin: 16px; background: #101418; color: #e8eef4; }}
+a {{ color: #8cc8ff; }}
+pre {{ white-space: pre-wrap; word-break: break-word; line-height: 1.35; }}
+.hint {{ color: #9fb0c0; margin-bottom: 12px; }}
+</style>
+</head>
+<body>
+<div class="hint">小游戏场次诊断日志 | JSON: /api/game/logs?session_id=...</div>
+<pre>{safe_body}</pre>
+</body>
+</html>"""
+    )
+
+
+@router.post("/logs")
+async def game_log_ingest(request: Request):
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    session_id = str(data.get("session_id") or data.get("sessionId") or "").strip()
+    game_type = str(data.get("game_type") or data.get("gameType") or "game").strip()
+    lanlan_name = str(data.get("lanlan_name") or data.get("lanlanName") or "").strip()
+    if not session_id:
+        return {"ok": False, "reason": "missing_session_id"}
+    ignored = {
+        "session_id", "sessionId", "game_type", "gameType", "lanlan_name", "lanlanName", "level",
+        "category", "event", "type", "source", "message",
+        "sensitive_possible", "sensitivePossible",
+        "preserve_message", "preserveMessage", "preserve_details", "preserveDetails",
+        "no_truncate", "noTruncate",
+    }
+    preserve_message = bool(data.get("preserve_message") or data.get("preserveMessage") or data.get("no_truncate") or data.get("noTruncate"))
+    preserve_details = bool(data.get("preserve_details") or data.get("preserveDetails") or data.get("no_truncate") or data.get("noTruncate"))
+    item = _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        level=str(data.get("level") or "info"),
+        category=str(data.get("category") or "frontend"),
+        event=str(data.get("event") or data.get("type") or "client_event"),
+        source=str(data.get("source") or "frontend"),
+        message=str(data.get("message") or ""),
+        details=data.get("details") if isinstance(data.get("details"), dict) else {
+            key: value for key, value in data.items()
+            if key not in ignored
+        },
+        sensitive_possible=bool(data.get("sensitive_possible") or data.get("sensitivePossible")),
+        preserve_message=preserve_message,
+        preserve_details=preserve_details,
+    )
+    return {"ok": item is not None, "seq": item.get("seq") if isinstance(item, dict) else None}
+
 
 # ── Session 池 ─────────────────────────────────────────────────────
 # key = f"{lanlan_name}:{game_type}:{session_id}"
@@ -6253,6 +6363,21 @@ async def _run_game_chat(
     lanlan_name = ""
     if isinstance(event, dict):
         lanlan_name = str(event.get("lanlan_name") or event.get("lanlanName") or "").strip()
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="llm",
+        event="game_chat_requested",
+        message="小游戏主 LLM 请求开始",
+        details={
+            "allow_postgame": allow_postgame,
+            "kind": event.get("kind") if isinstance(event, dict) else "",
+            "round": event.get("round") if isinstance(event, dict) else None,
+            "event_type": type(event).__name__,
+        },
+        sensitive_possible=isinstance(event, dict) and any(event.get(key) for key in ("textRaw", "userText", "userVoiceText")),
+    )
 
     if game_type == "soccer" and isinstance(event, dict):
         balance_hint = _build_soccer_balance_hint(event)
@@ -6451,6 +6576,16 @@ async def _run_game_chat(
                 )
             except asyncio.TimeoutError:
                 logger.warning("🎮 游戏 LLM 响应超时: game=%s sid=%s", game_type, session_id)
+                _append_game_session_debug_log(
+                    game_type,
+                    session_id,
+                    lanlan_name=lanlan_name,
+                    level="warning",
+                    category="llm",
+                    event="game_chat_timeout",
+                    message="小游戏主 LLM 响应超时，返回空台词",
+                    details={"timeout_seconds": 15.0},
+                )
                 err_result: Dict[str, Any] = {"error": "LLM 响应超时", "line": "", "control": {}}
                 if allow_postgame:
                     err_result["_postgame_entry"] = entry
@@ -6458,6 +6593,16 @@ async def _run_game_chat(
                 return err_result
             except Exception as e:
                 logger.error("🎮 游戏 LLM 调用失败: %s", e)
+                _append_game_session_debug_log(
+                    game_type,
+                    session_id,
+                    lanlan_name=lanlan_name,
+                    level="error",
+                    category="llm",
+                    event="game_chat_exception",
+                    message="小游戏主 LLM 调用失败",
+                    details={"error_type": type(e).__name__, "error": str(e)},
+                )
                 err_result = {"error": f"LLM 调用失败: {e}", "line": "", "control": {}}
                 if allow_postgame:
                     err_result["_postgame_entry"] = entry
@@ -6512,8 +6657,23 @@ async def _run_game_chat(
         game_type, session_id, llm_elapsed_ms, total_elapsed_ms,
         event_text[:80], result['line'][:60],
     )
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="llm",
+        event="game_chat_completed",
+        message="小游戏主 LLM 返回完成",
+        details={
+            "llm_ms": llm_elapsed_ms,
+            "total_ms": total_elapsed_ms,
+            "line_length": len(result.get("line") or ""),
+            "control_keys": sorted((result.get("control") or {}).keys()) if isinstance(result.get("control"), dict) else [],
+            "kind": event.get("kind") if isinstance(event, dict) else "",
+            "round": event.get("round") if isinstance(event, dict) else None,
+        },
+    )
     return result
-
 
 # ── 路由端点 ───────────────────────────────────────────────────────
 
@@ -6620,6 +6780,20 @@ async def game_route_start(game_type: str, request: Request):
     _absorb_request_language(data, lanlan_name)
 
     session_id = str(data.get("session_id") or "default")
+    _mark_game_session_debug_log_active(game_type, session_id, lanlan_name=lanlan_name)
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="route",
+        event="route_start_requested",
+        message="小游戏路由开始请求",
+        details={
+            "neko_initiated": bool(data.get("nekoInitiated")),
+            "mode": data.get("mode") or "",
+            "memory_tail_count": data.get("game_memory_tail_count", data.get("gameMemoryTailCount")),
+        },
+    )
     # 同一角色同一时刻只允许一个 active 游戏路由：启动新路由前先结束所有其它仍活跃的
     # 路由（同 game_type 旧 session、不同 game_type、未来跨游戏并存均覆盖）。否则
     # is_game_route_active(lanlan_name) / _get_active_game_route_state(lanlan_name)
@@ -6763,6 +6937,16 @@ async def game_route_start(game_type: str, request: Request):
                 )
         except Exception as exc:
             logger.warning("🎮 开局上下文构建异常，使用普通陪玩兜底: lanlan=%s err=%s", lanlan_name, exc)
+            _append_game_session_debug_log(
+                game_type,
+                session_id,
+                lanlan_name=lanlan_name,
+                level="warning",
+                category="route",
+                event="pregame_context_exception",
+                message="开局上下文构建异常，使用兜底上下文",
+                details={"error_type": type(exc).__name__, "error": str(exc)},
+            )
             if _is_badminton_game_type(game_type):
                 context = _default_badminton_pregame_context(mode=str(state.get("mode") or data.get("mode") or "spectator"))
             else:
@@ -6775,8 +6959,37 @@ async def game_route_start(game_type: str, request: Request):
         state["heartbeat_enabled"] = True
         state["last_heartbeat_at"] = now
         state["last_activity"] = now
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=lanlan_name,
+            category="route",
+            event="route_start_completed",
+            message="小游戏路由开始完成",
+            details={
+                "pre_game_context_source": source,
+                "pre_game_context_error": error,
+                "before_game_external_mode": state.get("before_game_external_mode"),
+                "before_game_external_active": state.get("before_game_external_active"),
+                "heartbeat_enabled": state.get("heartbeat_enabled"),
+            },
+        )
     if state.get("before_game_external_mode") == "audio" and state.get("before_game_external_active"):
         await route_external_stream_message(lanlan_name, {"input_type": "audio"})
+    if not (game_type == "soccer" or _is_badminton_game_type(game_type)):
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=lanlan_name,
+            category="route",
+            event="route_start_completed",
+            message="小游戏路由开始完成",
+            details={
+                "before_game_external_mode": state.get("before_game_external_mode"),
+                "before_game_external_active": state.get("before_game_external_active"),
+                "heartbeat_enabled": state.get("heartbeat_enabled"),
+            },
+        )
     return {"ok": True, "state": _public_route_state(state)}
 
 
@@ -6943,14 +7156,54 @@ async def _speak_game_line_via_project_tts(
         session_id=session_id,
         event=event if isinstance(event, dict) else {},
     )
-    return await speak(
-        line,
-        metadata=metadata,
-        request_id=request_id,
-        mirror_text=mirror_text,
-        emit_turn_end_after=emit_turn_end,
-        interrupt_audio=interrupt_audio,
-    )
+    before_state = _project_tts_pipeline_state(mgr)
+    try:
+        result = await speak(
+            line,
+            metadata=metadata,
+            request_id=request_id,
+            mirror_text=mirror_text,
+            emit_turn_end_after=emit_turn_end,
+            interrupt_audio=interrupt_audio,
+        )
+    except Exception as exc:
+        return {
+            "ok": False,
+            "reason": "project_tts_exception",
+            "audio_sent": False,
+            "audio_queued": False,
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+            "tts_pipeline": {
+                "before": before_state,
+                "after": _project_tts_pipeline_state(mgr),
+            },
+            "voice_source": {"provider": "project_tts", "method": "project_tts"},
+        }
+    if isinstance(result, dict):
+        result.setdefault("tts_pipeline", {})
+        result["tts_pipeline"] = {
+            "before": before_state,
+            "after": _project_tts_pipeline_state(mgr),
+        }
+    return result
+
+
+def _project_tts_pipeline_state(mgr: Any) -> dict[str, Any]:
+    tts_thread = getattr(mgr, "tts_thread", None)
+    pending_chunks = getattr(mgr, "tts_pending_chunks", None)
+    try:
+        pending_count = len(pending_chunks) if pending_chunks is not None else 0
+    except Exception:
+        pending_count = None
+    return {
+        "tts_thread_alive": bool(tts_thread and tts_thread.is_alive()),
+        "tts_ready": bool(getattr(mgr, "tts_ready", False)),
+        "tts_pending_chunks": pending_count,
+        "tts_done_queued_for_turn": bool(getattr(mgr, "_tts_done_queued_for_turn", False)),
+        "tts_done_pending_until_ready": bool(getattr(mgr, "_tts_done_pending_until_ready", False)),
+        "current_speech_id": str(getattr(mgr, "current_speech_id", "") or ""),
+    }
 
 
 def _game_route_event_has_user_input(event: dict | None) -> bool:
@@ -7246,7 +7499,34 @@ async def game_project_speak(game_type: str, request: Request):
         method="project_tts",
     )
     if stale_response:
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=lanlan_name,
+            level="warning",
+            category="speech",
+            event="project_speech_skipped",
+            message="小游戏项目语音请求被跳过",
+            details={"reason": stale_response.get("reason"), "method": "project_tts"},
+        )
         return stale_response
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="speech",
+        event="project_speech_requested",
+        message="小游戏项目语音请求开始",
+        details={
+            "request_id": str(data.get("request_id") or ""),
+            "line_length": len(line),
+            "interrupt_audio": interrupt_audio,
+            "mirror_text": data.get("mirror_text", True) is not False,
+            "emit_turn_end": data.get("emit_turn_end", True) is not False,
+            "event_kind": data.get("event", {}).get("kind") if isinstance(data.get("event"), dict) else "",
+        },
+        sensitive_possible=True,
+    )
     result = await _speak_game_line_via_project_tts(
         mgr,
         line,
@@ -7265,6 +7545,29 @@ async def game_project_speak(game_type: str, request: Request):
     result.setdefault("lanlan_name", lanlan_name)
     result.setdefault("method", "project_tts")
     result.setdefault("voice_source", {"provider": "project_tts", "method": "project_tts"})
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        level="info" if result.get("ok", True) else "warning",
+        category="speech",
+        event="project_speech_result",
+        message="小游戏项目语音请求结束",
+        details={
+            "ok": result.get("ok"),
+            "reason": result.get("reason"),
+            "audio_sent": result.get("audio_sent"),
+            "audio_queued": result.get("audio_queued"),
+            "speech_id": result.get("speech_id"),
+            "turn_end_emitted": result.get("turn_end_emitted"),
+            "interrupt_audio": result.get("interrupt_audio"),
+            "error_type": result.get("error_type"),
+            "error": result.get("error"),
+            "tts_pipeline": result.get("tts_pipeline"),
+            "voice_source": result.get("voice_source"),
+        },
+        preserve_details=True,
+    )
     return result
 
 
@@ -7418,6 +7721,23 @@ async def _route_external_transcript_to_game(
     game_type = str(state.get("game_type") or "soccer")
     session_id = str(state.get("session_id") or "default")
     memory_enabled = _game_memory_player_interaction_enabled(state)
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="external_input",
+        event="external_input_routed",
+        message="外部输入已转入小游戏路由",
+        details={
+            "source": source,
+            "mode": mode,
+            "kind": kind,
+            "request_id": request_id or "",
+            "text_length": len(text),
+            "memory_enabled": memory_enabled,
+        },
+        sensitive_possible=True,
+    )
     memory_fields = _game_memory_policy_fields(game_type)
     memory_player_camel_key = _game_memory_camel_key(
         _normalize_game_memory_type(game_type),
@@ -7803,13 +8123,29 @@ async def game_realtime_context(game_type: str, request: Request):
     # mgr.user_language），与其他 soccer 端点的 _absorb_request_language 调用同形。
     language = _resolve_game_prompt_language(lanlan_name, data=data)
     text = _compact_realtime_context_text(game_type, data, language)
+    session_id = str((data.get("state") or {}).get("sessionId") or data.get("session_id") or "")
     _log_game_debug_material(
         "realtime_context",
         text,
         game_type=game_type,
-        session_id=str((data.get("state") or {}).get("sessionId") or data.get("session_id") or ""),
+        session_id=session_id,
         lanlan_name=lanlan_name,
         source=str(data.get("source") or ""),
+    )
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="realtime_context",
+        event="realtime_context_requested",
+        message="小游戏 Realtime 上下文注入请求",
+        details={
+            "source": data.get("source") or "",
+            "bytes": len(text),
+            "items": len(data.get("pendingItems") or []),
+            "request_id": str(data.get("request_id") or ""),
+        },
+        sensitive_possible=True,
     )
 
     if _is_gemini_realtime_session(session):
@@ -7818,6 +8154,15 @@ async def game_realtime_context(game_type: str, request: Request):
             game_type,
             lanlan_name,
             len(text),
+        )
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=lanlan_name,
+            category="realtime_context",
+            event="realtime_context_skipped",
+            message="Realtime 上下文注入跳过",
+            details={"reason": "gemini_no_session_update", "bytes": len(text)},
         )
         return {
             "ok": True,
@@ -7851,15 +8196,49 @@ async def game_realtime_context(game_type: str, request: Request):
         )
     except Exception as e:
         logger.warning("🎮 Realtime 上下文注入失败: game=%s lanlan=%s err=%s", game_type, lanlan_name, e)
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=lanlan_name,
+            level="warning",
+            category="realtime_context",
+            event="realtime_context_failed",
+            message="Realtime 上下文注入失败",
+            details={"error_type": type(e).__name__, "error": str(e)},
+        )
         return {"ok": False, "reason": f"inject_failed: {e}", "lanlan_name": lanlan_name}
     if not getattr(append_result, "appended", False) and not getattr(append_result, "deduped", False):
+        reason = getattr(append_result, "reason", None) or "inject_failed"
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=lanlan_name,
+            level="warning",
+            category="realtime_context",
+            event="realtime_context_failed",
+            message="Realtime 上下文未写入",
+            details={"reason": reason},
+        )
         return {
             "ok": False,
-            "reason": getattr(append_result, "reason", None) or "inject_failed",
+            "reason": reason,
             "lanlan_name": lanlan_name,
         }
 
     logger.info("🎮 Realtime 上下文已注入: game=%s lanlan=%s bytes=%d", game_type, lanlan_name, len(text))
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="realtime_context",
+        event="realtime_context_completed",
+        message="Realtime 上下文已注入",
+        details={
+            "bytes": len(text),
+            "items": len(data.get("pendingItems") or []),
+            "deduped": getattr(append_result, "deduped", False),
+        },
+    )
     return {
         "ok": True,
         "lanlan_name": lanlan_name,
@@ -7882,6 +8261,19 @@ async def _complete_game_end_from_payload(
     exit_reason = str(data.get("reason") or default_reason)
     postgame_options = _normalize_postgame_options(data.get("postgameProactive"), reason=exit_reason)
     state = _get_active_game_route_state(lanlan_name, game_type) if lanlan_name else None
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="route",
+        event="route_end_requested",
+        message="小游戏路由结束请求",
+        details={
+            "reason": exit_reason,
+            "matched_active_route": bool(state and str(state.get("session_id") or "") == session_id),
+            "postgame_enabled": postgame_options.get("enabled"),
+        },
+    )
     archive = None
     archive_memory = None
     postgame_result = None
@@ -7971,6 +8363,22 @@ async def _complete_game_end_from_payload(
         result["should_resume_external_on_exit"] = state.get("should_resume_external_on_exit")
         result["before_game_external_mode"] = state.get("before_game_external_mode")
         result["state"] = _public_route_state(state)
+    _append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="route",
+        event="route_end_completed",
+        message="小游戏路由结束完成",
+        details={
+            "reason": exit_reason,
+            "closed": closed,
+            "route_closed": bool(archive),
+            "archive_memory_status": archive_memory.get("status") if isinstance(archive_memory, dict) else None,
+            "postgame_status": postgame_result.get("status") if isinstance(postgame_result, dict) else None,
+        },
+    )
+    _mark_game_session_debug_log_ended(game_type, session_id, lanlan_name=lanlan_name, reason=exit_reason)
     return result
 
 
@@ -8002,11 +8410,14 @@ async def game_quick_lines(game_type: str, request: Request):
         return {"ok": False, "error": f"暂不支持 {game_type} 的快路径文案生成", "lines": {}}
 
     fallback_language = None
+    session_id = ""
+    requested_name = ""
     try:
         try:
             data = await request.json()
         except Exception:
             data = {}
+        session_id = str(data.get("session_id") or data.get("sessionId") or "").strip()
         try:
             current_name = _get_current_character_info().get("lanlan_name") or ""
         except Exception:
@@ -8031,6 +8442,15 @@ async def game_quick_lines(game_type: str, request: Request):
             cached = _badminton_quick_lines_cache.get(cache_key)
             if cached:
                 _badminton_quick_lines_cache.move_to_end(cache_key)
+                _append_game_session_debug_log(
+                    game_type,
+                    session_id,
+                    lanlan_name=requested_name,
+                    category="quick_lines",
+                    event="quick_lines_cached",
+                    message="游戏快路径台词命中缓存",
+                    details={"character": char_info["lanlan_name"], "mode": cache_mode, "keys": sorted(cached.keys())},
+                )
                 return {
                     "ok": True,
                     "character": char_info["lanlan_name"],
@@ -8084,6 +8504,21 @@ async def game_quick_lines(game_type: str, request: Request):
             "🎮 生成游戏快路径台词: game=%s character=%s keys=%d missing=%s",
             game_type, char_info['lanlan_name'], len(lines), missing,
         )
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=requested_name,
+            category="quick_lines",
+            event="quick_lines_completed",
+            message="游戏快路径台词生成完成",
+            details={
+                "character": char_info["lanlan_name"],
+                "keys": sorted(lines.keys()),
+                "missing": missing,
+                "raw_length": len(raw),
+            },
+            sensitive_possible=True,
+        )
         return {
             "ok": bool(lines),
             "character": char_info['lanlan_name'],
@@ -8093,6 +8528,16 @@ async def game_quick_lines(game_type: str, request: Request):
         }
     except Exception as e:
         logger.warning("🎮 生成游戏快路径台词失败: game=%s err=%s", game_type, e, exc_info=True)
+        _append_game_session_debug_log(
+            game_type,
+            session_id,
+            lanlan_name=requested_name,
+            level="warning",
+            category="quick_lines",
+            event="quick_lines_failed",
+            message="游戏快路径台词生成失败",
+            details={"error_type": type(e).__name__, "error": str(e)},
+        )
         if _is_badminton_game_type(game_type):
             return {
                 "ok": True,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -210,7 +210,7 @@ async def game_log_ingest(request: Request):
         "category", "event", "type", "source", "message",
         "sensitive_possible", "sensitivePossible",
         "preserve_message", "preserveMessage", "preserve_details", "preserveDetails",
-        "no_truncate", "noTruncate",
+        "no_truncate", "noTruncate", "_csrf_token",
     }
     preserve_message = (
         _game_log_payload_flag_is_true(data.get("preserve_message"))

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -3229,8 +3229,6 @@
     error: console.error.bind(console),
   };
   const _soccerDebugLogState = {
-    inFlight: false,
-    pending: [],
     lastWindowStart: 0,
     sentInWindow: 0,
   };
@@ -3244,12 +3242,18 @@
     if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
     if (typeof value === 'string') return value.length > 1200 ? `${value.slice(0, 1200)}...<truncated>` : value;
     if (depth >= 3) return String(value).slice(0, 240);
-    if (Array.isArray(value)) return value.slice(0, 20).map((item) => _safeSoccerDebugValue(item, depth + 1));
+    if (Array.isArray(value)) {
+      const result = value.slice(0, 20).map((item) => _safeSoccerDebugValue(item, depth + 1));
+      if (value.length > 20) result.push({ _truncated: `+${value.length - 20} items` });
+      return result;
+    }
     if (typeof value === 'object') {
       const result = {};
-      for (const key of Object.keys(value).slice(0, 30)) {
+      const keys = Object.keys(value);
+      for (const key of keys.slice(0, 30)) {
         result[key] = _safeSoccerDebugValue(value[key], depth + 1);
       }
+      if (keys.length > 30) result._truncated = `+${keys.length - 30} keys`;
       return result;
     }
     return String(value).slice(0, 1200);

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -1396,6 +1396,29 @@
       if (!audio) return;
       const { key: nextKey, type, playlist, config: loopedConfig } = resolvePlaylist();
       if (nextKey === currentKey && isCurrentBgmTarget(type, playlist, loopedConfig)) return;
+      const beforeKey = currentKey || '';
+      const details = {
+        reason,
+        beforeKey,
+        nextKey,
+        type,
+        mood: moodKey,
+        difficulty: DIFFICULTY[difficultyIdx]?.name || '',
+        score: { player: state.score.player, ai: state.score.ai, round: state.round },
+        currentSrc: getCurrentBgmSrc(),
+        targetSrcs: type === 'loopedBgm'
+          ? [loopedConfig?.intro, loopedConfig?.loop, loopedConfig?.outro].filter(Boolean)
+          : (Array.isArray(playlist) ? playlist : [playlist]).map(item => item?.src || item).filter(Boolean),
+      };
+      try {
+        window.SoccerDemoDebugLog?.(
+          'info',
+          'audio',
+          'bgm_switch',
+          '足球小游戏 BGM 切换',
+          details,
+        );
+      } catch (_) {}
       currentKey = nextKey;
       if (type === 'loopedBgm') {
         console.log(`[SoccerAudio] 切换循环 BGM=${nextKey} reason=${reason}`);
@@ -3201,6 +3224,104 @@
     },
   };
 
+  const _soccerDebugConsole = {
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+  };
+  const _soccerDebugLogState = {
+    inFlight: false,
+    pending: [],
+    lastWindowStart: 0,
+    sentInWindow: 0,
+  };
+  const _soccerSpeechPlaybackLogState = {
+    lastSignature: '',
+    lastLoggedAt: 0,
+    lastHeartbeatAt: 0,
+  };
+  function _safeSoccerDebugValue(value, depth = 0, preserve = false) {
+    if (preserve) return value;
+    if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
+    if (typeof value === 'string') return value.length > 1200 ? `${value.slice(0, 1200)}...<truncated>` : value;
+    if (depth >= 3) return String(value).slice(0, 240);
+    if (Array.isArray(value)) return value.slice(0, 20).map((item) => _safeSoccerDebugValue(item, depth + 1));
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key of Object.keys(value).slice(0, 30)) {
+        result[key] = _safeSoccerDebugValue(value[key], depth + 1);
+      }
+      return result;
+    }
+    return String(value).slice(0, 1200);
+  }
+  function _sendSoccerDebugLog(payload) {
+    const now = Date.now();
+    if (now - _soccerDebugLogState.lastWindowStart > 60000) {
+      _soccerDebugLogState.lastWindowStart = now;
+      _soccerDebugLogState.sentInWindow = 0;
+    }
+    if (_soccerDebugLogState.sentInWindow >= 120) return;
+    _soccerDebugLogState.sentInWindow += 1;
+    const body = JSON.stringify({
+      session_id: _llm.sessionId,
+      game_type: 'soccer',
+      lanlan_name: _llm.routeLanlanName || '',
+      source: 'soccer_demo',
+      ...payload,
+    });
+    try {
+      if (navigator.sendBeacon) {
+        const ok = navigator.sendBeacon('/api/game/logs', new Blob([body], { type: 'application/json' }));
+        if (ok) return;
+      }
+    } catch (_) {}
+    fetch('/api/game/logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {});
+  }
+  function soccerSessionDebugLog(level, category, event, message, details = {}, sensitivePossible = false, options = {}) {
+    try {
+      const preserveDetails = !!(options.preserveDetails || options.noTruncate);
+      const preserveMessage = !!(options.preserveMessage || options.noTruncate);
+      _sendSoccerDebugLog({
+        level,
+        category,
+        event,
+        message: String(message || ''),
+        details: _safeSoccerDebugValue(details, 0, preserveDetails),
+        sensitive_possible: !!sensitivePossible,
+        preserve_message: preserveMessage,
+        preserve_details: preserveDetails,
+      });
+    } catch (_) {}
+  }
+  window.SoccerDemoDebugLog = soccerSessionDebugLog;
+  window.addEventListener('error', (event) => {
+    soccerSessionDebugLog('error', 'frontend', 'window_error', event.message || '前端脚本错误', {
+      filename: event.filename || '',
+      lineno: event.lineno || 0,
+      colno: event.colno || 0,
+      error: event.error && (event.error.stack || event.error.message || String(event.error)),
+    });
+  });
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    soccerSessionDebugLog('error', 'frontend', 'unhandled_rejection', '前端 Promise 未处理异常', {
+      reason: reason && (reason.stack || reason.message || String(reason)),
+    });
+  });
+  console.warn = function soccerDebugConsoleWarn(...args) {
+    _soccerDebugConsole.warn(...args);
+    soccerSessionDebugLog('warning', 'frontend', 'console_warn', args.map((item) => String(item)).join(' '), { args }, true);
+  };
+  console.error = function soccerDebugConsoleError(...args) {
+    _soccerDebugConsole.error(...args);
+    soccerSessionDebugLog('error', 'frontend', 'console_error', args.map((item) => String(item)).join(' '), { args }, true);
+  };
+
   const SPEECH_PLAYBACK_STATE_KEY = 'neko_speech_playback_state';
   const SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';
   function _soccerGameMemoryPolicyPayload(enabled = _isGameMemoryEnabled()) {
@@ -3369,6 +3490,70 @@
     return { active: false, speechId: '', turnId: '', remainingSeconds: 0, updatedAt: 0, reason: 'missing' };
   }
 
+  function _speechPlaybackDebugDetails(raw, bridgeSource = '') {
+    const updatedAt = Number(raw?.updatedAt || 0);
+    return {
+      bridgeSource,
+      reason: raw?.reason || '',
+      active: !!raw?.active,
+      speechId: raw?.speechId || '',
+      turnId: raw?.turnId || '',
+      playbackTurnId: raw?.playbackTurnId || '',
+      remainingSeconds: Number(raw?.remainingSeconds || 0),
+      pendingAudioWork: !!raw?.pendingAudioWork,
+      audioContextState: raw?.audioContextState || '',
+      audioContextTime: Number(raw?.audioContextTime || 0),
+      scheduledEndAudioTime: Number(raw?.scheduledEndAudioTime || 0),
+      playbackStartAudioTime: Number(raw?.playbackStartAudioTime || 0),
+      playbackEndAudioTime: Number(raw?.playbackEndAudioTime || 0),
+      updatedAt,
+      updatedAtIso: updatedAt ? new Date(updatedAt).toISOString() : '',
+      source: raw?.source || '',
+    };
+  }
+
+  function _logSpeechPlaybackState(raw, bridgeSource = '') {
+    if (!raw || typeof raw !== 'object') return;
+    const details = _speechPlaybackDebugDetails(raw, bridgeSource);
+    const now = Date.now();
+    const roundedRemaining = Math.round(details.remainingSeconds * 10) / 10;
+    const signature = [
+      details.reason,
+      details.active,
+      details.speechId,
+      details.turnId,
+      details.playbackTurnId,
+      details.audioContextState,
+      roundedRemaining,
+    ].join('|');
+    const important = details.reason && details.reason !== 'heartbeat';
+    if (!important) {
+      if (
+        signature === _soccerSpeechPlaybackLogState.lastSignature &&
+        now - _soccerSpeechPlaybackLogState.lastHeartbeatAt < 2500
+      ) {
+        return;
+      }
+      _soccerSpeechPlaybackLogState.lastHeartbeatAt = now;
+    } else if (
+      signature === _soccerSpeechPlaybackLogState.lastSignature &&
+      now - _soccerSpeechPlaybackLogState.lastLoggedAt < 500
+    ) {
+      return;
+    }
+    _soccerSpeechPlaybackLogState.lastSignature = signature;
+    _soccerSpeechPlaybackLogState.lastLoggedAt = now;
+    soccerSessionDebugLog(
+      'info',
+      'speech',
+      'speech_playback_state',
+      '主说话播放器状态更新',
+      details,
+      false,
+      { preserveDetails: true },
+    );
+  }
+
   function _initSpeechPlaybackStateBridge() {
     try {
       if (typeof BroadcastChannel !== 'undefined') {
@@ -3376,6 +3561,7 @@
         _llm.speechPlaybackChannel.onmessage = (event) => {
           if (event?.data?.type === 'speech_playback_state') {
             _llm.speechPlaybackState = event.data;
+            _logSpeechPlaybackState(event.data, 'broadcast_channel');
           }
         };
       }
@@ -3386,8 +3572,17 @@
       if (event.key !== SPEECH_PLAYBACK_STATE_KEY || !event.newValue) return;
       try {
         const data = JSON.parse(event.newValue);
-        if (data?.type === 'speech_playback_state') _llm.speechPlaybackState = data;
+        if (data?.type === 'speech_playback_state') {
+          _llm.speechPlaybackState = data;
+          _logSpeechPlaybackState(data, 'local_storage');
+        }
       } catch (_) { /* noop */ }
+    });
+    window.addEventListener('neko-speech-playback-state', (event) => {
+      const data = event?.detail;
+      if (data?.type !== 'speech_playback_state') return;
+      _llm.speechPlaybackState = data;
+      _logSpeechPlaybackState(data, 'window_event');
     });
     _readSpeechPlaybackState();
   }
@@ -4085,6 +4280,35 @@
           `line_match=${data.line_match !== undefined ? !!data.line_match : '-'} ` +
           `transcript="${(data.spoken_transcript || '').slice(0, 80)}" bytes=${data.bytes || 0}`
         );
+        soccerSessionDebugLog(
+          'info',
+          'speech',
+          'project_voice_result',
+          '小游戏项目语音返回成功',
+          {
+            ok: data.ok,
+            method: data.method || 'unknown',
+            language: data.language || '',
+            speech_id: data.speech_id || '',
+            audio_sent: data.audio_sent,
+            audio_queued: data.audio_queued,
+            audio_committed: data.audio_committed,
+            response_observed: data.response_observed,
+            audio_observed: data.audio_observed,
+            response_done: data.response_done,
+            line_match: data.line_match,
+            bytes: data.bytes,
+            voice_source: data.voice_source,
+            tts_pipeline: data.tts_pipeline,
+            interruptAudio,
+            voiceArbiterReason,
+            request_id: meta.request_id || result.request_id || '',
+            event_kind: meta.kind || 'mailbox',
+            round: meta.round,
+          },
+          false,
+          { preserveDetails: true },
+        );
         return data;
       }
       const skipDiag = [
@@ -4099,6 +4323,36 @@
       console.log(
         `[SoccerVoice] 原流水线输出未送达 | 原因=${data.reason || resp.status} ` +
         `来源=${_formatSourceLabel(data.voice_source || { provider: 'project_voice_unavailable' })} ${skipDiag}`
+      );
+      soccerSessionDebugLog(
+        'warning',
+        'speech',
+        'project_voice_result',
+        '小游戏项目语音未送达',
+        {
+          ok: data.ok,
+          status: resp.status,
+          reason: data.reason || '',
+          audio_sent: data.audio_sent,
+          audio_queued: data.audio_queued,
+          audio_committed: data.audio_committed,
+          response_observed: data.response_observed,
+          audio_observed: data.audio_observed,
+          response_done: data.response_done,
+          line_match: data.line_match,
+          use_tts: data.use_tts,
+          voice_source: data.voice_source || { provider: 'project_voice_unavailable' },
+          tts_pipeline: data.tts_pipeline,
+          error_type: data.error_type,
+          error: data.error,
+          interruptAudio,
+          voiceArbiterReason,
+          request_id: meta.request_id || result.request_id || '',
+          event_kind: meta.kind || 'mailbox',
+          round: meta.round,
+        },
+        false,
+        { preserveDetails: true },
       );
       _llm.lastVoiceFailure = {
         ok: false,
@@ -4116,6 +4370,23 @@
       return _llm.lastVoiceFailure;
     } catch (e) {
       console.log(`[SoccerVoice] 原流水线输出请求失败 | ${String(e)}`);
+      soccerSessionDebugLog(
+        'error',
+        'speech',
+        'project_voice_request_failed',
+        '小游戏项目语音请求失败',
+        {
+          reason: 'request_failed',
+          error: String(e),
+          interruptAudio,
+          voiceArbiterReason,
+          request_id: meta.request_id || result.request_id || '',
+          event_kind: meta.kind || 'mailbox',
+          round: meta.round,
+        },
+        false,
+        { preserveDetails: true },
+      );
       _llm.lastVoiceFailure = {
         ok: false,
         reason: 'request_failed',
@@ -4563,6 +4834,21 @@
       );
       const controlText = Object.keys(control).length > 0 ? JSON.stringify(control) : '无';
       console.log(`[SoccerLLM][Control] 返回 | 回合=${eventPayload.round} 事件=${eventLabel(kind)}(${kind}) 指令=${controlText}`);
+      if (Object.keys(control).length > 0) {
+        soccerSessionDebugLog(
+          'info',
+          'llm',
+          'game_control_returned',
+          '小游戏 LLM 返回控制指令',
+          {
+            round: eventPayload.round,
+            kind,
+            control,
+            mood: SoccerDemo.getMood(),
+            difficulty: SoccerDemo.getDifficulty(),
+          },
+        );
+      }
       if (control.reason) {
         console.log(`[SoccerLLM][Control] 理由 | 回合=${eventPayload.round} 事件=${eventLabel(kind)}(${kind}) ${control.reason}`);
       }
@@ -4664,6 +4950,22 @@
       }
       if (ignored.length > 0) {
         console.log(`[SoccerLLM][Control] 忽略 | 回合=${meta?.round ?? '?'} 非法指令 ${ignored.join('；')}，可选心情=${SoccerDemo.MOODS.join('/')}，可选难度=${SoccerDemo.DIFFICULTIES.join('/')}`);
+      }
+      if (applied.length > 0 || ignored.length > 0) {
+        soccerSessionDebugLog(
+          'info',
+          'llm',
+          'game_control_applied',
+          '小游戏 LLM 控制指令处理完成',
+          {
+            round: meta?.round ?? null,
+            requested: result.control,
+            applied,
+            ignored,
+            finalMood: SoccerDemo.getMood(),
+            finalDifficulty: SoccerDemo.getDifficulty(),
+          },
+        );
       }
 	    }
 	  }

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -3258,21 +3258,12 @@
     }
     return String(value).slice(0, 1200);
   }
-  function _sendSoccerDebugLog(payload) {
-    const now = Date.now();
-    if (now - _soccerDebugLogState.lastWindowStart > 60000) {
-      _soccerDebugLogState.lastWindowStart = now;
-      _soccerDebugLogState.sentInWindow = 0;
-    }
-    if (_soccerDebugLogState.sentInWindow >= 120) return;
-    _soccerDebugLogState.sentInWindow += 1;
-    const body = JSON.stringify({
-      session_id: _llm.sessionId,
-      game_type: 'soccer',
-      lanlan_name: _llm.routeLanlanName || '',
-      source: 'soccer_demo',
-      ...payload,
-    });
+  function _soccerDebugCsrfTokenFromHeaders(headers = {}) {
+    return headers['X-CSRF-Token'] || headers['x-csrf-token'] || '';
+  }
+  function _postSoccerDebugLogPayload(payload, mutationHeaders = {}) {
+    const token = _soccerDebugCsrfTokenFromHeaders(mutationHeaders);
+    const body = JSON.stringify(token ? { ...payload, _csrf_token: token } : payload);
     try {
       if (navigator.sendBeacon) {
         const ok = navigator.sendBeacon('/api/game/logs', new Blob([body], { type: 'application/json' }));
@@ -3281,10 +3272,43 @@
     } catch (_) {}
     fetch('/api/game/logs', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...mutationHeaders },
       body,
       keepalive: true,
     }).catch(() => {});
+  }
+  function _sendSoccerDebugLog(payload) {
+    const now = Date.now();
+    if (now - _soccerDebugLogState.lastWindowStart > 60000) {
+      _soccerDebugLogState.lastWindowStart = now;
+      _soccerDebugLogState.sentInWindow = 0;
+    }
+    if (_soccerDebugLogState.sentInWindow >= 120) return;
+    _soccerDebugLogState.sentInWindow += 1;
+    const logPayload = {
+      session_id: _llm.sessionId,
+      game_type: 'soccer',
+      lanlan_name: _llm.routeLanlanName || '',
+      source: 'soccer_demo',
+      ...payload,
+    };
+    const security = window.nekoLocalMutationSecurity;
+    try {
+      if (security && typeof security.peekCachedToken === 'function') {
+        const token = security.peekCachedToken();
+        if (token) {
+          _postSoccerDebugLogPayload(logPayload, { 'X-CSRF-Token': token });
+          return;
+        }
+      }
+    } catch (_) {}
+    if (security && typeof security.getMutationHeaders === 'function') {
+      Promise.resolve(security.getMutationHeaders())
+        .then((headers) => _postSoccerDebugLogPayload(logPayload, headers || {}))
+        .catch(() => _postSoccerDebugLogPayload(logPayload));
+      return;
+    }
+    _postSoccerDebugLogPayload(logPayload);
   }
   function soccerSessionDebugLog(level, category, event, message, details = {}, sensitivePossible = false, options = {}) {
     try {

--- a/tests/unit/test_game_llm_static_contracts.py
+++ b/tests/unit/test_game_llm_static_contracts.py
@@ -85,6 +85,10 @@ def test_soccer_realtime_context_posts_local_mutation_headers():
 @pytest.mark.unit
 def test_soccer_template_posts_session_debug_errors():
     html = ROOT.joinpath("templates/soccer_demo.html").read_text(encoding="utf-8")
+    debug_block = html.split("function _sendSoccerDebugLog(payload)", 1)[1].split(
+        "function soccerSessionDebugLog",
+        1,
+    )[0]
 
     assert "/api/game/logs" in html
     assert "window.SoccerDemoDebugLog = soccerSessionDebugLog" in html
@@ -95,6 +99,10 @@ def test_soccer_template_posts_session_debug_errors():
     assert "session_id: _llm.sessionId" in html
     assert "game_type: 'soccer'" in html
     assert "lanlan_name: _llm.routeLanlanName || ''" in html
+    assert "window.nekoLocalMutationSecurity" in debug_block
+    assert "peekCachedToken" in debug_block
+    assert "getMutationHeaders" in debug_block
+    assert "_csrf_token: token" in html
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_llm_static_contracts.py
+++ b/tests/unit/test_game_llm_static_contracts.py
@@ -83,6 +83,21 @@ def test_soccer_realtime_context_posts_local_mutation_headers():
 
 
 @pytest.mark.unit
+def test_soccer_template_posts_session_debug_errors():
+    html = ROOT.joinpath("templates/soccer_demo.html").read_text(encoding="utf-8")
+
+    assert "/api/game/logs" in html
+    assert "window.SoccerDemoDebugLog = soccerSessionDebugLog" in html
+    assert "window.addEventListener('error'" in html
+    assert "window.addEventListener('unhandledrejection'" in html
+    assert "console.warn = function soccerDebugConsoleWarn" in html
+    assert "console.error = function soccerDebugConsoleError" in html
+    assert "session_id: _llm.sessionId" in html
+    assert "game_type: 'soccer'" in html
+    assert "lanlan_name: _llm.routeLanlanName || ''" in html
+
+
+@pytest.mark.unit
 def test_pregame_prompt_must_not_be_format_called():
     """Pregame schema uses literal {} for JSON output; callers must not .format() it.
     If a future change needs a {placeholder}, every JSON literal must be doubled first."""

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -166,6 +166,47 @@ async def test_game_debug_log_ingest_and_query():
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_game_debug_log_ingest_requires_local_mutation_csrf():
+    result = await game_router.game_log_ingest(
+        _FakeRequest({
+            "session_id": "soccer-debug-csrf",
+            "game_type": "soccer",
+            "message": "blocked",
+        }, mutation_headers=False, path="/api/game/logs"),
+    )
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 403
+    assert b"csrf_validation_failed" in result.body
+    assert game_log.find_game_session_debug_log("soccer-debug-csrf", "soccer") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_game_debug_log_ingest_does_not_preserve_from_false_or_no_truncate():
+    result = await game_router.game_log_ingest(
+        _FakeRequest({
+            "session_id": "soccer-debug-truncate",
+            "game_type": "soccer",
+            "message": "m" * 1500,
+            "details": {"long": "d" * 2500},
+            "preserve_message": "false",
+            "preserve_details": "false",
+            "no_truncate": True,
+        }, path="/api/game/logs"),
+    )
+
+    assert result["ok"] is True
+    queried = await game_router.game_logs(session_id="soccer-debug-truncate", game_type="soccer")
+    entry = queried["log"]["entries"][0]
+    assert len(entry["message"]) < 1500
+    assert "<truncated" in entry["message"]
+    assert len(entry["details"]["long"]) < 2500
+    assert "<truncated" in entry["details"]["long"]
+
+
+@pytest.mark.unit
 def test_game_debug_logs_do_not_drop_ended_sessions_when_new_sessions_open():
     for index in range(14):
         session_id = f"soccer-old-{index}"

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -16,6 +16,7 @@ from .game_route_test_helpers import (
 from main_routers import game_router, system_router
 from main_routers.system_router import AUTOSTART_CSRF_TOKEN
 from main_logic.core import LLMSessionManager
+from utils import game_log
 from utils.llm_client import AIMessage, HumanMessage
 
 
@@ -93,6 +94,13 @@ class _FakeAppendContextManager:
         return self.result
 
 
+@pytest.fixture(autouse=True)
+def _clear_game_session_debug_logs():
+    game_log._game_session_debug_logs.clear()
+    yield
+    game_log._game_session_debug_logs.clear()
+
+
 @pytest.mark.unit
 def test_badminton_removed_modes_are_not_public_or_scored():
     assert game_router._normalize_badminton_mode("horse") == "spectator"
@@ -125,6 +133,52 @@ async def test_badminton_route_start_accepts_direct_debug_session(monkeypatch):
         assert result["state"]["session_id"] == "debug-badminton"
         assert result["state"]["mode"] == "shooter"
         assert game_router._route_state_key("Lan", "badminton") in game_router._game_route_states
+        debug_log = await game_router.game_logs(session_id="debug-badminton", game_type="badminton")
+        events = [item["event"] for item in debug_log["log"]["entries"]]
+        assert "session_active" in events
+        assert "route_start_requested" in events
+        assert "route_start_completed" in events
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_game_debug_log_ingest_and_query():
+    result = await game_router.game_log_ingest(
+        _FakeRequest({
+            "session_id": "soccer-debug-1",
+            "game_type": "soccer",
+            "lanlan_name": "Lan",
+            "level": "error",
+            "category": "frontend",
+            "event": "window_error",
+            "message": "boom",
+            "details": {"filename": "soccer_demo.html", "line": 12},
+        }),
+    )
+
+    assert result["ok"] is True
+    assert result["seq"] == 1
+    queried = await game_router.game_logs(session_id="soccer-debug-1", game_type="soccer")
+    assert queried["ok"] is True
+    assert queried["log"]["lanlan_name"] == "Lan"
+    assert queried["log"]["entries"][0]["event"] == "window_error"
+    assert queried["log"]["entries"][0]["details"]["filename"] == "soccer_demo.html"
+
+
+@pytest.mark.unit
+def test_game_debug_logs_do_not_drop_ended_sessions_when_new_sessions_open():
+    for index in range(14):
+        session_id = f"soccer-old-{index}"
+        game_log.mark_game_session_debug_log_active("soccer", session_id, lanlan_name="Lan")
+        game_log.mark_game_session_debug_log_ended("soccer", session_id, lanlan_name="Lan", reason="test")
+
+    game_log.mark_game_session_debug_log_active("soccer", "soccer-new", lanlan_name="Lan")
+    summaries = game_log.list_game_session_debug_log_summaries("soccer")
+
+    session_ids = {item["session_id"] for item in summaries}
+    assert "soccer-old-0" in session_ids
+    assert "soccer-old-13" in session_ids
+    assert "soccer-new" in session_ids
 
 
 @pytest.mark.unit

--- a/utils/game_log.py
+++ b/utils/game_log.py
@@ -13,7 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Mini-game session diagnostic log in-memory buffer and helpers."""
+"""Mini-game session diagnostic log in-memory buffer and helpers.
+
+Fallback/degrade contract:
+callers must make the primary log message itself explicit when a fallback,
+degrade, skip, timeout, parse failure, or recovery path is used. Do not rely on
+a second summary field or details-only metadata to explain that the path was not
+normal success. Shared logging helpers should reuse the original logger/console
+message and args; if that text is unclear, fix the original message at the call
+site. Structured fields such as fallback/degraded/skipped/reason are for
+filtering and diagnosis, not for correcting an ambiguous message.
+"""
 
 from __future__ import annotations
 
@@ -158,6 +168,15 @@ def append_game_session_debug_log(
     preserve_message: bool = False,
     preserve_details: bool = False,
 ) -> dict | None:
+    """Append one mini-game session log entry.
+
+    Fallback/error-recovery callers must make ``message`` itself say the source
+    path failed, timed out, degraded, skipped, or used fallback. Do not add a
+    second summary just to repair an unclear message; fix the original
+    logger/console text at the call site. ``details`` fields such as
+    reason/error_type/fallback/degraded/skipped_reason are structured filters,
+    not replacements for clear primary log text.
+    """
     try:
         entry = _get_or_create_game_session_debug_log(game_type, session_id, lanlan_name=lanlan_name)
         if entry is None:
@@ -270,4 +289,3 @@ def list_game_session_debug_log_summaries(game_type: str = "") -> list[dict]:
         })
     summaries.sort(key=lambda item: float(item.get("updated_at") or 0.0), reverse=True)
     return summaries
-

--- a/utils/game_log.py
+++ b/utils/game_log.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mini-game session diagnostic log in-memory buffer and helpers."""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from datetime import datetime
+from typing import Any
+
+GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT = 1000
+_GAME_SESSION_DEBUG_MESSAGE_LIMIT = 1200
+_GAME_SESSION_DEBUG_STRING_LIMIT = 2000
+_GAME_SESSION_DEBUG_DICT_LIMIT = 48
+_GAME_SESSION_DEBUG_LIST_LIMIT = 40
+_GAME_SESSION_DEBUG_MAX_DEPTH = 4
+
+_game_session_debug_logs: "OrderedDict[str, dict]" = OrderedDict()
+
+
+def _game_debug_log_key(game_type: Any, session_id: Any) -> str:
+    return f"{str(game_type or '').strip()}:{str(session_id or '').strip()}"
+
+
+def _find_game_session_debug_log(session_id: Any, game_type: Any = "") -> dict | None:
+    session_id_s = str(session_id or "").strip()
+    game_type_s = str(game_type or "").strip()
+    if not session_id_s:
+        return None
+    if game_type_s:
+        return _game_session_debug_logs.get(_game_debug_log_key(game_type_s, session_id_s))
+    matched = [
+        entry for entry in _game_session_debug_logs.values()
+        if str(entry.get("session_id") or "") == session_id_s
+    ]
+    if not matched:
+        return None
+    matched.sort(key=lambda entry: float(entry.get("updated_at") or 0.0), reverse=True)
+    return matched[0]
+
+
+def find_game_session_debug_log(session_id: Any, game_type: Any = "") -> dict | None:
+    return _find_game_session_debug_log(session_id, game_type)
+
+
+def _safe_game_debug_text(value: Any, *, limit: int = _GAME_SESSION_DEBUG_STRING_LIMIT) -> str:
+    text = str(value or "")
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}...<truncated +{len(text) - limit} chars>"
+
+
+def _safe_game_debug_value(value: Any, *, depth: int = 0) -> Any:
+    if depth >= _GAME_SESSION_DEBUG_MAX_DEPTH:
+        return _safe_game_debug_text(value, limit=240)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _safe_game_debug_text(value)
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= _GAME_SESSION_DEBUG_DICT_LIMIT:
+                result["_truncated"] = f"+{len(value) - _GAME_SESSION_DEBUG_DICT_LIMIT} keys"
+                break
+            result[_safe_game_debug_text(key, limit=120)] = _safe_game_debug_value(item, depth=depth + 1)
+        return result
+    if isinstance(value, (list, tuple, set)):
+        items = list(value)
+        result = [_safe_game_debug_value(item, depth=depth + 1) for item in items[:_GAME_SESSION_DEBUG_LIST_LIMIT]]
+        if len(items) > _GAME_SESSION_DEBUG_LIST_LIMIT:
+            result.append({"_truncated": f"+{len(items) - _GAME_SESSION_DEBUG_LIST_LIMIT} items"})
+        return result
+    return _safe_game_debug_text(value)
+
+
+def _game_debug_log_time(ts: float) -> str:
+    try:
+        return datetime.fromtimestamp(ts).astimezone().isoformat(timespec="milliseconds")
+    except Exception:
+        return ""
+
+
+def _get_or_create_game_session_debug_log(
+    game_type: Any,
+    session_id: Any,
+    *,
+    lanlan_name: str = "",
+    activate: bool = False,
+) -> dict | None:
+    game_type_s = str(game_type or "").strip()
+    session_id_s = str(session_id or "").strip()
+    if not game_type_s or not session_id_s:
+        return None
+    key = _game_debug_log_key(game_type_s, session_id_s)
+    now = time.time()
+    entry = _game_session_debug_logs.get(key)
+    if entry is None:
+        entry = {
+            "key": key,
+            "game_type": game_type_s,
+            "session_id": session_id_s,
+            "lanlan_name": str(lanlan_name or ""),
+            "status": "active" if activate else "open",
+            "created_at": now,
+            "created_time": _game_debug_log_time(now),
+            "updated_at": now,
+            "updated_time": _game_debug_log_time(now),
+            "ended_at": None,
+            "ended_time": None,
+            "last_viewed_at": None,
+            "seq": 0,
+            "entries": [],
+        }
+        _game_session_debug_logs[key] = entry
+    else:
+        _game_session_debug_logs.move_to_end(key)
+        entry["updated_at"] = now
+        if lanlan_name and not entry.get("lanlan_name"):
+            entry["lanlan_name"] = str(lanlan_name)
+        if activate:
+            entry["status"] = "active"
+            entry["ended_at"] = None
+    return entry
+
+
+def cleanup_game_session_debug_logs(now: float | None = None) -> None:
+    # 用户要求旧场次留在内存中用于对比；这里只保留函数入口，便于以后接入手动清理。
+    return None
+
+
+def append_game_session_debug_log(
+    game_type: Any,
+    session_id: Any,
+    *,
+    lanlan_name: str = "",
+    level: str = "info",
+    category: str = "backend",
+    event: str = "",
+    source: str = "backend",
+    message: str = "",
+    details: Any = None,
+    sensitive_possible: bool = False,
+    preserve_message: bool = False,
+    preserve_details: bool = False,
+) -> dict | None:
+    try:
+        entry = _get_or_create_game_session_debug_log(game_type, session_id, lanlan_name=lanlan_name)
+        if entry is None:
+            return None
+        entry["seq"] = int(entry.get("seq") or 0) + 1
+        now = time.time()
+        item = {
+            "seq": entry["seq"],
+            "ts": now,
+            "time": _game_debug_log_time(now),
+            "level": _safe_game_debug_text(level, limit=24) or "info",
+            "category": _safe_game_debug_text(category, limit=64) or "backend",
+            "event": _safe_game_debug_text(event, limit=96) or "event",
+            "source": _safe_game_debug_text(source, limit=96) or "backend",
+            "message": str(message or "") if preserve_message else _safe_game_debug_text(
+                message,
+                limit=_GAME_SESSION_DEBUG_MESSAGE_LIMIT,
+            ),
+            "sensitive_possible": bool(sensitive_possible),
+            "details": details if preserve_details else _safe_game_debug_value(details if details is not None else {}),
+        }
+        entry["entries"].append(item)
+        if len(entry["entries"]) > GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT:
+            del entry["entries"][:len(entry["entries"]) - GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT]
+        entry["updated_at"] = now
+        entry["updated_time"] = _game_debug_log_time(now)
+        _game_session_debug_logs.move_to_end(entry["key"])
+        cleanup_game_session_debug_logs(now)
+        return item
+    except Exception:
+        return None
+
+
+def mark_game_session_debug_log_active(game_type: Any, session_id: Any, *, lanlan_name: str = "") -> None:
+    entry = _get_or_create_game_session_debug_log(game_type, session_id, lanlan_name=lanlan_name, activate=True)
+    if entry is None:
+        return
+    append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="route",
+        event="session_active",
+        message="小游戏场次日志已激活",
+    )
+
+
+def mark_game_session_debug_log_ended(game_type: Any, session_id: Any, *, lanlan_name: str = "", reason: str = "") -> None:
+    entry = _get_or_create_game_session_debug_log(game_type, session_id, lanlan_name=lanlan_name)
+    if entry is None:
+        return
+    entry["status"] = "ended"
+    entry["ended_at"] = time.time()
+    entry["ended_time"] = _game_debug_log_time(entry["ended_at"])
+    append_game_session_debug_log(
+        game_type,
+        session_id,
+        lanlan_name=lanlan_name,
+        category="route",
+        event="session_ended",
+        message="小游戏场次已结束，日志进入保留窗口",
+        details={"reason": reason or "unknown"},
+    )
+
+
+def public_game_session_debug_log(entry: dict, *, since: int = 0, limit: int = 200) -> dict:
+    safe_limit = max(1, min(int(limit or 200), GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT))
+    safe_since = max(0, int(since or 0))
+    entries = [
+        item for item in list(entry.get("entries") or [])
+        if int(item.get("seq") or 0) > safe_since
+    ][-safe_limit:]
+    entry["last_viewed_at"] = time.time()
+    return {
+        "key": entry.get("key"),
+        "game_type": entry.get("game_type"),
+        "session_id": entry.get("session_id"),
+        "lanlan_name": entry.get("lanlan_name"),
+        "status": entry.get("status"),
+        "created_at": entry.get("created_at"),
+        "created_time": entry.get("created_time"),
+        "updated_at": entry.get("updated_at"),
+        "updated_time": entry.get("updated_time"),
+        "ended_at": entry.get("ended_at"),
+        "ended_time": entry.get("ended_time"),
+        "last_viewed_at": entry.get("last_viewed_at"),
+        "entry_count": len(entry.get("entries") or []),
+        "entries": entries,
+    }
+
+
+def list_game_session_debug_log_summaries(game_type: str = "") -> list[dict]:
+    cleanup_game_session_debug_logs()
+    summaries = []
+    for entry in _game_session_debug_logs.values():
+        if game_type and entry.get("game_type") != game_type:
+            continue
+        summaries.append({
+            "game_type": entry.get("game_type"),
+            "session_id": entry.get("session_id"),
+            "lanlan_name": entry.get("lanlan_name"),
+            "status": entry.get("status"),
+            "created_at": entry.get("created_at"),
+            "created_time": entry.get("created_time"),
+            "updated_at": entry.get("updated_at"),
+            "updated_time": entry.get("updated_time"),
+            "ended_at": entry.get("ended_at"),
+            "ended_time": entry.get("ended_time"),
+            "entry_count": len(entry.get("entries") or []),
+        })
+    summaries.sort(key=lambda item: float(item.get("updated_at") or 0.0), reverse=True)
+    return summaries
+


### PR DESCRIPTION
## 改动概述 / Summary

- Add an in-memory mini-game session diagnostics buffer keyed by game type and session id.
- Expose JSON and browser-readable diagnostics endpoints through the existing game router.
- Capture soccer mini-game frontend runtime issues plus backend route, LLM, speech, realtime, and session lifecycle events.
- Document that fallback and degraded paths must be explicit in the primary diagnostic message rather than hidden in metadata.

## 回归报告 / Regression Report

- Changed `main_routers/game_router.py` to register mini-game diagnostics endpoints and to emit diagnostics around existing soccer route, LLM, speech, realtime, and session lifecycle paths.
- The change is necessary so a running mini-game session can be inspected without manually copying browser console or backend terminal output.
- Before this PR, mini-game debugging depended on scattered console/backend logs and soccer startup failures could silently fall back in places that were hard to correlate with a game session. After this PR, each session has bounded diagnostic entries available through the game router while the normal game responses remain unchanged.
- Potential regression areas are game router registration, soccer startup/realtime request handling, and logging-side error handling. These were covered by targeted router tests, static LLM contract tests, ruff, and `git diff --check`.

## 不拆分理由 / Why Not Split

不适用。This PR changes 5 relevant files, below the split-report threshold.

## 测试 / Testing

- `uv run --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests\unit\test_game_router.py -q -k "debug_log or route_start_accepts_direct_debug_session"`
- `uv run --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests\unit\test_game_llm_static_contracts.py -q -k "session_debug_errors or realtime_context_posts_local_mutation_headers"`
- `uv run --project D:\AI\N.E.K.O\N.E.K.O ruff check main_routers\game_router.py utils\game_log.py app\main_server.py tests\unit\test_game_router.py tests\unit\test_game_llm_static_contracts.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 新增游戏会话诊断日志接口（查询、HTML查看、写入/摄取），支持可控保留/截断与安全转义。
  * 强化游戏关键流程会话生命周期标记与诊断埋点；语音 TTS 增加调用前后状态快照，并以结构化结果返回失败信息。
  * Soccer Demo 增加会话级调试上报：自动捕获页面错误/未处理异常，并重写控制台告警输出。
* **测试**
  * 新增/扩展日志接口与模板契约单测，覆盖写入/查询、CSRF校验、截断规则与会话汇总。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->