### PR TITLE
fix(test): 测试与 #1886 对齐——app-interpage.js 移出 react 缓存版本契约

### DIFF
--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -965,7 +965,6 @@ def test_react_chat_assets_use_react_chat_cache_version():
         "/static/app-react-chat-window.js",
         "/static/app-chat-adapter.js",
         "/static/app-buttons.js",
-        "/static/app-interpage.js",
     ]
 
     for asset in react_chat_assets:


### PR DESCRIPTION
## 根因

`test_react_chat_assets_use_react_chat_cache_version`（[test_new_user_icebreaker_static_contracts.py](tests/unit/test_new_user_icebreaker_static_contracts.py)）在 main 上就红：测试的 `react_chat_assets` 清单里仍列着 `/static/app-interpage.js`，断言它在模板里带 `?v={{ react_chat_asset_version }}`，但模板早已不是这个后缀。

- 测试由 #1839（`ed786dca4`）加入，当时模板里 app-interpage.js 确实用 `react_chat_asset_version`，能对上。
- #1886（`323aa49c0`，`修复新手教程模型加载与跳过收口`）**有意**把 `app-interpage.js` 从 `react_chat_asset_version` 切到 `static_asset_version`（index.html + chat.html 两处），并在 `pages_router.py` 把它归入 static 资源版本组。commit message 原话：「将 app-interpage.js 统一切到 static_asset_version，**并从 React chat 版本清单移除**」。
- 唯独漏改了测试清单。#1886 合并时未跑 pytest（其 commit message 自述「当前环境缺少 pytest…未能运行」），这条红就这么进了 main。

## 修法

把 `/static/app-interpage.js` 从测试的 `react_chat_assets` 清单移除，让测试跟上 #1886 的有意改动。

- 模板本身是对的——给它加回 react 后缀会回退 #1886 故意做的缓存失效修复。
- 末尾 `pages_router.count(... app-interpage.js ...) == 1` 断言（app-interpage 仍在 static 版本组里被追踪一次）保持不变。

## 验证

`uv run pytest tests/unit/test_new_user_icebreaker_static_contracts.py` → 60 passed（改前该测试 fail）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated static resource assertions in test suite to validate cache versioning for React chat components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->