### PR TITLE
feat(tutorial): 把新手破冰的有效选项落进持久化选项池

### DIFF
--- a/main_routers/icebreaker_router.py
+++ b/main_routers/icebreaker_router.py
@@ -12,6 +12,7 @@ make ``/api/game/route/active`` report an open mini-game window.
 """
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import Any, Dict
 
@@ -28,6 +29,7 @@ from utils.icebreaker_route_state import (
 )
 from utils.language_utils import is_supported_language_code, normalize_language_code
 from utils.logger_config import get_module_logger
+from utils.tutorial_choices_state import record_tutorial_choice
 
 from .shared_state import get_config_manager, get_session_manager
 
@@ -337,6 +339,56 @@ async def icebreaker_context(request: Request):
         "source": ICEBREAKER_SOURCE,
         "session_id": session_id,
     }
+
+
+@router.post("/choice")
+async def icebreaker_choice(request: Request):
+    """Persist a single effective tutorial choice into the durable choices pool.
+
+    Write-only for now: the choice is recorded so it survives across sessions,
+    but it does not enter the memory system and does not influence the model.
+    Kept separate from ``/context`` (which feeds transient session history) so the
+    pool stays an independent signal we can consume incrementally later.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return {"ok": False, "reason": "invalid_body"}
+    if not isinstance(data, dict):
+        return {"ok": False, "reason": "invalid_body"}
+
+    validation_error = _validate_icebreaker_local_mutation(request, data)
+    if validation_error is not None:
+        return validation_error
+
+    lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
+    if not lanlan_name:
+        return {"ok": False, "reason": "missing_lanlan_name"}
+
+    payload = {
+        "lanlan_name": lanlan_name,
+        "session_id": data.get("session_id"),
+        "day": data.get("day"),
+        "node_id": data.get("node_id"),
+        "choice": data.get("choice"),
+        "label": data.get("label"),
+        "handoff": data.get("handoff"),
+        "completed": data.get("completed"),
+        "source": ICEBREAKER_SOURCE,
+    }
+    try:
+        result = await asyncio.to_thread(record_tutorial_choice, payload)
+    except Exception as exc:
+        logger.warning("icebreaker choice persist failed for %s: %s", lanlan_name, exc, exc_info=True)
+        return {
+            "ok": False,
+            "reason": "choice_write_failed",
+            "error": str(exc),
+            "lanlan_name": lanlan_name,
+            "source": ICEBREAKER_SOURCE,
+        }
+    result.setdefault("source", ICEBREAKER_SOURCE)
+    return result
 
 
 @router.post("/speak")

--- a/main_routers/icebreaker_router.py
+++ b/main_routers/icebreaker_router.py
@@ -365,6 +365,23 @@ async def icebreaker_choice(request: Request):
     if not lanlan_name:
         return {"ok": False, "reason": "missing_lanlan_name"}
 
+    requested_session_id = str(data.get("session_id") or "")
+    # 双 tab 防污染：若同角色另起了新破冰 session（/route/start 把新 session 顶为
+    # active），被取代的旧 tab 的选择不该写进「有效路径」池。与 /context、/speak 一致
+    # 用 _stale_icebreaker_session_response 挡掉 session 不匹配的旧请求。
+    # 但与那两个端点不同：这里**不**要求 active route 必须存在——收尾的 handoff 选择
+    # 在 handleChoice 里先于 completeWithHandoff 的 route/end 触发，竞态下 route 可能已
+    # 结束，此时无 active state（不 stale）应照常落盘，避免丢掉最重要的最终选择。
+    active_state = _get_active_icebreaker_route_state(lanlan_name)
+    stale_response = _stale_icebreaker_session_response(
+        active_state,
+        requested_session_id,
+        lanlan_name=lanlan_name,
+        method="tutorial_choices",
+    )
+    if stale_response:
+        return stale_response
+
     payload = {
         "lanlan_name": lanlan_name,
         "session_id": data.get("session_id"),

--- a/main_routers/icebreaker_router.py
+++ b/main_routers/icebreaker_router.py
@@ -366,13 +366,22 @@ async def icebreaker_choice(request: Request):
         return {"ok": False, "reason": "missing_lanlan_name"}
 
     requested_session_id = str(data.get("session_id") or "")
-    # 双 tab 防污染：若同角色另起了新破冰 session（/route/start 把新 session 顶为
-    # active），被取代的旧 tab 的选择不该写进「有效路径」池。与 /context、/speak 一致
-    # 用 _stale_icebreaker_session_response 挡掉 session 不匹配的旧请求。
-    # 但与那两个端点不同：这里**不**要求 active route 必须存在——收尾的 handoff 选择
-    # 在 handleChoice 里先于 completeWithHandoff 的 route/end 触发，竞态下 route 可能已
-    # 结束，此时无 active state（不 stale）应照常落盘，避免丢掉最重要的最终选择。
+    # 选项必须属于当前 active 的破冰 route，才能写进「有效路径」池——与 /context、
+    # /speak 完全对齐：无 active route → route_not_active；session 不匹配（双 tab 下
+    # 新 session 顶掉旧的）→ stale 拒绝。这样被取代的旧 tab、以及 route 结束后迟到的
+    # 旧请求都进不来，池子不被污染。
+    # 不必担心丢掉收尾的 handoff 选择：前端 recordChoiceToPool 在 handleChoice 开头
+    # 同步发起本请求，而 route/end 要等之后两次 appendChatMessage（各含一个 /context
+    # 往返）才发起，本请求实质上比 route/end 早约两个往返，落地时 route 仍 active。
     active_state = _get_active_icebreaker_route_state(lanlan_name)
+    if not active_state:
+        return {
+            "ok": False,
+            "reason": "route_not_active",
+            "lanlan_name": lanlan_name,
+            "source": ICEBREAKER_SOURCE,
+            "method": "tutorial_choices",
+        }
     stale_response = _stale_icebreaker_session_response(
         active_state,
         requested_session_id,

--- a/main_routers/icebreaker_router.py
+++ b/main_routers/icebreaker_router.py
@@ -400,6 +400,7 @@ async def icebreaker_choice(request: Request):
         "label": data.get("label"),
         "handoff": data.get("handoff"),
         "completed": data.get("completed"),
+        "seq": data.get("seq"),
         "source": ICEBREAKER_SOURCE,
     }
     try:

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -791,7 +791,10 @@
                 sessionId: sessionId,
                 nodeId: nodeId
             });
