### PR TITLE
fix: hide GalGame options while tutorial locks chat input

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3429,6 +3429,12 @@
         }
     }
 
+    function syncTutorialGalgameSuppression() {
+        setGalgameModeTemporarilyDisabled(
+            state.homeTutorialInputLocked || isHomeTutorialInteractionLocked()
+        );
+    }
+
     function setGalgameModeEnabled(enabled, options) {
         var requestOptions = options || {};
         var next = !!enabled;
@@ -4350,6 +4356,7 @@
             compactChatState: getCurrentCompactChatState(),
             composerDisabled: !!next
         });
+        syncTutorialGalgameSuppression();
         renderWindow();
     }
 
@@ -4367,6 +4374,7 @@
             compactInputLocked: next,
             composerDisabled: !!state.homeTutorialInteractionLocked
         });
+        syncTutorialGalgameSuppression();
         renderWindow();
     }
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3414,24 +3414,30 @@
         }
     }
 
-    function setGalgameModeTemporarilyDisabled(disabled) {
+    function setGalgameModeTemporarilyDisabled(disabled, options) {
+        var requestOptions = options || {};
         var next = !!disabled;
         var changed = state.galgameTemporarilyDisabled !== next;
         state.galgameTemporarilyDisabled = next;
 
         if (next) {
-            setGalgameModeEnabled(false, { persist: false });
+            setGalgameModeEnabled(false, {
+                persist: false,
+                skipRender: requestOptions.skipRender === true
+            });
         } else if (changed) {
             setGalgameModeEnabled(readGalgameModePreference(), {
                 persist: false,
-                suppressRefetch: true
+                suppressRefetch: true,
+                skipRender: requestOptions.skipRender === true
             });
         }
     }
 
     function syncTutorialGalgameSuppression() {
         setGalgameModeTemporarilyDisabled(
-            state.homeTutorialInputLocked || isHomeTutorialInteractionLocked()
+            state.homeTutorialInputLocked || isHomeTutorialInteractionLocked(),
+            { skipRender: true }
         );
     }
 
@@ -3456,7 +3462,9 @@
         if ((!requestOptions || requestOptions.persist !== false) && !isGalgameModeTemporarilyDisabled()) {
             persistGalgameModePreference(next);
         }
-        renderWindow();
+        if (!requestOptions.skipRender) {
+            renderWindow();
+        }
         if (changed) {
             // 派发 effective 值（与 body class 一致）：composer 隐藏期间即使
             // setGalgameModeEnabled(true) 也广播 enabled=false，避免监听器

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -2579,6 +2579,48 @@ def test_home_tutorial_early_end_restores_temporarily_disabled_galgame_mode(
 
 
 @pytest.mark.frontend
+def test_home_tutorial_input_lock_suppresses_galgame_options_without_tutorial_event(
+    mock_page: Page,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.localStorage.setItem('neko.reactChatWindow.galgameMode', 'true');
+        """,
+        script_names=("app-react-chat-window.js",),
+    )
+
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost && window.reactChatWindowHost.isGalgameModeEnabled() === true",
+        timeout=5000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.reactChatWindowHost.setHomeTutorialInputLocked(true, 'avatar-floating-guide-day1');
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost.isGalgameModeEnabled() === false",
+        timeout=5000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.reactChatWindowHost.setHomeTutorialInputLocked(false, 'avatar-floating-guide-day1-complete');
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost.isGalgameModeEnabled() === true",
+        timeout=5000,
+    )
+
+
+@pytest.mark.frontend
 def test_home_tutorial_feature_controller_restores_live_galgame_state_after_legacy_listener(
     mock_page: Page,
 ):


### PR DESCRIPTION
## 改动概述 / Summary
- 在首页教程锁定聊天输入时，同步临时隐藏 GalGame 选项，避免教程期间仍出现选择项干扰引导。
- 保留用户原本的 GalGame 开关偏好；教程锁解除后按原状态恢复。
- 补充 React Chat 独立窗口只收到 input lock、没有 tutorial event 时的回归测试。

## 回归报告 / Regression Report
不适用。本 PR 未修改 `app/`、`main_logic/` 或 `memory/`。

## 不拆分理由 / Why Not Split
不适用。

## 测试 / Testing
- `uv run pytest tests/frontend/test_home_prompt_flow.py -q -k 'home_tutorial_skip_restores_temporarily_disabled_galgame_mode or home_tutorial_early_end_restores_temporarily_disabled_galgame_mode or home_tutorial_input_lock_suppresses_galgame_options_without_tutorial_event or home_tutorial_feature_controller_restores_live_galgame_state_after_legacy_listener'`
- `node --check static/app-react-chat-window.js`
- `git diff --check -- static/app-react-chat-window.js tests/frontend/test_home_prompt_flow.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **Bug Fixes**
  * 改进主页教程与 GalGame 模式的交互：当教程锁定用户交互或输入时，GalGame 选项会被自动抑制；解除锁定后将恢复开启状态。

* **Tests**
  * 新增前端用例，覆盖“输入被锁定但未触发教程事件”的场景，验证抑制与恢复逻辑是否按时序生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->