### PR TITLE
fix(chat): harden voice start failure recovery

### DIFF
--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -979,10 +979,23 @@
             console.error(window.t('console.getMicrophonePermissionFailed'), err);
             window.showStatusToast(window.t ? window.t('app.micAccessDenied') : '无法访问麦克风', 4000);
 
-            // 麦克风层只撤销本地录音态；语音会话和 composer 由外层启动生命周期统一收口。
+            const hasOuterVoiceStartLifecycle = !!(S.voiceStartPending || window.isMicStarting);
+
             if (_mic) {
                 _mic.classList.remove('recording');
                 _mic.classList.remove('active');
+            }
+            if (!hasOuterVoiceStartLifecycle) {
+                S.isRecording = false;
+                window.isRecording = false;
+                S.voiceChatActive = false;
+                const textInputArea = document.getElementById('text-input-area');
+                if (textInputArea) {
+                    textInputArea.classList.remove('hidden');
+                }
+                if (typeof window.syncVoiceChatComposerHidden === 'function') {
+                    window.syncVoiceChatComposerHidden(false);
+                }
             }
             stopGameVoiceSttGate({ restoreOrdinaryMic: false });
             throw err;

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -979,17 +979,7 @@
             console.error(window.t('console.getMicrophonePermissionFailed'), err);
             window.showStatusToast(window.t ? window.t('app.micAccessDenied') : '无法访问麦克风', 4000);
 
