### PR TITLE
[codex] Expand plugin detail surfaces

### DIFF
--- a/frontend/plugin-manager/src/views/PluginDetail.vue
+++ b/frontend/plugin-manager/src/views/PluginDetail.vue
@@ -44,10 +44,10 @@
                 :label="surface.title || surface.id"
                 :name="surface.id"
               >
-                <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" height="560px" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
+                <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="pluginSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
             </el-tabs>
-            <HostedSurfaceFrame v-else :plugin-id="pluginId" :surface="panelSurfaces[0]!" height="560px" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
+            <HostedSurfaceFrame v-else :plugin-id="pluginId" :surface="panelSurfaces[0]!" :height="pluginSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
           </div>
         </el-tab-pane>
 
@@ -75,15 +75,15 @@
                 :label="surface.title || surface.id"
                 :name="surface.id"
               >
-                <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" height="560px" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
+                <HostedSurfaceFrame :plugin-id="pluginId" :surface="surface" :height="pluginSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
               </el-tab-pane>
             </el-tabs>
-            <HostedSurfaceFrame v-else :plugin-id="pluginId" :surface="guideSurfaces[0]!" height="560px" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
+            <HostedSurfaceFrame v-else :plugin-id="pluginId" :surface="guideSurfaces[0]!" :height="pluginSurfaceFrameHeight" @open-logs="openLogsTab" @message="relayHostedSurfaceMessageToStaticUi" />
           </div>
         </el-tab-pane>
 
         <el-tab-pane v-if="hasStaticUI" :label="$t('plugins.ui.title')" name="ui">
-          <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" height="560px" @open-surface="openHostedSurfaceFromStaticUi" />
+          <PluginUIFrame ref="staticUiFrameRef" :plugin-id="pluginId" :height="pluginSurfaceFrameHeight" @open-surface="openHostedSurfaceFromStaticUi" />
         </el-tab-pane>
 
         <el-tab-pane :label="$t('plugins.basicInfo')" name="info">
@@ -199,6 +199,7 @@ const surfaceWarnings = ref<PluginUiWarning[]>([])
 const activePanelSurfaceId = ref('')
 const activeGuideSurfaceId = ref('')
 const staticUiFrameRef = ref<InstanceType<typeof PluginUIFrame> | null>(null)
+const pluginSurfaceFrameHeight = 'max(560px, calc(100vh - 320px))'
 const allowedTabs = new Set(['panel', 'guide', 'ui', 'info', 'entries', 'metrics', 'config', 'logs'])
 const studySurfaceRelayMessageTypes = new Set([
   'neko-study-review-completed',

--- a/tests/unit/test_plugin_manager_detail_layout.py
+++ b/tests/unit/test_plugin_manager_detail_layout.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_plugin_detail_surfaces_use_responsive_viewport_height():
+    source = Path("frontend/plugin-manager/src/views/PluginDetail.vue").read_text(encoding="utf-8")
+
+    assert "const pluginSurfaceFrameHeight = 'max(560px, calc(100vh - 320px))'" in source
+    assert 'height="560px"' not in source
+    assert source.count(":height=\"pluginSurfaceFrameHeight\"") == 5

--- a/tests/unit/test_plugin_manager_detail_layout.py
+++ b/tests/unit/test_plugin_manager_detail_layout.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 
 def test_plugin_detail_surfaces_use_responsive_viewport_height():
-    source = Path("frontend/plugin-manager/src/views/PluginDetail.vue").read_text(encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[2]
+    source = (repo_root / "frontend/plugin-manager/src/views/PluginDetail.vue").read_text(encoding="utf-8")
 
     assert "const pluginSurfaceFrameHeight = 'max(560px, calc(100vh - 320px))'" in source
     assert 'height="560px"' not in source


### PR DESCRIPTION
﻿## Summary
- Make plugin detail panel, guide, and legacy UI frames use a viewport-aware height instead of a fixed 560px.
- Keep 560px as the minimum height so smaller windows retain the previous usable area.
- Add a static regression test that prevents plugin detail surfaces from reverting to fixed-height iframe containers.

## Root Cause
Plugin detail surfaces were hard-coded to `height="560px"`. In a fullscreen plugin manager window, the outer detail card could grow while the embedded plugin surface stayed fixed, leaving a large empty area below the panel.

## Validation
- `uv run pytest tests/unit/test_plugin_manager_detail_layout.py -q`
- `npm run type-check`
- `npm run build-only`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 插件详情页面现已支持响应式高度布局：面板与引导标签页的容器不再使用固定高度，而是根据视口尺寸动态调整（同时统一相关静态容器的高度计算）。

* **Tests**
  * 新增单元测试，验证源码使用了响应式视口高度表达式，并确认移除固定高度设置及正确复用动态高度绑定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->