### PR TITLE
[codex] Fix badminton quick-line localization

### DIFF
--- a/config/prompts/prompts_badminton.py
+++ b/config/prompts/prompts_badminton.py
@@ -1,0 +1,413 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Badminton minigame prompt and quick-line fallback templates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils.language_utils import normalize_language_code
+
+
+NEKO_CORE_LOCALES = ("zh-CN", "zh-TW", "en", "ja", "ko", "ru", "es", "pt")
+
+BADMINTON_QUICK_LINE_KEYS = frozenset({
+    "line_in", "net_touch", "zone_in", "out", "net",
+    "shot_missed", "game_over", "long_aim", "close_to_record",
+    "new_record", "streak_5", "streak_10", "streak_15", "streak_20",
+})
+
+_LANGUAGE_ALIASES = {
+    "zh": "zh-CN",
+    "zh-cn": "zh-CN",
+    "zh-hans": "zh-CN",
+    "schinese": "zh-CN",
+    "zh-tw": "zh-TW",
+    "zh-hk": "zh-TW",
+    "zh-hant": "zh-TW",
+    "tchinese": "zh-TW",
+    "en-us": "en",
+    "english": "en",
+    "ja-jp": "ja",
+    "japanese": "ja",
+    "ko-kr": "ko",
+    "korean": "ko",
+    "koreana": "ko",
+    "ru-ru": "ru",
+    "russian": "ru",
+    "es-es": "es",
+    "spanish": "es",
+    "latam": "es",
+    "pt-br": "pt",
+    "pt-pt": "pt",
+    "portuguese": "pt",
+    "brazilian": "pt",
+}
+
+
+def normalize_badminton_prompt_locale(language: Any) -> str:
+    raw = str(language or "").strip().lower().replace("_", "-")
+    if not raw:
+        return "zh-CN"
+    if raw in _LANGUAGE_ALIASES:
+        return _LANGUAGE_ALIASES[raw]
+    try:
+        full = normalize_language_code(str(language), format="full")
+    except Exception:
+        full = ""
+    if full in NEKO_CORE_LOCALES:
+        return full
+    try:
+        short = normalize_language_code(str(language), format="short")
+    except Exception:
+        short = ""
+    if short in _LANGUAGE_ALIASES:
+        return _LANGUAGE_ALIASES[short]
+    if short in {"en", "ja", "ko", "ru", "es", "pt"}:
+        return short
+    return "en"
+
+
+def _normalize_mode(mode: Any) -> str:
+    mode_name = str(mode or "").strip().lower()
+    if mode_name.startswith("shooter"):
+        return "shooter"
+    if mode_name.startswith("duel"):
+        return "duel"
+    if mode_name.startswith("timed"):
+        return "timed"
+    if mode_name.startswith("horse"):
+        return "horse"
+    return "spectator"
+
+
+BADMINTON_QUICK_LINES_PROMPTS = {
+    "zh-CN": """\
+你是{name}，{personality}
+
+你正在为羽毛球小游戏生成快路径短台词。只输出 JSON，不要 Markdown，不要解释。
+规则：
+- 每个必需 key 输出 2-4 条短台词。
+- 台词必须像 NEKO 的现场反应，不要像系统旁白。
+- 不要输出 mood、expression、intensity 或控制 JSON。
+
+必需 keys:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+    "zh-TW": """\
+你是{name}，{personality}
+
+你正在為羽毛球小遊戲產生快路徑短台詞。只輸出 JSON，不要 Markdown，不要解釋。
+規則：
+- 每個必要 key 輸出 2-4 句短台詞。
+- 台詞必須像 NEKO 的現場反應，不要像系統旁白。
+- 不要輸出 mood、expression、intensity 或控制 JSON。
+
+必要 keys:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+    "en": """\
+You are {name}. {personality}
+
+Generate quick-path short lines for the badminton minigame. Output JSON only, with no Markdown or explanation.
+Rules:
+- Each required key must contain 2-4 short spoken lines.
+- Lines must sound like NEKO reacting in the moment, not system narration.
+- Do not include mood, expression, intensity, or control JSON.
+
+Required keys:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+    "ja": """\
+あなたは{name}です。{personality}
+
+バドミントンミニゲーム用のクイック短台詞を生成してください。Markdown や説明なしで JSON だけを出力してください。
+ルール:
+- 必須 key ごとに 2-4 個の短い台詞を入れる。
+- 台詞はシステム説明ではなく、NEKO のその場の反応にする。
+- mood、expression、intensity、制御 JSON は入れない。
+
+必須 keys:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+    "ko": """\
+당신은 {name}입니다. {personality}
+
+배드민턴 미니게임용 빠른 경로 짧은 대사를 생성하세요. Markdown 이나 설명 없이 JSON 만 출력하세요.
+규칙:
+- 필수 key마다 짧은 대사 2-4개를 넣으세요.
+- 대사는 시스템 설명이 아니라 NEKO의 현장 반응처럼 들려야 합니다.
+- mood, expression, intensity, 제어 JSON 을 포함하지 마세요.
+
+필수 keys:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+    "ru": """\
+Ты {name}. {personality}
+
+Сгенерируй короткие быстрые реплики для мини-игры в бадминтон. Выводи только JSON, без Markdown и объяснений.
+Правила:
+- Для каждого обязательного key дай 2-4 короткие реплики.
+- Реплики должны звучать как реакция NEKO в моменте, а не как системное описание.
+- Не добавляй mood, expression, intensity или управляющий JSON.
+
+Обязательные keys:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+    "es": """\
+Eres {name}. {personality}
+
+Genera frases cortas de ruta rápida para el minijuego de bádminton. Devuelve solo JSON, sin Markdown ni explicaciones.
+Reglas:
+- Cada key obligatorio debe tener 2-4 frases breves.
+- Las frases deben sonar como una reacción inmediata de NEKO, no como narración del sistema.
+- No incluyas mood, expression, intensity ni JSON de control.
+
+Keys obligatorios:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+    "pt": """\
+Você é {name}. {personality}
+
+Gere falas curtas de caminho rápido para o minijogo de badminton. Retorne apenas JSON, sem Markdown nem explicações.
+Regras:
+- Cada key obrigatório deve ter 2-4 falas curtas.
+- As falas devem soar como reação imediata da NEKO, não como narração do sistema.
+- Não inclua mood, expression, intensity nem JSON de controle.
+
+Keys obrigatórios:
+line_in, net_touch, zone_in, out, net, shot_missed, game_over, long_aim, close_to_record, new_record, streak_5, streak_10, streak_15, streak_20
+""",
+}
+
+BADMINTON_QUICK_LINES_USER_PROMPT = {
+    "zh-CN": "生成羽毛球小游戏快路径短台词 JSON。",
+    "zh-TW": "生成羽毛球小遊戲快路徑短台詞 JSON。",
+    "en": "Generate badminton minigame quick-path short-line JSON.",
+    "ja": "バドミントンミニゲーム用のクイック短台詞 JSON を生成してください。",
+    "ko": "배드민턴 미니게임용 빠른 경로 짧은 대사 JSON 을 생성하세요.",
+    "ru": "Сгенерируй JSON коротких быстрых реплик для бадминтонной мини-игры.",
+    "es": "Genera JSON de frases cortas de ruta rápida para el minijuego de bádminton.",
+    "pt": "Gere JSON de falas curtas de caminho rápido para o minijogo de badminton.",
+}
+
+_MODE_LABELS = {
+    "zh-CN": "当前模式",
+    "zh-TW": "目前模式",
+    "en": "Current mode",
+    "ja": "現在のモード",
+    "ko": "현재 모드",
+    "ru": "Текущий режим",
+    "es": "Modo actual",
+    "pt": "Modo atual",
+}
+
+_MODE_SUFFIXES = {
+    "duel": {
+        "zh-CN": "\n当前模式是 duel：你和玩家轮流击球，围绕比分、对拉节奏和胜负压力写台词。",
+        "zh-TW": "\n目前模式是 duel 對拉：你和玩家輪流擊球，圍繞比分、對拉節奏和勝負壓力寫台詞。",
+        "en": "\nCurrent mode is duel: you and the player take turns hitting, so focus on score pressure, rally rhythm, and competitive tension.",
+        "ja": "\n現在のモードは duel です。あなたとプレイヤーが交互に打つため、得点の圧力、ラリーのリズム、勝負感を中心にしてください。",
+        "ko": "\n현재 모드는 duel 입니다. 당신과 플레이어가 번갈아 치므로 점수 압박, 랠리 리듬, 승부 긴장감에 집중하세요.",
+        "ru": "\nТекущий режим — duel: ты и игрок бьете по очереди, поэтому фокусируйся на счете, ритме розыгрыша и соревновательном напряжении.",
+        "es": "\nEl modo actual es duel: tú y el jugador golpean por turnos, así que céntrate en el marcador, el ritmo del intercambio y la presión competitiva.",
+        "pt": "\nO modo atual é duel: você e o jogador rebatem em turnos, então foque no placar, ritmo da troca e tensão competitiva.",
+    },
+    "shooter": {
+        "zh-CN": "\n当前模式是 shooter：玩家控制 Yui 的瞄准、力度和出手，台词要评价玩家的操作。",
+        "zh-TW": "\n目前模式是 shooter：玩家控制 Yui 的瞄準、力度和出手，台詞要評價玩家的操作。",
+        "en": "\nCurrent mode is shooter: the player controls Yui's aim, power, and release, so lines should evaluate the player's control skill rather than Yui's own skill.",
+        "ja": "\n現在のモードは shooter です。プレイヤーが Yui の狙い、力加減、リリースを操作するため、プレイヤーの操作技術を評価してください。",
+        "ko": "\n현재 모드는 shooter 입니다. 플레이어가 Yui 의 조준, 힘, 릴리즈를 조작하므로 플레이어의 조작 실력을 평가하세요.",
+        "ru": "\nТекущий режим — shooter: игрок управляет прицелом, силой и релизом Yui, поэтому оценивай управление игрока.",
+        "es": "\nEl modo actual es shooter: el jugador controla la puntería, fuerza y lanzamiento de Yui, así que evalúa el control del jugador.",
+        "pt": "\nO modo atual é shooter: o jogador controla mira, força e soltura da Yui, então avalie o controle do jogador.",
+    },
+    "timed": {
+        "zh-CN": "\n当前模式是 timed：短台词要围绕倒计时、限时冲分、命中节奏，不要提三次机会。",
+        "zh-TW": "\n目前模式是 timed：短台詞要圍繞倒數、限時衝分、命中節奏，不要提三次機會。",
+        "en": "\nCurrent mode is timed: focus on countdown pressure, time-attack scoring, and shot rhythm; do not mention three chances.",
+        "ja": "\n現在のモードは timed です。カウントダウン、制限時間内の得点、返球リズムを中心にし、3 回のチャンスには触れないでください。",
+        "ko": "\n현재 모드는 timed 입니다. 카운트다운 압박, 제한 시간 득점, 타구 리듬에 집중하고 세 번의 기회는 언급하지 마세요.",
+        "ru": "\nТекущий режим — timed: фокусируйся на таймере, наборе очков за время и ритме ударов; не упоминай три попытки.",
+        "es": "\nEl modo actual es timed: céntrate en la cuenta atrás, puntuar contra reloj y el ritmo de golpeo; no menciones tres oportunidades.",
+        "pt": "\nO modo atual é timed: foque na contagem regressiva, pontuação contra o tempo e ritmo das rebatidas; não mencione três chances.",
+    },
+    "horse": {
+        "zh-CN": "\n当前模式是 HORSE：聚焦出题、复刻、字母惩罚和轮到谁，不要写成比分对战。",
+        "zh-TW": "\n目前模式是 HORSE：聚焦出題、複刻、字母懲罰和輪到誰，不要寫成比分對戰。",
+        "en": "\nCurrent mode is HORSE: focus on setting shots, copying shots, letter penalties, and whose turn it is; do not write scoreboard lines.",
+        "ja": "\n現在のモードは HORSE です。出題、再現、文字ペナルティ、誰の番かを中心にし、点数勝負として書かないでください。",
+        "ko": "\n현재 모드는 HORSE 입니다. 문제 내기, 따라 하기, 글자 벌칙, 누구 차례인지에 집중하고 점수 대결처럼 쓰지 마세요.",
+        "ru": "\nТекущий режим — HORSE: фокусируйся на задании удара, повторении, штрафных буквах и очереди хода; не пиши как игру по счету.",
+        "es": "\nEl modo actual es HORSE: céntrate en proponer golpes, copiarlos, letras de penalización y de quién es el turno; no lo escribas como marcador.",
+        "pt": "\nO modo atual é HORSE: foque em criar rebatidas, copiá-las, penalidades de letras e de quem é a vez; não escreva como placar.",
+    },
+}
+
+BADMINTON_QUICK_LINES_FALLBACKS = {
+    "zh-CN": {
+        "line_in": ["贴线了，算你准", "这球压得挺好"],
+        "net_touch": ["擦网偷过去了", "这角度有点险"],
+        "zone_in": ["刚好进区", "落点挺会挑"],
+        "out": ["差一点出去了", "这拍有点长"],
+        "net": ["被网挡住了", "拍面再抬一点"],
+        "shot_missed": ["没事，下一拍", "别急，先看准"],
+        "game_over": ["这局到这儿", "还要再打一局吗"],
+        "long_aim": ["再不挥球要落了", "想太久会僵哦"],
+        "close_to_record": ["纪录快到了", "再稳一拍就到"],
+        "new_record": ["好吧，破纪录了", "这球我认了"],
+        "streak_5": ["五拍连住了", "手感开始热了"],
+        "streak_10": ["十连了？有点稳", "别得意，还没完"],
+        "streak_15": ["十五连还不断", "我开始认真看了"],
+        "streak_20": ["二十连也太久了", "这回合还没结束？"],
+    },
+    "zh-TW": {
+        "line_in": ["壓線了，算你準", "這球落點挺漂亮"],
+        "net_touch": ["擦網也過去了", "這角度有點險"],
+        "zone_in": ["剛好進區", "落點很會挑"],
+        "out": ["差一點出界了", "這拍有點長"],
+        "net": ["被網擋住了", "拍面再抬一點"],
+        "shot_missed": ["沒事，下一拍", "別急，先看準"],
+        "game_over": ["這局到這裡", "還要再打一局嗎"],
+        "long_aim": ["再不揮球要落了", "想太久會僵住喔"],
+        "close_to_record": ["紀錄快到了", "再穩一拍就到"],
+        "new_record": ["好吧，破紀錄了", "這球我認了"],
+        "streak_5": ["五拍連住了", "手感開始熱了"],
+        "streak_10": ["十連了？有點穩", "別得意，還沒完"],
+        "streak_15": ["十五連還不斷", "我開始認真看了"],
+        "streak_20": ["二十連也太久了", "這回合還沒結束？"],
+    },
+    "en": {
+        "line_in": ["On the line!", "Nice placement"],
+        "net_touch": ["Net touch, still over", "That angle was close"],
+        "zone_in": ["Right in the zone", "Sharp landing"],
+        "out": ["Just out", "A little too long"],
+        "net": ["Caught by the net", "Lift the racket face a bit"],
+        "shot_missed": ["Still in it", "Settle in and try again"],
+        "game_over": ["Another round?", "I will remember that rally"],
+        "long_aim": ["Swing soon", "Wait too long and you will freeze"],
+        "close_to_record": ["Almost at the record", "One steadier beat"],
+        "new_record": ["New record!", "That one counts"],
+        "streak_5": ["Five in a row", "You are warming up"],
+        "streak_10": ["Ten straight?", "That is steady"],
+        "streak_15": ["Fifteen is wild", "This rally has grit"],
+        "streak_20": ["Twenty?!", "This round will not end"],
+    },
+    "ja": {
+        "line_in": ["ラインぎりぎり！", "いい落としどころ"],
+        "net_touch": ["ネットに触れたけど入った", "今の角度、危なかったね"],
+        "zone_in": ["ゾーンに入ったよ", "落点が鋭いね"],
+        "out": ["少しアウト", "ちょっと長かったね"],
+        "net": ["ネットに捕まったね", "ラケット面を少し上げて"],
+        "shot_missed": ["まだいけるよ", "落ち着いてもう一回"],
+        "game_over": ["もう一回やる？", "この一本、覚えておくね"],
+        "long_aim": ["そろそろ振って", "待ちすぎると固まるよ"],
+        "close_to_record": ["記録まであと少し", "もう一拍、安定させて"],
+        "new_record": ["新記録だね！", "今のは認めるよ"],
+        "streak_5": ["五連続だね", "調子が上がってきた"],
+        "streak_10": ["十連続？すごいね", "かなり安定してる"],
+        "streak_15": ["十五連続はすごい", "このラリー、粘るね"],
+        "streak_20": ["二十連続？！", "まだ終わらないの？"],
+    },
+    "ko": {
+        "line_in": ["라인에 걸쳤어!", "착지가 좋았어"],
+        "net_touch": ["네트를 스쳤지만 넘어갔어", "각도가 아슬아슬했네"],
+        "zone_in": ["정확히 존 안이야", "낙점이 날카로워"],
+        "out": ["조금 나갔어", "살짝 길었네"],
+        "net": ["네트에 걸렸어", "라켓 면을 조금 더 올려"],
+        "shot_missed": ["아직 괜찮아", "침착하게 다시 가자"],
+        "game_over": ["한 판 더 할래?", "이번 랠리는 기억해둘게"],
+        "long_aim": ["이제 휘둘러", "너무 오래 기다리면 굳어"],
+        "close_to_record": ["기록까지 조금 남았어", "한 박자만 더 안정적으로"],
+        "new_record": ["신기록이야!", "방금 건 인정할게"],
+        "streak_5": ["다섯 번 연속이야", "감이 올라오네"],
+        "streak_10": ["열 번 연속?", "꽤 안정적이야"],
+        "streak_15": ["열다섯 번은 대단해", "이 랠리, 끈질기네"],
+        "streak_20": ["스무 번이라고?!", "아직도 안 끝나?"],
+    },
+    "ru": {
+        "line_in": ["По линии!", "Хорошая точка"],
+        "net_touch": ["Задело сетку, но прошло", "Угол был на грани"],
+        "zone_in": ["Прямо в зону", "Резкое приземление"],
+        "out": ["Чуть в аут", "Немного длинно"],
+        "net": ["Сетка остановила", "Подними ракетку чуть выше"],
+        "shot_missed": ["Еще держимся", "Спокойно, попробуй снова"],
+        "game_over": ["Еще раунд?", "Этот розыгрыш я запомню"],
+        "long_aim": ["Пора бить", "Задержишься — застынешь"],
+        "close_to_record": ["Почти рекорд", "Еще один ровный удар"],
+        "new_record": ["Новый рекорд!", "Этот удар засчитан"],
+        "streak_5": ["Пять подряд", "Разогреваешься"],
+        "streak_10": ["Десять подряд?", "Стабильно"],
+        "streak_15": ["Пятнадцать — это сильно", "Розыгрыш упорный"],
+        "streak_20": ["Двадцать?!", "Этот раунд не заканчивается"],
+    },
+    "es": {
+        "line_in": ["¡En la línea!", "Buena colocación"],
+        "net_touch": ["Tocó la red, pero pasó", "Ese ángulo fue justo"],
+        "zone_in": ["Justo en la zona", "Caída afilada"],
+        "out": ["Apenas fuera", "Un poco larga"],
+        "net": ["La red la atrapó", "Sube un poco la cara de la raqueta"],
+        "shot_missed": ["Todavía puedes", "Calma y otra vez"],
+        "game_over": ["¿Otra ronda?", "Recordaré ese intercambio"],
+        "long_aim": ["Golpea pronto", "Si esperas tanto te quedas rígido"],
+        "close_to_record": ["Casi es récord", "Un golpe más estable"],
+        "new_record": ["¡Nuevo récord!", "Ese sí cuenta"],
+        "streak_5": ["Cinco seguidas", "Ya estás calentando"],
+        "streak_10": ["¿Diez seguidas?", "Eso está estable"],
+        "streak_15": ["Quince es fuerte", "Este intercambio tiene aguante"],
+        "streak_20": ["¿Veinte?!", "Esta ronda no termina"],
+    },
+    "pt": {
+        "line_in": ["Na linha!", "Boa colocação"],
+        "net_touch": ["Tocou na rede, mas passou", "Esse ângulo foi no limite"],
+        "zone_in": ["Bem na zona", "Queda afiada"],
+        "out": ["Pouco fora", "Um pouco longa"],
+        "net": ["A rede segurou", "Levante um pouco a face da raquete"],
+        "shot_missed": ["Ainda dá", "Calma e tenta de novo"],
+        "game_over": ["Mais uma rodada?", "Vou lembrar essa troca"],
+        "long_aim": ["Rebata logo", "Se esperar demais, trava"],
+        "close_to_record": ["Quase recorde", "Mais uma batida estável"],
+        "new_record": ["Novo recorde!", "Essa valeu"],
+        "streak_5": ["Cinco seguidas", "Você está aquecendo"],
+        "streak_10": ["Dez seguidas?", "Está bem firme"],
+        "streak_15": ["Quinze é forte", "Essa troca tem resistência"],
+        "streak_20": ["Vinte?!", "Essa rodada não acaba"],
+    },
+}
+
+
+def get_badminton_quick_lines_prompt(lang: str | None = None, mode: str = "spectator") -> str:
+    locale = normalize_badminton_prompt_locale(lang)
+    prompt = BADMINTON_QUICK_LINES_PROMPTS[locale]
+    mode_name = _normalize_mode(mode)
+    if mode_name == "spectator":
+        return prompt
+    return prompt + _MODE_SUFFIXES[mode_name][locale]
+
+
+def get_badminton_quick_lines_user_prompt(lang: str | None = None, mode: str = "spectator") -> str:
+    locale = normalize_badminton_prompt_locale(lang)
+    prompt = BADMINTON_QUICK_LINES_USER_PROMPT[locale]
+    mode_name = _normalize_mode(mode)
+    if mode_name == "spectator":
+        return prompt
+    return f"{prompt}\n{_MODE_LABELS[locale]}: {mode_name}"
+
+
+def get_badminton_quick_lines_fallback(lang: str | None = None) -> dict[str, list[str]]:
+    locale = normalize_badminton_prompt_locale(lang)
+    return {key: list(lines) for key, lines in BADMINTON_QUICK_LINES_FALLBACKS[locale].items()}

--- a/config/prompts/prompts_game.py
+++ b/config/prompts/prompts_game.py
@@ -16,6 +16,10 @@
 """Prompt templates for game routes."""
 
 from config.prompts.prompts_sys import _loc
+from config.prompts.prompts_badminton import (
+    get_badminton_quick_lines_prompt as _get_badminton_quick_lines_prompt,
+    get_badminton_quick_lines_user_prompt as _get_badminton_quick_lines_user_prompt,
+)
 
 
 def _normalize_prompt_lang(lang: str | None) -> str:
@@ -2243,24 +2247,8 @@ def get_badminton_system_prompt(lang: str | None = None, mode: str = "spectator"
 
 
 def get_badminton_quick_lines_prompt(lang: str | None = None, mode: str = "spectator") -> str:
-    mode_name = _normalize_badminton_prompt_mode(mode)
-    if mode_name == "shooter":
-        prompt_set = _BADMINTON_QUICK_LINES_PROMPTS_SHOOTER
-    elif mode_name == "duel":
-        prompt_set = _BADMINTON_QUICK_LINES_PROMPTS_DUEL
-    elif mode_name == "timed":
-        prompt_set = _BADMINTON_QUICK_LINES_PROMPTS_TIMED
-    elif mode_name == "horse":
-        prompt_set = _BADMINTON_QUICK_LINES_PROMPTS_HORSE
-    else:
-        prompt_set = BADMINTON_QUICK_LINES_PROMPTS
-    return _localized_template(prompt_set, lang)
+    return _get_badminton_quick_lines_prompt(lang, mode=mode)
 
 
 def get_badminton_quick_lines_user_prompt(lang: str | None = None, mode: str = "spectator") -> str:
-    prompt = _localized_template(BADMINTON_QUICK_LINES_USER_PROMPT, lang)
-    mode_name = _normalize_badminton_prompt_mode(mode)
-    if mode_name and mode_name != "spectator":
-        mode_label = "当前模式" if _normalize_prompt_lang(lang) == "zh" else "Current mode"
-        return f"{prompt}\n{mode_label}: {mode_name}"
-    return prompt
+    return _get_badminton_quick_lines_user_prompt(lang, mode=mode)

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -306,6 +306,22 @@ _BADMINTON_QUICK_LINES_FALLBACK_EN: Dict[str, list[str]] = {
     "streak_15": ["Fifteen is wild", "This run is steady"],
     "streak_20": ["Twenty?!", "This round is absurd"],
 }
+_BADMINTON_QUICK_LINES_FALLBACK_JA: Dict[str, list[str]] = {
+    "line_in": ["ラインぎりぎり！", "いい落としどころ"],
+    "net_touch": ["ネットに触れたけど入った", "今の角度、危なかったね"],
+    "zone_in": ["ゾーンに入ったよ", "落点が鋭いね"],
+    "out": ["少しアウト", "ちょっと長かったね"],
+    "net": ["ネットに捕まったね", "ラケット面を少し上げて"],
+    "shot_missed": ["まだいけるよ", "落ち着いてもう一回"],
+    "game_over": ["もう一回やる？", "この一本、覚えておくね"],
+    "long_aim": ["そろそろ振って", "待ちすぎると固まるよ"],
+    "close_to_record": ["記録まであと少し", "もう一拍、安定させて"],
+    "new_record": ["新記録だね！", "今のは認めるよ"],
+    "streak_5": ["五連続だね", "調子が上がってきた"],
+    "streak_10": ["十連続？すごいね", "かなり安定してる"],
+    "streak_15": ["十五連続はすごい", "このラリー、粘るね"],
+    "streak_20": ["二十連続？！", "まだ終わらないの？"],
+}
 _badminton_quick_lines_cache: OrderedDict[str, Dict[str, list[str]]] = OrderedDict()
 _BADMINTON_QUICK_LINES_CACHE_MAX = 32
 _badminton_chat_rate_windows: OrderedDict[str, list[float]] = OrderedDict()
@@ -1816,7 +1832,12 @@ def _get_badminton_quick_lines_fallback(language: str | None = None) -> Dict[str
         normalized = normalize_language_code(str(language or ""), format="short") if language else ""
     except Exception:
         normalized = ""
-    source = _BADMINTON_QUICK_LINES_FALLBACK if normalized == "zh" else _BADMINTON_QUICK_LINES_FALLBACK_EN
+    if normalized == "zh":
+        source = _BADMINTON_QUICK_LINES_FALLBACK
+    elif normalized == "ja":
+        source = _BADMINTON_QUICK_LINES_FALLBACK_JA
+    else:
+        source = _BADMINTON_QUICK_LINES_FALLBACK_EN
     return {key: list(lines) for key, lines in source.items()}
 
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -51,6 +51,7 @@ _SSML_TAG_PATTERN = re.compile(
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
+from config.prompts.prompts_badminton import get_badminton_quick_lines_fallback
 from config.prompts.prompts_game import (
     PREGAME_CONTEXT_INPUT_WATERMARK,
     get_badminton_pregame_context_formatter_labels,
@@ -273,54 +274,6 @@ _BADMINTON_QUICK_LINE_KEYS = {
     "line_in", "net_touch", "zone_in", "out", "net",
     "shot_missed", "game_over", "long_aim", "close_to_record",
     "new_record", "streak_5", "streak_10", "streak_15", "streak_20",
-}
-_BADMINTON_QUICK_LINES_FALLBACK: Dict[str, list[str]] = {
-    "line_in": ["贴线了，算你准", "这球压得挺好"],
-    "net_touch": ["擦网偷过去了", "这角度有点险"],
-    "zone_in": ["刚好进区", "落点挺会挑"],
-    "out": ["差一点出去了", "这拍有点长"],
-    "net": ["被网挡住了", "拍面再抬一点"],
-    "shot_missed": ["没事，下一拍", "别急，先看准"],
-    "game_over": ["这局到这儿", "还要再打一局吗"],
-    "long_aim": ["再不挥球要落了", "想太久会僵哦"],
-    "close_to_record": ["纪录快到了", "再稳一拍就到"],
-    "new_record": ["好吧，破纪录了", "这球我认了"],
-    "streak_5": ["五拍连住了", "手感开始热了"],
-    "streak_10": ["十连了？有点稳", "别得意，还没完"],
-    "streak_15": ["十五连还不断", "我开始认真看了"],
-    "streak_20": ["二十连也太久了", "这回合还没结束？"],
-}
-_BADMINTON_QUICK_LINES_FALLBACK_EN: Dict[str, list[str]] = {
-    "line_in": ["On the line!", "Nice placement"],
-    "net_touch": ["Net touch counts", "Nice angle"],
-    "zone_in": ["Right in the zone", "Sharp landing"],
-    "out": ["Just out", "A little too long"],
-    "net": ["Caught the net", "Open the racket face"],
-    "shot_missed": ["Still in it", "Settle and swing again"],
-    "game_over": ["One more round?", "I'll remember this one"],
-    "long_aim": ["Swing already", "Still waiting?"],
-    "close_to_record": ["Almost a record", "Just a little more"],
-    "new_record": ["New record!", "That was too far"],
-    "streak_5": ["Five rallies in a row!", "You're heating up"],
-    "streak_10": ["Ten straight rallies?!", "You're unreal"],
-    "streak_15": ["Fifteen is wild", "This run is steady"],
-    "streak_20": ["Twenty?!", "This round is absurd"],
-}
-_BADMINTON_QUICK_LINES_FALLBACK_JA: Dict[str, list[str]] = {
-    "line_in": ["ラインぎりぎり！", "いい落としどころ"],
-    "net_touch": ["ネットに触れたけど入った", "今の角度、危なかったね"],
-    "zone_in": ["ゾーンに入ったよ", "落点が鋭いね"],
-    "out": ["少しアウト", "ちょっと長かったね"],
-    "net": ["ネットに捕まったね", "ラケット面を少し上げて"],
-    "shot_missed": ["まだいけるよ", "落ち着いてもう一回"],
-    "game_over": ["もう一回やる？", "この一本、覚えておくね"],
-    "long_aim": ["そろそろ振って", "待ちすぎると固まるよ"],
-    "close_to_record": ["記録まであと少し", "もう一拍、安定させて"],
-    "new_record": ["新記録だね！", "今のは認めるよ"],
-    "streak_5": ["五連続だね", "調子が上がってきた"],
-    "streak_10": ["十連続？すごいね", "かなり安定してる"],
-    "streak_15": ["十五連続はすごい", "このラリー、粘るね"],
-    "streak_20": ["二十連続？！", "まだ終わらないの？"],
 }
 _badminton_quick_lines_cache: OrderedDict[str, Dict[str, list[str]]] = OrderedDict()
 _BADMINTON_QUICK_LINES_CACHE_MAX = 32
@@ -1828,17 +1781,19 @@ def _normalize_quick_lines(value: Any, allowed_keys: set[str] | None = None) -> 
 
 
 def _get_badminton_quick_lines_fallback(language: str | None = None) -> Dict[str, list[str]]:
+    return get_badminton_quick_lines_fallback(language)
+
+
+def _extract_request_language_full(data: Any) -> str | None:
+    if not isinstance(data, dict):
+        return None
+    raw = data.get('i18n_language') or data.get('language') or data.get('lang')
+    if not raw or not is_supported_language_code(raw):
+        return None
     try:
-        normalized = normalize_language_code(str(language or ""), format="short") if language else ""
+        return normalize_language_code(str(raw), format='full')
     except Exception:
-        normalized = ""
-    if normalized == "zh":
-        source = _BADMINTON_QUICK_LINES_FALLBACK
-    elif normalized == "ja":
-        source = _BADMINTON_QUICK_LINES_FALLBACK_JA
-    else:
-        source = _BADMINTON_QUICK_LINES_FALLBACK_EN
-    return {key: list(lines) for key, lines in source.items()}
+        return None
 
 
 def _absorb_request_language(data: Any, lanlan_name: str | None) -> str | None:
@@ -8363,8 +8318,9 @@ async def game_quick_lines(game_type: str, request: Request):
         # 的返回值，避免在 SessionManager 还没 ready / mgr 拿不到的窗口下，char_info 的
         # user_language 仍 stale 在全局缓存的旧值（首批 quick lines 落英文）。
         request_language = _absorb_request_language(data, requested_name)
+        request_language_full = _extract_request_language_full(data) if _is_badminton_game_type(game_type) else None
         char_info = _get_character_info(requested_name)
-        language = request_language or char_info.get("user_language")
+        language = request_language_full or request_language or char_info.get("user_language")
         fallback_language = language
         cache_key = ""
         if _is_badminton_game_type(game_type):

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -2112,11 +2112,29 @@
     if (/[A-Za-zÀ-ÖØ-öø-ÿ\u0400-\u04ff]/.test(text)) return false;
     return true;
   }
+  var _jaFallbackLineLookup = null;
+  function isKnownJapaneseFallbackLine(text) {
+    var t = String(text || '').trim();
+    if (!t) return false;
+    if (!_jaFallbackLineLookup) {
+      _jaFallbackLineLookup = Object.create(null);
+      [quickLinesFallbackJa, YUI_PASSIVE_LINES_DUEL_JA].forEach(function (pool) {
+        Object.keys(pool || {}).forEach(function (key) {
+          (pool[key] || []).forEach(function (line) {
+            var normalized = String(line || '').trim();
+            if (normalized) _jaFallbackLineLookup[normalized] = true;
+          });
+        });
+      });
+    }
+    return !!_jaFallbackLineLookup[t];
+  }
   function replaceUnexpectedChineseFallbackLine(line, event) {
     var text = String(line || '').trim();
     var primary = normalizeRequestLanguagePrimary(getRequestLanguage());
     if (primary === 'zh') return text;
     if (event && (event.kind === 'user_reply' || event.isUserReply || event.source === 'user_reply')) return text;
+    if (primary === 'ja' && isKnownJapaneseFallbackLine(text)) return text;
     if (!isLikelyChineseFallbackLine(text)) return text;
     var fallbackKey = getFallbackLineKey(event || {});
     var fallback = pickLine(fallbackKey);

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -1277,6 +1277,38 @@
     streak_15: ['十五连还不断', '我开始认真看了'],
     streak_20: ['二十连也太久了', '这回合还没结束？']
   };
+  var quickLinesFallbackEn = {
+    line_in: ['On the line!', 'Nice placement'],
+    net_touch: ['Net touch, still over', 'That angle was close'],
+    zone_in: ['Right in the zone', 'Sharp landing'],
+    out: ['Just out', 'A little too long'],
+    net: ['Caught by the net', 'Lift the racket face a bit'],
+    shot_missed: ['Still in it', 'Settle in and try again'],
+    game_over: ['Another round?', 'I will remember that rally'],
+    long_aim: ['Swing soon', 'Wait too long and you will freeze'],
+    close_to_record: ['Almost at the record', 'One steadier beat'],
+    new_record: ['New record!', 'That one counts'],
+    streak_5: ['Five in a row', 'You are warming up'],
+    streak_10: ['Ten straight?', 'That is steady'],
+    streak_15: ['Fifteen is wild', 'This rally has grit'],
+    streak_20: ['Twenty?!', 'This round will not end']
+  };
+  var quickLinesFallbackJa = {
+    line_in: ['ラインぎりぎり！', 'いい落としどころ'],
+    net_touch: ['ネットに触れたけど入った', '今の角度、危なかったね'],
+    zone_in: ['ゾーンに入ったよ', '落点が鋭いね'],
+    out: ['少しアウト', 'ちょっと長かったね'],
+    net: ['ネットに捕まったね', 'ラケット面を少し上げて'],
+    shot_missed: ['まだいけるよ', '落ち着いてもう一回'],
+    game_over: ['もう一回やる？', 'この一本、覚えておくね'],
+    long_aim: ['そろそろ振って', '待ちすぎると固まるよ'],
+    close_to_record: ['記録まであと少し', 'もう一拍、安定させて'],
+    new_record: ['新記録だね！', '今のは認めるよ'],
+    streak_5: ['五連続だね', '調子が上がってきた'],
+    streak_10: ['十連続？すごいね', 'かなり安定してる'],
+    streak_15: ['十五連続はすごい', 'このラリー、粘るね'],
+    streak_20: ['二十連続？！', 'まだ終わらないの？']
+  };
   var generatedQuickLines = {};
   var generatedQuickLinesRequestSeq = 0;
   var YUI_PASSIVE_LINES_DUEL = {
@@ -1294,6 +1326,38 @@
     streak_10: ['十连了？有意思', '我开始盯紧了'],
     streak_15: ['十五连还不断', '别让我太没面子'],
     streak_20: ['二十连也太久了', '这回合还不结束？']
+  };
+  var YUI_PASSIVE_LINES_DUEL_EN = {
+    line_in: ['That line was clean', 'The sideline helped you'],
+    net_touch: ['A net touch and still brave', 'That skim was close'],
+    zone_in: ['Nice landing choice', 'I almost reached that'],
+    out: ['Missed by a little', 'That one flew too deep'],
+    net: ['The net stopped it for me', 'You rushed that swing'],
+    shot_missed: ['Stay calm, next shot', 'You were half a beat late'],
+    game_over: ['That is it for now', 'Do not run from the next round'],
+    long_aim: ['Time to swing', 'Think too long and you will stiffen'],
+    close_to_record: ['The record is on your racket', 'One steadier shot'],
+    new_record: ['Fine, that was good', 'You can borrow the new record'],
+    streak_5: ['Five connected', 'The rhythm is coming together'],
+    streak_10: ['Ten straight? Interesting', 'I am watching more closely now'],
+    streak_15: ['Fifteen and still going', 'Do not make me look too bad'],
+    streak_20: ['Twenty is too long', 'Is this rally ever ending?']
+  };
+  var YUI_PASSIVE_LINES_DUEL_JA = {
+    line_in: ['今のライン、きれいだったね', 'サイドラインに助けられたね'],
+    net_touch: ['ネットに触れても攻めるんだ', '今のかすり方、ぎりぎり'],
+    zone_in: ['落点の選び方、いいね', 'もう少しで届いたのに'],
+    out: ['ほんの少し外れたね', '今のは奥まで飛びすぎ'],
+    net: ['ネットが私の味方をしたね', 'その一振り、急ぎすぎ'],
+    shot_missed: ['落ち着いて、次の一拍', '今のは半拍遅れたね'],
+    game_over: ['今回はここまで', '次のラウンド、逃げないでね'],
+    long_aim: ['そろそろ振ろうか', '考えすぎると固まるよ'],
+    close_to_record: ['記録はラケットの先だよ', 'もう一拍だけ安定させて'],
+    new_record: ['いいよ、今のはきれい', '新記録、少しだけ貸してあげる'],
+    streak_5: ['五本つながったね', 'リズムが合ってきた'],
+    streak_10: ['十連続？面白いね', '少し本気で見てるよ'],
+    streak_15: ['十五連続、まだ続くの？', '私の面目も少し考えて'],
+    streak_20: ['二十連続は長すぎるよ', 'このラリー、終わる気ある？']
   };
   // Endpoint contract:
   // /api/game/badminton/route/start
@@ -2019,27 +2083,68 @@
     if (mode === 'duel') return _i18n('leaderboard.mode.duel', '对拉');
     return _i18n('leaderboard.mode.duel', '对拉');
   }
+  function normalizeRequestLanguagePrimary(value) {
+    var lang = String(value || '').trim().replace(/_/g, '-').toLowerCase();
+    if (!lang || lang === 'undefined' || lang === 'null') return '';
+    return lang.split('-')[0] || '';
+  }
+  function normalizeRequestLanguageTag(value) {
+    var lang = String(value || '').trim().replace(/_/g, '-');
+    if (!lang || lang === 'undefined' || lang === 'null') return '';
+    return lang;
+  }
+  function getDefaultQuickLineFallback() {
+    var primary = normalizeRequestLanguagePrimary(getRequestLanguage());
+    if (primary === 'zh') return quickLines;
+    if (primary === 'ja') return quickLinesFallbackJa;
+    return quickLinesFallbackEn;
+  }
+  function getQuickLineFallbackSource() {
+    var primary = normalizeRequestLanguagePrimary(getRequestLanguage());
+    if (primary === 'zh') return YUI_PASSIVE_LINES_DUEL;
+    if (primary === 'ja') return YUI_PASSIVE_LINES_DUEL_JA;
+    return YUI_PASSIVE_LINES_DUEL_EN;
+  }
+  function isLikelyChineseFallbackLine(line) {
+    var text = String(line || '').trim();
+    if (!/[\u3400-\u9fff]/.test(text)) return false;
+    if (/[\u3040-\u30ff\uac00-\ud7af]/.test(text)) return false;
+    if (/[A-Za-zÀ-ÖØ-öø-ÿ\u0400-\u04ff]/.test(text)) return false;
+    return true;
+  }
+  function replaceUnexpectedChineseFallbackLine(line, event) {
+    var text = String(line || '').trim();
+    var primary = normalizeRequestLanguagePrimary(getRequestLanguage());
+    if (primary === 'zh') return text;
+    if (event && (event.kind === 'user_reply' || event.isUserReply || event.source === 'user_reply')) return text;
+    if (!isLikelyChineseFallbackLine(text)) return text;
+    var fallbackKey = getFallbackLineKey(event || {});
+    var fallback = pickLine(fallbackKey);
+    return fallback || (primary === 'ja' ? 'もう一回やる？' : 'One more rally.');
+  }
   function pickLocalizedLine(scope, key, fallback) {
     var generated = generatedQuickLines[key] || [];
     if (generated.length) return generated[Math.floor(Math.random() * generated.length)] || '';
+    var defaultFallback = getDefaultQuickLineFallback();
     var lines = _i18nArray('lines.' + scope + '.' + key, fallback || []);
-    if (!lines.length && scope !== 'default') lines = _i18nArray('lines.default.' + key, quickLines[key] || []);
-    if (!lines.length) lines = _i18nArray('lines.fallback', ['再来一次喵']);
+    if (!lines.length && scope !== 'default') lines = _i18nArray('lines.default.' + key, defaultFallback[key] || quickLinesFallbackEn[key] || quickLines[key] || []);
+    if (!lines.length) lines = _i18nArray('lines.fallback', normalizeRequestLanguagePrimary(getRequestLanguage()) === 'zh' ? ['再来一次喵'] : ['One more rally.']);
     return lines[Math.floor(Math.random() * lines.length)] || '';
   }
   function pickLine(key) {
-    var source = YUI_PASSIVE_LINES_DUEL;
+    var source = getQuickLineFallbackSource();
+    var defaultFallback = getDefaultQuickLineFallback();
     var scope = 'duel';
-    var fallback = source[key] || quickLines[key] || source.game_over || quickLines.game_over || ['再来一次喵'];
+    var fallback = source[key] || defaultFallback[key] || source.game_over || defaultFallback.game_over || ['One more rally.'];
     return moodStyleLine(pickLocalizedLine(scope, key, fallback), currentMood);
   }
   function getRequestLanguage() {
     var candidates = [];
     var hasResolvedI18nLanguage = false;
     function pushResolvedLanguage(value) {
-      var lang = String(value || '').trim();
-      if (!lang || lang === 'undefined' || lang === 'null') return false;
-      candidates.push(lang.replace('_', '-'));
+      var lang = normalizeRequestLanguageTag(value);
+      if (!lang) return false;
+      candidates.push(lang);
       hasResolvedI18nLanguage = true;
       return true;
     }
@@ -2056,15 +2161,15 @@
         pushResolvedLanguage(window.__nekoI18nLanguage || window.NEKO_I18N_LANGUAGE);
       }
     } catch (_) {}
+    try { pushResolvedLanguage(localStorage.getItem('i18nextLng')); } catch (_) {}
     var documentLang = '';
     try { documentLang = (document.documentElement && document.documentElement.lang) || ''; } catch (_) {}
     var documentLangIsTemplateDefault = /^zh(?:-CN)?$/i.test(documentLang) && !hasResolvedI18nLanguage;
     if (documentLang && !documentLangIsTemplateDefault) candidates.push(documentLang);
     candidates.push(navigator.language || '');
-    try { candidates.push(localStorage.getItem('i18nextLng')); } catch (_) {}
     for (var i = 0; i < candidates.length; i++) {
-      var lang = String(candidates[i] || '').trim();
-      if (lang && lang !== 'undefined' && lang !== 'null') return lang.replace('_', '-');
+      var lang = normalizeRequestLanguageTag(candidates[i]);
+      if (lang) return lang;
     }
     return 'zh';
   }
@@ -2331,6 +2436,7 @@
     if (debugMode) return;
     var quickLinesRequestSeq = ++generatedQuickLinesRequestSeq;
     var quickLinesRequestLanguage = getRequestLanguage();
+    var quickLinesRequestPrimary = normalizeRequestLanguagePrimary(quickLinesRequestLanguage);
     var QUICK_LINE_KEYS = [
       'line_in', 'net_touch', 'zone_in', 'out', 'net',
       'shot_missed', 'game_over', 'long_aim', 'close_to_record',
@@ -2338,13 +2444,12 @@
     ];
     post('/quick-lines', { lanlan_name: lanlanName, session_id: sessionId, mode: currentMode, i18n_language: quickLinesRequestLanguage }, 5000).then(function (res) {
       if (quickLinesRequestSeq !== generatedQuickLinesRequestSeq) return;
-      if (quickLinesRequestLanguage !== getRequestLanguage()) return;
+      if (quickLinesRequestPrimary !== normalizeRequestLanguagePrimary(getRequestLanguage())) return;
       if (!res || !res.lines) return;
       QUICK_LINE_KEYS.forEach(function (key) {
         var pool = (res.lines[key] || []).map(function (v) { return String(v).trim(); }).filter(Boolean).slice(0, 4);
         if (pool.length) {
           generatedQuickLines[key] = pool;
-          quickLines[key] = pool;
         }
       });
     }).catch(function () {});
@@ -2666,7 +2771,7 @@
       line: entry.line,
       expiresAt: Date.now() + holdMs
     };
-    showBubble(entry.line, entry.control);
+    showBubble(entry.line, entry.control, entry.event);
     return _mirrorAndSpeak(entry).finally(function () {
       if (voiceArbiter.inFlight && voiceArbiter.inFlight.id === entry.id) {
         setTimeout(function () {
@@ -2699,8 +2804,8 @@
     voiceArbiter.pending = null;
     void _requestVoicePlayback(pending);
   }
-  function showBubble(line, control) {
-    var text = String(line || '').trim();
+  function showBubble(line, control, event) {
+    var text = replaceUnexpectedChineseFallbackLine(line, event);
     if (!text) return;
     if (shouldKeepCurrentBubble(control || {})) return false;
     bubble.dataset.mood = (control && control.mood) || '';
@@ -2742,14 +2847,15 @@
     var lines = pools[kind] || pools.banana;
     var line = lines[Math.floor(Math.random() * lines.length)] || '';
     var control = { expression: 'tease', intensity: 'medium', mood: 'surprised', bubbleVariant: 'yui-cheat', bubblePriority: 8, bubbleHoldMs: 3200, bubbleDurationMs: 4200 };
-    showBubble(line, control);
-    speakLine(line, control, {
+    var event = {
       kind: 'yui_cheat_item',
       label: 'yui_cheat_' + kind,
       item_kind: kind,
       force_voice_in_debug: true,
       voice_deadline_ms: 3600
-    });
+    };
+    showBubble(line, control, event);
+    speakLine(line, control, event);
   }
   function showYuiCheatScoreLine(kind) {
     var pools = {
@@ -2759,14 +2865,15 @@
     var lines = pools[kind] || pools.banana;
     var line = lines[Math.floor(Math.random() * lines.length)] || '';
     var control = { expression: 'tease', intensity: 'high', mood: 'happy', bubbleVariant: 'yui-cheat-score', bubblePriority: 9, bubbleHoldMs: 3600, bubbleDurationMs: 4600 };
-    showBubble(line, control);
-    speakLine(line, control, {
+    var event = {
       kind: 'yui_cheat_score',
       label: 'yui_cheat_score_' + kind,
       item_kind: kind,
       force_voice_in_debug: true,
       voice_deadline_ms: 5200
-    });
+    };
+    showBubble(line, control, event);
+    speakLine(line, control, event);
   }
   function renderBubbleContent(text, emote) {
     text = String(text || '').trim();
@@ -2852,6 +2959,7 @@
     return false;
   }
   function speakLine(line, control, event) {
+    line = replaceUnexpectedChineseFallbackLine(line, event);
     if (!shouldReadBadmintonVoice(event, control)) {
       lastVoiceRequest = {
         line: line,
@@ -2865,7 +2973,7 @@
       };
       lastVoiceFallbackReason = '';
       lastVoiceMutedReason = 'voice_event_not_selected';
-      showBubble(line, control || {});
+      showBubble(line, control || {}, event);
       return;
     }
     lastVoiceMutedReason = '';

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -1278,6 +1278,7 @@
     streak_20: ['二十连也太久了', '这回合还没结束？']
   };
   var generatedQuickLines = {};
+  var generatedQuickLinesRequestSeq = 0;
   var YUI_PASSIVE_LINES_DUEL = {
     line_in: ['这球压得挺准', '边线都帮你了'],
     net_touch: ['擦网也敢打啊', '这球贴得真险'],
@@ -2034,17 +2035,36 @@
   }
   function getRequestLanguage() {
     var candidates = [];
+    var hasResolvedI18nLanguage = false;
+    function pushResolvedLanguage(value) {
+      var lang = String(value || '').trim();
+      if (!lang || lang === 'undefined' || lang === 'null') return false;
+      candidates.push(lang.replace('_', '-'));
+      hasResolvedI18nLanguage = true;
+      return true;
+    }
     try {
       var params = new URLSearchParams(window.location.search);
-      candidates.push(params.get('i18n_language'), params.get('lang'), params.get('locale'));
+      pushResolvedLanguage(params.get('i18n_language')) || pushResolvedLanguage(params.get('lang')) || pushResolvedLanguage(params.get('locale'));
     } catch (_) {}
-    try { candidates.push(window.i18next && window.i18next.language); } catch (_) {}
-    try { candidates.push(window.__nekoI18nLanguage || window.NEKO_I18N_LANGUAGE); } catch (_) {}
+    try {
+      var i18nInstance = window.i18n || window.i18next;
+      if (i18nInstance && i18nInstance.language && i18nInstance.isInitialized) pushResolvedLanguage(i18nInstance.language);
+    } catch (_) {}
+    try {
+      if (window.__nekoI18nLanguage || window.NEKO_I18N_LANGUAGE) {
+        pushResolvedLanguage(window.__nekoI18nLanguage || window.NEKO_I18N_LANGUAGE);
+      }
+    } catch (_) {}
+    var documentLang = '';
+    try { documentLang = (document.documentElement && document.documentElement.lang) || ''; } catch (_) {}
+    var documentLangIsTemplateDefault = /^zh(?:-CN)?$/i.test(documentLang) && !hasResolvedI18nLanguage;
+    if (documentLang && !documentLangIsTemplateDefault) candidates.push(documentLang);
+    candidates.push(navigator.language || '');
     try { candidates.push(localStorage.getItem('i18nextLng')); } catch (_) {}
-    candidates.push((document.documentElement && document.documentElement.lang) || '', navigator.language || '');
     for (var i = 0; i < candidates.length; i++) {
       var lang = String(candidates[i] || '').trim();
-      if (lang) return lang.replace('_', '-');
+      if (lang && lang !== 'undefined' && lang !== 'null') return lang.replace('_', '-');
     }
     return 'zh';
   }
@@ -2309,12 +2329,16 @@
   }
   function loadGeneratedQuickLines() {
     if (debugMode) return;
+    var quickLinesRequestSeq = ++generatedQuickLinesRequestSeq;
+    var quickLinesRequestLanguage = getRequestLanguage();
     var QUICK_LINE_KEYS = [
       'line_in', 'net_touch', 'zone_in', 'out', 'net',
       'shot_missed', 'game_over', 'long_aim', 'close_to_record',
       'new_record', 'streak_5', 'streak_10', 'streak_15', 'streak_20',
     ];
-    post('/quick-lines', { lanlan_name: lanlanName, session_id: sessionId, mode: currentMode, i18n_language: getRequestLanguage() }, 5000).then(function (res) {
+    post('/quick-lines', { lanlan_name: lanlanName, session_id: sessionId, mode: currentMode, i18n_language: quickLinesRequestLanguage }, 5000).then(function (res) {
+      if (quickLinesRequestSeq !== generatedQuickLinesRequestSeq) return;
+      if (quickLinesRequestLanguage !== getRequestLanguage()) return;
       if (!res || !res.lines) return;
       QUICK_LINE_KEYS.forEach(function (key) {
         var pool = (res.lines[key] || []).map(function (v) { return String(v).trim(); }).filter(Boolean).slice(0, 4);
@@ -9426,6 +9450,9 @@
   });
   window.addEventListener('localechange', function () {
     invalidateBadmintonCourtCache();
+    generatedQuickLinesRequestSeq++;
+    generatedQuickLines = {};
+    if (routeActive) loadGeneratedQuickLines();
     applyStaticI18n();
     updateHud();
     updateThemeButton();

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -1250,6 +1250,37 @@ def test_badminton_quick_lines_mode_prompts_are_distinct_and_localized(lang):
 
 
 @pytest.mark.unit
+def test_badminton_quick_lines_uses_dedicated_prompt_module_for_neko_core_locales():
+    from config.prompts import prompts_badminton
+
+    assert prompts_badminton.NEKO_CORE_LOCALES == (
+        "zh-CN",
+        "zh-TW",
+        "en",
+        "ja",
+        "ko",
+        "ru",
+        "es",
+        "pt",
+    )
+    router_source = (ROOT / "main_routers" / "game_router.py").read_text(encoding="utf-8")
+    assert "_BADMINTON_QUICK_LINES_FALLBACK" not in router_source
+
+    english_prompt = prompts_badminton.get_badminton_quick_lines_prompt("en", mode="duel")
+    simplified_prompt = prompts_badminton.get_badminton_quick_lines_prompt("zh-CN", mode="duel")
+    traditional_prompt = prompts_badminton.get_badminton_quick_lines_prompt("zh-TW", mode="duel")
+    assert simplified_prompt != english_prompt
+    assert traditional_prompt != simplified_prompt
+    assert "duel" in english_prompt
+    assert "對拉" in traditional_prompt
+
+    for locale in prompts_badminton.NEKO_CORE_LOCALES:
+        fallback = prompts_badminton.get_badminton_quick_lines_fallback(locale)
+        assert set(fallback) == prompts_badminton.BADMINTON_QUICK_LINE_KEYS
+        assert all(fallback[key] for key in prompts_badminton.BADMINTON_QUICK_LINE_KEYS)
+
+
+@pytest.mark.unit
 def test_badminton_english_quick_lines_do_not_mix_mode_suffixes():
     timed = prompts_game.get_badminton_quick_lines_prompt("en", mode="timed")
     horse = prompts_game.get_badminton_quick_lines_prompt("en", mode="horse")

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -1504,6 +1504,32 @@ def test_badminton_generated_quick_lines_override_static_i18n_lines():
 
 
 @pytest.mark.unit
+def test_badminton_request_language_ignores_template_default_until_i18n_resolves():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+
+    start = html.index("function getRequestLanguage()")
+    request_language = html[start:html.index("function api(path)", start)]
+
+    assert "var hasResolvedI18nLanguage = false;" in request_language
+    assert "var documentLangIsTemplateDefault = /^zh(?:-CN)?$/i.test(documentLang) && !hasResolvedI18nLanguage;" in request_language
+    assert "if (documentLang && !documentLangIsTemplateDefault) candidates.push(documentLang);" in request_language
+    assert "candidates.push(navigator.language || '')" in request_language
+
+
+@pytest.mark.unit
+def test_badminton_localechange_refreshes_generated_quick_lines():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+
+    start = html.index("window.addEventListener('localechange', function () {")
+    localechange = html[start:html.index("});", start) + len("});")]
+
+    assert "generatedQuickLines = {};" in localechange
+    assert "if (routeActive) loadGeneratedQuickLines();" in localechange
+    assert "var quickLinesRequestLanguage = getRequestLanguage();" in html
+    assert "if (quickLinesRequestLanguage !== getRequestLanguage()) return;" in html
+
+
+@pytest.mark.unit
 def test_badminton_route_end_payload_contains_archive_score():
     html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
 

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -1541,9 +1541,12 @@ def test_badminton_speak_line_guards_non_chinese_from_chinese_fallback_text():
     html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
 
     assert "function isLikelyChineseFallbackLine(line) {" in html
+    assert "var _jaFallbackLineLookup = null;" in html
+    assert "function isKnownJapaneseFallbackLine(text) {" in html
     assert "function replaceUnexpectedChineseFallbackLine(line, event) {" in html
     assert "if (primary === 'zh') return text;" in html
     assert "if (!isLikelyChineseFallbackLine(text)) return text;" in html
+    assert "if (primary === 'ja' && isKnownJapaneseFallbackLine(text)) return text;" in html
     assert "return fallback || (primary === 'ja' ? 'もう一回やる？' : 'One more rally.');" in html
 
     speak_start = html.index("function speakLine(line, control, event) {")

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -1501,6 +1501,7 @@ def test_badminton_generated_quick_lines_override_static_i18n_lines():
     assert "var generated = generatedQuickLines[key] || [];" in html
     assert "if (generated.length) return generated[Math.floor(Math.random() * generated.length)] || '';" in html
     assert "generatedQuickLines[key] = pool;" in html
+    assert "quickLines[key] = pool;" not in html
 
 
 @pytest.mark.unit
@@ -1510,10 +1511,48 @@ def test_badminton_request_language_ignores_template_default_until_i18n_resolves
     start = html.index("function getRequestLanguage()")
     request_language = html[start:html.index("function api(path)", start)]
 
+    assert "function normalizeRequestLanguagePrimary(value) {" in html
     assert "var hasResolvedI18nLanguage = false;" in request_language
     assert "var documentLangIsTemplateDefault = /^zh(?:-CN)?$/i.test(documentLang) && !hasResolvedI18nLanguage;" in request_language
     assert "if (documentLang && !documentLangIsTemplateDefault) candidates.push(documentLang);" in request_language
-    assert "candidates.push(navigator.language || '')" in request_language
+    assert request_language.index("localStorage.getItem('i18nextLng')") < request_language.index("navigator.language")
+
+
+@pytest.mark.unit
+def test_badminton_non_chinese_static_quick_line_fallbacks_are_not_chinese():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "var quickLinesFallbackEn = {" in html
+    assert "var quickLinesFallbackJa = {" in html
+    assert "var YUI_PASSIVE_LINES_DUEL_EN = {" in html
+    assert "var YUI_PASSIVE_LINES_DUEL_JA = {" in html
+    assert "function getQuickLineFallbackSource() {" in html
+    assert "if (primary === 'zh') return YUI_PASSIVE_LINES_DUEL;" in html
+    assert "if (primary === 'ja') return YUI_PASSIVE_LINES_DUEL_JA;" in html
+    assert "return YUI_PASSIVE_LINES_DUEL_EN;" in html
+    assert "function getDefaultQuickLineFallback() {" in html
+    assert "if (primary === 'zh') return quickLines;" in html
+    assert "if (primary === 'ja') return quickLinesFallbackJa;" in html
+    assert "return quickLinesFallbackEn;" in html
+
+
+@pytest.mark.unit
+def test_badminton_speak_line_guards_non_chinese_from_chinese_fallback_text():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "function isLikelyChineseFallbackLine(line) {" in html
+    assert "function replaceUnexpectedChineseFallbackLine(line, event) {" in html
+    assert "if (primary === 'zh') return text;" in html
+    assert "if (!isLikelyChineseFallbackLine(text)) return text;" in html
+    assert "return fallback || (primary === 'ja' ? 'もう一回やる？' : 'One more rally.');" in html
+
+    speak_start = html.index("function speakLine(line, control, event) {")
+    speak_section = html[speak_start:html.index("var isUserReply =", speak_start)]
+    assert "line = replaceUnexpectedChineseFallbackLine(line, event);" in speak_section
+    bubble_start = html.index("function showBubble(line, control, event) {")
+    bubble_section = html[bubble_start:html.index("function getBubblePriority(control)", bubble_start)]
+    assert "var text = replaceUnexpectedChineseFallbackLine(line, event);" in bubble_section
+    assert "showBubble(line, control, event);" in html
 
 
 @pytest.mark.unit
@@ -1526,7 +1565,8 @@ def test_badminton_localechange_refreshes_generated_quick_lines():
     assert "generatedQuickLines = {};" in localechange
     assert "if (routeActive) loadGeneratedQuickLines();" in localechange
     assert "var quickLinesRequestLanguage = getRequestLanguage();" in html
-    assert "if (quickLinesRequestLanguage !== getRequestLanguage()) return;" in html
+    assert "var quickLinesRequestPrimary = normalizeRequestLanguagePrimary(quickLinesRequestLanguage);" in html
+    assert "if (quickLinesRequestPrimary !== normalizeRequestLanguagePrimary(getRequestLanguage())) return;" in html
 
 
 @pytest.mark.unit
@@ -1764,7 +1804,7 @@ def test_badminton_voice_selection_reads_only_high_value_yui_lines():
     assert "kind === 'user_reply' || event.isUserReply || event.source === 'user_reply'" in selector_section
     assert "if (!shouldReadBadmintonVoice(event, control)) {" in speak_section
     assert "lastVoiceMutedReason = 'voice_event_not_selected';" in speak_section
-    assert "showBubble(line, control || {});" in speak_section
+    assert "showBubble(line, control || {}, event);" in speak_section
     assert "muted: true" in speak_section
     assert "lastMutedReason: lastVoiceMutedReason" in html
 
@@ -2727,8 +2767,8 @@ def test_badminton_yui_cheat_items_warn_player_with_bubble_lines():
     assert "if (shouldKeepCurrentBubble(emoteControl)) return false;" in html
     assert "bubblePriorityUntil = Date.now() + holdMs;" in html
     assert "var control = { expression: 'tease', intensity: 'medium', mood: 'surprised', bubbleVariant: 'yui-cheat', bubblePriority: 8, bubbleHoldMs: 3200, bubbleDurationMs: 4200 };" in html
-    assert "showBubble(line, control);" in html
-    assert "speakLine(line, control, {" in html
+    assert "showBubble(line, control, event);" in html
+    assert "speakLine(line, control, event);" in html
     assert "kind: 'yui_cheat_item'," in html
     assert "label: 'yui_cheat_' + kind," in html
     assert "item_kind: kind," in html

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -807,6 +807,55 @@ async def test_badminton_quick_lines_fallback_supports_japanese_request_language
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_badminton_quick_lines_fallback_preserves_traditional_chinese_request_language(monkeypatch):
+    monkeypatch.setattr(game_router, "_get_current_character_info", lambda: {
+        "lanlan_name": "Lan",
+        "lanlan_prompt": "Tsundere but focused.",
+        "user_language": "zh",
+        "model": "fake",
+        "base_url": "http://fake",
+        "api_key": "fake",
+    })
+
+    async def fail_llm_async(*_args, **_kwargs):
+        raise RuntimeError("llm unavailable")
+
+    import utils.llm_client as llm_client
+    monkeypatch.setattr(llm_client, "create_chat_llm_async", fail_llm_async)
+
+    result = await game_router.game_quick_lines(
+        "badminton",
+        _FakeRequest({"lanlan_name": "Lan", "session_id": "bd-zh-tw-1", "i18n_language": "zh-TW"}),
+    )
+
+    assert result["ok"] is True
+    assert result["fallback"] is True
+    assert result["lines"]["line_in"][0] == "壓線了，算你準"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("language", "expected_line"),
+    (
+        ("zh-CN", "贴线了，算你准"),
+        ("zh-TW", "壓線了，算你準"),
+        ("en", "On the line!"),
+        ("ja", "ラインぎりぎり！"),
+        ("ko", "라인에 걸쳤어!"),
+        ("ru", "По линии!"),
+        ("es", "¡En la línea!"),
+        ("pt", "Na linha!"),
+    ),
+)
+def test_badminton_quick_lines_fallback_supports_neko_core_languages(language, expected_line):
+    lines = game_router._get_badminton_quick_lines_fallback(language)
+
+    assert lines["line_in"][0] == expected_line
+    assert set(lines) == game_router._BADMINTON_QUICK_LINE_KEYS
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_badminton_quick_lines_uses_requested_character(monkeypatch):
     game_router._badminton_quick_lines_cache.clear()
     captured = {}

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -778,6 +778,35 @@ async def test_badminton_quick_lines_fallback_uses_request_language(monkeypatch)
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_badminton_quick_lines_fallback_supports_japanese_request_language(monkeypatch):
+    monkeypatch.setattr(game_router, "_get_current_character_info", lambda: {
+        "lanlan_name": "Lan",
+        "lanlan_prompt": "Tsundere but focused.",
+        "user_language": "zh",
+        "model": "fake",
+        "base_url": "http://fake",
+        "api_key": "fake",
+    })
+
+    def fail_llm(*_args, **_kwargs):
+        raise RuntimeError("llm unavailable")
+
+    import utils.llm_client as llm_client
+    monkeypatch.setattr(llm_client, "create_chat_llm", fail_llm)
+
+    result = await game_router.game_quick_lines(
+        "badminton",
+        _FakeRequest({"lanlan_name": "Lan", "session_id": "bd-ja-1", "i18n_language": "ja-JP"}),
+    )
+
+    assert result["ok"] is True
+    assert result["fallback"] is True
+    assert result["lines"]["line_in"][0] == "ラインぎりぎり！"
+    assert result["lines"]["game_over"][1] == "この一本、覚えておくね"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_badminton_quick_lines_uses_requested_character(monkeypatch):
     game_router._badminton_quick_lines_cache.clear()
     captured = {}

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -726,11 +726,11 @@ async def test_badminton_quick_lines_returns_fallback_on_llm_failure(monkeypatch
         "api_key": "fake",
     })
 
-    def fail_llm(*_args, **_kwargs):
+    async def fail_llm_async(*_args, **_kwargs):
         raise RuntimeError("llm unavailable")
 
     import utils.llm_client as llm_client
-    monkeypatch.setattr(llm_client, "create_chat_llm", fail_llm)
+    monkeypatch.setattr(llm_client, "create_chat_llm_async", fail_llm_async)
 
     result = await game_router.game_quick_lines(
         "badminton",
@@ -759,11 +759,11 @@ async def test_badminton_quick_lines_fallback_uses_request_language(monkeypatch)
         "api_key": "fake",
     })
 
-    def fail_llm(*_args, **_kwargs):
+    async def fail_llm_async(*_args, **_kwargs):
         raise RuntimeError("llm unavailable")
 
     import utils.llm_client as llm_client
-    monkeypatch.setattr(llm_client, "create_chat_llm", fail_llm)
+    monkeypatch.setattr(llm_client, "create_chat_llm_async", fail_llm_async)
 
     result = await game_router.game_quick_lines(
         "badminton",
@@ -788,11 +788,11 @@ async def test_badminton_quick_lines_fallback_supports_japanese_request_language
         "api_key": "fake",
     })
 
-    def fail_llm(*_args, **_kwargs):
+    async def fail_llm_async(*_args, **_kwargs):
         raise RuntimeError("llm unavailable")
 
     import utils.llm_client as llm_client
-    monkeypatch.setattr(llm_client, "create_chat_llm", fail_llm)
+    monkeypatch.setattr(llm_client, "create_chat_llm_async", fail_llm_async)
 
     result = await game_router.game_quick_lines(
         "badminton",


### PR DESCRIPTION
## Summary

Fixes badminton quick-line localization so the game does not leak Chinese generated lines when the frontend language is still resolving, and moves badminton quick-line prompt/fallback copy into a dedicated prompt module.

## What Changed

- `templates/badminton_demo.html`
  - Stops treating the template default `html lang=zh-CN` as the user language before i18n is initialized.
  - Sends a stable language snapshot with `/quick-lines` requests.
  - Ignores stale quick-line responses after language changes.
  - Clears generated quick lines on `localechange` and reloads them when the route is active.

- `config/prompts/prompts_badminton.py`
  - New dedicated badminton quick-lines prompt/fallback module.
  - Adds service-side fallback lines for the 8 N.E.K.O core locales: `zh-CN`, `zh-TW`, `en`, `ja`, `ko`, `ru`, `es`, `pt`.
  - Keeps mode-specific quick-line prompts for `spectator`, `duel`, `shooter`, `timed`, and `horse`.

- `main_routers/game_router.py`
  - Removes inline badminton fallback copy from the router.
  - Preserves full `zh-TW` for badminton `/quick-lines`, so Traditional Chinese does not collapse into Simplified Chinese fallback.

- Tests
  - Covers Japanese and Traditional Chinese fallback behavior through the endpoint.
  - Covers all 8 core locale fallback pools.
  - Adds a contract that badminton quick-lines live in the dedicated prompt module.
  - Keeps the difficulty-ramp line contract, including “现在你才是挑战者” and localized equivalents.

## Regression Report

This PR touches `main_routers/game_router.py`.

- Before: Japanese users could occasionally receive generated Chinese quick lines because the page template defaulted to `zh-CN` before i18n finished. LLM fallback only covered part of the locale matrix.
- After: frontend quick-line requests use the resolved language, stale responses are ignored, locale changes refresh generated lines, and backend fallback covers all 8 core locales from the dedicated prompt module.
- Risk: localized to badminton `/quick-lines`, route-start generated lines, locale switching, and LLM-failure fallback. GitNexus impact and staged `detect_changes` both reported LOW risk.

