### PR TITLE
fix(subtitle): hide panel during cat idle

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -76,6 +76,7 @@ _YUI_GUIDE_ASSET_VERSION_PATHS = (
     _PROJECT_ROOT / "static/app-react-chat-window.js",
     _PROJECT_ROOT / "static/app-chat-export.js",
     _PROJECT_ROOT / "static/avatar-ui-buttons.js",
+    _PROJECT_ROOT / "static/subtitle.js",
     _PROJECT_ROOT / "static/assets/neko-idle/cat-idle-cat1.gif",
     _PROJECT_ROOT / "static/assets/neko-idle/cat-idle-cat1-click.gif",
     _PROJECT_ROOT / "static/assets/neko-idle/cat-idle-cat1-eat.gif",

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -255,6 +255,12 @@
         } catch (err) {
             console.warn('[猫娘切换] 清理 goodbye 聊天框状态失败:', err);
         }
+
+        try {
+            window.dispatchEvent(new CustomEvent('neko:goodbye-state-cleared', {
+                detail: { reason: reason }
+            }));
+        } catch (_) {}
     }
 
     function supportsLocalModelRuntime() {

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -45,6 +45,8 @@ let subtitleEnabled = initialSubtitleSettings
     : ((typeof window.appState !== 'undefined' && typeof window.appState.subtitleEnabled !== 'undefined')
         ? window.appState.subtitleEnabled
         : localStorage.getItem('subtitleEnabled') === 'true');
+let subtitleSuppressedByGoodbye = false;
+let subtitleGoodbyeSuppressWasEnabled = false;
 
 function isSubtitleTranslationOwner() {
     return !(window.__NEKO_MULTI_WINDOW__ &&
@@ -494,6 +496,20 @@ function syncSubtitleRenderState(source) {
     }, { source: source || 'subtitle-core' });
 }
 
+function hideSubtitleDisplayOnly(source) {
+    const display = document.getElementById('subtitle-display');
+    if (!display) return;
+    clearSubtitleDanmakuLayer();
+    display.classList.remove('show');
+    display.classList.add('hidden');
+    display.style.opacity = '0';
+    syncSubtitleRenderState(source || 'subtitle-display-hidden');
+}
+
+function isSubtitleTemporarilySuppressed() {
+    return subtitleSuppressedByGoodbye;
+}
+
 /**
  * 设置用户语言并同步到 appState
  */
@@ -657,6 +673,10 @@ function getStructuredPlaceholder() {
 function ensureSubtitleVisibleIfEnabled() {
     const display = document.getElementById('subtitle-display');
     if (!display) return;
+    if (isSubtitleTemporarilySuppressed()) {
+        hideSubtitleDisplayOnly('subtitle-goodbye-suppressed-visible-request');
+        return;
+    }
     if (subtitleEnabled) {
         display.classList.remove('hidden');
         display.classList.add('show');
@@ -669,6 +689,7 @@ function ensureSubtitleVisibleIfEnabled() {
  * 把字幕显示元素隐藏并清空文字（开关关闭或手动 hideSubtitle 时使用）
  */
 function hideSubtitle() {
+    subtitleGoodbyeSuppressWasEnabled = false;
     const display = document.getElementById('subtitle-display');
     if (!display) return;
     const subtitleText = document.getElementById('subtitle-text');
@@ -720,6 +741,11 @@ function writeSubtitleText(text) {
     if (!subtitleText) return;
     subtitleText.textContent = text || '';
     subtitleText.style.fontSize = '';
+    if (isSubtitleTemporarilySuppressed()) {
+        clearSubtitleDanmakuLayer();
+        syncSubtitleRenderState('subtitle-text-write-goodbye-suppressed');
+        return;
+    }
     var danmakuRendering = renderSubtitleDanmakuLayer(subtitleText.textContent);
     if (!danmakuRendering) {
         requestSubtitleContentAutoScroll();
@@ -897,8 +923,8 @@ function markIncrementalSentenceHandled(requestSnapId) {
 function updateIncrementalDisplay() {
     if (!subtitleEnabled) return;
     var fullText = incrementalTranslatedSentences.join(' ');
-    ensureSubtitleVisibleIfEnabled();
     writeSubtitleText(fullText);
+    ensureSubtitleVisibleIfEnabled();
 }
 
 function showSubtitleWithoutOriginalAndRestartCurrentTurn() {
@@ -931,6 +957,42 @@ function showSubtitleWithoutOriginalAndRestartCurrentTurn() {
         return;
     }
     updateSubtitleStreamingText(currentTurnOriginalText);
+}
+
+function suppressSubtitleForGoodbye() {
+    if (!isSubtitleTranslationOwner()) {
+        return;
+    }
+    subtitleGoodbyeSuppressWasEnabled = !!subtitleEnabled;
+    subtitleSuppressedByGoodbye = true;
+    hideSubtitleDisplayOnly('subtitle-goodbye-suppress');
+}
+
+function restoreSubtitleAfterGoodbye() {
+    if (!subtitleSuppressedByGoodbye) {
+        return;
+    }
+    var shouldRestoreVisible = !!subtitleEnabled || subtitleGoodbyeSuppressWasEnabled;
+    subtitleSuppressedByGoodbye = false;
+    subtitleGoodbyeSuppressWasEnabled = false;
+    if (shouldRestoreVisible && subtitleEnabled) {
+        showSubtitleWithoutOriginalAndRestartCurrentTurn();
+    } else {
+        syncSubtitleRenderState('subtitle-goodbye-restore-disabled');
+    }
+}
+
+function bindGoodbyeSubtitleVisibility() {
+    window.addEventListener('live2d-goodbye-click', suppressSubtitleForGoodbye);
+    var returnEvents = [
+        'live2d-return-click',
+        'vrm-return-click',
+        'mmd-return-click',
+        'pngtuber-return-click'
+    ];
+    returnEvents.forEach(function(eventName) {
+        window.addEventListener(eventName, restoreSubtitleAfterGoodbye);
+    });
 }
 
 /**
@@ -983,8 +1045,8 @@ function markSubtitleStructured() {
     const placeholder = getStructuredPlaceholder();
     currentTurnOriginalText = placeholder;
     if (!subtitleEnabled) return;
-    ensureSubtitleVisibleIfEnabled();
     writeSubtitleText(placeholder);
+    ensureSubtitleVisibleIfEnabled();
 }
 
 /**
@@ -1002,8 +1064,8 @@ function finalizeSubtitleAsStructured() {
     const placeholder = getStructuredPlaceholder();
     currentTurnOriginalText = placeholder;
     if (!subtitleEnabled) return;
-    ensureSubtitleVisibleIfEnabled();
     writeSubtitleText(placeholder);
+    ensureSubtitleVisibleIfEnabled();
 }
 
 /**
@@ -1229,6 +1291,7 @@ async function initSubtitleAfterStorageBarrier() {
     }
     syncSubtitleRenderState('subtitle-dom-ready');
     window.addEventListener('neko-assistant-turn-start', onAssistantTurnStart);
+    bindGoodbyeSubtitleVisibility();
 
     // 通用引导管理器：index.html / chat.html 都加载 subtitle.js，
     // 但自身模板没有 init 调用，历史上靠这里兜底（其他子页面模板各自 init）。

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -46,7 +46,6 @@ let subtitleEnabled = initialSubtitleSettings
         ? window.appState.subtitleEnabled
         : localStorage.getItem('subtitleEnabled') === 'true');
 let subtitleSuppressedByGoodbye = false;
-let subtitleGoodbyeSuppressWasEnabled = false;
 
 function isSubtitleTranslationOwner() {
     return !(window.__NEKO_MULTI_WINDOW__ &&
@@ -689,7 +688,6 @@ function ensureSubtitleVisibleIfEnabled() {
  * 把字幕显示元素隐藏并清空文字（开关关闭或手动 hideSubtitle 时使用）
  */
 function hideSubtitle() {
-    subtitleGoodbyeSuppressWasEnabled = false;
     const display = document.getElementById('subtitle-display');
     if (!display) return;
     const subtitleText = document.getElementById('subtitle-text');
@@ -963,7 +961,6 @@ function suppressSubtitleForGoodbye() {
     if (!isSubtitleTranslationOwner()) {
         return;
     }
-    subtitleGoodbyeSuppressWasEnabled = !!subtitleEnabled;
     subtitleSuppressedByGoodbye = true;
     hideSubtitleDisplayOnly('subtitle-goodbye-suppress');
 }
@@ -972,10 +969,8 @@ function restoreSubtitleAfterGoodbye() {
     if (!subtitleSuppressedByGoodbye) {
         return;
     }
-    var shouldRestoreVisible = !!subtitleEnabled || subtitleGoodbyeSuppressWasEnabled;
     subtitleSuppressedByGoodbye = false;
-    subtitleGoodbyeSuppressWasEnabled = false;
-    if (shouldRestoreVisible && subtitleEnabled) {
+    if (subtitleEnabled) {
         showSubtitleWithoutOriginalAndRestartCurrentTurn();
     } else {
         syncSubtitleRenderState('subtitle-goodbye-restore-disabled');
@@ -993,6 +988,7 @@ function bindGoodbyeSubtitleVisibility() {
     returnEvents.forEach(function(eventName) {
         window.addEventListener(eventName, restoreSubtitleAfterGoodbye);
     });
+    window.addEventListener('neko:goodbye-state-cleared', restoreSubtitleAfterGoodbye);
 }
 
 /**

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -1103,13 +1103,32 @@ def test_goodbye_temporarily_hides_subtitle_without_disabling_translation(
     result = mock_page.evaluate(
         """
         async () => {
-            await new Promise((resolve) => setTimeout(resolve, 0));
+            const waitFor = async (predicate, label) => {
+                const deadline = Date.now() + 1000;
+                while (Date.now() < deadline) {
+                    if (predicate()) return;
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+                }
+                throw new Error(`Timed out waiting for ${label}`);
+            };
+            await waitFor(
+                () => window.nekoSubtitleShared
+                    && window.subtitleBridge
+                    && document.getElementById('subtitle-display')
+                    && document.getElementById('subtitle-text'),
+                'subtitle setup'
+            );
             const shared = window.nekoSubtitleShared;
             const display = document.getElementById('subtitle-display');
             const text = document.getElementById('subtitle-text');
             window.subtitleBridge.setSubtitleEnabled(true, { source: 'test-enable' });
             window.subtitleBridge.markStructured();
-            await new Promise((resolve) => setTimeout(resolve, 0));
+            await waitFor(
+                () => shared.getRenderState().visible === true
+                    && display.classList.contains('hidden') === false
+                    && text.textContent.length > 0,
+                'subtitle visible before goodbye'
+            );
             const before = {
                 enabled: shared.getSettings().subtitleEnabled,
                 renderEnabled: shared.getRenderState().subtitleEnabled,
@@ -1119,7 +1138,12 @@ def test_goodbye_temporarily_hides_subtitle_without_disabling_translation(
             };
 
             window.dispatchEvent(new CustomEvent('live2d-goodbye-click'));
-            await new Promise((resolve) => setTimeout(resolve, 0));
+            await waitFor(
+                () => shared.getSettings().subtitleEnabled === true
+                    && shared.getRenderState().visible === false
+                    && display.classList.contains('hidden') === true,
+                'subtitle hidden during goodbye'
+            );
             const duringGoodbye = {
                 enabled: shared.getSettings().subtitleEnabled,
                 renderEnabled: shared.getRenderState().subtitleEnabled,
@@ -1129,7 +1153,12 @@ def test_goodbye_temporarily_hides_subtitle_without_disabling_translation(
             };
 
             window.dispatchEvent(new CustomEvent('live2d-return-click'));
-            await new Promise((resolve) => setTimeout(resolve, 0));
+            await waitFor(
+                () => shared.getRenderState().visible === true
+                    && display.classList.contains('hidden') === false
+                    && text.textContent === before.text,
+                'subtitle restored after return'
+            );
             const afterReturn = {
                 enabled: shared.getSettings().subtitleEnabled,
                 renderEnabled: shared.getRenderState().subtitleEnabled,
@@ -1137,26 +1166,52 @@ def test_goodbye_temporarily_hides_subtitle_without_disabling_translation(
                 hidden: display.classList.contains('hidden'),
                 text: text.textContent,
             };
-            return { before, duringGoodbye, afterReturn };
+
+            window.dispatchEvent(new CustomEvent('live2d-goodbye-click'));
+            await waitFor(
+                () => shared.getRenderState().visible === false
+                    && display.classList.contains('hidden') === true,
+                'subtitle hidden before character switch clear'
+            );
+            window.dispatchEvent(new CustomEvent('neko:goodbye-state-cleared', {
+                detail: { reason: 'character-switch' },
+            }));
+            await waitFor(
+                () => shared.getRenderState().visible === true
+                    && display.classList.contains('hidden') === false
+                    && text.textContent === before.text,
+                'subtitle restored after character switch clear'
+            );
+            const afterCharacterSwitchClear = {
+                enabled: shared.getSettings().subtitleEnabled,
+                renderEnabled: shared.getRenderState().subtitleEnabled,
+                visible: shared.getRenderState().visible,
+                hidden: display.classList.contains('hidden'),
+                text: text.textContent,
+            };
+            return { before, duringGoodbye, afterReturn, afterCharacterSwitchClear };
         }
         """
     )
 
+    subtitle_text = result["before"]["text"]
+    assert subtitle_text
     assert result["before"] == {
         "enabled": True,
         "renderEnabled": True,
         "visible": True,
         "hidden": False,
-        "text": "[markdown]",
+        "text": subtitle_text,
     }
     assert result["duringGoodbye"] == {
         "enabled": True,
         "renderEnabled": True,
         "visible": False,
         "hidden": True,
-        "text": "[markdown]",
+        "text": subtitle_text,
     }
     assert result["afterReturn"] == result["before"]
+    assert result["afterCharacterSwitchClear"] == result["before"]
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -1067,6 +1067,99 @@ def _open_subtitle_harness(
 
 
 @pytest.mark.frontend
+def test_goodbye_temporarily_hides_subtitle_without_disabling_translation(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <div id="subtitle-panel-controls" aria-hidden="true">
+                <button type="button" id="subtitle-lock-btn"></button>
+                <button type="button" id="subtitle-settings-btn"></button>
+                <button type="button" id="subtitle-close-btn"></button>
+            </div>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+        </div>
+        """,
+        path="/subtitle-goodbye-suppress-harness",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.fetch = () => Promise.resolve({
+                json: () => Promise.resolve({ success: true, language: 'zh' }),
+            });
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+    mock_page.evaluate("() => document.dispatchEvent(new Event('DOMContentLoaded'))")
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const shared = window.nekoSubtitleShared;
+            const display = document.getElementById('subtitle-display');
+            const text = document.getElementById('subtitle-text');
+            window.subtitleBridge.setSubtitleEnabled(true, { source: 'test-enable' });
+            window.subtitleBridge.markStructured();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const before = {
+                enabled: shared.getSettings().subtitleEnabled,
+                renderEnabled: shared.getRenderState().subtitleEnabled,
+                visible: shared.getRenderState().visible,
+                hidden: display.classList.contains('hidden'),
+                text: text.textContent,
+            };
+
+            window.dispatchEvent(new CustomEvent('live2d-goodbye-click'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const duringGoodbye = {
+                enabled: shared.getSettings().subtitleEnabled,
+                renderEnabled: shared.getRenderState().subtitleEnabled,
+                visible: shared.getRenderState().visible,
+                hidden: display.classList.contains('hidden'),
+                text: text.textContent,
+            };
+
+            window.dispatchEvent(new CustomEvent('live2d-return-click'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const afterReturn = {
+                enabled: shared.getSettings().subtitleEnabled,
+                renderEnabled: shared.getRenderState().subtitleEnabled,
+                visible: shared.getRenderState().visible,
+                hidden: display.classList.contains('hidden'),
+                text: text.textContent,
+            };
+            return { before, duringGoodbye, afterReturn };
+        }
+        """
+    )
+
+    assert result["before"] == {
+        "enabled": True,
+        "renderEnabled": True,
+        "visible": True,
+        "hidden": False,
+        "text": "[markdown]",
+    }
+    assert result["duringGoodbye"] == {
+        "enabled": True,
+        "renderEnabled": True,
+        "visible": False,
+        "hidden": True,
+        "text": "[markdown]",
+    }
+    assert result["afterReturn"] == result["before"]
+
+
+@pytest.mark.frontend
 def test_subtitle_danmaku_renderer_groups_every_two_punctuation_marks(
     mock_page: Page,
 ):


### PR DESCRIPTION
本 PR 优化“请她离开 / 变成猫形态”期间的翻译字幕框表现。

- 进入猫形态时，翻译字幕框会临时隐藏，降低前台打扰和显示消耗。
- 点击猫回来后，如果用户原本开启了翻译字幕，会按原状态恢复显示。
- 补充前端回归测试，覆盖“临时隐藏但不关闭翻译、译文保留、回来后恢复”。
- 将 `static/subtitle.js` 纳入静态资源版本指纹，避免页面继续加载旧缓存。

## 回归报告 / Regression Report

不适用。本 PR 未触碰 `app/`、`main_logic/`、`memory/`。

## 不拆分理由 / Why Not Split

不适用。计入上限的改动文件数 ≤ 20。

## 测试 / Testing

已验证：

- `node --check static\subtitle.js`
- `.\.venv\Scripts\python.exe -m py_compile main_routers\pages_router.py`
- `.\.venv\Scripts\python.exe -m pytest tests\frontend\test_subtitle_incremental.py -k goodbye_temporarily_hides_subtitle_without_disabling_translation`

测试结果：通过。

未跑全量测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * Live2D告别动画体验优化：当触发“告别”流程时，字幕会被临时隐藏；在返回/恢复后自动重新显示，并保持字幕内容不变，不影响字幕启用/禁用设置。

* **Bug Fixes**
  * 改善角色切换后的告别状态清理，确保字幕恢复与显示状态同步生效。

* **Tests**
  * 新增前端用例覆盖“告别期间不改变字幕文本”的场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->