### PR TITLE
feat(focus): 凝神 thinking 按 provider 语义对偶翻转 + free 接入 + 退出清理历史

### DIFF
--- a/config/providers.py
+++ b/config/providers.py
@@ -33,11 +33,29 @@ from typing import Any
 # Extra-body 常量 & 映射（原 config/__init__.py）
 # ────────────────────────────────────────────────────────────────
 
+# 每个 provider 的 thinking 旋钮成对定义：上为默认（关思考，进 MODELS_EXTRA_BODY_MAP），
+# 下为凝神启用形式（_THINKING 后缀，由 focus_extra_body 取用）。对偶按各家 API 的
+# 自身语义，不是机械翻 bool —— 见 _THINKING_ENABLE_FORM 与 focus_extra_body。
 EXTRA_BODY_OPENAI = {"enable_thinking": False}
+EXTRA_BODY_OPENAI_THINKING = {"enable_thinking": True}
+
 EXTRA_BODY_CLAUDE = {"thinking": {"type": "disabled"}}
+EXTRA_BODY_CLAUDE_THINKING = {"thinking": {"type": "enabled"}}
+
 EXTRA_BODY_GEMINI = {"extra_body": {"google": {"thinking_config": {"thinking_budget": 0}}}}
+# Gemini 2.5: budget 0 = 关；-1 = 动态思考（模型自行决定预算），是官方表示「开思考」的值。
+EXTRA_BODY_GEMINI_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_budget": -1}}}}
+
 EXTRA_BODY_GEMINI_3 = {"extra_body": {"google": {"thinking_config": {"thinking_level": "low", "include_thoughts": False}}}}
+# Gemini 3: 思考档位 low→high，并透出思考过程（thoughts 走独立字段，不混进 content）。
+EXTRA_BODY_GEMINI_3_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_level": "high", "include_thoughts": True}}}}
+
 EXTRA_BODY_OPENROUTER = {"reasoning": {"effort": "none"}}
+# OpenRouter: effort none→high（凝神是深思场景）。
+EXTRA_BODY_OPENROUTER_THINKING = {"reasoning": {"effort": "high"}}
+
+# MiniMax 的 reasoning_split 在本仓无语义记录，且不像 thinking 的 on/off 开关；凝神
+# 暂不翻它（不收录进下方 _THINKING_ENABLE_FORM 即表示「保持原值」），待其真实语义确认。
 EXTRA_BODY_MINIMAX = {"reasoning_split": True}
 
 # Agent 调用统一开关：是否加载 extra_body。
@@ -84,6 +102,9 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     "Qwen/Qwen3.5-397B-A17B": EXTRA_BODY_OPENAI,
     # Step
     "step-2-mini": {"tools": [{"type": "web_search", "function": {"description": "这个web_search用来搜索互联网的信息"}}]},
+    # 免费版（lanlan.tech / lanlan.app，模型名固定 free-model）：用 thinking.type 风格，
+    # 平时下发 disabled、凝神由 focus_extra_body flip 成 enabled。
+    "free-model": EXTRA_BODY_CLAUDE,
     # Claude 系列
     "claude-sonnet-4-6": EXTRA_BODY_CLAUDE,
     "claude-haiku-4-5-20251001": EXTRA_BODY_CLAUDE,
@@ -126,32 +147,49 @@ def get_agent_extra_body(model: str) -> dict | None:
     return get_extra_body(model)
 
 
-# Top-level extra_body keys that *disable* thinking (one per provider family in
-# MODELS_EXTRA_BODY_MAP). Gemini nests its thinking_config under an "extra_body"
-# wrapper key whose only payload here is the thinking config, so the whole key is
-# thinking-related. Anything NOT in this set (e.g. step-2-mini's "tools" with the
-# built-in web_search) is unrelated provider config that must survive Focus.
-_THINKING_EXTRA_BODY_KEYS = frozenset({
-    "enable_thinking",   # EXTRA_BODY_OPENAI (qwen / silicon …)
-    "thinking",          # EXTRA_BODY_CLAUDE (claude / glm / kimi / doubao …)
-    "reasoning",         # EXTRA_BODY_OPENROUTER
-    "reasoning_split",   # EXTRA_BODY_MINIMAX
-    "extra_body",        # EXTRA_BODY_GEMINI/_3 (google.thinking_config wrapper)
-})
+# 凝神（thinking-on）时把各 provider 的「关思考」extra_body 翻成「开思考」形式。
+# 键 = 「关」常量的 id，值 = 对应「开」常量；按各家 API 语义一一对偶，不机械翻 bool。
+# 未收录的「关」常量（如 MiniMax 的 reasoning_split）表示「凝神保持原值不翻」；非
+# thinking 的 provider extra（如 step-2-mini 的 web_search tools）天然不在此表，在
+# MODELS_FOCUS_EXTRA_BODY_MAP 里回退为原值、原样保留。
+_THINKING_ENABLE_FORM: dict[int, dict] = {
+    id(EXTRA_BODY_OPENAI): EXTRA_BODY_OPENAI_THINKING,
+    id(EXTRA_BODY_CLAUDE): EXTRA_BODY_CLAUDE_THINKING,
+    id(EXTRA_BODY_GEMINI): EXTRA_BODY_GEMINI_THINKING,
+    id(EXTRA_BODY_GEMINI_3): EXTRA_BODY_GEMINI_3_THINKING,
+    id(EXTRA_BODY_OPENROUTER): EXTRA_BODY_OPENROUTER_THINKING,
+}
+
+# model → 凝神 extra_body，与 MODELS_EXTRA_BODY_MAP 同源派生（共用 model 列表，不会
+# 漂移）：命中对偶则取「开」形式，否则回退原值（保留 web_search / 不翻 MiniMax）。
+# 依赖 MODELS_EXTRA_BODY_MAP 的值是模块级常量引用，故可用 id 做配对键。
+MODELS_FOCUS_EXTRA_BODY_MAP: dict[str, dict] = {
+    model: _THINKING_ENABLE_FORM.get(id(body), body)
+    for model, body in MODELS_EXTRA_BODY_MAP.items()
+}
 
 
 def focus_extra_body(model: str) -> dict | None:
-    """extra_body for a Focus (thinking-on) turn: the model's resolved extra_body
-    with only the *thinking-disable* keys removed.
+    """extra_body for a Focus (thinking-on) turn.
 
-    Focus wants thinking to run free (drop the disable knob), but must NOT
-    silently nuke unrelated provider config — e.g. ``step-2-mini`` ships a
-    built-in ``web_search`` tool in its extra_body, which a blunt
-    ``extra_body=None`` would drop. Returns the surviving non-thinking dict, or
-    ``None`` when nothing remains (the body was purely thinking-disable)."""
-    resolved = get_extra_body(model) or {}
-    kept = {k: v for k, v in resolved.items() if k not in _THINKING_EXTRA_BODY_KEYS}
-    return kept or None
+    Regular turns send the provider's thinking-DISABLED extra_body (see
+    ``MODELS_EXTRA_BODY_MAP``). A Focus turn flips each provider's thinking knob
+    to its semantic ENABLED form — NOT by blindly dropping keys, but per the
+    provider's own dialect (see ``_THINKING_ENABLE_FORM`` and the paired
+    ``EXTRA_BODY_*_THINKING`` constants):
+      - enable_thinking: False -> True                  (Qwen / Silicon / free OpenAI-shape)
+      - thinking.type: disabled -> enabled              (GLM / Kimi / Doubao / Claude / free)
+      - thinking_budget: 0 -> -1 (dynamic)              (Gemini 2.5)
+      - thinking_level low->high, include_thoughts->True (Gemini 3)
+      - reasoning.effort: none -> high                  (OpenRouter)
+
+    Provider extras that are NOT thinking knobs (e.g. ``step-2-mini``'s built-in
+    ``web_search`` tools, or MiniMax's reasoning_split) are preserved unchanged.
+    Returns ``None`` when the model has no registered extra_body."""
+    if not model:
+        return None
+    enabled = MODELS_FOCUS_EXTRA_BODY_MAP.get(model)
+    return dict(enabled) if enabled else None
 
 
 def leaks_thinking_in_content(model: str) -> bool:

--- a/config/providers.py
+++ b/config/providers.py
@@ -43,6 +43,14 @@ EXTRA_BODY_OPENAI_THINKING = {"enable_thinking": True}
 EXTRA_BODY_CLAUDE = {"thinking": {"type": "disabled"}}
 EXTRA_BODY_CLAUDE_THINKING = {"thinking": {"type": "enabled"}}
 
+# Anthropic 原生 claude（经 OpenAI-compat 透传 thinking）跟 GLM/Kimi/Doubao 的
+# thinking.type 方言不一样：Opus 4.7+ 已移除 {type:enabled,budget_tokens}，发它直接
+# 400，启用思考必须用 {type:adaptive}；Opus 4.6/Sonnet 4.6 也用 adaptive；Haiku 4.5
+# 是否支持还要逐个验证 OpenAI-compat 行为。本 PR 暂只用 disabled（平时关思考），且
+# 故意不配 enable 对偶 —— 凝神对 claude 保持 thinking-off（安全退化，绝不 400），
+# adaptive 的正确 per-model 接入留 follow-up。
+EXTRA_BODY_ANTHROPIC = {"thinking": {"type": "disabled"}}
+
 EXTRA_BODY_GEMINI = {"extra_body": {"google": {"thinking_config": {"thinking_budget": 0}}}}
 # Gemini 2.5: budget 0 = 关；凝神给一个低固定预算 800 token（开思考但不深思）。
 EXTRA_BODY_GEMINI_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_budget": 800}}}}
