### PR TITLE
feat(middleware): 添加 ASGI 全局入站 body 体积守门 (#1586)

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -101,6 +101,7 @@ from utils.storage_location_bootstrap import get_storage_startup_blocking_reason
 from utils.logger_config import setup_logging # noqa: E402
 from utils.ssl_env_diagnostics import probe_ssl_environment, write_ssl_diagnostic # noqa: E402
 from utils.asyncio_executor import configure_default_executor # noqa: E402
+from utils.asgi_body_limit import InboundBodySizeLimitMiddleware # noqa: E402
 
 _main_log_level = getattr(logging, (os.environ.get("NEKO_LOG_LEVEL") or "INFO").upper(), logging.INFO)
 logger, log_config = setup_logging(service_name="Main", log_level=_main_log_level, silent=not _IS_MAIN_PROCESS)
@@ -1600,6 +1601,14 @@ async def main_storage_limited_mode_guard(request: Request, call_next):
             "error": "Main server 正处于存储受限启动状态，请等待存储位置选择、迁移或恢复完成。",
         },
     )
+
+
+# 全局入站 body 体积守门（issue #1586）：在 router 的 request.json()/form()
+# 解析之前，按 Content-Length 拒收超大「非 multipart」请求体，跨所有 router
+# 统一生效，与各 router 的业务校验（如 validate_chat_payload）正交。multipart
+# 文件上传（模型/音乐/角色卡等）一律放行，交给各上传 router 自带的流式分块守门。
+# add_middleware 后注册即处于最外层，最先执行——解析前拒收，不浪费后续处理。
+app.add_middleware(InboundBodySizeLimitMiddleware)
 
 
 @app.exception_handler(MaintenanceModeError)

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -101,6 +101,7 @@ from utils.cloudsave_runtime import (
 )
 from utils.config_manager import get_config_manager
 from utils.storage_location_bootstrap import get_storage_startup_blocking_reason
+from utils.asgi_body_limit import InboundBodySizeLimitMiddleware
 from pydantic import BaseModel
 import re
 import asyncio
@@ -175,6 +176,13 @@ async def storage_limited_mode_guard(request: Request, call_next):
             "error": "Memory server 正处于存储受限启动状态，请等待存储位置选择、迁移或恢复完成。",
         },
     )
+
+
+# 全局入站 body 体积守门（issue #1586）：与 main_server 对偶，memory_server 的
+# 端点（对话缓存 / reflection 记录等）都是小 JSON，统一加上同一守门保持一致。
+# agent_server 因 /openfang-llm-proxy 透明转发大 LLM 请求（vision/长上下文 JSON
+# 可超 16M）有意不装，见 PR 说明。
+app.add_middleware(InboundBodySizeLimitMiddleware)
 
 
 @app.exception_handler(MaintenanceModeError)

