### PR TITLE
延迟破冰对话选项展示时机，确保下一句 assistant 回复已出现并开始播放后再显示新选项，同时为偏题 fallback 后恢复选项补上…

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3545,6 +3545,12 @@
     function fetchGalgameOptionsForLatestTurn() {
         if (isGalgameModeTemporarilyDisabled()) return;
         if (!state.galgameModeEnabled) return;
+        // icebreaker 脚本选项激活期间不抢选项槽——含揭示延迟内 prompt 已就位、按钮尚未
+        // 露出（choicePrompt 非 null 但 getRevealedChoicePrompt 返回 null）的那段。否则
+        // icebreaker 台词的 turn-end 会触发 galgame A/B/C，在脚本选项露出前挤进同一槽位
+        // （Codex P2）。icebreaker 运行在 home tutorial 之外，galgameTemporarilyDisabled
+        // 此时并不覆盖它，故须单独按 choicePrompt 拦。
+        if (state.choicePrompt && state.choicePrompt.source === 'new_user_icebreaker') return;
         var history = getRecentGalgameMessageHistory();
         if (!history.length) return;
         if (history[history.length - 1].role !== 'assistant') return;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -2572,7 +2572,7 @@
             galgameModeEnabled: !!state.galgameModeEnabled,
             galgameOptions: Array.isArray(state.galgameOptions) ? state.galgameOptions : [],
             galgameOptionsLoading: !!state.galgameOptionsLoading,
-            choicePrompt: state.choicePrompt || null,
+            choicePrompt: getRevealedChoicePrompt(),
             onMessageAction: handleMessageAction,
             onComposerImportImage: handleComposerImportImage,
             onComposerScreenshot: handleComposerScreenshot,
@@ -3985,6 +3985,44 @@
         renderWindow();
     }
 
+    var choicePromptRevealTimer = null;
+
+    // icebreaker choicePrompt 的「视觉揭示」延迟：state.choicePrompt 一旦设置就立刻生效
+    // （handleComposerSubmit 据此把间隙内的自由文本判为 icebreaker free-text 而非普通
+    // 聊天），但带 revealAt 时，按钮要等到该时刻才传给 React 组件（见 getRevealedChoicePrompt
+    // + buildRenderProps）。延迟只藏按钮、不扣状态，这样既保留「选项晚于台词露出」的观感，
+    // 又不会重新打开间隙内输入落到普通聊天的窗口。
+    function scheduleChoicePromptReveal() {
+        if (choicePromptRevealTimer) {
+            window.clearTimeout(choicePromptRevealTimer);
+            choicePromptRevealTimer = null;
+        }
+        var prompt = state.choicePrompt;
+        if (!prompt || !prompt.revealAt) return;
+        var remaining = prompt.revealAt - Date.now();
+        if (remaining <= 0) {
+            prompt.revealAt = 0;
+            return;
+        }
+        choicePromptRevealTimer = window.setTimeout(function () {
+            choicePromptRevealTimer = null;
+            // 仅当同一个 prompt 仍在台上才揭示——期间被新 prompt 覆盖或清空则什么都不做。
+            if (state.choicePrompt === prompt) {
+                prompt.revealAt = 0;
+                renderWindow();
+            }
+        }, remaining);
+    }
+
+    // 渲染层取用的 choicePrompt：揭示时刻未到的 icebreaker prompt 先把按钮藏起来（返回
+    // null，视觉等同于尚未下发），其他 source 或已到点的照常返回。
+    function getRevealedChoicePrompt() {
+        var prompt = state.choicePrompt;
+        if (!prompt) return null;
+        if (prompt.revealAt && Date.now() < prompt.revealAt) return null;
+        return prompt;
+    }
+
     function setNewUserIcebreakerPrompt(payload) {
         if (!payload) return;
         var sessionId = String(payload.sessionId || '');
@@ -4002,13 +4040,16 @@
             console.warn('[NewUserIcebreaker] all options filtered out, skipping render', payload);
             return;
         }
+        var revealDelayMs = Number(payload.revealDelayMs) || 0;
         state.choicePrompt = {
             source: 'new_user_icebreaker',
             sessionId: sessionId,
             gameType: String(payload.gameType || 'new_user_icebreaker'),
-            options: cleanedOptions
+            options: cleanedOptions,
+            revealAt: revealDelayMs > 0 ? Date.now() + revealDelayMs : 0
         };
         invalidatePendingGalgameRequest();
