### PR TITLE
修复字幕弹幕模式下仍触发普通字幕自动滚动的问题，避免弹幕内容被纵向滚动顶出可视区域，并补充回归测试。

### DIFF
--- a/static/subtitle-shared.js
+++ b/static/subtitle-shared.js
@@ -1165,7 +1165,7 @@
         var scroll = getSubtitleScrollNode(target);
         if (!scroll || !scroll.dataset) return false;
         if (isSubtitleDanmakuScrollActive(scroll)) {
-            scroll.dataset.subtitleScrollable = 'false';
+            resetSubtitleDanmakuScroll(scroll);
             return false;
         }
         var scrollable = isSubtitleScrollScrollable(scroll);

--- a/static/subtitle-shared.js
+++ b/static/subtitle-shared.js
@@ -1052,6 +1052,26 @@
         }
     }
 
+    function isSubtitleDanmakuScrollActive(scroll) {
+        var display;
+        if (!scroll) return false;
+        if (scroll.classList && scroll.classList.contains('subtitle-danmaku-scroll')) {
+            return true;
+        }
+        display = scroll.closest ? scroll.closest('#subtitle-display') : null;
+        return !!(display && display.dataset && display.dataset.subtitleDanmakuActive === 'true');
+    }
+
+    function resetSubtitleDanmakuScroll(scroll) {
+        if (!scroll) return 0;
+        cancelSubtitleAutoScroll(scroll);
+        scroll.scrollTop = 0;
+        if (scroll.dataset) {
+            scroll.dataset.subtitleScrollable = 'false';
+        }
+        return 0;
+    }
+
     function renderSubtitleDanmakuText(refs, text, options) {
         var display = refs && refs.display;
         var scroll = refs && refs.scroll;
@@ -1119,6 +1139,7 @@
         scroll.classList.add('subtitle-danmaku-scroll');
         display.dataset.subtitleDanmakuActive = 'true';
         display.dataset.subtitleDanmakuCount = String(segments.length);
+        resetSubtitleDanmakuScroll(scroll);
         return segments;
     }
 