--- a/tests/unit/test_asgi_body_limit.py
+++ b/tests/unit/test_asgi_body_limit.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Tests for the global inbound body-size guard (issue #1586).
+
+The middleware caps oversized *non-multipart* request bodies before they reach
+any router, by inspecting only ``Content-Length``. Multipart uploads, requests
+without ``Content-Length``, and non-http scopes are passed through untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from utils.asgi_body_limit import (
+    DEFAULT_MAX_INBOUND_BODY_BYTES,
+    InboundBodySizeLimitMiddleware,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _http_scope(headers):
+    return {"type": "http", "method": "POST", "path": "/x", "headers": list(headers)}
+
+
+async def _drive(middleware, scope):
+    """Run the middleware once; return (downstream_called, sent_messages)."""
+    called = {"hit": False}
+
+    async def downstream(_scope, _receive, _send):
+        called["hit"] = True
+        # A real app would respond; emit a trivial 200 so send() is exercised.
+        await _send({"type": "http.response.start", "status": 200, "headers": []})
+        await _send({"type": "http.response.body", "body": b"ok"})
+
+    middleware.app = downstream
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return called["hit"], sent
+
+
+def _make(max_bytes=64):
+    # Tiny cap keeps the test payloads small; the guard logic is size-agnostic.
+    return InboundBodySizeLimitMiddleware(app=None, max_body_bytes=max_bytes)
+
+
+def test_under_limit_passes_through():
+    mw = _make(max_bytes=64)
+    scope = _http_scope([(b"content-length", b"10"), (b"content-type", b"application/json")])
+    hit, sent = _run(_drive(mw, scope))
+    assert hit is True
+    assert sent[0]["status"] == 200
+
+
+def test_at_limit_passes_through():
+    """Exactly at the cap is allowed (uses ``>`` not ``>=``)."""
+    mw = _make(max_bytes=64)
+    scope = _http_scope([(b"content-length", b"64"), (b"content-type", b"application/json")])
+    hit, sent = _run(_drive(mw, scope))
+    assert hit is True
+    assert sent[0]["status"] == 200
+
+
+def test_over_limit_rejected_with_413():
+    mw = _make(max_bytes=64)
+    scope = _http_scope([(b"content-length", b"65"), (b"content-type", b"application/json")])
+    hit, sent = _run(_drive(mw, scope))
+    assert hit is False, "downstream app must not be reached"
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 413
+    payload = json.loads(sent[1]["body"].decode("utf-8"))
+    assert payload["ok"] is False
+    assert payload["error_code"] == "payload_too_large"
+    assert payload["max_bytes"] == 64
+
+
+def test_multipart_over_limit_is_exempt():
+    """File uploads (multipart) are exempt — routers stream-guard them."""
+    mw = _make(max_bytes=64)
+    scope = _http_scope(
+        [
+            (b"content-length", b"100000000"),
+            (b"content-type", b"multipart/form-data; boundary=----abc"),
+        ]
+    )
+    hit, sent = _run(_drive(mw, scope))
+    assert hit is True
+    assert sent[0]["status"] == 200
+
+
+def test_multipart_content_type_is_case_insensitive():
+    mw = _make(max_bytes=64)
+    scope = _http_scope(
+        [
+            (b"content-length", b"100000000"),
+            (b"content-type", b"  Multipart/Form-Data; boundary=xyz"),
+        ]
+    )
+    hit, _sent = _run(_drive(mw, scope))
+    assert hit is True
+
+
+def test_missing_content_length_passes_through():
+    """Chunked / unknown-length requests are not rejected."""
+    mw = _make(max_bytes=64)
+    scope = _http_scope([(b"content-type", b"application/json")])
+    hit, sent = _run(_drive(mw, scope))
+    assert hit is True
+    assert sent[0]["status"] == 200
+
+
+def test_malformed_content_length_passes_through():
+    mw = _make(max_bytes=64)
+    scope = _http_scope([(b"content-length", b"not-a-number"), (b"content-type", b"application/json")])
+    hit, _sent = _run(_drive(mw, scope))
+    assert hit is True
+
+
+def test_over_limit_without_content_type_rejected():
+    """No Content-Type defaults to non-multipart → still capped."""
+    mw = _make(max_bytes=64)
+    scope = _http_scope([(b"content-length", b"65")])
+    hit, sent = _run(_drive(mw, scope))
+    assert hit is False
+    assert sent[0]["status"] == 413
+
+
+def test_websocket_scope_passes_through():
+    """Non-http scopes are forwarded untouched (Pet realtime ws must survive)."""
+    mw = _make(max_bytes=64)
+    scope = {"type": "websocket", "path": "/ws", "headers": [(b"content-length", b"999999")]}
+    hit, _sent = _run(_drive(mw, scope))
+    assert hit is True
+
+
+def test_default_cap_is_16_mib():
+    assert DEFAULT_MAX_INBOUND_BODY_BYTES == 16 * 1024 * 1024

--- a/utils/asgi_body_limit.py
+++ b/utils/asgi_body_limit.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ASGI middleware: global inbound request-body size guard.
+
+This rejects oversized request bodies *before* they reach the application
+layer (a router's ``request.json()`` / ``request.form()`` parse), uniformly
+across every router, and stays orthogonal to each router's business-level
+validation (e.g. ``memory_router.validate_chat_payload``).
+
+Design (see issue #1586, raised from the PR #1585 discussion):
+
+- Only non-multipart requests are capped. ``multipart/form-data`` is the file
+  upload path (Live2D/VRM/MMD models, jukebox music, character-card zips, ...)
+  whose legitimate bodies routinely run to hundreds of MB or GB. Those upload
+  routers already enforce their own 1 MB-chunk streaming guards (read-and-tally,
+  stop on overflow, never buffering the whole body in memory), so this guard
+  passes multipart straight through to avoid killing legitimate large uploads.
+- Only the ``Content-Length`` header is inspected; the body itself is never
+  read. That is what makes the rejection happen "before parsing". When
+  ``Content-Length`` is absent (e.g. chunked transfer encoding) the request is
+  passed through — we would rather under-guard than reject a valid request.
+- Only the ``http`` scope is handled; ``websocket`` / ``lifespan`` scopes are
+  forwarded untouched (the Pet realtime WebSocket endpoints must not be
+  affected).
+
+This app is a loopback-only desktop backend with no external trust boundary, so
+this guard is a memory / data-shape safeguard, not a security perimeter. A
+client can trivially bypass the cap by labelling its request ``multipart/*`` —
+but that only routes it back into the upload routers' own streaming guards, so
+an oversized body still never gets buffered whole. The cap's job is the bare
+``request.json()`` endpoints that would otherwise read an arbitrarily large
+body into memory before validating its shape.
+"""
+from __future__ import annotations
+
+import json
+
+# 16 MiB. Comfortably above every non-multipart endpoint's legitimate body
+# (the largest is the recent-chat payload's 2 MB business cap from PR #1585),
+# while still stopping an anomalous JSON/urlencoded body from being buffered
+# into memory before it is parsed.
+DEFAULT_MAX_INBOUND_BODY_BYTES = 16 * 1024 * 1024
+
+
+class InboundBodySizeLimitMiddleware:
+    """Reject oversized non-multipart request bodies before routers see them."""
+
+    def __init__(self, app, max_body_bytes: int = DEFAULT_MAX_INBOUND_BODY_BYTES):
+        self.app = app
+        self.max_body_bytes = int(max_body_bytes)
+
+    async def __call__(self, scope, receive, send):
+        # websocket / lifespan scopes carry no Content-Length body to cap.
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        content_length: bytes | None = None
+        content_type: bytes = b""
+        for key, value in scope.get("headers") or ():
+            lowered = key.lower()
+            if lowered == b"content-length":
+                content_length = value
+            elif lowered == b"content-type":
+                content_type = value
+
+        if self._exceeds_limit(content_length, content_type):
+            await self._reject(send)
+            return
+
+        await self.app(scope, receive, send)
+
+    def _exceeds_limit(self, content_length: bytes | None, content_type: bytes) -> bool:
+        if content_length is None:
+            # No Content-Length (chunked / unknown): pass through rather than
+            # risk rejecting a valid streaming request.
+            return False
+        # Multipart uploads are exempt — the upload routers guard them with
+        # their own streaming, much-larger caps.
+        if content_type.strip().lower().startswith(b"multipart/"):
+            return False
+        try:
+            length = int(content_length)
+        except (TypeError, ValueError):
+            # Malformed Content-Length: let the server / downstream handle it
+            # instead of guessing here.
+            return False
+        return length > self.max_body_bytes
+
+    async def _reject(self, send) -> None:
+        body = json.dumps(
+            {
+                "ok": False,
+                "error_code": "payload_too_large",
+                "max_bytes": self.max_body_bytes,
+                "error": "请求体超过全局体积上限。",
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json; charset=utf-8"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                    # Don't try to keep-alive a connection whose (unread) request
+                    # body may still be streaming in.
+                    (b"connection", b"close"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/utils/asgi_body_limit.py
+++ b/utils/asgi_body_limit.py
@@ -122,4 +122,4 @@ class InboundBodySizeLimitMiddleware:
                 ],
             }
         )
-        await send({"type": "http.response.body", "body": body})
+        await send({"type": "http.response.body", "body": body, "more_body": False})


### PR DESCRIPTION
## 背景

承接 #1586（由 #1585 讨论衍生）：`validate_chat_payload` 这类校验跑在 `request.json()` 之后，是数据形状护栏，不是体积守门。本 PR 在 ASGI middleware 层加全局入站 body 体积上限，跨所有 router 统一生效，与各 router 业务校验正交。

## 方案

新增 `utils/asgi_body_limit.py` 的纯 ASGI `InboundBodySizeLimitMiddleware`，用 `add_middleware` 注册到最外层。

- **只约束非 multipart 请求**（JSON / urlencoded / raw），上限 **16 MiB**。远高于所有非 multipart 端点的合法体积（最大是 recent chat 的 2 MB 业务上限），又能挡住异常 JSON 在 parse 前漫进内存。
- **multipart/form-data 一律放行**。文件上传（Live2D/VRM/MMD 模型、jukebox 音乐 1G / zip 10G、character card 100M 等）合法体积动辄上百 MB 到 GB，各上传 router 自带 1MB-chunk 流式守门（边读边累计、超限即停、不进内存），由它们负责。
- **只看 Content-Length header、不读 body**，真正做到「解析前」拒收；缺 Content-Length（chunked）放行，宁可漏守不误杀。
- **只处理 http scope**，websocket / lifespan 透传（Pet 实时 ws 不受影响）。

### 覆盖的 ASGI app

launcher 起了三个独立 uvicorn app，本守门注册情况：

| app | 是否注册 | 理由 |
|---|---|---|
| `main_server.app` | ✅ | 主服务，数十个 `request.json()` 端点 |
| `memory_server.app` | ✅ | 独立 app，对话缓存 / reflection 记录端点，body 都是小 JSON，对偶一致 |
| `agent_server.app` | ❌ 有意排除 | `/openfang-llm-proxy` 透明转发 LLM 请求（`await request.body()` 原样转发并保留 Content-Type），vision / 长上下文的 `application/json` body 合法可超 16M，套帽会误杀真实 LLM 调用 |

## 回归报告

**变更内容**：新增一个纯 ASGI middleware（`utils/asgi_body_limit.py`），在 `app/main_server.py` 与 `app/memory_server.py` 各加 2 行（import + `add_middleware`）注册，不改任何现有逻辑。

**必要性**：现状下所有 `request.json()` 端点会把整个 body 先读进内存再 parse，没有解析前的体积闸（#1585 暴露的问题）。本 middleware 把体积守门提前到解析前、且全局生效。

**前后行为对比**：
- 改之前：任意大小的 JSON/urlencoded body 都会被完整读入内存后才轮到业务校验。
- 改之后：main/memory server 上非 multipart 请求若 `Content-Length` > 16 MiB，在进入 router 前直接返回 413 `payload_too_large`；multipart、缺 Content-Length、websocket/lifespan 行为完全不变；agent_server 不受影响。

**潜在回归排查**：逐一确认全部合法的大请求体都是 multipart（豁免），所有非 multipart 请求合法体积都 ≪ 16 MiB：

| 请求类别 | 形态 | 结论 |
|---|---|---|
| Live2D/VRM/MMD 模型、jukebox 音乐/zip、card/音频/portrait、workshop 预览图/音频、avatar_drop 文档 | multipart | 豁免 ✓ |
| cloudsave export/import | JSON（只有 bool flags） | ≪16M ✓ |
| Market 代理 `/market/*` | JSON（id/token/oauth） | ≪16M ✓ |
| memory_server 对话缓存 / reflection 记录 | JSON（小） | ≪16M ✓ |
| agent_server LLM 代理 | JSON 可超 16M | **不注册守门**，无回归 ✓ |
| recent chat (#1585) 及其余数十个 `request.json()` | JSON 配置/参数 | ≪16M ✓ |

结论：功能性回归风险极小——无任何合法链路受影响。

## 设计权衡

multipart 豁免意味着全局帽只约束 JSON/urlencoded 体积。客户端把 Content-Type 伪造成 `multipart/*` 即可绕过此帽，但绕过后仍落到各上传 router 的流式守门，超大 body 依然不会被整体读进内存。loopback-only 桌面端无外部信任边界，此口径成立——全局帽负责裸奔的 JSON 端点，multipart 大文件继续归各 router 流式管。

## 测试

`tests/unit/test_asgi_body_limit.py` 10 条单测全过（边界值、413 payload、multipart 豁免、缺/畸形 Content-Length、websocket 透传、大小写）；另用 FastAPI TestClient 端到端验证小 JSON 200 / 超限 JSON 413 / 大 multipart 豁免 200。

Closes #1586

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 新增全局入站请求体大小限制（默认 16 MiB），在路由处理前基于 `Content-Length` 统一拦截非多部分请求。
  * 超限返回 `413`，错误响应包含 `ok=false`、`error_code=payload_too_large` 与 `max_bytes`，并设置 `connection: close`。
  * 多部分请求豁免；`websocket` 等非 HTTP 请求保持原样；缺失/畸形 `Content-Length` 或 multipart 识别不当时按规则放行。

* **Tests**
  * 补充中间件 ASGI 行为测试，覆盖阈值边界、豁免、多种头部组合与默认上限。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->