### PR TITLE
fix(ui): refine Day 1 guide focus and subtitle styling

### DIFF
--- a/static/css/subtitle.css
+++ b/static/css/subtitle.css
@@ -18,12 +18,12 @@ body.subtitle-window-host {
     --subtitle-panel-bg-rgb: 255, 255, 255;
     --subtitle-panel-text: #080a0d;
     --subtitle-text-fill: #05070a;
-    --subtitle-text-stroke: rgba(255, 255, 255, 0.78);
+    --subtitle-text-stroke: rgba(255, 255, 255, 0.58);
     --subtitle-placeholder-fill: rgba(5, 7, 10, 0.68);
-    --subtitle-placeholder-stroke: rgba(255, 255, 255, 0.72);
+    --subtitle-placeholder-stroke: rgba(255, 255, 255, 0.52);
     --subtitle-panel-shadow: none;
-    --subtitle-panel-text-shadow: 0 1px 2px rgba(255, 255, 255, 0.95),
-        0 0 8px rgba(255, 255, 255, 0.78);
+    --subtitle-panel-text-shadow: 0 1px 1px rgba(255, 255, 255, 0.72),
+        0 0 3px rgba(255, 255, 255, 0.36);
     --subtitle-control-bg: rgba(255, 255, 255, 0.68);
     --subtitle-control-hover-bg: rgba(255, 255, 255, 0.92);
     --subtitle-control-border: rgba(36, 43, 49, 0.14);
@@ -98,12 +98,12 @@ html.dark #subtitle-display {
     --subtitle-panel-bg-rgb: 18, 20, 23;
     --subtitle-panel-text: #ffffff;
     --subtitle-text-fill: #ffffff;
-    --subtitle-text-stroke: rgba(0, 0, 0, 0.46);
+    --subtitle-text-stroke: rgba(0, 0, 0, 0.34);
     --subtitle-placeholder-fill: rgba(255, 255, 255, 0.82);
-    --subtitle-placeholder-stroke: rgba(0, 0, 0, 0.5);
+    --subtitle-placeholder-stroke: rgba(0, 0, 0, 0.34);
     --subtitle-panel-shadow: none;
-    --subtitle-panel-text-shadow: 0 1px 3px rgba(0, 0, 0, 0.52),
-        0 0 8px rgba(0, 0, 0, 0.3);
+    --subtitle-panel-text-shadow: 0 1px 2px rgba(0, 0, 0, 0.38),
+        0 0 3px rgba(0, 0, 0, 0.18);
     --subtitle-control-bg: rgba(25, 28, 32, 0.72);
     --subtitle-control-hover-bg: rgba(44, 49, 55, 0.92);
     --subtitle-control-border: rgba(255, 255, 255, 0.14);
@@ -324,7 +324,7 @@ body.subtitle-window-host.subtitle-linux-host #subtitle-display {
     white-space: pre-wrap;
     overflow-wrap: break-word;
     text-shadow: var(--subtitle-panel-text-shadow);
-    -webkit-text-stroke: 0.35px var(--subtitle-text-stroke);
+    -webkit-text-stroke: 0.22px var(--subtitle-text-stroke);
     paint-order: stroke fill;
     pointer-events: auto;
 }
@@ -389,7 +389,7 @@ body.subtitle-window-host.subtitle-linux-host #subtitle-display {
     white-space: nowrap;
     color: var(--subtitle-text-fill);
     text-shadow: var(--subtitle-panel-text-shadow);
-    -webkit-text-stroke: 0.35px var(--subtitle-text-stroke);
+    -webkit-text-stroke: 0.22px var(--subtitle-text-stroke);
     paint-order: stroke fill;
 }
 
@@ -407,7 +407,7 @@ body.subtitle-window-host.subtitle-linux-host #subtitle-display {
     content: attr(data-subtitle-placeholder);
     display: inline-block;
     color: var(--subtitle-placeholder-fill);
-    -webkit-text-stroke: 0.3px var(--subtitle-placeholder-stroke);
+    -webkit-text-stroke: 0.2px var(--subtitle-placeholder-stroke);
     text-shadow: var(--subtitle-panel-text-shadow);
     opacity: 0.82;
 }

--- a/static/tutorial/core/scene-orchestrator.js
+++ b/static/tutorial/core/scene-orchestrator.js
@@ -874,15 +874,43 @@
             } else {
                 director.highlightChatWindow();
             }