+        scheduleChoicePromptReveal();
         renderWindow();
     }
 
@@ -4032,6 +4073,10 @@
         if (!state.choicePrompt || state.choicePrompt.source !== 'new_user_icebreaker') return false;
         if (sessionId && state.choicePrompt.sessionId !== String(sessionId)) return false;
         state.choicePrompt = null;
+        if (choicePromptRevealTimer) {
+            window.clearTimeout(choicePromptRevealTimer);
+            choicePromptRevealTimer = null;
+        }
         renderWindow();
         return true;
     }

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -302,15 +302,17 @@
         return Math.min(9000, Math.max(1400, value.length * 120));
     }
 
-    function waitBeforeChoicePromptReveal(text) {
+    // 选项揭示延迟：让选项按钮在 assistant 台词上屏、开始播放之后再露出，避免选项与
+    // 台词同时蹦出。注意这只是「视觉」延迟——choicePrompt 仍会立刻下发给 chat host 完成
+    // 输入路由绑定（host 据此把间隙内的自由文本判为 icebreaker free-text 而非普通聊天），
+    // 真正延后的只是按钮的可见性（host 按 revealDelayMs 计时露出）。延迟若改回「扣住
+    // choicePrompt 不下发」会重新打开间隙内输入落到普通聊天的窗口。
+    function computeChoicePromptRevealDelay(text) {
         var speechDuration = estimateSpeechDurationMs(text);
-        var delay = Math.min(
+        return Math.min(
             CHOICE_PROMPT_REVEAL_MAX_DELAY_MS,
             Math.max(CHOICE_PROMPT_REVEAL_MIN_DELAY_MS, speechDuration * CHOICE_PROMPT_REVEAL_SPEECH_RATIO)
         );
-        return new Promise(function (resolve) {
-            window.setTimeout(resolve, delay);
-        });
     }
 
     function resolveLanlanName() {
@@ -651,11 +653,12 @@
         });
     }
 
-    function setChoicePrompt(node, localeData) {
+    function setChoicePrompt(node, localeData, revealDelayMs) {
         var prompt = {
             sessionId: activeSession.sessionId,
             gameType: SOURCE,
-            options: buildPromptOptions(node, localeData)
+            options: buildPromptOptions(node, localeData),
+            revealDelayMs: revealDelayMs > 0 ? revealDelayMs : 0
         };
         broadcastIcebreakerChoicePrompt(prompt);
         if (!shouldRenderIcebreakerOnLocalChatHost()) {
@@ -762,10 +765,8 @@
         }).then(function () {
             if (activeSession !== session || session.nodeId !== nodeId) return false;
             speakLine(text, node.voiceKey || '');
-            return waitBeforeChoicePromptReveal(text).then(function () {
-                if (activeSession !== session || session.nodeId !== nodeId) return false;
-                return setChoicePrompt(node, localeData);
-            });
+            // 立刻下发 choicePrompt 绑定输入路由；按钮可见性由 host 按 revealDelayMs 延后。
+            return setChoicePrompt(node, localeData, computeChoicePromptRevealDelay(text));
         });
     }
 
@@ -907,12 +908,8 @@
                         ? session.dayConfig.nodes[nodeId]
                         : null;
                     if (currentNode) {
-                        return waitBeforeChoicePromptReveal(fallbackText).then(function () {
-                            if (activeSession === session && session.nodeId === nodeId) {
-                                return setChoicePrompt(currentNode, localeData);
-                            }
-                            return false;
-                        });
+                        // 同 deliverNode：立刻绑定路由，按钮可见性交给 host 延后揭示。
+                        return setChoicePrompt(currentNode, localeData, computeChoicePromptRevealDelay(fallbackText));
                     }
                 }
                 return null;

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -11,6 +11,9 @@
     var TRIGGER_WINDOW_MS = 2 * 60 * 1000;
     var PERSISTED_END_WINDOW_MS = 15 * 60 * 1000;
     var TUTORIAL_IDLE_RETRY_MS = 500;
+    var CHOICE_PROMPT_REVEAL_MIN_DELAY_MS = 700;
+    var CHOICE_PROMPT_REVEAL_MAX_DELAY_MS = 1400;
+    var CHOICE_PROMPT_REVEAL_SPEECH_RATIO = 0.18;
     var activeSession = null;
     var pendingStartDay = '';
     var scriptPromise = null;
