### PR TITLE
fix(tts): step/免费语音首 chunk jitter——抽出共享 jitter buffer 并接入

### DIFF
--- a/main_logic/tts_client/_infra.py
+++ b/main_logic/tts_client/_infra.py
@@ -75,6 +75,80 @@ def _resample_audio(audio_int16: np.ndarray, src_rate: int, dst_rate: int,
     resampled_int16 = (resampled_float * 32768.0).clip(-32768, 32767).astype(np.int16)
     return resampled_int16.tobytes()
 
+# 48kHz / 16-bit / mono PCM（所有 worker 重采样后的统一输出格式）每秒字节数。
+_TTS_OUTPUT_BYTES_PER_SECOND = 48000 * 2
+
+class AudioJitterBuffer:
+    """Coalesce upstream PCM chunks to ride over inter-chunk gaps.
+
+    Streaming TTS upstreams emit fragmented chunks, and the largest gap is right
+    after the first chunk (model first-frame latency). Holding back an initial
+    head-start of ``initial_buffer_bytes`` before releasing the first batch gives
+    the player a lead it can ride over that opening gap; steady state then flushes
+    whenever ``steady_buffer_bytes`` has accumulated. Either set to 0 falls back to
+    low-latency pass-through.
+
+    Provider-agnostic: a worker appends resampled PCM bytes and drives reset() on a
+    new utterance / interrupt and flush() on response.done. The buffer never owns
+    those boundaries because only the worker sees them.
+    """
+    def __init__(self, response_queue, initial_buffer_bytes: int, steady_buffer_bytes: int):
+        self._response_queue = response_queue
+        self._initial_buffer_bytes = initial_buffer_bytes
+        self._steady_buffer_bytes = steady_buffer_bytes
+        self.buffer = bytearray()
+        self.started = False
+
+    def reset(self):
+        self.buffer.clear()
+        self.started = False
+
+    def append(self, audio_bytes):
+        if not audio_bytes:
+            return
+        self.buffer.extend(audio_bytes)
+        if not self.started:
+            if len(self.buffer) < self._initial_buffer_bytes:
+                return
+            self._flush()
+            self.started = True
+            return
+        if len(self.buffer) >= self._steady_buffer_bytes:
+            self._flush()
+
+    def flush(self):
+        self._flush()
+
+    def _flush(self):
+        if not self.buffer:
+            return
+        self._response_queue.put(bytes(self.buffer))
+        self.buffer.clear()
+
+def make_audio_jitter_buffer(response_queue, initial_ms_default: float = 400,
+                             steady_ms_default: float = 200,
+                             legacy_env_prefix: str | None = None) -> AudioJitterBuffer:
+    """Build an :class:`AudioJitterBuffer` from the generic NEKO_TTS_JITTER_* env knobs.
+
+    ``legacy_env_prefix`` (e.g. "NEKO_QWEN_TTS") keeps honoring a provider's
+    pre-unification env names (``<prefix>_INITIAL_BUFFER_MS`` / ``_STEADY_BUFFER_MS``)
+    as a fallback when the generic knobs are unset, so existing overrides keep working.
+    """
+    def _resolve_ms(generic_env: str, legacy_suffix: str, default: float) -> float:
+        if os.getenv(generic_env) not in (None, ""):
+            return _parse_env_float(generic_env, default, 0)
+        if legacy_env_prefix:
+            legacy_env = f"{legacy_env_prefix}_{legacy_suffix}"
+            if os.getenv(legacy_env) not in (None, ""):
+                return _parse_env_float(legacy_env, default, 0)
+        return default
+
+    initial_ms = _resolve_ms("NEKO_TTS_JITTER_INITIAL_MS", "INITIAL_BUFFER_MS", initial_ms_default)
+    steady_ms = _resolve_ms("NEKO_TTS_JITTER_STEADY_MS", "STEADY_BUFFER_MS", steady_ms_default)
+    initial_bytes = int(initial_ms / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+    steady_bytes = int(steady_ms / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+    return AudioJitterBuffer(response_queue, initial_bytes, steady_bytes)
+
 def _enqueue_error(response_queue, error_value):
     """Unified error logging and error-message enqueueing."""
     if isinstance(error_value, str):

--- a/main_logic/tts_client/_infra.py
+++ b/main_logic/tts_client/_infra.py
@@ -85,7 +85,10 @@ class AudioJitterBuffer:
     after the first chunk (model first-frame latency). Holding back an initial
     head-start of ``initial_buffer_bytes`` before releasing the first batch gives
     the player a lead it can ride over that opening gap; steady state then flushes
-    whenever ``steady_buffer_bytes`` has accumulated. Either set to 0 falls back to
+    whenever ``steady_buffer_bytes`` has accumulated. The two knobs are independent:
+    ``initial_buffer_bytes=0`` releases the first chunk immediately (no head-start)
+    yet still coalesces later chunks by ``steady_buffer_bytes``; ``steady_buffer_bytes=0``
+    keeps the head-start but then passes each chunk straight through; both 0 is full
     low-latency pass-through.
 
     Provider-agnostic: a worker appends resampled PCM bytes and drives reset() on a
@@ -110,8 +113,7 @@ class AudioJitterBuffer:
         if not self.started:
             if len(self.buffer) < self._initial_buffer_bytes:
                 return
-            self._flush()
-            self.started = True
+            self._flush()  # 越过 head-start，放行并标记 started
             return
         if len(self.buffer) >= self._steady_buffer_bytes:
             self._flush()
@@ -124,6 +126,9 @@ class AudioJitterBuffer:
             return
         self._response_queue.put(bytes(self.buffer))
         self.buffer.clear()
+        # 放行即视为本轮已开播：短句不足 initial 阈值靠终结 flush 首次放行时，
+        # 后续若有上游晚到的 stray delta 走 steady 而非重新 head-start 再被 reset 丢弃。
+        self.started = True
 
 def make_audio_jitter_buffer(response_queue, initial_ms_default: float = 400,
                              steady_ms_default: float = 200,

--- a/main_logic/tts_client/workers/qwen.py
+++ b/main_logic/tts_client/workers/qwen.py
@@ -26,7 +26,7 @@ from urllib.parse import quote
 from utils.config_manager import get_config_manager
 from utils.dashscope_region import dashscope_ws_url_from_base
 
-from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, _parse_env_float, _enqueue_error
+from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, make_audio_jitter_buffer, _enqueue_error
 from .._telemetry import _record_tts_telemetry
 from utils.logger_config import get_module_logger
 
@@ -81,42 +81,8 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
         resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
         # Qwen realtime can produce 1-2s inter-chunk gaps. A small jitter buffer
         # gives the client enough queued PCM to ride over short upstream stalls.
-        qwen_audio_bytes_per_second = 48000 * 2
-        qwen_initial_buffer_bytes = int(_parse_env_float("NEKO_QWEN_TTS_INITIAL_BUFFER_MS", 400, 0) / 1000 * qwen_audio_bytes_per_second)
-        qwen_steady_buffer_bytes = int(_parse_env_float("NEKO_QWEN_TTS_STEADY_BUFFER_MS", 200, 0) / 1000 * qwen_audio_bytes_per_second)
-
-        class QwenAudioJitterBuffer:
-            def __init__(self):
-                self.buffer = bytearray()
-                self.started = False
-
-            def reset(self):
-                self.buffer.clear()
-                self.started = False
-
-            def append(self, audio_bytes):
-                if not audio_bytes:
-                    return
-                self.buffer.extend(audio_bytes)
-                if not self.started:
-                    if len(self.buffer) < qwen_initial_buffer_bytes:
-                        return
-                    self._flush()
-                    self.started = True
-                    return
-                if len(self.buffer) >= qwen_steady_buffer_bytes:
-                    self._flush()
-
-            def flush(self):
-                self._flush()
-
-            def _flush(self):
-                if not self.buffer:
-                    return
-                response_queue.put(bytes(self.buffer))
-                self.buffer.clear()
-
-        qwen_audio_jitter = QwenAudioJitterBuffer()
+        # 共享 AudioJitterBuffer，旧的 NEKO_QWEN_TTS_* 覆盖仍兼容（见 make_audio_jitter_buffer）。
+        qwen_audio_jitter = make_audio_jitter_buffer(response_queue, legacy_env_prefix="NEKO_QWEN_TTS")
 
         def build_config_message(lang_hint=None):
             """Build the session.update message; lang_hint='ja' specifies Japanese, anything else uses server-side Auto."""

--- a/main_logic/tts_client/workers/step.py
+++ b/main_logic/tts_client/workers/step.py
@@ -27,7 +27,7 @@ from utils.config_manager import get_config_manager
 from utils.native_voice_registry import make_native_tts_resolver, register_tts_worker_resolver
 from utils.stepfun_tts_voices import STEPFUN_TTS_DEFAULT_VOICE, get_stepfun_tts_default_voice, normalize_stepfun_tts_voice
 
-from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, _enqueue_error
+from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, make_audio_jitter_buffer, _enqueue_error
 from .._telemetry import _record_tts_telemetry
 from utils.logger_config import get_module_logger
 
@@ -139,6 +139,9 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
         pending_text_buffer = ""
         # 流式重采样器（24kHz→48kHz）- 维护 chunk 边界状态
         resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
+        # StepFun/免费上游首包后第一个 inter-chunk gap 偏大，会让开头几个字 jitter。
+        # 用与 qwen 对偶的共享 jitter buffer 攒出首包领先量盖过去。
+        audio_jitter = make_audio_jitter_buffer(response_queue)
 
         def _build_tts_create_data(sid_: str, lang_hint):
             """Assemble the tts.create data field from the URL and language hint.
@@ -292,12 +295,13 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                                     # 转换为 numpy 数组
                                     audio_array = np.frombuffer(pcm_data, dtype=np.int16)
                                     # 使用流式重采样器 24000Hz -> 48000Hz
-                                    response_queue.put(_resample_audio(audio_array, 24000, 48000, resampler))
+                                    audio_jitter.append(_resample_audio(audio_array, 24000, 48000, resampler))
                             except Exception as e:
                                 logger.error(f"处理音频数据时出错: {e}")
                         elif event_type in ["tts.response.done", "tts.response.audio.done"]:
                             # 服务器明确表示音频生成完成，设置完成标志
                             logger.debug(f"收到响应完成事件: {event_type}")
+                            audio_jitter.flush()  # 放掉缓冲区里不足 steady 阈值的尾音
                             response_done.set()
                 except websockets.exceptions.ConnectionClosed:
                     pass
@@ -338,6 +342,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     text_done_sent = False
                     session_created = False
                     pending_text_buffer = ""
+                    audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
                     continue
 
                 if sid is None:
@@ -370,6 +375,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     pending_text_buffer = ""
                     response_done.clear()
                     resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
+                    audio_jitter.reset()  # 新轮次重置 jitter buffer 领先量
                     if ws:
                         try:
                             await ws.close()
@@ -444,12 +450,13 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                                                 # 转换为 numpy 数组
                                                 audio_array = np.frombuffer(pcm_data, dtype=np.int16)
                                                 # 使用流式重采样器 24000Hz -> 48000Hz
-                                                response_queue.put(_resample_audio(audio_array, 24000, 48000, resampler))
+                                                audio_jitter.append(_resample_audio(audio_array, 24000, 48000, resampler))
                                         except Exception as e:
                                             logger.error(f"处理音频数据时出错: {e}")
                                     elif event_type in ["tts.response.done", "tts.response.audio.done"]:
                                         # 服务器明确表示音频生成完成，设置完成标志
                                         logger.debug(f"收到响应完成事件: {event_type}")
+                                        audio_jitter.flush()  # 放掉缓冲区里不足 steady 阈值的尾音
                                         response_done.set()
                             except websockets.exceptions.ConnectionClosed:
                                 pass

--- a/main_logic/tts_client/workers/step.py
+++ b/main_logic/tts_client/workers/step.py
@@ -374,8 +374,6 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     session_created = False
                     pending_text_buffer = ""
                     response_done.clear()
-                    resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
-                    audio_jitter.reset()  # 新轮次重置 jitter buffer 领先量
                     if ws:
                         try:
                             await ws.close()
@@ -387,7 +385,11 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             await receive_task
                         except asyncio.CancelledError:
                             pass
-                    
+                    # 旧接收任务已完全停止后再重置流式状态：await ws.close() 会让出，
+                    # 期间旧 receive_task 可能写入晚到的 audio.delta，若提前重置会被残留污染下一轮
+                    resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
+                    audio_jitter.reset()  # 新轮次重置 jitter buffer 领先量
+
                     # 建立新连接
                     try:
                         ws = await websockets.connect(tts_url, additional_headers=headers)

--- a/tests/unit/test_audio_jitter_buffer.py
+++ b/tests/unit/test_audio_jitter_buffer.py
@@ -1,0 +1,113 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared TTS jitter buffer semantics (qwen / step / 其它流式 worker 共用)."""
+
+from main_logic.tts_client._infra import (
+    AudioJitterBuffer,
+    make_audio_jitter_buffer,
+    _TTS_OUTPUT_BYTES_PER_SECOND,
+)
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+def test_initial_head_start_holds_back_until_threshold():
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=10, steady_buffer_bytes=4)
+    # 首包累计不足 initial 阈值时不放行（盖住开头 inter-chunk gap）。
+    buf.append(b"abc")
+    buf.append(b"def")
+    assert q.items == []
+    # 攒够 initial 后一次性放出累计领先量。
+    buf.append(b"ghij")
+    assert q.items == [b"abcdefghij"]
+
+
+def test_steady_flush_after_started():
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=4, steady_buffer_bytes=4)
+    buf.append(b"aaaa")  # 越过 initial，放行首包
+    assert q.items == [b"aaaa"]
+    buf.append(b"bb")  # 不足 steady，缓冲
+    assert q.items == [b"aaaa"]
+    buf.append(b"cc")  # 凑够 steady，放行
+    assert q.items == [b"aaaa", b"bbcc"]
+
+
+def test_flush_drains_remainder_below_threshold():
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=4, steady_buffer_bytes=4)
+    buf.append(b"aaaa")
+    buf.append(b"z")  # 尾音不足 steady
+    buf.flush()  # response.done 时强制放出
+    assert q.items == [b"aaaa", b"z"]
+
+
+def test_reset_discards_unsent_buffer_and_restarts_head_start():
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=10, steady_buffer_bytes=4)
+    buf.append(b"abc")  # 缓冲中、未放出
+    buf.reset()  # 打断 / 新轮次
+    assert q.items == []
+    # reset 后重新进入 head-start 状态：又要攒够 initial 才放行。
+    buf.append(b"xyz")
+    assert q.items == []
+
+
+def test_empty_append_is_noop():
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=4, steady_buffer_bytes=4)
+    buf.append(b"")
+    buf.append(None)
+    assert q.items == []
+
+
+def test_factory_defaults_to_400_200_ms():
+    q = _FakeQueue()
+    buf = make_audio_jitter_buffer(q)
+    assert buf._initial_buffer_bytes == int(400 / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+    assert buf._steady_buffer_bytes == int(200 / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+
+
+def test_factory_generic_env_override(monkeypatch):
+    monkeypatch.setenv("NEKO_TTS_JITTER_INITIAL_MS", "600")
+    monkeypatch.setenv("NEKO_TTS_JITTER_STEADY_MS", "100")
+    q = _FakeQueue()
+    buf = make_audio_jitter_buffer(q)
+    assert buf._initial_buffer_bytes == int(600 / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+    assert buf._steady_buffer_bytes == int(100 / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+
+
+def test_factory_legacy_env_fallback(monkeypatch):
+    # 旧 NEKO_QWEN_TTS_* 覆盖仍生效（generic 未设时回退）。
+    monkeypatch.delenv("NEKO_TTS_JITTER_INITIAL_MS", raising=False)
+    monkeypatch.setenv("NEKO_QWEN_TTS_INITIAL_BUFFER_MS", "800")
+    q = _FakeQueue()
+    buf = make_audio_jitter_buffer(q, legacy_env_prefix="NEKO_QWEN_TTS")
+    assert buf._initial_buffer_bytes == int(800 / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)
+
+
+def test_factory_generic_env_wins_over_legacy(monkeypatch):
+    monkeypatch.setenv("NEKO_TTS_JITTER_INITIAL_MS", "500")
+    monkeypatch.setenv("NEKO_QWEN_TTS_INITIAL_BUFFER_MS", "800")
+    q = _FakeQueue()
+    buf = make_audio_jitter_buffer(q, legacy_env_prefix="NEKO_QWEN_TTS")
+    assert buf._initial_buffer_bytes == int(500 / 1000 * _TTS_OUTPUT_BYTES_PER_SECOND)

--- a/tests/unit/test_audio_jitter_buffer.py
+++ b/tests/unit/test_audio_jitter_buffer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared TTS jitter buffer semantics (qwen / step / 其它流式 worker 共用)."""
+"""Shared TTS jitter buffer semantics (qwen / step / other streaming workers)."""
 
 from main_logic.tts_client._infra import (
     AudioJitterBuffer,
@@ -59,6 +59,29 @@ def test_flush_drains_remainder_below_threshold():
     buf.append(b"z")  # 尾音不足 steady
     buf.flush()  # response.done 时强制放出
     assert q.items == [b"aaaa", b"z"]
+
+
+def test_flush_during_head_start_marks_started():
+    # 短句不足 initial：靠终结 flush 首次放行后，stray delta 应走 steady 而非
+    # 重新 head-start（否则会被下一轮 reset 静默丢弃）。
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=10, steady_buffer_bytes=2)
+    buf.append(b"ab")  # 不足 initial，缓冲
+    assert q.items == []
+    buf.flush()  # response.done：放行短句
+    assert q.items == [b"ab"]
+    assert buf.started is True
+    # 晚到的 stray delta 直接走 steady（凑够 2 字节即放行），不再被 hold 400ms
+    buf.append(b"cd")
+    assert q.items == [b"ab", b"cd"]
+
+
+def test_flush_on_empty_buffer_does_not_mark_started():
+    # 空 flush 没放行任何音频，不应改变 head-start 状态。
+    q = _FakeQueue()
+    buf = AudioJitterBuffer(q, initial_buffer_bytes=10, steady_buffer_bytes=2)
+    buf.flush()
+    assert buf.started is False
 
 
 def test_reset_discards_unsent_buffer_and_restarts_head_start():


### PR DESCRIPTION
## 背景

step / 免费语音开头几个字 jitter，且只卡首 chunk。

排查发现 #1870 当年那一波 TTS 卡顿其实是**两类独立根因**，归宿完全不同：

| 根因 | 真正落地的修复 | 覆盖 step 吗 |
|---|---|---|
| 8-10s 大卡顿（event loop 被 SSL CA 加载阻塞） | #1872 `create_chat_llm_async`（全局 async 工厂） | ✅ provider 无关，step 已吃到 |
| 一字一顿 / 首包碎音（上游流式节奏偏碎） | qwen worker 内联的 jitter buffer | ❌ 只在 qwen 一家 |

（#1870 PR 本身 CLOSED 未合，只把 #1872 拆出去合了。）

## 根因

step / 免费语音首 chunk jitter 是**上游问题**：StepFun / lanlan.tech 首包后第一个 inter-chunk gap 偏大（模型首帧延迟方差最大），而 `step.py` 一直是每个 WAV delta 裸 `response_queue.put`，**零缓冲**，gap 完全暴露。qwen 当年靠 worker 内联 jitter buffer 攒出首包领先量盖过去就不卡了——但那段平滑逻辑只有 qwen 有。

## 改动

把 qwen 的 jitter buffer 提取为 `_infra.AudioJitterBuffer` + `make_audio_jitter_buffer` 共享设施（provider 无关的 PCM 攒包；worker 负责在打断 / 新轮次 `reset`、`response.done` 时 `flush`，因为只有 worker 看得到这些边界）：

- **qwen** 改用工厂，行为字节级不变；旧 `NEKO_QWEN_TTS_*` 覆盖经 `legacy_env_prefix` 仍兼容。
- **step / free / free_intl** 接入同一 buffer（默认 400/200ms，与 qwen 同）。
- env 统一为 `NEKO_TTS_JITTER_INITIAL_MS` / `NEKO_TTS_JITTER_STEADY_MS`（generic 优先、legacy 回退、设 0 退回低延迟直出）。

机制说明：buffer 是"开局攒够 initial(400ms) 才放第一包，建立领先量；之后每 steady(200ms) 放一批"。首包领先量正好盖过上游开头那个最大 gap。

> 注：grok / mimo / openai / elevenlabs 同样裸推，没接 buffer——它们暂无实测卡顿反馈，且接入会引入首字延迟，故本 PR 不动；将来需要可一行接上同一工厂。

## 测试

- 新增 `tests/unit/test_audio_jitter_buffer.py`：锁定 head-start / steady / flush / reset 语义 + 工厂 env 解析（generic 优先、legacy 回退）。9 passed。
- 既有 TTS 单测 `test_qwen_intl_tts_routing / test_tts_language_hint / test_mimo_tts_worker / test_minimax_tts_worker` 全绿（57 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 回归报告

- **变更内容**：把 qwen worker 内联的 jitter buffer 提取为 `_infra.AudioJitterBuffer` + `make_audio_jitter_buffer` 共享设施；qwen 改用工厂，step/free/free_intl 接入同一 buffer；env 统一为 `NEKO_TTS_JITTER_INITIAL_MS` / `_STEADY_MS`（旧 `NEKO_QWEN_TTS_*` 经 legacy_env_prefix 兼容）。后续评审又修了 step 新轮次 reset 时序、flush 后置 started、docstring 精确化。
- **前后行为**：qwen 行为**字节级不变**（同 400/200ms 默认、同 reset/flush 调用点，旧 env 仍生效）。step/free 从「每个 delta 裸推、零缓冲」变为「攒够 400ms head-start 才放首包、之后每 200ms 合批」，首 chunk jitter 消除；尾音经 response.done flush 放出；打断/新轮次 reset，且 reset 移到旧 receive_task 取消之后避免晚到 delta 污染下一轮。
- **潜在回归**：step/free 首字音频引入 ~400ms 缓冲延迟（与 qwen 一致，可经 env 调小或设 0 退回直出）。其余裸推 worker（grok/mimo/openai/elevenlabs）未改，行为不变。
- **测试**：新增 `tests/unit/test_audio_jitter_buffer.py`（head-start/steady/flush/reset/env 解析，含 flush 后 started）；既有 `test_qwen_intl_tts_routing` / `test_tts_language_hint` / `test_mimo_tts_worker` / `test_minimax_tts_worker` 全绿；`scripts/check_docstring_no_cjk.py` 本地通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增音频抖动缓冲机制，将上游音频碎片进行合并与分批放行，降低分片间隙带来的播放卡顿。
  * 支持基于首次缓冲与稳态缓冲的可配置放行策略，并提供立即投递（flush）能力以处理尾部音频。
* **改进**
  * 流式 TTS 在中断与切换新语句时会重置音频缓冲，避免旧音频污染新一轮播放。
* **测试**
  * 新增音频抖动缓冲单元测试，覆盖放行、flush、reset 与环境配置回退逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
