### PR TITLE
feat(telemetry): 给插件二段评估的纠错重试加触发/成功率计数

### DIFF
--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -1336,6 +1336,18 @@ class DirectTaskExecutor:
 
                 response = await llm.ainvoke(messages)
                 raw_text = response.content
+                # Telemetry: every LLM response that actually came back is one
+                # Stage-2 assessment — including the empty / unparseable ones that
+                # return early below. This is the *total* denominator, so the
+                # documented retry / extra-round-trip rates aren't overstated by
+                # silently dropping non-retry failures (a parse error never fires
+                # a correction retry but still cost a Stage-2 round-trip).
+                try:
+                    from utils.instrument import counter as _instr_counter
+                    _instr_counter("plugin_assess_stage2")
+                except Exception:
+                    # 埋点失败静默，绝不能影响插件评估主路径。
+                    pass
                 # Log the prompts we sent (truncated) and the raw response (truncated) at INFO level
                 try:
                     prompt_dump = (system_prompt + "\n\n" + user_prompt)[:2000]
@@ -1409,23 +1421,6 @@ class DirectTaskExecutor:
                 d_pid = decision.get("plugin_id")
                 d_eid = decision.get("entry_id") or decision.get("plugin_entry_id") or decision.get("event_id")
 
-                # Telemetry: count every parsed Stage-2 decision that reaches
-                # validation. Denominator for the correction-retry trigger rate.
-                # Early returns on empty / unparseable responses don't reach here
-                # and can't fire a retry, so they're correctly excluded.
-                #
-                # The ``actionable`` dim splits the base so both rates are derivable:
-                # a retry can only fire when the *initial* decision had
-                # has_task & can_execute, so retries/actionable=True is the
-                # conditional correction rate, while retries/(all) is the broader
-                # "extra round-trip per Stage-2 call" cost rate.
-                try:
-                    from utils.instrument import counter as _instr_counter
-                    _instr_counter("plugin_assess_stage2", actionable=bool(d_has and d_can))
-                except Exception:
-                    # 埋点失败静默，绝不能影响插件评估主路径。
-                    pass
-
                 # Build the executable lookup from the plugins actually shown in this
                 # Stage 2 prompt. In large plugin lists, Stage 1 may filter every
                 # plugin out; a hallucinated id from the full registry must not pass
@@ -1457,6 +1452,17 @@ class DirectTaskExecutor:
                     decision["plugin_id"] = d_pid
 
                 if d_has and d_can:
+                    # Telemetry: the subset of Stage-2 assessments where the LLM
+                    # claimed an executable task — the only state a correction
+                    # retry can fire from. retries / this counter = conditional
+                    # correction rate; retries / plugin_assess_stage2 = the broader
+                    # extra-round-trip cost rate across all Stage-2 calls.
+                    try:
+                        from utils.instrument import counter as _instr_counter
+                        _instr_counter("plugin_assess_stage2_actionable")
+                    except Exception:
+                        # 埋点失败静默，绝不能影响插件评估主路径。
+                        pass
                     correction_hint = None
                     visible_entries = valid_entries_map.get(d_pid)
                     if not d_pid:

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -1410,13 +1410,18 @@ class DirectTaskExecutor:
                 d_eid = decision.get("entry_id") or decision.get("plugin_entry_id") or decision.get("event_id")
 
                 # Telemetry: count every parsed Stage-2 decision that reaches
-                # validation. This is the denominator for the correction-retry
-                # trigger rate (retries / parsed Stage-2 decisions). Early returns
-                # on empty / unparseable responses don't reach here and can't fire
-                # a retry, so they're correctly excluded from the base.
+                # validation. Denominator for the correction-retry trigger rate.
+                # Early returns on empty / unparseable responses don't reach here
+                # and can't fire a retry, so they're correctly excluded.
+                #
+                # The ``actionable`` dim splits the base so both rates are derivable:
+                # a retry can only fire when the *initial* decision had
+                # has_task & can_execute, so retries/actionable=True is the
+                # conditional correction rate, while retries/(all) is the broader
+                # "extra round-trip per Stage-2 call" cost rate.
                 try:
                     from utils.instrument import counter as _instr_counter
