### PR TITLE
feat(agent): gate the turn-end analyzer with a cheap action-intent signal

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -1824,7 +1824,13 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
             # - Voice-mode hot-swap sending 'turn end agent_callback'
             Modules.last_user_turn_fingerprint[lanlan_key] = fp
             conversation_id = event.get("conversation_id")
-            _create_tracked_task(_background_analyze_and_plan(messages, lanlan_name, conversation_id=conversation_id))
+            # Cheap pre-gate hint from the input-time master-emotion call (rides
+            # the analyze_request payload). Absent → None → the gate fails open.
+            action_intent = event.get("action_intent")
+            _create_tracked_task(_background_analyze_and_plan(
+                messages, lanlan_name, conversation_id=conversation_id,
+                action_intent=action_intent,
+            ))
 
 
 
@@ -2131,7 +2137,7 @@ async def _computer_use_scheduler_loop():
             await asyncio.sleep(0.1)
 
 
-async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None):
+async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, action_intent: Optional[float] = None):
     """
     [Simplified] Uses DirectTaskExecutor to do everything in one step: analyze the conversation + decide the execution method + execute the task
     
@@ -2157,10 +2163,10 @@ async def _background_analyze_and_plan(messages: list[dict[str, Any]], lanlan_na
         Modules.analyze_lock = asyncio.Lock()
 
     async with Modules.analyze_lock:
-        await _do_analyze_and_plan(messages, lanlan_name, conversation_id=conversation_id)
+        await _do_analyze_and_plan(messages, lanlan_name, conversation_id=conversation_id, action_intent=action_intent)
 
 
-async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None):
+async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Optional[str], conversation_id: Optional[str] = None, action_intent: Optional[float] = None):
     """Inner implementation, always called under analyze_lock."""
     try:
         if not Modules.analyzer_enabled:
@@ -2183,7 +2189,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
             messages=enriched_messages,
             lanlan_name=lanlan_name,
             agent_flags=Modules.agent_flags,
-            conversation_id=conversation_id
+            conversation_id=conversation_id,
+            action_intent=action_intent,
         )
 
         if result is None:

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -436,9 +436,9 @@ class OpenClawAdapter:
     def rule_magic_command(user_text: str) -> Optional[str]:
         """Public zero-LLM magic-command detector: the command a rule match would
         dispatch, or None. Wraps the rule classifier so callers that need a
-        no-LLM magic-word check (e.g. the analyzer pre-gate) don't reach into the
-        private helper or pay the LLM path. Covers exact magic words AND the
-        natural-language phrase list ("取消这个任务" → /stop, "换个话题" → /new, …)."""
+        no-LLM magic-word check (e.g. the analyzer pre-gate) need not reach into
+        the private helper or pay the LLM path. Covers both exact magic words and
+        the natural-language phrase list (cancel-task, change-topic, approve, …)."""
         result = OpenClawAdapter._classify_magic_intent_with_rules(user_text)
         if isinstance(result, dict) and result.get("is_magic_intent"):
             return result.get("command")

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -432,6 +432,18 @@ class OpenClawAdapter:
 
         return {"is_magic_intent": False, "command": None, "source": "rule"}
 
+    @staticmethod
+    def rule_magic_command(user_text: str) -> Optional[str]:
+        """Public zero-LLM magic-command detector: the command a rule match would
+        dispatch, or None. Wraps the rule classifier so callers that need a
+        no-LLM magic-word check (e.g. the analyzer pre-gate) don't reach into the
+        private helper or pay the LLM path. Covers exact magic words AND the
+        natural-language phrase list ("取消这个任务" → /stop, "换个话题" → /new, …)."""
+        result = OpenClawAdapter._classify_magic_intent_with_rules(user_text)
+        if isinstance(result, dict) and result.get("is_magic_intent"):
+            return result.get("command")
+        return None
+
     async def classify_magic_intent(self, user_text: str) -> Dict[str, Any]:
         text = str(user_text or "").strip()
         if not text:

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -1610,7 +1610,11 @@ class DirectTaskExecutor:
         if openclaw_enabled:
             try:
                 from brain.openclaw_adapter import OpenClawAdapter
-                if OpenClawAdapter.normalize_magic_command(text):
+                # Full ZERO-LLM rule classifier, not just exact magic words: it
+                # also catches natural-language commands ("取消这个任务" → /stop,
+                # "换个话题" → /new, …). These are no-LLM shortcuts the gate must
+                # keep — only the LLM magic-intent path is fair to skip on chat.
+                if OpenClawAdapter.rule_magic_command(text):
                     return True
             except Exception:
                 return True  # can't run the shortcut → fail open

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -39,6 +39,8 @@ from config import (
     AGENT_PLUGIN_COARSE_MAX_TOKENS,
     AGENT_UNIFIED_ASSESS_MAX_TOKENS,
     AGENT_PLUGIN_FULL_MAX_TOKENS,
+    AGENT_ACTION_GATE_ENABLED,
+    AGENT_ACTION_GATE_THRESHOLD,
     TASK_DETAIL_MAX_TOKENS,
 )
 from utils.llm_client import (
@@ -1619,7 +1621,11 @@ class DirectTaskExecutor:
             try:
                 from brain.plugin_filter import _match_keywords
                 for p in plugins:
-                    if not isinstance(p, dict):
+                    # Skip passive plugins: they never participate in dispatch
+                    # (mirrors _assess_user_plugin), so a passive plugin's keyword
+                    # must not count as an action signal — it would only cause a
+                    # spurious fail-open and a wasted assessment.
+                    if not isinstance(p, dict) or p.get("passive"):
                         continue
                     kws = p.get("keywords", [])
                     if isinstance(kws, list) and kws and _match_keywords(text, kws):
@@ -1666,25 +1672,25 @@ class DirectTaskExecutor:
         normalized_intent = self._normalize_user_intent(latest_user_request, recent_context)
 
         # ── 廉价前置闸 ───────────────────────────────────────
-        # action_intent 来自 input-time 的 master-emotion 那次小模型调用（搭
-        # analyze_request payload 过来）。若这一轮被自信地读成「非操作意图」，且零
-        # LLM 的确定性 shortcut（magic word 规则 + 插件关键词）也全静默，就跳过下面
-        # 1~2 次大模型评估。闸是非对称的：action_intent 为 None（无可用信号）或任一
-        # 确定性命中都不刹车 —— 最坏多花一次评估，绝不漏真任务。
-        if action_intent is not None:
-            import config as _cfg
-            if bool(getattr(_cfg, "AGENT_ACTION_GATE_ENABLED", True)):
-                _threshold = float(getattr(_cfg, "AGENT_ACTION_GATE_THRESHOLD", 0.2))
-                if action_intent < _threshold and not self._deterministic_action_signal(
-                    latest_user_request,
-                    openclaw_enabled=openclaw_enabled,
-                    user_plugin_enabled=user_plugin_enabled,
-                ):
-                    logger.info(
-                        "[AgentGate] skip assessment: action_intent=%.2f < %.2f, no deterministic signal",
-                        action_intent, _threshold,
-                    )
-                    return None
+        # action_intent 是 master-emotion 在 input-time 那次小模型调用产出的
+        # 「agent 相关度」信号，已在 main 侧做过两件事：(1) 按本轮 user 文本做
+        # freshness 匹配（陈旧/异轮读数 → None，绝不用上一轮信号刹本轮）；(2) 折进
+        # complexity 取 max，所以高 complexity 的硬推理轮（如 openfang 多步推理）
+        # 即便 action 低也不会被刹。这里只要：自信地低 + 零 LLM 确定性 shortcut
+        # （magic word 规则 + 插件关键词）也全静默，就跳过下面 1~2 次大模型评估。
+        # 闸非对称：None（无可用信号/陈旧）或任一确定性命中都不刹车 —— 最坏多花一次
+        # 评估，绝不漏真任务。
+        if action_intent is not None and AGENT_ACTION_GATE_ENABLED:
+            if action_intent < AGENT_ACTION_GATE_THRESHOLD and not self._deterministic_action_signal(
+                latest_user_request,
+                openclaw_enabled=openclaw_enabled,
+                user_plugin_enabled=user_plugin_enabled,
+            ):
+                logger.info(
+                    "[AgentGate] skip assessment: action_intent=%.2f < %.2f, no deterministic signal",
+                    action_intent, AGENT_ACTION_GATE_THRESHOLD,
+                )
+                return None
 
         # ── 可用性检查 ──────────────────────────────────────
         cu_available = False

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -1626,13 +1626,21 @@ class DirectTaskExecutor:
                 from brain.plugin_filter import _match_keywords
                 for p in plugins:
                     # Skip passive plugins: they never participate in dispatch
-                    # (mirrors _assess_user_plugin), so a passive plugin's keyword
-                    # must not count as an action signal — it would only cause a
-                    # spurious fail-open and a wasted assessment.
+                    # (mirrors _assess_user_plugin), so a passive plugin must not
+                    # influence the gate at all.
                     if not isinstance(p, dict) or p.get("passive"):
                         continue
                     kws = p.get("keywords", [])
-                    if isinstance(kws, list) and kws and _match_keywords(text, kws):
+                    if isinstance(kws, list) and kws:
+                        if _match_keywords(text, kws):
+                            return True
+                    elif self._agent_visible_plugin_entries(p):
+                        # A dispatchable plugin with no usable keyword shortcut can
+                        # only be selected by the LLM _assess_user_plugin (e.g.
+                        # first-party plugins exposing agent entries but no
+                        # top-level keywords). The keyword shortcut can't represent
+                        # it, so the gate must fail open when one exists — never
+                        # brake a turn such a plugin could have handled.
                         return True
             except Exception:
                 return True  # on any error, fail open

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -1559,6 +1559,7 @@ class DirectTaskExecutor:
         agent_flags: Optional[Dict[str, bool]] = None,
         conversation_id: Optional[str] = None,
         lang: str = "en",
+        action_intent: Optional[float] = None,
     ) -> Optional[TaskResult]:
         """
         Assess each channel's feasibility and return a Decision (no execution).
@@ -1579,9 +1580,53 @@ class DirectTaskExecutor:
                 agent_flags=agent_flags,
                 conversation_id=conversation_id,
                 lang=lang,
+                action_intent=action_intent,
             )
         finally:
             reset_active_character(char_token)
+
+    def _deterministic_action_signal(
+        self, user_text: str, *, openclaw_enabled: bool, user_plugin_enabled: bool,
+    ) -> bool:
+        """Zero-LLM action shortcuts the cheap pre-gate must NEVER skip.
+
+        Returns True if either fires — meaning the gate must not brake even when
+        the small model read the turn as chat:
+        * OpenClaw magic word (pure rule match, no LLM).
+        * Plugin keyword match over the ALREADY-CACHED plugin list only (no fetch,
+          so the brake path never triggers short_description generation).
+
+        Fails open (returns True) when user_plugin is on but the plugin list is
+        not yet loaded: we cannot run the keyword shortcut, so we must not let the
+        gate skip it. A brand-new plugin's keyword may be missed by the gate until
+        the next non-braked turn refreshes ``self.plugin_list`` — acceptable since
+        a session's plugin set rarely changes mid-conversation.
+        """
+        text = (user_text or "").strip()
+        if not text:
+            return False
+        if openclaw_enabled:
+            try:
+                from brain.openclaw_adapter import OpenClawAdapter
+                if OpenClawAdapter.normalize_magic_command(text):
+                    return True
+            except Exception:
+                return True  # can't run the shortcut → fail open
+        if user_plugin_enabled:
+            plugins = self.plugin_list
+            if not plugins:
+                return True  # not loaded → can't run keyword shortcut → fail open
+            try:
+                from brain.plugin_filter import _match_keywords
+                for p in plugins:
+                    if not isinstance(p, dict):
+                        continue
+                    kws = p.get("keywords", [])
+                    if isinstance(kws, list) and kws and _match_keywords(text, kws):
+                        return True
+            except Exception:
+                return True  # on any error, fail open
+        return False
 
     async def _analyze_and_execute_inner(
         self,
@@ -1590,6 +1635,7 @@ class DirectTaskExecutor:
         agent_flags: Optional[Dict[str, bool]] = None,
         conversation_id: Optional[str] = None,
         lang: str = "en",
+        action_intent: Optional[float] = None,
     ) -> Optional[TaskResult]:
         task_id = str(uuid.uuid4())
 
@@ -1618,6 +1664,28 @@ class DirectTaskExecutor:
         latest_user_request = self._extract_latest_user_intent(conversation)
         recent_context = self._extract_recent_context(messages)
         normalized_intent = self._normalize_user_intent(latest_user_request, recent_context)
+
+        # ── 廉价前置闸 ───────────────────────────────────────
+        # action_intent 来自 input-time 的 master-emotion 那次小模型调用（搭
+        # analyze_request payload 过来）。若这一轮被自信地读成「非操作意图」，且零
+        # LLM 的确定性 shortcut（magic word 规则 + 插件关键词）也全静默，就跳过下面
+        # 1~2 次大模型评估。闸是非对称的：action_intent 为 None（无可用信号）或任一
+        # 确定性命中都不刹车 —— 最坏多花一次评估，绝不漏真任务。
+        if action_intent is not None:
+            import config as _cfg
+            if bool(getattr(_cfg, "AGENT_ACTION_GATE_ENABLED", True)):
+                _threshold = float(getattr(_cfg, "AGENT_ACTION_GATE_THRESHOLD", 0.2))
+                if action_intent < _threshold and not self._deterministic_action_signal(
+                    latest_user_request,
+                    openclaw_enabled=openclaw_enabled,
+                    user_plugin_enabled=user_plugin_enabled,
+                ):
+                    logger.info(
+                        "[AgentGate] skip assessment: action_intent=%.2f < %.2f, no deterministic signal",
+                        action_intent, _threshold,
+                    )
+                    return None
+
         # ── 可用性检查 ──────────────────────────────────────
         cu_available = False
         if computer_use_enabled:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1627,6 +1627,22 @@ AGENT_PLUGIN_FULL_MAX_TOKENS = 500
 - 用途：返回 plugin_id + plugin_args + reason。
 - 上游：LLM 输出。"""
 