-            return endIcebreakerRoute(session, 'icebreaker_handoff');
+            // 等收尾选择的池写入到达服务端再关 route，否则严格后端会拒掉迟到的它。
+            return Promise.resolve(session.pendingChoiceWrite).catch(function () {}).then(function () {
+                return endIcebreakerRoute(session, 'icebreaker_handoff');
+            });
         }).then(function () {
             if (activeSession === session) {
                 activeSession = null;
@@ -819,7 +822,7 @@
         // 带 next。两种都在这里被点，统一在此落进持久化选项池（session.nodeId 即本次选择
         // 所属节点，deliverNode 之后会被改写，所以现在就记）。
         var isHandoffChoice = !!option.handoffKey;
-        recordChoiceToPool({
+        var choiceWritePromise = recordChoiceToPool({
             day: session.day,
             sessionId: session.sessionId,
             nodeId: session.nodeId,
@@ -828,6 +831,13 @@
             handoff: isHandoffChoice,
             completed: isHandoffChoice
         });
+        if (isHandoffChoice) {
+            // 收尾选择会结束 route，而后端严格模式下 route 一关就拒收 /choice。fire-and-forget
+            // 下这条最重要的选择可能在网络重排中迟到被拒，故把写入 promise 挂到 session，让
+            // completeWithHandoff 在 endIcebreakerRoute 前 await 它（recordChoiceToPool 内部
+            // 已 catch、永不 reject，await 不会挂）。
+            session.pendingChoiceWrite = choiceWritePromise;
+        }
         appendChatMessage('user', label, {
             day: session.day,
             nodeId: session.nodeId,

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -516,6 +516,10 @@
                 method: 'POST',
                 headers: headers,
                 credentials: 'same-origin',
+                // keepalive：让本请求挺过页面卸载（reload/close），与 endIcebreakerRouteOnPageExit
+                // 用 beacon/keepalive 发 /route/end 对称，避免点完即关页时浏览器取消普通 fetch 致丢记。
+                // body 仅 ~200 字节，远低于 keepalive 的 64KB 上限。
+                keepalive: true,
                 body: JSON.stringify(body)
             }).then(function (response) {
                 if (allowRetry && response.status === 403) {

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -486,8 +486,12 @@
         var nodeId = String(info.nodeId || '').trim();
         var choice = String(info.choice || '').trim();
         if (!nodeId || !choice) return Promise.resolve(false);
+        // 用 session 起始钉死的角色快照，而非点击时现取 resolveLanlanName()：若中途换了
+        // 当前角色，选项仍归属到 /route/start 激活的那个角色，避免把后半段路径写到错角色
+        // 名下（正是这个 per-角色池要避免的串味）。同步取值，防 activeSession 在 await 中被清。
+        var lanlanName = String((activeSession && activeSession.lanlanName) || resolveLanlanName() || '');
         var body = {
-            lanlan_name: resolveLanlanName(),
+            lanlan_name: lanlanName,
             session_id: String(info.sessionId || (activeSession && activeSession.sessionId) || ''),
             day: String(info.day || (activeSession && activeSession.day) || ''),
             node_id: nodeId,
@@ -999,6 +1003,8 @@
                 localeData: localeData || {},
                 nodeId: dayConfig.root,
                 offTopicCount: 0,
+                // 钉死本 session 的角色：后续选项写入用这个快照而非现取，避免中途换角色串味。
+                lanlanName: resolveLanlanName(),
                 sessionId: 'icebreaker-day' + dayKey + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8)
             };
             return startIcebreakerRoute(nextSession).then(function (started) {

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -815,8 +815,12 @@
                 sessionId: sessionId,
                 nodeId: nodeId
             });
-            // 等收尾选择的池写入到达服务端再关 route，否则严格后端会拒掉迟到的它。
-            return Promise.resolve(session.pendingChoiceWrite).catch(function () {}).then(function () {
+            // 关 route 前 await 本 session 全部未决池写入（中间+收尾）：严格后端 route 一关就
+            // 拒收，迟到的写入会丢。绝大多数早已 resolve，Promise.all 实际几乎立即完成。
+            var pendingWrites = (session.pendingChoiceWrites || []).map(function (p) {
+                return Promise.resolve(p).catch(function () {});
+            });
+            return Promise.all(pendingWrites).then(function () {
                 return endIcebreakerRoute(session, 'icebreaker_handoff');
             });
         }).then(function () {
@@ -875,12 +879,11 @@
                 completed: isHandoffChoice,
                 seq: (session.choiceSeq = (session.choiceSeq || 0) + 1)
             });
-            if (isHandoffChoice) {
-                // 收尾选择会结束 route，严格后端 route 一关就拒收。把写入 promise 挂到 session，
-                // 让 completeWithHandoff 在 endIcebreakerRoute 前 await 它，保证它在 route 仍
-                // active 时到达服务端（recordChoiceToPool 内部已 catch、永不 reject，await 不挂）。
-                session.pendingChoiceWrite = choiceWritePromise;
-            }
+            // 收集本 session 每一条写入 promise（中间+收尾）。收尾选择会结束 route，而严格后端
+            // route 一关就拒收 /choice，故 completeWithHandoff 在 endIcebreakerRoute 前 await 全部
+            // 未决写入，确保任何仍在途的选择都在 route 仍 active 时到达服务端、不被拒掉丢失
+            // （recordChoiceToPool 内部已 catch、永不 reject，await 不会挂）。
+            (session.pendingChoiceWrites || (session.pendingChoiceWrites = [])).push(choiceWritePromise);
             if (option.next) {
                 return deliverNode(option.next);
             }

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -478,6 +478,42 @@
         return contextAppendPromise;
     }
 
+    // 把用户在破冰里点的「有效选项」追加进后端持久化选项池（/api/icebreaker/choice）。
+    // 这条独立于 appendLlmContext：后者写的是临时会话上下文，这里写的是跨会话留存、
+    // 当前不喂模型也不进记忆的独立信号，纯 fire-and-forget，失败只告警不阻断教程流。
+    function recordChoiceToPool(meta) {
+        var info = meta && typeof meta === 'object' ? meta : {};
+        var nodeId = String(info.nodeId || '').trim();
+        var choice = String(info.choice || '').trim();
+        if (!nodeId || !choice) return Promise.resolve(false);
+        var body = {
+            lanlan_name: resolveLanlanName(),
+            session_id: String(info.sessionId || (activeSession && activeSession.sessionId) || ''),
+            day: String(info.day || (activeSession && activeSession.day) || ''),
+            node_id: nodeId,
+            choice: choice,
+            label: String(info.label || ''),
+            handoff: info.handoff === true,
+            completed: info.completed === true
+        };
+        return getLocalMutationHeaders().then(function (headers) {
+            return fetch(ICEBREAKER_API_BASE + '/choice', {
+                method: 'POST',
+                headers: headers,
+                credentials: 'same-origin',
+                body: JSON.stringify(body)
+            });
+        }).then(function (response) {
+            if (!response.ok) throw new Error('HTTP ' + response.status);
+            return response.json();
+        }).then(function (data) {
+            return !!(data && data.ok);
+        }).catch(function (error) {
+            console.warn('[NewUserIcebreaker] record choice to pool failed:', error);
+            return false;
+        });
+    }
+
     function finalizeIcebreakerAssistantSubtitle(text) {
         var line = String(text || '').trim();
         if (!line) return;
@@ -775,6 +811,19 @@
         session.choiceInFlight = true;
         clearChoicePrompt();
         var label = (detail.option && detail.option.label) || getText(session.localeData, option.labelKey);
+        // 叶子节点的选项带 handoffKey（无 next），那一次点击就是这天的收尾选择；中间节点
+        // 带 next。两种都在这里被点，统一在此落进持久化选项池（session.nodeId 即本次选择
+        // 所属节点，deliverNode 之后会被改写，所以现在就记）。
+        var isHandoffChoice = !!option.handoffKey;
+        recordChoiceToPool({
+            day: session.day,
+            sessionId: session.sessionId,
+            nodeId: session.nodeId,
+            choice: choice,
+            label: label,
+            handoff: isHandoffChoice,
+            completed: isHandoffChoice
+        });
         appendChatMessage('user', label, {
             day: session.day,
             nodeId: session.nodeId,

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -498,20 +498,44 @@
             choice: choice,
             label: String(info.label || ''),
             handoff: info.handoff === true,
-            completed: info.completed === true
+            completed: info.completed === true,
+            seq: Number(info.seq) || 0
         };
-        return getLocalMutationHeaders().then(function (headers) {
+
+        function parseChoiceResponse(response) {
+            if (!response.ok) throw new Error('HTTP ' + response.status);
+            return response.json().then(function (data) {
+                return !!(data && data.ok);
+            });
+        }
+
+        // 与 /context 同款：缓存的 local-mutation token 过期（如后端重启而页面常驻）时，
+        // 403 csrf_validation_failed 不当普通失败丢弃，刷新 token 后重试一次，避免静默漏记。
+        function postChoiceWithHeaders(headers, allowRetry) {
             return fetch(ICEBREAKER_API_BASE + '/choice', {
                 method: 'POST',
                 headers: headers,
                 credentials: 'same-origin',
                 body: JSON.stringify(body)
+            }).then(function (response) {
+                if (allowRetry && response.status === 403) {
+                    return response.clone().json().catch(function () {
+                        return null;
+                    }).then(function (errorBody) {
+                        if (errorBody && errorBody.error_code === 'csrf_validation_failed') {
+                            return refreshLocalMutationHeaders().then(function (nextHeaders) {
+                                return postChoiceWithHeaders(nextHeaders, false);
+                            });
+                        }
+                        return parseChoiceResponse(response);
+                    });
+                }
+                return parseChoiceResponse(response);
             });
-        }).then(function (response) {
-            if (!response.ok) throw new Error('HTTP ' + response.status);
-            return response.json();
-        }).then(function (data) {
-            return !!(data && data.ok);
+        }
+
+        return getLocalMutationHeaders().then(function (headers) {
+            return postChoiceWithHeaders(headers, true);
         }).catch(function (error) {
             console.warn('[NewUserIcebreaker] record choice to pool failed:', error);
             return false;
@@ -818,26 +842,10 @@
         session.choiceInFlight = true;
         clearChoicePrompt();
         var label = (detail.option && detail.option.label) || getText(session.localeData, option.labelKey);
-        // 叶子节点的选项带 handoffKey（无 next），那一次点击就是这天的收尾选择；中间节点
-        // 带 next。两种都在这里被点，统一在此落进持久化选项池（session.nodeId 即本次选择
-        // 所属节点，deliverNode 之后会被改写，所以现在就记）。
+        // 叶子节点的选项带 handoffKey（无 next）即这天的收尾选择；中间节点带 next。
         var isHandoffChoice = !!option.handoffKey;
-        var choiceWritePromise = recordChoiceToPool({
-            day: session.day,
-            sessionId: session.sessionId,
-            nodeId: session.nodeId,
-            choice: choice,
-            label: label,
-            handoff: isHandoffChoice,
-            completed: isHandoffChoice
-        });
-        if (isHandoffChoice) {
-            // 收尾选择会结束 route，而后端严格模式下 route 一关就拒收 /choice。fire-and-forget
-            // 下这条最重要的选择可能在网络重排中迟到被拒，故把写入 promise 挂到 session，让
-            // completeWithHandoff 在 endIcebreakerRoute 前 await 它（recordChoiceToPool 内部
-            // 已 catch、永不 reject，await 不会挂）。
-            session.pendingChoiceWrite = choiceWritePromise;
-        }
+        // 本次选择所属节点：deliverNode 之后 session.nodeId 会被改写，先快照下来。
+        var choiceNodeId = session.nodeId;
         appendChatMessage('user', label, {
             day: session.day,
             nodeId: session.nodeId,
@@ -852,6 +860,26 @@
             }
             if (activeSession !== session) {
                 return null;
+            }
+            // 仅在用户消息被接受后才写池：appendChatMessage 返回 null（host 渲染超时）会回滚到
+            // 原节点，此刻不能留下一条用户可能改选的幻影选项（handoff 还会误标 completed）。
+            // seq 是 session 内自增步序，让消费侧按点击顺序还原路径，不受 fire-and-forget 写入
+            // 到达顺序被网络打乱的影响。
+            var choiceWritePromise = recordChoiceToPool({
+                day: session.day,
+                sessionId: session.sessionId,
+                nodeId: choiceNodeId,
+                choice: choice,
+                label: label,
+                handoff: isHandoffChoice,
+                completed: isHandoffChoice,
+                seq: (session.choiceSeq = (session.choiceSeq || 0) + 1)
+            });
+            if (isHandoffChoice) {
+                // 收尾选择会结束 route，严格后端 route 一关就拒收。把写入 promise 挂到 session，
+                // 让 completeWithHandoff 在 endIcebreakerRoute 前 await 它，保证它在 route 仍
+                // active 时到达服务端（recordChoiceToPool 内部已 catch、永不 reject，await 不挂）。
+                session.pendingChoiceWrite = choiceWritePromise;
             }
             if (option.next) {
                 return deliverNode(option.next);

--- a/utils/tutorial_choices_state.py
+++ b/utils/tutorial_choices_state.py
@@ -85,6 +85,9 @@ def _normalize_choice(raw_choice: Any) -> dict[str, Any] | None:
         "label": _clean_str(raw_choice.get("label"), limit=_LABEL_LIMIT),
         "handoff": bool(raw_choice.get("handoff")),
         "session_id": _clean_str(raw_choice.get("session_id"), limit=_SESSION_LIMIT),
+        # 客户端自增步序：消费侧按 seq 还原点击顺序，不依赖数组到达顺序（fire-and-forget
+        # 写入可能被网络打乱）。0 表示调用方未提供。
+        "seq": _clamp_int(raw_choice.get("seq")),
         "at": _clamp_int(raw_choice.get("at")),
     }
 
@@ -205,6 +208,7 @@ def record_tutorial_choice(
         "label": payload.get("label"),
         "handoff": payload.get("handoff"),
         "session_id": session_id,
+        "seq": payload.get("seq"),
         "at": now_ms,
     })
 

--- a/utils/tutorial_choices_state.py
+++ b/utils/tutorial_choices_state.py
@@ -173,6 +173,20 @@ def save_tutorial_choices_state(state: dict[str, Any], config_manager=None) -> d
     return normalized
 
 
+def _character_last_updated(character: Any) -> int:
+    """该角色所有天里最大的 updated_at，用于到角色上限时淘汰最久未更新的一个。"""
+    if not isinstance(character, dict):
+        return 0
+    days = character.get("days")
+    if not isinstance(days, dict):
+        return 0
+    latest = 0
+    for day in days.values():
+        if isinstance(day, dict):
+            latest = max(latest, _clamp_int(day.get("updated_at")))
+    return latest
+
+
 def _is_duplicate_choice(existing: list[dict[str, Any]], candidate: dict[str, Any], session_id: str) -> bool:
     # 只挡「同一 session 内的精确重放」（网络重试 / 重复事件把同一次点击重发）：
     # 按 (session_id, node_id, choice, handoff) 比较。session_id 入了比较键，所以
@@ -227,7 +241,15 @@ def record_tutorial_choice(
     with _STATE_LOCK:
         state = load_tutorial_choices_state(config_manager)
         characters = state["characters"]
-        character = characters.setdefault(lanlan_name, {"days": {}})
+        character = characters.get(lanlan_name)
+        if not isinstance(character, dict):
+            if len(characters) >= MAX_CHARACTERS:
+                # 已到角色上限：淘汰最久未更新的一个给当前写入腾位。否则 _normalize_state 会在
+                # save 时把新角色静默截掉，却仍返回 ok=True（单用户本地几乎不可触发，但不能谎报成功）。
+                oldest = min(characters, key=lambda n: _character_last_updated(characters.get(n)))
+                characters.pop(oldest, None)
+            character = {"days": {}}
+            characters[lanlan_name] = character
         days = character.setdefault("days", {})
         day = days.get(day_key)
         if not isinstance(day, dict):

--- a/utils/tutorial_choices_state.py
+++ b/utils/tutorial_choices_state.py
@@ -84,6 +84,7 @@ def _normalize_choice(raw_choice: Any) -> dict[str, Any] | None:
         "choice": choice,
         "label": _clean_str(raw_choice.get("label"), limit=_LABEL_LIMIT),
         "handoff": bool(raw_choice.get("handoff")),
+        "session_id": _clean_str(raw_choice.get("session_id"), limit=_SESSION_LIMIT),
         "at": _clamp_int(raw_choice.get("at")),
     }
 
@@ -168,14 +169,17 @@ def save_tutorial_choices_state(state: dict[str, Any], config_manager=None) -> d
 
 
 def _is_duplicate_choice(existing: list[dict[str, Any]], candidate: dict[str, Any], session_id: str) -> bool:
-    # 一棵分支树在同一 session 里不会重复经过同一节点，但网络重试 / 重复事件可能把
-    # 同一次点击重发。按 (session_id, node_id, choice, handoff) 去重，挡掉精确重放，
-    # 同时仍允许重定向后在同一节点改投另一个选项。
+    # 只挡「同一 session 内的精确重放」（网络重试 / 重复事件把同一次点击重发）：
+    # 按 (session_id, node_id, choice, handoff) 比较。session_id 入了比较键，所以
+    # 用户刷新后用新 session 重走同一天会照常落盘（视作新信号，不静默丢弃），而同一
+    # session 改投不同选项也不受影响（choice 字段不同）。session_id 为空则不去重，
+    # 让无 session 的调用方无损写入。
     if not session_id:
         return False
     for item in existing:
         if (
-            item.get("node_id") == candidate["node_id"]
+            item.get("session_id") == session_id
+            and item.get("node_id") == candidate["node_id"]
             and item.get("choice") == candidate["choice"]
             and bool(item.get("handoff")) == candidate["handoff"]
         ):
@@ -194,11 +198,13 @@ def record_tutorial_choice(
 
     lanlan_name = _clean_str(payload.get("lanlan_name"), limit=_NAME_LIMIT)
     day_key = _clean_str(payload.get("day"), limit=_DAY_LIMIT)
+    session_id = _clean_str(payload.get("session_id"), limit=_SESSION_LIMIT)
     candidate = _normalize_choice({
         "node_id": payload.get("node_id"),
         "choice": payload.get("choice"),
         "label": payload.get("label"),
         "handoff": payload.get("handoff"),
+        "session_id": session_id,
         "at": now_ms,
     })
 
@@ -209,7 +215,6 @@ def record_tutorial_choice(
     if candidate is None:
         return {"ok": False, "reason": "invalid_choice"}
 
-    session_id = _clean_str(payload.get("session_id"), limit=_SESSION_LIMIT)
     source = _clean_str(payload.get("source"), limit=_SOURCE_LIMIT)
     completed = bool(payload.get("completed"))
 
@@ -239,7 +244,7 @@ def record_tutorial_choice(
             day["first_recorded_at"] = now_ms
         day["updated_at"] = now_ms
 
-        state = save_tutorial_choices_state(state, config_manager)
+        save_tutorial_choices_state(state, config_manager)
 
     return {
         "ok": True,
@@ -255,6 +260,9 @@ def get_tutorial_choices_for_character(
     config_manager=None,
 ) -> dict[str, Any]:
     name = _clean_str(lanlan_name, limit=_NAME_LIMIT)
-    state = load_tutorial_choices_state(config_manager)
+    # 持锁读：load→save 在写路径里是临界区，atomic_write_json 已保证读不到撕裂的
+    # JSON，但持锁能让读到的恒为最近一次完整提交后的快照，未来消费侧上线也不必再补。
+    with _STATE_LOCK:
+        state = load_tutorial_choices_state(config_manager)
     character = state["characters"].get(name) if name else None
     return character if isinstance(character, dict) else {"days": {}}

--- a/utils/tutorial_choices_state.py
+++ b/utils/tutorial_choices_state.py
@@ -167,7 +167,9 @@ def load_tutorial_choices_state(config_manager=None) -> dict[str, Any]:
 def save_tutorial_choices_state(state: dict[str, Any], config_manager=None) -> dict[str, Any]:
     normalized = _normalize_state(state)
     path = get_tutorial_choices_state_path(config_manager)
-    atomic_write_json(path, normalized, ensure_ascii=False, indent=2)
+    # 通用 safe dump：原子写（写临时文件再 rename，绝不留半截文件），显式 utf-8、
+    # ensure_ascii=False 保留中文 label 原文。读侧 _load_state_file 同样显式 utf-8 打开。
+    atomic_write_json(path, normalized, encoding="utf-8", ensure_ascii=False, indent=2)
     return normalized
 
 

--- a/utils/tutorial_choices_state.py
+++ b/utils/tutorial_choices_state.py
@@ -174,7 +174,8 @@ def save_tutorial_choices_state(state: dict[str, Any], config_manager=None) -> d
 
 
 def _character_last_updated(character: Any) -> int:
-    """该角色所有天里最大的 updated_at，用于到角色上限时淘汰最久未更新的一个。"""
+    """Latest updated_at across the character's days; used to evict the
+    least-recently-updated character when the character cap is reached."""
     if not isinstance(character, dict):
         return 0
     days = character.get("days")

--- a/utils/tutorial_choices_state.py
+++ b/utils/tutorial_choices_state.py
@@ -1,0 +1,260 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Durable pool for the tutorial choices a user makes during onboarding.
+
+This is intentionally a *write-only* persistence layer for now: every effective
+option the user picks in the new-user icebreaker (the A/B branch picks plus the
+final handoff pick) is appended here so the data survives across sessions. The
+choices currently feed into nothing — they do not enter the memory system and do
+not influence the model. The point is to capture the signal now so future work
+can consume it incrementally, without having to retrofit a store later.
+
+The file lives next to ``tutorial_prompt.json`` (global config dir) but is keyed
+by ``lanlan_name`` so choices stay attributed to the character the user
+onboarded with.
+"""
+from __future__ import annotations
+
+import threading
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from utils.config_manager import get_config_manager
+from utils.file_utils import atomic_write_json
+from utils.prompt_state_core import (
+    clamp_int as _clamp_int,
+    clean_str as _clean_str,
+    load_state_file as _load_state_file,
+    now_ms as _now_ms,
+)
+
+TUTORIAL_CHOICES_STATE_FILENAME = "tutorial_choices.json"
+TUTORIAL_CHOICES_STATE_KIND = "tutorial_choices"
+TUTORIAL_CHOICES_SCHEMA_VERSION = 1
+
+# 防御性上限：单棵破冰二叉树满打满算 5 跳/天 × 7 天 = 35 条，留足冗余即可，不需要无限增长。
+MAX_CHARACTERS = 32
+MAX_DAYS_PER_CHARACTER = 64
+MAX_CHOICES_PER_DAY = 128
+
+_LABEL_LIMIT = 200
+_NODE_ID_LIMIT = 64
+_CHOICE_LIMIT = 16
+_SOURCE_LIMIT = 64
+_NAME_LIMIT = 128
+_DAY_LIMIT = 32
+_SESSION_LIMIT = 128
+
+DEFAULT_TUTORIAL_CHOICES_STATE = {
+    "version": TUTORIAL_CHOICES_SCHEMA_VERSION,
+    "kind": TUTORIAL_CHOICES_STATE_KIND,
+    "characters": {},
+}
+
+_STATE_LOCK = threading.RLock()
+
+
+def get_tutorial_choices_state_path(config_manager=None) -> Path:
+    config_manager = config_manager or get_config_manager()
+    return Path(config_manager.get_config_path(TUTORIAL_CHOICES_STATE_FILENAME))
+
+
+def _normalize_choice(raw_choice: Any) -> dict[str, Any] | None:
+    if not isinstance(raw_choice, dict):
+        return None
+    node_id = _clean_str(raw_choice.get("node_id"), limit=_NODE_ID_LIMIT)
+    choice = _clean_str(raw_choice.get("choice"), limit=_CHOICE_LIMIT)
+    if not node_id or not choice:
+        return None
+    return {
+        "node_id": node_id,
+        "choice": choice,
+        "label": _clean_str(raw_choice.get("label"), limit=_LABEL_LIMIT),
+        "handoff": bool(raw_choice.get("handoff")),
+        "at": _clamp_int(raw_choice.get("at")),
+    }
+
+
+def _normalize_day(raw_day: Any, day_key: str) -> dict[str, Any]:
+    raw_day = raw_day if isinstance(raw_day, dict) else {}
+
+    choices: list[dict[str, Any]] = []
+    raw_choices = raw_day.get("choices")
+    if isinstance(raw_choices, list):
+        for raw_choice in raw_choices:
+            normalized = _normalize_choice(raw_choice)
+            if normalized is not None:
+                choices.append(normalized)
+    if len(choices) > MAX_CHOICES_PER_DAY:
+        choices = choices[-MAX_CHOICES_PER_DAY:]
+
+    return {
+        "day": _clean_str(raw_day.get("day") or day_key, limit=_DAY_LIMIT) or day_key,
+        "session_id": _clean_str(raw_day.get("session_id"), limit=_SESSION_LIMIT),
+        "source": _clean_str(raw_day.get("source"), limit=_SOURCE_LIMIT),
+        "completed": bool(raw_day.get("completed")),
+        "first_recorded_at": _clamp_int(raw_day.get("first_recorded_at")),
+        "updated_at": _clamp_int(raw_day.get("updated_at")),
+        "choices": choices,
+    }
+
+
+def _normalize_character(raw_character: Any) -> dict[str, Any]:
+    raw_character = raw_character if isinstance(raw_character, dict) else {}
+    raw_days = raw_character.get("days")
+    raw_days = raw_days if isinstance(raw_days, dict) else {}
+
+    days: dict[str, Any] = {}
+    for raw_key, raw_day in raw_days.items():
+        day_key = _clean_str(raw_key, limit=_DAY_LIMIT)
+        if not day_key:
+            continue
+        days[day_key] = _normalize_day(raw_day, day_key)
+        if len(days) >= MAX_DAYS_PER_CHARACTER:
+            break
+
+    return {"days": days}
+
+
+def _normalize_state(raw_state: Any) -> dict[str, Any]:
+    if not isinstance(raw_state, dict):
+        return deepcopy(DEFAULT_TUTORIAL_CHOICES_STATE)
+
+    raw_characters = raw_state.get("characters")
+    raw_characters = raw_characters if isinstance(raw_characters, dict) else {}
+
+    characters: dict[str, Any] = {}
+    for raw_name, raw_character in raw_characters.items():
+        name = _clean_str(raw_name, limit=_NAME_LIMIT)
+        if not name:
+            continue
+        characters[name] = _normalize_character(raw_character)
+        if len(characters) >= MAX_CHARACTERS:
+            break
+
+    return {
+        "version": TUTORIAL_CHOICES_SCHEMA_VERSION,
+        "kind": TUTORIAL_CHOICES_STATE_KIND,
+        "characters": characters,
+    }
+
+
+def load_tutorial_choices_state(config_manager=None) -> dict[str, Any]:
+    path = get_tutorial_choices_state_path(config_manager)
+    data = _load_state_file(path)
+    if data is None:
+        return deepcopy(DEFAULT_TUTORIAL_CHOICES_STATE)
+    return _normalize_state(data)
+
+
+def save_tutorial_choices_state(state: dict[str, Any], config_manager=None) -> dict[str, Any]:
+    normalized = _normalize_state(state)
+    path = get_tutorial_choices_state_path(config_manager)
+    atomic_write_json(path, normalized, ensure_ascii=False, indent=2)
+    return normalized
+
+
+def _is_duplicate_choice(existing: list[dict[str, Any]], candidate: dict[str, Any], session_id: str) -> bool:
+    # 一棵分支树在同一 session 里不会重复经过同一节点，但网络重试 / 重复事件可能把
+    # 同一次点击重发。按 (session_id, node_id, choice, handoff) 去重，挡掉精确重放，
+    # 同时仍允许重定向后在同一节点改投另一个选项。
+    if not session_id:
+        return False
+    for item in existing:
+        if (
+            item.get("node_id") == candidate["node_id"]
+            and item.get("choice") == candidate["choice"]
+            and bool(item.get("handoff")) == candidate["handoff"]
+        ):
+            return True
+    return False
+
+
+def record_tutorial_choice(
+    payload: dict[str, Any] | None,
+    *,
+    config_manager=None,
+    now_ms: int | None = None,
+) -> dict[str, Any]:
+    payload = payload or {}
+    now_ms = _clamp_int(now_ms if now_ms is not None else _now_ms())
+
+    lanlan_name = _clean_str(payload.get("lanlan_name"), limit=_NAME_LIMIT)
+    day_key = _clean_str(payload.get("day"), limit=_DAY_LIMIT)
+    candidate = _normalize_choice({
+        "node_id": payload.get("node_id"),
+        "choice": payload.get("choice"),
+        "label": payload.get("label"),
+        "handoff": payload.get("handoff"),
+        "at": now_ms,
+    })
+
+    if not lanlan_name:
+        return {"ok": False, "reason": "missing_lanlan_name"}
+    if not day_key:
+        return {"ok": False, "reason": "missing_day"}
+    if candidate is None:
+        return {"ok": False, "reason": "invalid_choice"}
+
+    session_id = _clean_str(payload.get("session_id"), limit=_SESSION_LIMIT)
+    source = _clean_str(payload.get("source"), limit=_SOURCE_LIMIT)
+    completed = bool(payload.get("completed"))
+
+    with _STATE_LOCK:
+        state = load_tutorial_choices_state(config_manager)
+        characters = state["characters"]
+        character = characters.setdefault(lanlan_name, {"days": {}})
+        days = character.setdefault("days", {})
+        day = days.get(day_key)
+        if not isinstance(day, dict):
+            day = _normalize_day({"day": day_key}, day_key)
+            days[day_key] = day
+
+        deduped = _is_duplicate_choice(day["choices"], candidate, session_id)
+        if not deduped:
+            day["choices"].append(candidate)
+            if len(day["choices"]) > MAX_CHOICES_PER_DAY:
+                day["choices"] = day["choices"][-MAX_CHOICES_PER_DAY:]
+
+        if session_id:
+            day["session_id"] = session_id
+        if source:
+            day["source"] = source
+        if completed:
+            day["completed"] = True
+        if not day.get("first_recorded_at"):
+            day["first_recorded_at"] = now_ms
+        day["updated_at"] = now_ms
+
+        state = save_tutorial_choices_state(state, config_manager)
+
+    return {
+        "ok": True,
+        "deduped": deduped,
+        "lanlan_name": lanlan_name,
+        "day": day_key,
+    }
+
+
+def get_tutorial_choices_for_character(
+    lanlan_name: str,
+    *,
+    config_manager=None,
+) -> dict[str, Any]:
+    name = _clean_str(lanlan_name, limit=_NAME_LIMIT)
+    state = load_tutorial_choices_state(config_manager)
+    character = state["characters"].get(name) if name else None
+    return character if isinstance(character, dict) else {"days": {}}


### PR DESCRIPTION
## 做了什么

给新手破冰教程（new-user icebreaker）开了一个**额外的持久化选项池**，把用户在教程里点的每一个有效选项留存下来。

破冰是 7 天、每天一棵 A/B 二叉树：走到叶子是 4 次分支选择 + 叶子 handoff 1 次收尾选择 = 5 条/天。这些选择此前只有两个去向——前端 localStorage（纯进度、续播去重用）和 `/api/icebreaker/context`（临时会话上下文、`session_family` 生命周期）。**没有任何持久化的结构化选项池。** 这个 PR 补上。

## 关键取舍

- **现阶段刻意"无用"**：选项写进池子后**不进记忆系统、不影响模型**。这不是 bug，是 by-design——先把信号采下来留存，未来再逐步实现消费侧，避免事后回头补存储层。
- **与 `/context` 严格分离**：池子是独立信号，不复用喂会话历史的那条管线。
- **按 `lanlan_name` 归档**：破冰本身按角色走，选项归属到当时引导的角色，避免多角色串味。
- **记完整序列**：每步记 `day / node_id / choice / label / handoff / 时间戳`。跑满 7 天文件约 ~10KB（实测 3 条选项 989 字节），体积无虑，故不做精简。

## 改动

- `utils/tutorial_choices_state.py`（新）：`tutorial_choices.json` 存储层，原子写、归一化 schema、精确重放去重，写法对偶 `tutorial_prompt_state.py`。
- `main_routers/icebreaker_router.py`：新增 `POST /api/icebreaker/choice` 写入端点（走与其它破冰端点一致的本地 mutation CSRF 校验，IO 丢到 `asyncio.to_thread`）。
- `static/tutorial/icebreaker/new-user-icebreaker.js`：`recordChoiceToPool()` fire-and-forget，从 `handleChoice` 统一记录中间分支与叶子 handoff 两类选择，失败只告警不阻断教程流。

## 回归报告

**改动**：在 `main_routers/icebreaker_router.py` 新增一个独立端点 `POST /api/icebreaker/choice` 和一行 import；**不改动**既有 `/route/start`、`/route/end`、`/route/state`、`/context`、`/speak` 任何逻辑。配套新增后端存储模块和前端写入调用。

**必要性**：教程选项此前无任何持久化的结构化留存，未来要消费这些信号必须先有存储层。先采集后消费，避免事后回补存储层。

**前后行为**：
- 改动前：用户点破冰选项 → 仅写 localStorage 进度 + 临时会话上下文（`/context`）。
- 改动后：额外异步 POST 一份到独立选项池落盘；教程流程、台词、TTS、续播逻辑全部不变。

**潜在回归**：
- 新端点与既有端点完全隔离，复用同一套 `_validate_icebreaker_local_mutation` 本地 mutation CSRF 校验；导入与路由注册已实测通过。
- 前端写入 fire-and-forget、try/catch 包裹，失败只 `console.warn`，不阻断 `handleChoice` 后续的 `appendChatMessage`/`deliverNode`。
- 文件 IO 丢进 `asyncio.to_thread`，不阻塞事件循环。
- 最坏情况：池子写入异常 → 该条选项未落盘，对用户零感知、对教程零影响。

## 不拆分理由

不适用（仅 3 个文件、未超阈值）。

## 验证

- 后端：独立单测覆盖默认态、写入、精确重放去重、缺字段拒绝、读回一致、helper 读取；文件大小符合估算（3 条选项 989 字节）。
- 路由：模块导入成功，`/api/icebreaker/choice` 正常注册。
- 前端：`node --check` 语法通过，写入模式照搬现有 `postIcebreakerRoute`/`appendLlmContext`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 破冰教程的“有效选项”现在会跨会话持久化保存，并可按角色查看历史选择。
* **Bug 修复**
  * 写入前增加请求与会话有效性校验；旧会话会返回结构化拒绝结果。
  * 收尾前会等待选项落盘完成，避免“迟到”写入丢失；同时支持去重与原子保存。
  * 固定角色快照，防止中途角色变化导致记录到错误角色。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->