-            return await director.withLookAt({
-                isCancelled: () => director.isStopping(),
-                completeReason: roundId + '_complete',
-                startFailureMessage: '[YuiGuide] Avatar floating cursor look-at startup failed:'
-            }, async () => {
+            let day1LookAtHandle = null;
+            let day1LookAtPromise = null;
+            const startDay1LookAt = () => {
+                if (!isDay1Round || day1LookAtPromise || day1LookAtHandle) {
+                    return;
+                }
+                day1LookAtPromise = director.ensurePersistentGhostCursorLookAtPerformance({
+                    isCancelled: () => director.isStopping()
+                }).then((handle) => {
+                    day1LookAtHandle = handle || null;
+                    return day1LookAtHandle;
+                }).catch((error) => {
+                    console.warn('[YuiGuide] Avatar floating cursor look-at startup failed:', error);
+                    return null;
+                });
+            };
+            const stopDay1LookAt = async () => {
+                if (!day1LookAtPromise && !day1LookAtHandle) {
+                    return;
+                }
+                if (day1LookAtPromise && !day1LookAtHandle) {
+                    day1LookAtHandle = await day1LookAtPromise;
+                }
+                if (day1LookAtHandle) {
+                    await director.stopIntroVoiceCursorLookAtPerformance(day1LookAtHandle, roundId + '_complete');
+                } else {
+                    await director.stopPersistentGhostCursorLookAtPerformance(roundId + '_complete');
+                }
+            };
+            const playScenes = async () => {
                 try {
                     for (let index = 0; index < config.scenes.length; index += 1) {
                         if (director.isStopping()) {
                             return false;
+                        }
+                        if (isDay1Round && config.scenes[index].id === 'day1_capsule_drag_hint') {
+                            startDay1LookAt();
                         }
                         const keepGoing = await director.playAvatarFloatingScene(
                             config.scenes[index],
@@ -906,6 +934,7 @@
                     ) {
                         await director.waitForAngryExitPresentationCompletion();
                     }
+                    await stopDay1LookAt();
                     director.disableInterrupts();
                     director.clearAvatarStandIn({ clearPending: true, restoreModel: true });
                     director.setGuideChatInputLocked(false, 'avatar-floating-guide-day' + roundNumber + '-complete');
@@ -925,7 +954,15 @@
                     director.currentSceneId = null;
                     director.currentStep = null;
                 }
-            });
+            };
+            if (isDay1Round) {
+                return await playScenes();
+            }
+            return await director.withLookAt({
+                isCancelled: () => director.isStopping(),
+                completeReason: roundId + '_complete',
+                startFailureMessage: '[YuiGuide] Avatar floating cursor look-at startup failed:'
+            }, playScenes);
         }
     }
 

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -677,16 +677,21 @@ def test_avatar_floating_round_does_not_start_idle_sway_before_first_scene():
     assert "ensureGuideIdleSwayPerformance()" not in before_scene_loop
 
 
-def test_avatar_floating_round_does_not_await_look_at_before_first_scene():
+def test_day1_round_defers_cursor_look_at_until_capsule_mouse_hint():
     source = (ROOT / "static" / "tutorial/core/scene-orchestrator.js").read_text(encoding="utf-8")
     round_block = source.split("async playRound(round, options)", 1)[1].split(
         "return {",
         1,
     )[0]
-    before_scene_loop = round_block.split("for (let index = 0; index < config.scenes.length; index += 1)", 1)[0]
+    scene_loop = round_block.split("for (let index = 0; index < config.scenes.length; index += 1)", 1)[1].split(
+        "const keepGoing = await director.playAvatarFloatingScene",
+        1,
+    )[0]
 
-    assert "director.withLookAt({" in before_scene_loop
-    assert "director.ensurePersistentGhostCursorLookAtPerformance(" not in before_scene_loop
+    assert "return await playScenes();" in round_block
+    assert "return await director.withLookAt({" in round_block
+    assert "config.scenes[index].id === 'day1_capsule_drag_hint'" in scene_loop
+    assert "startDay1LookAt();" in scene_loop
 
 
 def test_day1_chat_input_round_rect_highlight_excludes_mid_flow_cursor_scenes():


### PR DESCRIPTION
## 改动概述 / Summary

- 调整 Day 1 新手教程第一大段的模型视线逻辑：Yui 在左右跳/送爱心表演时不再追踪猫爪鼠标，改为正视用户。
- 到 `day1_capsule_drag_hint` 猫爪鼠标引导段后，再恢复原有持久 look-at 追踪。
- 同步 Day 1 回归契约测试。
- 纳入当前字幕描边和阴影强度调整。

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `node --test static/yui-guide-scene-orchestrator.test.cjs`
- `.venv/bin/python -m pytest tests/unit/test_avatar_floating_day1_round_contracts.py::test_day1_round_defers_cursor_look_at_until_capsule_mouse_hint -q`
- `node --check static/tutorial/core/scene-orchestrator.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更说明

* **Style**
  * 优化字幕样式，调整了字幕描边和阴影效果
  * 提升字幕文本清晰度与对比度，改进标准主题和暗黑主题下的视觉表现

<!-- end of auto-generated comment: release notes by coderabbit.ai -->