### PR TITLE
fix(tutorial): 重走教程某天时覆盖选项池里的上一轮

### DIFF
--- a/utils/tutorial_choices_state.py
+++ b/utils/tutorial_choices_state.py
@@ -257,6 +257,15 @@ def record_tutorial_choice(
             day = _normalize_day({"day": day_key}, day_key)
             days[day_key] = day
 
+        # 重置教程后用新 session 重走这一天：新一轮覆盖旧一轮——清掉上一轮该天的选择、完成
+        # 标记和起始时间，只保留最新一次走法。仅当该天已记过、且来的是另一个非空 session 时
+        # 触发（同一 session 的后续选择 prior_session==session_id，不会误清）。
+        prior_session = _clean_str(day.get("session_id"), limit=_SESSION_LIMIT)
+        if session_id and prior_session and prior_session != session_id:
+            day["choices"] = []
+            day["completed"] = False
+            day["first_recorded_at"] = 0
+
         deduped = _is_duplicate_choice(day["choices"], candidate, session_id)
         if not deduped:
             day["choices"].append(candidate)


### PR DESCRIPTION
## 背景

#1998 给破冰教程加了选项持久化池。合并后发现一个语义问题：**用户重置教程后重走某一天，新一轮不会覆盖旧一轮，而是累加**。

实测（重置后用新 session 重走 day1）：
- 该天 `choices` 变成「旧 session 的 N 条 + 新 session 的 M 条」混在一起；
- 该天 `completed` 还**残留旧轮的 True**，哪怕新一轮其实没走完。

于是池子会累积每一次重置的尝试，且把进行中的重走误标成已完成。

## 改动

`record_tutorial_choice` 写入时，若该天已记过、且来的是**另一个非空 session**（重置后的新一轮），先清掉这天上一轮的 `choices` / `completed` / `first_recorded_at`，再写新的——**新一轮覆盖旧一轮，只留最新一次走法**。

- **逐天粒度**：每天在它自己那一轮重走写入时被覆盖；重置只重走 day1 则 day2–7 的旧记录保留。
- **按 session 变化触发**：同一 session 的后续选择 `prior_session==session_id`，不会误清；exact-replay 重试（同 session 同 seq/node）仍照常去重，不受影响。
- 纯后端逻辑，前端无需改：`startForDay` 每次重走都生成新 `sessionId`，自然触发覆盖。

## 验证

单测覆盖：重置后只留最新一轮 + `completed` 先重置再随 handoff 置回、同 session 重试仍去重、逐天隔离（重置 day1 不动 day2）。`docstring-cjk` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
