### PR TITLE
fix: 固定新手教程胶囊聊天框布局

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -160,8 +160,6 @@
         return (message && message.bypassDedup === true)
             || action === 'yui_guide_set_chat_spotlight'
             || action === 'yui_guide_set_chat_cursor'
-            || action === 'yui_guide_drag_chat_cursor'
-            || action === 'yui_guide_arc_chat_cursor'
             || action === 'yui_guide_rotate_compact_tool_wheel'
             || action === 'yui_guide_set_chat_buttons_disabled'
             || action === 'yui_guide_set_chat_input_locked'

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -160,9 +160,12 @@
         return (message && message.bypassDedup === true)
             || action === 'yui_guide_set_chat_spotlight'
             || action === 'yui_guide_set_chat_cursor'
+            || action === 'yui_guide_drag_chat_cursor'
+            || action === 'yui_guide_arc_chat_cursor'
             || action === 'yui_guide_rotate_compact_tool_wheel'
             || action === 'yui_guide_set_chat_buttons_disabled'
             || action === 'yui_guide_set_chat_input_locked'
+            || action === 'yui_guide_set_compact_chat_fixed_layout'
             || action === 'yui_guide_set_compact_history_open'
             || action === 'yui_guide_set_avatar_tool_menu_open'
             || action === 'yui_guide_set_compact_tool_fan_open'
@@ -2801,6 +2804,11 @@
                 applyYuiGuideChatInputLocked(message.locked === true, message.reason || '');
                 return true;
             }
+            case 'yui_guide_set_compact_chat_fixed_layout': {
+                if (!isStandaloneChatPage()) return true;
+                applyYuiGuideCompactChatFixedLayout(message.fixed === true);
+                return true;
+            }
             case 'yui_guide_set_chat_spotlight': {
                 if (!isStandaloneChatPage() || !document.body) return true;
                 ensureYuiGuideExternalChatExpanded();
@@ -3222,6 +3230,11 @@
                         applyYuiGuideChatInputLocked(event.data.locked === true, event.data.reason || '');
                         break;
                     }
+                    case 'yui_guide_set_compact_chat_fixed_layout': {
+                        if (!isStandaloneChatPage() || !document.body) break;
+                        applyYuiGuideCompactChatFixedLayout(event.data.fixed === true);
+                        break;
+                    }
                     case 'yui_guide_set_chat_cursor':
                     case 'yui_guide_drag_chat_cursor':
                     case 'yui_guide_arc_chat_cursor': {
@@ -3553,6 +3566,13 @@
         if (host && typeof host.setHomeTutorialInputLocked === 'function') {
             host.setHomeTutorialInputLocked(locked === true, reason || 'externalized-chat-guide');
         }
+    }
+
+    function applyYuiGuideCompactChatFixedLayout(fixed) {
+        if (!document.body) {
+            return;
+        }
+        document.body.classList.toggle('yui-guide-compact-chat-fixed', fixed === true);
     }
 
     function applyYuiGuideCompactHistoryOpen(open, reason) {
@@ -3946,6 +3966,7 @@
         switch (action) {
             case 'yui_guide_set_chat_buttons_disabled':
             case 'yui_guide_set_chat_input_locked':
+            case 'yui_guide_set_compact_chat_fixed_layout':
             case 'yui_guide_set_chat_spotlight':
             case 'yui_guide_set_chat_cursor':
             case 'yui_guide_drag_chat_cursor':
@@ -4931,6 +4952,7 @@
         });
         applyYuiGuideChatLockState(false);
         applyYuiGuideChatInputLocked(false, rawReason);
+        applyYuiGuideCompactChatFixedLayout(false);
         applyYuiGuideAvatarToolMenuOpen(false, rawReason);
         applyYuiGuideCompactHistoryOpen(false, rawReason);
         applyYuiGuideCompactToolFanOpen(false, rawReason);

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -3681,6 +3681,28 @@ body.react-chat-window-dragging {
     }
 }
 
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
+    left: clamp(24px, 6vw, 72px) !important;
+    top: min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) !important;
+    bottom: auto !important;
+    width: min(400px, calc(100vw - 32px)) !important;
+    transform: none !important;
+}
+
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {
+    left: calc(clamp(24px, 6vw, 72px) + 200px);
+}
+
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="above"] {
+    top: auto;
+    bottom: calc(100vh - min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) + 16px);
+}
+
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="below"] {
+    top: calc(min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) + var(--compact-surface-height, 58px) + 16px);
+    bottom: auto;
+}
+
 /* Agent HUD 空状态折叠按钮样式 */
 .collapse-button {
     background: rgba(68, 183, 254, 0.12);

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -3681,7 +3681,7 @@ body.react-chat-window-dragging {
     }
 }
 
-body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.neko-electron-runtime) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
     left: clamp(24px, 6vw, 72px) !important;
     top: min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) !important;
     bottom: auto !important;
@@ -3689,16 +3689,16 @@ body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) #
     transform: none !important;
 }
 
-body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.neko-electron-runtime) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {
     left: calc(clamp(24px, 6vw, 72px) + 200px);
 }
 
-body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="above"] {
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.neko-electron-runtime) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="above"] {
     top: auto;
     bottom: calc(100vh - min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) + 16px);
 }
 
-body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="below"] {
+body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.neko-electron-runtime) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"][data-compact-choice-placement="below"] {
     top: calc(min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) + var(--compact-surface-height, 58px) + 16px);
     bottom: auto;
 }

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -435,6 +435,62 @@
         tutorialResetBtn.disabled = selection.type !== 'page' && selection.type !== 'home-day' && selection.type !== 'home-all';
     }
 