@@ -1143,6 +1164,10 @@
     function updateSubtitleScrollState(target) {
         var scroll = getSubtitleScrollNode(target);
         if (!scroll || !scroll.dataset) return false;
+        if (isSubtitleDanmakuScrollActive(scroll)) {
+            scroll.dataset.subtitleScrollable = 'false';
+            return false;
+        }
         var scrollable = isSubtitleScrollScrollable(scroll);
         scroll.dataset.subtitleScrollable = scrollable ? 'true' : 'false';
         return scrollable;
@@ -1164,6 +1189,9 @@
     function scrollSubtitleToBottom(target) {
         var scroll = getSubtitleScrollNode(target);
         if (!scroll) return 0;
+        if (isSubtitleDanmakuScrollActive(scroll)) {
+            return resetSubtitleDanmakuScroll(scroll);
+        }
         cancelSubtitleAutoScroll(scroll);
         updateSubtitleScrollState(scroll);
         scroll.scrollTop = getSubtitleScrollMax(scroll);
@@ -1173,6 +1201,9 @@
     function requestSubtitleAutoScroll(target, options) {
         var scroll = getSubtitleScrollNode(target);
         if (!scroll) return 0;
+        if (isSubtitleDanmakuScrollActive(scroll)) {
+            return resetSubtitleDanmakuScroll(scroll);
+        }
         if (!updateSubtitleScrollState(scroll)) {
             cancelSubtitleAutoScroll(scroll);
             scroll.scrollTop = 0;
@@ -1213,6 +1244,10 @@
 
         function step(timestamp) {
             if (scroll._nekoSubtitleAutoScroll !== state) return;
+            if (isSubtitleDanmakuScrollActive(scroll)) {
+                resetSubtitleDanmakuScroll(scroll);
+                return;
+            }
             if (!updateSubtitleScrollState(scroll)) {
                 cancelSubtitleAutoScroll(scroll);
                 return;

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -7323,6 +7323,99 @@ def test_subtitle_window_transcript_event_starts_overflow_auto_scroll(
 
 
 @pytest.mark.frontend
+def test_subtitle_window_danmaku_mode_suppresses_overflow_auto_scroll(
+    mock_page: Page,
+):
+    mock_page.set_viewport_size({"width": 360, "height": 120})
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-window-danmaku-auto-scroll-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitleDanmakuMode', 'true');
+            window.localStorage.setItem('subtitlePanelBounds', JSON.stringify({
+                width: 240,
+                height: 60,
+            }));
+            window.nekoSubtitle = {
+                setSize: () => {},
+                changeSettings: () => {},
+                dragStart: () => {},
+                dragStop: () => {},
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-window.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const waitFrames = (count) => new Promise((resolve) => {
+                const tick = () => {
+                    count -= 1;
+                    if (count <= 0) {
+                        resolve();
+                        return;
+                    }
+                    requestAnimationFrame(tick);
+                };
+                requestAnimationFrame(tick);
+            });
+            const shared = window.nekoSubtitleShared;
+            const display = document.getElementById('subtitle-display');
+            const scroll = document.getElementById('subtitle-scroll');
+            window.dispatchEvent(new CustomEvent('neko-ws-transcript', {
+                detail: {
+                    translated: true,
+                    transcript: Array.from(
+                        { length: 30 },
+                        (_, index) => `line ${index + 1}, phrase ${index + 1}.`
+                    ).join('\\n'),
+                },
+            }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const maxScrollTop = scroll.scrollHeight - scroll.clientHeight;
+            const afterRender = scroll.scrollTop;
+            shared.requestSubtitleAutoScroll(scroll, {
+                speedPixelsPerSecond: 240,
+                delayMs: 0,
+            });
+            await waitFrames(20);
+            return {
+                active: display.dataset.subtitleDanmakuActive || '',
+                afterRender,
+                afterAuto: scroll.scrollTop,
+                itemCount: document.querySelectorAll('.subtitle-danmaku-item').length,
+                maxScrollTop,
+                scrollableDataset: scroll.dataset.subtitleScrollable,
+            };
+        }
+        """
+    )
+
+    assert result["active"] == "true"
+    assert result["itemCount"] > 0
+    assert result["maxScrollTop"] > 0
+    assert result["afterRender"] == 0
+    assert result["afterAuto"] == 0
+    assert result["scrollableDataset"] == "false"
+
+
+@pytest.mark.frontend
 def test_subtitle_window_ignores_raw_transcript_after_translated_render_state(
     mock_page: Page,
 ):

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -7395,13 +7395,17 @@ def test_subtitle_window_danmaku_mode_suppresses_overflow_auto_scroll(
                 delayMs: 0,
             });
             await waitFrames(20);
+            const scrollToBottomReturn = shared.scrollSubtitleToBottom(scroll);
+            const afterScrollToBottom = scroll.scrollTop;
             return {
                 active: display.dataset.subtitleDanmakuActive || '',
                 afterRender,
                 afterAuto: scroll.scrollTop,
+                afterScrollToBottom,
                 itemCount: document.querySelectorAll('.subtitle-danmaku-item').length,
                 maxScrollTop,
                 scrollableDataset: scroll.dataset.subtitleScrollable,
+                scrollToBottomReturn,
             };
         }
         """
@@ -7412,6 +7416,8 @@ def test_subtitle_window_danmaku_mode_suppresses_overflow_auto_scroll(
     assert result["maxScrollTop"] > 0
     assert result["afterRender"] == 0
     assert result["afterAuto"] == 0
+    assert result["scrollToBottomReturn"] == 0
+    assert result["afterScrollToBottom"] == 0
     assert result["scrollableDataset"] == "false"
 
 

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -7390,6 +7390,14 @@ def test_subtitle_window_danmaku_mode_suppresses_overflow_auto_scroll(
             await new Promise((resolve) => setTimeout(resolve, 0));
             const maxScrollTop = scroll.scrollHeight - scroll.clientHeight;
             const afterRender = scroll.scrollTop;
+            scroll.scrollTop = maxScrollTop;
+            const wheelDuringDanmaku = new WheelEvent('wheel', {
+                bubbles: true,
+                cancelable: true,
+                deltaY: 24,
+            });
+            scroll.dispatchEvent(wheelDuringDanmaku);
+            const afterStateUpdate = scroll.scrollTop;
             shared.requestSubtitleAutoScroll(scroll, {
                 speedPixelsPerSecond: 240,
                 delayMs: 0,
@@ -7401,11 +7409,13 @@ def test_subtitle_window_danmaku_mode_suppresses_overflow_auto_scroll(
                 active: display.dataset.subtitleDanmakuActive || '',
                 afterRender,
                 afterAuto: scroll.scrollTop,
+                afterStateUpdate,
                 afterScrollToBottom,
                 itemCount: document.querySelectorAll('.subtitle-danmaku-item').length,
                 maxScrollTop,
                 scrollableDataset: scroll.dataset.subtitleScrollable,
                 scrollToBottomReturn,
+                wheelPrevented: wheelDuringDanmaku.defaultPrevented,
             };
         }
         """
@@ -7415,9 +7425,11 @@ def test_subtitle_window_danmaku_mode_suppresses_overflow_auto_scroll(
     assert result["itemCount"] > 0
     assert result["maxScrollTop"] > 0
     assert result["afterRender"] == 0
+    assert result["afterStateUpdate"] == 0
     assert result["afterAuto"] == 0
     assert result["scrollToBottomReturn"] == 0
     assert result["afterScrollToBottom"] == 0
+    assert result["wheelPrevented"] is False
     assert result["scrollableDataset"] == "false"
 
 

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -7403,12 +7403,13 @@ def test_subtitle_window_danmaku_mode_suppresses_overflow_auto_scroll(
                 delayMs: 0,
             });
             await waitFrames(20);
+            const afterAuto = scroll.scrollTop;
             const scrollToBottomReturn = shared.scrollSubtitleToBottom(scroll);
             const afterScrollToBottom = scroll.scrollTop;
             return {
                 active: display.dataset.subtitleDanmakuActive || '',
                 afterRender,
-                afterAuto: scroll.scrollTop,
+                afterAuto,
                 afterStateUpdate,
                 afterScrollToBottom,
                 itemCount: document.querySelectorAll('.subtitle-danmaku-item').length,


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复字幕弹幕模式下仍触发普通字幕自动滚动的问题，避免弹幕内容被纵向滚动顶出可视区域


## 测试 / Testing

手动测试翻译框


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 优化弹幕滚动激活态的检测与同步重置：当弹幕处于激活时，会停止字幕的自动滚动/增量滚动逻辑，并将字幕滚动位置重置到顶部，同时禁用字幕可滚动状态，避免弹幕与字幕滚动冲突。
* **测试**
  * 新增前端用例覆盖“窗口弹幕模式抑制溢出自动滚动”：验证弹幕激活后多次触发滚动与自动滚动仍保持在顶部，且滚动标记与滚轮行为符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->