### PR TITLE
fix: persist icebreaker dialogue to memory cache

### DIFF
--- a/main_routers/icebreaker_router.py
+++ b/main_routers/icebreaker_router.py
@@ -37,6 +37,7 @@ router = APIRouter(tags=["icebreaker"], prefix="/api/icebreaker")
 
 ICEBREAKER_SOURCE = "new_user_icebreaker"
 MAX_ICEBREAKER_CONTEXT_TEXT_LENGTH = 2000
+ICEBREAKER_MEMORY_CACHE_TIMEOUT_SECONDS = 10.0
 _SSML_TAG_PATTERN = re.compile(
     r"</?(?:[a-z][\w-]*:)?(?:"
     r"speak|p|s|break|say-as|phoneme|sub|prosody|emphasis|voice|audio|mark|lang|w|token|express-as|effect"
@@ -99,6 +100,37 @@ def _coerce_payload_bool(value: Any) -> bool | None:
         if normalized in {"0", "false", "no", "n", "off"}:
             return False
     return None
+
+
+def _build_icebreaker_memory_message(role: str, text: str) -> dict | None:
+    normalized_role = str(role or "").strip().lower()
+    if normalized_role not in {"assistant", "user"}:
+        return None
+    content = str(text or "").strip()
+    if not content:
+        return None
+    return {
+        "role": normalized_role,
+        "content": [{"type": "text", "text": content}],
+    }
+
+
+async def _cache_icebreaker_context_memory(*, lanlan_name: str, role: str, text: str) -> tuple[bool, str]:
+    message = _build_icebreaker_memory_message(role, text)
+    if message is None:
+        return False, "invalid_memory_message"
+    try:
+        from main_logic.cross_server import _post_memory_server
+
+        ok, err_detail, _ = await _post_memory_server(
+            "cache",
+            lanlan_name,
+            [message],
+            timeout_s=ICEBREAKER_MEMORY_CACHE_TIMEOUT_SECONDS,
+        )
+        return bool(ok), str(err_detail or "")
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
 
 
 def _stale_icebreaker_session_response(state: dict | None, session_id: str, *, lanlan_name: str, method: str) -> dict | None:
@@ -318,6 +350,7 @@ async def icebreaker_context(request: Request):
             "lanlan_name": lanlan_name,
             "source": ICEBREAKER_SOURCE,
             "session_id": session_id,
+            "memory_cached": False,
         }
     ok = getattr(append_result, "appended", False)
     if not ok:
@@ -329,14 +362,30 @@ async def icebreaker_context(request: Request):
             "session_id": session_id,
         }
 
+    memory_cached, memory_cache_error = await _cache_icebreaker_context_memory(
+        lanlan_name=lanlan_name,
+        role=role,
+        text=text,
+    )
+    if not memory_cached:
+        logger.warning(
+            "icebreaker memory cache failed for %s role=%s session=%s: %s",
+            lanlan_name,
+            role,
+            session_id,
+            memory_cache_error,
+        )
+
     touch_icebreaker_route(state)
-    return {
+    result = {
         "ok": True,
         "method": "project_session_history",
         "lanlan_name": lanlan_name,
         "source": ICEBREAKER_SOURCE,
         "session_id": session_id,
+        "memory_cached": memory_cached,
     }
+    return result
 
 
 @router.post("/speak")

--- a/tests/unit/test_icebreaker_router.py
+++ b/tests/unit/test_icebreaker_router.py
@@ -58,6 +58,10 @@ def _allow_local_mutation(request, payload=None, **kwargs):
     return None
 
 
+async def _fake_cache_memory(**kwargs):
+    return True, ""
+
+
 @pytest.mark.asyncio
 async def test_icebreaker_route_start_does_not_activate_game_route(monkeypatch):
     monkeypatch.setattr(icebreaker_router, "get_session_manager", lambda: {})
@@ -102,8 +106,15 @@ async def test_icebreaker_route_start_requires_local_mutation_csrf(monkeypatch):
 @pytest.mark.asyncio
 async def test_icebreaker_context_endpoint_appends_session_history(monkeypatch):
     mgr = _FakeAppendContextManager()
+    memory_cache_calls = []
+
+    async def fake_cache_memory(**kwargs):
+        memory_cache_calls.append(kwargs)
+        return True, ""
+
     monkeypatch.setattr(icebreaker_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
+    monkeypatch.setattr(icebreaker_router, "_cache_icebreaker_context_memory", fake_cache_memory)
     icebreaker_route_state.activate_icebreaker_route("Lan", "icebreaker-day1-test")
 
     result = await icebreaker_router.icebreaker_context(
@@ -131,6 +142,109 @@ async def test_icebreaker_context_endpoint_appends_session_history(monkeypatch):
             "session_id": "icebreaker-day1-test",
         },
     }]
