### PR TITLE
fix(icebreaker): stop auto-opening subtitle translation

### DIFF
--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -17,7 +17,6 @@
     var localePromises = Object.create(null);
     var icebreakerSortKeySeq = 0;
     var icebreakerBridgeTimestampSeq = 0;
-    var icebreakerSubtitlePanelOpenedSessionId = '';
     var contextAppendPromise = Promise.resolve();
 
     function safeJsonParse(raw, fallback) {
@@ -146,36 +145,6 @@
         return postIcebreakerRoute('/route/start', session, {
             source: SOURCE
         });
-    }
-
-    function openSubtitleTranslationForIcebreakerAssistantMessage() {
-        var opened = false;
-        try {
-            var bridge = window.subtitleBridge;
-            if (bridge && typeof bridge.setSubtitleEnabled === 'function') {
-                bridge.setSubtitleEnabled(true, {
-                    persist: false,
-                    source: 'new-user-icebreaker-auto-open'
-                });
-                opened = true;
-            }
-        } catch (error) {
-            console.warn('[NewUserIcebreaker] subtitle bridge open failed:', error);
-        }
-        try {
-            var host = window.reactChatWindowHost;
-            if (host && typeof host.setTranslateEnabled === 'function') {
-                host.setTranslateEnabled(true, {
-                    syncBridge: false,
-                    suppressHostEvent: true,
-                    persist: false
-                });
-                opened = true;
-            }
-        } catch (error) {
-            console.warn('[NewUserIcebreaker] subtitle host translation open failed:', error);
-        }
-        return opened;
     }
 
     function clearPendingStartDay(dayKey) {
@@ -467,19 +436,8 @@
         }
     }
 
-    function shouldOpenIcebreakerSubtitlePanelOnce() {
-        var sessionId = activeSession && activeSession.sessionId ? activeSession.sessionId : '';
-        if (!sessionId || icebreakerSubtitlePanelOpenedSessionId === sessionId) return false;
-        return true;
-    }
-
     function syncIcebreakerAssistantSubtitle(role, contextOk, text) {
         if (role !== 'assistant' || contextOk !== true) return;
-        if (shouldOpenIcebreakerSubtitlePanelOnce()) {
-            if (openSubtitleTranslationForIcebreakerAssistantMessage()) {
-                icebreakerSubtitlePanelOpenedSessionId = activeSession && activeSession.sessionId ? activeSession.sessionId : '';
-            }
-        }
         finalizeIcebreakerAssistantSubtitle(text);
     }
 

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -417,54 +417,35 @@ def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal
         1,
     )[0]
     assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
-    assert "openSubtitleTranslationForIcebreakerAssistantMessage()" in sync_block
-    assert "icebreakerSubtitlePanelOpenedSessionId = activeSession && activeSession.sessionId" in sync_block
+    assert "openSubtitleTranslationForIcebreakerAssistantMessage()" not in sync_block
+    assert "setSubtitleEnabled(true" not in sync_block
+    assert "setTranslateEnabled(true" not in sync_block
     assert "finalizeIcebreakerAssistantSubtitle(text);" in sync_block
 
 
-def test_icebreaker_assistant_message_auto_opens_subtitle_translation_panel():
+def test_icebreaker_assistant_message_does_not_auto_open_subtitle_translation_panel():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
-    chat_host = CHAT_HOST_PATH.read_text(encoding="utf-8")
 
-    assert "function openSubtitleTranslationForIcebreakerAssistantMessage()" in runtime
-    open_block = runtime.split("function openSubtitleTranslationForIcebreakerAssistantMessage()", 1)[1].split(
-        "function startIcebreakerRoute(session)",
-        1,
-    )[0]
-    assert "var opened = false;" in open_block
-    assert "window.subtitleBridge" in open_block
-    assert "bridge.setSubtitleEnabled(true, {" in open_block
-    assert "opened = true;" in open_block
-    assert "persist: false" in open_block
-    assert "window.reactChatWindowHost" in open_block
-    assert "host.setTranslateEnabled(true" in open_block
-    assert "console.warn('[NewUserIcebreaker] subtitle bridge open failed:'" in open_block
-    assert "console.warn('[NewUserIcebreaker] subtitle host translation open failed:'" in open_block
-    assert "return opened;" in open_block
+    assert "function openSubtitleTranslationForIcebreakerAssistantMessage()" not in runtime
+    assert "new-user-icebreaker-auto-open" not in runtime
+    assert "icebreakerSubtitlePanelOpenedSessionId" not in runtime
+    assert "shouldOpenIcebreakerSubtitlePanelOnce" not in runtime
 
     start_block = runtime.split("return startIcebreakerRoute(nextSession).then(function (started)", 1)[1].split(
         "activeSession = nextSession;",
         1,
     )[0]
