### PR TITLE
修复当前头像预览刷新时最小化再展开后按钮暂时不可点击的问题，并调整头像预览弹窗关闭按钮图标居中显示

### DIFF
--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -11,6 +11,7 @@
     let isCapturing = false;
     let pendingAutoCapture = false;
     let activeCaptureToken = 0;
+    let activeCaptureCardVisible = false;
     let cachedPreview = null;
     let autoCaptureTimer = null;
     let lastScheduledCacheKey = '';
@@ -872,6 +873,7 @@
         if (isCapturing) {
             if (showCard) {
                 setPreviewVisible(true, trigger);
+                activeCaptureCardVisible = true;
             }
             if (!showCard && silent) {
                 pendingAutoCapture = true;
@@ -893,6 +895,7 @@
 
         isCapturing = true;
         const token = ++activeCaptureToken;
+        activeCaptureCardVisible = showCard;
         const cacheKey = getCurrentModelCacheKey();
         const prevCachedPreview = cachedPreview ? Object.assign({}, cachedPreview) : null;
         if (showCard) {
@@ -964,7 +967,7 @@
         } catch (error) {
             if (token !== activeCaptureToken) return;
 
-            if (showCard) {
+            if (showCard || activeCaptureCardVisible) {
                 setPreviewImage('');
                 setPreviewStatus(translateLabel('chat.avatarPreviewFailed', '生成头像失败'));
                 setPreviewNote(getErrorMessage(error));
@@ -978,6 +981,7 @@
         } finally {
             if (token === activeCaptureToken) {
                 isCapturing = false;
+                activeCaptureCardVisible = false;
                 setLoadingState(false);
                 if (pendingAutoCapture) {
                     pendingAutoCapture = false;

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -254,7 +254,11 @@
         [legacyButton, headerButton].forEach(function (btn) {
             if (!btn) return;
             btn.classList.toggle('is-loading', loading);
-            btn.disabled = loading;
+            if (loading) {
+                btn.setAttribute('aria-busy', 'true');
+            } else {
+                btn.removeAttribute('aria-busy');
+            }
         });
         if (refreshButton) {
             refreshButton.disabled = loading;
@@ -866,6 +870,9 @@
         const manualCrop = options.manualCrop === true;
 
         if (isCapturing) {
+            if (showCard) {
+                setPreviewVisible(true, trigger);
+            }
             if (!showCard && silent) {
                 pendingAutoCapture = true;
             }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2072,6 +2072,7 @@ body.react-chat-window-dragging {
 
 .chat-avatar-preview-card-close {
     flex: 0 0 auto;
+    position: relative;
     width: 28px;
     height: 28px;
     border-radius: 999px;
@@ -2079,12 +2080,34 @@ body.react-chat-window-dragging {
     background: rgba(68, 183, 254, 0.08);
     color: #2497d9;
     cursor: pointer;
-    font-size: 18px;
-    line-height: 1;
+    font-size: 0;
+    line-height: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    padding: 0;
     transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.chat-avatar-preview-card-close::before,
+.chat-avatar-preview-card-close::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 12px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+    pointer-events: none;
+}
+
+.chat-avatar-preview-card-close::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.chat-avatar-preview-card-close::after {
+    transform: translate(-50%, -50%) rotate(-45deg);
 }
 
 .chat-avatar-preview-card-close:hover {


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复当前头像预览刷新时最小化再展开后按钮暂时不可点击的问题，并调整头像预览弹窗关闭按钮图标居中显示

## 测试 / Testing

手动测试显示当前头像功能按钮

## 对比
之前:
<img width="462" height="328" alt="image" src="https://github.com/user-attachments/assets/7a187381-9eea-4c68-bc92-2296dffbfc36" />

之后:
<img width="459" height="338" alt="image" src="https://github.com/user-attachments/assets/93499569-6c3f-4ea1-b682-ccd8a9b000c4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **UI改进**
  * 优化了头像预览的加载状态反馈：在加载时使用忙碌状态标识更新预览卡片按钮表现，结束后自动恢复
  * 改进了头像预览在采集进行时的打开与错误展示逻辑，避免影响后续渲染
  * 改进了头像预览关闭按钮的视觉设计：使用伪元素绘制“X”形关闭图标
<!-- end of auto-generated comment: release notes by coderabbit.ai -->