### PR TITLE
[codex] 优化羽毛球小游戏性能与手感

### DIFF
--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -36,6 +36,20 @@
     display: block; position: fixed; inset: 0; z-index: 15;
     pointer-events: none;
   }
+  #player-charge-meter {
+    position: fixed; left: 0; top: 0; z-index: 16;
+    width: 74px; height: 8px; pointer-events: none;
+    opacity: 0; transform: translate3d(-9999px, -9999px, 0);
+    contain: layout paint style; will-change: transform, opacity;
+    border: 1px solid rgba(255,255,255,.32);
+    border-radius: 999px; overflow: hidden;
+    background: rgba(5,13,19,.54);
+  }
+  #player-charge-meter[data-active="1"] { opacity: 1; }
+  #player-charge-fill {
+    width: 100%; height: 100%; transform: scaleX(0); transform-origin: 0 50%;
+    background: #ffca3a; will-change: transform;
+  }
   #badminton-loading {
     position: fixed; inset: 0; z-index: 70;
     display: flex; align-items: center; justify-content: center;
@@ -541,6 +555,7 @@
 </div>
 <canvas id="game" width="900" height="500"></canvas>
 <canvas id="aiming-canvas" width="900" height="500"></canvas>
+<div id="player-charge-meter" aria-hidden="true"><div id="player-charge-fill"></div></div>
 <div id="hud" aria-live="polite">
   <span id="score-label">得分 0</span>
   <span id="streak-label">连中 0</span>
@@ -770,6 +785,8 @@
   var ctx = canvas.getContext('2d');
   var aimingCanvas = document.getElementById('aiming-canvas');
   var aimingCtx = aimingCanvas.getContext('2d');
+  var playerChargeMeter = document.getElementById('player-charge-meter');
+  var playerChargeFill = document.getElementById('player-charge-fill');
   var badmintonLoading = document.getElementById('badminton-loading');
   var badmintonLoadingBar = document.getElementById('badminton-loading-bar');
   var badmintonLoadingPercent = document.getElementById('badminton-loading-percent');
@@ -1050,12 +1067,14 @@
   var YUI_CHEAT_INK_DURATION_MS = 3600;
   var YUI_CHEAT_INK_VISUAL_SCALE = 0.82;
   var YUI_CHEAT_SCORE_TAUNT_GRACE_MS = 6500;
+  var YUI_LIVE2D_RACKET_ANCHOR_SAMPLE_MS = 64;
   var netNodes = [];
   var modeParams = null;
   try { modeParams = new URLSearchParams(window.location.search); } catch (_) { modeParams = null; }
   var debugMode = modeParams ? modeParams.get('debug') === '1' : false;
   var debugVoiceMode = modeParams ? modeParams.get('debug_voice') === '1' : false;
   var debugVoiceMuted = modeParams ? modeParams.get('debug_mute_voice') === '1' : false;
