### PR TITLE
fix: clear icebreaker route on reload

### DIFF
--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -44,7 +44,10 @@ from .shared_state import (
     get_session_id,
 )
 from .game_router import is_game_route_active, route_external_stream_message
-from utils.icebreaker_route_state import finalize_icebreaker_route
+from utils.icebreaker_route_state import (
+    finalize_icebreaker_route,
+    get_active_icebreaker_route_session_id,
+)
 
 router = APIRouter(tags=["websocket"])
 logger = get_module_logger(__name__, "Main")
@@ -510,11 +513,21 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
         async with _lock:
             session_id = get_session_id()
             is_current = session_id.get(lanlan_name) == this_session_id
+            icebreaker_session_id = ""
+            if is_current:
+                icebreaker_session_id = get_active_icebreaker_route_session_id(lanlan_name)
             if is_current:
                 session_id.pop(lanlan_name, None)
 
-        if is_current:
-            finalize_icebreaker_route(lanlan_name, reason="websocket_disconnect")
+        if is_current and icebreaker_session_id:
+            try:
+                finalize_icebreaker_route(
+                    lanlan_name,
+                    session_id=icebreaker_session_id,
+                    reason="websocket_disconnect",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[icebreaker] finalize on ws disconnect failed: %s", exc)
 
         if is_current and lanlan_name in session_manager:
             await session_manager[lanlan_name].cleanup(expected_websocket=websocket)

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -44,6 +44,7 @@ from .shared_state import (
     get_session_id,
 )
 from .game_router import is_game_route_active, route_external_stream_message
+from utils.icebreaker_route_state import finalize_icebreaker_route
 
 router = APIRouter(tags=["websocket"])
 logger = get_module_logger(__name__, "Main")
@@ -511,6 +512,9 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
             is_current = session_id.get(lanlan_name) == this_session_id
             if is_current:
                 session_id.pop(lanlan_name, None)
+
+        if is_current:
+            finalize_icebreaker_route(lanlan_name, reason="websocket_disconnect")
 
         if is_current and lanlan_name in session_manager:
             await session_manager[lanlan_name].cleanup(expected_websocket=websocket)

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -1087,11 +1087,6 @@
     window.addEventListener('unload', function () {
         endIcebreakerRouteOnPageExit('icebreaker_unload');
     });
-    document.addEventListener('visibilitychange', function () {
-        if (document.visibilityState === 'hidden') {
-            endIcebreakerRouteOnPageExit('icebreaker_visibility_hidden');
-        }
-    });
     window.addEventListener('neko:icebreaker-choice-selected', function (event) {
         handleChoice(event && event.detail);
     });

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -193,6 +193,54 @@
         });
     }
 