+AGENT_ACTION_GATE_ENABLED = True
+"""廉价前置闸总开关（默认开）。
+- 用途：开 = 用 master-emotion 在 input-time 顺带产出的 action_intent，在 agent
+  侧 turn_end 评估前做一道零成本前置判断：若这一轮被自信地读成「非操作意图」，且零
+  LLM 的确定性 shortcut（magic word 规则 + 插件关键词）也全静默，就跳过那 1~2 次
+  大模型评估，省掉闲聊轮的 analyzer 开销。关掉则每个 turn 照常全量评估。
+- 闸是非对称的：action_intent 缺失（None）或确定性命中都不刹车，所以最坏只是多花
+  一次评估，绝不漏真任务。
+- 上游：DirectTaskExecutor._analyze_and_execute_inner 的前置判定。"""
+
+AGENT_ACTION_GATE_THRESHOLD = 0.2
+"""action_intent 刹车阈值（0~1）。
+- 用途：action_intent < 此值才视为「自信闲聊」、进入刹车候选；>= 此值或为 None 一律放行。
+- 取保守低位（默认 0.2）：小模型只需可靠认出「显然在闲聊」这 90% 的易判 case，
+  模棱两可的全 fail-open 到准确的大评估。调高 = 更激进省钱但漏判风险上升。"""
+
 PLUGIN_INPUT_DESC_MAX_TOKENS = 1000
 """_ensure_short_descriptions 输入的 plugin manifest description 上限。
 - 用途：生成 short_description 时把原始 description 截断后再送入 prompt
@@ -2435,6 +2451,8 @@ __all__ = [
     'AGENT_PLUGIN_COARSE_MAX_TOKENS',
     'AGENT_UNIFIED_ASSESS_MAX_TOKENS',
     'AGENT_PLUGIN_FULL_MAX_TOKENS',
+    'AGENT_ACTION_GATE_ENABLED',
+    'AGENT_ACTION_GATE_THRESHOLD',
     'PLUGIN_INPUT_DESC_MAX_TOKENS',
     'COMPUTER_USE_MAX_TOKENS',
     'LLM_PING_MAX_TOKENS',

--- a/config/prompts/prompts_emotion.py
+++ b/config/prompts/prompts_emotion.py
@@ -184,13 +184,14 @@ outward_emotion_analysis_prompt = OUTWARD_EMOTION_ANALYSIS_PROMPT['zh']
 # （用户）自己」的情绪，产出连续的 valence（效价）/ arousal（唤醒度）二维读数，
 # 供凝神等后端基建消费。module-agnostic，不绑定任何具体角色 / 场景。
 MASTER_EMOTION_VA_PROMPT = {
-    'zh': """你是一个情感分析专家。请分析下面这段对话中说话者流露出的情绪状态，并只返回 JSON：{"valence": 效价, "arousal": 唤醒度, "confidence": 置信度, "complexity": 认知复杂度}。
+    'zh': """你是一个情感分析专家。请分析下面这段对话中说话者流露出的情绪状态，并只返回 JSON：{"valence": 效价, "arousal": 唤醒度, "confidence": 置信度, "complexity": 认知复杂度, "action_intent": 操作意图}。
 
 维度定义：
 - valence（效价）：-1 到 1 之间的小数。-1 = 强烈负面（痛苦、难过、愤怒、绝望），0 = 中性，+1 = 强烈正面（开心、满足、兴奋、温暖）。
 - arousal（唤醒度）：0 到 1 之间的小数。0 = 平静、低能量、放松，1 = 高度激动、强烈、能量很高（无论正负）。
 - confidence（置信度）：0 到 1 之间的小数，表示你对本次判断的把握。
 - complexity（认知复杂度）：0 到 1 之间的小数。表示说话者正在提出一个**复杂的、客观的问题**（数学题、逻辑题、推理题、需要多步推导的客观问题等）的程度。1 = 明确在问这类烧脑客观题，0 = 没有在问、或只是闲聊／情绪倾诉／简单问题。与情绪独立判断。
+- action_intent（操作意图）：0 到 1 之间的小数。表示说话者在多大程度上**明确要求执行一个对外的动作/操作**（打开、搜索、控制、运行某个外部东西，操作某 app 或设备，获取或改动外部状态）。1 = 明确就是一个操作请求，0 = 只是闲聊、倾诉、表达观点、或单纯提问而没有要求做任何事。默认取 0——只有用户明确要求"去做某件事"时才调高。与情绪和复杂度都独立判断。
 
 判断规则：
 1. 只依据这段文本本身流露的情绪，不要脑补未给出的背景。
@@ -200,13 +201,14 @@ MASTER_EMOTION_VA_PROMPT = {
 
 只返回 JSON，不要附加任何解释文本。""",
 
-    'en': """你是一个情感分析专家。Analyze the emotional state the speaker reveals in the conversation text below and return JSON only: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity}.
+    'en': """你是一个情感分析专家。Analyze the emotional state the speaker reveals in the conversation text below and return JSON only: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity, "action_intent": action_intent}.
 
 Dimensions:
 - valence: a number between -1 and 1. -1 = strongly negative (distress, sadness, anger, despair), 0 = neutral, +1 = strongly positive (joy, contentment, excitement, warmth).
 - arousal: a number between 0 and 1. 0 = calm, low energy, relaxed; 1 = highly activated, intense, high energy (regardless of sign).
 - confidence: a number between 0 and 1 indicating your certainty.
 - complexity: a number between 0 and 1 — how much the speaker is posing a COMPLEX, OBJECTIVE question (math, logic, reasoning, multi-step analytical problems). 1 = clearly asking such a hard objective question; 0 = not asking, or just chatting / venting / a simple question. Judge independently of emotion.