+  var perfMode = debugMode || (modeParams ? modeParams.get('perf') === '1' : false);
   var currentMode = 'duel';
   var netContactEffects = [];
   var DUEL_DIFFICULTY = [
@@ -1091,6 +1110,21 @@
   var psychologicalTalkAt = 0;
   var screenFlashUntil = 0;
   var aimingOverlayWasActive = false;
+  var playerAvatarStyleCache = {};
+  var playerChargeMeterStyleCache = {};
+  var playerChargeFillStyleCache = {};
+  var yuiLive2dDrawableHandCache = null;
+  var yuiInkOverlayCache = { canvas: null, ctx: null, key: '', ready: false };
+  var badmintonPerfState = {
+    frame: 0,
+    updateMs: 0,
+    renderMs: 0,
+    aimingMs: 0,
+    racketMs: 0,
+    frameMs: 0,
+    worstFrameMs: 0,
+    lastSlowFrameAt: 0
+  };
   var fireExtinguishedUntil = 0;
   var isPositionTransitioning = false;
   var shotAnimationTimer = 0;
@@ -1344,6 +1378,39 @@
   function setDatasetValueIfChanged(element, key, value) {
     var stringValue = String(value == null ? '' : value);
     if (element && element.dataset && element.dataset[key] !== stringValue) element.dataset[key] = stringValue;
+  }
+  function setStyleIfChanged(element, cache, key, value) {
+    if (!element || !cache) return;
+    var stringValue = String(value == null ? '' : value);
+    if (cache[key] === stringValue) return;
+    cache[key] = stringValue;
+    element.style[key] = stringValue;
+  }
+  function setStylePropertyIfChanged(element, cache, key, value) {
+    if (!element || !cache) return;
+    var stringValue = String(value == null ? '' : value);
+    if (cache[key] === stringValue) return;
+    cache[key] = stringValue;
+    element.style.setProperty(key, stringValue);
+  }
+  function recordBadmintonPerfSample(key, startedAt, now) {
+    if (!perfMode || !Number.isFinite(startedAt)) return;
+    var endedAt = Number.isFinite(now) ? now : performance.now();
+    var elapsed = Math.max(0, endedAt - startedAt);
+    badmintonPerfState[key] = elapsed;
+    if (key === 'frameMs') {
+      badmintonPerfState.frame += 1;
+      if (elapsed > badmintonPerfState.worstFrameMs) badmintonPerfState.worstFrameMs = elapsed;
+      if (elapsed > 33) badmintonPerfState.lastSlowFrameAt = endedAt;
+    }
+  }
+  function getBadmintonPerfSnapshot() {
+    var racketDebug = window.__badmintonYuiRacketDebug || null;
+    return Object.assign({}, badmintonPerfState, {
+      live2dRacketSource: racketDebug ? racketDebug.source : '',
+      live2dRacketAnchorAgeMs: yuiLive2dDrawableHandCache ? Math.max(0, Math.round(getBadmintonFrameNow() - (yuiLive2dDrawableHandCache.sampledAt || 0))) : 0,
+      inkOverlayCached: !!(yuiInkOverlayCache && yuiInkOverlayCache.ready)
+    });
   }
   function pxToMeters(px) {
     return ((Number(px) || 0) / PX_PER_METER).toFixed(1) + 'm';
@@ -3012,7 +3079,7 @@
     if (currentMode !== 'duel') return;
     var container = getActiveAvatarContainer();
     if (!container) return;
-    container.dataset.courtAvatar = 'opponent';
+    setDatasetValueIfChanged(container, 'courtAvatar', 'opponent');
     var baseX = getYuiX();
     var baseY = getYuiY() + 71;
     var sx = baseX / BASE_W * window.innerWidth;
@@ -3029,7 +3096,7 @@
   }
   function updateDuelShooterAvatars() {
     if (currentMode !== 'duel') return;
-    if (playerSenseiContainer && !playerSenseiContainer.hidden) playerSenseiContainer.style.opacity = '0.96';
+    if (playerSenseiContainer && !playerSenseiContainer.hidden) setStyleIfChanged(playerSenseiContainer, playerAvatarStyleCache, 'opacity', '0.96');
     updateYuiPosition(game.distance);
   }
   function clearYuiActionClasses(container) {
@@ -4043,6 +4110,8 @@
     aimingCanvas.height = canvas.height;
     ctx.setTransform(canvas.width / BASE_W, 0, 0, canvas.height / BASE_H, 0, 0);
     aimingCtx.setTransform(aimingCanvas.width / BASE_W, 0, 0, aimingCanvas.height / BASE_H, 0, 0);
+    yuiInkOverlayCache.ready = false;
+    yuiInkOverlayCache.key = '';
     updateYuiPosition(game.distance);
     updatePlayerAvatarPosition();
     updateDuelShooterAvatars();
@@ -4641,11 +4710,11 @@
     var sx = getPlayerX() / BASE_W * window.innerWidth;
     var sy = (getPlayerY() + 63) / BASE_H * window.innerHeight;
     var slipDeg = ((game.playerCheatEffect && game.playerCheatEffect.spinAngle) || 0) * 180 / Math.PI;
-    playerSenseiContainer.style.width = PLAYER_AVATAR_W + 'px';
-    playerSenseiContainer.style.height = PLAYER_AVATAR_H + 'px';
-    playerSenseiContainer.style.setProperty('--sensei-x', Math.round(sx - PLAYER_AVATAR_W / 2) + 'px');
-    playerSenseiContainer.style.setProperty('--sensei-y', Math.round(sy - PLAYER_AVATAR_H) + 'px');
-    playerSenseiContainer.style.setProperty('--sensei-slip-rotation', slipDeg.toFixed(2) + 'deg');
+    setStyleIfChanged(playerSenseiContainer, playerAvatarStyleCache, 'width', PLAYER_AVATAR_W + 'px');
+    setStyleIfChanged(playerSenseiContainer, playerAvatarStyleCache, 'height', PLAYER_AVATAR_H + 'px');
+    setStylePropertyIfChanged(playerSenseiContainer, playerAvatarStyleCache, '--sensei-x', Math.round(sx - PLAYER_AVATAR_W / 2) + 'px');
+    setStylePropertyIfChanged(playerSenseiContainer, playerAvatarStyleCache, '--sensei-y', Math.round(sy - PLAYER_AVATAR_H) + 'px');
+    setStylePropertyIfChanged(playerSenseiContainer, playerAvatarStyleCache, '--sensei-slip-rotation', slipDeg.toFixed(2) + 'deg');
   }
   async function initPlayerAvatar() {
     if (!playerSenseiContainer || !playerSenseiCanvas) {
@@ -7747,20 +7816,16 @@
     var trail = getShuttleTrailPoints(ball);
     if (trail.length > 1) {
       ctx.save();
-      var start = trail[0];
-      var trailGrad = ctx.createLinearGradient(start.x, start.y, ball.x, ball.y);
-      trailGrad.addColorStop(0, 'rgba(182,231,255,0)');
-      trailGrad.addColorStop(0.48, ball.isSmash ? 'rgba(255,190,92,.46)' : (ball.wasPerfect ? 'rgba(255,239,159,.36)' : 'rgba(204,241,255,.28)'));
-      trailGrad.addColorStop(1, ball.isSmash ? 'rgba(255,242,190,.78)' : (ball.wasPerfect ? 'rgba(255,250,210,.68)' : 'rgba(242,252,255,.54)'));
-      ctx.strokeStyle = trailGrad;
-      ctx.lineWidth = ball.isSmash ? 4.2 : (ball.wasPerfect ? 3.4 : 2.4);
+      var firstTrailIndex = ball.isSmash ? Math.max(0, trail.length - 5) : 0;
+      var start = trail[firstTrailIndex];
+      ctx.globalAlpha = ball.isSmash ? 0.50 : (ball.wasPerfect ? 0.62 : 0.48);
+      ctx.strokeStyle = ball.isSmash ? 'rgba(255,210,118,.72)' : (ball.wasPerfect ? 'rgba(255,244,178,.62)' : 'rgba(204,241,255,.48)');
+      ctx.lineWidth = ball.isSmash ? 2.8 : (ball.wasPerfect ? 3.0 : 2.2);
       ctx.lineCap = 'round';
       ctx.lineJoin = 'round';
-      ctx.shadowColor = ball.isSmash ? 'rgba(255,174,80,.34)' : (ball.wasPerfect ? 'rgba(255,225,122,.28)' : 'rgba(150,220,255,.22)');
-      ctx.shadowBlur = ball.isSmash ? 9 : (ball.wasPerfect ? 7 : 5);
       ctx.beginPath();
       ctx.moveTo(start.x, start.y);
-      for (var i = 1; i < trail.length; i++) ctx.lineTo(trail[i].x, trail[i].y);
+      for (var i = firstTrailIndex + 1; i < trail.length; i++) ctx.lineTo(trail[i].x, trail[i].y);
       ctx.lineTo(ball.x, ball.y);
       ctx.stroke();
       ctx.restore();
@@ -8092,6 +8157,29 @@
     };
   }
 
+  function getCachedYuiLive2dDrawableHand(domRect, modelFrame, layoutW, layoutH, shooting, charging, now) {
+    var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
+    var cached = yuiLive2dDrawableHandCache;
+    if (cached
+        && cached.shooting === !!shooting
+        && cached.charging === !!charging
+        && cached.layoutW === layoutW
+        && cached.layoutH === layoutH
+        && t - (cached.sampledAt || 0) < YUI_LIVE2D_RACKET_ANCHOR_SAMPLE_MS) {
+      return cached.drawable || null;
+    }
+    var drawableHand = getYuiLive2dHandAnchorFromDrawables(domRect, modelFrame, layoutW, layoutH, shooting, charging);
+    yuiLive2dDrawableHandCache = {
+      sampledAt: t,
+      shooting: !!shooting,
+      charging: !!charging,
+      layoutW: layoutW,
+      layoutH: layoutH,
+      drawable: drawableHand || null
+    };
+    return drawableHand;
+  }
+
   function setYuiLive2dParameter(id, value) {
     var model = window.live2dManager && window.live2dManager.currentModel;
     var coreModel = model && (model.coreModel || (model.internalModel && model.internalModel.coreModel));
@@ -8119,8 +8207,11 @@
     if (nekoL2dContainer.hidden || currentMode !== 'duel') {
       yuiLive2dRacketCtx.clearRect(0, 0, yuiLive2dRacketCanvas.width || 1, yuiLive2dRacketCanvas.height || 1);
       applyYuiLive2dRacketPose(false, false);
+      window.__badmintonYuiRacketDebug = null;
+      yuiLive2dDrawableHandCache = null;
       return;
     }
+    var now = getBadmintonFrameNow();
     var rect = nekoL2dContainer.getBoundingClientRect();
     if (rect.width < 20 || rect.height < 20) return;
     var dpr = window.devicePixelRatio || 1;
@@ -8142,7 +8233,7 @@
     var swing = shooting ? 0.62 : (charging ? -0.28 : 0);
     var racketScale = Math.max(0.98, Math.min(1.08, modelFrame.height / 320));
     var fallbackHand = getYuiLive2dFallbackHandPoint(modelFrame, shooting, charging);
-    var drawableHand = getYuiLive2dHandAnchorFromDrawables(rect, modelFrame, layoutW, layoutH, shooting, charging);
+    var drawableHand = getCachedYuiLive2dDrawableHand(rect, modelFrame, layoutW, layoutH, shooting, charging, now);
     var handX = drawableHand ? drawableHand.x : fallbackHand.x;
     var handY = drawableHand ? drawableHand.y : fallbackHand.y;
     if (drawableHand) {
@@ -8344,82 +8435,76 @@
   function isAimingOverlayActive(now) {
     var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
     return !!(isIncomingPlayerReturnCandidate()
-      || (game.charging && canPlayerChargeShot())
       || (game.yuiCheat && getYuiInkState(t).active));
   }
   function drawAiming(now) {
     var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
     var overlayActive = isAimingOverlayActive(t);
+    drawPlayerChargeMeter(game.charging && canPlayerChargeShot() ? clamp(game.power, 0, 100) : 0, t);
     if (!overlayActive && !aimingOverlayWasActive) return;
     aimingOverlayWasActive = overlayActive;
     aimingCtx.clearRect(0, 0, BASE_W, BASE_H);
     if (!overlayActive) return;
     drawPlayerReturnHitCue(t);
-    if (game.charging && canPlayerChargeShot()) drawPlayerChargeMeter(clamp(game.power, 0, 100), t);
     drawYuiInkOverlay(t);
   }
   function drawPlayerChargeMeter(percent, now) {
     var chargePercent = clamp(percent, 0, 100);
-    if (chargePercent <= 0) return;
-    var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
-    var pulse = 0.5 + 0.5 * Math.sin(t / 118);
+    if (!playerChargeMeter || !playerChargeFill) return;
+    if (chargePercent <= 0) {
+      setDatasetValueIfChanged(playerChargeMeter, 'active', '0');
+      return;
+    }
     var meterW = 74;
     var meterH = 8;
-    var meterX = getPlayerX() - meterW / 2;
-    var meterY = getPlayerY() - 146;
-    var fillW = meterW * chargePercent / 100;
-    aimingCtx.save();
-    aimingCtx.globalCompositeOperation = 'lighter';
-    aimingCtx.shadowColor = 'rgba(114,216,255,.42)';
-    aimingCtx.shadowBlur = 8 + pulse * 4;
-    aimingCtx.fillStyle = 'rgba(5,13,19,.52)';
-    aimingCtx.strokeStyle = 'rgba(255,255,255,.32)';
-    aimingCtx.lineWidth = 1;
-    aimingCtx.beginPath();
-    if (typeof aimingCtx.roundRect === 'function') aimingCtx.roundRect(meterX, meterY, meterW, meterH, 4);
-    else aimingCtx.rect(meterX, meterY, meterW, meterH);
-    aimingCtx.fill();
-    aimingCtx.stroke();
-    aimingCtx.fillStyle = 'rgba(255,202,58,.92)';
-    aimingCtx.beginPath();
-    if (typeof aimingCtx.roundRect === 'function') aimingCtx.roundRect(meterX + 1.5, meterY + 1.5, Math.max(0, fillW - 3), meterH - 3, 3);
-    else aimingCtx.rect(meterX + 1.5, meterY + 1.5, Math.max(0, fillW - 3), meterH - 3);
-    aimingCtx.fill();
-    aimingCtx.restore();
+    var screenScaleX = window.innerWidth / BASE_W;
+    var screenScaleY = window.innerHeight / BASE_H;
+    var meterX = (getPlayerX() - meterW / 2) * screenScaleX;
+    var meterY = (getPlayerY() - 146) * screenScaleY;
+    setDatasetValueIfChanged(playerChargeMeter, 'active', '1');
+    setStyleIfChanged(playerChargeMeter, playerChargeMeterStyleCache, 'width', Math.max(1, Math.round(meterW * screenScaleX)) + 'px');
+    setStyleIfChanged(playerChargeMeter, playerChargeMeterStyleCache, 'height', Math.max(1, Math.round(meterH * screenScaleY)) + 'px');
+    setStyleIfChanged(playerChargeMeter, playerChargeMeterStyleCache, 'transform', 'translate3d(' + Math.round(meterX) + 'px,' + Math.round(meterY) + 'px,0)');
+    setStyleIfChanged(playerChargeFill, playerChargeFillStyleCache, 'transform', 'scaleX(' + (chargePercent / 100).toFixed(3) + ')');
   }
-  function drawYuiInkOverlay(now) {
-    if (!aimingCtx || !game.yuiCheat) return;
-    var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
-    var ink = getYuiInkState(t);
-    if (!ink.active || ink.alpha <= 0) return;
-    var pulse = 0.5 + Math.sin(t / 180) * 0.5;
+  function ensureYuiInkOverlayCache() {
     var inkScale = YUI_CHEAT_INK_VISUAL_SCALE;
-    aimingCtx.save();
-    aimingCtx.globalAlpha = Math.min(0.34, ink.alpha * 0.38);
-    aimingCtx.fillStyle = 'rgba(1,5,10,.46)';
-    aimingCtx.fillRect(0, 0, BASE_W, BASE_H);
+    var key = BASE_W + 'x' + BASE_H + ':' + inkScale;
+    if (yuiInkOverlayCache.ready && yuiInkOverlayCache.key === key && yuiInkOverlayCache.canvas) return yuiInkOverlayCache.canvas;
+    if (!yuiInkOverlayCache.canvas) {
+      yuiInkOverlayCache.canvas = document.createElement('canvas');
+      yuiInkOverlayCache.ctx = yuiInkOverlayCache.canvas.getContext('2d');
+    }
+    var inkCanvas = yuiInkOverlayCache.canvas;
+    var inkCtx = yuiInkOverlayCache.ctx;
+    if (!inkCtx) return null;
+    inkCanvas.width = BASE_W;
+    inkCanvas.height = BASE_H;
+    inkCtx.setTransform(1, 0, 0, 1, 0, 0);
+    inkCtx.clearRect(0, 0, BASE_W, BASE_H);
 
-    var centralInk = aimingCtx.createRadialGradient(BASE_W * 0.50, BASE_H * 0.48, 24 * inkScale, BASE_W * 0.50, BASE_H * 0.48, BASE_W * 0.34 * inkScale);
+    var pulse = 0.5;
+    var centralInk = inkCtx.createRadialGradient(BASE_W * 0.50, BASE_H * 0.48, 24 * inkScale, BASE_W * 0.50, BASE_H * 0.48, BASE_W * 0.34 * inkScale);
     centralInk.addColorStop(0, 'rgba(0,0,0,.96)');
     centralInk.addColorStop(0.44, 'rgba(1,4,9,.92)');
     centralInk.addColorStop(0.72, 'rgba(4,12,19,.62)');
     centralInk.addColorStop(1, 'rgba(0,0,0,0)');
-    aimingCtx.globalAlpha = Math.min(0.96, ink.alpha * 1.04);
-    aimingCtx.fillStyle = centralInk;
-    aimingCtx.fillRect(0, 0, BASE_W, BASE_H);
+    inkCtx.globalAlpha = 1;
+    inkCtx.fillStyle = centralInk;
+    inkCtx.fillRect(0, 0, BASE_W, BASE_H);
 
     function drawCenterInkBlob(cx, cy, rx, ry, rot, alpha) {
-      aimingCtx.save();
-      aimingCtx.translate(cx, cy);
-      aimingCtx.rotate(rot);
-      aimingCtx.globalAlpha = Math.min(0.94, ink.alpha * alpha);
-      aimingCtx.fillStyle = 'rgba(0,2,6,.9)';
-      aimingCtx.shadowColor = 'rgba(0,0,0,.42)';
-      aimingCtx.shadowBlur = 22;
-      aimingCtx.beginPath();
-      aimingCtx.ellipse(0, 0, rx, ry, 0, 0, Math.PI * 2);
-      aimingCtx.fill();
-      aimingCtx.restore();
+      inkCtx.save();
+      inkCtx.translate(cx, cy);
+      inkCtx.rotate(rot);
+      inkCtx.globalAlpha = Math.min(0.94, alpha);
+      inkCtx.fillStyle = 'rgba(0,2,6,.9)';
+      inkCtx.shadowColor = 'rgba(0,0,0,.42)';
+      inkCtx.shadowBlur = 22;
+      inkCtx.beginPath();
+      inkCtx.ellipse(0, 0, rx, ry, 0, 0, Math.PI * 2);
+      inkCtx.fill();
+      inkCtx.restore();
     }
 
     var centerSplashes = [
@@ -8434,49 +8519,68 @@
       drawCenterInkBlob(splash[0], splash[1], (splash[2] + pulse * 8) * inkScale, (splash[3] + pulse * 6) * inkScale, splash[4], splash[5]);
     }
 
-    aimingCtx.shadowBlur = 0;
-    aimingCtx.lineCap = 'round';
+    inkCtx.shadowBlur = 0;
+    inkCtx.lineCap = 'round';
     for (var drip = 0; drip < 8; drip++) {
       var centerDripX = BASE_W * (0.36 + ((drip * 17) % 28) / 100);
       var centerDripTop = BASE_H * (0.38 + (drip % 3) * 0.05);
       var centerDripLen = (40 + (drip % 5) * 16 + pulse * 8) * inkScale;
-      aimingCtx.globalAlpha = Math.min(0.76, ink.alpha * (0.58 + (drip % 3) * 0.06));
-      aimingCtx.strokeStyle = 'rgba(0,2,5,.86)';
-      aimingCtx.lineWidth = (5 + (drip % 3) * 3) * inkScale;
-      aimingCtx.beginPath();
-      aimingCtx.moveTo(centerDripX, centerDripTop);
-      aimingCtx.bezierCurveTo(centerDripX - 8, centerDripTop + centerDripLen * 0.34, centerDripX + 10, centerDripTop + centerDripLen * 0.68, centerDripX + Math.sin(t / 360 + drip) * 4, centerDripTop + centerDripLen);
-      aimingCtx.stroke();
-      aimingCtx.fillStyle = 'rgba(0,2,5,.82)';
-      aimingCtx.beginPath();
-      aimingCtx.ellipse(centerDripX, centerDripTop + centerDripLen + 4, aimingCtx.lineWidth * 0.72, aimingCtx.lineWidth * 1.05, 0, 0, Math.PI * 2);
-      aimingCtx.fill();
+      inkCtx.globalAlpha = Math.min(0.76, 0.58 + (drip % 3) * 0.06);
+      inkCtx.strokeStyle = 'rgba(0,2,5,.86)';
+      inkCtx.lineWidth = (5 + (drip % 3) * 3) * inkScale;
+      inkCtx.beginPath();
+      inkCtx.moveTo(centerDripX, centerDripTop);
+      inkCtx.bezierCurveTo(centerDripX - 8, centerDripTop + centerDripLen * 0.34, centerDripX + 10, centerDripTop + centerDripLen * 0.68, centerDripX + Math.sin(drip) * 4, centerDripTop + centerDripLen);
+      inkCtx.stroke();
+      inkCtx.fillStyle = 'rgba(0,2,5,.82)';
+      inkCtx.beginPath();
+      inkCtx.ellipse(centerDripX, centerDripTop + centerDripLen + 4, inkCtx.lineWidth * 0.72, inkCtx.lineWidth * 1.05, 0, 0, Math.PI * 2);
+      inkCtx.fill();
     }
     for (var speck = 0; speck < 22; speck++) {
       var spread = 0.16 + (speck % 5) * 0.025;
-      var orbitAngle = speck * 2.28 + t / 900;
+      var orbitAngle = speck * 2.28;
       var speckX = BASE_W * 0.5 + Math.cos(orbitAngle) * BASE_W * spread;
       var speckY = BASE_H * 0.48 + Math.sin(orbitAngle * 0.9) * BASE_H * (spread * 0.72);
-      var speckAngle = speck * 1.17 + t / 900;
-      aimingCtx.globalAlpha = Math.min(0.56, ink.alpha * 0.54);
-      aimingCtx.fillStyle = 'rgba(0,3,8,.72)';
-      aimingCtx.beginPath();
-      aimingCtx.ellipse(speckX, speckY, (8 + (speck % 4) * 4) * inkScale, (5 + (speck % 3) * 3) * inkScale, speckAngle * 0.18, 0, Math.PI * 2);
-      aimingCtx.fill();
+      var speckAngle = speck * 1.17;
+      inkCtx.globalAlpha = 0.54;
+      inkCtx.fillStyle = 'rgba(0,3,8,.72)';
+      inkCtx.beginPath();
+      inkCtx.ellipse(speckX, speckY, (8 + (speck % 4) * 4) * inkScale, (5 + (speck % 3) * 3) * inkScale, speckAngle * 0.18, 0, Math.PI * 2);
+      inkCtx.fill();
     }
 
-    if (ink.alpha > 0.58) {
-      aimingCtx.globalAlpha = Math.min(0.16, ink.alpha * 0.18);
-      aimingCtx.strokeStyle = 'rgba(114,216,226,.42)';
-      aimingCtx.lineWidth = 1.2;
-      for (var arc = 0; arc < 2; arc++) {
-        var arcY = BASE_H * (0.42 + arc * 0.12) + Math.sin(t / 460 + arc) * 4;
-        aimingCtx.beginPath();
-        aimingCtx.ellipse(BASE_W * 0.5, arcY, BASE_W * (0.22 + arc * 0.04) * inkScale, BASE_H * 0.10 * inkScale, -0.08 + arc * 0.16, 0, Math.PI * 2);
-        aimingCtx.stroke();
-      }
+    inkCtx.globalAlpha = 0.16;
+    inkCtx.strokeStyle = 'rgba(114,216,226,.42)';
+    inkCtx.lineWidth = 1.2;
+    for (var arc = 0; arc < 2; arc++) {
+      var arcY = BASE_H * (0.42 + arc * 0.12);
+      inkCtx.beginPath();
+      inkCtx.ellipse(BASE_W * 0.5, arcY, BASE_W * (0.22 + arc * 0.04) * inkScale, BASE_H * 0.10 * inkScale, -0.08 + arc * 0.16, 0, Math.PI * 2);
+      inkCtx.stroke();
     }
+    yuiInkOverlayCache.ready = true;
+    yuiInkOverlayCache.key = key;
+    return inkCanvas;
+  }
 
+  function drawYuiInkOverlay(now) {
+    if (!aimingCtx || !game.yuiCheat) return;
+    var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
+    var ink = getYuiInkState(t);
+    if (!ink.active || ink.alpha <= 0) return;
+    var inkCanvas = ensureYuiInkOverlayCache();
+    if (!inkCanvas) return;
+    var pulse = 0.5 + Math.sin(t / 180) * 0.5;
+    var scale = 1 + pulse * 0.012;
+    var drawW = BASE_W * scale;
+    var drawH = BASE_H * scale;
+    aimingCtx.save();
+    aimingCtx.globalAlpha = Math.min(0.34, ink.alpha * 0.38);
+    aimingCtx.fillStyle = 'rgba(1,5,10,.46)';
+    aimingCtx.fillRect(0, 0, BASE_W, BASE_H);
+    aimingCtx.globalAlpha = Math.min(0.96, ink.alpha * 1.04);
+    aimingCtx.drawImage(inkCanvas, (BASE_W - drawW) / 2, (BASE_H - drawH) / 2, drawW, drawH);
     aimingCtx.restore();
   }
   function drawPlayerReturnHitCue(now) {
@@ -8506,11 +8610,8 @@
     var cueAlpha = canReturnNow ? 1 : 0.46;
 
     aimingCtx.save();
-    aimingCtx.globalCompositeOperation = 'lighter';
-    aimingCtx.shadowColor = 'rgba(255,221,122,.26)';
-    aimingCtx.shadowBlur = 5 + pulse * 3;
     aimingCtx.strokeStyle = canReturnNow ? 'rgba(255,236,168,.075)' : 'rgba(114,216,255,.055)';
-    aimingCtx.lineWidth = 7 + pulse * 1.5;
+    aimingCtx.lineWidth = 5.8 + pulse * 0.8;
     aimingCtx.lineCap = 'round';
     aimingCtx.globalAlpha = cueAlpha;
     aimingCtx.beginPath();
@@ -8518,13 +8619,8 @@
     aimingCtx.quadraticCurveTo(controlX, controlY, endX, endY);
     aimingCtx.stroke();
 
-    var cueGradient = aimingCtx.createLinearGradient(startX, startY, endX, endY);
-    cueGradient.addColorStop(0, 'rgba(255,255,255,0)');
-    cueGradient.addColorStop(0.42, canReturnNow ? 'rgba(255,246,190,.16)' : 'rgba(114,216,255,.13)');
-    cueGradient.addColorStop(1, canReturnNow ? 'rgba(255,210,96,.30)' : 'rgba(114,216,255,.25)');
-    aimingCtx.shadowBlur = 3 + pulse * 2;
-    aimingCtx.strokeStyle = cueGradient;
-    aimingCtx.lineWidth = 1.8 + pulse * 0.55;
+    aimingCtx.strokeStyle = canReturnNow ? 'rgba(255,210,96,.30)' : 'rgba(114,216,255,.25)';
+    aimingCtx.lineWidth = 1.5 + pulse * 0.35;
     aimingCtx.beginPath();
     aimingCtx.moveTo(startX, startY);
     aimingCtx.quadraticCurveTo(controlX, controlY, endX, endY);
@@ -8539,8 +8635,7 @@
     var sideX = -tangentY;
     var sideY = tangentX;
     var head = 6 + shimmer * 1.5;
-    aimingCtx.fillStyle = 'rgba(255,218,102,.24)';
-    aimingCtx.shadowBlur = 3;
+    aimingCtx.fillStyle = canReturnNow ? 'rgba(255,218,102,.24)' : 'rgba(114,216,255,.20)';
     aimingCtx.beginPath();
     aimingCtx.moveTo(endX + tangentX * 4, endY + tangentY * 4);
     aimingCtx.lineTo(endX - tangentX * head + sideX * head * 0.32, endY - tangentY * head + sideY * head * 0.32);
@@ -8549,17 +8644,12 @@
     aimingCtx.fill();
 
     var glowRadius = radius + 3 + pulse * 2;
-    var glow = aimingCtx.createRadialGradient(ball.x, ball.y, Math.max(2, radius * 0.4), ball.x, ball.y, glowRadius + 7);
-    glow.addColorStop(0, 'rgba(255,255,255,.055)');
-    glow.addColorStop(0.45, 'rgba(255,232,150,.085)');
-    glow.addColorStop(1, 'rgba(255,216,94,0)');
-    aimingCtx.fillStyle = glow;
+    aimingCtx.fillStyle = canReturnNow ? 'rgba(255,232,150,.055)' : 'rgba(114,216,255,.050)';
     aimingCtx.beginPath();
     aimingCtx.arc(ball.x, ball.y, glowRadius + 7, 0, Math.PI * 2);
     aimingCtx.fill();
     aimingCtx.strokeStyle = 'rgba(255,242,183,.18)';
     aimingCtx.lineWidth = 0.9;
-    aimingCtx.shadowBlur = 2;
     aimingCtx.beginPath();
     aimingCtx.arc(ball.x, ball.y, glowRadius, 0, Math.PI * 2);
     aimingCtx.stroke();
@@ -8673,10 +8763,27 @@
     badmintonFrameNow = ts || performance.now();
     var dt = game.lastTs ? Math.min(0.033, (ts - game.lastTs) / 1000) : 0.016;
     game.lastTs = ts;
-    update(dt, badmintonFrameNow);
-    render(badmintonFrameNow);
-    drawAiming(badmintonFrameNow);
-    renderYuiLive2dRacket();
+    if (perfMode) {
+      var frameStarted = performance.now();
+      var segmentStarted = performance.now();
+      update(dt, badmintonFrameNow);
+      recordBadmintonPerfSample('updateMs', segmentStarted);
+      segmentStarted = performance.now();
+      render(badmintonFrameNow);
+      recordBadmintonPerfSample('renderMs', segmentStarted);
+      segmentStarted = performance.now();
+      drawAiming(badmintonFrameNow);
+      recordBadmintonPerfSample('aimingMs', segmentStarted);
+      segmentStarted = performance.now();
+      renderYuiLive2dRacket();
+      recordBadmintonPerfSample('racketMs', segmentStarted);
+      recordBadmintonPerfSample('frameMs', frameStarted);
+    } else {
+      update(dt, badmintonFrameNow);
+      render(badmintonFrameNow);
+      drawAiming(badmintonFrameNow);
+      renderYuiLive2dRacket();
+    }
     markFirstFrameRendered();
     requestAnimationFrame(loop);
   }
@@ -9067,6 +9174,7 @@
     window._bdEventListeners = badmintonEventListeners;
     var apiObject = {
       getMode: function () { return currentMode; },
+      getPerf: getBadmintonPerfSnapshot,
       getState: function () {
         var playerRacketContact = getRacketContactPoint('player');
         return {

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -1049,6 +1049,8 @@
   var YUI_RACKET_BODY_OFFSET_X = 58;
   var YUI_RACKET_HIT_REACH_X = 46;
   var YUI_RACKET_HIT_REACH_Y = 62;
+  var YUI_RACKET_RESCUE_GATE_REACH_X = 38;
+  var YUI_RACKET_RESCUE_GATE_REACH_Y = 54;
   var YUI_RACKET_SAVE_REACH_X = 84;
   var YUI_RACKET_SAVE_REACH_Y = 86;
   var YUI_SMASH_MIN_SHUTTLE_Z = 64;
@@ -4349,11 +4351,14 @@
   function isYuiRacketHitInRange(incomingBall) {
     return getYuiRacketHitRangeState(incomingBall).normalized <= 1;
   }
+  function getYuiRacketRescueGateState(incomingBall) {
+    return getYuiRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);
+  }
   function getYuiRacketSaveRangeState(incomingBall) {
     return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);
   }
   function isYuiSmashSaveReachable(incomingBall) {
-    return !!(incomingBall && incomingBall.isSmash) && getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;
+    return !!(incomingBall && incomingBall.isSmash) && getYuiRacketRescueGateState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;
   }
   function getYuiSmashHeightQuality(incomingBall) {
     if (!incomingBall) return 0;

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -1016,7 +1016,7 @@
   var NET_BALL_RADIUS = BALL_R + 6;
   var NET_CONTACT_RADIUS = 42;
   var NET_CONTACT_IMPULSE = 320;
-  var NET_CONTACT_HOLD_MS = 230;
+  var NET_CONTACT_HOLD_MS = 90;
   var PLAYER_MOVE_SPEED = 1040;
   var PLAYER_JUMP_SPEED = 430;
   var PLAYER_JUMP_GRAVITY = 1350;
@@ -1047,8 +1047,8 @@
   var YUI_START_X = BADMINTON.netX + (BADMINTON.courtRight - BADMINTON.netX) * 0.58;
   var YUI_START_Y = 405;
   var YUI_RACKET_BODY_OFFSET_X = 58;
-  var YUI_RACKET_HIT_REACH_X = 38;
-  var YUI_RACKET_HIT_REACH_Y = 54;
+  var YUI_RACKET_HIT_REACH_X = 46;
+  var YUI_RACKET_HIT_REACH_Y = 62;
   var YUI_RACKET_SAVE_REACH_X = 84;
   var YUI_RACKET_SAVE_REACH_Y = 86;
   var YUI_SMASH_MIN_SHUTTLE_Z = 64;
@@ -1068,6 +1068,9 @@
   var YUI_CHEAT_INK_VISUAL_SCALE = 0.82;
   var YUI_CHEAT_SCORE_TAUNT_GRACE_MS = 6500;
   var YUI_LIVE2D_RACKET_ANCHOR_SAMPLE_MS = 64;
+  var YUI_LIVE2D_RACKET_LAYOUT_SAMPLE_MS = 240;
+  var YUI_LIVE2D_RACKET_IDLE_RENDER_MS = 66;
+  var BADMINTON_HIDDEN_FRAME_DELAY_MS = 250;
   var netNodes = [];
   var modeParams = null;
   try { modeParams = new URLSearchParams(window.location.search); } catch (_) { modeParams = null; }
@@ -1077,6 +1080,8 @@
   var perfMode = debugMode || (modeParams ? modeParams.get('perf') === '1' : false);
   var currentMode = 'duel';
   var netContactEffects = [];
+  var netPhysicsActiveUntil = 0;
+  var netPhysicsAtRest = true;
   var DUEL_DIFFICULTY = [
     { name: 'max', skillBase: 0.985, growth: 0.004, pressure: 0.025, angleVar: 0.25, powerVar: 0.55, windupMs: 90, reactionMs: 120 },
     { name: 'lv2', skillBase: 0.88, growth: 0.010, pressure: 0.07, angleVar: 0.9, powerVar: 1.6, windupMs: 240, reactionMs: 320 },
@@ -1114,6 +1119,8 @@
   var playerChargeMeterStyleCache = {};
   var playerChargeFillStyleCache = {};
   var yuiLive2dDrawableHandCache = null;
+  var yuiLive2dRacketLayoutCache = { sampledAt: 0, rect: null, layoutW: 0, layoutH: 0, dpr: 0, modelFrame: null };
+  var yuiLive2dRacketLastRenderAt = 0;
   var yuiInkOverlayCache = { canvas: null, ctx: null, key: '', ready: false };
   var badmintonPerfState = {
     frame: 0,
@@ -2400,18 +2407,13 @@
     userReplyProtectedUntil: 0,
     waitingForUserReply: false
   };
-  var SPEECH_PLAYBACK_STATE_KEY = 'neko_speech_playback_state';
-  var SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';
-  var speechPlaybackState = null;
-  var speechPlaybackChannel = null;
   var lastVoiceRequest = null;
   var lastVoiceResult = null;
   var lastVoiceFallbackReason = '';
   var lastVoiceMutedReason = '';
   var VOICE_ARBITER_DEFAULTS = {
     tailWaitMs: 850,
-    inFlightGuardMs: 2400,
-    stalePlaybackStateMs: 3500
+    inFlightGuardMs: 2400
   };
   function _voicePriorityForEvent(event) {
     var kind = String(event && event.kind || '');
@@ -2472,163 +2474,6 @@
     voiceArbiter.pending = entry;
     _scheduleVoiceArbiterFlush(entry.tailWaitMs);
   }
-  function normalizeSpeechPlaybackState(raw) {
-    if (!raw || typeof raw !== 'object') return null;
-    var updatedAt = Number(raw.updatedAt || 0);
-    if (!isFinite(updatedAt)) return null;
-    var ageMs = Math.max(0, Date.now() - updatedAt);
-    var rawRemainingSeconds = Math.max(0, Number(raw.remainingSeconds || 0));
-    var shouldAdvanceByWallClock = raw.audioContextState !== 'suspended';
-    var remainingSeconds = shouldAdvanceByWallClock
-      ? Math.max(0, rawRemainingSeconds - ageMs / 1000)
-      : rawRemainingSeconds;
-    if (ageMs > VOICE_ARBITER_DEFAULTS.stalePlaybackStateMs && remainingSeconds <= 0.5) return null;
-    return {
-      active: !!raw.active && remainingSeconds > 0.05,
-      speechId: raw.speechId ? String(raw.speechId) : '',
-      turnId: raw.turnId ? String(raw.turnId) : '',
-      remainingSeconds: remainingSeconds,
-      remainingMs: Math.round(remainingSeconds * 1000),
-      updatedAt: updatedAt,
-      ageMs: ageMs,
-      reason: raw.reason || '',
-      source: 'playback_state'
-    };
-  }
-  function readSpeechPlaybackState() {
-    var live = normalizeSpeechPlaybackState(speechPlaybackState);
-    if (live) return live;
-    try {
-      var stored = JSON.parse(localStorage.getItem(SPEECH_PLAYBACK_STATE_KEY) || 'null');
-      var normalized = normalizeSpeechPlaybackState(stored);
-      if (normalized) {
-        speechPlaybackState = stored;
-        return normalized;
-      }
-    } catch (_) {}
-    return { active: false, speechId: '', turnId: '', remainingSeconds: 0, remainingMs: 0, updatedAt: 0, reason: 'missing', source: 'playback_state' };
-  }
-  function initSpeechPlaybackStateBridge() {
-    try {
-      if (typeof BroadcastChannel !== 'undefined') {
-        speechPlaybackChannel = new BroadcastChannel(SPEECH_PLAYBACK_CHANNEL_NAME);
-        speechPlaybackChannel.onmessage = function (event) {
-          var data = event && event.data;
-          if (data && data.type === 'speech_playback_state') speechPlaybackState = data;
-        };
-      }
-    } catch (_) {}
-    window.addEventListener('storage', function (event) {
-      if (event.key !== SPEECH_PLAYBACK_STATE_KEY || !event.newValue) return;
-      try {
-        var data = JSON.parse(event.newValue);
-        if (data && data.type === 'speech_playback_state') speechPlaybackState = data;
-      } catch (_) {}
-    });
-    window.addEventListener('neko-speech-playback-state', function (event) {
-      var data = event && event.detail;
-      if (data && data.type === 'speech_playback_state') speechPlaybackState = data;
-    });
-    readSpeechPlaybackState();
-  }
-  function closeSpeechPlaybackStateBridge() {
-    if (!speechPlaybackChannel) return;
-    try {
-      speechPlaybackChannel.close();
-    } catch (_) {}
-    speechPlaybackChannel = null;
-  }
-  function readVoiceOccupancy() {
-    var playback = readSpeechPlaybackState();
-    if (playback.active) return playback;
-    if (voiceArbiter.inFlight && Date.now() < voiceArbiter.inFlight.expiresAt) {
-      var inFlightMs = Math.max(100, voiceArbiter.inFlight.expiresAt - Date.now());
-      return {
-        active: true,
-        speechId: '',
-        turnId: '',
-        remainingSeconds: inFlightMs / 1000,
-        remainingMs: inFlightMs,
-        reason: 'local_inflight',
-        source: 'local_inflight'
-      };
-    }
-    var protectedMs = Math.max(0, voiceArbiter.userReplyProtectedUntil - Date.now());
-    if (protectedMs > 0) {
-      return {
-        active: true,
-        speechId: '',
-        turnId: '',
-        remainingSeconds: protectedMs / 1000,
-        remainingMs: protectedMs,
-        reason: 'user_reply_protection',
-        source: 'user_reply_protection'
-      };
-    }
-    return { active: false, speechId: '', turnId: '', remainingSeconds: 0, remainingMs: 0, reason: 'idle', source: 'idle' };
-  }
-  function waitForProjectVoicePlayback(speechId, timeoutMs, requestStartedAt) {
-    var targetSpeechId = String(speechId || '');
-    var startedAt = Date.now();
-    var minUpdatedAt = Number.isFinite(requestStartedAt) ? requestStartedAt - 100 : startedAt - 100;
-    return new Promise(function (resolve) {
-      function check() {
-        var state = readSpeechPlaybackState();
-        var stateSpeechId = state && state.speechId ? String(state.speechId) : '';
-        var isFresh = !!(state && state.active && state.updatedAt >= minUpdatedAt);
-        var matchesTarget = !!(targetSpeechId && stateSpeechId === targetSpeechId);
-        var matchesAnonymousFreshPlayback = !!(!targetSpeechId && isFresh);
-        if (matchesTarget || matchesAnonymousFreshPlayback) {
-          resolve({ observed: true, state: state });
-          return;
-        }
-        if (Date.now() - startedAt >= (timeoutMs || 1100)) {
-          resolve({ observed: false, state: state });
-          return;
-        }
-        setTimeout(check, 80);
-      }
-      check();
-    });
-  }
-  function pickLocalSpeechVoice(lang) {
-    var synth = window.speechSynthesis;
-    if (!synth || typeof synth.getVoices !== 'function') return null;
-    var voices = synth.getVoices() || [];
-    var normalizedLang = String(lang || '').toLowerCase();
-    var primary = normalizedLang.split('-')[0] || 'zh';
-    for (var i = 0; i < voices.length; i++) {
-      var voice = voices[i];
-      var voiceLang = String(voice && voice.lang || '').toLowerCase();
-      if (voiceLang === normalizedLang) return voice;
-    }
-    for (var j = 0; j < voices.length; j++) {
-      var fallbackVoice = voices[j];
-      var fallbackLang = String(fallbackVoice && fallbackVoice.lang || '').toLowerCase();
-      if (fallbackLang.indexOf(primary) === 0) return fallbackVoice;
-    }
-    return null;
-  }
-  function speakLineLocally(line) {
-    var text = String(line || '').trim();
-    if (!text || !window.speechSynthesis || !window.SpeechSynthesisUtterance) return false;
-    try {
-      var synth = window.speechSynthesis;
-      var utterance = new SpeechSynthesisUtterance(text);
-      var lang = getRequestLanguage() || 'zh-CN';
-      utterance.lang = lang;
-      utterance.rate = 1.03;
-      utterance.pitch = 1.18;
-      utterance.volume = 0.95;
-      var voice = pickLocalSpeechVoice(lang);
-      if (voice) utterance.voice = voice;
-      synth.cancel();
-      synth.speak(utterance);
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
   function _mirrorAndSpeak(entry) {
     if (debugMode && debugVoiceMuted && !debugVoiceMode && !(entry.event && entry.event.force_voice_in_debug)) return Promise.resolve();
     var entrySessionId = entry.sessionId || sessionId;
@@ -2666,43 +2511,21 @@
     lastVoiceRequest = speakPayload;
     lastVoiceResult = null;
     lastVoiceFallbackReason = '';
-    var speakStartedAt = Date.now();
     return post('/mirror-assistant', mirrorPayload, 2500)
       .catch(function () {})
       .then(function () {
         return post('/speak', speakPayload, 3500).then(function (res) {
           lastVoiceResult = res || null;
-          if (!res || !(res.audio_sent || res.audio_queued)) {
-            lastVoiceFallbackReason = 'project_voice_not_queued';
-            speakLineLocally(entry.line);
-            return res;
-          }
-          return waitForProjectVoicePlayback(res.speech_id, 1100, speakStartedAt).then(function (observed) {
-            if (!observed || !observed.observed) {
-              lastVoiceFallbackReason = 'project_voice_unobserved';
-              speakLineLocally(entry.line);
-            }
-            return res;
-          });
+          return res;
         }).catch(function () {
           lastVoiceFallbackReason = 'project_speak_failed';
-          speakLineLocally(entry.line);
-          return { ok: false, local_speech: true, reason: 'project_speak_failed' };
+          lastVoiceResult = { ok: false, reason: 'project_speak_failed' };
+          return lastVoiceResult;
         });
       });
   }
   function _requestVoicePlayback(entry) {
     if (!_voiceEntryMatchesCurrentSession(entry)) return Promise.resolve();
-    var playback = readVoiceOccupancy();
-    var deadlineMs = entry.expiresAt ? Math.max(0, entry.expiresAt - Date.now()) : 0;
-    var canDeferWithoutExpiring = !entry.expiresAt || deadlineMs > entry.tailWaitMs + 250;
-    if (playback.active && playback.source === 'playback_state' && playback.remainingMs > entry.tailWaitMs && canDeferWithoutExpiring && !entry.playbackDeferredOnce) {
-      entry.playbackDeferredOnce = true;
-      _storeVoicePending(entry);
-      var playbackDeferDelayMs = entry.expiresAt ? Math.max(120, deadlineMs - 250) : 900;
-      _scheduleVoiceArbiterFlush(Math.min(Math.max(entry.tailWaitMs, 120), playback.remainingMs, playbackDeferDelayMs));
-      return Promise.resolve({ ok: false, queued: true, reason: 'voice_deferred_once' });
-    }
     var holdMs = Math.max(VOICE_ARBITER_DEFAULTS.inFlightGuardMs, Math.round(_estimateVoiceDuration(entry.line) * 1000));
     voiceArbiter.inFlight = {
       id: entry.id,
@@ -2926,8 +2749,7 @@
       priority: _voicePriorityForEvent(event),
       tailWaitMs: VOICE_ARBITER_DEFAULTS.tailWaitMs,
       expiresAt: event && event.voice_deadline_ms ? Date.now() + Math.max(0, event.voice_deadline_ms) : 0,
-      isUserReply: isUserReply,
-      playbackDeferredOnce: false
+      isUserReply: isUserReply
     };
     if (isUserReply) {
       voiceArbiter.userReplyProtectedUntil = Date.now() + 5000;
@@ -4112,6 +3934,7 @@
     aimingCtx.setTransform(aimingCanvas.width / BASE_W, 0, 0, aimingCanvas.height / BASE_H, 0, 0);
     yuiInkOverlayCache.ready = false;
     yuiInkOverlayCache.key = '';
+    resetYuiLive2dRacketLayoutCache();
     updateYuiPosition(game.distance);
     updatePlayerAvatarPosition();
     updateDuelShooterAvatars();
@@ -4208,7 +4031,7 @@
     var now = performance.now();
     var opts = options || {};
     var x = Number.isFinite(opts.x) ? opts.x : randomYuiBananaCourtX();
-    var y = Number.isFinite(opts.y) ? opts.y : getPlayerFootY();
+    var y = Number.isFinite(opts.y) ? opts.y : getPlayerGroundFootY();
     return {
       id: ++game.yuiCheat.seq,
       kind: 'banana',
@@ -4416,6 +4239,9 @@
   function getPlayerFootY() {
     return clamp(getPlayerY() + PLAYER_FOOT_CONTACT_OFFSET_Y, PLAYER_COURT_Y_MIN, BADMINTON.courtBottom - 8);
   }
+  function getPlayerGroundFootY() {
+    return clamp(game.playerCourt.y + PLAYER_FOOT_CONTACT_OFFSET_Y, PLAYER_COURT_Y_MIN, BADMINTON.courtBottom - 8);
+  }
   function getPlayerEyeY() {
     return getPlayerY() - 66;
   }
@@ -4495,26 +4321,36 @@
     if (isPlayerServeSetup()) return false;
     return getPlayerSmashQuality(incomingBall) >= 0.22;
   }
+  function getYuiNeutralRacketContactPoint() {
+    var contact = getYuiShotOrigin();
+    return { x: contact.x, y: contact.y, source: 'neutral-racket-anchor' };
+  }
+  function getYuiRacketRangeState(incomingBall, reachX, reachY) {
+    var neutral = getYuiNeutralRacketContactPoint();
+    var visible = getYuiVisibleRacketContactPoint();
+    var ballX = incomingBall && Number.isFinite(incomingBall.x) ? incomingBall.x : neutral.x;
+    var ballY = incomingBall && Number.isFinite(incomingBall.y) ? incomingBall.y : neutral.y;
+    function stateFor(racket) {
+      var dx = Math.abs(ballX - racket.x);
+      var dy = Math.abs(ballY - racket.y);
+      var normalized = Math.pow(dx / reachX, 2) + Math.pow(dy / reachY, 2);
+      return { dx: dx, dy: dy, normalized: normalized, racket: racket, source: racket.source || '' };
+    }
+    var best = stateFor(neutral);
+    if (visible) {
+      var visibleState = stateFor(visible);
+      if (visibleState.normalized < best.normalized) best = visibleState;
+    }
+    return best;
+  }
   function getYuiRacketHitRangeState(incomingBall) {
-    var racket = getYuiRacketContactPoint();
-    var ballX = incomingBall && Number.isFinite(incomingBall.x) ? incomingBall.x : racket.x;
-    var ballY = incomingBall && Number.isFinite(incomingBall.y) ? incomingBall.y : racket.y;
-    var dx = Math.abs(ballX - racket.x);
-    var dy = Math.abs(ballY - racket.y);
-    var normalized = Math.pow(dx / YUI_RACKET_HIT_REACH_X, 2) + Math.pow(dy / YUI_RACKET_HIT_REACH_Y, 2);
-    return { dx: dx, dy: dy, normalized: normalized };
+    return getYuiRacketRangeState(incomingBall, YUI_RACKET_HIT_REACH_X, YUI_RACKET_HIT_REACH_Y);
   }
   function isYuiRacketHitInRange(incomingBall) {
     return getYuiRacketHitRangeState(incomingBall).normalized <= 1;
   }
   function getYuiRacketSaveRangeState(incomingBall) {
-    var racket = getYuiRacketContactPoint();
-    var ballX = incomingBall && Number.isFinite(incomingBall.x) ? incomingBall.x : racket.x;
-    var ballY = incomingBall && Number.isFinite(incomingBall.y) ? incomingBall.y : racket.y;
-    var dx = Math.abs(ballX - racket.x);
-    var dy = Math.abs(ballY - racket.y);
-    var normalized = Math.pow(dx / YUI_RACKET_SAVE_REACH_X, 2) + Math.pow(dy / YUI_RACKET_SAVE_REACH_Y, 2);
-    return { dx: dx, dy: dy, normalized: normalized };
+    return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);
   }
   function isYuiSmashSaveReachable(incomingBall) {
     return !!(incomingBall && incomingBall.isSmash) && getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;
@@ -5064,13 +4900,17 @@
   }
   function updateNetPhysics(dt) {
     if (!netNodes.length) initNetNodes();
+    var t = getBadmintonFrameNow();
     var ball = game.ball;
+    var ballInNet = false;
     if (ball && !ball.resolved) {
       var shuttleCourtY = getShuttleCourtY(ball, false);
       var netHalfWidth = NET_COLLISION_HALF_WIDTH;
-      var ballInNet = isShuttleInsideNetZ(ball, { z: getShuttleCourtZ(ball, false) })
+      ballInNet = isShuttleInsideNetZ(ball, { z: getShuttleCourtZ(ball, false) })
         && Math.abs(shuttleCourtY - getMidcourtNetY()) <= netHalfWidth + (ball.radius || BALL_R) * 0.45;
       if (ballInNet) {
+        netPhysicsActiveUntil = Math.max(netPhysicsActiveUntil, t + 360);
+        netPhysicsAtRest = false;
         for (var col = 0; col < NET_COLS; col++) {
           for (var row = 0; row < NET_ROWS; row++) {
             var n = netNodes[col][row];
@@ -5091,6 +4931,21 @@
           }
         }
       }
+    }
+    if (!ballInNet && t > netPhysicsActiveUntil && !netContactEffects.length) {
+      if (!netPhysicsAtRest) {
+        for (var rc = 0; rc < NET_COLS; rc++) {
+          for (var rr0 = 0; rr0 < NET_ROWS; rr0++) {
+            var restNode = netNodes[rc][rr0];
+            restNode.x = restNode.restX;
+            restNode.y = restNode.restY;
+            restNode.vx = 0;
+            restNode.vy = 0;
+          }
+        }
+        netPhysicsAtRest = true;
+      }
+      return;
     }
     for (var c = 0; c < NET_COLS; c++) {
       for (var r = 0; r < NET_ROWS; r++) {
@@ -5132,6 +4987,8 @@
   function applyNetContactImpulse(ball, crossing) {
     if (!ball) return;
     if (!netNodes.length) initNetNodes();
+    netPhysicsActiveUntil = Math.max(netPhysicsActiveUntil, getBadmintonFrameNow() + 720);
+    netPhysicsAtRest = false;
     var contactX = crossing && Number.isFinite(crossing.screenX) ? crossing.screenX : ball.x;
     var contactY = crossing && Number.isFinite(crossing.screenY) ? crossing.screenY : ball.y;
     var direction = ball.direction === -1 ? -1 : 1;
@@ -5190,6 +5047,8 @@
       strength: strength,
       direction: ball && ball.direction === -1 ? -1 : 1
     });
+    netPhysicsActiveUntil = Math.max(netPhysicsActiveUntil, now + 720);
+    netPhysicsAtRest = false;
     if (netContactEffects.length > 5) netContactEffects = netContactEffects.slice(netContactEffects.length - 5);
     if (debugMode) {
       window.__badmintonNetEffectDebug = {
@@ -7398,9 +7257,14 @@
   function drawNetContactEffects(now) {
     if (!netContactEffects.length) return;
     var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
-    netContactEffects = netContactEffects.filter(function (effect) {
-      return t - effect.startAt < effect.duration;
-    });
+    var activeCount = 0;
+    for (var effectIndex = 0; effectIndex < netContactEffects.length; effectIndex++) {
+      var retainedEffect = netContactEffects[effectIndex];
+      if (t - retainedEffect.startAt < retainedEffect.duration) {
+        netContactEffects[activeCount++] = retainedEffect;
+      }
+    }
+    netContactEffects.length = activeCount;
     if (!netContactEffects.length) return;
     ctx.save();
     ctx.globalCompositeOperation = 'lighter';
@@ -8202,21 +8066,60 @@
     setYuiLive2dParameter('Param96', active ? pose : 0);
   }
 
+  function resetYuiLive2dRacketLayoutCache() {
+    yuiLive2dRacketLayoutCache.sampledAt = 0;
+    yuiLive2dRacketLayoutCache.rect = null;
+    yuiLive2dRacketLayoutCache.layoutW = 0;
+    yuiLive2dRacketLayoutCache.layoutH = 0;
+    yuiLive2dRacketLayoutCache.dpr = 0;
+    yuiLive2dRacketLayoutCache.modelFrame = null;
+    yuiLive2dDrawableHandCache = null;
+  }
+
+  function getYuiLive2dRacketLayout(now, forceRefresh) {
+    var t = Number.isFinite(now) ? now : getBadmintonFrameNow();
+    var cached = yuiLive2dRacketLayoutCache;
+    var dpr = window.devicePixelRatio || 1;
+    if (!forceRefresh && cached.rect && cached.dpr === dpr && t - (cached.sampledAt || 0) < YUI_LIVE2D_RACKET_LAYOUT_SAMPLE_MS) {
+      return cached;
+    }
+    var rect = nekoL2dContainer.getBoundingClientRect();
+    if (rect.width < 20 || rect.height < 20) return null;
+    var layoutW = yuiLive2dRacketCanvas.clientWidth || nekoL2dContainer.offsetWidth || rect.width;
+    var layoutH = yuiLive2dRacketCanvas.clientHeight || nekoL2dContainer.offsetHeight || rect.height;
+    cached.sampledAt = t;
+    cached.rect = rect;
+    cached.layoutW = layoutW;
+    cached.layoutH = layoutH;
+    cached.dpr = dpr;
+    cached.modelFrame = getYuiLive2dModelFrame({ width: layoutW, height: layoutH });
+    return cached;
+  }
+
   function renderYuiLive2dRacket() {
     if (!yuiLive2dRacketCanvas || !yuiLive2dRacketCtx || !nekoL2dContainer || activeAvatarType !== 'live2d') return;
     if (nekoL2dContainer.hidden || currentMode !== 'duel') {
       yuiLive2dRacketCtx.clearRect(0, 0, yuiLive2dRacketCanvas.width || 1, yuiLive2dRacketCanvas.height || 1);
       applyYuiLive2dRacketPose(false, false);
       window.__badmintonYuiRacketDebug = null;
-      yuiLive2dDrawableHandCache = null;
+      resetYuiLive2dRacketLayoutCache();
+      yuiLive2dRacketLastRenderAt = 0;
       return;
     }
     var now = getBadmintonFrameNow();
-    var rect = nekoL2dContainer.getBoundingClientRect();
-    if (rect.width < 20 || rect.height < 20) return;
-    var dpr = window.devicePixelRatio || 1;
-    var layoutW = yuiLive2dRacketCanvas.clientWidth || nekoL2dContainer.offsetWidth || rect.width;
-    var layoutH = yuiLive2dRacketCanvas.clientHeight || nekoL2dContainer.offsetHeight || rect.height;
+    var shooting = nekoL2dContainer.classList.contains('shooting');
+    var charging = nekoL2dContainer.classList.contains('charging');
+    var saving = nekoL2dContainer.classList.contains('saving');
+    var smashing = nekoL2dContainer.classList.contains('smashing');
+    var activeRacketAction = shooting || charging || saving || smashing;
+    if (!activeRacketAction && yuiLive2dRacketLastRenderAt && now - yuiLive2dRacketLastRenderAt < YUI_LIVE2D_RACKET_IDLE_RENDER_MS) return;
+    yuiLive2dRacketLastRenderAt = now;
+    var layout = getYuiLive2dRacketLayout(now, activeRacketAction);
+    if (!layout) return;
+    var rect = layout.rect;
+    var dpr = layout.dpr;
+    var layoutW = layout.layoutW;
+    var layoutH = layout.layoutH;
     var targetW = Math.max(1, Math.round(layoutW * dpr));
     var targetH = Math.max(1, Math.round(layoutH * dpr));
     if (yuiLive2dRacketCanvas.width !== targetW || yuiLive2dRacketCanvas.height !== targetH) {
@@ -8226,10 +8129,8 @@
     var renderCtx = yuiLive2dRacketCtx;
     renderCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
     renderCtx.clearRect(0, 0, layoutW, layoutH);
-    var shooting = nekoL2dContainer.classList.contains('shooting');
-    var charging = nekoL2dContainer.classList.contains('charging');
     applyYuiLive2dRacketPose(shooting, charging);
-    var modelFrame = getYuiLive2dModelFrame({ width: layoutW, height: layoutH });
+    var modelFrame = layout.modelFrame;
     var swing = shooting ? 0.62 : (charging ? -0.28 : 0);
     var racketScale = Math.max(0.98, Math.min(1.08, modelFrame.height / 320));
     var fallbackHand = getYuiLive2dFallbackHandPoint(modelFrame, shooting, charging);
@@ -8785,6 +8686,15 @@
       renderYuiLive2dRacket();
     }
     markFirstFrameRendered();
+    scheduleBadmintonNextFrame();
+  }
+  function scheduleBadmintonNextFrame() {
+    if (document.hidden) {
+      setTimeout(function () {
+        requestAnimationFrame(loop);
+      }, BADMINTON_HIDDEN_FRAME_DELAY_MS);
+      return;
+    }
     requestAnimationFrame(loop);
   }
 
@@ -9000,6 +8910,7 @@
   }
   function updateDebugReadout() {
     if (!debugReadout) return;
+    if (debugPanel && debugPanel.dataset.debugVisible !== 'true') return;
     setInputValueIfChanged(debugPowerInput, Math.round(game.power || 0));
     setTextIfChanged(debugPowerValue, String(Math.round(game.power || 0)));
     setCheckedIfChanged(debugGuideInput, !!assists.guide);
@@ -9206,6 +9117,7 @@
           courtServiceLines: getCourtServiceLinePositions(BADMINTON),
           playerServeX: PLAYER_START_X,
           playerFootY: getPlayerFootY(),
+          playerGroundFootY: getPlayerGroundFootY(),
           lastPlayerPointer: lastPlayerPointer ? Object.assign({}, lastPlayerPointer) : null,
           playerJump: {
             offset: getPlayerJumpOffset(),
@@ -9298,8 +9210,7 @@
             lastRequest: lastVoiceRequest,
             lastResult: lastVoiceResult,
             lastFallbackReason: lastVoiceFallbackReason,
-            lastMutedReason: lastVoiceMutedReason,
-            playback: readSpeechPlaybackState()
+            lastMutedReason: lastVoiceMutedReason
           },
         };
       },
@@ -9378,8 +9289,10 @@
     return !!target.closest('button, input, select, textarea, a, [contenteditable="true"]');
   }
   function handleBadmintonPointerMove(ev) {
+    if (ev && ev.__badmintonPointerMoveHandled) return;
     if (isBadmintonLoadingActive()) return;
     if (shouldIgnoreBadmintonPointerEvent(ev)) return;
+    if (ev) ev.__badmintonPointerMoveHandled = true;
     rememberPlayerPointer(ev);
     var canMoveCourt = canPlayerMoveCourt();
     var canControlShot = canPlayerControlShot();
@@ -9529,7 +9442,6 @@
   }
   window.addEventListener('resize', scheduleBadmintonResize);
   window.addEventListener('beforeunload', function () {
-    closeSpeechPlaybackStateBridge();
     endRoute(true);
   });
   window.addEventListener('localechange', function () {
@@ -9547,7 +9459,6 @@
   _syncGameAudioVolumeControls();
   _initBadmintonGameMemoryToggle();
   installBadmintonDemoApi();
-  initSpeechPlaybackStateBridge();
   setDebugVisible((function () {
     return debugMode || localStorage.getItem('bdDebugVisible') === '1';
   })());

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -8456,18 +8456,24 @@
       inkCtx.fill();
     }
 
-    inkCtx.globalAlpha = 0.16;
-    inkCtx.strokeStyle = 'rgba(114,216,226,.42)';
-    inkCtx.lineWidth = 1.2;
-    for (var arc = 0; arc < 2; arc++) {
-      var arcY = BASE_H * (0.42 + arc * 0.12);
-      inkCtx.beginPath();
-      inkCtx.ellipse(BASE_W * 0.5, arcY, BASE_W * (0.22 + arc * 0.04) * inkScale, BASE_H * 0.10 * inkScale, -0.08 + arc * 0.16, 0, Math.PI * 2);
-      inkCtx.stroke();
-    }
     yuiInkOverlayCache.ready = true;
     yuiInkOverlayCache.key = key;
     return inkCanvas;
+  }
+
+  function drawYuiInkArcRings(ink, t) {
+    if (!ink || ink.alpha <= 0.58) return;
+    var inkScale = YUI_CHEAT_INK_VISUAL_SCALE;
+    aimingCtx.globalAlpha = Math.min(0.16, ink.alpha * 0.18);
+    aimingCtx.strokeStyle = 'rgba(114,216,226,.42)';
+    aimingCtx.lineWidth = 1.2;
+    aimingCtx.lineCap = 'round';
+    for (var arc = 0; arc < 2; arc++) {
+      var arcY = BASE_H * (0.42 + arc * 0.12) + Math.sin(t / 460 + arc) * 4;
+      aimingCtx.beginPath();
+      aimingCtx.ellipse(BASE_W * 0.5, arcY, BASE_W * (0.22 + arc * 0.04) * inkScale, BASE_H * 0.10 * inkScale, -0.08 + arc * 0.16, 0, Math.PI * 2);
+      aimingCtx.stroke();
+    }
   }
 
   function drawYuiInkOverlay(now) {
@@ -8487,6 +8493,7 @@
     aimingCtx.fillRect(0, 0, BASE_W, BASE_H);
     aimingCtx.globalAlpha = Math.min(0.96, ink.alpha * 1.04);
     aimingCtx.drawImage(inkCanvas, (BASE_W - drawW) / 2, (BASE_H - drawH) / 2, drawW, drawH);
+    drawYuiInkArcRings(ink, t);
     aimingCtx.restore();
   }
   function drawPlayerReturnHitCue(now) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -483,12 +483,27 @@
     <script>
     (function() {
         'use strict';
+        function applyGameWindowRenderingState(paused) {
+            var managers = [
+                window.live2dManager,
+                window.vrmManager,
+                window.mmdManager
+            ];
+            var method = paused ? 'pauseRendering' : 'resumeRendering';
+            managers.forEach(function(manager) {
+                if (manager && typeof manager[method] === 'function') {
+                    try { manager[method](); } catch (_) {}
+                }
+            });
+        }
         function applyGameWindowState(action) {
             if (!document.body || !document.body.classList) return;
             if (action === 'opened') {
                 document.body.classList.add('neko-game-active');
+                applyGameWindowRenderingState(true);
             } else if (action === 'closed') {
                 document.body.classList.remove('neko-game-active');
+                applyGameWindowRenderingState(false);
             }
         }
         window.addEventListener('neko-game-window-state-change', function(ev) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -503,7 +503,9 @@
                 applyGameWindowRenderingState(true);
             } else if (action === 'closed') {
                 document.body.classList.remove('neko-game-active');
-                applyGameWindowRenderingState(false);
+                if (!window.__nekoPetInteracting__) {
+                    applyGameWindowRenderingState(false);
+                }
             }
         }
         window.addEventListener('neko-game-window-state-change', function(ev) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -483,6 +483,28 @@
     <script>
     (function() {
         'use strict';
+        var pngtuberHiddenForGameWindow = false;
+        function applyPngtuberGameWindowState(paused) {
+            var manager = window.pngtuberManager;
+            if (!manager) return;
+            if (paused) {
+                var container = document.getElementById('pngtuber-container');
+                var visible = container && container.style.display !== 'none' && !container.classList.contains('hidden');
+                if (visible && typeof manager.hide === 'function') {
+                    try {
+                        manager.hide();
+                        pngtuberHiddenForGameWindow = true;
+                    } catch (_) {}
+                }
+                return;
+            }
+            if (pngtuberHiddenForGameWindow && typeof manager.show === 'function') {
+                try {
+                    manager.show();
+                    pngtuberHiddenForGameWindow = false;
+                } catch (_) {}
+            }
+        }
         function applyGameWindowRenderingState(paused) {
             var managers = [
                 window.live2dManager,
@@ -495,12 +517,13 @@
                     try { manager[method](); } catch (_) {}
                 }
             });
+            applyPngtuberGameWindowState(paused);
         }
         function applyGameWindowState(action) {
             if (!document.body || !document.body.classList) return;
             if (action === 'opened') {
-                document.body.classList.add('neko-game-active');
                 applyGameWindowRenderingState(true);
+                document.body.classList.add('neko-game-active');
             } else if (action === 'closed') {
                 document.body.classList.remove('neko-game-active');
                 if (!window.__nekoPetInteracting__) {

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -677,10 +677,32 @@ def test_badminton_yui_saves_player_smash_just_outside_racket_hit_range(mock_pag
     _goto_badminton(page, running_server, "duel")
 
     page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    page.evaluate(
+        """() => {
+          window.__badmintonObservedYuiSave = null;
+          window.__badmintonStopYuiSaveObserver = false;
+          const observe = () => {
+            const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+            const saving = !!document.querySelector('.neko-avatar-container[data-court-avatar="opponent"].saving');
+            if (state && state.pendingSwing && state.pendingSwing.shooter === 'neko' &&
+              state.pendingSwing.save === true) {
+              window.__badmintonObservedYuiSave = {
+                shooter: state.pendingSwing.shooter,
+                save: state.pendingSwing.save,
+                isSmash: state.pendingSwing.isSmash,
+                saving
+              };
+              return;
+            }
+            if (!window.__badmintonStopYuiSaveObserver) requestAnimationFrame(observe);
+          };
+          requestAnimationFrame(observe);
+        }"""
+    )
     setup = page.evaluate(
         """() => {
           const contact = window.BadmintonDemo._debugGetYuiRacketContactPoint();
-          const dx = contact.reachX + 22;
+          const dx = contact.reachX + 32;
           const dy = 10;
           const courtY = contact.x + dx;
           const screenY = contact.y + dy;
@@ -710,28 +732,18 @@ def test_badminton_yui_saves_player_smash_just_outside_racket_hit_range(mock_pag
     assert setup["normalNormalized"] > 1
     assert setup["saveNormalized"] <= 1
 
-    page.evaluate("window.__badmintonObservedYuiSave = null")
-    page.wait_for_function(
-        """() => {
-          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
-          const saving = !!document.querySelector('.neko-avatar-container[data-court-avatar="opponent"].saving');
-          if (state && state.pendingSwing && state.pendingSwing.shooter === 'neko' &&
-            state.pendingSwing.save === true && saving) {
-            window.__badmintonObservedYuiSave = {
-              shooter: state.pendingSwing.shooter,
-              save: state.pendingSwing.save,
-              isSmash: state.pendingSwing.isSmash
-            };
-            return true;
-          }
-          return false;
-        }""",
-        timeout=3000,
-    )
+    try:
+        page.wait_for_function(
+            "window.__badmintonObservedYuiSave !== null",
+            timeout=3000,
+        )
+    finally:
+        page.evaluate("window.__badmintonStopYuiSaveObserver = true")
     saved = page.evaluate("window.__badmintonObservedYuiSave")
     assert saved["shooter"] == "neko"
     assert saved["save"] is True
     assert saved["isSmash"] is False
+    assert saved["saving"] is True
 
 
 @pytest.mark.e2e
@@ -1577,7 +1589,19 @@ def test_badminton_project_voice_unobserved_does_not_start_local_speech(
         }"""
     )
 
-    page.wait_for_timeout(1400)
+    page.wait_for_function(
+        """() => {
+          const s = window.BadmintonDemo.getState();
+          return !!(
+            s &&
+            s.voice &&
+            s.voice.lastResult &&
+            s.voice.lastResult.speech_id === 'e2e-unobserved-project-voice' &&
+            s.voice.lastFallbackReason === ''
+          );
+        }""",
+        timeout=3000,
+    )
     assert speak_payloads
     state = page.evaluate("window.BadmintonDemo.getState()")
     assert speak_payloads[-1]["line"] == "unobserved project voice"

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -710,19 +710,28 @@ def test_badminton_yui_saves_player_smash_just_outside_racket_hit_range(mock_pag
     assert setup["normalNormalized"] > 1
     assert setup["saveNormalized"] <= 1
 
+    page.evaluate("window.__badmintonObservedYuiSave = null")
     page.wait_for_function(
         """() => {
           const state = window.BadmintonDemo && window.BadmintonDemo.getState();
           const saving = !!document.querySelector('.neko-avatar-container[data-court-avatar="opponent"].saving');
-          return state && state.pendingSwing && state.pendingSwing.shooter === 'neko' &&
-            state.pendingSwing.save === true && saving;
+          if (state && state.pendingSwing && state.pendingSwing.shooter === 'neko' &&
+            state.pendingSwing.save === true && saving) {
+            window.__badmintonObservedYuiSave = {
+              shooter: state.pendingSwing.shooter,
+              save: state.pendingSwing.save,
+              isSmash: state.pendingSwing.isSmash
+            };
+            return true;
+          }
+          return false;
         }""",
         timeout=3000,
     )
-    saved = page.evaluate("window.BadmintonDemo.getState()")
-    assert saved["pendingSwing"]["shooter"] == "neko"
-    assert saved["pendingSwing"]["save"] is True
-    assert saved["pendingSwing"]["isSmash"] is False
+    saved = page.evaluate("window.__badmintonObservedYuiSave")
+    assert saved["shooter"] == "neko"
+    assert saved["save"] is True
+    assert saved["isSmash"] is False
 
 
 @pytest.mark.e2e
@@ -1510,7 +1519,7 @@ def test_badminton_short_deadline_voice_ignores_stuck_playback_state(
 
 
 @pytest.mark.e2e
-def test_badminton_project_voice_unobserved_falls_back_to_local_speech(
+def test_badminton_project_voice_unobserved_does_not_start_local_speech(
     mock_page: Page, running_server: str
 ):
     page = mock_page
@@ -1568,12 +1577,13 @@ def test_badminton_project_voice_unobserved_falls_back_to_local_speech(
         }"""
     )
 
-    page.wait_for_function("window.__spokenText && window.__spokenText.includes('unobserved project voice')", timeout=3000)
+    page.wait_for_timeout(1400)
     assert speak_payloads
     state = page.evaluate("window.BadmintonDemo.getState()")
     assert speak_payloads[-1]["line"] == "unobserved project voice"
     assert state["voice"]["lastResult"]["speech_id"] == "e2e-unobserved-project-voice"
-    assert state["voice"]["lastFallbackReason"] == "project_voice_unobserved"
+    assert state["voice"]["lastFallbackReason"] == ""
+    assert page.evaluate("window.__spokenText") == []
 
 
 @pytest.mark.e2e
@@ -1737,6 +1747,46 @@ def test_badminton_default_banana_spawns_on_player_foot_line_with_random_court_x
     assert abs(spawned["itemY"] - spawned["playerFootY"]) <= 1
     assert state["yuiCheat"]["items"][0]["kind"] == "banana"
     assert state["yuiCheat"]["player_effect"]["slipping"] is False
+
+
+@pytest.mark.e2e
+def test_badminton_default_banana_spawns_on_ground_foot_line_while_player_jumps(mock_page: Page, running_server: str):
+    page = mock_page
+    _goto_badminton(page, running_server, "duel")
+
+    page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    spawned = page.evaluate(
+        """() => new Promise((resolve) => {
+          window.BadmintonDemo._debugSetAwaitingPlayerReturnBall();
+          window.BadmintonDemo.jump();
+          function waitForJump() {
+            const jumpingState = window.BadmintonDemo.getState();
+            if (jumpingState.playerJump && jumpingState.playerJump.offset > 18) {
+              const originalRandom = Math.random;
+              Math.random = () => 0.999;
+              try {
+                const item = window.BadmintonDemo._debugSpawnYuiCheat('banana');
+                const state = window.BadmintonDemo.getState();
+                resolve({
+                  itemY: item.y,
+                  playerFootY: state.playerFootY,
+                  playerGroundFootY: state.playerGroundFootY,
+                  jumpOffset: state.playerJump.offset
+                });
+              } finally {
+                Math.random = originalRandom;
+              }
+              return;
+            }
+            requestAnimationFrame(waitForJump);
+          }
+          waitForJump();
+        })"""
+    )
+
+    assert spawned["jumpOffset"] > 18
+    assert spawned["playerFootY"] < spawned["playerGroundFootY"] - 12
+    assert abs(spawned["itemY"] - spawned["playerGroundFootY"]) <= 1
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -340,14 +340,14 @@ def test_badminton_yui_bubble_anchors_to_avatar_and_supports_emote_marks():
     html = _badminton_html()
 
     assert "var BADMINTON_BUBBLE_EMOTE_IMAGES = {" in html
-    assert 'font: 16px/1.45 "PingFang SC", "Segoe UI", sans-serif;' in html
-    assert "max-width: 380px; text-align: left;" in html
-    assert "padding: 12px 15px; border-radius: 8px;" in html
+    assert 'font: 17px/1.45 "PingFang SC", "Segoe UI", sans-serif;' in html
+    assert "max-width: min(410px, calc(100vw - 32px)); text-align: left;" in html
+    assert "padding: 13px 17px; border-radius: 8px;" in html
     assert ".neko-bubble-body" in html
     assert ".neko-bubble-text" in html
     assert ".neko-bubble-emote" in html
-    assert "display: flex; align-items: center; gap: 12px;" in html
-    assert "flex: 0 0 72px; width: 72px; height: 72px;" in html
+    assert "display: flex; align-items: center; gap: 14px;" in html
+    assert "flex: 0 0 92px; width: 92px; height: 92px;" in html
     assert "surprised: '/static/game/games/badminton/images/emotes/yui-surprised.png'" in html
     assert "dominant: '/static/game/games/badminton/images/emotes/yui-dominant.png'" in html
     assert "awkward: '/static/game/games/badminton/images/emotes/yui-awkward.png'" in html
@@ -839,7 +839,7 @@ def test_badminton_aiming_overlay_does_not_double_draw_ink():
     draw_section = html[draw_start:draw_end]
     assert draw_section.count("drawYuiInkOverlay(t);") == 1
     assert "drawPlayerReturnHitCue(t);" in draw_section
-    assert "drawPlayerChargeMeter(clamp(game.power, 0, 100), t);" in draw_section
+    assert "drawPlayerChargeMeter(game.charging && canPlayerChargeShot() ? clamp(game.power, 0, 100) : 0, t);" in draw_section
 
 
 @pytest.mark.unit
@@ -890,15 +890,40 @@ def test_badminton_aiming_overlay_skips_idle_frames():
     assert "function isAimingOverlayActive(now) {" in html
     assert "return !!(isIncomingPlayerReturnCandidate()" in html
     assert "getYuiInkState(t).active" in html
+    overlay_start = html.index("function isAimingOverlayActive(now) {")
+    overlay_end = html.index("function drawAiming(now) {", overlay_start)
+    overlay_predicate = html[overlay_start:overlay_end]
+    assert "game.charging && canPlayerChargeShot()" not in overlay_predicate
 
     draw_start = html.index("function drawAiming(now) {")
     draw_end = html.index("function drawPlayerChargeMeter(", draw_start)
     draw_section = html[draw_start:draw_end]
     assert "var overlayActive = isAimingOverlayActive(t);" in draw_section
+    assert "drawPlayerChargeMeter(game.charging && canPlayerChargeShot() ? clamp(game.power, 0, 100) : 0, t);" in draw_section
     assert "if (!overlayActive && !aimingOverlayWasActive) return;" in draw_section
     assert "aimingOverlayWasActive = overlayActive;" in draw_section
     assert "aimingCtx.clearRect(0, 0, BASE_W, BASE_H);" in draw_section
     assert draw_section.index("if (!overlayActive && !aimingOverlayWasActive) return;") < draw_section.index("aimingCtx.clearRect(0, 0, BASE_W, BASE_H);")
+
+
+@pytest.mark.unit
+def test_badminton_player_charge_meter_uses_dom_transform_not_canvas_shadow():
+    html = _badminton_html()
+
+    assert 'id="player-charge-meter"' in html
+    assert 'id="player-charge-fill"' in html
+    assert "will-change: transform, opacity;" in html
+    assert "var playerChargeMeter = document.getElementById('player-charge-meter');" in html
+    assert "var playerChargeFill = document.getElementById('player-charge-fill');" in html
+
+    charge_start = html.index("function drawPlayerChargeMeter(percent, now) {")
+    charge_end = html.index("function ensureYuiInkOverlayCache()", charge_start)
+    charge_section = html[charge_start:charge_end]
+    assert "setDatasetValueIfChanged(playerChargeMeter, 'active', '1');" in charge_section
+    assert "setStyleIfChanged(playerChargeMeter, playerChargeMeterStyleCache, 'transform'," in charge_section
+    assert "setStyleIfChanged(playerChargeFill, playerChargeFillStyleCache, 'transform', 'scaleX('" in charge_section
+    assert "aimingCtx.shadowBlur" not in charge_section
+    assert "aimingCtx.globalCompositeOperation" not in charge_section
 
 
 @pytest.mark.unit
@@ -2033,10 +2058,10 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "ctx.ellipse(court.netX, serviceWearY, 88, 21, 0, 0, Math.PI * 2);" in html
     assert "var shortServiceOffset = halfCourtLength * (1.98 / 6.70);" in html
     assert "var doublesLongServiceInset = halfCourtLength * (0.76 / 6.70);" in html
-    assert "ctx.moveTo(leftShortServiceX, groundTop + 6);" in html
-    assert "ctx.moveTo(rightShortServiceX, groundTop + 6);" in html
-    assert "ctx.moveTo(leftDoublesLongServiceX, groundTop + 6);" in html
-    assert "ctx.moveTo(rightDoublesLongServiceX, groundTop + 6);" in html
+    assert "ctx.moveTo(serviceLines.leftShortServiceX, groundTop + 6);" in html
+    assert "ctx.moveTo(serviceLines.rightShortServiceX, groundTop + 6);" in html
+    assert "ctx.moveTo(serviceLines.leftDoublesLongServiceX, groundTop + 6);" in html
+    assert "ctx.moveTo(serviceLines.rightDoublesLongServiceX, groundTop + 6);" in html
     assert "var netTop = getNetSurfacePoint(0.5, 0);" in html
     assert "var netBottom = getNetSurfacePoint(0.5, 1);" in html
     assert "var leftTop = getNetSurfacePoint(0, 0);" in html
@@ -2056,14 +2081,13 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "ctx.roundRect(postX - 5, topClampY - 2.2, 10, 4.4, 2.1);" not in html
     assert "ctx.strokeStyle = 'rgba(255,68,68,.78)';" not in html
     assert "ctx.strokeStyle = 'rgba(255,68,68,.62)';" not in html
-    assert "for (var speck = 0;" not in html
     assert "ctx.rect(BADMINTON.courtLeft, groundTop - 8, BADMINTON.courtRight - BADMINTON.courtLeft, groundBottom - groundTop + 18);" in html
     assert "ctx.fillRect(court.courtLeft, groundTop, court.courtRight - court.courtLeft, groundBottom - groundTop);" in html
     assert "BADMINTON.courtTop + (BADMINTON.courtBottom - BADMINTON.courtTop) * t" not in html
     assert "ctx.rect(BADMINTON.courtLeft, BADMINTON.courtTop, BADMINTON.courtRight - BADMINTON.courtLeft, BADMINTON.courtBottom - BADMINTON.courtTop);" not in html
     assert "ctx.fillRect(court.courtLeft, court.courtTop, court.courtRight - court.courtLeft, court.courtBottom - court.courtTop);" not in html
     assert "var shadowAlpha = clamp(0.30 - shuttleZ / 760, 0.06, 0.30);" in html
-    assert "ctx.ellipse(ball.x, FLOOR_Y + 3, SHUTTLE_VISUAL_R * 1.35 * shadowScale" in html
+    assert "ctx.ellipse(ball.x, FLOOR_Y + 3, SHUTTLE_FLIGHT_VISUAL_R * 1.35 * shadowScale" in html
     assert "var DISTANCE_MARKERS_STORAGE_KEY = 'bd_badminton_distance_markers_enabled';" in html
     assert "var distanceMarkersEnabled = readJson(DISTANCE_MARKERS_STORAGE_KEY, false) === true;" in html
     assert "ctx.fillRect(court.targetLeft" not in html
@@ -2071,11 +2095,14 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "plank:" not in html
     assert "threeLine:" not in html
     assert "laneFill:" not in html
-    assert "playerSenseiContainer.style.width = PLAYER_AVATAR_W + 'px';" in html
-    assert "playerSenseiContainer.style.height = PLAYER_AVATAR_H + 'px';" in html
+    assert "setStyleIfChanged(playerSenseiContainer, playerAvatarStyleCache, 'width', PLAYER_AVATAR_W + 'px');" in html
+    assert "setStyleIfChanged(playerSenseiContainer, playerAvatarStyleCache, 'height', PLAYER_AVATAR_H + 'px');" in html
     assert "container.style.width = YUI_SHOOTER_W + 'px';" in html
     assert "container.style.height = YUI_SHOOTER_H + 'px';" in html
-    assert "container.dataset.courtAvatar = 'opponent';" in html
+    assert "container.style.left = sx + 'px';" in html
+    assert "container.style.top = sy + 'px';" in html
+    assert "yuiShooterStyleCache" not in html
+    assert "setDatasetValueIfChanged(container, 'courtAvatar', 'opponent');" in html
     assert "var baseX = getYuiX();" in html
     assert "function getYuiShotOrigin() {" in html
     assert "var origin = impulse.contact || getRacketContactPoint(shotShooter);" in html
@@ -2094,7 +2121,7 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "shuttle.courtY = origin.x;" in html
     assert "shuttle.z = screenYToCourtZ(origin.y);" in html
     assert "shuttle.vCourtY = shuttle.vx;" in html
-    assert "shuttle.vz = -shuttle.vy;" in html
+    assert "shuttle.vz = -(shuttle.vy || 0);" in html
     assert "var crossedNet = didShuttleCrossMidcourtNet(ball, direction);" in html
     assert "var netCrossing = getMidcourtNetCrossing(ball);" in html
     assert "if (isShuttleInsideNetZ(ball, netCrossing)) {" in html
@@ -2145,8 +2172,9 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "var collar =" not in html
     assert "cork.addColorStop(0.58, '#e4b76c');" not in html
     assert "ctx.ellipse(0, radius * 0.34, radius * 0.50, radius * 0.34" not in html
-    assert "var trailGrad = ctx.createLinearGradient(start.x, start.y, ball.x, ball.y);" in html
-    assert "rgba(182,231,255,0)" in html
+    assert "var firstTrailIndex = ball.isSmash ? Math.max(0, trail.length - 5) : 0;" in html
+    assert "ctx.globalAlpha = ball.isSmash ? 0.50 : (ball.wasPerfect ? 0.62 : 0.48);" in html
+    assert "ctx.strokeStyle = ball.isSmash ? 'rgba(255,210,118,.72)' : (ball.wasPerfect ? 'rgba(255,244,178,.62)' : 'rgba(204,241,255,.48)');" in html
     assert "ctx.strokeStyle = 'rgba(255,143,61,.34)';" not in html
     assert "drawShuttlecock(ball.x, ball.y, SHUTTLE_FLIGHT_VISUAL_R, ball.spinAngle || 0);" in html
     assert "if (ball.y < -SHUTTLE_FLIGHT_VISUAL_R * 2) {" in html
@@ -2174,7 +2202,7 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "function isBadmintonRacketSpriteReady() {" in html
     assert "try { preloadBadmintonRacketSprite(); } catch (_) { badmintonRacketSpriteImage = null; }" in html
     draw_start = html.index("function drawPlayer() {")
-    draw_section = html[draw_start:html.index("function drawAiming()", draw_start)]
+    draw_section = html[draw_start:html.index("function drawAiming(now)", draw_start)]
     assert "var s = PLAYER_FIGURE_SCALE;" in draw_section
     assert "ctx.arc(px, py - 62 * s, 16 * s" in draw_section
     assert "ctx.lineWidth = 8 * s;" in draw_section
@@ -2204,10 +2232,16 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "renderYuiLive2dRacket();" in html
     assert "var shooting = nekoL2dContainer.classList.contains('shooting');" in html
     assert "var charging = nekoL2dContainer.classList.contains('charging');" in html
+    assert "function getYuiLive2dRacketLayout(now) {" not in html
+    assert "YUI_LIVE2D_RACKET_LAYOUT_SAMPLE_MS" not in html
+    assert "var rect = nekoL2dContainer.getBoundingClientRect();" in html
     assert "var layoutW = yuiLive2dRacketCanvas.clientWidth || nekoL2dContainer.offsetWidth || rect.width;" in html
     assert "var modelFrame = getYuiLive2dModelFrame({ width: layoutW, height: layoutH });" in html
     assert "var fallbackHand = getYuiLive2dFallbackHandPoint(modelFrame, shooting, charging);" in html
-    assert "var drawableHand = getYuiLive2dHandAnchorFromDrawables(rect, modelFrame, layoutW, layoutH, shooting, charging);" in html
+    assert "function getCachedYuiLive2dDrawableHand(domRect, modelFrame, layoutW, layoutH, shooting, charging, now) {" in html
+    assert "YUI_LIVE2D_RACKET_ANCHOR_SAMPLE_MS" in html
+    assert "var drawableHand = getCachedYuiLive2dDrawableHand(rect, modelFrame, layoutW, layoutH, shooting, charging, now);" in html
+    assert "domRect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height }" in html
     assert "var handX = drawableHand ? drawableHand.x : fallbackHand.x;" in html
     assert "var handY = drawableHand ? drawableHand.y : fallbackHand.y;" in html
     assert "var racketScale = Math.max(0.98, Math.min(1.08, modelFrame.height / 320));" in html
@@ -2273,7 +2307,7 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "var featherPlaneCount" not in held_shuttle_create_section
     assert "new THREE.ConeGeometry" not in held_shuttle_create_section
     held_shuttle_overlay_start = html.index("function getPlayerVrmHeldShuttleCanvasPoint() {")
-    held_shuttle_overlay_section = html[held_shuttle_overlay_start:html.index("function drawAiming()", held_shuttle_overlay_start)]
+    held_shuttle_overlay_section = html[held_shuttle_overlay_start:html.index("function drawAiming(now)", held_shuttle_overlay_start)]
     assert "playerVrmHeldShuttle.localToWorld(heldPoint);" in held_shuttle_overlay_section
     assert "heldPoint.clone().project(window.badmintonPlayerVrmManager.camera);" in held_shuttle_overlay_section
     assert "var hand = getPlayerVrmBone(vrm, 'leftHand');" in held_shuttle_overlay_section
@@ -2288,7 +2322,7 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "var point = getPlayerHeldShuttleServeHandCanvasPoint() || getPlayerVrmHeldShuttleCanvasPoint();" in held_shuttle_overlay_section
     assert "var corkOffsetX = -Math.sin(heldRotation) * heldRadius * 0.42;" in held_shuttle_overlay_section
     assert "drawBadmintonShuttlecockOnContext(playerSenseiHeldShuttleCtx, shuttleX, shuttleY, heldRadius, heldRotation);" in held_shuttle_overlay_section
-    render_start = html.index("function render() {")
+    render_start = html.index("function render(now) {")
     render_section = html[render_start:html.index("function loop(ts) {", render_start)]
     assert "drawBall();\n    drawPlayerVrmHeldShuttleOverlay();" in render_section
     assert "function attachPlayerHeldShuttleToHand(vrm) {" in html
@@ -2373,7 +2407,7 @@ def test_badminton_mouse_input_is_gated_to_player_controlled_shots():
     assert "var playerShotInFlight = game.ball && game.ball.shooter === 'player' && game.ball.direction === 1 && !game.ball.resolved;" in html
     assert "var yuiTurnActive = game.state === 'neko_thinking' || game.duel.activeShooter === 'neko';" in html
     assert "var yuiSwinging = game.pendingSwing && game.pendingSwing.shooter === 'neko';" in html
-    assert "return isDuelMode() && (canPlayerControlShot() || playerShotInFlight || yuiTurnActive || incomingYuiBall || yuiSwinging);" in html
+    assert "return isDuelMode() && (isPlayerServeSetup() || canPlayerControlShot() || playerShotInFlight || yuiTurnActive || incomingYuiBall || yuiSwinging);" in html
     assert "function isIncomingPlayerShuttleInReach(ball) {" in html
     assert "var PLAYER_RETURN_REACH_X = 84;" in html
     assert "var PLAYER_RETURN_REACH_Y = 108;" in html
@@ -2388,9 +2422,10 @@ def test_badminton_mouse_input_is_gated_to_player_controlled_shots():
     assert "if (isBadmintonLoadingActive()) return;" in mousemove
     assert "if (shouldIgnoreBadmintonPointerEvent(ev)) return;" in mousemove
     assert "rememberPlayerPointer(ev);" in mousemove
-    assert "if (canPlayerMoveCourt()) updatePlayerCourtTarget(ev.clientX, ev.clientY);" in mousemove
-    assert "if (!canPlayerControlShot()) return;" in mousemove
-    assert mousemove.index("if (!canPlayerControlShot()) return;") < mousemove.index("game.aimAngle =")
+    assert "if (canMoveCourt) updatePlayerCourtTarget(ev.clientX, ev.clientY);" in mousemove
+    assert "var canControlShot = canPlayerControlShot();" in mousemove
+    assert "if (!canControlShot) return;" in mousemove
+    assert mousemove.index("if (!canControlShot) return;") < mousemove.index("game.aimAngle =")
 
     mousedown = html[
         html.index("function handleBadmintonPointerDown(ev) {"):
@@ -2628,6 +2663,10 @@ def test_badminton_shuttle_trail_uses_ring_buffer_without_changing_public_state(
     draw_start = html.index("function drawBackspinBall(ball) {")
     draw_section = html[draw_start:html.index("function drawNet()", draw_start)]
     assert "var trail = getShuttleTrailPoints(ball);" in draw_section
+    assert "var firstTrailIndex = ball.isSmash ? Math.max(0, trail.length - 5) : 0;" in draw_section
+    assert "for (var i = firstTrailIndex + 1; i < trail.length; i++)" in draw_section
+    assert "ctx.createLinearGradient" not in draw_section
+    assert "ctx.shadowBlur" not in draw_section
 
     state_start = html.index("getState: function () {")
     state_section = html[state_start:html.index("resetGame: resetGame", state_start)]
@@ -2661,13 +2700,15 @@ def test_badminton_yui_octopus_ink_has_stronger_screen_coverage():
 
     assert "alpha: active ? clamp(0.38 + fade * 0.52, 0, 0.9) : 0," in html
     assert "aimingCtx.fillRect(0, 0, BASE_W, BASE_H);" in html
-    assert "var centralInk = aimingCtx.createRadialGradient(BASE_W * 0.50, BASE_H * 0.48" in html
+    assert "function ensureYuiInkOverlayCache() {" in html
+    assert "var centralInk = inkCtx.createRadialGradient(BASE_W * 0.50, BASE_H * 0.48" in html
     assert "centralInk.addColorStop(0, 'rgba(0,0,0,.96)');" in html
     assert "function drawCenterInkBlob(cx, cy, rx, ry, rot, alpha) {" in html
     assert "var centerSplashes = [" in html
     assert "for (var drip = 0; drip < 8; drip++) {" in html
     assert "for (var speck = 0; speck < 22; speck++) {" in html
-    assert "aimingCtx.bezierCurveTo(" in html
+    assert "inkCtx.bezierCurveTo(" in html
+    assert "aimingCtx.drawImage(inkCanvas," in html
     assert "function drawInkBlob(" not in html
     assert "var edgeVeil =" not in html
     assert "badmintonGameAudio.playSfx('yuiCheat.octopusInk', { volumeMultiplier: 0.92 });" in html
@@ -2978,16 +3019,25 @@ def test_badminton_player_can_receive_and_return_yui_shuttle():
     assert "aimingCtx.clearRect(0, 0, BASE_W, BASE_H);" in draw_section
     assert "function drawReturnChargeTrace(" not in draw_section
     assert "function drawPlayerChargeMeter(" in draw_section
-    assert "if (game.charging && canPlayerChargeShot()) drawPlayerChargeMeter(clamp(game.power, 0, 100), t);" in draw_section
+    assert "drawPlayerChargeMeter(game.charging && canPlayerChargeShot() ? clamp(game.power, 0, 100) : 0, t);" in draw_section
     assert "if (!isIncomingPlayerReturnCandidate()) return;" in draw_section
     assert "if (!canReturnNow) return;" not in draw_section
     assert "var cueAlpha = canReturnNow ? 1 : 0.46;" in draw_section
     assert "'rgba(114,216,255,.055)'" in draw_section
     assert "var returnPercent = clamp(returnDeadlineMs / 2400 * 100, 0, 100);" not in draw_section
     assert "drawReturnChargeTrace" not in draw_section
-    assert "var meterX = getPlayerX() - meterW / 2;" in draw_section
-    assert "var meterY = getPlayerY() - 146;" in draw_section
+
+    charge_start = html.index("function drawPlayerChargeMeter(percent, now) {")
+    charge_section = html[charge_start:html.index("function ensureYuiInkOverlayCache()", charge_start)]
+    assert "var meterX = (getPlayerX() - meterW / 2) * screenScaleX;" in charge_section
+    assert "var meterY = (getPlayerY() - 146) * screenScaleY;" in charge_section
+    assert "aimingCtx.shadowBlur" not in charge_section
     assert "aimingCtx.quadraticCurveTo(controlX, controlY, endX, endY);" in draw_section
+    return_cue_start = html.index("function drawPlayerReturnHitCue(now) {")
+    return_cue_section = html[return_cue_start:html.index("function drawBall()", return_cue_start)]
+    assert "aimingCtx.createLinearGradient" not in return_cue_section
+    assert "aimingCtx.createRadialGradient" not in return_cue_section
+    assert "aimingCtx.shadowBlur" not in return_cue_section
     assert "var chargePercent = game.charging ? clamp(game.power, 0, 100) : clamp(returnDeadlineMs / 2400 * 100, 0, 100);" not in draw_section
 
     pointer_down = html[

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -2715,6 +2715,7 @@ def test_badminton_yui_octopus_ink_has_stronger_screen_coverage():
     assert "alpha: active ? clamp(0.38 + fade * 0.52, 0, 0.9) : 0," in html
     assert "aimingCtx.fillRect(0, 0, BASE_W, BASE_H);" in html
     assert "function ensureYuiInkOverlayCache() {" in html
+    assert "function drawYuiInkArcRings(ink, t) {" in html
     assert "var centralInk = inkCtx.createRadialGradient(BASE_W * 0.50, BASE_H * 0.48" in html
     assert "centralInk.addColorStop(0, 'rgba(0,0,0,.96)');" in html
     assert "function drawCenterInkBlob(cx, cy, rx, ry, rot, alpha) {" in html
@@ -2723,6 +2724,12 @@ def test_badminton_yui_octopus_ink_has_stronger_screen_coverage():
     assert "for (var speck = 0; speck < 22; speck++) {" in html
     assert "inkCtx.bezierCurveTo(" in html
     assert "aimingCtx.drawImage(inkCanvas," in html
+    assert "drawYuiInkArcRings(ink, t);" in html
+    assert "if (!ink || ink.alpha <= 0.58) return;" in html
+    cache_start = html.index("function ensureYuiInkOverlayCache() {")
+    cache_end = html.index("function drawYuiInkArcRings(ink, t) {", cache_start)
+    cache_section = html[cache_start:cache_end]
+    assert "rgba(114,216,226,.42)" not in cache_section
     assert "function drawInkBlob(" not in html
     assert "var edgeVeil =" not in html
     assert "badmintonGameAudio.playSfx('yuiCheat.octopusInk', { volumeMultiplier: 0.92 });" in html

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -216,7 +216,7 @@ def test_badminton_hidden_tab_keeps_route_alive():
 
     beforeunload_start = html.index("window.addEventListener('beforeunload', function () {")
     beforeunload_section = html[beforeunload_start:html.index("window.addEventListener('localechange'", beforeunload_start)]
-    assert "closeSpeechPlaybackStateBridge();" in beforeunload_section
+    assert "closeSpeechPlaybackStateBridge();" not in beforeunload_section
     assert "endRoute(true);" in beforeunload_section
     assert "var pageVisible = !document.hidden;" in html
     assert "visible: pageVisible" in html
@@ -950,6 +950,11 @@ def test_badminton_low_risk_frame_time_is_reused_in_overlay_hot_path():
     assert "badmintonFrameNow = ts || performance.now();" in html
     assert "update(dt, badmintonFrameNow);" in html
     assert "drawAiming(badmintonFrameNow);" in html
+    assert "var BADMINTON_HIDDEN_FRAME_DELAY_MS = 250;" in html
+    assert "function scheduleBadmintonNextFrame() {" in html
+    assert "if (document.hidden) {" in html
+    assert "}, BADMINTON_HIDDEN_FRAME_DELAY_MS);" in html
+    assert "scheduleBadmintonNextFrame();" in html
 
     overlay_start = html.index("function isAimingOverlayActive(")
     overlay_end = html.index("function drawAiming(", overlay_start)
@@ -980,6 +985,7 @@ def test_badminton_low_risk_hud_text_updates_are_deduped():
     debug_start = html.index("function updateDebugReadout() {")
     debug_end = html.index("function setDebugVisible(", debug_start)
     debug_section = html[debug_start:debug_end]
+    assert "if (debugPanel && debugPanel.dataset.debugVisible !== 'true') return;" in debug_section
     assert "setTextIfChanged(debugPowerValue, String(Math.round(game.power || 0)));" in debug_section
     assert "setTextIfChanged(debugReadout, readoutText);" in debug_section
 
@@ -1043,6 +1049,10 @@ def test_badminton_low_risk_pointer_move_reuses_control_checks():
     pointer_start = html.index("function handleBadmintonPointerMove(ev) {")
     pointer_end = html.index("function handleBadmintonPointerDown(ev) {", pointer_start)
     pointer_section = html[pointer_start:pointer_end]
+    assert "if (ev && ev.__badmintonPointerMoveHandled) return;" in pointer_section
+    assert "if (ev) ev.__badmintonPointerMoveHandled = true;" in pointer_section
+    assert pointer_section.index("if (ev && ev.__badmintonPointerMoveHandled) return;") < pointer_section.index("rememberPlayerPointer(ev);")
+    assert pointer_section.index("if (ev) ev.__badmintonPointerMoveHandled = true;") < pointer_section.index("rememberPlayerPointer(ev);")
     assert "var canMoveCourt = canPlayerMoveCourt();" in pointer_section
     assert "var canControlShot = canPlayerControlShot();" in pointer_section
     assert "if (canMoveCourt) updatePlayerCourtTarget(ev.clientX, ev.clientY);" in pointer_section
@@ -1118,7 +1128,10 @@ def test_badminton_low_risk_net_contact_effects_reuse_frame_time():
     effects_end = html.index("function drawNetCord()", effects_start)
     effects_section = html[effects_start:effects_end]
     assert "var t = Number.isFinite(now) ? now : getBadmintonFrameNow();" in effects_section
-    assert "t - effect.startAt < effect.duration" in effects_section
+    assert "var activeCount = 0;" in effects_section
+    assert "netContactEffects[activeCount++] = retainedEffect;" in effects_section
+    assert "netContactEffects.length = activeCount;" in effects_section
+    assert "netContactEffects = netContactEffects.filter" not in effects_section
     assert "var age = clamp((t - effect.startAt) / effect.duration, 0, 1);" in effects_section
     assert "performance.now()" not in effects_section
 
@@ -1703,15 +1716,15 @@ def test_badminton_user_reply_voice_deadline_survives_inflight_guard():
 
 
 @pytest.mark.unit
-def test_badminton_voice_deferral_without_deadline_uses_fallback_delay():
+def test_badminton_voice_request_does_not_use_browser_playback_bridge():
     html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
     request_start = html.index("function _requestVoicePlayback(entry) {")
     request_section = html[request_start:html.index("function _flushVoiceArbiter()", request_start)]
 
-    assert "var deadlineMs = entry.expiresAt ? Math.max(0, entry.expiresAt - Date.now()) : 0;" in request_section
-    assert "var playbackDeferDelayMs = entry.expiresAt ? Math.max(120, deadlineMs - 250) : 900;" in request_section
-    assert "deadlineMs - 250 || 900" not in request_section
-    assert "_scheduleVoiceArbiterFlush(Math.min(Math.max(entry.tailWaitMs, 120), playback.remainingMs, playbackDeferDelayMs));" in request_section
+    assert "readVoiceOccupancy()" not in request_section
+    assert "playbackDeferredOnce" not in request_section
+    assert "voice_deferred_once" not in request_section
+    assert "showBubble(entry.line, entry.control);" in request_section
 
 
 @pytest.mark.unit
@@ -1722,27 +1735,20 @@ def test_badminton_debug_voice_mode_allows_tts_when_debugging():
 
     assert "var debugVoiceMode = modeParams ? modeParams.get('debug_voice') === '1' : false;" in html
     assert "var debugVoiceMuted = modeParams ? modeParams.get('debug_mute_voice') === '1' : false;" in html
-    assert "var SPEECH_PLAYBACK_STATE_KEY = 'neko_speech_playback_state';" in html
-    assert "var SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';" in html
-    assert "function normalizeSpeechPlaybackState(raw) {" in html
-    assert "localStorage.getItem(SPEECH_PLAYBACK_STATE_KEY)" in html
-    assert "new BroadcastChannel(SPEECH_PLAYBACK_CHANNEL_NAME)" in html
-    assert "window.addEventListener('storage', function (event) {" in html
-    assert "window.addEventListener('neko-speech-playback-state', function (event) {" in html
-    assert "function readVoiceOccupancy() {" in html
-    assert "function waitForProjectVoicePlayback(speechId, timeoutMs, requestStartedAt) {" in html
-    assert "initSpeechPlaybackStateBridge();" in html
-    assert "function closeSpeechPlaybackStateBridge() {" in html
-    assert "speechPlaybackChannel.close();" in html
-    assert "function speakLineLocally(line) {" in html
-    assert "new SpeechSynthesisUtterance(text)" in html
+    assert "SPEECH_PLAYBACK_STATE_KEY" not in html
+    assert "SPEECH_PLAYBACK_CHANNEL_NAME" not in html
+    assert "function normalizeSpeechPlaybackState(raw) {" not in html
+    assert "function readVoiceOccupancy() {" not in html
+    assert "function waitForProjectVoicePlayback(speechId, timeoutMs, requestStartedAt) {" not in html
+    assert "initSpeechPlaybackStateBridge();" not in html
+    assert "function closeSpeechPlaybackStateBridge() {" not in html
+    assert "function speakLineLocally(line) {" not in html
+    assert "SpeechSynthesisUtterance" not in html
+    assert "speechSynthesis" not in html
     assert "if (debugMode && debugVoiceMuted && !debugVoiceMode && !(entry.event && entry.event.force_voice_in_debug)) return Promise.resolve();" in mirror_section
     assert "hasProjectVoicePlaybackBridge" not in mirror_section
     assert "missing_project_voice_playback_bridge" not in mirror_section
     assert "lastVoiceRequest = speakPayload;" in mirror_section
-    assert "waitForProjectVoicePlayback(res.speech_id, 1100, speakStartedAt)" in mirror_section
-    assert "lastVoiceFallbackReason = 'project_voice_not_queued';" in mirror_section
-    assert "lastVoiceFallbackReason = 'project_voice_unobserved';" in mirror_section
     assert "reason: 'project_speak_failed'" in mirror_section
     assert "return post('/speak', speakPayload, 3500).then(function (res) {" in mirror_section
 
@@ -1942,7 +1948,7 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "var NET_ROWS = 7;" in html
     assert "var NET_CONTACT_RADIUS = 42;" in html
     assert "var NET_CONTACT_IMPULSE = 320;" in html
-    assert "var NET_CONTACT_HOLD_MS = 230;" in html
+    assert "var NET_CONTACT_HOLD_MS = 90;" in html
     assert "function getSideViewCourtTop() {" in html
     assert "return FLOOR_Y - 62;" in html
     assert "function getSideViewCourtBottom() {" in html
@@ -2232,11 +2238,19 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "renderYuiLive2dRacket();" in html
     assert "var shooting = nekoL2dContainer.classList.contains('shooting');" in html
     assert "var charging = nekoL2dContainer.classList.contains('charging');" in html
-    assert "function getYuiLive2dRacketLayout(now) {" not in html
-    assert "YUI_LIVE2D_RACKET_LAYOUT_SAMPLE_MS" not in html
-    assert "var rect = nekoL2dContainer.getBoundingClientRect();" in html
-    assert "var layoutW = yuiLive2dRacketCanvas.clientWidth || nekoL2dContainer.offsetWidth || rect.width;" in html
-    assert "var modelFrame = getYuiLive2dModelFrame({ width: layoutW, height: layoutH });" in html
+    assert "var saving = nekoL2dContainer.classList.contains('saving');" in html
+    assert "var smashing = nekoL2dContainer.classList.contains('smashing');" in html
+    assert "YUI_LIVE2D_RACKET_LAYOUT_SAMPLE_MS" in html
+    assert "YUI_LIVE2D_RACKET_IDLE_RENDER_MS" in html
+    assert "var yuiLive2dRacketLayoutCache = { sampledAt: 0, rect: null, layoutW: 0, layoutH: 0, dpr: 0, modelFrame: null };" in html
+    assert "var yuiLive2dRacketLastRenderAt = 0;" in html
+    assert "function resetYuiLive2dRacketLayoutCache() {" in html
+    assert "function getYuiLive2dRacketLayout(now, forceRefresh) {" in html
+    assert "if (!forceRefresh && cached.rect && cached.dpr === dpr && t - (cached.sampledAt || 0) < YUI_LIVE2D_RACKET_LAYOUT_SAMPLE_MS)" in html
+    assert "var layout = getYuiLive2dRacketLayout(now, activeRacketAction);" in html
+    assert "if (!activeRacketAction && yuiLive2dRacketLastRenderAt && now - yuiLive2dRacketLastRenderAt < YUI_LIVE2D_RACKET_IDLE_RENDER_MS) return;" in html
+    assert "resetYuiLive2dRacketLayoutCache();" in html
+    assert "var modelFrame = layout.modelFrame;" in html
     assert "var fallbackHand = getYuiLive2dFallbackHandPoint(modelFrame, shooting, charging);" in html
     assert "function getCachedYuiLive2dDrawableHand(domRect, modelFrame, layoutW, layoutH, shooting, charging, now) {" in html
     assert "YUI_LIVE2D_RACKET_ANCHOR_SAMPLE_MS" in html
@@ -2769,7 +2783,10 @@ def test_badminton_banana_slip_flips_player_avatar_360_degrees():
 
     assert "function randomYuiBananaCourtX() {" in html
     assert "var x = Number.isFinite(opts.x) ? opts.x : randomYuiBananaCourtX();" in banana_section
-    assert "var y = Number.isFinite(opts.y) ? opts.y : getPlayerFootY();" in banana_section
+    assert "var y = Number.isFinite(opts.y) ? opts.y : getPlayerGroundFootY();" in banana_section
+    assert "function getPlayerGroundFootY() {" in html
+    assert "playerGroundFootY: getPlayerGroundFootY()," in html
+    assert "var dy = getPlayerFootY() - item.y;" in html
     assert "getPlayerX()" not in banana_section
     assert "game.playerCourt.targetX + defaultOffset" not in banana_section
     assert "var YUI_CHEAT_BANANA_SLIP_ROTATION_RAD = Math.PI * 2;" in html
@@ -2797,22 +2814,27 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "var shuttleZ = getShuttleCourtZ(ball, false);" in html
     assert "var yuiContactTopZ = screenYToCourtZ(contact.y - 26);" in html
     assert "var yuiContactBottomZ = screenYToCourtZ(FLOOR_Y - 110);" in html
-    assert "var YUI_RACKET_HIT_REACH_X = 38;" in html
-    assert "var YUI_RACKET_HIT_REACH_Y = 54;" in html
+    assert "var YUI_RACKET_HIT_REACH_X = 46;" in html
+    assert "var YUI_RACKET_HIT_REACH_Y = 62;" in html
     assert "function getYuiVisibleRacketContactPoint() {" in html
     assert "source: 'live2d-racket-head'" in html
     assert "function getYuiRacketContactPoint() {" in html
     assert "x: getYuiX() + YUI_RACKET_BODY_OFFSET_X," in html
     assert "return getYuiVisibleRacketContactPoint() || getYuiShotOrigin();" in html
+    assert "function getYuiNeutralRacketContactPoint() {" in html
+    assert "source: 'neutral-racket-anchor'" in html
+    assert "function getYuiRacketRangeState(incomingBall, reachX, reachY) {" in html
+    assert "var neutral = getYuiNeutralRacketContactPoint();" in html
+    assert "var visible = getYuiVisibleRacketContactPoint();" in html
+    assert "if (visibleState.normalized < best.normalized) best = visibleState;" in html
     assert "function getYuiRacketHitRangeState(incomingBall) {" in html
-    assert "var racket = getYuiRacketContactPoint();" in html
-    assert "var normalized = Math.pow(dx / YUI_RACKET_HIT_REACH_X, 2) + Math.pow(dy / YUI_RACKET_HIT_REACH_Y, 2);" in html
+    assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_HIT_REACH_X, YUI_RACKET_HIT_REACH_Y);" in html
     assert "function isYuiRacketHitInRange(incomingBall) {" in html
     assert "return getYuiRacketHitRangeState(incomingBall).normalized <= 1;" in html
     assert "var YUI_RACKET_SAVE_REACH_X = 84;" in html
     assert "var YUI_RACKET_SAVE_REACH_Y = 86;" in html
     assert "function getYuiRacketSaveRangeState(incomingBall) {" in html
-    assert "var normalized = Math.pow(dx / YUI_RACKET_SAVE_REACH_X, 2) + Math.pow(dy / YUI_RACKET_SAVE_REACH_Y, 2);" in html
+    assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);" in html
     assert "function isYuiSmashSaveReachable(incomingBall) {" in html
     assert "return !!(incomingBall && incomingBall.isSmash) && getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;" in html
     assert "var YUI_SMASH_MIN_SHUTTLE_Z = 64;" in html

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -2816,6 +2816,8 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "var yuiContactBottomZ = screenYToCourtZ(FLOOR_Y - 110);" in html
     assert "var YUI_RACKET_HIT_REACH_X = 46;" in html
     assert "var YUI_RACKET_HIT_REACH_Y = 62;" in html
+    assert "var YUI_RACKET_RESCUE_GATE_REACH_X = 38;" in html
+    assert "var YUI_RACKET_RESCUE_GATE_REACH_Y = 54;" in html
     assert "function getYuiVisibleRacketContactPoint() {" in html
     assert "source: 'live2d-racket-head'" in html
     assert "function getYuiRacketContactPoint() {" in html
@@ -2831,12 +2833,14 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_HIT_REACH_X, YUI_RACKET_HIT_REACH_Y);" in html
     assert "function isYuiRacketHitInRange(incomingBall) {" in html
     assert "return getYuiRacketHitRangeState(incomingBall).normalized <= 1;" in html
+    assert "function getYuiRacketRescueGateState(incomingBall) {" in html
+    assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);" in html
     assert "var YUI_RACKET_SAVE_REACH_X = 84;" in html
     assert "var YUI_RACKET_SAVE_REACH_Y = 86;" in html
     assert "function getYuiRacketSaveRangeState(incomingBall) {" in html
     assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);" in html
     assert "function isYuiSmashSaveReachable(incomingBall) {" in html
-    assert "return !!(incomingBall && incomingBall.isSmash) && getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;" in html
+    assert "return !!(incomingBall && incomingBall.isSmash) && getYuiRacketRescueGateState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;" in html
     assert "var YUI_SMASH_MIN_SHUTTLE_Z = 64;" in html
     assert "var YUI_SMASH_FULL_SHUTTLE_Z = 138;" in html
     assert "function getYuiSmashHeightQuality(incomingBall) {" in html

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -56,18 +56,24 @@ def assert_no_layout_transition(block: str) -> None:
 
 def test_index_game_window_state_pauses_hidden_avatar_rendering():
     source = INDEX_TEMPLATE_PATH.read_text(encoding="utf-8")
-    block = source.split("function applyGameWindowRenderingState(paused) {", 1)[1].split(
+    block = source.split("var pngtuberHiddenForGameWindow = false;", 1)[1].split(
         "window.addEventListener('neko-game-window-state-change'",
         1,
     )[0]
 
+    assert "var pngtuberHiddenForGameWindow = false;" in source
+    assert "function applyGameWindowRenderingState(paused) {" in block
     assert "window.live2dManager" in block
     assert "window.vrmManager" in block
     assert "window.mmdManager" in block
+    assert "var manager = window.pngtuberManager;" in block
+    assert "manager.hide();" in block
+    assert "manager.show();" in block
     assert "var method = paused ? 'pauseRendering' : 'resumeRendering';" in block
     assert "manager[method]();" in block
-    assert "document.body.classList.add('neko-game-active');" in block
     assert "applyGameWindowRenderingState(true);" in block
+    assert "document.body.classList.add('neko-game-active');" in block
+    assert block.index("applyGameWindowRenderingState(true);") < block.index("document.body.classList.add('neko-game-active');")
     assert "document.body.classList.remove('neko-game-active');" in block
     assert "if (!window.__nekoPetInteracting__) {" in block
     assert "applyGameWindowRenderingState(false);" in block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -54,6 +54,24 @@ def assert_no_layout_transition(block: str) -> None:
         assert prop not in transition_section
 
 
+def test_index_game_window_state_pauses_hidden_avatar_rendering():
+    source = INDEX_TEMPLATE_PATH.read_text(encoding="utf-8")
+    block = source.split("function applyGameWindowRenderingState(paused) {", 1)[1].split(
+        "window.addEventListener('neko-game-window-state-change'",
+        1,
+    )[0]
+
+    assert "window.live2dManager" in block
+    assert "window.vrmManager" in block
+    assert "window.mmdManager" in block
+    assert "var method = paused ? 'pauseRendering' : 'resumeRendering';" in block
+    assert "manager[method]();" in block
+    assert "document.body.classList.add('neko-game-active');" in block
+    assert "applyGameWindowRenderingState(true);" in block
+    assert "document.body.classList.remove('neko-game-active');" in block
+    assert "applyGameWindowRenderingState(false);" in block
+
+
 def css_z_index(block: str) -> int:
     match = re.search(r"\bz-index:\s*(\d+)\s*;", block)
     if not match:

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -69,6 +69,7 @@ def test_index_game_window_state_pauses_hidden_avatar_rendering():
     assert "document.body.classList.add('neko-game-active');" in block
     assert "applyGameWindowRenderingState(true);" in block
     assert "document.body.classList.remove('neko-game-active');" in block
+    assert "if (!window.__nekoPetInteracting__) {" in block
     assert "applyGameWindowRenderingState(false);" in block
 
 


### PR DESCRIPTION
﻿## 改动概述

这次聚焦羽毛球小游戏在 Electron 端运行时的卡顿、重复语音和手感稳定性问题。触网后网物理会在空闲时复位并跳过不必要计算，触网停顿时间缩短；小游戏页面不再使用浏览器本地 speechSynthesis 兜底，避免和项目原有语音系统叠加播放。

同时对页面热路径做了收敛：隐藏 debug 面板时停止刷新 readout，pointer move 事件去重，触网特效数组原地压缩；Live2D 球拍 overlay 增加布局缓存和空闲降频；YUI 普通接球判定小幅放宽，减少明明接近球拍却漏接的体感；页面不可见时主循环降频，降低 Electron 后台占用。

## 为什么改

羽毛球小游戏在桌面端会和 Electron 窗口层级、Live2D/VRM 渲染、语音路由同时运行，触网和 overlay 热路径容易放大卡顿。重复语音机制还会让同一句台词出现两套播放效果，影响体验并增加调试复杂度。

## 风险与边界

本轮不改游戏 LLM、记忆路由、核心后端接口和基础物理 timestep。YUI 接球只调整普通命中范围，不扩大扣杀救球范围，也不改难度表和出球随机。隐藏页降频只影响 document.hidden 状态，前台可见时仍使用 requestAnimationFrame。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 新增玩家蓄力条可视化，并在瞄准/激活时自动、稳定刷新状态与动画表现  
  * Demo 新增性能监测快照接口；并在状态中补充玩家落脚参考值  
  * 游戏窗口联动：暂停/恢复 Live2D/VRM/MMD 渲染，同时隐藏/显示 PNGtuber

* **优化改进**
  * 优化网接触的激活窗口与特效时长控制  
  * 统一命中/回球范围判定，并完善香蕉等道具落点计算

* **可靠性**
  * 更新并新增端到端/单测，覆盖蓄力、语音回退、香蕉落点等行为契约
<!-- end of auto-generated comment: release notes by coderabbit.ai -->