### PR TITLE
perf(agent): 把插件 short_description 生成移出 analyze 热路径并持久化缓存

### DIFF
--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -20,6 +20,7 @@ Evaluates ComputerUse / BrowserUse / UserPlugin feasibility in parallel
 import json
 import os
 import re
+import hashlib
 import asyncio
 import time
 from pathlib import Path
@@ -236,9 +237,12 @@ class DirectTaskExecutor:
         self._cached_llms: dict[tuple, ChatOpenAI] = {}
         self._cached_llm_config_key: tuple = ()  # tracks (api_key, base_url, model) to detect config changes
         self._cleanup_tasks: set = set()  # 持有关闭任务的强引用，防止 GC 回收
-        # plugin_id -> (full_description, generated_short_description)
-        # 只有 LLM 生成的条目会落盘（见 _persist_generated_short_descriptions）；
-        # manifest 自带 short_description 的插件每次加载都能免费重新 prime，无需持久化。
+        # plugin_id -> (description_key, generated_short_description)
+        # description_key = full description 的 hash（见 _desc_key）：既精确反映完整
+        # description 的变化（截断只用于喂 LLM，不能当失效 key），又有界，避免超大
+        # description 撑爆内存/缓存文件。只有 LLM 生成的条目会落盘（见
+        # _persist_generated_short_descriptions）；manifest 自带 short_description
+        # 的插件每次加载都能免费重新 prime，无需持久化。
         self._short_desc_cache_filename = "plugin_short_desc_cache.json"
         self._short_desc_cache: dict[str, tuple[str, str]] = self._load_short_desc_cache()
         # plugin ids currently being generated in a background prewarm task —
@@ -293,6 +297,13 @@ class DirectTaskExecutor:
         """Allow agent_server to inject a custom async provider for plugin discovery."""
         self._external_plugin_provider = provider
 