+- action_intent: a number between 0 and 1 — how strongly the speaker is EXPLICITLY asking to perform an external action / operation (open, search, control, run something, operate an app or device, fetch or change external state). 1 = clearly an explicit action request; 0 = just chatting, venting, giving an opinion, or asking a question without asking to do anything. Default to 0 — raise it only on an explicit request to DO something. Judge independently of both emotion and complexity.
 
 Rules:
 1. Judge only from the emotion this text reveals; do not invent unstated context.
@@ -216,13 +218,14 @@ Rules:
 
 Return JSON only, with no explanation.""",
 
-    'ja': """你是一个情感分析专家。次の会話文で話し手がにじませている感情の状態を JSONのみで返してください：{"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity}。
+    'ja': """你是一个情感分析专家。次の会話文で話し手がにじませている感情の状態を JSONのみで返してください：{"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity, "action_intent": action_intent}。
 
 各次元の定義：
 - valence（感情価）：-1〜1 の数値。-1 = 強い負（つらさ・悲しみ・怒り・絶望）、0 = 中立、+1 = 強い正（喜び・満足・高揚・あたたかさ）。
 - arousal（覚醒度）：0〜1 の数値。0 = 落ち着き・低エネルギー・リラックス、1 = 強い興奮・激しさ・高エネルギー（正負を問わず）。
 - confidence（確信度）：0〜1 の数値で、今回の判断の確かさ。
 - complexity（認知的複雑さ）：0〜1 の数値。話し手が**複雑で客観的な問い**（数学・論理・推論、多段階の分析が要る客観的な問題など）をどれだけ投げかけているか。1 = 明確にそうした難しい客観的問題を問うている、0 = 問うていない、または雑談／感情の吐露／単純な質問。感情とは独立に判断する。
+- action_intent（操作意図）：0〜1 の数値。話し手が**外部の動作/操作を明確に要求している**度合い（何かを開く・検索・制御・実行する、アプリや機器を操作する、外部の状態を取得/変更する）。1 = 明確に操作の要求、0 = 雑談・吐露・意見・単なる質問で何かを依頼していない。既定は 0——「何かをして」と明確に頼んだときだけ上げる。感情とも複雑さとも独立に判断する。
 
 判断ルール：
 1. この文章がにじませる感情だけで判断し、書かれていない背景を補わない。
@@ -232,13 +235,14 @@ Return JSON only, with no explanation.""",
 
 JSONのみを返し、説明文は付けないでください。""",
 
-    'ko': """你是一个情感分析专家。아래 대화문에서 말하는 사람이 드러내는 감정 상태를 JSON만 반환하세요: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity}.
+    'ko': """你是一个情感分析专家。아래 대화문에서 말하는 사람이 드러내는 감정 상태를 JSON만 반환하세요: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity, "action_intent": action_intent}.
 
 차원 정의:
 - valence(정서가): -1~1 사이 숫자. -1 = 강한 부정(괴로움, 슬픔, 분노, 절망), 0 = 중립, +1 = 강한 긍정(기쁨, 만족, 들뜸, 따뜻함).
 - arousal(각성도): 0~1 사이 숫자. 0 = 차분함, 낮은 에너지, 이완; 1 = 강한 흥분, 격렬함, 높은 에너지(긍·부정 무관).
 - confidence(확신도): 0~1 사이 숫자로 이번 판단에 대한 확신.
 - complexity(인지적 복잡도): 0~1 사이 숫자. 말하는 사람이 **복잡하고 객관적인 질문**(수학·논리·추론, 다단계 분석이 필요한 객관적 문제 등)을 얼마나 던지고 있는지. 1 = 그런 어려운 객관적 문제를 분명히 묻는 중, 0 = 묻지 않음, 또는 잡담／감정 토로／단순한 질문. 감정과 독립적으로 판단.
+- action_intent(조작 의도): 0~1 사이 숫자. 말하는 사람이 **외부 동작/조작을 명시적으로 요청하는** 정도(무언가를 열기·검색·제어·실행, 앱이나 기기 조작, 외부 상태 조회/변경). 1 = 분명한 조작 요청, 0 = 잡담·토로·의견·단순 질문으로 아무 것도 시키지 않음. 기본값 0 — "무엇을 해 달라"고 분명히 요청할 때만 올리세요. 감정 및 복잡도와 독립적으로 판단.
 
 판단 규칙:
 1. 이 문장이 드러내는 감정만으로 판단하고, 주어지지 않은 배경을 지어내지 마세요.
@@ -248,13 +252,14 @@ JSONのみを返し、説明文は付けないでください。""",
 
 설명 없이 JSON만 반환하세요.""",
 
-    'ru': """你是一个情感分析专家。Проанализируйте эмоциональное состояние, которое говорящий выражает в приведённом ниже тексте разговора, и верните только JSON: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity}.
+    'ru': """你是一个情感分析专家。Проанализируйте эмоциональное состояние, которое говорящий выражает в приведённом ниже тексте разговора, и верните только JSON: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity, "action_intent": action_intent}.
 
 Измерения:
 - valence (валентность): число от -1 до 1. -1 = сильно негативное (боль, грусть, гнев, отчаяние), 0 = нейтрально, +1 = сильно позитивное (радость, удовлетворение, воодушевление, теплота).
 - arousal (возбуждение): число от 0 до 1. 0 = спокойствие, низкая энергия, расслабленность; 1 = сильное возбуждение, интенсивность, высокая энергия (независимо от знака).
 - confidence (уверенность): число от 0 до 1, отражающее вашу уверенность.
 - complexity (когнитивная сложность): число от 0 до 1 — насколько говорящий задаёт СЛОЖНЫЙ ОБЪЕКТИВНЫЙ вопрос (математика, логика, рассуждение, многошаговые аналитические задачи). 1 = явно задаёт такой трудный объективный вопрос; 0 = не задаёт, либо просто болтает / делится чувствами / простой вопрос. Оценивайте независимо от эмоции.
+- action_intent (намерение к действию): число от 0 до 1 — насколько говорящий ЯВНО просит выполнить внешнее действие/операцию (открыть, найти, управлять, запустить что-то, работать с приложением или устройством, получить/изменить внешнее состояние). 1 = явная просьба о действии; 0 = просто болтает, делится, высказывает мнение или задаёт вопрос, ничего не прося сделать. По умолчанию 0 — повышайте только при явной просьбе что-то СДЕЛАТЬ. Оценивайте независимо и от эмоции, и от сложности.
 
 Правила:
 1. Судите только по эмоции, выраженной в этом тексте; не домысливайте неуказанный контекст.
@@ -264,13 +269,14 @@ JSONのみを返し、説明文は付けないでください。""",
 
 Верните только JSON без пояснений.""",
 
-    'es': """你是一个情感分析专家。Analiza el estado emocional que revela quien habla en el texto de conversación siguiente y devuelve solo JSON: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity}.
+    'es': """你是一个情感分析专家。Analiza el estado emocional que revela quien habla en el texto de conversación siguiente y devuelve solo JSON: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity, "action_intent": action_intent}.
 
 Dimensiones:
 - valence (valencia): un número entre -1 y 1. -1 = fuertemente negativo (dolor, tristeza, ira, desesperación), 0 = neutral, +1 = fuertemente positivo (alegría, satisfacción, entusiasmo, calidez).
 - arousal (activación): un número entre 0 y 1. 0 = calma, baja energía, relajación; 1 = muy activado, intenso, alta energía (sin importar el signo).
 - confidence (confianza): un número entre 0 y 1 que indica tu seguridad.
 - complexity (complejidad cognitiva): un número entre 0 y 1 — cuánto está planteando quien habla una PREGUNTA COMPLEJA y OBJETIVA (matemáticas, lógica, razonamiento, problemas analíticos de varios pasos). 1 = claramente hace una de esas preguntas objetivas difíciles; 0 = no pregunta, o solo charla / se desahoga / pregunta simple. Júzgalo independientemente de la emoción.
+- action_intent (intención de acción): un número entre 0 y 1 — cuánto pide EXPLÍCITAMENTE quien habla realizar una acción/operación externa (abrir, buscar, controlar, ejecutar algo, operar una app o dispositivo, obtener/cambiar estado externo). 1 = claramente una petición de acción; 0 = solo conversa, se desahoga, opina o pregunta sin pedir hacer nada. Por defecto 0 — súbelo solo ante una petición explícita de HACER algo. Júzgalo independientemente de la emoción y de la complejidad.
 
 Reglas:
 1. Juzga solo por la emoción que revela este texto; no inventes contexto no dado.
@@ -280,13 +286,14 @@ Reglas:
 
 Devuelve solo JSON, sin explicación.""",
 
-    'pt': """你是一个情感分析专家。Analise o estado emocional que o falante revela no texto de conversa abaixo e retorne apenas JSON: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity}.
+    'pt': """你是一个情感分析专家。Analise o estado emocional que o falante revela no texto de conversa abaixo e retorne apenas JSON: {"valence": valence, "arousal": arousal, "confidence": confidence, "complexity": complexity, "action_intent": action_intent}.
 
 Dimensões:
 - valence (valência): um número entre -1 e 1. -1 = fortemente negativo (sofrimento, tristeza, raiva, desespero), 0 = neutro, +1 = fortemente positivo (alegria, satisfação, empolgação, calor).
 - arousal (ativação): um número entre 0 e 1. 0 = calmo, baixa energia, relaxado; 1 = muito ativado, intenso, alta energia (independente do sinal).
 - confidence (confiança): um número entre 0 e 1 indicando sua certeza.
 - complexity (complexidade cognitiva): um número entre 0 e 1 — o quanto o falante está fazendo uma PERGUNTA COMPLEXA e OBJETIVA (matemática, lógica, raciocínio, problemas analíticos de várias etapas). 1 = claramente faz uma dessas perguntas objetivas difíceis; 0 = não pergunta, ou apenas conversa / desabafa / pergunta simples. Julgue independentemente da emoção.