@@ -110,11 +118,11 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     # 免费版（lanlan.tech / lanlan.app，模型名固定 free-model）：用 thinking.type 风格，
     # 平时下发 disabled、凝神由 focus_extra_body flip 成 enabled。
     "free-model": EXTRA_BODY_CLAUDE,
-    # Claude 系列
-    "claude-sonnet-4-6": EXTRA_BODY_CLAUDE,
-    "claude-haiku-4-5-20251001": EXTRA_BODY_CLAUDE,
-    "claude-opus-4-7": EXTRA_BODY_CLAUDE,
-    "claude-opus-4-6": EXTRA_BODY_CLAUDE,
+    # Claude 系列（Anthropic 原生：enable 须用 adaptive，本 PR 暂不翻，见 EXTRA_BODY_ANTHROPIC）
+    "claude-sonnet-4-6": EXTRA_BODY_ANTHROPIC,
+    "claude-haiku-4-5-20251001": EXTRA_BODY_ANTHROPIC,
+    "claude-opus-4-7": EXTRA_BODY_ANTHROPIC,
+    "claude-opus-4-6": EXTRA_BODY_ANTHROPIC,
     # Doubao Seed 2.0 系列
     "doubao-seed-2-0-lite-260215": EXTRA_BODY_CLAUDE,
     "doubao-seed-2-0-mini-260215": EXTRA_BODY_CLAUDE,

--- a/config/providers.py
+++ b/config/providers.py
@@ -43,8 +43,8 @@ EXTRA_BODY_CLAUDE = {"thinking": {"type": "disabled"}}
 EXTRA_BODY_CLAUDE_THINKING = {"thinking": {"type": "enabled"}}
 
 EXTRA_BODY_GEMINI = {"extra_body": {"google": {"thinking_config": {"thinking_budget": 0}}}}
-# Gemini 2.5: budget 0 = 关；-1 = 动态思考（模型自行决定预算），是官方表示「开思考」的值。
-EXTRA_BODY_GEMINI_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_budget": -1}}}}
+# Gemini 2.5: budget 0 = 关；凝神给一个低固定预算 800 token（开思考但不深思）。
+EXTRA_BODY_GEMINI_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_budget": 800}}}}
 
 EXTRA_BODY_GEMINI_3 = {"extra_body": {"google": {"thinking_config": {"thinking_level": "low", "include_thoughts": False}}}}
 # Gemini 3: 思考档位保持最低(low)，只把思考过程透出(thoughts 走独立字段，不混进 content)。
@@ -54,8 +54,12 @@ EXTRA_BODY_OPENROUTER = {"reasoning": {"effort": "none"}}
 # OpenRouter: effort none→low（开思考但取最低努力档）。
 EXTRA_BODY_OPENROUTER_THINKING = {"reasoning": {"effort": "low"}}
 
-# MiniMax 的 reasoning_split 在本仓无语义记录，且不像 thinking 的 on/off 开关；凝神
-# 暂不翻它（不收录进下方 _THINKING_ENABLE_FORM 即表示「保持原值」），待其真实语义确认。
+# MiniMax 的 reasoning_split 只控制思考的「输出格式」，不是 on/off 开关：M3 始终内部
+# 推理、无法关闭；True=思考走独立 reasoning_details 字段，False/省略=思考以 <think>
+# 标签嵌进 content。凝神保持 True（不收录进下方 _THINKING_ENABLE_FORM 即「不翻」）：
+# 思考本就常开、无需动它；且 True 让 CoT 留在独立字段、不混进 content 被 TTS 当台词
+# 念出（与 leaks_thinking_in_content 防的是同一类问题）。
+# 文档 https://platform.minimax.io/docs/guides/text-m3-function-call
 EXTRA_BODY_MINIMAX = {"reasoning_split": True}
 
 # Agent 调用统一开关：是否加载 extra_body。