+    @staticmethod
+    def _desc_key(desc: str) -> str:
+        """Stable, bounded validity key for a plugin description. The cache hits
+        only while the *full* description is unchanged; hashing keeps the key
+        small (a plugin's raw description is uncapped)."""
+        return hashlib.sha256((desc or "").encode("utf-8")).hexdigest()
+
     def _apply_cached_short_descriptions(self, plugins: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Apply manifest-provided or previously-generated short_description
         onto each plugin dict. Pure manifest/cache read — NEVER calls the LLM,
@@ -309,9 +320,11 @@ class DirectTaskExecutor:
             short = str(p.get("short_description", "") or "").strip()
             desc = str(p.get("description", "") or "").strip()
             if not short:
-                # Apply cached value if available and description hasn't changed.
+                # Apply cached value if available and the (full) description
+                # hasn't changed. Key off the full description, not the truncated
+                # one used for the LLM prompt, so long-description plugins still hit.
                 cached = self._short_desc_cache.get(pid)
-                if cached and cached[0] == desc:
+                if cached and cached[0] == self._desc_key(desc):
                     p["short_description"] = cached[1]
                     continue
                 if desc:
@@ -319,7 +332,7 @@ class DirectTaskExecutor:
             elif pid:
                 # (a) manifest already carries short_description — use it as-is,
                 # zero LLM. Prime the cache so it survives a desc-unchanged refresh.
-                self._short_desc_cache[pid] = (desc, short)
+                self._short_desc_cache[pid] = (self._desc_key(desc), short)
         return missing
 
     def _schedule_short_desc_prewarm(self, plugins: List[Dict[str, Any]]) -> None:
@@ -352,14 +365,15 @@ class DirectTaskExecutor:
         if not pending:
             return
         pids = {str(p.get("id", "")) for p in pending}
-        inflight |= pids
+        # Resolve the loop BEFORE constructing the coroutine: if there's no
+        # running event loop (sync context), bail out without leaving an
+        # un-awaited coroutine behind. analyze still falls back to full desc.
         try:
-            task = asyncio.create_task(self._prewarm_short_descriptions(pending, pids))
+            loop = asyncio.get_running_loop()
         except RuntimeError:
-            # No running event loop (called from a sync context) — skip prewarm;
-            # analyze still falls back to the full description.
-            inflight -= pids
             return
+        inflight |= pids
+        task = loop.create_task(self._prewarm_short_descriptions(pending, pids))
         self._short_desc_prewarm_tasks.add(task)
         task.add_done_callback(self._short_desc_prewarm_tasks.discard)
 
@@ -394,9 +408,12 @@ class DirectTaskExecutor:
                     from utils.tokenize import count_tokens
                     if text and count_tokens(text) <= AGENT_PLUGIN_SHORTDESC_MAX_TOKENS:
                         p["short_description"] = text
-                        self._short_desc_cache[pid] = (desc, text)
+                        # Key off the FULL description (truncation is prompt-only),
+                        # so apply-time lookup hits even for long-description plugins.
+                        desc_key = self._desc_key(raw_desc)
+                        self._short_desc_cache[pid] = (desc_key, text)
                         if isinstance(pid, str) and pid:
-                            generated[pid] = (desc, text)
+                            generated[pid] = (desc_key, text)
                         # LLM 生成原文不写 logger
                         logger.debug("[Agent] Generated short_description for %s (len=%d chars)", pid, len(text))
                         print(f"[Agent] short_description {pid}: {text[:80]}")
@@ -824,10 +841,11 @@ class DirectTaskExecutor:
     def _load_short_desc_cache(self) -> dict[str, tuple[str, str]]:
         """Load the on-disk short_description cache (LLM-generated entries only).
 
-        Returns ``{plugin_id: (description, short_description)}``. ``description``
-        is the validity key: at apply time we re-generate when the plugin's
-        current description no longer matches the stored one. Best-effort —
-        a missing or corrupt file just yields an empty cache.
+        Returns ``{plugin_id: (description_key, short_description)}``.
+        ``description_key`` is a hash of the full description (see ``_desc_key``):
+        at apply time we re-generate when the plugin's current description no
+        longer hashes to the stored key. Best-effort — a missing or corrupt file
+        just yields an empty cache.
         """
         try:
             path = self._get_short_desc_cache_path()
@@ -849,10 +867,10 @@ class DirectTaskExecutor:
         for pid, item in entries.items():
             if not isinstance(pid, str) or not isinstance(item, dict):
                 continue
-            desc = item.get("desc")
+            key = item.get("key")
             short = item.get("short")
-            if isinstance(desc, str) and isinstance(short, str) and short:
-                cache[pid] = (desc, short)
+            if isinstance(key, str) and isinstance(short, str) and short:
+                cache[pid] = (key, short)
         return cache
 
     def _persist_generated_short_descriptions(self, generated: dict[str, tuple[str, str]]) -> None:
@@ -874,7 +892,7 @@ class DirectTaskExecutor:
         on_disk.update(generated)
         payload = {
             "version": 1,
-            "entries": {pid: {"desc": d, "short": s} for pid, (d, s) in on_disk.items()},
+            "entries": {pid: {"key": k, "short": s} for pid, (k, s) in on_disk.items()},
         }
         try:
             path.parent.mkdir(parents=True, exist_ok=True)

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -237,7 +237,15 @@ class DirectTaskExecutor:
         self._cached_llm_config_key: tuple = ()  # tracks (api_key, base_url, model) to detect config changes
         self._cleanup_tasks: set = set()  # 持有关闭任务的强引用，防止 GC 回收
         # plugin_id -> (full_description, generated_short_description)
-        self._short_desc_cache: dict[str, tuple[str, str]] = {}
+        # 只有 LLM 生成的条目会落盘（见 _persist_generated_short_descriptions）；
+        # manifest 自带 short_description 的插件每次加载都能免费重新 prime，无需持久化。
+        self._short_desc_cache_filename = "plugin_short_desc_cache.json"
+        self._short_desc_cache: dict[str, tuple[str, str]] = self._load_short_desc_cache()
+        # plugin ids currently being generated in a background prewarm task —
+        # dedupes the per-analyze force_refresh so we don't pile up duplicate
+        # generation tasks. The tasks set holds strong refs to prevent GC.
+        self._short_desc_prewarm_inflight: set[str] = set()
+        self._short_desc_prewarm_tasks: set = set()
         self._correction_memory_filename = "correction_memory.json"
         self._search_term_allowlist = {"id", "os", "db", "ui", "ux", "qa"}
         # 白名单 + alias 归一化，防止任意字符串被写进 correction_memory.json
@@ -285,30 +293,87 @@ class DirectTaskExecutor:
         """Allow agent_server to inject a custom async provider for plugin discovery."""
         self._external_plugin_provider = provider
 
-    async def _ensure_short_descriptions(self, plugins: List[Dict[str, Any]]) -> None:
-        """For plugins missing short_description, generate one via LLM (best-effort, cached)."""
-        to_generate: list[dict] = []
+    def _apply_cached_short_descriptions(self, plugins: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Apply manifest-provided or previously-generated short_description
+        onto each plugin dict. Pure manifest/cache read — NEVER calls the LLM,
+        so it is safe on the analyze hot path.
+
+        Returns the plugins that are still missing a short_description (and have
+        a description to summarize) — i.e. the candidates for background prewarm.
+        """
+        missing: list[dict] = []
         for p in plugins:
             if not isinstance(p, dict):
                 continue
             pid = p.get("id", "")
             short = str(p.get("short_description", "") or "").strip()
             desc = str(p.get("description", "") or "").strip()
-            # Apply cached value if available and description hasn't changed
-            cached = self._short_desc_cache.get(pid)
-            if cached and cached[0] == desc and not short:
-                p["short_description"] = cached[1]
-                continue
-            if not short and desc:
-                to_generate.append(p)
-            elif pid and short:
+            if not short:
+                # Apply cached value if available and description hasn't changed.
+                cached = self._short_desc_cache.get(pid)
+                if cached and cached[0] == desc:
+                    p["short_description"] = cached[1]
+                    continue
+                if desc:
+                    missing.append(p)
+            elif pid:
+                # (a) manifest already carries short_description — use it as-is,
+                # zero LLM. Prime the cache so it survives a desc-unchanged refresh.
                 self._short_desc_cache[pid] = (desc, short)
+        return missing
 
-        if not to_generate:
+    def _schedule_short_desc_prewarm(self, plugins: List[Dict[str, Any]]) -> None:
+        """Apply cached/manifest short_descriptions onto ``plugins`` (hot-path
+        safe, zero LLM) and, for any plugin still missing one, schedule a
+        fire-and-forget background task to generate it at plugin-load time.
+
+        NEVER awaited on the analyze path: the current analyze safely falls back
+        to the full description for plugins whose short_description hasn't been
+        generated yet (see ``_stage1_llm_coarse_screen``). The generated value
+        lands in ``_short_desc_cache`` for subsequent analyze runs.
+
+        Deduped by plugin id via ``_short_desc_prewarm_inflight`` so the
+        per-analyze ``force_refresh`` doesn't pile up duplicate generation tasks.
+        """
+        missing = self._apply_cached_short_descriptions(plugins)
+        if not missing:
             return
-
-        logger.info("[Agent] Generating short_description for %d plugin(s)", len(to_generate))
+        # Lazy-init for instances built via object.__new__ (test fixtures bypass __init__).
+        inflight = getattr(self, "_short_desc_prewarm_inflight", None)
+        if inflight is None:
+            inflight = set()
+            self._short_desc_prewarm_inflight = inflight
+        if getattr(self, "_short_desc_prewarm_tasks", None) is None:
+            self._short_desc_prewarm_tasks = set()
+        pending = [
+            p for p in missing
+            if str(p.get("id", "")).strip() and str(p.get("id", "")) not in inflight
+        ]
+        if not pending:
+            return
+        pids = {str(p.get("id", "")) for p in pending}
+        inflight |= pids
         try:
+            task = asyncio.create_task(self._prewarm_short_descriptions(pending, pids))
+        except RuntimeError:
+            # No running event loop (called from a sync context) — skip prewarm;
+            # analyze still falls back to the full description.
+            inflight -= pids
+            return
+        self._short_desc_prewarm_tasks.add(task)
+        task.add_done_callback(self._short_desc_prewarm_tasks.discard)
+
+    async def _prewarm_short_descriptions(
+        self, to_generate: List[Dict[str, Any]], pids: set[str],
+    ) -> None:
+        """Background LLM generation of short_description for plugins missing one
+        (best-effort, cached). Runs OFF the analyze hot path — scheduled by
+        ``_schedule_short_desc_prewarm`` at plugin-load time. Newly generated
+        entries are persisted to disk so subsequent app restarts reuse them
+        (keyed by description, so a manifest change still invalidates)."""
+        generated: dict[str, tuple[str, str]] = {}
+        try:
+            logger.info("[Agent] Generating short_description for %d plugin(s)", len(to_generate))
             llm = self._get_llm(temperature=0, max_completion_tokens=AGENT_PLUGIN_SHORTDESC_MAX_TOKENS)
             for p in to_generate:
                 pid = p.get("id", "unknown")
@@ -330,6 +395,8 @@ class DirectTaskExecutor:
                     if text and count_tokens(text) <= AGENT_PLUGIN_SHORTDESC_MAX_TOKENS:
                         p["short_description"] = text
                         self._short_desc_cache[pid] = (desc, text)
+                        if isinstance(pid, str) and pid:
+                            generated[pid] = (desc, text)
                         # LLM 生成原文不写 logger
                         logger.debug("[Agent] Generated short_description for %s (len=%d chars)", pid, len(text))
                         print(f"[Agent] short_description {pid}: {text[:80]}")
@@ -338,6 +405,10 @@ class DirectTaskExecutor:
                     logger.debug("[Agent] Failed to generate short_description for %s: %s", pid, e)
         except Exception as e:
             logger.warning("[Agent] short_description generation batch failed: %s", e)
+        finally:
+            self._short_desc_prewarm_inflight -= pids
+            # 把本批生成的（贵的）条目落盘，下次启动直接复用、不再现生成。
+            self._persist_generated_short_descriptions(generated)
 
     async def plugin_list_provider(self, force_refresh: bool = True) -> List[Dict[str, Any]]:
         # return cached list when allowed
@@ -350,7 +421,10 @@ class DirectTaskExecutor:
                 plugins = await self._external_plugin_provider(force_refresh)
                 if isinstance(plugins, list):
                     self.plugin_list = plugins
-                    await self._ensure_short_descriptions(self.plugin_list)
+                    # Apply cached/manifest short_descriptions synchronously
+                    # (zero LLM) and prewarm any missing ones in the background —
+                    # never generate on the analyze hot path.
+                    self._schedule_short_desc_prewarm(self.plugin_list)
                     logger.info(f"[Agent] Loaded {len(self.plugin_list)} plugins via external provider")
                     return self.plugin_list
             except Exception as e:
@@ -373,7 +447,9 @@ class DirectTaskExecutor:
                     # only update cache when we obtained a non-empty list
                     if plugin_list:
                         self.plugin_list = plugin_list  # 更新实例变量
-                        await self._ensure_short_descriptions(self.plugin_list)
+                        # 同步应用缓存/manifest 的 short_description（零 LLM），
+                        # 缺失的放后台预热，绝不在 analyze 热路径上现生成。
+                        self._schedule_short_desc_prewarm(self.plugin_list)
             except Exception as e:
                 logger.warning(f"[Agent] plugin_list_provider http fetch failed: {e}")
         logger.info(f"[Agent] Loaded {len(self.plugin_list)} plugins: {[p.get('id', 'unknown') for p in self.plugin_list if isinstance(p, dict)]}")
@@ -740,6 +816,86 @@ class DirectTaskExecutor:
             os.chmod(path, 0o600)
         except OSError:
             pass
+
+    def _get_short_desc_cache_path(self) -> Path:
+        self._config_manager.ensure_config_directory()
+        return Path(self._config_manager.config_dir) / self._short_desc_cache_filename
+
+    def _load_short_desc_cache(self) -> dict[str, tuple[str, str]]:
+        """Load the on-disk short_description cache (LLM-generated entries only).
+
+        Returns ``{plugin_id: (description, short_description)}``. ``description``
+        is the validity key: at apply time we re-generate when the plugin's
+        current description no longer matches the stored one. Best-effort —
+        a missing or corrupt file just yields an empty cache.
+        """
+        try:
+            path = self._get_short_desc_cache_path()
+        except Exception as exc:
+            logger.debug("[Agent] short_desc cache path unavailable: %s", exc)
+            return {}
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except FileNotFoundError:
+            return {}
+        except Exception as exc:
+            logger.warning("[Agent] Failed to load short_desc cache %s: %s", path, exc)
+            return {}
+        entries = data.get("entries") if isinstance(data, dict) else None
+        if not isinstance(entries, dict):
+            return {}
+        cache: dict[str, tuple[str, str]] = {}
+        for pid, item in entries.items():
+            if not isinstance(pid, str) or not isinstance(item, dict):
+                continue
+            desc = item.get("desc")
+            short = item.get("short")
+            if isinstance(desc, str) and isinstance(short, str) and short:
+                cache[pid] = (desc, short)
+        return cache
+
+    def _persist_generated_short_descriptions(self, generated: dict[str, tuple[str, str]]) -> None:
+        """Merge newly LLM-generated entries into the on-disk cache (atomic write).
+
+        Only generated entries are persisted; manifest-provided short_descriptions
+        are re-derived for free on every load and would only bloat the file (a
+        plugin's raw ``description`` is uncapped). Best-effort — a write failure
+        just means the next session regenerates."""
+        if not generated:
+            return
+        try:
+            path = self._get_short_desc_cache_path()
+        except Exception as exc:
+            logger.debug("[Agent] short_desc cache path unavailable, skip persist: %s", exc)
+            return
+        # Re-read so concurrent prewarm batches don't clobber each other's entries.
+        on_disk = self._load_short_desc_cache()
+        on_disk.update(generated)
+        payload = {
+            "version": 1,
+            "entries": {pid: {"desc": d, "short": s} for pid, (d, s) in on_disk.items()},
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.chmod(path.parent, 0o700)
+            except OSError:
+                pass
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, indent=2)
+            try:
+                os.chmod(tmp_path, 0o600)
+            except OSError:
+                pass
+            tmp_path.replace(path)
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
+        except Exception as exc:
+            logger.warning("[Agent] Failed to persist short_desc cache %s: %s", path, exc)
 
     def _is_allowed_search_term(self, term: str) -> bool:
         if not term or term.isdigit():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1914,9 +1914,11 @@ def test_task_executor_skips_plugin_with_only_agent_hidden_entries():
 
 
 def test_apply_cached_short_descriptions_manifest_cache_and_fallback():
-    """_apply_cached_short_descriptions 是纯 manifest/缓存读取（零 LLM）：
-    manifest 自带的直接用并 prime 缓存；缓存命中（desc 未变）则应用；缺失或
-    缓存陈旧的留空并作为后台预热候选返回，绝不在此处现生成。"""
+    """_apply_cached_short_descriptions is a pure manifest/cache read (zero LLM):
+    a manifest-provided short_description is used as-is and primes the cache; a
+    cache hit (description unchanged) is applied; missing or stale entries are
+    left empty and returned as background-prewarm candidates — never generated
+    here."""
     from brain.task_executor import DirectTaskExecutor
 
     key = DirectTaskExecutor._desc_key
@@ -1954,9 +1956,10 @@ def test_apply_cached_short_descriptions_manifest_cache_and_fallback():
 
 @pytest.mark.asyncio
 async def test_plugin_list_provider_never_generates_short_description_on_hot_path():
-    """验收核心：analyze 热路径（plugin_list_provider）绝不现生成
-    short_description。缺失的插件交给后台预热，当次调用立即返回、_get_llm 不被
-    同步触发，分析侧安全回退到完整 description。"""
+    """Core acceptance: the analyze hot path (plugin_list_provider) must never
+    generate a short_description inline. Plugins missing one are handed to the
+    background prewarm; the call returns immediately, _get_llm is not invoked
+    synchronously, and analyze safely falls back to the full description."""
     from unittest.mock import AsyncMock, MagicMock, patch
     from brain.task_executor import DirectTaskExecutor
 
@@ -1988,8 +1991,10 @@ async def test_plugin_list_provider_never_generates_short_description_on_hot_pat
 
 
 def test_short_desc_cache_persists_generated_entries_across_instances(tmp_path):
-    """LLM 生成的 short_description 落盘，重启后新实例直接复用、零 LLM；
-    description 的 hash 作为 key——manifest 变了缓存自动失效重新生成。"""
+    """LLM-generated short_descriptions are persisted to disk; a fresh instance
+    (simulating a restart) reuses them with zero LLM. The key is a hash of the
+    full description, so a manifest change invalidates the entry and triggers
+    regeneration."""
     from types import SimpleNamespace
     from brain.task_executor import DirectTaskExecutor
 
@@ -2023,9 +2028,10 @@ def test_short_desc_cache_persists_generated_entries_across_instances(tmp_path):
 
 
 def test_short_desc_cache_key_uses_full_description_not_truncated_prompt():
-    """回归（Codex P2）：缓存键基于完整 description 的 hash，截断只用于喂 LLM。
-    超长 description（远超 PLUGIN_INPUT_DESC_MAX_TOKENS）也应命中缓存，而不是因
-    截断后的键与完整 description 不符而反复重新生成。"""
+    """Regression (Codex P2): the cache key is a hash of the FULL description;
+    truncation is prompt-only. A very long description (far above
+    PLUGIN_INPUT_DESC_MAX_TOKENS) must still hit the cache, rather than missing
+    forever because a truncated key never matches the full description."""
     from config import PLUGIN_INPUT_DESC_MAX_TOKENS
     from brain.task_executor import DirectTaskExecutor
 
@@ -2041,7 +2047,7 @@ def test_short_desc_cache_key_uses_full_description_not_truncated_prompt():
 
 
 def test_short_desc_cache_load_tolerates_missing_and_corrupt_file(tmp_path):
-    """缺文件 / 损坏 JSON → 安全返回空缓存，不抛。"""
+    """A missing file or corrupt JSON yields an empty cache safely (no raise)."""
     from types import SimpleNamespace
     from brain.task_executor import DirectTaskExecutor
 

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1919,10 +1919,12 @@ def test_apply_cached_short_descriptions_manifest_cache_and_fallback():
     缓存陈旧的留空并作为后台预热候选返回，绝不在此处现生成。"""
     from brain.task_executor import DirectTaskExecutor
 
+    key = DirectTaskExecutor._desc_key
     executor = object.__new__(DirectTaskExecutor)
     executor._short_desc_cache = {}
-    executor._short_desc_cache["from_cache"] = ("full B", "cached B")
-    executor._short_desc_cache["stale_cache"] = ("old D", "cached D")
+    # 缓存键是完整 description 的 hash（截断只用于喂 LLM，不当失效 key）
+    executor._short_desc_cache["from_cache"] = (key("full B"), "cached B")
+    executor._short_desc_cache["stale_cache"] = (key("old D"), "cached D")
 
     plugins = [
         {"id": "has_manifest", "description": "full A", "short_description": "short A"},
@@ -1937,7 +1939,7 @@ def test_apply_cached_short_descriptions_manifest_cache_and_fallback():
 
     # (a) manifest 自带 → 直接用，并把它写进缓存供后续 refresh 复用
     assert plugins[0]["short_description"] == "short A"
-    assert executor._short_desc_cache["has_manifest"] == ("full A", "short A")
+    assert executor._short_desc_cache["has_manifest"] == (key("full A"), "short A")
     # 缓存命中（desc 未变）→ 应用缓存值
     assert plugins[1]["short_description"] == "cached B"
     # 缓存陈旧（desc 变了）→ 不应用，进 missing 候选
@@ -1955,7 +1957,6 @@ async def test_plugin_list_provider_never_generates_short_description_on_hot_pat
     """验收核心：analyze 热路径（plugin_list_provider）绝不现生成
     short_description。缺失的插件交给后台预热，当次调用立即返回、_get_llm 不被
     同步触发，分析侧安全回退到完整 description。"""
-    import asyncio
     from unittest.mock import AsyncMock, MagicMock, patch
     from brain.task_executor import DirectTaskExecutor
 
@@ -1988,17 +1989,18 @@ async def test_plugin_list_provider_never_generates_short_description_on_hot_pat
 
 def test_short_desc_cache_persists_generated_entries_across_instances(tmp_path):
     """LLM 生成的 short_description 落盘，重启后新实例直接复用、零 LLM；
-    description 作为 key——manifest 变了缓存自动失效重新生成。"""
+    description 的 hash 作为 key——manifest 变了缓存自动失效重新生成。"""
     from types import SimpleNamespace
     from brain.task_executor import DirectTaskExecutor
 
     cfg = SimpleNamespace(config_dir=str(tmp_path), ensure_config_directory=lambda: None)
+    key = DirectTaskExecutor._desc_key
 
-    # 实例一：把一条生成的缓存落盘
+    # 实例一：把一条生成的缓存落盘（key = 完整 description 的 hash）
     exec1 = object.__new__(DirectTaskExecutor)
     exec1._config_manager = cfg
     exec1._short_desc_cache_filename = "plugin_short_desc_cache.json"
-    exec1._persist_generated_short_descriptions({"genplug": ("full desc", "generated short")})
+    exec1._persist_generated_short_descriptions({"genplug": (key("full desc"), "generated short")})
     assert (tmp_path / "plugin_short_desc_cache.json").exists()
 
     # 实例二：从盘上加载（模拟重启）
@@ -2006,18 +2008,36 @@ def test_short_desc_cache_persists_generated_entries_across_instances(tmp_path):
     exec2._config_manager = cfg
     exec2._short_desc_cache_filename = "plugin_short_desc_cache.json"
     exec2._short_desc_cache = exec2._load_short_desc_cache()
-    assert exec2._short_desc_cache == {"genplug": ("full desc", "generated short")}
+    assert exec2._short_desc_cache == {"genplug": (key("full desc"), "generated short")}
 
     # desc 未变 → 命中持久化缓存，零 LLM，不进 missing
     plugins = [{"id": "genplug", "description": "full desc"}]
     assert exec2._apply_cached_short_descriptions(plugins) == []
     assert plugins[0]["short_description"] == "generated short"
 
-    # desc 变了 → key 校验失效，重新作为生成候选
+    # desc 变了 → hash key 失效，重新作为生成候选
     changed = [{"id": "genplug", "description": "CHANGED desc"}]
     missing = exec2._apply_cached_short_descriptions(changed)
     assert "short_description" not in changed[0]
     assert [p["id"] for p in missing] == ["genplug"]
+
+
+def test_short_desc_cache_key_uses_full_description_not_truncated_prompt():
+    """回归（Codex P2）：缓存键基于完整 description 的 hash，截断只用于喂 LLM。
+    超长 description（远超 PLUGIN_INPUT_DESC_MAX_TOKENS）也应命中缓存，而不是因
+    截断后的键与完整 description 不符而反复重新生成。"""
+    from config import PLUGIN_INPUT_DESC_MAX_TOKENS
+    from brain.task_executor import DirectTaskExecutor
+
+    key = DirectTaskExecutor._desc_key
+    long_desc = ("word " * (PLUGIN_INPUT_DESC_MAX_TOKENS * 4)).strip()  # 远超输入截断阈值
+
+    executor = object.__new__(DirectTaskExecutor)
+    executor._short_desc_cache = {"big": (key(long_desc), "cached short")}
+
+    plugins = [{"id": "big", "description": long_desc}]
+    assert executor._apply_cached_short_descriptions(plugins) == []
+    assert plugins[0]["short_description"] == "cached short"
 
 
 def test_short_desc_cache_load_tolerates_missing_and_corrupt_file(tmp_path):

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1913,6 +1913,131 @@ def test_task_executor_skips_plugin_with_only_agent_hidden_entries():
     assert entry is None
 
 
+def test_apply_cached_short_descriptions_manifest_cache_and_fallback():
+    """_apply_cached_short_descriptions 是纯 manifest/缓存读取（零 LLM）：
+    manifest 自带的直接用并 prime 缓存；缓存命中（desc 未变）则应用；缺失或
+    缓存陈旧的留空并作为后台预热候选返回，绝不在此处现生成。"""
+    from brain.task_executor import DirectTaskExecutor
+
+    executor = object.__new__(DirectTaskExecutor)
+    executor._short_desc_cache = {}
+    executor._short_desc_cache["from_cache"] = ("full B", "cached B")
+    executor._short_desc_cache["stale_cache"] = ("old D", "cached D")
+
+    plugins = [
+        {"id": "has_manifest", "description": "full A", "short_description": "short A"},
+        {"id": "from_cache", "description": "full B"},
+        {"id": "stale_cache", "description": "new D"},
+        {"id": "missing", "description": "full C"},
+        {"id": "no_desc"},
+        "not_a_dict",
+    ]
+
+    missing = executor._apply_cached_short_descriptions(plugins)
+
+    # (a) manifest 自带 → 直接用，并把它写进缓存供后续 refresh 复用
+    assert plugins[0]["short_description"] == "short A"
+    assert executor._short_desc_cache["has_manifest"] == ("full A", "short A")
+    # 缓存命中（desc 未变）→ 应用缓存值
+    assert plugins[1]["short_description"] == "cached B"
+    # 缓存陈旧（desc 变了）→ 不应用，进 missing 候选
+    assert "short_description" not in plugins[2]
+    # 缺失且无缓存 → 不现生成，留空，进 missing 候选
+    assert "short_description" not in plugins[3]
+    # 无 description → 无可摘要内容，不进 missing 也不留空
+    assert "short_description" not in plugins[4]
+
+    assert sorted(p["id"] for p in missing) == ["missing", "stale_cache"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_list_provider_never_generates_short_description_on_hot_path():
+    """验收核心：analyze 热路径（plugin_list_provider）绝不现生成
+    short_description。缺失的插件交给后台预热，当次调用立即返回、_get_llm 不被
+    同步触发，分析侧安全回退到完整 description。"""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from brain.task_executor import DirectTaskExecutor
+
+    plugins = [{"id": "no_short", "description": "a plugin without a short description"}]
+    executor = object.__new__(DirectTaskExecutor)
+    executor.plugin_list = []
+    executor._external_plugin_provider = AsyncMock(return_value=plugins)
+    executor._short_desc_cache = {}
+    executor._short_desc_prewarm_inflight = set()
+    executor._short_desc_prewarm_tasks = set()
+
+    llm_factory = MagicMock(
+        side_effect=AssertionError("_get_llm must not be called on the analyze hot path")
+    )
+    with patch.object(DirectTaskExecutor, "_get_llm", llm_factory), \
+         patch.object(
+             DirectTaskExecutor, "_prewarm_short_descriptions", new_callable=AsyncMock,
+         ) as mock_prewarm:
+        result = await executor.plugin_list_provider(force_refresh=True)
+
+    # 返回的插件仍缺 short_description（未现生成）→ 分析侧回退到完整 description
+    assert not result[0].get("short_description")
+    # 热路径上 _get_llm 没被同步调用
+    llm_factory.assert_not_called()
+    # 缺失插件被调度进后台预热
+    mock_prewarm.assert_called_once()
+    assert "no_short" in executor._short_desc_prewarm_inflight
+    await asyncio.sleep(0)  # 让后台任务跑掉，避免 "coroutine never awaited" 警告
+
+
+def test_short_desc_cache_persists_generated_entries_across_instances(tmp_path):
+    """LLM 生成的 short_description 落盘，重启后新实例直接复用、零 LLM；
+    description 作为 key——manifest 变了缓存自动失效重新生成。"""
+    from types import SimpleNamespace
+    from brain.task_executor import DirectTaskExecutor
+
+    cfg = SimpleNamespace(config_dir=str(tmp_path), ensure_config_directory=lambda: None)
+
+    # 实例一：把一条生成的缓存落盘
+    exec1 = object.__new__(DirectTaskExecutor)
+    exec1._config_manager = cfg
+    exec1._short_desc_cache_filename = "plugin_short_desc_cache.json"
+    exec1._persist_generated_short_descriptions({"genplug": ("full desc", "generated short")})
+    assert (tmp_path / "plugin_short_desc_cache.json").exists()
+
+    # 实例二：从盘上加载（模拟重启）
+    exec2 = object.__new__(DirectTaskExecutor)
+    exec2._config_manager = cfg
+    exec2._short_desc_cache_filename = "plugin_short_desc_cache.json"
+    exec2._short_desc_cache = exec2._load_short_desc_cache()
+    assert exec2._short_desc_cache == {"genplug": ("full desc", "generated short")}
+
+    # desc 未变 → 命中持久化缓存，零 LLM，不进 missing
+    plugins = [{"id": "genplug", "description": "full desc"}]
+    assert exec2._apply_cached_short_descriptions(plugins) == []
+    assert plugins[0]["short_description"] == "generated short"
+
+    # desc 变了 → key 校验失效，重新作为生成候选
+    changed = [{"id": "genplug", "description": "CHANGED desc"}]
+    missing = exec2._apply_cached_short_descriptions(changed)
+    assert "short_description" not in changed[0]
+    assert [p["id"] for p in missing] == ["genplug"]
+
+
+def test_short_desc_cache_load_tolerates_missing_and_corrupt_file(tmp_path):
+    """缺文件 / 损坏 JSON → 安全返回空缓存，不抛。"""
+    from types import SimpleNamespace
+    from brain.task_executor import DirectTaskExecutor
+
+    cfg = SimpleNamespace(config_dir=str(tmp_path), ensure_config_directory=lambda: None)
+    executor = object.__new__(DirectTaskExecutor)
+    executor._config_manager = cfg
+    executor._short_desc_cache_filename = "plugin_short_desc_cache.json"
+
+    # 文件不存在
+    assert executor._load_short_desc_cache() == {}
+
+    # 损坏的 JSON
+    (tmp_path / "plugin_short_desc_cache.json").write_text("{not json", encoding="utf-8")
+    assert executor._load_short_desc_cache() == {}
+
+
 @pytest.mark.asyncio
 async def test_task_executor_routes_galgame_continue_phrase_through_plugin_assessment():
     from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
## 背景

`brain/task_executor.py` 里插件 `short_description` 的 LLM 生成原本发生在 analyze 热路径上：`_ensure_short_descriptions` 在每次 `analyze_and_execute` 的 `plugin_list_provider(force_refresh=True)` 上，对缺 `short_description` 的插件**串行 N 次 `await llm.ainvoke`** 现生成。稳态命中缓存 ~0 次调用，但冷启动 / 插件新增或描述变更后的第一次 analyze 仍会在热路径上现生成，串行 N 次；`_get_llm` 用 `max_retries=0`，免费 agent 模型限流（429）时是一串接连失败的脆弱窗口。

## 改动

**1. 把生成移出 analyze 热路径**（拆成三部分，职责分离）

- `_apply_cached_short_descriptions`：同步、零 LLM、热路径安全。优先用 manifest 自带的 `short_description`，其次读缓存（`description` 未变才命中），缺失则留空并作为后台预热候选返回——分析侧 `_stage1_llm_coarse_screen` 已有 `short = p.get('short_description') or p.get('description','')` 的安全回退。
- `_schedule_short_desc_prewarm`：对缺失插件用 `asyncio.create_task` fire-and-forget 调度后台生成，按 plugin id 去重，避免每次 analyze 的 `force_refresh` 堆积重复任务。
- `_prewarm_short_descriptions`：原 LLM 生成循环原样搬到后台跑，结果落 `_short_desc_cache` 供下次 analyze 零 LLM 复用。

`plugin_list_provider` 两处 `await self._ensure_short_descriptions(...)` 改为 `self._schedule_short_desc_prewarm(...)`，不再 await 生成。

**2. 跨重启持久化**（对齐 `correction_memory.json` 模式：`config_dir` + 原子写 tmp→replace + chmod 0600）

- 缓存文件 `<config_dir>/plugin_short_desc_cache.json`，`__init__` 时读盘 seed 缓存。
- **只持久化 LLM 生成的（贵的）条目**；manifest 自带 `short_description` 的不落盘——每次加载都能从 manifest 免费重新 prime，且插件 `description` 字段无 cap，落盘会被恶意/超大文本撑爆。
- **key = `description`**：加载回内存后沿用 `cached[0] == desc` 的比较作为失效判据，插件 `description` 变了（manifest 更新）缓存自动失效、重新进后台预热。完全复用现有内存缓存语义，只是延伸到跨重启。

## 验收

- analyze 执行路径不再触发任何 `short_description` 的 LLM 生成。
- 缺失 `short_description` 的插件在分析时安全回退到完整 `description`。
- `_short_desc_cache` 缓存语义不被破坏，仅延伸为可跨重启复用。
- 未改 prompt 文案。

## 测试

`uv run pytest tests/test_agent_rewrite_regression.py` 新增 4 个单测全过：
- `test_apply_cached_short_descriptions_manifest_cache_and_fallback` — manifest 直接用 / 缓存命中 / 陈旧缓存不误用 / 缺失留空进候选。
- `test_plugin_list_provider_never_generates_short_description_on_hot_path` — 热路径上 `_get_llm` 不被同步调用、返回插件仍缺 short（回退完整 desc）、缺失插件被调度进后台。
- `test_short_desc_cache_persists_generated_entries_across_instances` — 落盘后新实例（模拟重启）加载复用；desc 变了 key 失效重新生成。
- `test_short_desc_cache_load_tolerates_missing_and_corrupt_file` — 缺文件 / 坏 JSON 安全返回空。

全文件其余失败经 stash 同源对比确认全是本分支既有的前端断言失败（yui/tutorial 源码哈希类），与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 性能优化与缓存增强

* **新特性**
  * 为插件的 `short_description` 引入磁盘持久化缓存，并按 `description` 稳定变化自动失效
  * 支持后台预热生成，减少主流程等待开销，并对生成任务进行去重

* **性能改进**
  * 分析热路径优先直接使用 manifest 自带 `short_description`；缺失则尝试缓存回填
  * 缓存命中时快速补齐；缓存陈旧或缺失时保持降级为 missing 候选，避免阻塞

* **测试**
  * 新增回归与容错测试：缓存命中/失效、跨实例持久化复用、缓存键基于完整 `description`、缺失/损坏缓存文件容错，以及热路径不触发同步生成的断言
<!-- end of auto-generated comment: release notes by coderabbit.ai -->