+    async function getTutorialPromptResetHeaders() {
+        const headers = { 'Content-Type': 'application/json' };
+        const helper = window.nekoLocalMutationSecurity;
+        if (helper && typeof helper.getMutationHeaders === 'function') {
+            try {
+                return Object.assign(headers, await helper.getMutationHeaders());
+            } catch (error) {
+                console.warn('[MemoryBrowser] 获取教程重置安全头失败，尝试页面配置:', error);
+            }
+        }
+
+        try {
+            const response = await fetch('/api/config/page_config', { cache: 'no-store' });
+            if (!response.ok) return headers;
+            const data = await response.json();
+            if (data && typeof data.autostart_csrf_token === 'string' && data.autostart_csrf_token) {
+                headers['X-CSRF-Token'] = data.autostart_csrf_token;
+            }
+        } catch (error) {
+            console.warn('[MemoryBrowser] 读取页面配置失败，继续使用基础教程重置请求头:', error);
+        }
+        return headers;
+    }
+
+    async function resetHomeTutorialPromptStateViaApi(reason) {
+        const normalizedReason = typeof reason === 'string' && reason.trim()
+            ? reason.trim()
+            : 'memory_browser_home_all_reset';
+        const body = JSON.stringify({ reason: normalizedReason });
+        const sendResetRequest = async () => fetch('/api/tutorial-prompt/reset', {
+            method: 'POST',
+            headers: await getTutorialPromptResetHeaders(),
+            body,
+        });
+
+        let response = await sendResetRequest();
+        if (response.status === 403 && window.nekoLocalMutationSecurity &&
+            typeof window.nekoLocalMutationSecurity.refreshToken === 'function') {
+            let shouldRetry = false;
+            try {
+                const payload = await response.clone().json();
+                shouldRetry = payload && payload.error_code === 'csrf_validation_failed';
+            } catch (_) {
+                shouldRetry = false;
+            }
+            if (shouldRetry) {
+                await window.nekoLocalMutationSecurity.refreshToken();
+                response = await sendResetRequest();
+            }
+        }
+        if (!response.ok) {
+            throw new Error('tutorial prompt reset failed: ' + response.status);
+        }
+        return response.json();
+    }
+
     async function resetSelectedTutorial() {
         const selection = resolveSelectedTutorialReset();
         if (selection.type === 'home-day') {
@@ -465,6 +521,8 @@
             }
             if (window.universalTutorialManager && typeof window.universalTutorialManager.resetHomeTutorialPromptState === 'function') {
                 await window.universalTutorialManager.resetHomeTutorialPromptState('memory_browser_home_all_reset');
+            } else {
+                await resetHomeTutorialPromptStateViaApi('memory_browser_home_all_reset');
             }
             alert(getTutorialHomeAllResetSuccessMessage());
             return;

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -305,6 +305,7 @@
     }
 
     let selectedTutorialDay = 0;
+    let selectedTutorialHomeAll = false;
 
     const TUTORIAL_CASCADER_PAGE_LABELS = {
         all: '全部页面',
@@ -333,7 +334,28 @@
         return translated && translated !== 'memory.tutorialHomeDayLabel' ? translated : fallback;
     }
 
