### PR TITLE
JSON 落盘崩溃安全审计：task_executor 收口 + galgame 角色档案补 fsync

### DIFF
--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -60,7 +60,7 @@ from config.prompts.prompts_agent import (
     USER_PLUGIN_COARSE_SCREEN_PROMPT,
 )
 from config.prompts.prompts_sys import _loc
-from utils.file_utils import robust_json_loads
+from utils.file_utils import atomic_write_json, robust_json_loads
 from plugin.settings import PLUGIN_EXECUTION_TIMEOUT
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
@@ -829,14 +829,9 @@ class DirectTaskExecutor:
             os.chmod(path.parent, 0o700)
         except OSError:
             pass
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
-        with tmp_path.open("w", encoding="utf-8") as handle:
-            json.dump(data, handle, ensure_ascii=False, indent=2)
-        try:
-            os.chmod(tmp_path, 0o600)
-        except OSError:
-            pass
-        tmp_path.replace(path)
+        # 走统一原子写（tmp + fsync + os.replace）：补齐此前缺的 fsync，断电不留 0
+        # 字节文件；mkstemp 的 tmp 天生 0o600，不经过 umask 决定的可读窗口。
+        atomic_write_json(path, data, ensure_ascii=False, indent=2)
         try:
             os.chmod(path, 0o600)
         except OSError:
@@ -908,14 +903,8 @@ class DirectTaskExecutor:
                 os.chmod(path.parent, 0o700)
             except OSError:
                 pass
-            tmp_path = path.with_suffix(path.suffix + ".tmp")
-            with tmp_path.open("w", encoding="utf-8") as handle:
-                json.dump(payload, handle, ensure_ascii=False, indent=2)
-            try:
-                os.chmod(tmp_path, 0o600)
-            except OSError:
-                pass
-            tmp_path.replace(path)
+            # 统一原子写：tmp + fsync + os.replace，崩溃只丢 .tmp 不破坏原文件。
+            atomic_write_json(path, payload, ensure_ascii=False, indent=2)
             try:
                 os.chmod(path, 0o600)
             except OSError:

--- a/plugin/plugins/galgame_plugin/_tutorial_migration.py
+++ b/plugin/plugins/galgame_plugin/_tutorial_migration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -23,10 +24,12 @@ def _read_flat_progress(store_path: Path) -> dict[str, Any] | None:
 def _write_flat_progress(store_path: Path, progress: dict[str, Any]) -> None:
     store_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = store_path.with_suffix(store_path.suffix + ".tmp")
-    tmp_path.write_text(
-        json.dumps(progress, ensure_ascii=False, sort_keys=True, indent=2),
-        encoding="utf-8",
-    )
+    # flush + fsync 后再 replace：断电只丢 .tmp 不破坏存档，对齐写同一个
+    # galgame_store.json 的 owner（store/core.py）的原子写法。
+    with tmp_path.open("w", encoding="utf-8") as tmp_file:
+        json.dump(progress, tmp_file, ensure_ascii=False, sort_keys=True, indent=2)
+        tmp_file.flush()
+        os.fsync(tmp_file.fileno())
     tmp_path.replace(store_path)
 
 

--- a/plugin/plugins/galgame_plugin/character_profile.py
+++ b/plugin/plugins/galgame_plugin/character_profile.py
@@ -982,6 +982,10 @@ class CharacterProfileManager:
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 json.dump(payload, fh, ensure_ascii=False, indent=2)
                 fh.write("\n")
+                # flush + fsync 后再 os.replace：断电只丢 .tmp 不破坏原档案，
+                # 对齐 memory_reader / ocr_bridge_writer / store 三处同款写法。
+                fh.flush()
+                os.fsync(fh.fileno())
             os.replace(tmp_name, target)
         except Exception:
             try:


### PR DESCRIPTION
## 背景

全仓审计「把 JSON / NDJSON 写到磁盘」的地方，确认崩溃安全等级：是否走统一工具 `utils/file_utils.atomic_write_json`（mkstemp 0o600 + flush + fsync + os.replace），或自身手搓的 tmp + fsync + os.replace。修所有真正有 fsync 缺口的运行时状态写入。

## 改动 1 — 框架：`brain/task_executor.py` 收口到统一函数

`_save_correction_memory` / `_persist_generated_short_descriptions` 各自手搓 `tmp + os.replace`，但都**漏了 flush+fsync**。改走 `atomic_write_json`：补齐 fsync（断电只丢 .tmp）、`mkstemp` 的 tmp 天生 0o600 去掉原 `open("w")` 受 umask 影响的可读窗口、删重复 tmp dance（0o700/0o600 权限加固不变）。

## 改动 2 — 小游戏(galgame)：两处存档写入补 fsync

galgame 存储层约定是各自手搓 tmp+fsync+replace（不收口 file_utils）。其中两处漏了 fsync，按同插件已正确的写法对齐补上：

- `character_profile.py::_atomic_write_json` —— 角色档案 `character_profile.json`。
- `_tutorial_migration.py::_write_flat_progress` —— 教程进度存档 `galgame_store.json`（写同一文件的 owner store/core.py 已 fsync，这里对齐）。

至此 galgame 运行时状态写入（character_profile / _tutorial_migration / memory_reader / ocr_bridge_writer / store.core）**fsync 全部完备**。

## 审计中确认安全 / 不在范围，未改动

- 安全：`memory/*`、多数 `utils/` 状态文件、main_routers（workshop_router）已用 atomic_write_json；galgame memory_reader/ocr_bridge_writer/store.core 已手搓 fsync。
- 非崩溃安全范围：pngtuber/jukebox 写临时目录后整目录原子 rename；local_server telemetry/survey 是 SQLite 列；debug/event/ocr_manager 是 append-only 日志；galgame training/ 与 screen_awareness 是离线训练产物（崩了重跑）。
- 无后端 minigame（羽毛球等）状态写盘——纯前端 canvas。
- **范围外、留给后续单独评估**（非游戏插件裸写，连 tmp+replace 都没有）：`bilibili_danmaku/__init__.py:3926`(config.json)、`mijia/*`(凭证/缓存/翻译表)、`claude_companion`(消息队列)；按惯例默认不碰插件内部。

## 测试

- `tests/test_agent_rewrite_regression.py` correction/short-desc 相关 14 项全过。
- galgame：`test_character_profile.py` + autoload 43 项、tutorial 迁移相关 13 项全过。
- （回归文件另有 10 项 yui_guide/前端断言失败，已 `git stash` 确认 base 既有、与本改动无关。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)