### PR TITLE
fix(tts): grok/elevenlabs 首 chunk jitter——接入共享 jitter buffer

### DIFF
--- a/main_logic/tts_client/workers/elevenlabs.py
+++ b/main_logic/tts_client/workers/elevenlabs.py
@@ -25,7 +25,7 @@ import asyncio
 from functools import partial
 from utils.elevenlabs_tts_voices import ELEVENLABS_TTS_DEFAULT_MODEL, ELEVENLABS_TTS_DEFAULT_OUTPUT_FORMAT, normalize_elevenlabs_voice_id
 
-from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, _enqueue_error
+from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, make_audio_jitter_buffer, _enqueue_error
 from .._telemetry import _record_tts_telemetry
 from utils.logger_config import get_module_logger
 
@@ -122,6 +122,9 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
         resampler = None
         pending_text: list[str] = []
         pending_text_sid: str | None = None
+        # 与 step/qwen 对偶：ElevenLabs 流式音频首包后第一个 inter-chunk gap 偏大，
+        # 用共享 jitter buffer 攒首包领先量盖过开头几个字的 jitter。
+        audio_jitter = make_audio_jitter_buffer(response_queue)
 
         def _reset_session_metrics() -> None:
             nonlocal response_finished, text_done_sent, resampler
@@ -132,6 +135,9 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                 if pcm_sample_rate != 48000
                 else None
             )
+            # 在新会话开 ws、建 receive_task 之前重置（_open_ws 已先 _close_ws 停掉旧
+            # receive_task），避免上一轮残留音频串入新轮次首包。
+            audio_jitter.reset()
 
         async def _close_ws(send_final_empty: bool = False, wait_for_final: bool = False) -> None:
             nonlocal ws, receive_task, text_done_sent
@@ -247,8 +253,9 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                         if usable_len < len(audio_bytes):
                             audio_bytes = audio_bytes[:usable_len]
                         audio_array = np.frombuffer(audio_bytes, dtype=np.int16)
-                        response_queue.put(_resample_audio(audio_array, pcm_sample_rate, 48000, resampler))
+                        audio_jitter.append(_resample_audio(audio_array, pcm_sample_rate, 48000, resampler))
                     if is_final:
+                        audio_jitter.flush()  # 本轮音频结束，放掉缓冲区里不足 steady 阈值的尾音
                         response_finished.set()
                         break
             except websockets.exceptions.ConnectionClosed as exc:
@@ -329,6 +336,7 @@ def elevenlabs_tts_worker(request_queue, response_queue, audio_api_key, voice_id
                     current_speech_id = None
                     pending_text.clear()
                     pending_text_sid = None
+                    audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
                     continue
 
                 if sid is None:

--- a/main_logic/tts_client/workers/grok.py
+++ b/main_logic/tts_client/workers/grok.py
@@ -23,7 +23,7 @@ import asyncio
 
 from utils.native_voice_registry import make_native_tts_resolver, register_tts_worker_resolver
 
-from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, _enqueue_error
+from .._infra import TTS_SHUTDOWN_SENTINEL, _resample_audio, make_audio_jitter_buffer, _enqueue_error
 from .._telemetry import _record_tts_telemetry
 from utils.logger_config import get_module_logger
 
@@ -90,6 +90,9 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
         receive_task = None
         text_done_sent = False
         resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
+        # 与 step/qwen 对偶：xAI 流式音频首包后第一个 inter-chunk gap 偏大，用共享
+        # jitter buffer 攒首包领先量盖过开头几个字的 jitter。
+        audio_jitter = make_audio_jitter_buffer(response_queue)
         # 当 reconnect 失败时缓冲尚未发出的文本 chunks（同一 utterance）。下一次
         # 同 sid chunk 到达并 reconnect 成功后，缓冲内容会拼到第一条 text.delta
         # 前一起发送 —— 避免触发 reconnect 的那一条 chunk 在 continue 后丢失，
@@ -110,7 +113,7 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                     if isinstance(message, bytes):
                         try:
                             audio_array = np.frombuffer(message, dtype=np.int16)
-                            response_queue.put(_resample_audio(audio_array, 24000, 48000, resampler))
+                            audio_jitter.append(_resample_audio(audio_array, 24000, 48000, resampler))
                         except Exception as e:
                             logger.error(f"xAI TTS 二进制音频解码失败: {e}")
                         continue
@@ -129,11 +132,12 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                         try:
                             audio_bytes = base64.b64decode(audio_b64)
                             audio_array = np.frombuffer(audio_bytes, dtype=np.int16)
-                            response_queue.put(_resample_audio(audio_array, 24000, 48000, resampler))
+                            audio_jitter.append(_resample_audio(audio_array, 24000, 48000, resampler))
                         except Exception as e:
                             logger.error(f"xAI TTS 音频解码失败: {e}")
                     elif event_type == "audio.done":
-                        pass
+                        # 本轮音频结束，放掉缓冲区里不足 steady 阈值的尾音
+                        audio_jitter.flush()
                     elif event_type == "error":
                         logger.error(f"xAI TTS server error: {event}")
                         _enqueue_error(response_queue, event)
@@ -186,6 +190,7 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                     text_done_sent = False
                     pending_text.clear()
                     pending_text_sid = None
+                    audio_jitter.reset()  # 打断：丢弃未放出的缓冲音频
                     continue
 
                 if sid is None:
@@ -201,6 +206,7 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                             current_speech_id = pending_text_sid
                             text_done_sent = False
                             resampler.clear()
+                            audio_jitter.reset()
                             logger.info("xAI TTS last-chance reconnect on utterance end succeeded")
                         except Exception as e:
                             logger.warning(f"xAI TTS last-chance reconnect 失败，pending 丢弃: {e}")
@@ -290,6 +296,7 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                     current_speech_id = sid
                     text_done_sent = False
                     resampler.clear()
+                    audio_jitter.reset()  # 新轮次重置 jitter buffer 领先量
 
                 if not tts_text or not tts_text.strip():
                     continue

--- a/main_logic/tts_client/workers/grok.py
+++ b/main_logic/tts_client/workers/grok.py
@@ -235,6 +235,11 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                                 try:
                                     ws = await websockets.connect(tts_url, additional_headers=headers, close_timeout=0.5)
                                     receive_task = asyncio.create_task(receive_messages())
+                                    # 换了新 receive_task：与 last-chance reconnect 一致，reset 掉旧连接
+                                    # 里未 flush 的残留音频，避免拼到重试音频前面（ws 原本存活、上一轮
+                                    # 已 append 过的路径才会非空；走过 last-chance 的路径 buffer 已空）。
+                                    resampler.clear()
+                                    audio_jitter.reset()
                                     for delta in _grok_chunk_text_delta("".join(pending_text)):
                                         await ws.send(json.dumps({"type": "text.delta", "delta": delta}))
                                     logger.info("flush pending_text 重连重试成功")


### PR DESCRIPTION
## 背景

#1982 把 jitter buffer 抽成共享 `_infra.AudioJitterBuffer` + `make_audio_jitter_buffer` 并接入 qwen / step，解决首 chunk jitter。本 PR 把**剩下两个云 WS realtime worker**（grok、elevenlabs）也接上同一工厂——它们改之前和 step 一样是「每个 delta 裸 `response_queue.put`、零缓冲」，开头几个字会 jitter。

## 范围（为什么只有这两个）

按推流结构分类，只有 realtime WS 逐 chunk 流式的 worker 需要：

- **接**：`grok`、`elevenlabs` —— 仅有的两个云 WS realtime 逐 chunk 裸推（qwen/step 已在 #1982 接）。
- **不碰**：
  - 整句 HTTP 那批（`openai`/`gemini`/`cogtts`/`mimo`/`minimax`）走 `_run_sentence_tts_worker`，是 **per-sentence 合成**而非 realtime delta 流，首包卡顿性质不同；`minimax` 还自带 4096B chunk 聚合。
  - 本地那批（`local_cosyvoice`/`gptsovits`/`vllm_omni`）按现状保留。
  - `cosyvoice` 已自带等价的 `bootstrap`(1024B head-start) + `agg`(4096B steady) 聚合，再套一层是重复。

## 改动

- **grok** [grok.py](main_logic/tts_client/workers/grok.py)：binary frame 与 JSON `audio.delta` 两路 `put` 改 `audio_jitter.append`；`audio.done` 触发 `flush()`；`interrupt` / last-chance reconnect / 新 `speech_id` 三处 `reset()`——均放在旧 `receive_task` cancel+await **之后**，避免 `await ws.close()` 让出期间晚到的 delta 污染下一轮（与 step 在 #1982 的修复时序一致）。
- **elevenlabs** [elevenlabs.py](main_logic/tts_client/workers/elevenlabs.py)：audio `append`；`is_final` 触发 `flush()`；`reset()` 收进 `_reset_session_metrics()`（`_open_ws` 里、建新 `receive_task` 之前调用，此时旧 task 已被 `_close_ws` 停掉）+ `interrupt` 兜底。

默认 400/200ms（与 qwen/step 同），env 复用 `NEKO_TTS_JITTER_INITIAL_MS` / `NEKO_TTS_JITTER_STEADY_MS`。

## 回归报告

- **变更内容**：grok、elevenlabs 两个 WS realtime worker 把裸 `response_queue.put(_resample_audio(...))` 换成共享 `AudioJitterBuffer` 的 append/flush/reset。无新增依赖、无接口变更。
- **前后行为**：从「每 delta 立即推」变为「攒够 400ms head-start 才放首包、之后每 200ms 合批」，首 chunk jitter 消除；尾音经 audio.done(grok) / is_final(elevenlabs) flush 放出；打断/新轮次/重连各边界 reset。其余 provider 行为完全不变。
- **潜在回归**：grok/elevenlabs 首字音频引入 ~400ms 缓冲延迟（与 qwen/step 一致，可经 env 调小或设 0 退回直出）。reset 时序若放错会让晚到 delta 串入下一轮——已统一放在旧 receive_task 停止之后规避。
- **测试**：`py_compile` 两 worker + `_infra` 通过；`import` 两 worker 触发 registry 注册成功；`tests/unit/test_audio_jitter_buffer.py`（共享 buffer 语义）/ `test_elevenlabs_voice_design.py` / `test_qwen_intl_tts_routing.py` 全绿（16 passed）。worker 级流式行为为多进程 WS，无自动化测试（与 #1982 接入 qwen/step 时一致），靠结构审查 + buffer 单测保证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 优化 ElevenLabs 与 Grok 的流式音频播放：改进音频包时序同步与缓冲衔接，减少断续与错位。
  * 增强中断、重连与轮次切换场景的稳定性，降低尾音串入与播放延迟。

* **Performance**
  * 改善首包响应体验，提升跨包连续播放的平滑度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->