-                    _instr_counter("plugin_assess_stage2")
+                    _instr_counter("plugin_assess_stage2", actionable=bool(d_has and d_can))
                 except Exception:
                     # 埋点失败静默，绝不能影响插件评估主路径。
                     pass
@@ -1560,6 +1565,7 @@ class DirectTaskExecutor:
                             result="success" if _retry_ok else "fail",
                         )
                     except Exception:
+                        # 埋点失败静默，绝不能影响插件评估主路径。
                         pass
 
                 return UserPluginDecision(

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -1409,6 +1409,18 @@ class DirectTaskExecutor:
                 d_pid = decision.get("plugin_id")
                 d_eid = decision.get("entry_id") or decision.get("plugin_entry_id") or decision.get("event_id")
 
+                # Telemetry: count every parsed Stage-2 decision that reaches
+                # validation. This is the denominator for the correction-retry
+                # trigger rate (retries / parsed Stage-2 decisions). Early returns
+                # on empty / unparseable responses don't reach here and can't fire
+                # a retry, so they're correctly excluded from the base.
+                try:
+                    from utils.instrument import counter as _instr_counter
+                    _instr_counter("plugin_assess_stage2")
+                except Exception:
+                    # 埋点失败静默，绝不能影响插件评估主路径。
+                    pass
+
                 # Build the executable lookup from the plugins actually shown in this
                 # Stage 2 prompt. In large plugin lists, Stage 1 may filter every
                 # plugin out; a hallucinated id from the full registry must not pass
@@ -1530,6 +1542,25 @@ class DirectTaskExecutor:
                         final_can = False
                         decision["can_execute"] = False
                         decision["reason"] = f"entry_id '{final_eid}' not found in plugin '{final_pid}'"
+
+                # Telemetry: if a correction retry fired, record whether the
+                # re-asked decision ended up actionable. At this point
+                # decision["can_execute"] reflects final validation (forced False
+                # when plugin_id/entry_id is still invalid), so has_task &
+                # can_execute both true means a valid plugin_id/entry_id survived.
+                # Combined with the plugin_assess_stage2 denominator this gives the
+                # retry trigger rate (sum of this counter / stage2) and the
+                # post-retry success rate, without logging any LLM text.
+                if up_retry_done:
+                    try:
+                        from utils.instrument import counter as _instr_counter
+                        _retry_ok = bool(decision.get("has_task") and decision.get("can_execute"))
+                        _instr_counter(
+                            "plugin_assess_correction_retry",
+                            result="success" if _retry_ok else "fail",
+                        )
+                    except Exception:
+                        pass
 
                 return UserPluginDecision(
                     has_task=decision.get("has_task", False),

--- a/tests/unit/test_user_plugin_stage1_filtering.py
+++ b/tests/unit/test_user_plugin_stage1_filtering.py
@@ -12,7 +12,9 @@ class _FakeLLM:
         self.calls = []
 
     async def ainvoke(self, messages):
-        self.calls.append(messages)
+        # Copy the outer list: the assessor mutates `messages` in place on the
+        # correction retry, which would otherwise rewrite this captured snapshot.
+        self.calls.append(list(messages))
         return _FakeResponse(self.content)
 
 
@@ -24,7 +26,9 @@ class _SeqLLM:
         self.calls = []
 
     async def ainvoke(self, messages):
-        self.calls.append(messages)
+        # Copy the outer list: the assessor mutates `messages` in place on the
+        # correction retry, which would otherwise rewrite this captured snapshot.
+        self.calls.append(list(messages))
         idx = min(len(self.calls) - 1, len(self._contents) - 1)
         return _FakeResponse(self._contents[idx])
 

--- a/tests/unit/test_user_plugin_stage1_filtering.py
+++ b/tests/unit/test_user_plugin_stage1_filtering.py
@@ -140,7 +140,9 @@ async def test_correction_retry_telemetry_records_fail(monkeypatch):
     assert len(fake_llm.calls) == 2
 
     counters = instrument.snapshot()["counters"]
-    assert counters.get("plugin_assess_stage2") == 1
+    # actionable=True because the initial decision had has_task & can_execute
+    # (the only state from which a correction retry can fire).
+    assert counters.get("plugin_assess_stage2|actionable=True") == 1
     assert counters.get("plugin_assess_correction_retry|result=fail") == 1
     assert "plugin_assess_correction_retry|result=success" not in counters
 
@@ -161,9 +163,9 @@ async def test_correction_retry_telemetry_records_success(monkeypatch):
     # First response has a bogus entry_id (triggers correction); retry fixes it.
     seq_llm = _SeqLLM([
         '{"has_task": true, "can_execute": true, "task_description": "run alpha", '
-        '"plugin_id": "alpha", "entry_id": "bogus", "plugin_args": {}, "reason": "bad entry"}',
+        + '"plugin_id": "alpha", "entry_id": "bogus", "plugin_args": {}, "reason": "bad entry"}',
         '{"has_task": true, "can_execute": true, "task_description": "run alpha", '
-        '"plugin_id": "alpha", "entry_id": "run", "plugin_args": {}, "reason": "fixed"}',
+        + '"plugin_id": "alpha", "entry_id": "run", "plugin_args": {}, "reason": "fixed"}',
     ])
     executor._get_llm = lambda **_kwargs: seq_llm
 
@@ -179,6 +181,8 @@ async def test_correction_retry_telemetry_records_success(monkeypatch):
     assert len(seq_llm.calls) == 2
 
     counters = instrument.snapshot()["counters"]
-    assert counters.get("plugin_assess_stage2") == 1
+    # actionable=True because the initial decision had has_task & can_execute
+    # (the only state from which a correction retry can fire).
+    assert counters.get("plugin_assess_stage2|actionable=True") == 1
     assert counters.get("plugin_assess_correction_retry|result=success") == 1
     assert "plugin_assess_correction_retry|result=fail" not in counters

--- a/tests/unit/test_user_plugin_stage1_filtering.py
+++ b/tests/unit/test_user_plugin_stage1_filtering.py
@@ -140,9 +140,11 @@ async def test_correction_retry_telemetry_records_fail(monkeypatch):
     assert len(fake_llm.calls) == 2
 
     counters = instrument.snapshot()["counters"]
-    # actionable=True because the initial decision had has_task & can_execute
-    # (the only state from which a correction retry can fire).
-    assert counters.get("plugin_assess_stage2|actionable=True") == 1
+    # One Stage-2 call total; it was actionable (has_task & can_execute), the only
+    # state a correction retry can fire from. The retry's own ainvoke is not a new
+    # Stage-2 assessment, so the denominators stay at 1.
+    assert counters.get("plugin_assess_stage2") == 1
+    assert counters.get("plugin_assess_stage2_actionable") == 1
     assert counters.get("plugin_assess_correction_retry|result=fail") == 1
     assert "plugin_assess_correction_retry|result=success" not in counters
 
@@ -181,8 +183,42 @@ async def test_correction_retry_telemetry_records_success(monkeypatch):
     assert len(seq_llm.calls) == 2
 
     counters = instrument.snapshot()["counters"]
-    # actionable=True because the initial decision had has_task & can_execute
-    # (the only state from which a correction retry can fire).
-    assert counters.get("plugin_assess_stage2|actionable=True") == 1
+    assert counters.get("plugin_assess_stage2") == 1
+    assert counters.get("plugin_assess_stage2_actionable") == 1
     assert counters.get("plugin_assess_correction_retry|result=success") == 1
     assert "plugin_assess_correction_retry|result=fail" not in counters
+
+
+@pytest.mark.asyncio
+async def test_stage2_denominator_includes_unparsed_response(monkeypatch):
+    """An unparseable Stage-2 response counts toward the total denominator but is
+    neither actionable nor a retry — so the cost rate isn't overstated."""
+    from brain import task_executor as task_executor_module
+    from brain.task_executor import DirectTaskExecutor
+    from utils import instrument
+
+    monkeypatch.setattr(task_executor_module, "stage1_filter", lambda *args, **kwargs: ([], []))
+    instrument.snapshot()  # clear any data from earlier tests in this process
+
+    executor = object.__new__(DirectTaskExecutor)
+    executor._STAGE1_TRIGGER_TOKENS = 1
+    executor._stage1_llm_coarse_screen = _no_coarse_ids
+
+    # No JSON object at all -> early return on the parse-failure path, before any
+    # validation / retry can happen.
+    fake_llm = _FakeLLM("sorry, I cannot help with that")
+    executor._get_llm = lambda **_kwargs: fake_llm
+
+    result = await executor._assess_user_plugin(
+        "LATEST_USER_REQUEST: unrelated request",
+        _make_plugins(),
+        lang="en",
+    )
+
+    assert result.can_execute is False
+    assert len(fake_llm.calls) == 1  # no correction retry fired
+
+    counters = instrument.snapshot()["counters"]
+    assert counters.get("plugin_assess_stage2") == 1
+    assert "plugin_assess_stage2_actionable" not in counters
+    assert not any(k.startswith("plugin_assess_correction_retry") for k in counters)

--- a/tests/unit/test_user_plugin_stage1_filtering.py
+++ b/tests/unit/test_user_plugin_stage1_filtering.py
@@ -16,6 +16,19 @@ class _FakeLLM:
         return _FakeResponse(self.content)
 
 
+class _SeqLLM:
+    """Returns a different canned response per call (last one sticks)."""
+
+    def __init__(self, contents):
+        self._contents = list(contents)
+        self.calls = []
+
+    async def ainvoke(self, messages):
+        self.calls.append(messages)
+        idx = min(len(self.calls) - 1, len(self._contents) - 1)
+        return _FakeResponse(self._contents[idx])
+
+
 def _make_plugins():
     return [
         {
@@ -92,3 +105,80 @@ async def test_stage1_empty_union_rejects_hallucinated_existing_plugin(monkeypat
     assert result.can_execute is False
     assert result.plugin_id == "alpha"
     assert result.reason == "plugin_id 'alpha' not available in current candidates"
+
+
+@pytest.mark.asyncio
+async def test_correction_retry_telemetry_records_fail(monkeypatch):
+    """A retry that still yields an invalid id is counted as a failed retry."""
+    from brain import task_executor as task_executor_module
+    from brain.task_executor import DirectTaskExecutor
+    from utils import instrument
+
+    monkeypatch.setattr(task_executor_module, "stage1_filter", lambda *args, **kwargs: ([], []))
+    instrument.snapshot()  # clear any data from earlier tests in this process
+
+    executor = object.__new__(DirectTaskExecutor)
+    executor._STAGE1_TRIGGER_TOKENS = 1
+    executor._stage1_llm_coarse_screen = _no_coarse_ids
+
+    # Stage 1 filters everything out, so any plugin_id is invalid -> retry, and the
+    # retry returns the same invalid decision -> still fails final validation.
+    fake_llm = _FakeLLM(
+        '{"has_task": true, "can_execute": true, "task_description": "run alpha", '
+        '"plugin_id": "alpha", "entry_id": "run", "plugin_args": {}, "reason": "hallucinated"}'
+    )
+    executor._get_llm = lambda **_kwargs: fake_llm
+
+    result = await executor._assess_user_plugin(
+        "LATEST_USER_REQUEST: unrelated request",
+        _make_plugins(),
+        lang="en",
+    )
+
+    assert result.can_execute is False
+    # initial call + one correction retry
+    assert len(fake_llm.calls) == 2
+
+    counters = instrument.snapshot()["counters"]
+    assert counters.get("plugin_assess_stage2") == 1
+    assert counters.get("plugin_assess_correction_retry|result=fail") == 1
+    assert "plugin_assess_correction_retry|result=success" not in counters
+
+
+@pytest.mark.asyncio
+async def test_correction_retry_telemetry_records_success(monkeypatch):
+    """A retry that fixes the id is counted as a successful retry."""
+    from brain.task_executor import DirectTaskExecutor
+    from utils import instrument
+
+    instrument.snapshot()  # clear any data from earlier tests in this process
+
+    executor = object.__new__(DirectTaskExecutor)
+    # High threshold -> skip Stage 1, so the full plugin list is the candidate set.
+    executor._STAGE1_TRIGGER_TOKENS = 1_000_000
+    executor._stage1_llm_coarse_screen = _no_coarse_ids
+
+    # First response has a bogus entry_id (triggers correction); retry fixes it.
+    seq_llm = _SeqLLM([
+        '{"has_task": true, "can_execute": true, "task_description": "run alpha", '
+        '"plugin_id": "alpha", "entry_id": "bogus", "plugin_args": {}, "reason": "bad entry"}',
+        '{"has_task": true, "can_execute": true, "task_description": "run alpha", '
+        '"plugin_id": "alpha", "entry_id": "run", "plugin_args": {}, "reason": "fixed"}',
+    ])
+    executor._get_llm = lambda **_kwargs: seq_llm
+
+    result = await executor._assess_user_plugin(
+        "LATEST_USER_REQUEST: run alpha",
+        _make_plugins(),
+        lang="en",
+    )
+
+    assert result.can_execute is True
+    assert result.plugin_id == "alpha"
+    assert result.entry_id == "run"
+    assert len(seq_llm.calls) == 2
+
+    counters = instrument.snapshot()["counters"]
+    assert counters.get("plugin_assess_stage2") == 1
+    assert counters.get("plugin_assess_correction_retry|result=success") == 1
+    assert "plugin_assess_correction_retry|result=fail" not in counters


### PR DESCRIPTION
@
## 背景

`brain/task_executor.py` 的 `_assess_user_plugin` 里有一个纠错重试分支：当 Stage-2 LLM 返回的 `plugin_id`/`entry_id` 非法（不在候选集里）时，会追加一条 CORRECTION 提示并**再发一次 LLM**。这是一次额外的大模型 round-trip，但此前只有文本 `logger.info/warning`，没有任何聚合埋点能回答它的**真实触发频率**和**重试后成功率**——而这正是决定"是否值得用 enum 约束输出 / 本地最近邻匹配替换它"的关键数据。

排查确认：`task_executor.py` 整个文件此前 0 处 instrument/counter 调用，`token_tracker.py`、`telemetry_smoke.py` 也都没有这条链路的 metric。

## 改动

复用 `utils/instrument` 的 `counter`（本地 import + `try/except` 兜底，埋点失败绝不影响插件评估主路径），加两个 metric，命名沿用 `memory_recall_invoke` 等现有风格：

| metric | 含义 |
|---|---|
| `plugin_assess_stage2` | 每次解析出 Stage-2 decision 进入校验时 +1，作为触发率分母。空响应/JSON 解析失败的早返回走不到这里、也不可能触发重试，天然排除。 |
| `plugin_assess_correction_retry{result=success\|fail}` | 仅当重试真正发生时记一次。`success` = 重试后 `has_task & can_execute` 通过最终校验存活（即 plugin_id/entry_id 合法）；`fail` = 仍非法。 |

**查询方式**：
- 触发次数 = `success + fail` 之和
- 触发率 = 该和 / `plugin_assess_stage2`
- 重试成功率 = `result=success` / (`success + fail`)

数据走 instrument 单例 → token_tracker 60s snapshot → 同 daily_stats 的 HTTP 通道上报。不新造遥测框架，不把任何 LLM 原文写进维度。

## 测试

新增两个单测覆盖重试→`fail`（stage1 全过滤、重试仍非法）和重试→`success`（首响应 entry_id 非法、重试修正），断言计数能区分触发次数与成功/失败。

`uv run pytest tests/unit/test_user_plugin_stage1_filtering.py tests/test_instrument.py` → **31 passed**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强插件评估流程可观测性：新增 Stage-2 遥测埋点，统计 Stage-2 总分母、可执行性子集；纠错重试后上报 success/fail 结果。

* **测试**
  * 新增顺序式 LLM 测试替身及调整现有断言数据记录方式。
  * 新增覆盖纠错重试成功/失败、以及 Stage-2 不可解析不触发相关计数的单元测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->