+- action_intent (intenção de ação): um número entre 0 e 1 — o quanto o falante pede EXPLICITAMENTE para realizar uma ação/operação externa (abrir, buscar, controlar, executar algo, operar um app ou dispositivo, obter/alterar estado externo). 1 = claramente um pedido de ação; 0 = apenas conversa, desabafa, opina ou pergunta sem pedir para fazer nada. Padrão 0 — aumente apenas diante de um pedido explícito de FAZER algo. Julgue independentemente da emoção e da complexidade.
 
 Regras:
 1. Julgue apenas pela emoção que este texto revela; não invente contexto não fornecido.

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -82,6 +82,10 @@ class MasterEmotionReading:
     complexity: float = 0.0
     action_intent: Optional[float] = None
     source_excerpt: str = ""
+    # Whitespace-normalized prefix of the analyzed text, used to match this
+    # reading to the turn it came from — the agent pre-gate must not consume a
+    # stale reading from an earlier turn. See ``_normalize_for_match``.
+    source_norm: str = ""
 
 
 def _clamp(value, lo: float, hi: float, default: float) -> float:
@@ -124,6 +128,14 @@ def _action_intent_from(value) -> Optional[float]:
     return max(0.0, min(1.0, v))
 
 
+def _normalize_for_match(text: Optional[str]) -> str:
+    """Collapse whitespace and cap length, to match a cached reading to the turn
+    it was produced from. Two different user messages rarely normalize to the
+    same string, so an equality test is a sound "same turn" check; any mismatch
+    makes the gate fail open (run the assessment), never a wrong brake."""
+    return " ".join((text or "").split())[:280]
+
+
 # Per-lanlan registry of live trackers, so an out-of-band caller — the
 # cross-server analyze_request publisher at turn_end — can read the latest
 # ``action_intent`` without holding the session / core handle. A
@@ -135,14 +147,22 @@ _TRACKERS_BY_LANLAN: "weakref.WeakValueDictionary[str, MasterEmotionTracker]" = 
 )
 
 
-def latest_action_intent_for(lanlan_name: str) -> Optional[float]:
-    """Latest ``action_intent`` for ``lanlan_name``, or ``None`` if unavailable.
+def gate_signal_for(lanlan_name: str, user_text: str) -> Optional[float]:
+    """Combined agent-relevance signal for the cheap analyzer pre-gate, or
+    ``None`` when there is no usable, current signal (→ the agent fails open and
+    runs its assessment). Purely an optimization hint, never a hard brake.
 
-    Reads the live tracker's ``.latest`` (which already honors the
-    MASTER_EMOTION_ENABLED switch and the reading TTL), so a missing / disabled /
-    stale reading — or a turn whose model output carried no usable action signal
-    — all collapse to ``None``. The agent gate consuming this MUST fail open (run
-    the assessment) on ``None``; it is purely an optimization hint, never a brake.
+    Returns ``None`` unless the live tracker holds a reading that:
+    (a) passes the MASTER_EMOTION_ENABLED switch + reading TTL (via ``.latest``);
+    (b) was produced from THIS turn's ``user_text`` — a freshness match, so a
+        stale reading from an earlier (chattier) turn can never gate the current
+        one (master-emotion is throttled + fire-and-forget, so ``.latest`` may
+        lag the current turn);
+    (c) carried a usable ``action_intent``.
+
+    When all hold, returns ``max(action_intent, complexity)`` so a hard reasoning
+    turn (high complexity — e.g. an openfang multi-step request) keeps the gate
+    open even at low action_intent.
     """
     tracker = _TRACKERS_BY_LANLAN.get(lanlan_name)
     if tracker is None:
@@ -150,7 +170,12 @@ def latest_action_intent_for(lanlan_name: str) -> Optional[float]:
     reading = tracker.latest
     if reading is None:
         return None
-    return reading.action_intent
+    norm = _normalize_for_match(user_text)
+    if not norm or norm != reading.source_norm:
+        return None  # stale / different turn → fail open
+    if reading.action_intent is None:
+        return None  # no usable action signal → fail open
+    return max(reading.action_intent, reading.complexity)
 
 
 class MasterEmotionTracker:
@@ -328,4 +353,5 @@ class MasterEmotionTracker:
             # 0.0 as "confidently no action" and braking a real request.
             action_intent=_action_intent_from(data.get("action_intent")),
             source_excerpt=source[:80],
+            source_norm=_normalize_for_match(source),
         )

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -40,6 +40,7 @@ hook a future memory consumer pulls from.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
 import re
@@ -129,11 +130,17 @@ def _action_intent_from(value) -> Optional[float]:
 
 
 def _normalize_for_match(text: Optional[str]) -> str:
-    """Collapse whitespace and cap length, to match a cached reading to the turn
-    it was produced from. Two different user messages rarely normalize to the
-    same string, so an equality test is a sound "same turn" check; any mismatch
-    makes the gate fail open (run the assessment), never a wrong brake."""
-    return " ".join((text or "").split())[:280]
+    """A stable fingerprint of the analyzed text, to match a cached reading to
+    the turn it came from. Whitespace is collapsed and the FULL text is hashed
+    (not a prefix) so two long messages that merely share a prefix never collide
+    into a false "same turn" match — which would let a stale reading brake a
+    different turn. Any real difference → different fingerprint → mismatch → the
+    gate fails open (run the assessment), never a wrong brake. ``""`` for empty
+    input (never matches a real reading)."""
+    norm = " ".join((text or "").split())
+    if not norm:
+        return ""
+    return hashlib.sha1(norm.encode("utf-8")).hexdigest()
 
 
 # Per-lanlan registry of live trackers, so an out-of-band caller — the

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -46,7 +46,7 @@ import math
 import re
 import time
 import weakref
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Optional
 
 import config
@@ -259,6 +259,15 @@ class MasterEmotionTracker:
         reading = self._parse(raw, now=now, source=cleaned)
         if reading is None:
             return None
+        # Truncation guard: the model only saw ``cleaned[:MAX_INPUT_CHARS]``. If
+        # the turn was longer, an action verb in the unseen tail makes the
+        # action_intent read an unreliable basis for the agent gate — null it so
+        # the gate fails open (run the assessment). Emotion / complexity, which
+        # are judgeable from the opening, stay valid. The source_norm fingerprint
+        # remains the FULL text so the freshness match is unaffected.
+        _max_chars = max(1, int(getattr(config, "MASTER_EMOTION_MAX_INPUT_CHARS", 500)))
+        if reading.action_intent is not None and len(cleaned) > _max_chars:
+            reading = replace(reading, action_intent=None)
         # Stale-result guard: if a newer analysis (or a reset) was kicked off
         # while this one awaited — possible under a slow tier — the newer turn
         # wins; never let this older turn's reading overwrite it.

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -83,9 +83,10 @@ class MasterEmotionReading:
     complexity: float = 0.0
     action_intent: Optional[float] = None
     source_excerpt: str = ""
-    # Whitespace-normalized prefix of the analyzed text, used to match this
-    # reading to the turn it came from — the agent pre-gate must not consume a
-    # stale reading from an earlier turn. See ``_normalize_for_match``.
+    # Stable fingerprint (sha1 of the whitespace-normalized FULL text) of the
+    # analyzed turn, used to match this reading to the turn it came from — the
+    # agent pre-gate must not consume a stale reading from an earlier turn.
+    # See ``_normalize_for_match``.
     source_norm: str = ""
 
 

--- a/main_logic/activity/master_emotion.py
+++ b/main_logic/activity/master_emotion.py
@@ -44,6 +44,7 @@ import logging
 import math
 import re
 import time
+import weakref
 from dataclasses import dataclass
 from typing import Optional
 
@@ -65,7 +66,13 @@ class MasterEmotionReading:
     (calm → activated), ``confidence`` ∈ [0, 1]. ``complexity`` ∈ [0, 1] is an
     orthogonal cognitive read — how much the speaker is posing a COMPLEX,
     OBJECTIVE question (math / logic / reasoning), a Focus bonus axis independent
-    of emotion. ``source_excerpt`` keeps a short prefix for diagnostics only.
+    of emotion. ``action_intent`` ∈ [0, 1] (or ``None``) is a second orthogonal
+    read — how strongly the user is EXPLICITLY asking to perform an external
+    action / operation. It rides this same cheap call so the agent analyzer can
+    cheaply gate its expensive turn-end assessment. ``None`` means the model gave
+    no usable signal: the consuming gate MUST fail open (run the assessment),
+    never treat it as "no action". ``source_excerpt`` keeps a short prefix for
+    diagnostics only.
     """
 
     valence: float
@@ -73,6 +80,7 @@ class MasterEmotionReading:
     confidence: float
     updated_at: float
     complexity: float = 0.0
+    action_intent: Optional[float] = None
     source_excerpt: str = ""
 
 
@@ -102,6 +110,49 @@ def _coerce_axis(value) -> Optional[float]:
     return v
 
 
+def _action_intent_from(value) -> Optional[float]:
+    """Clamp a parsed ``action_intent`` to [0, 1], or ``None`` when absent/junk.
+
+    Unlike the emotion axes, ``None`` is meaningful downstream: the agent gate
+    must fail open (run the assessment) when it has no usable action signal,
+    instead of reading a phantom ``0.0`` as "confidently no action" and wrongly
+    braking a real tool request.
+    """
+    v = _coerce_axis(value)
+    if v is None:
+        return None
+    return max(0.0, min(1.0, v))
+
+
+# Per-lanlan registry of live trackers, so an out-of-band caller — the
+# cross-server analyze_request publisher at turn_end — can read the latest
+# ``action_intent`` without holding the session / core handle. A
+# ``WeakValueDictionary`` so a torn-down session's tracker auto-evicts (no leak
+# across sessions); a stale entry is harmless anyway since ``.latest`` is
+# TTL-gated.
+_TRACKERS_BY_LANLAN: "weakref.WeakValueDictionary[str, MasterEmotionTracker]" = (
+    weakref.WeakValueDictionary()
+)
+
+
+def latest_action_intent_for(lanlan_name: str) -> Optional[float]:
+    """Latest ``action_intent`` for ``lanlan_name``, or ``None`` if unavailable.
+
+    Reads the live tracker's ``.latest`` (which already honors the
+    MASTER_EMOTION_ENABLED switch and the reading TTL), so a missing / disabled /
+    stale reading — or a turn whose model output carried no usable action signal
+    — all collapse to ``None``. The agent gate consuming this MUST fail open (run
+    the assessment) on ``None``; it is purely an optimization hint, never a brake.
+    """
+    tracker = _TRACKERS_BY_LANLAN.get(lanlan_name)
+    if tracker is None:
+        return None
+    reading = tracker.latest
+    if reading is None:
+        return None
+    return reading.action_intent
+
+
 class MasterEmotionTracker:
     """Per-session instantaneous master-emotion state. Async-fed, throttled."""
 