+    function getTutorialHomeAllResetLabel() {
+        const fallback = '全部重置';
+        if (!window.t || typeof window.t !== 'function') {
+            return fallback;
+        }
+        const translated = window.t('memory.tutorialHomeAllReset', fallback);
+        return translated && translated !== 'memory.tutorialHomeAllReset' ? translated : fallback;
+    }
+
+    function getTutorialHomeAllResetSuccessMessage() {
+        const fallback = '已重置主页 7 天新手教程，请重新加载 Neko 后从第 1 天开始。';
+        if (!window.t || typeof window.t !== 'function') {
+            return fallback;
+        }
+        const translated = window.t('memory.tutorialHomeAllResetSuccess', fallback);
+        return translated && translated !== 'memory.tutorialHomeAllResetSuccess' ? translated : fallback;
+    }
+
     function refreshTutorialCascaderDayLabels() {
+        document.querySelectorAll('.tutorial-cascader-option[data-tutorial-home-all]').forEach(function (option) {
+            option.textContent = getTutorialHomeAllResetLabel();
+        });
         document.querySelectorAll('.tutorial-cascader-option[data-tutorial-day]').forEach(function (option) {
             const day = Number(option.dataset.tutorialDay || 0);
             if (day > 0) {
@@ -347,6 +369,12 @@
         const pageKey = tutorialSelect ? String(tutorialSelect.value || '') : '';
         if (pageKey !== 'home') {
             return { type: pageKey ? 'page' : '', pageKey: pageKey };
+        }
+        if (selectedTutorialHomeAll) {
+            return {
+                type: 'home-all',
+                pageKey: 'home'
+            };
         }
         return {
             type: selectedTutorialDay ? 'home-day' : '',
@@ -377,6 +405,7 @@
         const pageKey = String(tutorialSelect.value || '');
         if (pageKey !== 'home') {
             selectedTutorialDay = 0;
+            selectedTutorialHomeAll = false;
         }
         if (dayColumn) {
             dayColumn.hidden = pageKey !== 'home';
@@ -387,9 +416,14 @@
         document.querySelectorAll('.tutorial-cascader-option[data-tutorial-day]').forEach(function (option) {
             option.classList.toggle('is-selected', Number(option.dataset.tutorialDay) === selectedTutorialDay);
         });
+        document.querySelectorAll('.tutorial-cascader-option[data-tutorial-home-all]').forEach(function (option) {
+            option.classList.toggle('is-selected', selectedTutorialHomeAll);
+        });
         if (valueEl) {
             if (!pageKey) {
                 valueEl.textContent = getTutorialPageLabel('');
+            } else if (pageKey === 'home' && selectedTutorialHomeAll) {
+                valueEl.textContent = getTutorialPageLabel('home') + ' / ' + getTutorialHomeAllResetLabel();
             } else if (pageKey === 'home' && selectedTutorialDay) {
                 valueEl.textContent = getTutorialPageLabel('home') + ' / ' + getTutorialDayLabel(selectedTutorialDay);
             } else {
@@ -398,7 +432,7 @@
         }
 
         const selection = resolveSelectedTutorialReset();
-        tutorialResetBtn.disabled = selection.type !== 'page' && selection.type !== 'home-day';
+        tutorialResetBtn.disabled = selection.type !== 'page' && selection.type !== 'home-day' && selection.type !== 'home-all';
     }
 
     async function resetSelectedTutorial() {
@@ -417,6 +451,22 @@
                     source: 'memory_browser_reset_select',
                 });
             }
+            return;
+        }
+        if (selection.type === 'home-all') {
+            if (window.AvatarFloatingGuideReset && typeof window.AvatarFloatingGuideReset.resetAllAvatarFloatingGuideDays === 'function') {
+                await window.AvatarFloatingGuideReset.resetAllAvatarFloatingGuideDays({
+                    source: 'memory_browser_reset_home_all',
+                });
+            } else if (typeof window.resetAllAvatarFloatingGuideDays === 'function') {
+                await window.resetAllAvatarFloatingGuideDays({
+                    source: 'memory_browser_reset_home_all',
+                });
+            }
+            if (window.universalTutorialManager && typeof window.universalTutorialManager.resetHomeTutorialPromptState === 'function') {
+                await window.universalTutorialManager.resetHomeTutorialPromptState('memory_browser_home_all_reset');
+            }
+            alert(getTutorialHomeAllResetSuccessMessage());
             return;
         }
         if (selection.type === 'page' && typeof window.resetTutorialForPage === 'function') {
@@ -1472,13 +1522,23 @@
                         tutorialSelect.value = pageOption.dataset.tutorialPage || '';
                         if (tutorialSelect.value !== 'home') {
                             selectedTutorialDay = 0;
+                            selectedTutorialHomeAll = false;
                             setTutorialCascaderOpen(false);
                         }
                         syncTutorialResetCascader();
                         return;
                     }
+                    const homeAllOption = event.target.closest('[data-tutorial-home-all]');
+                    if (homeAllOption) {
+                        selectedTutorialHomeAll = true;
+                        selectedTutorialDay = 0;
+                        syncTutorialResetCascader();
+                        setTutorialCascaderOpen(false);
+                        return;
+                    }
                     const dayOption = event.target.closest('[data-tutorial-day]');
                     if (dayOption) {
+                        selectedTutorialHomeAll = false;
                         selectedTutorialDay = Number(dayOption.dataset.tutorialDay || 0);
                         syncTutorialResetCascader();
                         setTutorialCascaderOpen(false);

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "Tutorial for \"{{pageName}}\" has been reset. It will be shown again when you visit that page.",
         "tutorialHomeDayLabel": "Day {{day}}",
         "tutorialHomeDayColumn": "Home Seven-Day Tutorial",
+        "tutorialHomeAllReset": "Reset All",
+        "tutorialHomeAllResetSuccess": "Home seven-day tutorial has been reset. Reload Neko to start again from Day 1.",
         "refreshed": "Memory updated, new memory will be used in the next conversation",
         "refreshingContext": "Refreshing context...",
         "storageLocation": "Storage Location",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "Se ha restablecido el tutorial para \"{{pageName}}\". Se mostrará nuevamente cuando visite esa página.",
         "tutorialHomeDayLabel": "Día {{day}}",
         "tutorialHomeDayColumn": "Tutorial de siete días de la página de inicio",
+        "tutorialHomeAllReset": "Restablecer todo",
+        "tutorialHomeAllResetSuccess": "Se ha restablecido el tutorial de siete días de la página de inicio. Recarga Neko para empezar de nuevo desde el día 1.",
         "refreshed": "Memoria actualizada, la nueva memoria se utilizará en la próxima conversación.",
         "refreshingContext": "Actualizando contexto...",
         "storageLocation": "Ubicación de almacenamiento",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "「{{pageName}}」のチュートリアルがリセットされました。次回アクセス時に再度表示されます。",
         "tutorialHomeDayLabel": "{{day}}日目",
         "tutorialHomeDayColumn": "ホーム7日間チュートリアル",
+        "tutorialHomeAllReset": "すべてリセット",
+        "tutorialHomeAllResetSuccess": "ホームの7日間チュートリアルをリセットしました。Nekoを再読み込みすると1日目から始まります。",
         "refreshed": "メモリが更新されました。次回の会話から新しいメモリが使用されます",
         "refreshingContext": "コンテキストを更新中...",
         "storageLocation": "ストレージ位置",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "\"{{pageName}}\" 튜토리얼이 재설정되었습니다. 해당 페이지를 방문하면 다시 표시됩니다.",
         "tutorialHomeDayLabel": "{{day}}일차",
         "tutorialHomeDayColumn": "홈 7일 튜토리얼",
+        "tutorialHomeAllReset": "전체 재설정",
+        "tutorialHomeAllResetSuccess": "홈 7일 튜토리얼이 재설정되었습니다. Neko를 다시 로드하면 1일차부터 시작합니다.",
         "refreshed": "메모리가 업데이트되었습니다. 다음 대화에서 새 메모리가 사용됩니다",
         "refreshingContext": "컨텍스트 새로고침 중...",
         "storageLocation": "저장 위치",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "O tutorial para \"{{pageName}}\" foi redefinido. Ele será mostrado novamente quando você visitar essa página.",
         "tutorialHomeDayLabel": "Dia {{day}}",
         "tutorialHomeDayColumn": "Tutorial de sete dias da página inicial",
+        "tutorialHomeAllReset": "Redefinir tudo",
+        "tutorialHomeAllResetSuccess": "O tutorial de sete dias da página inicial foi redefinido. Recarregue o Neko para começar novamente a partir do dia 1.",
         "refreshed": "Memória atualizada, nova memória será usada na próxima conversa",
         "refreshingContext": "Atualizando contexto...",
         "storageLocation": "Local de armazenamento",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "Руководство для «{{pageName}}» сброшено.",
         "tutorialHomeDayLabel": "День {{day}}",
         "tutorialHomeDayColumn": "Семидневный туториал для главной страницы",
+        "tutorialHomeAllReset": "Сбросить все",
+        "tutorialHomeAllResetSuccess": "Семидневный туториал главной страницы сброшен. Перезагрузите Neko, чтобы начать снова с дня 1.",
         "refreshed": "Память обновлена, новая память будет использована в следующем разговоре",
         "refreshingContext": "Обновление контекста...",
         "storageLocation": "Расположение хранилища",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "已重置「{{pageName}}」的引导，下次进入该页面时将重新显示引导。",
         "tutorialHomeDayLabel": "第 {{day}} 天",
         "tutorialHomeDayColumn": "主页七日新手教程",
+        "tutorialHomeAllReset": "全部重置",
+        "tutorialHomeAllResetSuccess": "已重置主页 7 天新手教程，请重新加载 Neko 后从第 1 天开始。",
         "refreshed": "记忆已更新，下次对话将使用新记忆",
         "refreshingContext": "正在刷新上下文...",
         "storageLocation": "存储位置",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1787,6 +1787,8 @@
         "tutorialPageResetSuccessWithName": "已重置「{{pageName}}」的引導，下次進入該頁面時將重新顯示引導。",
         "tutorialHomeDayLabel": "第 {{day}} 天",
         "tutorialHomeDayColumn": "主頁七日新手教程",
+        "tutorialHomeAllReset": "全部重置",
+        "tutorialHomeAllResetSuccess": "已重置主頁 7 天新手教程，請重新載入 Neko 後從第 1 天開始。",
         "refreshed": "記憶已更新，下次對話將使用新記憶",
         "refreshingContext": "正在刷新上下文...",
         "storageLocation": "儲存位置",

--- a/static/tutorial/avatar/floating-guide-reset.js
+++ b/static/tutorial/avatar/floating-guide-reset.js
@@ -176,6 +176,7 @@
         const state = loadGuideState();
 
         resetAllIcebreakerDays();
+        state.firstSeenDate = getTodayLocalDate();
         state.completedRounds = [];
         state.skippedRounds = [];
         state.currentRound = null;

--- a/static/tutorial/core/interaction-takeover.js
+++ b/static/tutorial/core/interaction-takeover.js
@@ -467,6 +467,13 @@
             this.postExternalChatCommand('yui_guide_arc_chat_cursor', message);
         }
 
+        setExternalizedChatCompactFixedLayout(fixed, reason) {
+            this.postExternalChatCommand('yui_guide_set_compact_chat_fixed_layout', {
+                fixed: fixed === true,
+                reason: typeof reason === 'string' ? reason : ''
+            });
+        }
+
         clearExternalizedChatGuideMessages() {
             this.postExternalChatCommand('yui_guide_clear_chat_messages');
         }
@@ -487,6 +494,12 @@
             }
 
             this.setExternalizedChatButtonsDisabled(true);
+            if (
+                this.document.body
+                && this.document.body.classList.contains('yui-guide-compact-chat-fixed')
+            ) {
+                this.setExternalizedChatCompactFixedLayout(true, 'external-chat-ready');
+            }
             if (this.externalizedChatSpotlightKind) {
                 this.setExternalizedChatSpotlight(this.externalizedChatSpotlightKind);
             }

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1037,6 +1037,7 @@ class UniversalTutorialManager {
         const rawReason = this.normalizeTutorialEndRawReason(reason);
         const director = this.yuiGuideDirector;
         this.syncPcSystemCursorHidden(false, rawReason);
+        this.clearYuiGuideCompactChatFixedLayout(rawReason);
 
         try {
             this.notifyYuiGuideTutorialEnd(rawReason);
@@ -1111,6 +1112,46 @@ class UniversalTutorialManager {
             && typeof window.YuiGuideCommon.syncPcSystemCursorHidden === 'function'
         ) {
             window.YuiGuideCommon.syncPcSystemCursorHidden(hidden === true, reason);
+        }
+    }
+
+    syncYuiGuideCompactChatFixedLayout(fixed, reason = 'tutorial') {
+        const normalizedReason = typeof reason === 'string' && reason.trim()
+            ? reason.trim()
+            : 'tutorial';
+        let tutorialRunId = '';
+        try {
+            tutorialRunId = window.localStorage
+                ? (window.localStorage.getItem('yuiGuidePcOverlayRunId') || '')
+                : '';
+        } catch (_) {}
+
+        const message = {
+            action: 'yui_guide_set_compact_chat_fixed_layout',
+            fixed: fixed === true,
+            reason: normalizedReason,
+            tutorialRunId: tutorialRunId,
+            timestamp: Date.now()
+        };
+
+        const channel = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
+        if (channel && typeof channel.postMessage === 'function') {
+            try {
+                channel.postMessage(message);
+            } catch (error) {
+                console.warn('[Tutorial] 同步胶囊聊天框固定布局失败:', error);
+            }
+        }
+
+        if (
+            window.nekoTutorialOverlay
+            && typeof window.nekoTutorialOverlay.relayToChat === 'function'
+        ) {
+            try {
+                window.nekoTutorialOverlay.relayToChat(message);
+            } catch (error) {
+                console.warn('[Tutorial] 原生转发胶囊聊天框固定布局失败:', error);
+            }
         }
     }
 
@@ -2811,6 +2852,10 @@ class UniversalTutorialManager {
         this.isTutorialRunning = true;
         window.isInTutorial = true;
         this.lockBodyScroll();
+        if (document.body) {
+            document.body.classList.add('yui-guide-compact-chat-fixed');
+        }
+        this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start');
         this._tutorialModelPrefix = 'live2d';
         this.emitTutorialStarted('home', source);
 
@@ -3269,6 +3314,13 @@ class UniversalTutorialManager {
         return startupGreetingReleasePromise;
     }
 
+    clearYuiGuideCompactChatFixedLayout(reason = 'tutorial-ended') {
+        if (document.body) {
+            document.body.classList.remove('yui-guide-compact-chat-fixed');
+        }
+        this.syncYuiGuideCompactChatFixedLayout(false, reason);
+    }
+
     restoreYuiGuideChatInputState(reason = 'tutorial-ended') {
         const restoreReason = typeof reason === 'string' && reason.trim()
             ? reason.trim()
@@ -3277,6 +3329,7 @@ class UniversalTutorialManager {
         if (document.body) {
             document.body.classList.remove('yui-guide-chat-buttons-disabled');
         }
+        this.clearYuiGuideCompactChatFixedLayout(restoreReason);
 
         const readonlyTargets = document.querySelectorAll(
             '#react-chat-window-shell textarea, '
@@ -3346,6 +3399,11 @@ class UniversalTutorialManager {
      */
     _teardownTutorialUI() {
         this.revealTutorialLive2dPrepared();
+        this.clearYuiGuideCompactChatFixedLayout(
+            this.lifecycleStateStore.getEndRawReason()
+            || this.lifecycleStateStore.getEndReason()
+            || 'tutorial-ended'
+        );
         try {
             this.hideSkipButton();
         } catch (error) {

--- a/templates/memory_browser.html
+++ b/templates/memory_browser.html
@@ -104,6 +104,7 @@
                                         <button type="button" class="tutorial-cascader-option" data-tutorial-page="current_personality" data-i18n="memory.tutorialPageCurrentPersonality">当前角色性格</button>
                                     </div>
                                     <div class="tutorial-cascader-column tutorial-cascader-day-column" role="listbox" aria-label="主页七日新手教程" data-i18n-aria="memory.tutorialHomeDayColumn" hidden>
+                                        <button type="button" class="tutorial-cascader-option" data-tutorial-home-all="true" data-i18n="memory.tutorialHomeAllReset">全部重置</button>
                                         <button type="button" class="tutorial-cascader-option" data-tutorial-day="1">第 1 天</button>
                                         <button type="button" class="tutorial-cascader-option" data-tutorial-day="2">第 2 天</button>
                                         <button type="button" class="tutorial-cascader-option" data-tutorial-day="3">第 3 天</button>

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -307,12 +307,9 @@ def test_memory_browser_home_all_reset_restarts_avatar_guide_from_day_one(
     expect(mock_page.locator(".tutorial-cascader-popup")).to_be_hidden()
     expect(mock_page.locator("#tutorial-reset-btn")).to_be_enabled()
 
-    with mock_page.expect_event("dialog") as dialog_info:
-        mock_page.locator("#tutorial-reset-btn").click()
-
-    dialog = dialog_info.value
-    dialog_messages = [dialog.message]
-    dialog.accept()
+    dialog_messages = []
+    mock_page.once("dialog", lambda dialog: (dialog_messages.append(dialog.message), dialog.accept()))
+    mock_page.locator("#tutorial-reset-btn").click()
     mock_page.wait_for_function("window.__tutorialResetCalls.length === 2")
 
     assert mock_page.evaluate("window.__tutorialResetCalls") == [
@@ -320,6 +317,53 @@ def test_memory_browser_home_all_reset_restarts_avatar_guide_from_day_one(
         {"type": "prompt", "reason": "memory_browser_home_all_reset"},
     ]
     assert dialog_messages == ["已重置主页 7 天新手教程，请重新加载 Neko 后从第 1 天开始。"]
+
+
+@pytest.mark.frontend
+def test_avatar_guide_all_reset_refreshes_first_seen_date(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector(".tutorial-cascader-trigger", timeout=10000)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const key = 'neko_avatar_floating_guide_v1';
+            const today = (() => {
+                const now = new Date();
+                const year = now.getFullYear();
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const day = String(now.getDate()).padStart(2, '0');
+                return `${year}-${month}-${day}`;
+            })();
+            window.localStorage.setItem(key, JSON.stringify({
+                version: 1,
+                firstSeenDate: '2020-01-01',
+                completedRounds: [1],
+                skippedRounds: [2],
+                lastAutoShownRound: 2,
+                lastAutoShownDate: '2020-01-02',
+            }));
+            await window.AvatarFloatingGuideReset.resetAllAvatarFloatingGuideDays({
+                source: 'test_reset_all',
+            });
+            return {
+                today,
+                state: JSON.parse(window.localStorage.getItem(key)),
+            };
+        }
+        """
+    )
+
+    assert state["state"]["firstSeenDate"] == state["today"]
+    assert state["state"]["completedRounds"] == []
+    assert state["state"]["skippedRounds"] == []
+    assert state["state"]["pendingRound"] == 1
+    assert state["state"]["manualResetRound"] == 1
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -360,7 +360,8 @@ def test_memory_browser_home_all_reset_falls_back_to_prompt_reset_api_without_ma
         mock_page.locator("#tutorial-reset-btn").click()
 
     dialog = dialog_info.value
-    dialog.accept()
+    with mock_page.expect_response("**/api/tutorial-prompt/reset"):
+        dialog.accept()
     mock_page.wait_for_function("window.__tutorialResetCalls.length === 1")
 
     assert mock_page.evaluate("window.__tutorialResetCalls") == [

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -169,6 +169,7 @@ def test_memory_browser_page_load(mock_page: Page, running_server: str, seed_mem
     mock_page.locator(".tutorial-cascader-option[data-tutorial-page='home']").click()
     expect(mock_page.locator(".tutorial-cascader-day-column")).to_be_visible()
     expect(mock_page.locator("#tutorial-reset-btn")).to_be_disabled()
+    expect(mock_page.locator(".tutorial-cascader-option[data-tutorial-home-all='true']")).to_have_count(1)
     mock_page.locator(".tutorial-cascader-option[data-tutorial-day='1']").click()
     expect(mock_page.locator(".tutorial-reset-value")).to_have_text("主页 / 第 1 天")
     expect(mock_page.locator(".tutorial-cascader-popup")).to_be_hidden()
@@ -267,6 +268,58 @@ def test_memory_browser_all_tutorial_reset_includes_avatar_guide_state(
         {"type": "avatar", "options": {"source": "memory_browser_reset_all"}},
         {"type": "legacy", "pageKey": "all"},
     ]
+
+
+@pytest.mark.frontend
+def test_memory_browser_home_all_reset_restarts_avatar_guide_from_day_one(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector(".tutorial-cascader-trigger", timeout=10000)
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialResetCalls = [];
+            window.AvatarFloatingGuideReset = Object.assign({}, window.AvatarFloatingGuideReset || {}, {
+                resetAllAvatarFloatingGuideDays: async (options) => {
+                    window.__tutorialResetCalls.push({ type: 'avatar', options });
+                }
+            });
+            window.resetTutorialForPage = async (pageKey) => {
+                window.__tutorialResetCalls.push({ type: 'legacy', pageKey });
+            };
+            window.universalTutorialManager = Object.assign({}, window.universalTutorialManager || {}, {
+                resetHomeTutorialPromptState: async (reason) => {
+                    window.__tutorialResetCalls.push({ type: 'prompt', reason });
+                }
+            });
+        }
+        """
+    )
+
+    mock_page.locator(".tutorial-cascader-trigger").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-page='home']").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-home-all='true']").click()
+    expect(mock_page.locator(".tutorial-reset-value")).to_have_text("主页 / 全部重置")
+    expect(mock_page.locator(".tutorial-cascader-popup")).to_be_hidden()
+    expect(mock_page.locator("#tutorial-reset-btn")).to_be_enabled()
+
+    with mock_page.expect_event("dialog") as dialog_info:
+        mock_page.locator("#tutorial-reset-btn").click()
+
+    dialog = dialog_info.value
+    dialog_messages = [dialog.message]
+    dialog.accept()
+    mock_page.wait_for_function("window.__tutorialResetCalls.length === 2")
+
+    assert mock_page.evaluate("window.__tutorialResetCalls") == [
+        {"type": "avatar", "options": {"source": "memory_browser_reset_home_all"}},
+        {"type": "prompt", "reason": "memory_browser_home_all_reset"},
+    ]
+    assert dialog_messages == ["已重置主页 7 天新手教程，请重新加载 Neko 后从第 1 天开始。"]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -323,6 +323,53 @@ def test_memory_browser_home_all_reset_restarts_avatar_guide_from_day_one(
 
 
 @pytest.mark.frontend
+def test_memory_browser_home_all_reset_falls_back_to_prompt_reset_api_without_manager(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    prompt_reset_payloads = []
+
+    def handle_prompt_reset(route):
+        prompt_reset_payloads.append(_request_json(route))
+        route.fulfill(status=200, content_type="application/json", json={"ok": True})
+
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.route("**/api/tutorial-prompt/reset", handle_prompt_reset)
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector(".tutorial-cascader-trigger", timeout=10000)
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialResetCalls = [];
+            window.AvatarFloatingGuideReset = Object.assign({}, window.AvatarFloatingGuideReset || {}, {
+                resetAllAvatarFloatingGuideDays: async (options) => {
+                    window.__tutorialResetCalls.push({ type: 'avatar', options });
+                }
+            });
+            delete window.universalTutorialManager;
+        }
+        """
+    )
+
+    mock_page.locator(".tutorial-cascader-trigger").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-page='home']").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-home-all='true']").click()
+
+    with mock_page.expect_event("dialog") as dialog_info:
+        mock_page.locator("#tutorial-reset-btn").click()
+
+    dialog = dialog_info.value
+    dialog.accept()
+    mock_page.wait_for_function("window.__tutorialResetCalls.length === 1")
+
+    assert mock_page.evaluate("window.__tutorialResetCalls") == [
+        {"type": "avatar", "options": {"source": "memory_browser_reset_home_all"}},
+    ]
+    assert prompt_reset_payloads == [{"reason": "memory_browser_home_all_reset"}]
+
+
+@pytest.mark.frontend
 def test_memory_browser_tutorial_cascader_localizes_home_day_labels_for_english(
     mock_page: Page,
     running_server: str,

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -356,12 +356,12 @@ def test_memory_browser_home_all_reset_falls_back_to_prompt_reset_api_without_ma
     mock_page.locator(".tutorial-cascader-option[data-tutorial-page='home']").click()
     mock_page.locator(".tutorial-cascader-option[data-tutorial-home-all='true']").click()
 
-    with mock_page.expect_event("dialog") as dialog_info:
-        mock_page.locator("#tutorial-reset-btn").click()
+    with mock_page.expect_response("**/api/tutorial-prompt/reset"):
+        with mock_page.expect_event("dialog") as dialog_info:
+            mock_page.locator("#tutorial-reset-btn").click()
 
     dialog = dialog_info.value
-    with mock_page.expect_response("**/api/tutorial-prompt/reset"):
-        dialog.accept()
+    dialog.accept()
     mock_page.wait_for_function("window.__tutorialResetCalls.length === 1")
 
     assert mock_page.evaluate("window.__tutorialResetCalls") == [

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -490,6 +490,24 @@ def test_pc_external_chat_spotlight_preserves_highlight_during_resistance_pause(
     )[1]
 
 
+def test_external_chat_ready_replays_compact_fixed_layout_when_tutorial_is_active():
+    takeover_source = (ROOT / "static" / "tutorial/core/interaction-takeover.js").read_text(encoding="utf-8")
+    ready_block = takeover_source.split("onExternalChatReady() {", 1)[1].split(
+        "destroy()",
+        1,
+    )[0]
+    fixed_method_block = takeover_source.split("setExternalizedChatCompactFixedLayout(fixed, reason) {", 1)[1].split(
+        "clearExternalizedChatGuideMessages()",
+        1,
+    )[0]
+
+    assert "this.document.body.classList.contains('yui-guide-compact-chat-fixed')" in ready_block
+    assert "this.setExternalizedChatCompactFixedLayout(true, 'external-chat-ready')" in ready_block
+    assert "yui_guide_set_compact_chat_fixed_layout" in fixed_method_block
+    assert "fixed: fixed === true" in fixed_method_block
+    assert "reason: typeof reason === 'string' ? reason : ''" in fixed_method_block
+
+
 def test_pc_overlay_sequence_is_shared_between_home_and_external_chat():
     interpage_source = INTERPAGE_PATH.read_text(encoding="utf-8")
     overlay_source = (ROOT / "static" / "tutorial/yui-guide/overlay.js").read_text(encoding="utf-8")

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -857,6 +857,13 @@ def test_home_tutorial_reset_also_resets_day1_icebreaker_state():
     assert "state.skippedRounds = []" in reset_source
     assert "selection.pageKey === 'all'" in memory_browser_source
     assert "resetAllAvatarFloatingGuideDays({" in memory_browser_source
+    home_all_block = memory_browser_source.split("if (selection.type === 'home-all') {", 1)[1].split(
+        "if (selection.type === 'page'",
+        1,
+    )[0]
+    assert "resetHomeTutorialPromptState('memory_browser_home_all_reset')" in home_all_block
+    assert "resetHomeTutorialPromptStateViaApi('memory_browser_home_all_reset')" in home_all_block
+    assert "'/api/tutorial-prompt/reset'" in memory_browser_source
 
 
 def test_react_chat_fallback_sort_key_stays_after_existing_timestamped_messages():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -752,15 +752,16 @@ def test_yui_guide_fixed_compact_chat_uses_400_width_and_left_middle_lower_posit
 
     fixed_block = css_block(
         styles,
-        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {',
-        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {',
+        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.neko-electron-runtime) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {',
+        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.neko-electron-runtime) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {',
     )
     choice_anchor_block = css_block(
         styles,
-        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {',
+        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.neko-electron-runtime) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {',
         '/* Agent HUD 空状态折叠按钮样式 */',
     )
 
+    assert "body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window)" not in styles
     assert "left: clamp(24px, 6vw, 72px) !important;" in fixed_block
     assert "top: min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) !important;" in fixed_block
     assert "width: min(400px, calc(100vw - 32px)) !important;" in fixed_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1135,7 +1135,7 @@ def test_externalized_chat_input_spotlight_uses_global_overlay_only():
     assert "function renderYuiGuideChatSpotlight" not in script
 
 
-def test_yui_guide_spotlight_state_messages_bypass_cross_channel_dedup():
+def test_yui_guide_state_messages_bypass_cross_channel_dedup_but_cursor_deltas_do_not():
     script = (Path(__file__).resolve().parents[2] / "static" / "app-interpage.js").read_text(encoding="utf-8")
 
     bypass_block = script.split("function shouldBypassYuiGuideMessageDedup(action, message)", 1)[1].split(
@@ -1146,8 +1146,8 @@ def test_yui_guide_spotlight_state_messages_bypass_cross_channel_dedup():
     assert "message && message.bypassDedup === true" in bypass_block
     assert "action === 'yui_guide_set_chat_spotlight'" in bypass_block
     assert "action === 'yui_guide_set_chat_cursor'" in bypass_block
-    assert "action === 'yui_guide_drag_chat_cursor'" in bypass_block
-    assert "action === 'yui_guide_arc_chat_cursor'" in bypass_block
+    assert "action === 'yui_guide_drag_chat_cursor'" not in bypass_block
+    assert "action === 'yui_guide_arc_chat_cursor'" not in bypass_block
     assert "action === 'yui_guide_set_compact_history_open'" in bypass_block
     assert "action === 'yui_guide_set_compact_chat_fixed_layout'" in bypass_block
     assert "action === 'yui_guide_rotate_compact_tool_wheel'" in bypass_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -747,6 +747,29 @@ def test_mobile_web_compact_surface_respects_width_bounds_and_position_vars():
     assert "overflow: visible;" in mobile_compact_overflow_block
 
 
+def test_yui_guide_fixed_compact_chat_uses_400_width_and_left_middle_lower_position():
+    styles = STATIC_INDEX_CSS_PATH.read_text(encoding="utf-8")
+
+    fixed_block = css_block(
+        styles,
+        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {',
+        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {',
+    )
+    choice_anchor_block = css_block(
+        styles,
+        'body.yui-guide-compact-chat-fixed.subtitle-web-host:not(.electron-chat-window) > .compact-chat-choice-anchor[data-chat-surface-mode="compact"] {',
+        '/* Agent HUD 空状态折叠按钮样式 */',
+    )
+
+    assert "left: clamp(24px, 6vw, 72px) !important;" in fixed_block
+    assert "top: min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) !important;" in fixed_block
+    assert "width: min(400px, calc(100vw - 32px)) !important;" in fixed_block
+    assert "bottom: auto !important;" in fixed_block
+    assert "left: calc(clamp(24px, 6vw, 72px) + 200px);" in choice_anchor_block
+    assert "top: calc(min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) + var(--compact-surface-height, 58px) + 16px);" in choice_anchor_block
+    assert "bottom: calc(100vh - min(62vh, calc(100vh - var(--compact-surface-height, 58px) - 24px)) + 16px);" in choice_anchor_block
+
+
 def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
@@ -1125,6 +1148,7 @@ def test_yui_guide_spotlight_state_messages_bypass_cross_channel_dedup():
     assert "action === 'yui_guide_drag_chat_cursor'" in bypass_block
     assert "action === 'yui_guide_arc_chat_cursor'" in bypass_block
     assert "action === 'yui_guide_set_compact_history_open'" in bypass_block
+    assert "action === 'yui_guide_set_compact_chat_fixed_layout'" in bypass_block
     assert "action === 'yui_guide_rotate_compact_tool_wheel'" in bypass_block
     assert "action === 'yui_guide_set_chat_spotlight'" in bypass_block
     assert "action === 'yui_guide_set_chat_buttons_disabled'" in bypass_block
@@ -1133,7 +1157,7 @@ def test_yui_guide_spotlight_state_messages_bypass_cross_channel_dedup():
     assert "case 'yui_guide_set_chat_cursor':" in script
     assert "case 'yui_guide_drag_chat_cursor':" in script
     assert "case 'yui_guide_arc_chat_cursor':" in script
-    assert "relayYuiGuideChatCommand(event.data);" in script
+    assert "relayYuiGuideChatCommand(Object.assign({}, event.data," in script
     assert "neko:tutorial-overlay-relay" in script
     assert "__nekoTutorialOverlayRelay" in script
 
@@ -1148,6 +1172,36 @@ def test_yui_guide_external_compact_history_open_is_bridged_to_react_host():
     assert "case 'yui_guide_set_compact_history_open'" in interpage
     assert "function applyYuiGuideCompactHistoryOpen(open, reason)" in interpage
     assert "host.setCompactHistoryOpen(open === true, reason || 'external-yui-guide');" in interpage
+
+
+def test_yui_guide_compact_chat_fixed_layout_is_bridged_to_standalone_chat_body():
+    interpage = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+
+    relayed_block = interpage.split("function handleYuiGuideRelayedMessage(message)", 1)[1].split(
+        "function ensureYuiGuideStandaloneInteractionShield",
+        1,
+    )[0]
+    broadcast_block = interpage.split("nekoBroadcastChannel.onmessage = async function (event)", 1)[1].split(
+        "console.log('[BroadcastChannel] 初始化失败",
+        1,
+    )[0]
+    scoped_block = interpage.split("function isYuiGuideLifecycleScopedAction(action)", 1)[1].split(
+        "function resetYuiGuidePcOverlayRunForRetry()",
+        1,
+    )[0]
+    cleanup_block = interpage.split("function clearYuiGuidePcOverlayBridgeState(reason", 1)[1].split(
+        "function cleanupAppInterpageTransientResources()",
+        1,
+    )[0]
+
+    assert "function applyYuiGuideCompactChatFixedLayout(fixed)" in interpage
+    assert "document.body.classList.toggle('yui-guide-compact-chat-fixed', fixed === true);" in interpage
+    assert "case 'yui_guide_set_compact_chat_fixed_layout':" in relayed_block
+    assert "applyYuiGuideCompactChatFixedLayout(message.fixed === true);" in relayed_block
+    assert "case 'yui_guide_set_compact_chat_fixed_layout':" in broadcast_block
+    assert "applyYuiGuideCompactChatFixedLayout(event.data.fixed === true);" in broadcast_block
+    assert "case 'yui_guide_set_compact_chat_fixed_layout':" in scoped_block
+    assert "applyYuiGuideCompactChatFixedLayout(false);" in cleanup_block
 
 
 def test_new_user_icebreaker_choice_prompt_dispatches_host_event():

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -252,6 +252,7 @@ def test_home_tutorial_teardown_restores_chat_input_lock_before_early_return():
         1,
     )[0]
     assert "this.restoreYuiGuideChatInputState(" in teardown_prefix
+    assert "this.clearYuiGuideCompactChatFixedLayout(" in teardown_prefix
 
     restore_block = source.split("    restoreYuiGuideChatInputState(reason = 'tutorial-ended') {", 1)[1].split(
         "    _teardownTutorialUI() {",
@@ -264,3 +265,33 @@ def test_home_tutorial_teardown_restores_chat_input_lock_before_early_return():
     assert "disabled: false" in restore_block
     assert "reactChatWindowHost" in restore_block
     assert "setHomeTutorialInteractionLocked(false" in restore_block
+
+
+def test_avatar_floating_guide_lifecycle_toggles_compact_chat_fixed_layout_class():
+    source = _read_manager()
+
+    start_round_block = source.split("    async startAvatarFloatingGuideRound(day, options = {}) {", 1)[1].split(
+        "            const director = this.ensureYuiGuideDirector();",
+        1,
+    )[0]
+    restore_block = source.split("    restoreYuiGuideChatInputState(reason = 'tutorial-ended') {", 1)[1].split(
+        "    _teardownTutorialUI() {",
+        1,
+    )[0]
+    lifecycle_block = source.split("    clearAllTutorialLifecycles(reason = 'destroy') {", 1)[1].split(
+        "    normalizeTutorialEndRawReason(reason) {",
+        1,
+    )[0]
+    clear_method_block = source.split("    clearYuiGuideCompactChatFixedLayout(reason = 'tutorial-ended') {", 1)[1].split(
+        "    restoreYuiGuideChatInputState(reason = 'tutorial-ended') {",
+        1,
+    )[0]
+
+    assert "document.body.classList.add('yui-guide-compact-chat-fixed')" in start_round_block
+    assert "this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start')" in start_round_block
+    assert "this.clearYuiGuideCompactChatFixedLayout(restoreReason)" in restore_block
+    assert "this.clearYuiGuideCompactChatFixedLayout(rawReason)" in lifecycle_block
+    assert "document.body.classList.remove('yui-guide-compact-chat-fixed')" in clear_method_block
+    assert "this.syncYuiGuideCompactChatFixedLayout(false, reason)" in clear_method_block
+    assert "action: 'yui_guide_set_compact_chat_fixed_layout'" in source
+    assert "window.nekoTutorialOverlay.relayToChat(message)" in source


### PR DESCRIPTION
## 改动概述 / Summary

- 在【主页】的新手引导级联选项中新增“全部重置”，用于一次性重置 day1-7 新手教程进度，让用户重新按首次启动后的天数节奏进入新手教程。
- 新手教程开始时同步胶囊聊天框固定布局状态，教程期间将胶囊固定在左中偏下位置，并在非 Electron 兜底样式中固定宽度为 400px。
- 教程生气退出、跳过退出、正常结束以及生命周期清理时统一解除胶囊布局固定，避免教程结束后继续锁定用户聊天框位置。
- 增加静态回归测试，覆盖教程生命周期、独立聊天页桥接、固定布局样式和跨窗口去重旁路。

## 回归报告 / Regression Report

本 PR 未修改 `app/`、`main_logic/`、`memory/` 下的任一 Python 文件；按 CI 规则本节不触发强制回归报告，但按本次提交要求补充三块必要性说明：

- `main_logic`：未改动。新手教程的开始/结束状态已经由前端 `UniversalTutorialManager` 管理，本次问题是教程期间聊天框展示位置和跨窗口状态同步，不需要改动主流程编排，否则会扩大回归面。
- `memory`：未改动。主页“全部重置”只重置 day1-7 教程进度，胶囊固定布局只影响教程 UI 展示，不涉及记忆浏览、记忆整理的数据读取、写入或归档链路。
- `app`：未改动 Python 入口，但修改了前端 app bridge。独立聊天页和教程 overlay 分属不同运行上下文，仅在教程管理器里加 body class 无法让独立聊天页生效；必须通过 app-interpage/overlay relay 传递 `yui_guide_set_compact_chat_fixed_layout`，并在教程结束时清理状态。

改动前后表现对比：

- 改动前：新手教程期间胶囊聊天框可能跟随原 compact 布局/用户拖拽状态变化，独立聊天页无法稳定接收固定布局状态；教程结束后也缺少统一的固定状态清理。
- 改动后：教程开始即广播固定布局；教程退出、跳过、正常结束都会解除固定；非 Electron 兜底样式固定到左中偏下、400px 宽。

潜在回归点与验证：

- 跨窗口消息去重：新增固定布局 action 到生命周期/去重旁路，避免教程 relay 被错误丢弃；静态测试覆盖。
- 教程结束清理：生气退出、跳过退出、正常结束都走统一清理；静态测试覆盖。
- 非 Electron compact 样式：新增固定布局 class 的样式规则，只作用于非 Electron standalone chat，避免和 PC 原生窗口 bounds 双重偏移；静态测试覆盖。

## 不拆分理由 / Why Not Split

不适用。计入上限的文件数 ≤ 20。

## 测试 / Testing

- `node --check static/tutorial/core/universal-manager.js && node --check static/app-interpage.js`
- `python3 -m py_compile tests/unit/test_universal_tutorial_manager_static.py tests/unit/test_react_chat_window_static.py`
- 单点静态测试：`test_avatar_floating_guide_lifecycle_toggles_compact_chat_fixed_layout_class`
- 单点静态测试：`test_home_tutorial_teardown_restores_chat_input_lock_before_early_return`
- 单点静态测试：`test_yui_guide_compact_chat_fixed_layout_is_bridged_to_standalone_chat_body`
- 单点静态测试：`test_yui_guide_fixed_compact_chat_uses_400_width_and_left_middle_lower_position`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **New Features**
  * “主页七日新手教程”新增“全部重置”：一键重置主页进度与提示，并在完成后从第 1 天重新开始。
  * 增强紧凑聊天固定布局：支持跨页/跨端同步；外置聊天就绪后自动初始化当前布局状态。
* **Bug Fixes**
  * 完善固定布局在教程启动、恢复与退出/清理场景下的启用与回收，降低状态残留；同步更新紧凑模式下聊天窗口与选择锚点定位。
* **Localization**
  * 新增“全部重置”与成功提示的多语言文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->