--- a/config/providers.py
+++ b/config/providers.py
@@ -47,12 +47,12 @@ EXTRA_BODY_GEMINI = {"extra_body": {"google": {"thinking_config": {"thinking_bud
 EXTRA_BODY_GEMINI_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_budget": -1}}}}
 
 EXTRA_BODY_GEMINI_3 = {"extra_body": {"google": {"thinking_config": {"thinking_level": "low", "include_thoughts": False}}}}
-# Gemini 3: 思考档位 low→high，并透出思考过程（thoughts 走独立字段，不混进 content）。
-EXTRA_BODY_GEMINI_3_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_level": "high", "include_thoughts": True}}}}
+# Gemini 3: 思考档位保持最低(low)，只把思考过程透出(thoughts 走独立字段，不混进 content)。
+EXTRA_BODY_GEMINI_3_THINKING = {"extra_body": {"google": {"thinking_config": {"thinking_level": "low", "include_thoughts": True}}}}
 
 EXTRA_BODY_OPENROUTER = {"reasoning": {"effort": "none"}}
-# OpenRouter: effort none→high（凝神是深思场景）。
-EXTRA_BODY_OPENROUTER_THINKING = {"reasoning": {"effort": "high"}}
+# OpenRouter: effort none→low（开思考但取最低努力档）。
+EXTRA_BODY_OPENROUTER_THINKING = {"reasoning": {"effort": "low"}}
 
 # MiniMax 的 reasoning_split 在本仓无语义记录，且不像 thinking 的 on/off 开关；凝神
 # 暂不翻它（不收录进下方 _THINKING_ENABLE_FORM 即表示「保持原值」），待其真实语义确认。
@@ -180,8 +180,8 @@ def focus_extra_body(model: str) -> dict | None:
       - enable_thinking: False -> True                  (Qwen / Silicon / free OpenAI-shape)
       - thinking.type: disabled -> enabled              (GLM / Kimi / Doubao / Claude / free)
       - thinking_budget: 0 -> -1 (dynamic)              (Gemini 2.5)
-      - thinking_level low->high, include_thoughts->True (Gemini 3)
-      - reasoning.effort: none -> high                  (OpenRouter)
+      - thinking_level low (最低档), include_thoughts->True (Gemini 3)
+      - reasoning.effort: none -> low                   (OpenRouter)
 
     Provider extras that are NOT thinking knobs (e.g. ``step-2-mini``'s built-in
     ``web_search`` tools, or MiniMax's reasoning_split) are preserved unchanged.

--- a/config/providers.py
+++ b/config/providers.py
@@ -25,6 +25,7 @@ hard-coding their own.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -183,7 +184,7 @@ def focus_extra_body(model: str) -> dict | None:
     ``EXTRA_BODY_*_THINKING`` constants):
       - enable_thinking: False -> True                  (Qwen / Silicon / free OpenAI-shape)
       - thinking.type: disabled -> enabled              (GLM / Kimi / Doubao / Claude / free)
-      - thinking_budget: 0 -> -1 (dynamic)              (Gemini 2.5)
+      - thinking_budget: 0 -> 800 (low fixed budget)    (Gemini 2.5)
       - thinking_level low (最低档), include_thoughts->True (Gemini 3)
       - reasoning.effort: none -> low                   (OpenRouter)
 
@@ -193,7 +194,10 @@ def focus_extra_body(model: str) -> dict | None:
     if not model:
         return None
     enabled = MODELS_FOCUS_EXTRA_BODY_MAP.get(model)
-    return dict(enabled) if enabled else None
+    # deepcopy: enabled is a shared module-level constant, possibly nested
+    # (Gemini's thinking_config); a caller mutating the result must not poison
+    # the registry. Cheap — focus_extra_body runs once per focus turn.
+    return copy.deepcopy(enabled) if enabled else None
 
 
 def leaks_thinking_in_content(model: str) -> bool:

--- a/config/providers.py
+++ b/config/providers.py
@@ -193,7 +193,7 @@ def focus_extra_body(model: str) -> dict | None:
       - enable_thinking: False -> True                  (Qwen / Silicon / free OpenAI-shape)
       - thinking.type: disabled -> enabled              (GLM / Kimi / Doubao / Claude / free)
       - thinking_budget: 0 -> 800 (low fixed budget)    (Gemini 2.5)
-      - thinking_level low (最低档), include_thoughts->True (Gemini 3)
+      - thinking_level low (kept minimal), include_thoughts->True (Gemini 3)
       - reasoning.effort: none -> low                   (OpenRouter)
 
     Provider extras that are NOT thinking knobs (e.g. ``step-2-mini``'s built-in

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -803,6 +803,53 @@ class ContextAppendResult:
 
 
 # --- 一个带有定期上下文压缩+在线热切换的语音会话管理器 ---
+def _purge_closed_tool_calls(history: list) -> int:
+    """Remove every CLOSED tool-call pair from the conversation history: an
+    assistant message (role=assistant, carrying tool_calls) plus the tool-result
+    messages immediately following it whose tool_call_id matches. Any
+    reasoning_content (the thinking model's chain, parked on that assistant
+    message for provider replay) is dropped together with it — deleting the
+    whole pair, NOT just the field, since a thinking endpoint rejects a
+    tool_calls turn whose reasoning_content went missing on replay.
+
+    "Closed" = every tool_call id on the assistant message is answered by a
+    following contiguous tool message. Unclosed calls (a call with no result —
+    an interrupted / in-flight turn) are kept so live state is never corrupted.
+    Plain Human / AI / System (BaseMessage) entries are never touched. Returns
+    the number of messages deleted.
+    """
+    if not history:
+        return 0
+    n = len(history)
+    remove: set[int] = set()
+    for i, msg in enumerate(history):
+        if not (isinstance(msg, dict) and msg.get("role") == "assistant"):
+            continue
+        tool_calls = msg.get("tool_calls") or []
+        if not tool_calls:
+            continue
+        call_ids = {tc.get("id") for tc in tool_calls if tc.get("id")}
+        if not call_ids:
+            continue
+        # execute 路径原子追加 assistant + 紧随其后的各 tool result，所以闭合的
+        # 结果消息是「连续」的；遇到非 tool 消息即停止该 assistant 的结果收集。
+        result_idx: list[int] = []
+        covered: set = set()
+        for j in range(i + 1, n):
+            rj = history[j]
+            if isinstance(rj, dict) and rj.get("role") == "tool":
+                result_idx.append(j)
+                covered.add(rj.get("tool_call_id"))
+            else:
+                break
+        if call_ids <= covered:  # 每个 call 都有结果 → 已闭合，整对删
+            remove.add(i)
+            remove.update(result_idx)
+    for idx in sorted(remove, reverse=True):
+        del history[idx]
+    return len(remove)
+
+
 class LLMSessionManager:
     def __init__(self, sync_message_queue, lanlan_name, lanlan_prompt):
         self.websocket = None
@@ -1072,6 +1119,9 @@ class LLMSessionManager:
         # cadence 基线滚动 buffer。两条触发路径（inline stream_text / idle
         # proactive）共用同一个 scorer，保证行为不分裂。
         self._focus_scorer = FocusScorer(lanlan_name)
+        # 凝神退出时清理历史 thinking/已闭合 tool call 残留的边沿标志：进入 FOCUS
+        # 时 arm，退出并清理后 disarm（见 _maybe_purge_focus_artifacts）。
+        self._focus_artifacts_pending = False
 
         # Master 情绪画像（基建，docs 见 config MASTER_EMOTION_*）：异步分析「用户
         # 说的话」的 valence-arousal，单一权威源。凝神是第一个消费者（_focus_scorer
@@ -2415,6 +2465,9 @@ class LLMSessionManager:
             mode = await self.state.update_focus(
                 scored.score, topic_changed=topic_changed,
             )
+            if mode is CognitionMode.FOCUS:
+                # arm：本 episode 的 thinking/tool 残留，退出时要清（见下）。
+                self._focus_artifacts_pending = True
             # Log every turn (incl. REGULAR) so tuning can watch the charge
             # accumulate toward FOCUS_CHARGE_ENTER, not just the entry moment.
             logger.info(
@@ -2424,6 +2477,10 @@ class LLMSessionManager:
             )
             # Stream the post-turn charge for the frontend edge glow.
             await self._push_focus_charge(self.state.snapshot().get("focus_charge"))
+            # 退出边沿同步清理（此刻在 stream_text 之前、无并发）：inline 自然退出
+            # （decayed / hard_cap / topic_switch）都在此命中并清；FOCUS 维持时是
+            # no-op（仍在 episode 内）。silent early-return 路径由 reconcile 兜底。
+            await self._maybe_purge_focus_artifacts()
             return mode is CognitionMode.FOCUS
         except Exception as e:
             logger.warning("[%s] focus inline decision failed (degrading to regular): %s",
@@ -2465,17 +2522,64 @@ class LLMSessionManager:
 
     async def _on_focus_transition(self, event: SessionEvent, payload: dict) -> None:
         """SM subscriber for FOCUS_ENTER / FOCUS_EXIT — immediate badge update on
-        the normal hysteresis path. Delegates to the idempotent push."""
+        the normal hysteresis path. Delegates to the idempotent push.
+
+        NB: history artifact arm/purge is deliberately NOT done here.
+        ``_dispatch_subscribers`` fires async callbacks fire-and-forget
+        (``ensure_future``), so a FOCUS_EXIT-driven purge could race the reply
+        stream. Arming + purging happen SYNCHRONOUSLY on the inline decision path
+        and the per-turn reconcile instead (see ``_maybe_purge_focus_artifacts``)."""
         await self._push_focus_indicator(event is SessionEvent.FOCUS_ENTER)
+
+    async def _maybe_purge_focus_artifacts(self) -> None:
+        """On the edge where 凝神 (Focus) turns OFF, wipe the thinking + closed
+        tool-call traces the just-ended episode left in history, so they can't
+        bias the REGULAR reply that follows (or a fresh session).
+
+        Called SYNCHRONOUSLY from two places (NOT the async FOCUS_EXIT event,
+        which fires fire-and-forget and could race the stream):
+          - the inline decision, right after update_focus and BEFORE stream_text
+            — catches inline exits (decayed / hard_cap / topic_switch);
+          - the per-turn _reconcile_focus_indicator — catches the silent exits
+            (master switch / per-user setting / privacy self-clear / clear_focus)
+            and a proactive-cooldown exit on the next inline turn.
+
+        Idempotent: runs once per episode, only when Focus was actually entered
+        (``_focus_artifacts_pending``) AND the mode has dropped back to REGULAR.
+        All call sites sit OUTSIDE the stream boundary, so there is no concurrent
+        history mutation. Only text sessions (OmniOfflineClient) keep history.
+        """
+        if not self._focus_artifacts_pending:
+            return
+        if self.state.mode is CognitionMode.FOCUS:
+            return  # 仍在 focus，残留还在用，不能清
+        self._focus_artifacts_pending = False
+        sess = self.session
+        if not isinstance(sess, OmniOfflineClient):
+            return
+        history = getattr(sess, "_conversation_history", None)
+        if not history:
+            return
+        try:
+            removed = _purge_closed_tool_calls(history)
+            if removed:
+                logger.info(
+                    "[%s] 凝神退出：从历史清除 thinking/已闭合 tool call 残留 %d 条",
+                    self.lanlan_name, removed,
+                )
+        except Exception as e:
+            logger.warning("[%s] 凝神退出历史清理失败(忽略): %s", self.lanlan_name, e)
 
     async def _reconcile_focus_indicator(self) -> None:
         """Catch Focus states dropped WITHOUT a FOCUS_EXIT event (clear_focus
         history-wipe, master-switch / privacy self-clear in update_focus) so the
         badge AND the charge glow can't get stuck on. Called once per turn. The
         charge push reads the (now-cleared → 0) snapshot, so a silent exit that
-        only reconciles the binary state still tells the glow to fade out."""
+        only reconciles the binary state still tells the glow to fade out. Also
+        the catch-all purge point for silent Focus exits (no FOCUS_EXIT event)."""
         await self._push_focus_indicator(self.state.mode is CognitionMode.FOCUS)
         await self._push_focus_charge()
+        await self._maybe_purge_focus_artifacts()
 
     async def resync_focus_for_new_window(self) -> None:
         """Re-emit ALL focus signals to a freshly-connected window (greeting_check):

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2845,6 +2845,11 @@ class LLMSessionManager:
                 self.state.snapshot().get("focus_charge"), mode.value,
             )
             await self._push_focus_charge(self.state.snapshot().get("focus_charge"))
+            # 若这次 cooldown 把 Focus 衰减出去(→REGULAR)，立即清 episode 残留：
+            # proactive/greeting 的 prompt_ephemeral 会在下个 inline turn 之前就从
+            # _conversation_history 构建、且不走 reconcile，必须赶在它前面清掉，否则
+            # 会把刚结束的 Focus tool-call/reasoning 残留带进随后的 REGULAR 轮。
+            await self._maybe_purge_focus_artifacts()
         except Exception as e:
             logger.warning("[%s] focus idle cooldown failed (degrading to regular): %s",
                            self.lanlan_name, e)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2550,7 +2550,7 @@ class LLMSessionManager:
         await self._push_focus_indicator(event is SessionEvent.FOCUS_ENTER)
 
     async def _maybe_purge_focus_artifacts(self) -> None:
-        """On the edge where 凝神 (Focus) turns OFF, wipe the thinking + closed
+        """On the edge where Focus mode turns OFF, wipe the thinking + closed
         tool-call traces the just-ended episode left in history, so they can't
         bias the REGULAR reply that follows (or a fresh session).
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -803,7 +803,7 @@ class ContextAppendResult:
 
 
 # --- 一个带有定期上下文压缩+在线热切换的语音会话管理器 ---
-def _purge_closed_tool_calls(history: list) -> int:
+def _purge_closed_tool_calls(history: list, *, start: int = 0) -> int:
     """Remove every CLOSED tool-call pair from the conversation history: an
     assistant message (role=assistant, carrying tool_calls) plus the tool-result
     messages immediately following it whose tool_call_id matches. Any
@@ -811,6 +811,11 @@ def _purge_closed_tool_calls(history: list) -> int:
     message for provider replay) is dropped together with it — deleting the
     whole pair, NOT just the field, since a thinking endpoint rejects a
     tool_calls turn whose reasoning_content went missing on replay.
+
+    Only assistant messages at index >= ``start`` are considered, so a Focus
+    exit scopes the purge to the episode's history suffix (recorded when Focus
+    was entered) and leaves closed tool calls from regular turns BEFORE Focus
+    began intact. ``start`` is clamped to [0, len].
 
     "Closed" = every tool_call id on the assistant message is answered by a
     following contiguous tool message. Unclosed calls (a call with no result —
@@ -821,8 +826,10 @@ def _purge_closed_tool_calls(history: list) -> int:
     if not history:
         return 0
     n = len(history)
+    start = max(0, min(int(start or 0), n))
     remove: set[int] = set()
-    for i, msg in enumerate(history):
+    for i in range(start, n):
+        msg = history[i]
         if not (isinstance(msg, dict) and msg.get("role") == "assistant"):
             continue
         tool_calls = msg.get("tool_calls") or []
@@ -1122,6 +1129,8 @@ class LLMSessionManager:
         # 凝神退出时清理历史 thinking/已闭合 tool call 残留的边沿标志：进入 FOCUS
         # 时 arm，退出并清理后 disarm（见 _maybe_purge_focus_artifacts）。
         self._focus_artifacts_pending = False
+        # 进入 FOCUS 那刻的历史长度；退出只清这之后（episode 期间）的闭合 tool call。
+        self._focus_artifacts_history_start: int | None = None
 
         # Master 情绪画像（基建，docs 见 config MASTER_EMOTION_*）：异步分析「用户
         # 说的话」的 valence-arousal，单一权威源。凝神是第一个消费者（_focus_scorer
@@ -2466,6 +2475,15 @@ class LLMSessionManager:
                 scored.score, topic_changed=topic_changed,
             )
             if mode is CognitionMode.FOCUS:
+                if not self._focus_artifacts_pending:
+                    # 首次进入本 episode：记下历史长度，退出时只清这之后（episode
+                    # 期间）产生的闭合 tool call，不动 Focus 之前的普通工具调用。
+                    hist = getattr(
+                        getattr(self, "session", None), "_conversation_history", None
+                    )
+                    self._focus_artifacts_history_start = (
+                        len(hist) if isinstance(hist, list) else None
+                    )
                 # arm：本 episode 的 thinking/tool 残留，退出时要清（见下）。
                 self._focus_artifacts_pending = True
             # Log every turn (incl. REGULAR) so tuning can watch the charge
@@ -2554,14 +2572,16 @@ class LLMSessionManager:
         if self.state.mode is CognitionMode.FOCUS:
             return  # 仍在 focus，残留还在用，不能清
         self._focus_artifacts_pending = False
-        sess = self.session
+        start = self._focus_artifacts_history_start or 0
+        self._focus_artifacts_history_start = None
+        sess = getattr(self, "session", None)
         if not isinstance(sess, OmniOfflineClient):
             return
         history = getattr(sess, "_conversation_history", None)
         if not history:
             return
         try:
-            removed = _purge_closed_tool_calls(history)
+            removed = _purge_closed_tool_calls(history, start=start)
             if removed:
                 logger.info(
                     "[%s] 凝神退出：从历史清除 thinking/已闭合 tool call 残留 %d 条",

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1529,14 +1529,6 @@ class OmniOfflineClient:
             old_llm = self.llm
             self.llm = new_llm
             self.model = new_model
-            # Focus vision guard: this is the single choke point for vision-model
-            # switches. Record whether the session is now committed to a separate
-            # persistent vision model — used to recompute _focus_images_seen after
-            # repetition recovery wipes _conversation_history (the in-history image
-            # is gone, so only a permanent model switch should keep thinking off).
-            # Name-comparison can't tell vision from conversation when they're
-            # equal (shared-model profiles), hence this explicit flag.
-            self._focus_vision_committed = bool(use_vision_config)
             # ⚠️ 同步 self.base_url / self.api_key —— 否则后续 _astream_with_tools
             # 重新计算 _use_genai_sdk 时拿到的还是旧 conversation 配置，会
             # 把 vision 走的 Gemini endpoint 错误路由到 OpenAI-compat（反之亦然）。
@@ -1590,15 +1582,6 @@ class OmniOfflineClient:
                 self._conversation_history = [self._conversation_history[0]]
             else:
                 self._conversation_history = []
-
-            # Focus vision guard: the image-bearing history just got erased, so
-            # an image that only "persisted in history" (shared-model profile)
-            # no longer suppresses thinking — recompute the sticky flag from the
-            # one thing that survives a history wipe: an actual persistent
-            # vision-model switch. In shared-model profiles _focus_vision_committed
-            # is False (no switch happened) → flag clears; on a separate vision
-            # model it stays True (switch is irreversible).
-            self._focus_images_seen = getattr(self, "_focus_vision_committed", False)
 
             # 清空重复检测缓存
             self._recent_responses.clear()
@@ -1746,22 +1729,22 @@ class OmniOfflineClient:
         return summary
 
     @staticmethod
-    def _focus_stream_overrides(thinking_on: bool, uses_vision: bool, model: str) -> dict:
+    def _focus_stream_overrides(thinking_on: bool, model: str) -> dict:
         """Per-call streaming overrides for a Focus turn.
 
-        When thinking-on (and not on a vision model), override extra_body with
-        ``focus_extra_body(model)`` — the provider's resolved extra_body minus
-        the thinking-disable keys. This lets thinking run free while PRESERVING
-        non-thinking provider extras (e.g. step-2-mini's built-in web_search),
-        which a blunt ``extra_body=None`` would silently drop. Returns ``{}``
-        (instance default, thinking off) otherwise.
+        When thinking-on, override extra_body with ``focus_extra_body(model)`` —
+        the provider's thinking knob flipped to its ENABLED form (per provider
+        dialect) while PRESERVING non-thinking provider extras (e.g. step-2-mini's
+        built-in web_search), which a blunt ``extra_body=None`` would drop.
+        Returns ``{}`` (instance default, thinking off) otherwise.
 
-        ``uses_vision`` must be True both when this turn carries images AND when
-        the session has already sent images (image data persists in history, so
-        a later text-only turn still runs on the vision model — vision + thinking
-        reliably times out, see ``main_routers/system_router.py`` Phase-2 note).
+        Vision-model turns are included: 凝神 runs thinking-on regardless of
+        whether the turn carries images. The inline streaming timeout
+        (``DIALOG_LLM_STREAM_TIMEOUT_SECONDS``, 180s) is generous enough for a
+        vision reasoning turn — unlike the short-windowed proactive Phase-2 path,
+        which still keeps thinking off (its 16-25s window would time out).
         """
-        if not (thinking_on and not uses_vision):
+        if not thinking_on:
             return {}
         from config.providers import focus_extra_body
         return {"extra_body": focus_extra_body(model)}
@@ -1821,20 +1804,6 @@ class OmniOfflineClient:
 
         # Check if we need to switch to vision model
         has_images = len(self._pending_images) > 0
-        # Focus vision guard (sticky): mark the session vision-unsafe-for-thinking
-        # ONLY when this turn leaves a PERSISTENT vision state — either a separate
-        # vision-model switch (vision_model != model, irreversible once it
-        # happens), or an image that actually stays in _conversation_history.
-        # When history_replacement_text is set the image-bearing message is
-        # evicted to text-only in the finally block, so in shared-model profiles
-        # (vision_model == conversation_model) nothing persists; flagging there
-        # would falsely freeze thinking off on every later text-only Focus turn.
-        # Sticky (never cleared here) so a real earlier image still counts.
-        _persistent_vision_switch = bool(self.vision_model and self.vision_model != self.model)
-        _image_will_persist = not (history_replacement_text and str(history_replacement_text).strip())
-        self._focus_images_seen = getattr(self, "_focus_images_seen", False) or (
-            has_images and (_persistent_vision_switch or _image_will_persist)
-        )
         # 就地植入 system_prefix：拼到 user content 的 text 段前缀（watermark
         # 自带，不补 separator 也能区分）。callback 文本随 HumanMessage 一起
         # 落 history，跟 voice mode user-role 注入对偶。
@@ -2041,26 +2010,20 @@ class OmniOfflineClient:
                         # instance's thinking-off extra_body applies. Routed
                         # through the visible (tool-leak-filtered) variant,
                         # which forwards **overrides to ``_astream_with_tools``.
-                        # uses_vision = images sent this turn or earlier this
-                        # session (sticky flag, not model-name equality — see the
-                        # _focus_images_seen note where has_images is computed).
                         _focus_overrides = self._focus_stream_overrides(
-                            thinking_on, self._focus_images_seen, self.model,
+                            thinking_on, self.model,
                         )
                         # Focus 凝神: leak-prone models (qwen3.5/3.6/3.7 hybrids)
                         # stream their chain-of-thought into ``content`` ending in
                         # a lone ``</think>``; hold + drop it before TTS/UI ever
                         # see it. Clean providers (reasoning_content path) get no
                         # stripper, so their streaming stays byte-for-byte untouched.
-                        # Gate on the SAME effective-thinking condition as
-                        # _focus_stream_overrides (``thinking_on and not uses_vision``):
-                        # a vision Focus turn runs thinking-OFF, so no </think> ever
-                        # arrives and a stripper would needlessly hold the stream.
+                        # Gate on the SAME condition as _focus_stream_overrides
+                        # (just ``thinking_on`` — vision turns now reason too).
                         from config.providers import leaks_thinking_in_content
                         think_stripper = (
                             ThinkingStreamStripper()
-                            if thinking_on and not self._focus_images_seen
-                            and leaks_thinking_in_content(self.model)
+                            if thinking_on and leaks_thinking_in_content(self.model)
                             else None
                         )
                         async for chunk in self._astream_visible_with_tools(
@@ -3152,15 +3115,9 @@ class OmniOfflineClient:
         # stream_text does (一旦带图就永久切 vision — 既定设计；vision model 也能跑
         # 后续纯文本轮). The instruction itself stays ephemeral (not persisted).
         if images:
-            # Focus vision guard: these proactive images are EPHEMERAL (not
-            # persisted to _conversation_history), so the only lasting effect is
-            # the model switch — which is irreversible once it happens. Mark the
-            # sticky guard ONLY when we actually switch to a separate persistent
-            # vision model. In shared-model profiles (vision_model ==
-            # conversation_model) nothing persists, so setting the flag would
-            # falsely suppress thinking on every later text-only Focus turn.
+            # 一旦带图就永久切到 vision model（既定设计，见上）。vision model 也能
+            # 跑后续纯文本轮，且凝神不再因 vision 而关闭思考。
             if self.vision_model and self.vision_model != self.model:
-                self._focus_images_seen = True
                 logger.info(
                     f"🖼️ prompt_ephemeral: switching to vision model {self.vision_model} (from {self.model}) for proactive media"
                 )

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1738,7 +1738,7 @@ class OmniOfflineClient:
         built-in web_search), which a blunt ``extra_body=None`` would drop.
         Returns ``{}`` (instance default, thinking off) otherwise.
 
-        Vision-model turns are included: 凝神 runs thinking-on regardless of
+        Vision-model turns are included: Focus runs thinking-on regardless of
         whether the turn carries images. The inline streaming timeout
         (``DIALOG_LLM_STREAM_TIMEOUT_SECONDS``, 180s) is generous enough for a
         vision reasoning turn — unlike the short-windowed proactive Phase-2 path,

--- a/tests/unit/test_focus_indicator_bridge.py
+++ b/tests/unit/test_focus_indicator_bridge.py
@@ -53,6 +53,14 @@ def _stub(mode=CognitionMode.REGULAR):
     stub._push_focus_thinking = LLMSessionManager._push_focus_thinking.__get__(
         stub, LLMSessionManager
     )
+    # _reconcile also calls _maybe_purge_focus_artifacts (history cleanup on a
+    # silent Focus exit). Not armed here → it's a no-op, but must resolve on the
+    # bare stub. session absent → the no-op returns before touching it.
+    stub._focus_artifacts_pending = False
+    stub.session = None
+    stub._maybe_purge_focus_artifacts = (
+        LLMSessionManager._maybe_purge_focus_artifacts.__get__(stub, LLMSessionManager)
+    )
     return stub
 
 

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -415,9 +415,14 @@ def test_focus_stream_overrides_decision():
     thinking knob to its enabled form (per provider dialect) while keeping
     non-thinking extras (e.g. web_search)."""
     from main_logic.omni_offline_client import OmniOfflineClient as _C
-    # thinking.type provider → flipped to enabled (not dropped to None)
-    assert _C._focus_stream_overrides(True, "claude-sonnet-4-6") == {
+    # thinking.type provider (GLM/Kimi/Doubao) → flipped to enabled (not dropped to None)
+    assert _C._focus_stream_overrides(True, "glm-5.2") == {
         "extra_body": {"thinking": {"type": "enabled"}}
+    }
+    # Anthropic claude: enable needs {type:adaptive} via OpenAI-compat; 本 PR 暂不翻 →
+    # 保持 disabled（安全退化，绝不 400），adaptive 接入留 follow-up
+    assert _C._focus_stream_overrides(True, "claude-opus-4-7") == {
+        "extra_body": {"thinking": {"type": "disabled"}}
     }
     # free server (model 名固定 free-model) shares the thinking.type dialect
     assert _C._focus_stream_overrides(True, "free-model") == {
@@ -463,6 +468,9 @@ def test_focus_extra_body_provider_dialects():
     }
     assert focus_extra_body("google/gemini-2.5-flash") == {"reasoning": {"effort": "low"}}
 
+    # Anthropic claude: enable 须 {type:adaptive}(OpenAI-compat)，本 PR 暂不翻 → 凝神保持 disabled
+    assert get_extra_body("claude-opus-4-7") == {"thinking": {"type": "disabled"}}
+    assert focus_extra_body("claude-opus-4-7") == {"thinking": {"type": "disabled"}}
     # MiniMax reasoning_split is not an on/off knob → preserved, not flipped
     assert focus_extra_body("MiniMax-M2.5") == EXTRA_BODY_MINIMAX
     # non-thinking provider extra (step web_search) preserved on a focus turn
@@ -528,6 +536,7 @@ def _bare_mgr():
     mgr.lanlan_name = "x"
     mgr._focus_scorer = FocusScorer("x")
     mgr._focus_artifacts_pending = False
+    mgr._focus_artifacts_history_start = None
     # Deliberately NO _activity_tracker: the inline path must not touch it
     # (Focus scores the message, not the screen — privacy-independent).
     return mgr
@@ -835,6 +844,20 @@ def test_purge_multiple_calls_one_turn():
     assert history == []
 
 
+def test_purge_respects_start():
+    """start 把清理限定在 episode 的历史后缀：start 之前的闭合 tool call 保留。"""
+    from main_logic.core import _purge_closed_tool_calls
+    pre_a, pre_r = _tool_pair("pre")
+    ep_a, ep_r = _tool_pair("ep", reasoning="…")
+    history = [pre_a, pre_r, ep_a, ep_r]
+    # start=2 → 只清 index>=2 的那对，保留 Focus 之前的
+    assert _purge_closed_tool_calls(history, start=2) == 2
+    assert history == [pre_a, pre_r]
+    # start 越界 → no-op（历史已被 wipe/缩短的兜底）
+    assert _purge_closed_tool_calls(history, start=99) == 0
+    assert history == [pre_a, pre_r]
+
+
 def _purge_mgr(monkeypatch, history):
     """裸 LLMSessionManager + 携带 _conversation_history 的假 OmniOfflineClient。"""
     from main_logic.core import LLMSessionManager
@@ -843,6 +866,7 @@ def _purge_mgr(monkeypatch, history):
     mgr.lanlan_name = "x"
     mgr.state = SessionStateMachine(lanlan_name="x")
     mgr._focus_artifacts_pending = False
+    mgr._focus_artifacts_history_start = None
     sess = OmniOfflineClient.__new__(OmniOfflineClient)
     sess._conversation_history = history
     mgr.session = sess
@@ -883,19 +907,20 @@ async def test_maybe_purge_only_after_exit(monkeypatch):
     assert sess._conversation_history == []
 
 
-async def test_inline_decision_purges_history_on_exit(monkeypatch):
-    """inline 路径端到端：vulnerable 消息进 FOCUS(arm)、历史保留；neutral 消息衰减
-    退出时，在 stream_text 之前同步把已闭合 tool call(含 reasoning_content)清掉。"""
+async def test_inline_decision_purges_episode_only(monkeypatch):
+    """inline 端到端 + episode-scope：进 FOCUS 记历史起点；退出只清 episode 期间
+    产生的已闭合 tool call，Focus 之前的普通 tool call 保留。"""
     from main_logic.omni_offline_client import OmniOfflineClient
     keyword_full = config.FOCUS_SIGNAL_WEIGHTS["keyword"]
     _patch_charge(monkeypatch, enter=max(0.0, keyword_full - 0.1), exit=0.3, retention=0.5)
     monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", True)
     _stub_user_focus_setting(monkeypatch, enabled=True)
 
-    a, r = _tool_pair("c1", reasoning="思考链…")
+    # Focus 之前就有一对普通(非 thinking) tool call —— 必须保留
+    pre_a, pre_r = _tool_pair("pre", name="weather")
     mgr = _bare_mgr()
     sess = OmniOfflineClient.__new__(OmniOfflineClient)
-    sess._conversation_history = [a, r]
+    sess._conversation_history = [pre_a, pre_r]
     mgr.session = sess
 
     async def _noop(*x, **k):
@@ -903,14 +928,17 @@ async def test_inline_decision_purges_history_on_exit(monkeypatch):
     mgr._push_focus_indicator = _noop
     mgr._push_focus_charge = _noop
 
-    # vulnerable message → enter FOCUS, arm；episode 进行中历史不动
+    # vulnerable message → enter FOCUS；记下 history 起点(=2)
     assert await mgr._focus_inline_decision("好累，一个人，没意思，撑不住了") is True
     assert mgr.state.mode is CognitionMode.FOCUS
-    assert mgr._focus_artifacts_pending is True
-    assert len(sess._conversation_history) == 2
+    assert mgr._focus_artifacts_history_start == 2
+    # 模拟 episode 期间又产生一对(带 reasoning_content 的)闭合 tool call
+    ep_a, ep_r = _tool_pair("ep", reasoning="思考链…")
+    sess._conversation_history.extend([ep_a, ep_r])
 
-    # neutral message → charge 衰减出 FOCUS → REGULAR → stream 前同步清历史
+    # neutral message → 衰减出 FOCUS → REGULAR → 只清 episode 期间的(index>=2)
     assert await mgr._focus_inline_decision("嗯那个文件改好了发你了") is False
     assert mgr.state.mode is CognitionMode.REGULAR
-    assert sess._conversation_history == []
+    assert sess._conversation_history == [pre_a, pre_r]  # Focus 前的保留
     assert mgr._focus_artifacts_pending is False
+    assert mgr._focus_artifacts_history_start is None

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -913,6 +913,34 @@ async def test_maybe_purge_only_after_exit(monkeypatch):
     assert sess._conversation_history == []
 
 
+async def test_idle_cooldown_exit_purges_history(monkeypatch):
+    """A proactive idle cooldown that decays Focus out must also purge the episode
+    history artifacts — covering the exit path outside the inline decision, so a
+    later proactive/greeting prompt_ephemeral can't replay them."""
+    _patch_charge(monkeypatch, enter=1.0, exit=0.3, idle_replied=0.6, idle_silent=0.6)
+    a, r = _tool_pair("c1", reasoning="…")
+    mgr, sess = _purge_mgr(monkeypatch, [a, r])
+    # 模拟 inline 已进 FOCUS 并 arm（idle 路径自身不会 enter）
+    mgr._focus_artifacts_pending = True
+    mgr._focus_artifacts_history_start = 0
+    await mgr.state.update_focus(1.0)  # FOCUS, charge 1.0
+    snap = mgr.state.snapshot()
+    tok, turn = snap["focus_episode_id"], snap["focus_turn_count"]
+    assert mgr.state.mode is CognitionMode.FOCUS
+
+    # 第一次 cooldown：1.0*0.6=0.6 ≥ exit 0.3 → 仍 FOCUS，历史不动
+    await mgr._focus_idle_cooldown(replied=True, episode_token=tok, turn_token=turn)
+    assert mgr.state.mode is CognitionMode.FOCUS
+    assert len(sess._conversation_history) == 2
+
+    # 继续衰减直到退出：0.36 → 0.216 < 0.3 → EXIT 时清历史
+    await mgr._focus_idle_cooldown(replied=True, episode_token=tok, turn_token=turn)
+    await mgr._focus_idle_cooldown(replied=True, episode_token=tok, turn_token=turn)
+    assert mgr.state.mode is CognitionMode.REGULAR
+    assert sess._conversation_history == []
+    assert mgr._focus_artifacts_pending is False
+
+
 async def test_inline_decision_purges_episode_only(monkeypatch):
     """inline end-to-end + episode-scope: entering FOCUS records the history start;
     exiting purges only the closed tool calls produced during the episode, keeping

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -794,7 +794,7 @@ async def test_update_focus_retention_override_and_count_turn(monkeypatch):
 # 凝神退出(任何路径)时，把上一个 episode 留在历史里的 reasoning_content + 已闭合
 # tool call 配对清掉，防止带偏退出后的 REGULAR 对话乃至新 session。
 def _tool_pair(call_id="c1", *, reasoning=None, name="t"):
-    """构造一条 assistant tool_calls 消息 + 紧随的 tool result（已闭合配对）。"""
+    """Build one assistant tool_calls message + the following tool result (closed pair)."""
     assistant = {
         "role": "assistant",
         "content": "",
@@ -808,8 +808,9 @@ def _tool_pair(call_id="c1", *, reasoning=None, name="t"):
 
 
 def test_purge_closed_tool_calls():
-    """已闭合 tool-call 配对(assistant tool_calls + tool result)连同寄生其上的
-    reasoning_content 一并整对删除；普通 Human/AI/System 消息保留。"""
+    """A closed tool-call pair (assistant tool_calls + tool result) is deleted as a
+    whole, together with the reasoning_content riding on it; plain Human/AI/System
+    messages are kept."""
     from main_logic.core import _purge_closed_tool_calls
     from utils.llm_client import SystemMessage, HumanMessage, AIMessage
 
@@ -849,7 +850,7 @@ def test_purge_multiple_calls_one_turn():
 
 
 def test_purge_respects_start():
-    """start 把清理限定在 episode 的历史后缀：start 之前的闭合 tool call 保留。"""
+    """start confines the purge to the episode's history suffix: closed tool calls before start are kept."""
     from main_logic.core import _purge_closed_tool_calls
     pre_a, pre_r = _tool_pair("pre")
     ep_a, ep_r = _tool_pair("ep", reasoning="…")
@@ -863,7 +864,7 @@ def test_purge_respects_start():
 
 
 def _purge_mgr(monkeypatch, history):
-    """裸 LLMSessionManager + 携带 _conversation_history 的假 OmniOfflineClient。"""
+    """Bare LLMSessionManager + a fake OmniOfflineClient carrying _conversation_history."""
     from main_logic.core import LLMSessionManager
     from main_logic.omni_offline_client import OmniOfflineClient
     mgr = LLMSessionManager.__new__(LLMSessionManager)
@@ -883,8 +884,9 @@ def _purge_mgr(monkeypatch, history):
 
 
 async def test_maybe_purge_only_after_exit(monkeypatch):
-    """_maybe_purge 只在「曾进入 FOCUS(armed) 且已回到 REGULAR」时清一次；未 arm /
-    仍在 FOCUS 时不动；清后 disarm 且幂等。"""
+    """_maybe_purge cleans once only when Focus was entered (armed) AND has dropped
+    back to REGULAR; no-ops when not armed / still in FOCUS; after cleaning it
+    disarms and is idempotent."""
     _patch_charge(monkeypatch, enter=1.0, exit=0.3)
     a, r = _tool_pair("c1", reasoning="…")
     mgr, sess = _purge_mgr(monkeypatch, [a, r])
@@ -912,8 +914,9 @@ async def test_maybe_purge_only_after_exit(monkeypatch):
 
 
 async def test_inline_decision_purges_episode_only(monkeypatch):
-    """inline 端到端 + episode-scope：进 FOCUS 记历史起点；退出只清 episode 期间
-    产生的已闭合 tool call，Focus 之前的普通 tool call 保留。"""
+    """inline end-to-end + episode-scope: entering FOCUS records the history start;
+    exiting purges only the closed tool calls produced during the episode, keeping
+    the plain tool calls from before Focus."""
     from main_logic.omni_offline_client import OmniOfflineClient
     keyword_full = config.FOCUS_SIGNAL_WEIGHTS["keyword"]
     _patch_charge(monkeypatch, enter=max(0.0, keyword_full - 0.1), exit=0.3, retention=0.5)

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -412,10 +412,21 @@ def test_focus_stream_overrides_decision():
     """The thinking-on override decision, vision guard, and provider-extra
     preservation. ``stream_text`` applies this before streaming: thinking-on
     only when focus is active AND not on a vision model; and when it does
-    override, it strips only thinking keys (keeps e.g. web_search)."""
+    override, it FLIPS the provider's thinking knob to its enabled form (per
+    provider dialect) while keeping non-thinking extras (e.g. web_search)."""
     from main_logic.omni_offline_client import OmniOfflineClient as _C
-    # pure-thinking provider → override drops to None (nothing non-thinking left)
-    assert _C._focus_stream_overrides(True, False, "claude-sonnet-4-6") == {"extra_body": None}
+    # thinking.type provider → flipped to enabled (not dropped to None)
+    assert _C._focus_stream_overrides(True, False, "claude-sonnet-4-6") == {
+        "extra_body": {"thinking": {"type": "enabled"}}
+    }
+    # free server (model 名固定 free-model) shares the thinking.type dialect
+    assert _C._focus_stream_overrides(True, False, "free-model") == {
+        "extra_body": {"thinking": {"type": "enabled"}}
+    }
+    # OpenAI-shape bool knob flips False→True
+    assert _C._focus_stream_overrides(True, False, "qwen-flash") == {
+        "extra_body": {"enable_thinking": True}
+    }
     # unknown model → no resolved extra_body → None
     assert _C._focus_stream_overrides(True, False, "test-model") == {"extra_body": None}
     # step-2-mini ships a web_search tool → it MUST survive (not nuked to None)
@@ -424,6 +435,46 @@ def test_focus_stream_overrides_decision():
     # vision guard / not-thinking → no override at all
     assert _C._focus_stream_overrides(True, True, "step-2-mini") == {}
     assert _C._focus_stream_overrides(False, False, "step-2-mini") == {}
+
+
+def test_focus_extra_body_provider_dialects():
+    """focus_extra_body flips each provider's thinking knob to its ENABLED form
+    per that provider's own dialect (not a blind key-drop). Free server defaults
+    to disabled and flips to enabled; non-thinking extras and MiniMax's
+    reasoning_split (no on/off semantics) are preserved unchanged."""
+    from config.providers import (
+        focus_extra_body, get_extra_body, EXTRA_BODY_CLAUDE,
+    )
+    from config.providers import EXTRA_BODY_MINIMAX  # not re-exported via config/__init__
+
+    # free server (model 名固定 free-model): regular turn sends thinking DISABLED…
+    assert get_extra_body("free-model") == {"thinking": {"type": "disabled"}}
+    assert get_extra_body("free-model") == EXTRA_BODY_CLAUDE
+    # …凝神 flips it to enabled (thinking.type dialect)
+    assert focus_extra_body("free-model") == {"thinking": {"type": "enabled"}}
+
+    # per-dialect enabled forms
+    assert focus_extra_body("qwen-flash") == {"enable_thinking": True}
+    assert focus_extra_body("glm-5.2") == {"thinking": {"type": "enabled"}}
+    assert focus_extra_body("gemini-2.5-flash") == {
+        "extra_body": {"google": {"thinking_config": {"thinking_budget": -1}}}
+    }
+    assert focus_extra_body("gemini-3-flash-preview") == {
+        "extra_body": {"google": {"thinking_config": {"thinking_level": "high", "include_thoughts": True}}}
+    }
+    assert focus_extra_body("google/gemini-2.5-flash") == {"reasoning": {"effort": "high"}}
+
+    # MiniMax reasoning_split is not an on/off knob → preserved, not flipped
+    assert focus_extra_body("MiniMax-M2.5") == EXTRA_BODY_MINIMAX
+    # non-thinking provider extra (step web_search) preserved on a focus turn
+    assert "tools" in focus_extra_body("step-2-mini")
+    # unknown / empty model → no extra_body
+    assert focus_extra_body("nonexistent") is None
+    assert focus_extra_body("") is None
+
+    # returns a fresh dict each call — mutating the result can't poison the constant
+    focus_extra_body("qwen-flash")["enable_thinking"] = False
+    assert focus_extra_body("qwen-flash") == {"enable_thinking": True}
 
 
 async def test_focus_override_threads_through_visible_stream():

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -457,7 +457,7 @@ def test_focus_extra_body_provider_dialects():
     assert focus_extra_body("qwen-flash") == {"enable_thinking": True}
     assert focus_extra_body("glm-5.2") == {"thinking": {"type": "enabled"}}
     assert focus_extra_body("gemini-2.5-flash") == {
-        "extra_body": {"google": {"thinking_config": {"thinking_budget": -1}}}
+        "extra_body": {"google": {"thinking_config": {"thinking_budget": 800}}}
     }
     assert focus_extra_body("gemini-3-flash-preview") == {
         "extra_body": {"google": {"thinking_config": {"thinking_level": "low", "include_thoughts": True}}}

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -482,6 +482,10 @@ def test_focus_extra_body_provider_dialects():
     # returns a fresh dict each call — mutating the result can't poison the constant
     focus_extra_body("qwen-flash")["enable_thinking"] = False
     assert focus_extra_body("qwen-flash") == {"enable_thinking": True}
+    # deepcopy also protects NESTED dialects (glm thinking dict) from alias pollution
+    nested = focus_extra_body("glm-5.2")
+    nested["thinking"]["type"] = "disabled"
+    assert focus_extra_body("glm-5.2") == {"thinking": {"type": "enabled"}}
 
 
 async def test_focus_override_threads_through_visible_stream():

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -556,6 +556,7 @@ def _bare_mgr():
     mgr.state = SessionStateMachine(lanlan_name="x")
     mgr.lanlan_name = "x"
     mgr._focus_scorer = FocusScorer("x")
+    mgr._focus_artifacts_pending = False
     # Deliberately NO _activity_tracker: the inline path must not touch it
     # (Focus scores the message, not the screen — privacy-independent).
     return mgr
@@ -803,3 +804,142 @@ async def test_update_focus_retention_override_and_count_turn(monkeypatch):
     await sm.update_focus(0.0, retention_override=0.9, count_turn=False)
     assert abs(sm.snapshot()["focus_charge"] - 0.9) < 1e-9  # override applied
     assert sm.snapshot()["focus_turn_count"] == tc_before    # not bumped
+
+
+# ── 8. 凝神退出：历史 thinking + 已闭合 tool call 清理 ─────────────────────
+# 凝神退出(任何路径)时，把上一个 episode 留在历史里的 reasoning_content + 已闭合
+# tool call 配对清掉，防止带偏退出后的 REGULAR 对话乃至新 session。
+def _tool_pair(call_id="c1", *, reasoning=None, name="t"):
+    """构造一条 assistant tool_calls 消息 + 紧随的 tool result（已闭合配对）。"""
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": call_id, "type": "function",
+                        "function": {"name": name, "arguments": "{}"}}],
+    }
+    if reasoning is not None:
+        assistant["reasoning_content"] = reasoning
+    result = {"role": "tool", "tool_call_id": call_id, "name": name, "content": "ok"}
+    return assistant, result
+
+
+def test_purge_closed_tool_calls():
+    """已闭合 tool-call 配对(assistant tool_calls + tool result)连同寄生其上的
+    reasoning_content 一并整对删除；普通 Human/AI/System 消息保留。"""
+    from main_logic.core import _purge_closed_tool_calls
+    from utils.llm_client import SystemMessage, HumanMessage, AIMessage
+
+    a, r = _tool_pair("c1", reasoning="让我想想要不要调工具…")
+    history = [SystemMessage(content="sys"), HumanMessage(content="查天气"), a, r,
+               AIMessage(content="今天晴")]
+    removed = _purge_closed_tool_calls(history)
+    assert removed == 2
+    # 只剩 system / human / ai，dict(tool 配对)及 reasoning_content 全没了
+    assert all(not isinstance(m, dict) for m in history)
+    assert [type(m).__name__ for m in history] == ["SystemMessage", "HumanMessage", "AIMessage"]
+
+
+def test_purge_keeps_unclosed_and_empty():
+    from main_logic.core import _purge_closed_tool_calls
+    from utils.llm_client import HumanMessage
+    # 未闭合：assistant 有 call 但没有对应 tool result → 保留(不破坏在途状态)
+    a, _ = _tool_pair("c9")
+    history = [HumanMessage(content="hi"), a]
+    assert _purge_closed_tool_calls(history) == 0
+    assert len(history) == 2
+    assert _purge_closed_tool_calls([]) == 0
+
+
+def test_purge_multiple_calls_one_turn():
+    from main_logic.core import _purge_closed_tool_calls
+    # 一个 assistant 两个 call + 两条 result → 全闭合，删 3 条
+    history = [
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "a", "type": "function", "function": {"name": "f", "arguments": "{}"}},
+            {"id": "b", "type": "function", "function": {"name": "g", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "a", "name": "f", "content": "1"},
+        {"role": "tool", "tool_call_id": "b", "name": "g", "content": "2"},
+    ]
+    assert _purge_closed_tool_calls(history) == 3
+    assert history == []
+
+
+def _purge_mgr(monkeypatch, history):
+    """裸 LLMSessionManager + 携带 _conversation_history 的假 OmniOfflineClient。"""
+    from main_logic.core import LLMSessionManager
+    from main_logic.omni_offline_client import OmniOfflineClient
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "x"
+    mgr.state = SessionStateMachine(lanlan_name="x")
+    mgr._focus_artifacts_pending = False
+    sess = OmniOfflineClient.__new__(OmniOfflineClient)
+    sess._conversation_history = history
+    mgr.session = sess
+
+    async def _noop(*a, **k):
+        return None
+    mgr._push_focus_indicator = _noop
+    mgr._push_focus_charge = _noop
+    return mgr, sess
+
+
+async def test_maybe_purge_only_after_exit(monkeypatch):
+    """_maybe_purge 只在「曾进入 FOCUS(armed) 且已回到 REGULAR」时清一次；未 arm /
+    仍在 FOCUS 时不动；清后 disarm 且幂等。"""
+    _patch_charge(monkeypatch, enter=1.0, exit=0.3)
+    a, r = _tool_pair("c1", reasoning="…")
+    mgr, sess = _purge_mgr(monkeypatch, [a, r])
+
+    # 没进过 focus（未 arm）→ 不清
+    await mgr._maybe_purge_focus_artifacts()
+    assert len(sess._conversation_history) == 2
+
+    # arm 且仍在 FOCUS → 不清（残留还在用）
+    mgr._focus_artifacts_pending = True
+    await mgr.state.update_focus(1.0)
+    assert mgr.state.mode is CognitionMode.FOCUS
+    await mgr._maybe_purge_focus_artifacts()
+    assert len(sess._conversation_history) == 2
+
+    # silent 退出回 REGULAR → 清 + disarm
+    await mgr.state.clear_focus()
+    assert mgr.state.mode is CognitionMode.REGULAR
+    await mgr._maybe_purge_focus_artifacts()
+    assert sess._conversation_history == []
+    assert mgr._focus_artifacts_pending is False
+    # 幂等：再调不报错、无副作用
+    await mgr._maybe_purge_focus_artifacts()
+    assert sess._conversation_history == []
+
+
+async def test_inline_decision_purges_history_on_exit(monkeypatch):
+    """inline 路径端到端：vulnerable 消息进 FOCUS(arm)、历史保留；neutral 消息衰减
+    退出时，在 stream_text 之前同步把已闭合 tool call(含 reasoning_content)清掉。"""
+    from main_logic.omni_offline_client import OmniOfflineClient
+    keyword_full = config.FOCUS_SIGNAL_WEIGHTS["keyword"]
+    _patch_charge(monkeypatch, enter=max(0.0, keyword_full - 0.1), exit=0.3, retention=0.5)
+    monkeypatch.setattr(config, "FOCUS_MODE_ENABLED", True)
+    _stub_user_focus_setting(monkeypatch, enabled=True)
+
+    a, r = _tool_pair("c1", reasoning="思考链…")
+    mgr = _bare_mgr()
+    sess = OmniOfflineClient.__new__(OmniOfflineClient)
+    sess._conversation_history = [a, r]
+    mgr.session = sess
+
+    async def _noop(*x, **k):
+        return None
+    mgr._push_focus_indicator = _noop
+    mgr._push_focus_charge = _noop
+
+    # vulnerable message → enter FOCUS, arm；episode 进行中历史不动
+    assert await mgr._focus_inline_decision("好累，一个人，没意思，撑不住了") is True
+    assert mgr.state.mode is CognitionMode.FOCUS
+    assert mgr._focus_artifacts_pending is True
+    assert len(sess._conversation_history) == 2
+
+    # neutral message → charge 衰减出 FOCUS → REGULAR → stream 前同步清历史
+    assert await mgr._focus_inline_decision("嗯那个文件改好了发你了") is False
+    assert mgr.state.mode is CognitionMode.REGULAR
+    assert sess._conversation_history == []
+    assert mgr._focus_artifacts_pending is False

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -409,32 +409,31 @@ async def _drain(agen):
 
 
 def test_focus_stream_overrides_decision():
-    """The thinking-on override decision, vision guard, and provider-extra
-    preservation. ``stream_text`` applies this before streaming: thinking-on
-    only when focus is active AND not on a vision model; and when it does
-    override, it FLIPS the provider's thinking knob to its enabled form (per
-    provider dialect) while keeping non-thinking extras (e.g. web_search)."""
+    """The thinking-on override decision + provider-extra preservation.
+    ``stream_text`` applies this before streaming: thinking-on whenever focus is
+    active (vision turns included now); when it overrides, it FLIPS the provider's
+    thinking knob to its enabled form (per provider dialect) while keeping
+    non-thinking extras (e.g. web_search)."""
     from main_logic.omni_offline_client import OmniOfflineClient as _C
     # thinking.type provider → flipped to enabled (not dropped to None)
-    assert _C._focus_stream_overrides(True, False, "claude-sonnet-4-6") == {
+    assert _C._focus_stream_overrides(True, "claude-sonnet-4-6") == {
         "extra_body": {"thinking": {"type": "enabled"}}
     }
     # free server (model 名固定 free-model) shares the thinking.type dialect
-    assert _C._focus_stream_overrides(True, False, "free-model") == {
+    assert _C._focus_stream_overrides(True, "free-model") == {
         "extra_body": {"thinking": {"type": "enabled"}}
     }
     # OpenAI-shape bool knob flips False→True
-    assert _C._focus_stream_overrides(True, False, "qwen-flash") == {
+    assert _C._focus_stream_overrides(True, "qwen-flash") == {
         "extra_body": {"enable_thinking": True}
     }
     # unknown model → no resolved extra_body → None
-    assert _C._focus_stream_overrides(True, False, "test-model") == {"extra_body": None}
+    assert _C._focus_stream_overrides(True, "test-model") == {"extra_body": None}
     # step-2-mini ships a web_search tool → it MUST survive (not nuked to None)
-    so = _C._focus_stream_overrides(True, False, "step-2-mini")
+    so = _C._focus_stream_overrides(True, "step-2-mini")
     assert so["extra_body"] is not None and "tools" in so["extra_body"]
-    # vision guard / not-thinking → no override at all
-    assert _C._focus_stream_overrides(True, True, "step-2-mini") == {}
-    assert _C._focus_stream_overrides(False, False, "step-2-mini") == {}
+    # thinking off → no override (vision no longer gates thinking)
+    assert _C._focus_stream_overrides(False, "step-2-mini") == {}
 
 
 def test_focus_extra_body_provider_dialects():
@@ -505,42 +504,14 @@ async def test_focus_override_threads_through_visible_stream():
 
     # focus turn (no images, unknown model): _focus_stream_overrides → {"extra_body": None}
     c = _make_client()
-    overrides = OmniOfflineClient._focus_stream_overrides(True, False, c.model)
+    overrides = OmniOfflineClient._focus_stream_overrides(True, c.model)
     await _drain(c._astream_visible_with_tools(["m"], **overrides))
     assert captured[-1].get("extra_body", "MISSING") is None
 
     # regular turn: no extra_body threaded
     c2 = _make_client()
-    await _drain(c2._astream_visible_with_tools(["m"], **OmniOfflineClient._focus_stream_overrides(False, False, c2.model)))
+    await _drain(c2._astream_visible_with_tools(["m"], **OmniOfflineClient._focus_stream_overrides(False, c2.model)))
     assert "extra_body" not in captured[-1]
-
-
-async def test_check_repetition_resets_vision_guard():
-    """Repetition recovery wipes _conversation_history → the sticky Focus vision
-    guard must recompute from the only thing that survives a wipe: a real
-    persistent vision-model switch. Shared-model (no switch) clears it; a
-    committed separate vision model keeps it (the switch is irreversible)."""
-    from main_logic.omni_offline_client import OmniOfflineClient
-
-    def _mk(committed):
-        c = OmniOfflineClient.__new__(OmniOfflineClient)
-        c._recent_responses = ["同一句重复回复", "同一句重复回复"]
-        c._max_recent_responses = 5
-        c._repetition_threshold = 0.5
-        c._conversation_history = []
-        c.on_repetition_detected = None
-        c._focus_vision_committed = committed
-        c._focus_images_seen = True  # set earlier by an image-bearing turn
-        return c
-
-    # shared-model profile (no persistent switch) → flag clears after wipe
-    c1 = _mk(False)
-    assert await c1._check_repetition("同一句重复回复") is True
-    assert c1._focus_images_seen is False
-    # separate vision model committed → flag survives (irreversible switch)
-    c2 = _mk(True)
-    assert await c2._check_repetition("同一句重复回复") is True
-    assert c2._focus_images_seen is True
 
 
 # ── 6. caller-level Focus gates: charge hygiene + privacy-independence ─────

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -460,9 +460,9 @@ def test_focus_extra_body_provider_dialects():
         "extra_body": {"google": {"thinking_config": {"thinking_budget": -1}}}
     }
     assert focus_extra_body("gemini-3-flash-preview") == {
-        "extra_body": {"google": {"thinking_config": {"thinking_level": "high", "include_thoughts": True}}}
+        "extra_body": {"google": {"thinking_config": {"thinking_level": "low", "include_thoughts": True}}}
     }
-    assert focus_extra_body("google/gemini-2.5-flash") == {"reasoning": {"effort": "high"}}
+    assert focus_extra_body("google/gemini-2.5-flash") == {"reasoning": {"effort": "low"}}
 
     # MiniMax reasoning_split is not an on/off knob → preserved, not flipped
     assert focus_extra_body("MiniMax-M2.5") == EXTRA_BODY_MINIMAX


### PR DESCRIPTION
## 背景

凝神（thinking-on）原先靠「删掉 thinking-disable key、回退 provider 默认」来开启思考。这套范式对 free server 失效（free-model 不在 extra_body 表里，无 key 可删，凝神时什么都不发），且退出凝神后 thinking / tool 痕迹会残留在历史里污染后续对话。本 PR 把凝神的 thinking 控制改成按各家 provider 语义显式翻转，接入 free server，并在退出时清理历史。

## 改动

### 1. thinking 按 provider 语义对偶翻转（不再删 key）

每个 provider 的 thinking 旋钮成对定义「关 / 开」常量，凝神时按各家 API 自身语义 flip 到启用形式，而非机械翻 bool：

| provider | 平时（关） | 凝神（开） |
|---|---|---|
| Qwen / Silicon | `enable_thinking: False` | `True` |
| GLM/Kimi/Doubao/Claude/**free** | `thinking.type: disabled` | `enabled` |
| Gemini 2.5 | `thinking_budget: 0` | `800`（固定低预算） |
| Gemini 3 | `level: low, include_thoughts: False` | `level: low, include_thoughts: True` |
| OpenRouter | `effort: none` | `low` |
| MiniMax | `reasoning_split: True` | 不翻 |

- 档位类一律取最低开启档（凝神只需开思考、不追求深思）。
- MiniMax 的 `reasoning_split` 经官方文档确认只控制思考的输出格式、M3 思考无法关闭，故不参与翻转（保持 True 还能避免 CoT 混进 content 被 TTS 念出）。
- 非 thinking 的 provider extra（step-2-mini 的 web_search）原样保留。

### 2. free server 接入

注册 `"free-model": EXTRA_BODY_CLAUDE`，平时下发 disabled、凝神 flip 成 enabled。

### 3. 凝神退出时清理历史

退出凝神时，从对话历史清掉「已闭合的 tool call 配对」（assistant tool_calls 消息 + 对应 tool result），寄生其上的 `reasoning_content` 随之整对删除——必须整对删而非单删字段，否则 thinking provider 下一轮因缺 reasoning_content 报 400。纯文本 thinking 本就被 ThinkingStreamStripper 挡在历史外。

清理走**同步路径**而非 FOCUS_EXIT 事件：`_dispatch_subscribers` 对 async 回调是 fire-and-forget，事件驱动的清理会和 reply stream 抢跑。改为 inline 决策在 `update_focus` 之后、`stream_text` 之前同步清（覆盖 decayed / hard_cap / topic_switch），加每轮 `_reconcile_focus_indicator` 兜底 silent 退出（总开关 / user-setting / privacy self-clear / clear_focus）。`_focus_artifacts_pending` 边沿标志保证只清一次。

## 测试

- `tests/unit/test_focus_mode.py`：新增各 provider 方言对偶、free 平时/凝神、历史清理（纯函数 + 边沿幂等 + inline 端到端）。
- `tests/unit/test_focus_indicator_bridge.py`：夹具同步补 `_maybe_purge_focus_artifacts`。

（预存失败 `test_inline_gate_user_setting_default_on_allows` 与本 PR 无关，base 上同样红。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 扩展多 AI 提供商的思考开关与凝神（Focus）适配，新增 Minimax，并细化 OpenAI/Claude/Gemini/OpenRouter 的启用/禁用映射，统一翻转规则。

* **Bug修复**
  * 优化凝神退出后的历史清理：仅移除已闭合的工具调用配对及其关联内容，补齐静默退出与回合边界场景，降低对后续普通回复的影响。
  * 改善视觉路径下的凝神行为，使其不再依赖视觉粘性状态。

* **测试**
  * 更新并新增多提供商映射、流式覆盖与退出清理幂等性的单元测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->