-            // 失败时恢复文本输入区
-            S.voiceChatActive = false;
-            const textInputArea = document.getElementById('text-input-area');
-            if (textInputArea) {
-                textInputArea.classList.remove('hidden');
-            }
-            if (typeof window.syncVoiceChatComposerHidden === 'function') {
-                window.syncVoiceChatComposerHidden(false);
-            }
-
-            // 失败时移除录音状态类
+            // 麦克风层只撤销本地录音态；语音会话和 composer 由外层启动生命周期统一收口。
             if (_mic) {
                 _mic.classList.remove('recording');
                 _mic.classList.remove('active');

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -4209,13 +4209,18 @@
                 if (S.isRecording) {
                     return;
                 }
+                if (S.voiceStartPending || window.isMicStarting) {
+                    return;
+                }
                 if (!micButton.classList.contains('active')) {
                     micButton.click();
                     return;
                 }
-                if (typeof window.startMicCapture === 'function') {
-                    await window.startMicCapture();
-                }
+                micButton.classList.remove('active');
+                micButton.classList.remove('recording');
+                micButton.disabled = false;
+                micButton.click();
+                return;
             } else {
                 if (!S.isRecording) {
                     return;

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -24,11 +25,42 @@ def _js_function_block(source: str, function_name: str) -> str:
     if brace < 0:
         raise AssertionError(f"missing opening brace for JS function {function_name}")
 
+    end = _balanced_js_block_end(source, brace)
+    return source[start : end + 1]
+
+
+def _balanced_js_block_end(source: str, brace: int) -> int:
     depth = 0
     quote: str | None = None
     escaped = False
-    for index in range(brace, len(source)):
+    line_comment = False
+    block_comment = False
+    regex_literal = False
+    regex_char_class = False
+    previous_significant: str | None = None
+
+    def can_start_regex(previous: str | None) -> bool:
+        return previous is None or previous in "({[=,:;!&|?+-*~^<>"
+
+    index = brace
+    while index < len(source):
         char = source[index]
+        next_char = source[index + 1] if index + 1 < len(source) else ""
+
+        if line_comment:
+            if char in "\r\n":
+                line_comment = False
+            index += 1
+            continue
+
+        if block_comment:
+            if char == "*" and next_char == "/":
+                block_comment = False
+                index += 2
+                continue
+            index += 1
+            continue
+
         if quote:
             if escaped:
                 escaped = False
@@ -36,27 +68,84 @@ def _js_function_block(source: str, function_name: str) -> str:
                 escaped = True
             elif char == quote:
                 quote = None
+            index += 1
+            continue
+
+        if regex_literal:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == "[":
+                regex_char_class = True
+            elif char == "]":
+                regex_char_class = False
+            elif char == "/" and not regex_char_class:
+                regex_literal = False
+                previous_significant = "/"
+            index += 1
+            continue
+
+        if char == "/" and next_char == "/":
+            line_comment = True
+            index += 2
+            continue
+        if char == "/" and next_char == "*":
+            block_comment = True
+            index += 2
+            continue
+        if char == "/" and can_start_regex(previous_significant):
+            regex_literal = True
+            index += 1
             continue
         if char in {"'", '"', "`"}:
             quote = char
+            index += 1
             continue
         if char == "{":
             depth += 1
+            previous_significant = char
         elif char == "}":
             depth -= 1
+            previous_significant = char
             if depth == 0:
-                return source[start : index + 1]
-    raise AssertionError(f"unterminated JS function {function_name}")
+                return index
+        elif not char.isspace():
+            previous_significant = char
+        index += 1
+    raise AssertionError("unterminated JS block")
 
 
 def _catch_block_after(source: str, marker: str) -> str:
     start = source.find(marker)
     if start < 0:
         raise AssertionError(f"missing marker {marker!r}")
-    catch_start = source.find("catch (err) {", start)
-    if catch_start < 0:
+    match = re.search(r"\bcatch\s*\([^)]*\)\s*\{", source[start:])
+    if not match:
         raise AssertionError(f"missing catch block after {marker!r}")
-    return source[catch_start:].split("throw err;", 1)[0]
+    catch_start = start + match.start()
+    brace = source.find("{", catch_start)
+    return source[catch_start : _balanced_js_block_end(source, brace) + 1]
+
+
+def _event_listener_block(source: str, event_name: str) -> str:
+    marker = f"window.addEventListener('{event_name}'"
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing event listener {event_name}")
+    brace = source.find("{", start)
+    if brace < 0:
+        raise AssertionError(f"missing event listener body for {event_name}")
+    return source[start : _balanced_js_block_end(source, brace) + 1]
+
+
+def _mic_button_start_flow(source: str) -> str:
+    marker = "micButton.addEventListener('click', async function () {"
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError("missing mic button click listener")
+    brace = source.find("{", start)
+    return source[start : _balanced_js_block_end(source, brace) + 1]
 
 
 def _run_floating_mic_toggle_scenario(script_body: str) -> dict:
@@ -179,27 +268,29 @@ runScenario()
     return json.loads(result.stdout)
 
 
-def test_mic_capture_failure_does_not_own_voice_lifecycle_or_composer_restore():
+def test_mic_capture_failure_restores_composer_without_outer_voice_start_lifecycle():
     source = _read(APP_AUDIO_CAPTURE_PATH)
     start_mic = _js_function_block(source, "startMicCapture")
     failure = _catch_block_after(start_mic, "S.stream = await navigator.mediaDevices.getUserMedia(constraints);")
 
-    assert "window.syncVoiceChatComposerHidden(false)" not in failure
-    assert "textInputArea.classList.remove('hidden')" not in failure
     assert "S.voiceStartPending = false;" not in failure
     assert "window.isMicStarting = false;" not in failure
-    assert "S.voiceChatActive = false;" not in failure
-    assert "S.isRecording = false;" not in failure
-    assert "window.isRecording = false;" not in failure
+    assert "const hasOuterVoiceStartLifecycle = !!(S.voiceStartPending || window.isMicStarting);" in failure
+    restore_start = failure.index("if (!hasOuterVoiceStartLifecycle) {")
+    throw_index = failure.index("throw err;")
+    restore_block = failure[restore_start:throw_index]
+    assert "S.isRecording = false;" in restore_block
+    assert "window.isRecording = false;" in restore_block
+    assert "S.voiceChatActive = false;" in restore_block
+    assert "textInputArea.classList.remove('hidden')" in restore_block
+    assert "window.syncVoiceChatComposerHidden(false)" in restore_block
     assert "stopGameVoiceSttGate({ restoreOrdinaryMic: false });" in failure
+    assert failure.index("stopGameVoiceSttGate({ restoreOrdinaryMic: false });") < throw_index
 
 
 def test_outer_voice_start_failure_clears_pending_flags_before_composer_restore():
     source = _read(APP_BUTTONS_PATH)
-    start_flow = source.split("micButton.addEventListener('click', async function () {", 1)[1].split(
-        "// ----------------------------------------------------------------\n        // Screen button click",
-        1,
-    )[0]
+    start_flow = _mic_button_start_flow(source)
     failure = start_flow.split("} catch (error) {", 1)[1].split("screenButton.classList.remove('active');", 1)[0]
 
     sync_call = "window.syncVoiceChatComposerHidden(preserveGoodbyeUi);"
@@ -217,10 +308,7 @@ def test_outer_voice_start_failure_clears_pending_flags_before_composer_restore(
 def test_floating_mic_stale_active_state_reenters_main_voice_start_lifecycle():
     source = _read(APP_UI_PATH)
     listeners = _js_function_block(source, "initFloatingButtonListeners")
-    mic_toggle = listeners.split("window.addEventListener('live2d-mic-toggle'", 1)[1].split(
-        "// 屏幕分享按钮（toggle模式）",
-        1,
-    )[0]
+    mic_toggle = _event_listener_block(listeners, "live2d-mic-toggle")
 
     assert "micButton.click();" in mic_toggle
     pending_guard = "if (S.voiceStartPending || window.isMicStarting) {"

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -1,0 +1,315 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+APP_AUDIO_CAPTURE_PATH = PROJECT_ROOT / "static" / "app-audio-capture.js"
+APP_BUTTONS_PATH = PROJECT_ROOT / "static" / "app-buttons.js"
+APP_UI_PATH = PROJECT_ROOT / "static" / "app-ui.js"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _js_function_block(source: str, function_name: str) -> str:
+    marker = f"function {function_name}("
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing JS function {function_name}")
+    brace = source.find("{", start)
+    if brace < 0:
+        raise AssertionError(f"missing opening brace for JS function {function_name}")
+
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index in range(brace, len(source)):
+        char = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated JS function {function_name}")
+
+
+def _catch_block_after(source: str, marker: str) -> str:
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing marker {marker!r}")
+    catch_start = source.find("catch (err) {", start)
+    if catch_start < 0:
+        raise AssertionError(f"missing catch block after {marker!r}")
+    return source[catch_start:].split("throw err;", 1)[0]
+
+
+def _run_floating_mic_toggle_scenario(script_body: str) -> dict:
+    node_executable = shutil.which("node")
+    if node_executable is None:
+        pytest.skip("node not found")
+
+    listeners = _js_function_block(_read(APP_UI_PATH), "initFloatingButtonListeners")
+    node_harness = f"""
+const assert = require('assert');
+const vm = require('vm');
+
+class FakeClassList {{
+  constructor() {{
+    this.names = new Set();
+  }}
+  add(...names) {{
+    for (const name of names) this.names.add(String(name));
+  }}
+  remove(...names) {{
+    for (const name of names) this.names.delete(String(name));
+  }}
+  contains(name) {{
+    return this.names.has(String(name));
+  }}
+  toArray() {{
+    return Array.from(this.names).sort();
+  }}
+}}
+
+class FakeButton {{
+  constructor() {{
+    this.classList = new FakeClassList();
+    this.disabled = false;
+    this.clickCount = 0;
+  }}
+  click() {{
+    this.clickCount += 1;
+  }}
+}}
+
+const micButton = new FakeButton();
+const stopCalls = [];
+
+global.window = {{
+  appState: {{
+    dom: {{
+      micButton,
+      screenButton: new FakeButton(),
+      resetSessionButton: new FakeButton(),
+      muteButton: new FakeButton(),
+      stopButton: new FakeButton(),
+      textSendButton: new FakeButton(),
+      textInputBox: {{}},
+      screenshotButton: new FakeButton(),
+    }},
+    isRecording: false,
+    voiceStartPending: false,
+  }},
+  _listeners: new Map(),
+  isMicStarting: false,
+  addEventListener(type, handler) {{
+    const handlers = this._listeners.get(type) || [];
+    handlers.push(handler);
+    this._listeners.set(type, handlers);
+  }},
+  async dispatchMicToggle(active) {{
+    const handlers = this._listeners.get('live2d-mic-toggle') || [];
+    for (const handler of handlers) {{
+      await handler({{ detail: {{ active }} }});
+    }}
+  }},
+  stopMicCapture: async function () {{
+    stopCalls.push('stop');
+  }},
+  startMicCapture: async function () {{
+    throw new Error('floating mic toggle must not call startMicCapture directly');
+  }},
+}};
+
+const S = window.appState;
+vm.runInThisContext({json.dumps(listeners)}, {{ filename: 'initFloatingButtonListeners.js' }});
+initFloatingButtonListeners();
+
+async function runScenario() {{
+{script_body}
+}}
+
+runScenario()
+  .then((result) => {{
+    process.stdout.write(JSON.stringify({{
+      result,
+      mic: {{
+        clicks: micButton.clickCount,
+        disabled: micButton.disabled,
+        classes: micButton.classList.toArray(),
+      }},
+      stopCalls,
+    }}));
+  }})
+  .catch((error) => {{
+    process.stderr.write(String(error && error.stack ? error.stack : error));
+    process.exit(1);
+  }});
+"""
+
+    result = subprocess.run(
+        [node_executable, "-"],
+        input=node_harness,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "Node floating mic toggle scenario failed:\n"
+            f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def test_mic_capture_failure_does_not_own_voice_lifecycle_or_composer_restore():
+    source = _read(APP_AUDIO_CAPTURE_PATH)
+    start_mic = _js_function_block(source, "startMicCapture")
+    failure = _catch_block_after(start_mic, "S.stream = await navigator.mediaDevices.getUserMedia(constraints);")
+
+    assert "window.syncVoiceChatComposerHidden(false)" not in failure
+    assert "textInputArea.classList.remove('hidden')" not in failure
+    assert "S.voiceStartPending = false;" not in failure
+    assert "window.isMicStarting = false;" not in failure
+    assert "S.voiceChatActive = false;" not in failure
+    assert "S.isRecording = false;" not in failure
+    assert "window.isRecording = false;" not in failure
+    assert "stopGameVoiceSttGate({ restoreOrdinaryMic: false });" in failure
+
+
+def test_outer_voice_start_failure_clears_pending_flags_before_composer_restore():
+    source = _read(APP_BUTTONS_PATH)
+    start_flow = source.split("micButton.addEventListener('click', async function () {", 1)[1].split(
+        "// ----------------------------------------------------------------\n        // Screen button click",
+        1,
+    )[0]
+    failure = start_flow.split("} catch (error) {", 1)[1].split("screenButton.classList.remove('active');", 1)[0]
+
+    sync_call = "window.syncVoiceChatComposerHidden(preserveGoodbyeUi);"
+    assert "S.voiceStartPending = false;" in failure
+    assert "window.isMicStarting = false;" in failure
+    assert "S.voiceChatActive = false;" in failure
+    assert "S.isRecording = false;" in failure
+    assert "window.isRecording = false;" in failure
+    assert sync_call in failure
+    assert failure.index("S.voiceStartPending = false;") < failure.index(sync_call)
+    assert failure.index("window.isMicStarting = false;") < failure.index(sync_call)
+    assert failure.index("S.voiceChatActive = false;") < failure.index(sync_call)
+
+
+def test_floating_mic_stale_active_state_reenters_main_voice_start_lifecycle():
+    source = _read(APP_UI_PATH)
+    listeners = _js_function_block(source, "initFloatingButtonListeners")
+    mic_toggle = listeners.split("window.addEventListener('live2d-mic-toggle'", 1)[1].split(
+        "// 屏幕分享按钮（toggle模式）",
+        1,
+    )[0]
+
+    assert "micButton.click();" in mic_toggle
+    pending_guard = "if (S.voiceStartPending || window.isMicStarting) {"
+    stale_cleanup = "micButton.classList.remove('active');"
+    assert pending_guard in mic_toggle
+    assert mic_toggle.index(pending_guard) < mic_toggle.index(stale_cleanup)
+    assert "micButton.classList.remove('active');" in mic_toggle
+    assert "micButton.classList.remove('recording');" in mic_toggle
+    assert "micButton.disabled = false;" in mic_toggle
+    assert "window.startMicCapture()" not in mic_toggle
+
+
+@pytest.mark.parametrize(
+    ("name", "script_body", "expected"),
+    [
+        (
+            "idle active click enters the main mic lifecycle",
+            """
+    await window.dispatchMicToggle(true);
+    return {};
+            """,
+            {"clicks": 1, "disabled": False, "classes": [], "stopCalls": []},
+        ),
+        (
+            "recording active click is ignored",
+            """
+    S.isRecording = true;
+    micButton.classList.add('active', 'recording');
+    await window.dispatchMicToggle(true);
+    return {};
+            """,
+            {"clicks": 0, "disabled": False, "classes": ["active", "recording"], "stopCalls": []},
+        ),
+        (
+            "pending voice start active click does not restart or clean active state",
+            """
+    S.voiceStartPending = true;
+    micButton.disabled = true;
+    micButton.classList.add('active');
+    await window.dispatchMicToggle(true);
+    return {};
+            """,
+            {"clicks": 0, "disabled": True, "classes": ["active"], "stopCalls": []},
+        ),
+        (
+            "mic starting active click does not restart or clean active state",
+            """
+    window.isMicStarting = true;
+    micButton.disabled = true;
+    micButton.classList.add('active');
+    await window.dispatchMicToggle(true);
+    return {};
+            """,
+            {"clicks": 0, "disabled": True, "classes": ["active"], "stopCalls": []},
+        ),
+        (
+            "stale active failed start is normalized before re-entering main lifecycle",
+            """
+    micButton.disabled = true;
+    micButton.classList.add('active', 'recording');
+    await window.dispatchMicToggle(true);
+    return {};
+            """,
+            {"clicks": 1, "disabled": False, "classes": [], "stopCalls": []},
+        ),
+        (
+            "inactive toggle during recording stops mic capture",
+            """
+    S.isRecording = true;
+    micButton.classList.add('active', 'recording');
+    await window.dispatchMicToggle(false);
+    return {};
+            """,
+            {"clicks": 0, "disabled": False, "classes": ["active", "recording"], "stopCalls": ["stop"]},
+        ),
+        (
+            "inactive toggle while already stopped is ignored",
+            """
+    await window.dispatchMicToggle(false);
+    return {};
+            """,
+            {"clicks": 0, "disabled": False, "classes": [], "stopCalls": []},
+        ),
+    ],
+)
+def test_floating_mic_toggle_actual_state_matrix(name, script_body, expected):
+    result = _run_floating_mic_toggle_scenario(script_body)
+
+    assert result["mic"]["clicks"] == expected["clicks"], name
+    assert result["mic"]["disabled"] is expected["disabled"], name
+    assert result["mic"]["classes"] == expected["classes"], name
+    assert result["stopCalls"] == expected["stopCalls"], name

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -40,7 +40,7 @@ def _balanced_js_block_end(source: str, brace: int) -> int:
     previous_significant: str | None = None
 
     def can_start_regex(previous: str | None) -> bool:
-        return previous is None or previous in "({[=,:;!&|?+-*~^<>"
+        return previous is None or previous in "({[=,:;!&|?~^<>"
 
     index = brace
     while index < len(source):
@@ -68,6 +68,7 @@ def _balanced_js_block_end(source: str, brace: int) -> int:
                 escaped = True
             elif char == quote:
                 quote = None
+                previous_significant = "operand"
             index += 1
             continue
 
@@ -291,7 +292,12 @@ def test_mic_capture_failure_restores_composer_without_outer_voice_start_lifecyc
 def test_outer_voice_start_failure_clears_pending_flags_before_composer_restore():
     source = _read(APP_BUTTONS_PATH)
     start_flow = _mic_button_start_flow(source)
-    failure = start_flow.split("} catch (error) {", 1)[1].split("screenButton.classList.remove('active');", 1)[0]
+    catch_split = start_flow.split("} catch (error) {", 1)
+    assert len(catch_split) == 2, "missing outer catch in mic button start flow"
+    cleanup_marker = "screenButton.classList.remove('active');"
+    cleanup_split = catch_split[1].split(cleanup_marker, 1)
+    assert len(cleanup_split) == 2, "missing screen button cleanup in mic button failure flow"
+    failure = cleanup_split[0]
 
     sync_call = "window.syncVoiceChatComposerHidden(preserveGoodbyeUi);"
     assert "S.voiceStartPending = false;" in failure


### PR DESCRIPTION
## 改动概述 / Summary

修复角色右侧语音对话按钮在启动失败后可能遗留错误状态的问题。

本次改动将失败恢复边界收口到原有语音启动生命周期中：

- `startMicCapture()` 失败时只清理麦克风本地录音态，不再直接恢复 composer 或改写全局语音会话状态。
- 右侧浮动语音按钮不再绕过主按钮生命周期直接调用 `startMicCapture()`。
- 启动中重复触发会被忽略，避免多次失败/重复点击导致状态重入。
- 失败后若按钮残留 `active/recording/disabled`，会先归一化按钮状态，再重新走主语音按钮入口。
- 新增语音启动失败和浮动按钮状态矩阵测试，覆盖实际可能出现的失败与重入场景。

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `.venv/bin/python -m pytest -q tests/unit/test_voice_start_failure_static.py tests/unit/test_avatar_drop_frontend_static.py tests/unit/test_react_chat_window_static.py::test_compact_history_drop_payload_suppresses_real_send_in_voice_mode_only_at_host_send_boundary tests/unit/test_auto_goodbye_goodbye_return_contract.py`
- `node --check static/app-audio-capture.js`
- `node --check static/app-ui.js`
- `node --check static/app-buttons.js`
- `git diff --check`

覆盖场景：

- 空闲时点击右侧语音按钮会进入主语音按钮生命周期。
- 已录音时重复 active 不会重复启动。
- `S.voiceStartPending` 启动中重复 active 不会重启或清理启动态。
- `window.isMicStarting` 启动中重复 active 不会重启或清理启动态。
- 麦克风启动失败后残留按钮状态会先归一化，再重走主入口。
- 录音中 inactive 会正常调用停止录音链路。
- 已停止 inactive 会被忽略。
- 底层麦克风失败不再直接接管 composer/global voice lifecycle。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化麦克风/语音启动失败后的界面与状态恢复：仅在非并发启动过程中才回退文本输入区与语音合成显示，并清空语音激活状态；随后仍会正确停止语音 STT 并抛出错误。
  * 改善浮动麦克风按钮的失败恢复流程，避免与外层启动生命周期状态发生冲突。

* **测试**
  * 新增语音启动失败与浮动麦克风重入场景单元测试，覆盖 UI/状态清理、停止调用与按钮触发次数/可用性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->