@@ -297,6 +300,17 @@
         var value = String(text || '');
         if (!value) return 0;
         return Math.min(9000, Math.max(1400, value.length * 120));
+    }
+
+    function waitBeforeChoicePromptReveal(text) {
+        var speechDuration = estimateSpeechDurationMs(text);
+        var delay = Math.min(
+            CHOICE_PROMPT_REVEAL_MAX_DELAY_MS,
+            Math.max(CHOICE_PROMPT_REVEAL_MIN_DELAY_MS, speechDuration * CHOICE_PROMPT_REVEAL_SPEECH_RATIO)
+        );
+        return new Promise(function (resolve) {
+            window.setTimeout(resolve, delay);
+        });
     }
 
     function resolveLanlanName() {
@@ -726,26 +740,32 @@
 
     function deliverNode(nodeId) {
         if (!activeSession) return Promise.resolve();
-        var dayConfig = activeSession.dayConfig;
+        var session = activeSession;
+        var localeData = session.localeData;
+        var dayConfig = session.dayConfig;
         var node = dayConfig && dayConfig.nodes ? dayConfig.nodes[nodeId] : null;
         if (!node) return Promise.resolve();
-        activeSession.nodeId = nodeId;
-        markDay(activeSession.day, {
+        session.nodeId = nodeId;
+        markDay(session.day, {
             started: true,
             completed: false,
-            sessionId: activeSession.sessionId,
+            sessionId: session.sessionId,
             nodeId: nodeId,
             updatedAt: Date.now()
         });
-        var text = getText(activeSession.localeData, node.lineKey);
+        var text = getText(localeData, node.lineKey);
         applyAssistantTextEmotion(text);
         return appendChatMessage('assistant', text, {
-            day: activeSession.day,
+            day: session.day,
             nodeId: nodeId,
             voiceKey: node.voiceKey || ''
         }).then(function () {
+            if (activeSession !== session || session.nodeId !== nodeId) return false;
             speakLine(text, node.voiceKey || '');
-            return setChoicePrompt(node, activeSession.localeData);
+            return waitBeforeChoicePromptReveal(text).then(function () {
+                if (activeSession !== session || session.nodeId !== nodeId) return false;
+                return setChoicePrompt(node, localeData);
+            });
         });
     }
 
@@ -887,7 +907,12 @@
                         ? session.dayConfig.nodes[nodeId]
                         : null;
                     if (currentNode) {
-                        setChoicePrompt(currentNode, localeData);
+                        return waitBeforeChoicePromptReveal(fallbackText).then(function () {
+                            if (activeSession === session && session.nodeId === nodeId) {
+                                return setChoicePrompt(currentNode, localeData);
+                            }
+                            return false;
+                        });
                     }
                 }
                 return null;

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -558,15 +558,17 @@ def test_icebreaker_reveals_next_choice_prompt_after_assistant_line_delay():
     )[0]
 
     assert "var CHOICE_PROMPT_REVEAL_MIN_DELAY_MS = 700;" in runtime
-    assert "function waitBeforeChoicePromptReveal(text)" in runtime
+    assert "function computeChoicePromptRevealDelay(text)" in runtime
     assert "var session = activeSession;" in deliver_node_block
     assert "var localeData = session.localeData;" in deliver_node_block
     assert "if (activeSession !== session || session.nodeId !== nodeId) return false;" in deliver_node_block
+    # 揭示延迟改为「只扣视觉」：choicePrompt 立刻下发（绑定输入路由），延迟值随
+    # revealDelayMs 交给 chat host 按 revealAt 延后露出按钮。deliverNode 不再用
+    # promise 把 setChoicePrompt 整体往后拖，避免间隙内输入落到普通聊天。
+    assert "waitBeforeChoicePromptReveal" not in runtime
+    assert "return setChoicePrompt(node, localeData, computeChoicePromptRevealDelay(text));" in deliver_node_block
     assert deliver_node_block.index("speakLine(text, node.voiceKey || '');") < deliver_node_block.index(
-        "return waitBeforeChoicePromptReveal(text).then(function ()"
-    )
-    assert deliver_node_block.index("return waitBeforeChoicePromptReveal(text).then(function ()") < deliver_node_block.index(
-        "return setChoicePrompt(node, localeData);"
+        "return setChoicePrompt(node, localeData, computeChoicePromptRevealDelay(text));"
     )
 
 
@@ -884,11 +886,9 @@ def test_icebreaker_free_text_fallback_uses_session_snapshot_after_async_append(
     assert "nodeId: nodeId" in continuation_block
     assert "sessionId: sessionId" in continuation_block
     assert "var currentNode = session.dayConfig && session.dayConfig.nodes" in continuation_block
-    assert "waitBeforeChoicePromptReveal(fallbackText)" in continuation_block
-    assert "setChoicePrompt(currentNode, localeData)" in continuation_block
-    assert continuation_block.index("waitBeforeChoicePromptReveal(fallbackText)") < continuation_block.index(
-        "setChoicePrompt(currentNode, localeData)"
-    )
+    # fallback 同 deliverNode：立刻下发带 revealDelayMs 的 choicePrompt 绑定路由，
+    # 不再用 waitBeforeChoicePromptReveal 整体延后调用。
+    assert "setChoicePrompt(currentNode, localeData, computeChoicePromptRevealDelay(fallbackText))" in continuation_block
     assert "activeSession.localeData" not in continuation_block
     assert "activeSession.day" not in continuation_block
     assert "activeSession.nodeId" not in continuation_block

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -550,6 +550,26 @@ def test_icebreaker_choice_submission_is_mutexed_and_restores_prompt_on_failure(
     assert "setChoicePrompt(node, session.localeData);" in handle_choice_block
 
 
+def test_icebreaker_reveals_next_choice_prompt_after_assistant_line_delay():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+    deliver_node_block = runtime.split("function deliverNode(nodeId)", 1)[1].split(
+        "function completeWithHandoff(option)",
+        1,
+    )[0]
+
+    assert "var CHOICE_PROMPT_REVEAL_MIN_DELAY_MS = 700;" in runtime
+    assert "function waitBeforeChoicePromptReveal(text)" in runtime
+    assert "var session = activeSession;" in deliver_node_block
+    assert "var localeData = session.localeData;" in deliver_node_block
+    assert "if (activeSession !== session || session.nodeId !== nodeId) return false;" in deliver_node_block
+    assert deliver_node_block.index("speakLine(text, node.voiceKey || '');") < deliver_node_block.index(
+        "return waitBeforeChoicePromptReveal(text).then(function ()"
+    )
+    assert deliver_node_block.index("return waitBeforeChoicePromptReveal(text).then(function ()") < deliver_node_block.index(
+        "return setChoicePrompt(node, localeData);"
+    )
+
+
 def test_icebreaker_handoff_waits_for_context_append_before_route_end():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
     handoff_block = runtime.split("function completeWithHandoff(option)", 1)[1].split(
@@ -864,6 +884,7 @@ def test_icebreaker_free_text_fallback_uses_session_snapshot_after_async_append(
     assert "nodeId: nodeId" in continuation_block
     assert "sessionId: sessionId" in continuation_block
     assert "var currentNode = session.dayConfig && session.dayConfig.nodes" in continuation_block
+    assert "waitBeforeChoicePromptReveal(fallbackText)" in continuation_block
     assert "setChoicePrompt(currentNode, localeData)" in continuation_block
     assert "activeSession.localeData" not in continuation_block
     assert "activeSession.day" not in continuation_block

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -886,6 +886,9 @@ def test_icebreaker_free_text_fallback_uses_session_snapshot_after_async_append(
     assert "var currentNode = session.dayConfig && session.dayConfig.nodes" in continuation_block
     assert "waitBeforeChoicePromptReveal(fallbackText)" in continuation_block
     assert "setChoicePrompt(currentNode, localeData)" in continuation_block
+    assert continuation_block.index("waitBeforeChoicePromptReveal(fallbackText)") < continuation_block.index(
+        "setChoicePrompt(currentNode, localeData)"
+    )
     assert "activeSession.localeData" not in continuation_block
     assert "activeSession.day" not in continuation_block
     assert "activeSession.nodeId" not in continuation_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1269,8 +1269,8 @@ def test_new_user_icebreaker_prompt_is_exposed_by_react_host():
 
 
 def test_icebreaker_choice_prompt_reveal_delay_hides_buttons_not_state():
-    """揭示延迟必须只藏按钮、不扣 state.choicePrompt——否则间隙内的自由文本会绕过
-    icebreaker free-text 路由落到普通聊天。"""
+    # 揭示延迟必须只藏按钮、不扣 state.choicePrompt——否则间隙内的自由文本会绕过
+    # icebreaker free-text 路由落到普通聊天。
     react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 
     # 渲染层走 getRevealedChoicePrompt（揭示未到点返回 null 藏按钮）；输入路由仍直接
@@ -1295,6 +1295,14 @@ def test_icebreaker_choice_prompt_reveal_delay_hides_buttons_not_state():
         1,
     )[0]
     assert "if (state.choicePrompt === prompt)" in schedule_block
+
+    # galgame 选项拉取必须在 icebreaker prompt 激活（含揭示延迟内已就位但未露出）时让位，
+    # 否则 turn-end 会把 galgame A/B/C 挤进尚未露出 icebreaker 选项的同一槽位（Codex P2）。
+    galgame_fetch_block = react_host.split("function fetchGalgameOptionsForLatestTurn()", 1)[1].split(
+        "function ",
+        1,
+    )[0]
+    assert "if (state.choicePrompt && state.choicePrompt.source === 'new_user_icebreaker') return;" in galgame_fetch_block
 
 
 def test_new_user_icebreaker_choice_listener_posts_context():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1261,6 +1261,40 @@ def test_new_user_icebreaker_prompt_is_exposed_by_react_host():
     assert "function setChoicePrompt(payload)" in react_host
     assert "setChoicePrompt: setChoicePrompt" in react_host
     assert "setNewUserIcebreakerPrompt: setNewUserIcebreakerPrompt" in react_host
+    # 揭示延迟「只扣视觉」：prompt 立刻入 state（绑定输入路由），按 revealDelayMs
+    # 记下 revealAt 并交给计时器延后露出按钮。
+    assert "var revealDelayMs = Number(payload.revealDelayMs) || 0;" in prompt_block
+    assert "revealAt: revealDelayMs > 0 ? Date.now() + revealDelayMs : 0" in prompt_block
+    assert "scheduleChoicePromptReveal();" in prompt_block
+
+
+def test_icebreaker_choice_prompt_reveal_delay_hides_buttons_not_state():
+    """揭示延迟必须只藏按钮、不扣 state.choicePrompt——否则间隙内的自由文本会绕过
+    icebreaker free-text 路由落到普通聊天。"""
+    react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    # 渲染层走 getRevealedChoicePrompt（揭示未到点返回 null 藏按钮）；输入路由仍直接
+    # 读 state.choicePrompt，所以间隙内打字会被判为 icebreaker free-text。
+    assert "function getRevealedChoicePrompt()" in react_host
+    assert "choicePrompt: getRevealedChoicePrompt()," in react_host
+    reveal_block = react_host.split("function getRevealedChoicePrompt()", 1)[1].split(
+        "function setNewUserIcebreakerPrompt",
+        1,
+    )[0]
+    assert "if (prompt.revealAt && Date.now() < prompt.revealAt) return null;" in reveal_block
+
+    submit_block = react_host.split("function handleComposerSubmit(payload)", 1)[1].split(
+        "function prepareCompactHistoryDropSubmit",
+        1,
+    )[0]
+    assert "if (state.choicePrompt && state.choicePrompt.source === 'new_user_icebreaker')" in submit_block
+
+    # 计时器只在同一个 prompt 仍在台上时才揭示，避免延迟期间被覆盖/清空后揭示过期选项。
+    schedule_block = react_host.split("function scheduleChoicePromptReveal()", 1)[1].split(
+        "function getRevealedChoicePrompt",
+        1,
+    )[0]
+    assert "if (state.choicePrompt === prompt)" in schedule_block
 
 
 def test_new_user_icebreaker_choice_listener_posts_context():


### PR DESCRIPTION
…相同延迟与回归测试

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

延迟破冰对话选项展示时机

## 测试 / Testing

手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 选择提示的可见揭示现在支持按语音/文本长度计算延迟：在揭示时间到达前先隐藏选项按钮，避免过早出现。
  * 冰霜破冰期间会拦截同槽位选项填充，防止延迟内选项被抢占或混入。

* **体验优化**
  * 在会话切换与节点不一致时，保证延迟揭示只对仍匹配的节点生效。

* **测试**
  * 新增与更新单元测试，覆盖延迟揭示、自由文本兜底路径及定时触发条件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->