### PR TITLE
修复完整聊天框中表情/头像工具右上角关闭按钮出现字符与叉号重叠的问题

### DIFF
--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -3715,7 +3715,7 @@ export default function FullChatSurface({
             setToolMenuOpen(false);
           }}
         >
-          <span aria-hidden="true">×</span>
+          <span className="composer-tool-clear-icon" aria-hidden="true" />
         </button>
       ) : null}
       {toolMenuOpen ? (
@@ -4184,7 +4184,7 @@ export default function FullChatSurface({
               closeCompactInputToolFanFromUserClick();
             }}
           >
-            <span aria-hidden="true">×</span>
+            <span className="composer-tool-clear-icon" aria-hidden="true" />
           </button>
         ) : null}
       </div>


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复完整聊天框中表情/头像工具右上角关闭按钮出现字符与叉号重叠的问题

## 测试 / Testing

手动测试功能

## 修复对比

之前:
<img width="61" height="62" alt="image" src="https://github.com/user-attachments/assets/d0f524a0-409f-43d2-a0b7-be72300216cf" />

之后:
<img width="57" height="57" alt="image" src="https://github.com/user-attachments/assets/f01d6126-10f6-4756-9c15-51950f44ffd0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式**
  * 优化了清除工具选择按钮的显示样式，改进了视觉呈现效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->