@@ -110,6 +161,9 @@ class MasterEmotionTracker:
         self._latest: Optional[MasterEmotionReading] = None
         self._last_attempt_at: float = 0.0
         self._seq: int = 0
+        # Register so the cross-server analyze_request publisher can read the
+        # latest action_intent by lanlan_name without the core/session handle.
+        _TRACKERS_BY_LANLAN[lanlan_name] = self
 
     # ── public API ──────────────────────────────────────────────────
     @property
@@ -269,5 +323,9 @@ class MasterEmotionTracker:
             # missing value safely defaults to 0 (no cognitive bonus), so it
             # never blocks a valid emotional reading.
             complexity=_clamp(data.get("complexity"), 0.0, 1.0, 0.0),
+            # action_intent: keep None when the model omitted it / gave junk so
+            # the consuming agent gate fails open instead of reading a phantom
+            # 0.0 as "confidently no action" and braking a real request.
+            action_intent=_action_intent_from(data.get("action_intent")),
             source_excerpt=source[:80],
         )

--- a/main_logic/agent_event_bus.py
+++ b/main_logic/agent_event_bus.py
@@ -481,8 +481,16 @@ async def publish_analyze_request_reliably(
     ack_timeout_s: float = 0.8,
     retries: int = 1,
     conversation_id: Optional[str] = None,
+    action_intent: Optional[float] = None,
 ) -> bool:
-    """Reliably publish analyze_request: carries event_id + ack, with short retries."""
+    """Reliably publish analyze_request: carries event_id + ack, with short retries.
+
+    ``action_intent`` (0..1, or ``None``) is the cheap pre-gate hint produced by
+    the master-emotion call that already ran at input-time. It rides this same
+    payload so the agent can cheaply decide whether to skip its expensive
+    assessment. ``None`` (reading unavailable / no usable signal) is omitted from
+    the event → the agent gate fails open (runs the assessment).
+    """
     event_id = uuid.uuid4().hex
     sent_at = time.perf_counter()
 
@@ -496,6 +504,9 @@ async def publish_analyze_request_reliably(
         }
         if conversation_id:
             event["conversation_id"] = conversation_id
+        # Only an optimization hint; omitted when None so the agent fails open.
+        if action_intent is not None:
+            event["action_intent"] = action_intent
 
         loop = asyncio.get_running_loop()
         waiter: asyncio.Future = loop.create_future()

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -62,19 +62,24 @@ emotion_pattern = re.compile('<(.*?)>')
 async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str, messages: list[dict], *, conversation_id: str | None = None) -> bool:
     """Publish analyze request via EventBus with ack/retry."""
     try:
-        # Non-blocking read of the cheap pre-gate signal the master-emotion call
-        # produced at input-time. Lazy import keeps cross_server's module graph
-        # clean. Cache miss / disabled / stale (different turn) / no-signal →
-        # None → the agent gate fails open (runs the assessment). turn_end must
-        # never block on the emotion call, so this only reads an already-cached
-        # value, matched to THIS turn's latest user message.
-        from main_logic.activity.master_emotion import gate_signal_for
-        _latest_user_text = next(
-            (str(m.get("content") or m.get("text") or "")
-             for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
-            "",
-        )
-        action_intent = gate_signal_for(lanlan_name, _latest_user_text)
+        # Optional optimization hint: the cheap pre-gate signal the master-emotion
+        # call produced at input-time, matched to THIS turn's latest user message.
+        # It must NEVER block or abort the publish — wrapped in its own try so any
+        # lazy-import/read failure degrades to None (the agent gate then fails open
+        # and runs its assessment). turn_end also never blocks on the emotion call,
+        # so this only reads an already-cached value. Cache miss / disabled / stale
+        # (different turn) / no-signal → None.
+        action_intent = None
+        try:
+            from main_logic.activity.master_emotion import gate_signal_for
+            _latest_user_text = next(
+                (str(m.get("content") or m.get("text") or "")
+                 for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
+                "",
+            )
+            action_intent = gate_signal_for(lanlan_name, _latest_user_text)
+        except Exception:
+            action_intent = None
         sent = await publish_analyze_request_reliably(
             lanlan_name=lanlan_name,
             trigger=trigger,

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -62,6 +62,13 @@ emotion_pattern = re.compile('<(.*?)>')
 async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str, messages: list[dict], *, conversation_id: str | None = None) -> bool:
     """Publish analyze request via EventBus with ack/retry."""
     try:
+        # Non-blocking read of the cheap action-intent hint the master-emotion
+        # call produced at input-time. Lazy import keeps cross_server's module
+        # graph clean. Cache miss / disabled / stale / no-signal → None → the
+        # agent gate fails open (runs the assessment). turn_end must never block
+        # on the emotion call, so this only ever reads an already-cached value.
+        from main_logic.activity.master_emotion import latest_action_intent_for
+        action_intent = latest_action_intent_for(lanlan_name)
         sent = await publish_analyze_request_reliably(
             lanlan_name=lanlan_name,
             trigger=trigger,
@@ -69,6 +76,7 @@ async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str,
             ack_timeout_s=0.8,
             retries=1,
             conversation_id=conversation_id,
+            action_intent=action_intent,
         )
         if sent:
             logger.debug(

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -72,12 +72,17 @@ async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str,
         action_intent = None
         try:
             from main_logic.activity.master_emotion import gate_signal_for
-            _latest_user_text = next(
-                (str(m.get("content") or m.get("text") or "")
-                 for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
-                "",
+            _latest_user_msg = next(
+                (m for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
+                None,
             )
-            action_intent = gate_signal_for(lanlan_name, _latest_user_text)
+            # Skip the gate hint when the latest user turn carries attachments:
+            # the actionable intent may live in the image, which the text-only
+            # signal never saw → leave action_intent None so the agent fails open
+            # and assesses the turn (never drop an image-driven task).
+            if _latest_user_msg is not None and not _latest_user_msg.get("attachments"):
+                _latest_user_text = str(_latest_user_msg.get("content") or _latest_user_msg.get("text") or "")
+                action_intent = gate_signal_for(lanlan_name, _latest_user_text)
         except Exception:
             action_intent = None
         sent = await publish_analyze_request_reliably(

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -62,13 +62,19 @@ emotion_pattern = re.compile('<(.*?)>')
 async def _publish_analyze_request_with_fallback(lanlan_name: str, trigger: str, messages: list[dict], *, conversation_id: str | None = None) -> bool:
     """Publish analyze request via EventBus with ack/retry."""
     try:
-        # Non-blocking read of the cheap action-intent hint the master-emotion
-        # call produced at input-time. Lazy import keeps cross_server's module
-        # graph clean. Cache miss / disabled / stale / no-signal → None → the
-        # agent gate fails open (runs the assessment). turn_end must never block
-        # on the emotion call, so this only ever reads an already-cached value.
-        from main_logic.activity.master_emotion import latest_action_intent_for
-        action_intent = latest_action_intent_for(lanlan_name)
+        # Non-blocking read of the cheap pre-gate signal the master-emotion call
+        # produced at input-time. Lazy import keeps cross_server's module graph
+        # clean. Cache miss / disabled / stale (different turn) / no-signal →
+        # None → the agent gate fails open (runs the assessment). turn_end must
+        # never block on the emotion call, so this only reads an already-cached
+        # value, matched to THIS turn's latest user message.
+        from main_logic.activity.master_emotion import gate_signal_for
+        _latest_user_text = next(
+            (str(m.get("content") or m.get("text") or "")
+             for m in reversed(messages) if isinstance(m, dict) and m.get("role") == "user"),
+            "",
+        )
+        action_intent = gate_signal_for(lanlan_name, _latest_user_text)
         sent = await publish_analyze_request_reliably(
             lanlan_name=lanlan_name,
             trigger=trigger,

--- a/tests/unit/test_agent_action_gate.py
+++ b/tests/unit/test_agent_action_gate.py
@@ -39,11 +39,26 @@ def _exec():
     return DirectTaskExecutor(computer_use=object())
 
 
+class _SpyCU:
+    """computer_use stub that counts is_available() calls, to prove the gate
+    brakes BEFORE the availability probe (not a None that fell through later)."""
+
+    def __init__(self):
+        self.is_available_calls = 0
+
+    def is_available(self):
+        self.is_available_calls += 1
+        return {"ready": True}
+
+
 # ── _deterministic_action_signal: the zero-LLM shortcuts the gate must keep ──
 def test_det_signal_magic_word():
     ex = _exec()
     assert ex._deterministic_action_signal("/clear", openclaw_enabled=True, user_plugin_enabled=False) is True
     assert ex._deterministic_action_signal("stop", openclaw_enabled=True, user_plugin_enabled=False) is True
+    # natural-language magic commands (zero-LLM rule classifier) count too
+    assert ex._deterministic_action_signal("取消这个任务", openclaw_enabled=True, user_plugin_enabled=False) is True
+    assert ex._deterministic_action_signal("换个话题吧", openclaw_enabled=True, user_plugin_enabled=False) is True
     assert ex._deterministic_action_signal("随便聊聊", openclaw_enabled=True, user_plugin_enabled=False) is False
     # magic word is ignored when openclaw is off
     assert ex._deterministic_action_signal("/clear", openclaw_enabled=False, user_plugin_enabled=False) is False
@@ -78,7 +93,8 @@ def test_det_signal_none_when_no_shortcuts():
 def test_gate_brakes_on_confident_chat(monkeypatch):
     monkeypatch.setattr(te, "AGENT_ACTION_GATE_ENABLED", True)
     monkeypatch.setattr(te, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
-    ex = _exec()
+    cu = _SpyCU()
+    ex = DirectTaskExecutor(computer_use=cu)
     msgs = [{"role": "user", "text": "今天天气真好心情不错"}]
     # computer_use only, action_intent below the line, no deterministic signal →
     # the gate brakes and returns None before any availability check / LLM call.
@@ -86,6 +102,9 @@ def test_gate_brakes_on_confident_chat(monkeypatch):
         messages=msgs, agent_flags={"computer_use_enabled": True}, action_intent=0.05,
     ))
     assert res is None
+    # Proven to brake AT THE GATE: the availability probe was never reached, so
+    # no assessment / channel work happened — not a None that fell through later.
+    assert cu.is_available_calls == 0
 
 
 def test_gate_consults_deterministic_only_when_braking(monkeypatch):

--- a/tests/unit/test_agent_action_gate.py
+++ b/tests/unit/test_agent_action_gate.py
@@ -75,6 +75,22 @@ def test_det_signal_plugin_keyword():
     assert ex._deterministic_action_signal("帮我查下天气", openclaw_enabled=False, user_plugin_enabled=False) is False
 
 
+def test_det_signal_failopen_keywordless_dispatchable_plugin():
+    ex = _exec()
+    # A dispatchable plugin with no top-level keywords (e.g. music_pusher exposes
+    # an agent entry but defines no keywords) can only be selected by the LLM
+    # assessment; the keyword shortcut can't represent it, so the gate must fail
+    # open even on chat text — never brake a turn that plugin could handle.
+    ex.plugin_list = [{"id": "music_pusher"}]  # no keywords, default visible entry
+    assert ex._deterministic_action_signal("今天好无聊", openclaw_enabled=False, user_plugin_enabled=True) is True
+    # When ALL active plugins DO have keywords and none match → brakeable (False).
+    ex.plugin_list = [{"id": "weather", "keywords": ["天气预报"]}]
+    assert ex._deterministic_action_signal("今天好无聊", openclaw_enabled=False, user_plugin_enabled=True) is False
+    # A passive keywordless plugin never dispatches → it must NOT force fail-open.
+    ex.plugin_list = [{"id": "bg", "passive": True}]
+    assert ex._deterministic_action_signal("今天好无聊", openclaw_enabled=False, user_plugin_enabled=True) is False
+
+
 def test_det_signal_failopen_when_plugins_unloaded():
     ex = _exec()
     ex.plugin_list = []  # not loaded yet

--- a/tests/unit/test_agent_action_gate.py
+++ b/tests/unit/test_agent_action_gate.py
@@ -24,11 +24,12 @@ from __future__ import annotations
 import asyncio
 
 import brain.task_executor as te
-from brain.task_executor import DirectTaskExecutor
 
-# The gate reads AGENT_ACTION_GATE_* as module-level names imported into
-# brain.task_executor (the repo's `from config import (...)` convention), so the
-# knobs are patched on that module here, not on the `config` module.
+# Single import style for brain.task_executor: reference both the class
+# (``te.DirectTaskExecutor``) and the gate knobs (``te.AGENT_ACTION_GATE_*``)
+# through the module. The knobs are module-level names imported into
+# brain.task_executor (the repo's `from config import (...)` convention), so
+# they are patched on that module here, not on the `config` module.
 
 
 def _exec():
@@ -36,7 +37,7 @@ def _exec():
     # ComputerUseAdapter; these tests never invoke a real adapter method (the
     # brake returns before availability checks, and the proceed paths hit only
     # the guarded ``is_available`` access which fails closed to "not available").
-    return DirectTaskExecutor(computer_use=object())
+    return te.DirectTaskExecutor(computer_use=object())
 
 
 class _SpyCU:
@@ -94,7 +95,7 @@ def test_gate_brakes_on_confident_chat(monkeypatch):
     monkeypatch.setattr(te, "AGENT_ACTION_GATE_ENABLED", True)
     monkeypatch.setattr(te, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
     cu = _SpyCU()
-    ex = DirectTaskExecutor(computer_use=cu)
+    ex = te.DirectTaskExecutor(computer_use=cu)
     msgs = [{"role": "user", "text": "今天天气真好心情不错"}]
     # computer_use only, action_intent below the line, no deterministic signal →
     # the gate brakes and returns None before any availability check / LLM call.

--- a/tests/unit/test_agent_action_gate.py
+++ b/tests/unit/test_agent_action_gate.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the cheap action-intent pre-gate in DirectTaskExecutor.
+
+The gate skips the expensive turn-end assessment when the input-time
+master-emotion call confidently read the turn as NON-action — but only when the
+zero-LLM deterministic shortcuts (openclaw magic word, plugin keyword) also find
+nothing, and never when action_intent is None (no usable signal).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import config
+from brain.task_executor import DirectTaskExecutor
+
+
+def _exec():
+    # Pass a truthy stub for computer_use so __init__ skips constructing a real
+    # ComputerUseAdapter; these tests never invoke a real adapter method (the
+    # brake returns before availability checks, and the proceed paths hit only
+    # the guarded ``is_available`` access which fails closed to "not available").
+    return DirectTaskExecutor(computer_use=object())
+
+
+# ── _deterministic_action_signal: the zero-LLM shortcuts the gate must keep ──
+def test_det_signal_magic_word():
+    ex = _exec()
+    assert ex._deterministic_action_signal("/clear", openclaw_enabled=True, user_plugin_enabled=False) is True
+    assert ex._deterministic_action_signal("stop", openclaw_enabled=True, user_plugin_enabled=False) is True
+    assert ex._deterministic_action_signal("随便聊聊", openclaw_enabled=True, user_plugin_enabled=False) is False
+    # magic word is ignored when openclaw is off
+    assert ex._deterministic_action_signal("/clear", openclaw_enabled=False, user_plugin_enabled=False) is False
+
+
+def test_det_signal_plugin_keyword():
+    ex = _exec()
+    ex.plugin_list = [{"id": "p1", "keywords": ["天气", "weather"]}]
+    assert ex._deterministic_action_signal("帮我查下天气", openclaw_enabled=False, user_plugin_enabled=True) is True
+    assert ex._deterministic_action_signal("check the weather", openclaw_enabled=False, user_plugin_enabled=True) is True
+    assert ex._deterministic_action_signal("今天好开心", openclaw_enabled=False, user_plugin_enabled=True) is False
+    # keyword shortcut ignored when user_plugin is off
+    assert ex._deterministic_action_signal("帮我查下天气", openclaw_enabled=False, user_plugin_enabled=False) is False
+
+
+def test_det_signal_failopen_when_plugins_unloaded():
+    ex = _exec()
+    ex.plugin_list = []  # not loaded yet
+    # user_plugin on but the cached list is empty → cannot run the keyword
+    # shortcut → must NOT let the gate skip it → fail open (True).
+    assert ex._deterministic_action_signal("今天好开心", openclaw_enabled=False, user_plugin_enabled=True) is True
+
+
+def test_det_signal_none_when_no_shortcuts():
+    ex = _exec()
+    assert ex._deterministic_action_signal("今天好开心", openclaw_enabled=False, user_plugin_enabled=False) is False
+    # empty / whitespace text is never an action signal
+    assert ex._deterministic_action_signal("   ", openclaw_enabled=True, user_plugin_enabled=True) is False
+
+
+# ── the gate control flow inside _analyze_and_execute_inner ──
+def test_gate_brakes_on_confident_chat(monkeypatch):
+    monkeypatch.setattr(config, "AGENT_ACTION_GATE_ENABLED", True)
+    monkeypatch.setattr(config, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
+    ex = _exec()
+    msgs = [{"role": "user", "text": "今天天气真好心情不错"}]
+    # computer_use only, action_intent below the line, no deterministic signal →
+    # the gate brakes and returns None before any availability check / LLM call.
+    res = asyncio.run(ex._analyze_and_execute_inner(
+        messages=msgs, agent_flags={"computer_use_enabled": True}, action_intent=0.05,
+    ))
+    assert res is None
+
+
+def test_gate_consults_deterministic_only_when_braking(monkeypatch):
+    monkeypatch.setattr(config, "AGENT_ACTION_GATE_ENABLED", True)
+    monkeypatch.setattr(config, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
+    ex = _exec()
+    calls = []
+    monkeypatch.setattr(ex, "_deterministic_action_signal", lambda *a, **k: calls.append(1) or False)
+    msgs = [{"role": "user", "text": "随便聊聊"}]
+    flags = {"computer_use_enabled": True}
+
+    # low action_intent → gate consults the deterministic shortcuts, then brakes.
+    res = asyncio.run(ex._analyze_and_execute_inner(messages=msgs, agent_flags=flags, action_intent=0.05))
+    assert res is None and len(calls) == 1
+
+    # high action_intent (>= threshold) → gate skipped, shortcuts NOT consulted.
+    calls.clear()
+    asyncio.run(ex._analyze_and_execute_inner(messages=msgs, agent_flags=flags, action_intent=0.9))
+    assert len(calls) == 0
+
+    # None action_intent (no usable signal) → gate skipped entirely (fail open).
+    asyncio.run(ex._analyze_and_execute_inner(messages=msgs, agent_flags=flags, action_intent=None))
+    assert len(calls) == 0
+
+    # gate disabled by config → not consulted even on a low action_intent.
+    monkeypatch.setattr(config, "AGENT_ACTION_GATE_ENABLED", False)
+    asyncio.run(ex._analyze_and_execute_inner(messages=msgs, agent_flags=flags, action_intent=0.05))
+    assert len(calls) == 0

--- a/tests/unit/test_agent_action_gate.py
+++ b/tests/unit/test_agent_action_gate.py
@@ -23,8 +23,12 @@ from __future__ import annotations
 
 import asyncio
 
-import config
+import brain.task_executor as te
 from brain.task_executor import DirectTaskExecutor
+
+# The gate reads AGENT_ACTION_GATE_* as module-level names imported into
+# brain.task_executor (the repo's `from config import (...)` convention), so the
+# knobs are patched on that module here, not on the `config` module.
 
 
 def _exec():
@@ -72,8 +76,8 @@ def test_det_signal_none_when_no_shortcuts():
 
 # ── the gate control flow inside _analyze_and_execute_inner ──
 def test_gate_brakes_on_confident_chat(monkeypatch):
-    monkeypatch.setattr(config, "AGENT_ACTION_GATE_ENABLED", True)
-    monkeypatch.setattr(config, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
+    monkeypatch.setattr(te, "AGENT_ACTION_GATE_ENABLED", True)
+    monkeypatch.setattr(te, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
     ex = _exec()
     msgs = [{"role": "user", "text": "今天天气真好心情不错"}]
     # computer_use only, action_intent below the line, no deterministic signal →
@@ -85,8 +89,8 @@ def test_gate_brakes_on_confident_chat(monkeypatch):
 
 
 def test_gate_consults_deterministic_only_when_braking(monkeypatch):
-    monkeypatch.setattr(config, "AGENT_ACTION_GATE_ENABLED", True)
-    monkeypatch.setattr(config, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
+    monkeypatch.setattr(te, "AGENT_ACTION_GATE_ENABLED", True)
+    monkeypatch.setattr(te, "AGENT_ACTION_GATE_THRESHOLD", 0.2)
     ex = _exec()
     calls = []
     monkeypatch.setattr(ex, "_deterministic_action_signal", lambda *a, **k: calls.append(1) or False)
@@ -107,6 +111,6 @@ def test_gate_consults_deterministic_only_when_braking(monkeypatch):
     assert len(calls) == 0
 
     # gate disabled by config → not consulted even on a low action_intent.
-    monkeypatch.setattr(config, "AGENT_ACTION_GATE_ENABLED", False)
+    monkeypatch.setattr(te, "AGENT_ACTION_GATE_ENABLED", False)
     asyncio.run(ex._analyze_and_execute_inner(messages=msgs, agent_flags=flags, action_intent=0.05))
     assert len(calls) == 0

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -504,6 +504,27 @@ def test_gate_signal_for_registry(monkeypatch):
     assert gate_signal_for("regtest", "运行一下") is None
 
 
+def test_truncated_input_nulls_action_intent(monkeypatch):
+    # When the analyzed text is longer than MASTER_EMOTION_MAX_INPUT_CHARS, the
+    # model only saw the opening; an action verb in the unseen tail would make
+    # action_intent unreliable → it is nulled (the agent gate then fails open).
+    # Emotion axes (judgeable from the opening) stay valid.
+    monkeypatch.setattr(config, "MASTER_EMOTION_MAX_INPUT_CHARS", 20)
+    fake, _ = _fake_tier('{"valence": -0.3, "arousal": 0.4, "action_intent": 0.9}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("trunc")
+    r = asyncio.run(t.analyze("x" * 100, now=100.0))  # 100 > 20 → truncated
+    assert r is not None
+    assert r.action_intent is None                  # nulled due to truncation
+    assert r.valence == -0.3 and r.arousal == 0.4   # emotion preserved
+    # Short input (<= max) keeps action_intent.
+    fake2, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.9}')
+    _patch_tier(monkeypatch, fake2)
+    t2 = MasterEmotionTracker("trunc2")
+    r2 = asyncio.run(t2.analyze("short", now=100.0))
+    assert r2.action_intent == 0.9
+
+
 def test_gate_signal_long_text_no_prefix_collision(monkeypatch):
     # A prefix-truncated match key would treat two long messages that share a
     # long prefix (but differ at the end) as the SAME turn — letting a stale
@@ -511,6 +532,9 @@ def test_gate_signal_long_text_no_prefix_collision(monkeypatch):
     # full-text fingerprint must reject that → fail open (None).
     from main_logic.activity.master_emotion import gate_signal_for
 
+    # Raise the input cap so the truncation guard does NOT fire here — this test
+    # isolates the fingerprint behavior (full text vs the old 280-char prefix).
+    monkeypatch.setattr(config, "MASTER_EMOTION_MAX_INPUT_CHARS", 100000)
     long_prefix = "这是一段很长的对话内容反复出现并且超过二百八十个字符的前缀" * 20  # > 280 chars
     fake, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.05}')
     _patch_tier(monkeypatch, fake)

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -502,3 +502,22 @@ def test_gate_signal_for_registry(monkeypatch):
     assert gate_signal_for("regtest", "运行一下") == 0.9
     monkeypatch.setattr(config, "MASTER_EMOTION_ENABLED", False)
     assert gate_signal_for("regtest", "运行一下") is None
+
+
+def test_gate_signal_long_text_no_prefix_collision(monkeypatch):
+    # A prefix-truncated match key would treat two long messages that share a
+    # long prefix (but differ at the end) as the SAME turn — letting a stale
+    # low-action reading brake a real action request in the latter half. The
+    # full-text fingerprint must reject that → fail open (None).
+    from main_logic.activity.master_emotion import gate_signal_for
+
+    long_prefix = "这是一段很长的对话内容反复出现并且超过二百八十个字符的前缀" * 20  # > 280 chars
+    fake, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.05}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("longtest")
+    asyncio.run(t.analyze(long_prefix + "前半段只是闲聊", now=100.0))
+    # Same long prefix, different tail = a different turn → must NOT reuse the
+    # prior low-action reading (which would wrongly brake the real request).
+    assert gate_signal_for("longtest", long_prefix + "后半段请帮我打开浏览器并搜索") is None
+    # The exact same text still matches (sanity check).
+    assert gate_signal_for("longtest", long_prefix + "前半段只是闲聊") == 0.05

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -457,33 +457,48 @@ def test_to_profile_sample(monkeypatch):
     assert t.to_profile_sample() is None
 
 
-def test_latest_action_intent_for_registry(monkeypatch):
-    # The cross-server analyze_request publisher reads the latest action_intent
-    # by lanlan_name (no core handle). Verify the registry bridge end to end.
-    from main_logic.activity.master_emotion import latest_action_intent_for
+def test_gate_signal_for_registry(monkeypatch):
+    # The cross-server analyze_request publisher reads the combined pre-gate
+    # signal by lanlan_name + current user text (no core handle). Verify the
+    # registry bridge, the freshness (turn) match, and the complexity fold.
+    from main_logic.activity.master_emotion import gate_signal_for
 
     # Unknown lanlan → None (fail-open: the agent gate runs the assessment).
-    assert latest_action_intent_for("nobody-here") is None
+    assert gate_signal_for("nobody-here", "anything") is None
 
     fake, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.7}')
     _patch_tier(monkeypatch, fake)
     t = MasterEmotionTracker("regtest")  # registers itself on init
     # No reading yet → None.
-    assert latest_action_intent_for("regtest") is None
+    assert gate_signal_for("regtest", "帮我打开浏览器") is None
     asyncio.run(t.analyze("帮我打开浏览器", now=100.0))
-    assert latest_action_intent_for("regtest") == 0.7
+    # Matching turn text → action_intent (complexity 0 → max is action_intent).
+    assert gate_signal_for("regtest", "帮我打开浏览器") == 0.7
+    # Freshness: a DIFFERENT user text → None (stale / other turn → fail open),
+    # so an earlier turn's signal can never gate the current one.
+    assert gate_signal_for("regtest", "完全不一样的另一句话") is None
+    # Match is whitespace-insensitive.
+    assert gate_signal_for("regtest", "  帮我打开浏览器  ") == 0.7
+
+    # Complexity fold: a hard reasoning turn (low action, high complexity) keeps
+    # the gate OPEN — max(0.1, 0.8) = 0.8 — so openfang-style reasoning requests
+    # are not braked.
+    fake2, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.1, "complexity": 0.8}')
+    _patch_tier(monkeypatch, fake2)
+    asyncio.run(t.analyze("这道题怎么一步步推导出来", now=200.0))
+    assert gate_signal_for("regtest", "这道题怎么一步步推导出来") == 0.8
 
     # A turn whose model output carried NO action_intent → None (fail-open),
     # even though a valid emotion reading exists this turn.
-    fake2, _ = _fake_tier('{"valence": -0.5, "arousal": 0.5}')
-    _patch_tier(monkeypatch, fake2)
-    asyncio.run(t.analyze("我好难过", now=200.0))
-    assert t.latest is not None and latest_action_intent_for("regtest") is None
+    fake3, _ = _fake_tier('{"valence": -0.5, "arousal": 0.5}')
+    _patch_tier(monkeypatch, fake3)
+    asyncio.run(t.analyze("我好难过", now=300.0))
+    assert t.latest is not None and gate_signal_for("regtest", "我好难过") is None
 
     # Honors the master switch (reads through .latest).
-    fake3, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.9}')
-    _patch_tier(monkeypatch, fake3)
-    asyncio.run(t.analyze("运行一下", now=300.0))
-    assert latest_action_intent_for("regtest") == 0.9
+    fake4, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.9}')
+    _patch_tier(monkeypatch, fake4)
+    asyncio.run(t.analyze("运行一下", now=400.0))
+    assert gate_signal_for("regtest", "运行一下") == 0.9
     monkeypatch.setattr(config, "MASTER_EMOTION_ENABLED", False)
-    assert latest_action_intent_for("regtest") is None
+    assert gate_signal_for("regtest", "运行一下") is None

--- a/tests/unit/test_master_emotion.py
+++ b/tests/unit/test_master_emotion.py
@@ -266,6 +266,38 @@ def test_parse_complexity_field():
     assert r3.complexity == 1.0
 
 
+def test_parse_action_intent_field():
+    # action_intent rides this same cheap call as a signal for the agent gate.
+    r = MasterEmotionTracker._parse(
+        '{"valence": 0, "arousal": 0, "action_intent": 0.8}', now=1.0, source="x",
+    )
+    assert r is not None and r.action_intent == 0.8
+    # CRITICAL — unlike complexity, a MISSING action_intent is None, NOT 0.0.
+    # The consuming agent gate must fail open (run the expensive assessment) when
+    # it has no usable signal, never read a phantom 0.0 as "confidently no
+    # action" and brake a real tool request. Absence must not reject the reading.
+    r2 = MasterEmotionTracker._parse('{"valence": 0, "arousal": 0}', now=1.0, source="x")
+    assert r2 is not None and r2.action_intent is None
+    # null / non-numeric → None (fail-open), reading still valid.
+    r3 = MasterEmotionTracker._parse(
+        '{"valence": 0, "arousal": 0, "action_intent": null}', now=1.0, source="x",
+    )
+    assert r3 is not None and r3.action_intent is None
+    r4 = MasterEmotionTracker._parse(
+        '{"valence": 0, "arousal": 0, "action_intent": "lots"}', now=1.0, source="x",
+    )
+    assert r4 is not None and r4.action_intent is None
+    # out-of-range clamps into [0, 1] when present.
+    r5 = MasterEmotionTracker._parse(
+        '{"valence": 0, "arousal": 0, "action_intent": 9}', now=1.0, source="x",
+    )
+    assert r5.action_intent == 1.0
+    r6 = MasterEmotionTracker._parse(
+        '{"valence": 0, "arousal": 0, "action_intent": -3}', now=1.0, source="x",
+    )
+    assert r6.action_intent == 0.0
+
+
 def test_parse_rejects_garbage():
     assert MasterEmotionTracker._parse("not json at all", now=1.0, source="x") is None
     assert MasterEmotionTracker._parse("[1, 2, 3]", now=1.0, source="x") is None  # not a dict
@@ -423,3 +455,35 @@ def test_to_profile_sample(monkeypatch):
     # honors the switch (reads via self.latest), same as latest
     monkeypatch.setattr(config, "MASTER_EMOTION_ENABLED", False)
     assert t.to_profile_sample() is None
+
+
+def test_latest_action_intent_for_registry(monkeypatch):
+    # The cross-server analyze_request publisher reads the latest action_intent
+    # by lanlan_name (no core handle). Verify the registry bridge end to end.
+    from main_logic.activity.master_emotion import latest_action_intent_for
+
+    # Unknown lanlan → None (fail-open: the agent gate runs the assessment).
+    assert latest_action_intent_for("nobody-here") is None
+
+    fake, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.7}')
+    _patch_tier(monkeypatch, fake)
+    t = MasterEmotionTracker("regtest")  # registers itself on init
+    # No reading yet → None.
+    assert latest_action_intent_for("regtest") is None
+    asyncio.run(t.analyze("帮我打开浏览器", now=100.0))
+    assert latest_action_intent_for("regtest") == 0.7
+
+    # A turn whose model output carried NO action_intent → None (fail-open),
+    # even though a valid emotion reading exists this turn.
+    fake2, _ = _fake_tier('{"valence": -0.5, "arousal": 0.5}')
+    _patch_tier(monkeypatch, fake2)
+    asyncio.run(t.analyze("我好难过", now=200.0))
+    assert t.latest is not None and latest_action_intent_for("regtest") is None
+
+    # Honors the master switch (reads through .latest).
+    fake3, _ = _fake_tier('{"valence": 0, "arousal": 0, "action_intent": 0.9}')
+    _patch_tier(monkeypatch, fake3)
+    asyncio.run(t.analyze("运行一下", now=300.0))
+    assert latest_action_intent_for("regtest") == 0.9
+    monkeypatch.setattr(config, "MASTER_EMOTION_ENABLED", False)
+    assert latest_action_intent_for("regtest") is None


### PR DESCRIPTION
## 问题

agent analyzer 在**每个 turn_end** 都跑 1~2 次大模型评估去判断"要不要派工具任务"——但约 90% 的 turn 是闲聊,答案恒为"否"。单轮开销量级接近一次主对话本身,纯浪费在恒为否的分类上。而凝神引入的 master-emotion 又在**每个 user turn** 多调一次小模型读情绪。两者频率相同但不同进程、不同时机。

## 方案:把工具意图判断折叠进已经在跑的那次廉价小模型

不新增任何调用、不新增跨进程通道:

1. **master-emotion 顺带产 `action_intent`**(0~1):用户在多大程度上**明确要求执行一个对外动作**。它搭在那次本来就在 input-time 读情绪的小模型调用上,一次调用两个判断。`缺失/垃圾 → None`(fail-open 哨兵,刻意区别于真实 0.0)。
2. **bit 搭已有的 analyze_request payload 过河**(main→agent):按 lanlan_name 的弱引用 tracker 注册表,cross_server 在 turn_end **非阻塞**读缓存值塞进 payload。turn_end 绝不等待情绪调用——小模型超时/被配成大模型/没算出来,一律 `None → fail-open`。
3. **analyzer 前置闸**:`action_intent` 自信地低(`< 阈值`)**且**零 LLM 的确定性 shortcut(openclaw magic word 规则 + 插件关键词)也全静默时,才跳过那 1~2 次大模型评估。

## 闸是非对称的(防过敏 + 防漏判)

- 闸**永不**决定派任务,只决定"要不要去问那个准确的大评估"。所以**过敏(误判有意图)只多花一次评估、行为零错误**;只有**漏判(误判闲聊)**才危险。
- 因此闸**只在确定性 shortcut 也全静默 + action_intent 自信低**时才刹车;`action_intent=None` 或任一确定性命中都**不刹车**。一个抖动的小模型最坏多花一次评估,**绝不漏掉真工具请求**。
- 确定性层只读**已缓存**的 plugin_list(不 force-fetch),所以刹车路径不会触发 short_description 现生成;plugin_list 还没加载时 fail-open。

旋钮:`AGENT_ACTION_GATE_ENABLED`(默认开)/ `AGENT_ACTION_GATE_THRESHOLD`(默认 0.2,保守低位)。

## 不在本 PR 范围(已另开后台任务/待定)

- 短描述生成移出 analyze 热路径(manifest 自带 / 安装时离线生成)——独立任务。
- 插件纠错重试的遥测(先查是否已有再决定)——独立任务。
- analyzer / emotion 链路里残留的 `temperature=` 清理(`check_no_temperature.py` 当前只扫 memory/utils,brain/main_logic 不在范围)——独立小 PR 料。

## 测试

- `tests/unit/test_master_emotion.py`:`action_intent` 解析(缺失→None≠0.0 的 fail-open 语义)+ 注册表桥接(未知 lanlan/无读数/无信号→None、有值→值、关开关→None)。
- `tests/unit/test_agent_action_gate.py`:确定性 shortcut(magic word / 关键词 / plugin 未加载 fail-open / 无 shortcut)+ 闸控制流(自信闲聊刹车 / 确定性覆盖 / None fail-open / 关闸不咨询)。
- 回归:focus_mode、module_layering、agent_runtime_intent 全绿(83 passed),无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 回归报告

**改动的高风险模块文件**:`app/agent_server.py`、`main_logic/activity/master_emotion.py`、`main_logic/agent_event_bus.py`、`main_logic/cross_server.py`。

**改了什么 / 为什么**:给 analyzer 加一道廉价前置闸,把工具意图判断折叠进已有的 master-emotion 小模型调用,省掉闲聊 turn 的 analyzer 大模型开销(详见上方"方案")。

**前后行为对比**
- 改前:每个 turn_end,只要 analyzer 开 + 有渠道,就跑 1~2 次大模型评估;master-emotion 只产 VA(valence/arousal/confidence/complexity)。
- 改后:master-emotion 同一次调用多产一个 `action_intent` 字段(边际几个 token);turn_end 时 analyzer 先读这个 bit,自信闲聊 + 确定性 shortcut 全静默才跳过大评估。`AGENT_ACTION_GATE_ENABLED=False` 可逐字节回到改前行为。

**潜在回归 / 风险点**
- `master_emotion.py`:新增弱引用注册表 `_TRACKERS_BY_LANLAN`,`__init__` 登记自身(WeakValueDictionary 防泄漏);`.latest` 的 TTL/开关门禁不变;VA 解析仅新增 `action_intent`(缺失→None,不影响既有 4 轴)。
- `cross_server.py`:turn_end 发布前**非阻塞**读注册表(lazy import),读不到→None→agent fail-open;不改变 turn_end 的任何阻塞/时序特性。
- `agent_event_bus.py`:`publish_analyze_request_reliably` 新增可选 `action_intent`,None 时不写进 event(向后兼容)。
- `agent_server.py`:仅把 `action_intent` 透传进分析管线;闸逻辑在 task_executor,fail-open——`None`/确定性命中/关开关都照常全量评估,绝不漏真任务。
- 主要风险是小模型误判闲聊导致漏派任务,已由「非对称闸 + 确定性 shortcut 无条件覆盖 + 保守阈值 0.2 + fail-open」四重收窄,最坏只是某轮多花一次评估。

**回归测试**:`uv`/venv 下 `test_master_emotion`(36)+ `test_agent_action_gate`(6)+ 回归批 `focus_mode`/`module_layering`/`agent_runtime_intent`(83 passed)全绿,无回归。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

- **新功能**
  - 分析请求增加 `action_intent` 传递，并用于低意图场景的快速放行/制动。
  - 支持零大模型的动作意图判定：魔法命令识别与插件关键词命中快速判断。
- **配置选项**
  - 新增 `AGENT_ACTION_GATE_ENABLED`（默认启用）
  - 新增 `AGENT_ACTION_GATE_THRESHOLD`（默认 0.2）
- **改进**
  - 主情绪多语言结果新增 `action_intent` 维度，进一步优化门控以减少不必要的大模型评估轮次。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->