+    function endIcebreakerRouteOnPageExit(reason) {
+        var session = activeSession;
+        if (!session || session.routeEnded || !session.sessionId) return;
+        session.routeEnded = true;
+        var body = {
+            lanlan_name: resolveLanlanName(),
+            session_id: String(session.sessionId || ''),
+            i18n_language: currentLocale(),
+            reason: reason || 'icebreaker_page_exit',
+            postgameProactive: { enabled: false }
+        };
+        try {
+            var security = window.nekoLocalMutationSecurity;
+            if (security && typeof security.peekCachedToken === 'function') {
+                var token = security.peekCachedToken();
+                if (token) {
+                    body._csrf_token = token;
+                }
+            }
+        } catch (_) {}
+        var rawBody = JSON.stringify(body);
+        try {
+            if (navigator.sendBeacon && typeof Blob === 'function') {
+                if (navigator.sendBeacon(
+                    ICEBREAKER_API_BASE + '/route/end',
+                    new Blob([rawBody], { type: 'application/json' })
+                )) {
+                    return;
+                }
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] route lifecycle beacon failed:', error);
+        }
+        try {
+            fetch(ICEBREAKER_API_BASE + '/route/end', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                keepalive: true,
+                body: rawBody
+            }).catch(function (error) {
+                console.warn('[NewUserIcebreaker] route lifecycle keepalive failed:', error);
+            });
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] route lifecycle keepalive threw:', error);
+        }
+    }
+
     function loadScripts() {
         if (!scriptPromise) {
             scriptPromise = fetchJson(SCRIPT_URL);
@@ -1030,6 +1078,20 @@
     window.addEventListener('neko:avatar-floating-guide-skip', handleGuideEndEvent);
     window.addEventListener('neko:tutorial-completed', handleGuideEndEvent);
     window.addEventListener('neko:tutorial-skipped', handleGuideEndEvent);
+    window.addEventListener('pagehide', function () {
+        endIcebreakerRouteOnPageExit('icebreaker_pagehide');
+    });
+    window.addEventListener('beforeunload', function () {
+        endIcebreakerRouteOnPageExit('icebreaker_beforeunload');
+    });
+    window.addEventListener('unload', function () {
+        endIcebreakerRouteOnPageExit('icebreaker_unload');
+    });
+    document.addEventListener('visibilitychange', function () {
+        if (document.visibilityState === 'hidden') {
+            endIcebreakerRouteOnPageExit('icebreaker_visibility_hidden');
+        }
+    });
     window.addEventListener('neko:icebreaker-choice-selected', function (event) {
         handleChoice(event && event.detail);
     });

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -325,10 +325,20 @@ def test_icebreaker_route_is_separate_from_game_route_active_state():
 
 def test_icebreaker_route_is_finalized_when_renderer_websocket_disconnects():
     websocket_router = WEBSOCKET_ROUTER_PATH.read_text(encoding="utf-8")
-    cleanup_block = websocket_router.split('logger.info(f"Cleaning up WebSocket resources: {websocket.client}")', 1)[1]
+    cleanup_block = websocket_router.split('logger.info(f"Cleaning up WebSocket resources: {websocket.client}")', 1)[1].split(
+        "if is_current and lanlan_name in session_manager:",
+        1,
+    )[0]
 
     assert "finalize_icebreaker_route" in websocket_router
-    assert 'finalize_icebreaker_route(lanlan_name, reason="websocket_disconnect")' in cleanup_block
+    assert "get_active_icebreaker_route_session_id" in websocket_router
+    assert "icebreaker_session_id = get_active_icebreaker_route_session_id(lanlan_name)" in cleanup_block
+    assert "if is_current and icebreaker_session_id:" in cleanup_block
+    assert "try:" in cleanup_block
+    assert "finalize_icebreaker_route(" in cleanup_block
+    assert "session_id=icebreaker_session_id" in cleanup_block
+    assert 'reason="websocket_disconnect"' in cleanup_block
+    assert "except Exception as exc:" in cleanup_block
     assert "_get_active_game_route_state" not in cleanup_block
 
 
@@ -568,11 +578,11 @@ def test_icebreaker_unload_ends_active_route_without_completing_day():
     assert "window.addEventListener('pagehide', function () {" in runtime
     assert "window.addEventListener('beforeunload', function () {" in runtime
     assert "window.addEventListener('unload', function () {" in runtime
-    assert "document.addEventListener('visibilitychange', function () {" in runtime
     assert "endIcebreakerRouteOnPageExit('icebreaker_pagehide')" in runtime
     assert "endIcebreakerRouteOnPageExit('icebreaker_beforeunload')" in runtime
     assert "endIcebreakerRouteOnPageExit('icebreaker_unload')" in runtime
-    assert "endIcebreakerRouteOnPageExit('icebreaker_visibility_hidden')" in runtime
+    assert "icebreaker_visibility_hidden" not in runtime
+    assert "document.addEventListener('visibilitychange'" not in runtime
 
     cleanup_block = runtime.split("function endIcebreakerRouteOnPageExit(reason)", 1)[1].split(
         "function loadScripts()",

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -323,6 +323,15 @@ def test_icebreaker_route_is_separate_from_game_route_active_state():
     assert 'action="opened"' in game_router
 
 
+def test_icebreaker_route_is_finalized_when_renderer_websocket_disconnects():
+    websocket_router = WEBSOCKET_ROUTER_PATH.read_text(encoding="utf-8")
+    cleanup_block = websocket_router.split('logger.info(f"Cleaning up WebSocket resources: {websocket.client}")', 1)[1]
+
+    assert "finalize_icebreaker_route" in websocket_router
+    assert 'finalize_icebreaker_route(lanlan_name, reason="websocket_disconnect")' in cleanup_block
+    assert "_get_active_game_route_state" not in cleanup_block
+
+
 def test_icebreaker_context_reuses_existing_session_context_paths():
     core = (ROOT / "main_logic" / "core.py").read_text(encoding="utf-8")
 
@@ -548,6 +557,29 @@ def test_icebreaker_handoff_waits_for_context_append_before_route_end():
     assert handoff_block.index("return endIcebreakerRoute(session, 'icebreaker_handoff');") < handoff_block.index(
         "activeSession = null;"
     )
+
+
+def test_icebreaker_unload_ends_active_route_without_completing_day():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+
+    assert "function endIcebreakerRouteOnPageExit(reason)" in runtime
+    assert "navigator.sendBeacon" in runtime
+    assert "keepalive: true" in runtime
+    assert "window.addEventListener('pagehide', function () {" in runtime
+    assert "window.addEventListener('beforeunload', function () {" in runtime
+    assert "window.addEventListener('unload', function () {" in runtime
+    assert "document.addEventListener('visibilitychange', function () {" in runtime
+    assert "endIcebreakerRouteOnPageExit('icebreaker_pagehide')" in runtime
+    assert "endIcebreakerRouteOnPageExit('icebreaker_beforeunload')" in runtime
+    assert "endIcebreakerRouteOnPageExit('icebreaker_unload')" in runtime
+    assert "endIcebreakerRouteOnPageExit('icebreaker_visibility_hidden')" in runtime
+
+    cleanup_block = runtime.split("function endIcebreakerRouteOnPageExit(reason)", 1)[1].split(
+        "function loadScripts()",
+        1,
+    )[0]
+    assert "markDay(" not in cleanup_block
+    assert "completed" not in cleanup_block
 
 
 def test_icebreaker_waits_long_enough_for_react_chat_host():

--- a/utils/icebreaker_route_state.py
+++ b/utils/icebreaker_route_state.py
@@ -47,6 +47,11 @@ def is_icebreaker_route_active(lanlan_name: str) -> bool:
     return _get_active_icebreaker_route_state(lanlan_name) is not None
 
 
+def get_active_icebreaker_route_session_id(lanlan_name: str) -> str:
+    state = _get_active_icebreaker_route_state(lanlan_name)
+    return str(state.get("session_id") or "") if state else ""
+
+
 def activate_icebreaker_route(lanlan_name: str, session_id: str) -> dict:
     now = time.time()
     state = {


### PR DESCRIPTION
## 改动概述 / Summary
- 破冰运行中页面 `pagehide` / `beforeunload` / `unload` 时，用 `sendBeacon` / `fetch keepalive` 结束独立 icebreaker route，不写 completed，不推进教程天数。
- 在主 renderer WebSocket 断开且仍是当前 session 时，backend 兜底清理对应猫娘的独立 icebreaker route，避免 PC reload / 窗口重建后残留 active。
- WebSocket 兜底清理会带上断开时捕获到的 icebreaker session_id，避免极小竞态下误清新会话；清理失败也不会阻断后续 WebSocket cleanup。
- 增加静态契约测试，锁住破冰 route 不回到 game route、reload 不留下 active 的边界。

## 回归报告 / Regression Report
- 影响范围：`main_routers/websocket_router.py` 的 WebSocket cleanup 路径，以及 `static/tutorial/icebreaker/new-user-icebreaker.js` 的破冰页面退出清理。
- 必要性：实际手测发现 PC reload 时 Electron 不保证页面 unload 请求送达，backend `/api/icebreaker/route/state` 会残留 `icebreaker_active=true`；下一次 reload / 重连可能误判仍在破冰运行态。
- Before：破冰中 reload 后，旧 renderer WebSocket 断开但 icebreaker route 仍可能 active。
- After：前端在真实页面退出事件上尽力发 `/api/icebreaker/route/end`；若请求没送达，当前 renderer WebSocket 断开时 backend 会兜底 finalize 同一 icebreaker session 的 route。
- 回归点：普通 WebSocket 重连、教程/破冰 completed 标记、game route active 状态。当前实现只调用独立 `finalize_icebreaker_route`，不触碰 game route，也不写破冰 completed；不再使用 `visibilitychange:hidden`，避免最小化/切标签页时误结束 route。

## 不拆分理由 / Why Not Split
不适用，只有 4 个文件的小范围生命周期修复。

## 测试 / Testing
- `uv run pytest tests/unit/test_new_user_icebreaker_static_contracts.py -q -k 'websocket_disconnects or unload_ends_active_route or route_is_separate'`
- `uv run pytest tests/unit/test_icebreaker_router.py -q`
- `uv run python -m py_compile main_routers/websocket_router.py utils/icebreaker_route_state.py`
- `node --check static/tutorial/icebreaker/new-user-icebreaker.js`
- `git diff --check -- main_routers/websocket_router.py static/tutorial/icebreaker/new-user-icebreaker.js tests/unit/test_new_user_icebreaker_static_contracts.py utils/icebreaker_route_state.py`
- `uv run ruff check main_routers/websocket_router.py utils/icebreaker_route_state.py tests/unit/test_new_user_icebreaker_static_contracts.py`
- 手测：PC 破冰过程中 reload 后查询 `/api/icebreaker/route/state?lanlan_name=簡`，返回 `icebreaker_active=false`。

备注：`uv run pytest tests/unit/test_new_user_icebreaker_static_contracts.py -q` 在最新 `main` 上有一条既有失败：`test_react_chat_assets_use_react_chat_cache_version` 仍断言 `index.html` 加载 `/static/app-interpage.js?v={{ react_chat_asset_version }}`，与本 PR 无关，本 PR 未修改该资产契约。

Relates #1862


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复与改进**
  * 优化连接意外断开后的冰球引导会话收尾，确保会话状态被正确清理并带上断开原因。
  * 增强页面离开/卸载时的会话结束上报：在页面 `pagehide / beforeunload / unload` 触发时自动结束当前路由，并优先使用可靠上报方式（失败后回退到备用方案）。

* **测试**
  * 新增单元“静态契约”测试，覆盖断开收尾与页面卸载结束且不触发“完成天数”相关逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->