### PR TITLE
[codex] Rotate mini-game session diagnostics

### DIFF
--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -105,6 +105,8 @@ from utils.game_log import (
     append_game_session_debug_log as _append_game_session_debug_log,
     find_game_session_debug_log as _find_game_session_debug_log,
     GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT,
+    GAME_SESSION_DEBUG_RETAINED_SESSION_LIMIT,
+    GAME_SESSION_DEBUG_RETAINED_SESSION_TTL_SECONDS,
     list_game_session_debug_log_summaries,
     mark_game_session_debug_log_active as _mark_game_session_debug_log_active,
     mark_game_session_debug_log_ended as _mark_game_session_debug_log_ended,
@@ -138,7 +140,8 @@ async def game_logs(session_id: str = "", game_type: str = "", since: int = 0, l
         "sessions": list_game_session_debug_log_summaries(str(game_type or "").strip()),
         "retention": {
             "entry_limit": GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT,
-            "ended_session_cleanup": "disabled",
+            "retained_completed_session_limit": GAME_SESSION_DEBUG_RETAINED_SESSION_LIMIT,
+            "retained_completed_session_ttl_seconds": GAME_SESSION_DEBUG_RETAINED_SESSION_TTL_SECONDS,
         },
     }
 

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -224,11 +224,23 @@ def test_game_debug_logs_keep_latest_completed_session_until_next_active_session
 
 
 @pytest.mark.unit
+def test_game_debug_logs_drop_ended_session_when_active_session_exists():
+    game_log.mark_game_session_debug_log_active("soccer", "soccer-old", lanlan_name="Lan")
+    game_log.mark_game_session_debug_log_active("soccer", "soccer-new", lanlan_name="Lan")
+    game_log.mark_game_session_debug_log_ended("soccer", "soccer-old", lanlan_name="Lan", reason="superseded")
+
+    summaries = game_log.list_game_session_debug_log_summaries("soccer")
+
+    assert {item["session_id"] for item in summaries} == {"soccer-new"}
+
+
+@pytest.mark.unit
 def test_game_debug_logs_drop_completed_session_after_retention_ttl():
     now = 1_000_000.0
     game_log.mark_game_session_debug_log_active("soccer", "soccer-old", lanlan_name="Lan")
     game_log.mark_game_session_debug_log_ended("soccer", "soccer-old", lanlan_name="Lan", reason="test")
     entry = game_log.find_game_session_debug_log("soccer-old", "soccer")
+    assert entry is not None
     entry["ended_at"] = now - game_log.GAME_SESSION_DEBUG_RETAINED_SESSION_TTL_SECONDS - 1
     entry["updated_at"] = entry["ended_at"]
 

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -207,19 +207,34 @@ async def test_game_debug_log_ingest_does_not_preserve_from_false_or_no_truncate
 
 
 @pytest.mark.unit
-def test_game_debug_logs_do_not_drop_ended_sessions_when_new_sessions_open():
-    for index in range(14):
+def test_game_debug_logs_keep_latest_completed_session_until_next_active_session():
+    for index in range(3):
         session_id = f"soccer-old-{index}"
         game_log.mark_game_session_debug_log_active("soccer", session_id, lanlan_name="Lan")
         game_log.mark_game_session_debug_log_ended("soccer", session_id, lanlan_name="Lan", reason="test")
+
+    summaries_before_new_session = game_log.list_game_session_debug_log_summaries("soccer")
+    assert {item["session_id"] for item in summaries_before_new_session} == {"soccer-old-2"}
 
     game_log.mark_game_session_debug_log_active("soccer", "soccer-new", lanlan_name="Lan")
     summaries = game_log.list_game_session_debug_log_summaries("soccer")
 
     session_ids = {item["session_id"] for item in summaries}
-    assert "soccer-old-0" in session_ids
-    assert "soccer-old-13" in session_ids
-    assert "soccer-new" in session_ids
+    assert session_ids == {"soccer-new"}
+
+
+@pytest.mark.unit
+def test_game_debug_logs_drop_completed_session_after_retention_ttl():
+    now = 1_000_000.0
+    game_log.mark_game_session_debug_log_active("soccer", "soccer-old", lanlan_name="Lan")
+    game_log.mark_game_session_debug_log_ended("soccer", "soccer-old", lanlan_name="Lan", reason="test")
+    entry = game_log.find_game_session_debug_log("soccer-old", "soccer")
+    entry["ended_at"] = now - game_log.GAME_SESSION_DEBUG_RETAINED_SESSION_TTL_SECONDS - 1
+    entry["updated_at"] = entry["ended_at"]
+
+    game_log.cleanup_game_session_debug_logs(now)
+
+    assert game_log.find_game_session_debug_log("soccer-old", "soccer") is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -235,6 +235,19 @@ def test_game_debug_logs_drop_ended_session_when_active_session_exists():
 
 
 @pytest.mark.unit
+def test_game_debug_logs_retention_is_not_partitioned_by_type_or_lanlan():
+    game_log.mark_game_session_debug_log_active("soccer", "soccer-old", lanlan_name="LanA")
+    game_log.mark_game_session_debug_log_ended("soccer", "soccer-old", lanlan_name="LanA", reason="test")
+
+    assert game_log.find_game_session_debug_log("soccer-old", "soccer") is not None
+
+    game_log.mark_game_session_debug_log_active("badminton", "badminton-new", lanlan_name="LanB")
+
+    assert game_log.find_game_session_debug_log("soccer-old", "soccer") is None
+    assert {item["session_id"] for item in game_log.list_game_session_debug_log_summaries()} == {"badminton-new"}
+
+
+@pytest.mark.unit
 def test_game_debug_logs_drop_completed_session_after_retention_ttl():
     now = 1_000_000.0
     game_log.mark_game_session_debug_log_active("soccer", "soccer-old", lanlan_name="Lan")

--- a/utils/game_log.py
+++ b/utils/game_log.py
@@ -156,6 +156,7 @@ def _get_or_create_game_session_debug_log(
         if activate:
             entry["status"] = "active"
             entry["ended_at"] = None
+            _drop_completed_game_session_debug_logs()
     return entry
 
 
@@ -163,10 +164,16 @@ def cleanup_game_session_debug_logs(now: float | None = None) -> None:
     current_time = time.time() if now is None else float(now)
     retained_keys: set[str] = set()
     completed_entries: list[dict] = []
+    has_active_session = False
     for entry in _game_session_debug_logs.values():
         if entry.get("status") == "active":
+            has_active_session = True
             continue
         completed_entries.append(entry)
+
+    if has_active_session:
+        _drop_completed_game_session_debug_logs()
+        return
 
     completed_entries.sort(
         key=lambda entry: float(entry.get("ended_at") or entry.get("updated_at") or entry.get("created_at") or 0.0),

--- a/utils/game_log.py
+++ b/utils/game_log.py
@@ -35,6 +35,11 @@ from typing import Any
 GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT = 1000
 GAME_SESSION_DEBUG_RETAINED_SESSION_LIMIT = 1
 GAME_SESSION_DEBUG_RETAINED_SESSION_TTL_SECONDS = 5 * 60
+# Retention is scoped to the single current mini-game scene for this process.
+# game_type and lanlan_name are diagnostic/filter metadata, not retention keys:
+# a new active scene intentionally clears completed logs from other game types
+# or characters. A future multi-scene log pool should introduce an explicit
+# scene/scope id instead of reusing these metadata fields.
 _GAME_SESSION_DEBUG_MESSAGE_LIMIT = 1200
 _GAME_SESSION_DEBUG_STRING_LIMIT = 2000
 _GAME_SESSION_DEBUG_DICT_LIMIT = 48

--- a/utils/game_log.py
+++ b/utils/game_log.py
@@ -33,6 +33,8 @@ from datetime import datetime
 from typing import Any
 
 GAME_SESSION_DEBUG_LOG_ENTRY_LIMIT = 1000
+GAME_SESSION_DEBUG_RETAINED_SESSION_LIMIT = 1
+GAME_SESSION_DEBUG_RETAINED_SESSION_TTL_SECONDS = 5 * 60
 _GAME_SESSION_DEBUG_MESSAGE_LIMIT = 1200
 _GAME_SESSION_DEBUG_STRING_LIMIT = 2000
 _GAME_SESSION_DEBUG_DICT_LIMIT = 48
@@ -64,6 +66,7 @@ def _find_game_session_debug_log(session_id: Any, game_type: Any = "") -> dict |
 
 
 def find_game_session_debug_log(session_id: Any, game_type: Any = "") -> dict | None:
+    cleanup_game_session_debug_logs()
     return _find_game_session_debug_log(session_id, game_type)
 
 
@@ -105,6 +108,12 @@ def _game_debug_log_time(ts: float) -> str:
         return ""
 
 
+def _drop_completed_game_session_debug_logs() -> None:
+    for key, entry in list(_game_session_debug_logs.items()):
+        if entry.get("status") != "active":
+            del _game_session_debug_logs[key]
+
+
 def _get_or_create_game_session_debug_log(
     game_type: Any,
     session_id: Any,
@@ -137,6 +146,8 @@ def _get_or_create_game_session_debug_log(
             "entries": [],
         }
         _game_session_debug_logs[key] = entry
+        if activate:
+            _drop_completed_game_session_debug_logs()
     else:
         _game_session_debug_logs.move_to_end(key)
         entry["updated_at"] = now
@@ -149,8 +160,28 @@ def _get_or_create_game_session_debug_log(
 
 
 def cleanup_game_session_debug_logs(now: float | None = None) -> None:
-    # 用户要求旧场次留在内存中用于对比；这里只保留函数入口，便于以后接入手动清理。
-    return None
+    current_time = time.time() if now is None else float(now)
+    retained_keys: set[str] = set()
+    completed_entries: list[dict] = []
+    for entry in _game_session_debug_logs.values():
+        if entry.get("status") == "active":
+            continue
+        completed_entries.append(entry)
+
+    completed_entries.sort(
+        key=lambda entry: float(entry.get("ended_at") or entry.get("updated_at") or entry.get("created_at") or 0.0),
+        reverse=True,
+    )
+    for entry in completed_entries[:GAME_SESSION_DEBUG_RETAINED_SESSION_LIMIT]:
+        reference_time = float(entry.get("ended_at") or entry.get("updated_at") or entry.get("created_at") or 0.0)
+        if reference_time and current_time - reference_time <= GAME_SESSION_DEBUG_RETAINED_SESSION_TTL_SECONDS:
+            retained_keys.add(str(entry.get("key") or ""))
+
+    for key, entry in list(_game_session_debug_logs.items()):
+        if entry.get("status") == "active":
+            continue
+        if key not in retained_keys:
+            del _game_session_debug_logs[key]
 
 
 def append_game_session_debug_log(


### PR DESCRIPTION
## Summary
- keep mini-game diagnostics scoped to the current active scene
- retain only the latest completed/open session for five minutes when no new active scene has started
- drop completed/open sessions as soon as a new active session starts
- expose the retention policy from `/api/game/logs`

## 回归报告 / Regression Report
- Targeted game router pytest: 6 passed, 164 deselected, 2 warnings
- Ruff check on `main_routers/game_router.py`, `utils/game_log.py`, and `tests/unit/test_game_router.py`: passed; existing invalid `# noqa` warnings remain in `main_routers/game_router.py`
- `git diff --check`: passed

## 不拆分理由 / Why Not Split
- This is a single retention-policy fix spanning the in-memory buffer, the retention metadata endpoint, and the matching regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进游戏会话调试日志的保留与清理策略：依据 TTL 与保留上限进行过期条目淘汰；当存在活动会话时，已结束日志会被直接丢弃。
  * 更新 `/api/game/logs` 的返回内容：新增保留上限与 TTL 相关字段，移除旧的清理字段。

* **Tests**
  * 重构并细化单元测试，覆盖保留/清理规则、跨分区不串扰以及超 TTL 后的移除断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->