-    assert "openSubtitleTranslationForIcebreakerAssistantMessage();" not in start_block
+    assert "setSubtitleEnabled(true" not in start_block
+    assert "setTranslateEnabled(true" not in start_block
 
     sync_block = runtime.split("function syncIcebreakerAssistantSubtitle(role, contextOk, text)", 1)[1].split(
         "function appendChatMessage(role, text, meta)",
         1,
     )[0]
     assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
-    assert "if (shouldOpenIcebreakerSubtitlePanelOnce()) {" in sync_block
-    assert "if (openSubtitleTranslationForIcebreakerAssistantMessage()) {" in sync_block
-    assert "icebreakerSubtitlePanelOpenedSessionId = activeSession && activeSession.sessionId" in sync_block
-    assert sync_block.index("openSubtitleTranslationForIcebreakerAssistantMessage()") < sync_block.index(
-        "finalizeIcebreakerAssistantSubtitle(text);"
-    )
-    open_once_block = runtime.split("function shouldOpenIcebreakerSubtitlePanelOnce()", 1)[1].split(
-        "function syncIcebreakerAssistantSubtitle",
-        1,
-    )[0]
-    assert "icebreakerSubtitlePanelOpenedSessionId === sessionId" in open_once_block
-    assert "icebreakerSubtitlePanelOpenedSessionId = sessionId;" not in open_once_block
+    assert "setSubtitleEnabled(true" not in sync_block
+    assert "setTranslateEnabled(true" not in sync_block
+    assert "finalizeIcebreakerAssistantSubtitle(text);" in sync_block
 
     append_message_block = runtime.split("function appendChatMessage(role, text, meta)", 1)[1].split(
         "function speakViaProjectTts",
@@ -475,27 +456,6 @@ def test_icebreaker_assistant_message_auto_opens_subtitle_translation_panel():
     assert "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);" in append_message_block
     assert append_message_block.index("return host.appendMessage(message);") < append_message_block.rindex(
         "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);"
-    )
-
-    assert "setTranslateEnabled: function (enabled, options)" in chat_host
-    set_translate_block = chat_host.split("function setTranslateEnabled(enabled, options)", 1)[1].split(
-        "function handleTranslateToggle()",
-        1,
-    )[0]
-    assert "var shouldPersist = requestOptions.persist !== false;" in set_translate_block
-    assert "bridge.setSubtitleEnabled(next, {" in set_translate_block
-    assert "persist: shouldPersist" in set_translate_block
-    assert "source: syncSource" in set_translate_block
-    assert "var synced = false;" in set_translate_block
-    assert "if (!synced && shouldPersist) {" in set_translate_block
-    assert "console.warn('[ReactChatWindow] subtitle shared update failed:'" in set_translate_block
-    assert "console.warn('[ReactChatWindow] localStorage subtitleEnabled persist failed:'" in set_translate_block
-    assert "console.warn('[ReactChatWindow] appSettings.saveSettings failed:'" in set_translate_block
-    assert set_translate_block.index("window.appSettings.saveSettings();") > set_translate_block.index(
-        "} catch (err) {"
-    )
-    assert set_translate_block.index("window.appSettings.saveSettings();") < set_translate_block.index(
-        "state.viewProps = Object.assign"
     )
 
 


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 调整破冰流程中的字幕翻译行为：破冰助手消息不再主动打开字幕翻译面板，而是尊重用户当前已有的字幕翻译开关状态。

同时更新破冰静态契约测试，明确防止后续重新引入“破冰自动开启翻译框”的行为。

## 回归报告 / Regression Report

不适用。本 PR 未触碰 `app/`、`main_logic/`、`memory/`。

## 不拆分理由 / Why Not Split

不适用。本 PR 仅改动 2 个相关文件，未超过拆分阈值。

## 测试 / Testing

- 通过：`node --check static/tutorial/icebreaker/new-user-icebreaker.js`
- 通过：相关破冰字幕静态契约测试 2 项
- 已运行：`tests/unit/test_new_user_icebreaker_static_contracts.py`
  - 结果：56 passed, 1 failed
  - 剩余失败为既有的 React 资源 cache version 契约问题，失败点是 `templates/index.html` 中 `/static/app-interpage.js` 的版本参数校验，和本 PR 的破冰字幕翻译改动无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了新用户助手消息场景中，字幕翻译面板不必要自动打开的问题。相关的自动启用逻辑已被移除，字幕翻译面板现在仅在特定条件满足时才会启用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->