### PR TITLE
fix(vision): 屏幕分享核心流补 avatar 注解 + 注解文字回正中心

### DIFF
--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -635,6 +635,29 @@
     }
     mod.syncFloatingScreenButtonState = syncFloatingScreenButtonState;
 
+    // ======================== buildStreamDataMessage ========================
+    /**
+     * 构造屏幕/相机分享的 stream_data 消息，并在适用时附带 Avatar 位置元数据。
+     * 与主动搭话截图（app-proactive.js）口径保持一致：仅桌面/全屏分享叠加注解，
+     * 窗口分享 / 移动相机不含 Avatar（captureType 为 null → 不附带）。
+     */
+    function buildStreamDataMessage(dataUrl, input_type) {
+        var msg = { action: 'stream_data', data: dataUrl, input_type: input_type };
+        // 仅屏幕分享可能包含 Avatar；移动相机拍的是现实画面，无 Avatar
+        if (input_type === 'screen') {
+            var captureType = detectScreenshotCaptureType(S.screenCaptureStream, S.selectedScreenSourceId);
+            if (captureType === null && !S.screenCaptureStream && !S.selectedScreenSourceId) {
+                captureType = 'screen'; // 无流无源 → pyautogui 全屏兜底
+            }
+            var avatarPos = getAvatarScreenPosition(captureType);
+            if (avatarPos) {
+                msg.avatar_position = avatarPos;
+            }
+        }
+        return msg;
+    }
+    mod.buildStreamDataMessage = buildStreamDataMessage;
+
     // ======================== startScreenVideoStreaming ========================
     function startScreenVideoStreaming(stream, input_type) {
         // 更新最后使用时间并调度闲置检查
@@ -663,11 +686,7 @@
             S.videoSenderInterval = setInterval(function () {
                 var frame = captureCanvasFrame(video, 0.8);
                 if (frame && frame.dataUrl && S.socket && S.socket.readyState === WebSocket.OPEN) {
-                    S.socket.send(JSON.stringify({
-                        action: 'stream_data',
-                        data: frame.dataUrl,
-                        input_type: input_type,
-                    }));
+                    S.socket.send(JSON.stringify(buildStreamDataMessage(frame.dataUrl, input_type)));
 
                     // 刷新最后使用时间，防止活跃屏幕分享被误释放
                     if (stream === S.screenCaptureStream) {
@@ -919,7 +938,7 @@
 
                 // 立即发送第一帧
                 if (S.socket && S.socket.readyState === WebSocket.OPEN) {
-                    S.socket.send(JSON.stringify({ action: 'stream_data', data: backendTest, input_type: 'screen' }));
+                    S.socket.send(JSON.stringify(buildStreamDataMessage(backendTest, 'screen')));
                 }
 
                 // 复用 videoSenderInterval，stopScreening() 可统一清理
@@ -928,7 +947,7 @@
                         var r = await fetchBackendScreenshot();
                         var frame = r.dataUrl;
                         if (frame && S.socket && S.socket.readyState === WebSocket.OPEN) {
-                            S.socket.send(JSON.stringify({ action: 'stream_data', data: frame, input_type: 'screen' }));
+                            S.socket.send(JSON.stringify(buildStreamDataMessage(frame, 'screen')));
                         }
                     } catch (e) {
                         console.warn('[屏幕源] 后端轮询帧失败:', e);

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -645,10 +645,12 @@
         var msg = { action: 'stream_data', data: dataUrl, input_type: input_type };
         // 仅屏幕分享可能包含 Avatar；移动相机拍的是现实画面，无 Avatar
         if (input_type === 'screen') {
-            var captureType = detectScreenshotCaptureType(S.screenCaptureStream, S.selectedScreenSourceId);
-            if (captureType === null && !S.screenCaptureStream && !S.selectedScreenSourceId) {
-                captureType = 'screen'; // 无流无源 → pyautogui 全屏兜底
-            }
+            // 有前端流时按流/源判定；无前端流即 pyautogui 全屏兜底（后端截整屏），
+            // 此时忽略可能残留的 selectedScreenSourceId（窗口源捕获失败才会进兜底，
+            // 若仍读旧的 window:* 源会被判为 null 而漏标）
+            var captureType = S.screenCaptureStream
+                ? detectScreenshotCaptureType(S.screenCaptureStream, S.selectedScreenSourceId)
+                : 'screen';
             var avatarPos = getAvatarScreenPosition(captureType);
             if (avatarPos) {
                 msg.avatar_position = avatarPos;

--- a/utils/screenshot_utils.py
+++ b/utils/screenshot_utils.py
@@ -439,7 +439,6 @@ def overlay_avatar_annotation(
         # 计算 Avatar 中心点在图片上的像素坐标
         px = int(cx * iw)
         py = int(cy * ih)
-        model_h = int(avatar_position.get('height', 0.3) * ih)
 
         # 自适应字号：基于图片高度，但限制范围
         font_size = max(12, min(28, int(ih * 0.022)))
@@ -460,9 +459,9 @@ def overlay_avatar_annotation(
         total_tw = max(m[0] for m in line_metrics)
         total_th = sum(m[1] for m in line_metrics) + line_gap * (len(lines) - 1)
 
-        # 文字放在 Avatar 中心偏下（模型身体区域）
+        # 文字放在 Avatar 中心（不再向下偏移到身体区域，否则显得太靠下）
         text_cx = px
-        text_cy = py + int(model_h * 0.15)
+        text_cy = py
 
         # 背景矩形（半透明）
         pad_x = max(6, font_size // 2)


### PR DESCRIPTION
## 背景

发给后端 LLM 的屏幕截图上会叠一段文字注解，标定 Live2D Avatar 自己的位置。两个问题：

1. **核心流（连续屏幕分享）的截图没有 avatar 注解**，但主动搭话的截图有。
2. 注解文字偏下。

## 根因

后端 `core.py` 对 `input_type in {"screen","camera"}` 的帧，只要带了 `avatar_position` 就会调 `overlay_avatar_annotation` 叠注解。问题出在**前端附带元数据的口径不一致**：

- 主动搭话（`app-proactive.js`）：算 `captureType` → `getAvatarScreenPosition` → 把 `avatar_position` 塞进请求体 ✅
- 核心流连续帧（`app-screen.js` 的 `startScreenVideoStreaming` 定时循环 + pyautogui 兜底）：只发 `{action, data, input_type}`，**从不附带 `avatar_position`** → 后端 `av_pos` 为 None → 跳过叠加 ❌

## 改动

1. **`static/app-screen.js`**：新增 `buildStreamDataMessage(dataUrl, input_type)` 助手，按与主动搭话**完全一致**的口径算 `captureType` + `avatar_position`；连续帧循环和 pyautogui 两处兜底统一改用它。
   - 仅 `input_type === 'screen'` 才算（移动相机拍现实画面、无 Avatar）。
   - 窗口分享 / 无法确定来源时 `captureType` 为 null，`getAvatarScreenPosition` 返回 null，自然不叠（只有全屏/桌面分享才标注）。
   - Electron 全屏分享走的也是 `startScreenVideoStreaming`，同样覆盖。

2. **`utils/screenshot_utils.py`**：注解文字位置由「中心 + 向下偏移 15% 模型高」改为「直接落在 Avatar 中心」，并删掉不再使用的 `model_h`。

## 验证

需在带后端 vision 链路的环境实测：开屏幕分享后看后端收到的图，确认核心流现在也有注解、文字位置在角色中心。窗口分享应仍不叠加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 屏幕推流的消息现在会统一封装为同一口径，自动在需要时推断截图类型，并按结果补充头像位置（如适用）。
* **改进**
  * 截图中的头像标注文字位置已调整：不再依赖额外偏移计算，而是直接以头像中心位置进行放置。
* **Bug 修复**
  * 在缺少可用流或来源时，推流消息会使用更稳妥的默认值，降低发送失败与标注异常风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->