### PR TITLE
chore: add .kilo/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ data/embedding_models/
 *.code-workspace
 .claude
 .trae/
+.kilo/
 plans/
 CLAUDE.md
 /.workbuddy/


### PR DESCRIPTION
Add .kilo/ directory to .gitignore, alongside .claude, .trae/, .cursor/ and other tool config directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新版本控制配置，增加目录排除规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->