+    assert memory_cache_calls == [{
+        "lanlan_name": "Lan",
+        "role": "assistant",
+        "text": "教程看完啦？",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_icebreaker_context_caches_user_choice_to_recent_memory(monkeypatch):
+    mgr = _FakeAppendContextManager()
+    memory_cache_calls = []
+
+    async def fake_cache_memory(**kwargs):
+        memory_cache_calls.append(kwargs)
+        return True, ""
+
+    monkeypatch.setattr(icebreaker_router, "get_session_manager", lambda: {"Lan": mgr})
+    monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
+    monkeypatch.setattr(icebreaker_router, "_cache_icebreaker_context_memory", fake_cache_memory)
+    icebreaker_route_state.activate_icebreaker_route("Lan", "icebreaker-day1-test")
+
+    result = await icebreaker_router.icebreaker_context(
+        _FakeRequest({
+            "lanlan_name": "Lan",
+            "role": "user",
+            "text": "可以，多陪一会儿",
+            "session_id": "icebreaker-day1-test",
+            "request_id": "choice-1",
+        })
+    )
+
+    assert result["ok"] is True
+    assert result["memory_cached"] is True
+    assert memory_cache_calls == [{
+        "lanlan_name": "Lan",
+        "role": "user",
+        "text": "可以，多陪一会儿",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_icebreaker_context_cache_failure_does_not_block_context(monkeypatch, caplog):
+    mgr = _FakeAppendContextManager()
+    memory_cache_calls = []
+
+    async def fake_cache_memory(**kwargs):
+        memory_cache_calls.append(kwargs)
+        return False, "timeout"
+
+    monkeypatch.setattr(icebreaker_router, "get_session_manager", lambda: {"Lan": mgr})
+    monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
+    monkeypatch.setattr(icebreaker_router, "_cache_icebreaker_context_memory", fake_cache_memory)
+    icebreaker_route_state.activate_icebreaker_route("Lan", "icebreaker-day1-test")
+
+    result = await icebreaker_router.icebreaker_context(
+        _FakeRequest({
+            "lanlan_name": "Lan",
+            "role": "assistant",
+            "text": "教程看完啦？",
+            "session_id": "icebreaker-day1-test",
+            "request_id": "line-1",
+        })
+    )
+
+    assert result["ok"] is True
+    assert result["memory_cached"] is False
+    assert mgr.calls[0]["text"] == "教程看完啦？"
+    assert memory_cache_calls == [{
+        "lanlan_name": "Lan",
+        "role": "assistant",
+        "text": "教程看完啦？",
+    }]
+    assert "icebreaker memory cache failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_icebreaker_context_deduped_response_keeps_memory_cached_field(monkeypatch):
+    mgr = _FakeAppendContextManager(result=SimpleNamespace(appended=False, deduped=True, reason="duplicate"))
+    memory_cache_calls = []
+
+    async def fake_cache_memory(**kwargs):
+        memory_cache_calls.append(kwargs)
+        return True, ""
+
+    monkeypatch.setattr(icebreaker_router, "get_session_manager", lambda: {"Lan": mgr})
+    monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
+    monkeypatch.setattr(icebreaker_router, "_cache_icebreaker_context_memory", fake_cache_memory)
+    icebreaker_route_state.activate_icebreaker_route("Lan", "icebreaker-day1-test")
+
+    result = await icebreaker_router.icebreaker_context(
+        _FakeRequest({
+            "lanlan_name": "Lan",
+            "role": "assistant",
+            "text": "教程看完啦？",
+            "session_id": "icebreaker-day1-test",
+            "request_id": "line-1",
+        })
+    )
+
+    assert result["ok"] is True
+    assert result["deduped"] is True
+    assert result["memory_cached"] is False
+    assert memory_cache_calls == []
 
 
 @pytest.mark.asyncio
@@ -138,6 +252,7 @@ async def test_icebreaker_context_falls_back_to_active_session_id(monkeypatch):
     mgr = _FakeAppendContextManager()
     monkeypatch.setattr(icebreaker_router, "get_session_manager", lambda: {"Lan": mgr})
     monkeypatch.setattr(system_router, "_validate_local_mutation_request", _allow_local_mutation)
+    monkeypatch.setattr(icebreaker_router, "_cache_icebreaker_context_memory", _fake_cache_memory)
     icebreaker_route_state.activate_icebreaker_route("Lan", "active-session")
 
     result = await icebreaker_router.icebreaker_context(
@@ -152,6 +267,42 @@ async def test_icebreaker_context_falls_back_to_active_session_id(monkeypatch):
     assert result["session_id"] == "active-session"
     assert mgr.calls[0]["ordering_key"] == "active-session"
     assert mgr.calls[0]["metadata"]["session_id"] == "active-session"
+
+
+@pytest.mark.asyncio
+async def test_icebreaker_context_memory_cache_uses_existing_cache_endpoint(monkeypatch):
+    calls = []
+
+    async def fake_post_memory_server(endpoint, lanlan_name, payload, *, timeout_s):
+        calls.append({
+            "endpoint": endpoint,
+            "lanlan_name": lanlan_name,
+            "payload": payload,
+            "timeout_s": timeout_s,
+        })
+        return True, "", {"status": "cached", "count": 1}
+
+    import main_logic.cross_server as cross_server
+
+    monkeypatch.setattr(cross_server, "_post_memory_server", fake_post_memory_server)
+
+    ok, err = await icebreaker_router._cache_icebreaker_context_memory(
+        lanlan_name="Lan",
+        role="user",
+        text="可以，多陪一会儿",
+    )
+
+    assert ok is True
+    assert err == ""
+    assert calls == [{
+        "endpoint": "cache",
+        "lanlan_name": "Lan",
+        "payload": [{
+            "role": "user",
+            "content": [{"type": "text", "text": "可以，多陪一会儿"}],
+        }],
+        "timeout_s": icebreaker_router.ICEBREAKER_MEMORY_CACHE_TIMEOUT_SECONDS,
+    }]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 改动概述 / Summary
- 让破冰流程中的 YUI 台词和用户选项在写入破冰上下文后，同步复用现有 memory /cache 链路写入近期记忆。
- 仅在 main_routers/icebreaker_router.py 里调用现有 main_logic.cross_server._post_memory_server("cache")，没有新增 memory 存储、长期记忆逻辑、后台任务或表结构。
- memory cache 失败时只记录 warning，不阻断破冰上下文写入和前端流程。

## 回归报告 / Regression Report
- 改动原因：破冰脚本此前只进入当前 LLM session context，中断、重载或结束后无法沉淀到普通记忆链路。
- 必要性：用户期望破冰过程中的每句台词和回答都能像普通聊天一样进入近期记忆，再由既有长期记忆链路自行筛选。
- 前后表现：之前 /api/icebreaker/context 只 append session history；现在在 append 成功后额外复用 /cache 写 recent/time_index/outbox。
- 潜在回归点：memory server 异常、cache 超时、重复 request_id、旧 session_id、破冰上下文写入失败。
- 验证方式：单测覆盖 assistant 台词、user 选项、复用现有 cache endpoint、cache 失败不阻断、dedup 响应 schema、旧 session 拒绝；手测完整破冰后确认 YUI/recent.json、time_indexed.db、outbox.ndjson 均出现对应记录。

## 不拆分理由 / Why Not Split
不适用。本 PR 只改 2 个文件，范围限定在破冰 context endpoint 和对应单测。

## 测试 / Testing
- uv run pytest tests/unit/test_icebreaker_router.py tests/unit/test_new_user_icebreaker_context.py tests/unit/test_new_user_icebreaker_static_contracts.py -q
- python3 -m py_compile main_routers/icebreaker_router.py tests/unit/test_icebreaker_router.py
- git diff --check
- 本地新用户 PC 手测：完整走完破冰后，YUI/recent.json 保留完整破冰对话，time_indexed_original 写入 14 条记录，outbox extract_facts 记录为 done。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能与改进

* **新功能**
  * 冰碎功能现已支持上下文记忆自动缓存，将交互内容写入跨服务记忆库
  * `/context` 端点响应新增 `memory_cached` 字段，用于标识缓存是否成功
  * 引入记忆缓存超时控制机制，提升缓存写入一致性
* **测试**
  * 新增并扩展冰碎上下文“记忆缓存”相关单元测试，覆盖成功/失败不阻塞与去重等场景

<!-- end of auto-generated comment: release notes by coderabbit.ai -->