### PR TITLE
feat(focus): 思考气泡改由真实 reasoning 流驱动，解耦凝神

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2734,6 +2734,20 @@ class LLMSessionManager:
         idempotent via ``_push_focus_thinking``'s cached state."""
         await self._push_focus_thinking(active)
 
+    def _make_thinking_active_callback(self, session_ref):
+        """Bind ``handle_thinking_active`` to ONE specific OmniOfflineClient so a
+        reasoning pulse only drives the bubble while that client is the live
+        session. The thinking bubble is a single per-window surface; a pulse from
+        a NON-current client — a pending hot-swap session, or a just-demoted old
+        session still draining a stream after the swap — must not light or clear
+        the current window (CodeRabbit). The live session always matches, so its
+        pulses/clears pass through unchanged; everything else is a silent no-op.
+        getattr default tolerates call-time teardown where self.session is None."""
+        async def _on_thinking_active(active: bool) -> None:
+            if session_ref is getattr(self, "session", None):
+                await self.handle_thinking_active(active)
+        return _on_thinking_active
+
     async def _focus_idle_cooldown(
         self, *, replied: bool, episode_token, turn_token=None,
     ) -> None:
@@ -6179,7 +6193,8 @@ class LLMSessionManager:
                         provider_type=conversation_config.get('provider_type'),
                         vision_provider_type=vision_config.get('provider_type'),
                         on_text_delta=self.handle_text_data,
-                        on_thinking_active=self.handle_thinking_active,
+                        # on_thinking_active bound below via a session-scoped
+                        # closure so only the LIVE session drives the bubble.
                         on_input_transcript=self.handle_text_input_transcript,
                         on_output_transcript=self.handle_output_transcript,
                         on_connection_error=self.handle_connection_error,
@@ -6205,6 +6220,7 @@ class LLMSessionManager:
                         ),
                     )
                     new_session.on_proactive_done = self.handle_proactive_complete
+                    new_session.on_thinking_active = self._make_thinking_active_callback(new_session)
                 else:
                     realtime_config = self._config_manager.get_model_api_config('realtime')
                     new_session = OmniRealtimeClient(
@@ -6665,7 +6681,9 @@ class LLMSessionManager:
                     vision_base_url=vision_config['base_url'],
                     vision_api_key=vision_config['api_key'],
                     on_text_delta=self.handle_text_data,
-                    on_thinking_active=self.handle_thinking_active,
+                    # on_thinking_active bound below via a session-scoped closure:
+                    # the pending session must NOT light the current window's
+                    # bubble while it warms up / before the hot-swap promotes it.
                     on_input_transcript=self.handle_text_input_transcript,
                     on_output_transcript=self.handle_output_transcript,
                     on_connection_error=self.handle_connection_error,
@@ -6688,6 +6706,7 @@ class LLMSessionManager:
                     ),
                 )
                 self.pending_session.on_proactive_done = self.handle_proactive_complete
+                self.pending_session.on_thinking_active = self._make_thinking_active_callback(self.pending_session)
                 logger.info("🔄 热切换准备: 创建文本模式 OmniOfflineClient")
             else:
                 # 语音模式：使用 OmniRealtimeClient

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2719,6 +2719,18 @@ class LLMSessionManager:
         except Exception as e:
             logger.debug("[%s] focus_thinking ws push failed: %s", self.lanlan_name, e)
 
+    async def handle_thinking_active(self) -> None:
+        """Session callback: the model just emitted a reasoning/thinking chunk
+        (the text is filtered out upstream; only this boolean pulse reaches us).
+        Drives the chat thinking-dots bubble for ANY reasoning turn — decoupled
+        from the Focus inline decision. A Focus turn pre-pulses the bubble before
+        streaming (still works, idempotent); a non-Focus turn whose provider
+        reasons internally pulses here on its first reasoning chunk. The bubble
+        is cleared on the first visible token (send_lanlan_response) or when the
+        turn ends (the unconditional finally in the text path). Best-effort —
+        idempotent via ``_push_focus_thinking``'s cached state."""
+        await self._push_focus_thinking(True)
+
     async def _focus_idle_cooldown(
         self, *, replied: bool, episode_token, turn_token=None,
     ) -> None:
@@ -6164,6 +6176,7 @@ class LLMSessionManager:
                         provider_type=conversation_config.get('provider_type'),
                         vision_provider_type=vision_config.get('provider_type'),
                         on_text_delta=self.handle_text_data,
+                        on_thinking_active=self.handle_thinking_active,
                         on_input_transcript=self.handle_text_input_transcript,
                         on_output_transcript=self.handle_output_transcript,
                         on_connection_error=self.handle_connection_error,
@@ -6649,6 +6662,7 @@ class LLMSessionManager:
                     vision_base_url=vision_config['base_url'],
                     vision_api_key=vision_config['api_key'],
                     on_text_delta=self.handle_text_data,
+                    on_thinking_active=self.handle_thinking_active,
                     on_input_transcript=self.handle_text_input_transcript,
                     on_output_transcript=self.handle_output_transcript,
                     on_connection_error=self.handle_connection_error,
@@ -9529,16 +9543,24 @@ class LLMSessionManager:
                     if memory_text:
                         stream_text_kwargs["history_replacement_text"] = memory_text
                     if _focus_thinking:
-                        # 凝神 turn runs thinking-on: pulse the frontend so the chat
-                        # history shows a thinking-dots bubble until the first visible
-                        # token lands (cleared in send_lanlan_response) or the turn
-                        # ends (the finally below covers tool-only / empty / error turns).
+                        # 凝神 turn runs thinking-on: pre-pulse the frontend so the
+                        # bubble shows up the instant the turn starts (immediate
+                        # feedback), before any reasoning chunk arrives. Idempotent
+                        # and harmless — a non-Focus turn instead pulses lazily from
+                        # OmniOfflineClient.on_thinking_active on its first reasoning
+                        # chunk (handle_thinking_active). Either way the bubble clears
+                        # on the first visible token (send_lanlan_response) or in the
+                        # unconditional finally below.
                         await self._push_focus_thinking(True)
                     try:
                         await self.session.stream_text(data, **stream_text_kwargs)
                     finally:
-                        if _focus_thinking:
-                            await self._push_focus_thinking(False)
+                        # Clear unconditionally: a non-Focus turn may have pulsed the
+                        # bubble True via the reasoning callback, so gating the clear
+                        # on _focus_thinking would leave it stuck on tool-only / empty
+                        # / error turns. _push_focus_thinking is idempotent, so a no-op
+                        # clear when nothing pulsed costs nothing.
+                        await self._push_focus_thinking(False)
                 else:
                     logger.error(f"💥 Stream: Invalid text data type: {type(data)}")
                 return

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2719,17 +2719,20 @@ class LLMSessionManager:
         except Exception as e:
             logger.debug("[%s] focus_thinking ws push failed: %s", self.lanlan_name, e)
 
-    async def handle_thinking_active(self) -> None:
-        """Session callback: the model just emitted a reasoning/thinking chunk
+    async def handle_thinking_active(self, active: bool = True) -> None:
+        """Session callback: the model started (active=True) or finished
+        (active=False) emitting reasoning/thinking chunks for the current stream
         (the text is filtered out upstream; only this boolean pulse reaches us).
         Drives the chat thinking-dots bubble for ANY reasoning turn — decoupled
         from the Focus inline decision. A Focus turn pre-pulses the bubble before
         streaming (still works, idempotent); a non-Focus turn whose provider
         reasons internally pulses here on its first reasoning chunk. The bubble
-        is cleared on the first visible token (send_lanlan_response) or when the
-        turn ends (the unconditional finally in the text path). Best-effort —
+        is cleared on the first visible token (send_lanlan_response), when the
+        text turn ends (the unconditional finally in the text path), or — for a
+        proactive/greeting/avatar turn that reasons but commits no visible text —
+        by the active=False clear from prompt_ephemeral's finally. Best-effort —
         idempotent via ``_push_focus_thinking``'s cached state."""
-        await self._push_focus_thinking(True)
+        await self._push_focus_thinking(active)
 
     async def _focus_idle_cooldown(
         self, *, replied: bool, episode_token, turn_token=None,

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -616,8 +616,16 @@ class OmniOfflineClient:
         # forced-finalize, genai) pulse at most once per stream, and so the
         # end-of-stream clear only fires when this stream actually pulsed.
         # Re-armed at the top of BOTH stream entry points (stream_text and
-        # prompt_ephemeral).
+        # prompt_ephemeral) via _begin_reasoning_stream().
         self._reasoning_pulsed_this_stream = False
+        # Stream-ownership token: a proactive prompt_ephemeral turn can interleave
+        # with a user stream_text on this same client (core drops stale proactive
+        # chunks rather than awaiting the prompt). Each stream entry bumps the seq;
+        # a pulse stamps the pulsing seq; the prompt_ephemeral clear only fires for
+        # ITS OWN seq, so a backgrounded stream's finally can't clear the bubble a
+        # newer foreground stream just pulsed (Codex P2).
+        self._reasoning_stream_seq = 0
+        self._reasoning_pulsed_seq: Optional[int] = None
         self.on_input_transcript = on_input_transcript
         self.on_output_transcript = on_output_transcript
         self.handle_connection_error = on_connection_error
@@ -854,6 +862,7 @@ class OmniOfflineClient:
         if getattr(self, "_reasoning_pulsed_this_stream", False):
             return
         self._reasoning_pulsed_this_stream = True
+        self._reasoning_pulsed_seq = getattr(self, "_reasoning_stream_seq", 0)
         cb = getattr(self, "on_thinking_active", None)
         if cb is None:
             return
@@ -862,7 +871,16 @@ class OmniOfflineClient:
         except Exception as e:
             logger.debug("on_thinking_active(True) callback failed (ignored): %s", e)
 
-    async def _notify_reasoning_done(self) -> None:
+    def _begin_reasoning_stream(self) -> int:
+        """Open a new reasoning-pulse scope for one stream and return its ownership
+        token. Bumps the seq (so an older interleaving stream's clear can't fire
+        for this scope) and re-arms the per-stream pulse guard. Called at the top
+        of both stream entry points (stream_text and prompt_ephemeral)."""
+        self._reasoning_stream_seq = getattr(self, "_reasoning_stream_seq", 0) + 1
+        self._reasoning_pulsed_this_stream = False
+        return self._reasoning_stream_seq
+
+    async def _notify_reasoning_done(self, owner_seq: Optional[int] = None) -> None:
         """Symmetric clear for ``_notify_reasoning_active``: if THIS stream pulsed
         the thinking bubble True, push it back to False. Required for callers
         without an external unconditional clear — ``prompt_ephemeral``'s
@@ -874,9 +892,16 @@ class OmniOfflineClient:
         pre-pulse, which fires with no reasoning chunk), so this is wired into
         ``prompt_ephemeral``'s finally only.
 
-        Resets the guard so it is idempotent. Best-effort; getattr default guards
-        ``__new__`` test stubs that bypass ``__init__``."""
+        ``owner_seq`` is the token from this stream's ``_begin_reasoning_stream``:
+        the clear is suppressed when a NEWER interleaving stream has since pulsed
+        (its seq differs), so a backgrounded proactive turn can't clear the bubble
+        a foreground user turn is still reasoning under (Codex P2). Resets the
+        guard so it is idempotent. Best-effort; getattr defaults guard ``__new__``
+        test stubs that bypass ``__init__``."""
         if not getattr(self, "_reasoning_pulsed_this_stream", False):
+            return
+        if owner_seq is not None and getattr(self, "_reasoning_pulsed_seq", None) != owner_seq:
+            # A newer stream owns the current pulse — don't clear its bubble.
             return
         self._reasoning_pulsed_this_stream = False
         cb = getattr(self, "on_thinking_active", None)
@@ -1043,6 +1068,13 @@ class OmniOfflineClient:
                     streamed_text_buffer += chunk.content
                 if getattr(chunk, "reasoning_content", None):
                     streamed_reasoning_buffer += chunk.reasoning_content
+                    # Pulse the thinking bubble on ANY chunk carrying reasoning,
+                    # BEFORE the pure-reasoning skip below — a thinking provider
+                    # can pack reasoning_content onto the SAME delta as a
+                    # tool_call_delta / finish_reason (the OpenAI adapter keeps
+                    # them in one LLMStreamChunk), and a reasoning tool-call turn
+                    # has no visible token to show feedback otherwise (Codex P2).
+                    await self._notify_reasoning_active()
                 if chunk.tool_call_deltas:
                     deltas_per_chunk.append(chunk.tool_call_deltas)
                 if chunk.finish_reason:
@@ -1065,9 +1097,8 @@ class OmniOfflineClient:
                     and not chunk.finish_reason
                     and not chunk.usage_metadata
                 ):
-                    # Surface "model is thinking" (boolean only, text stays
-                    # filtered) so the bubble pulses on ANY reasoning turn.
-                    await self._notify_reasoning_active()
+                    # Pure reasoning-only chunk: already pulsed above; drop it so
+                    # the "first token" TTFT埋点 isn't fooled by a reasoning token.
                     continue
                 # 永远 yield 文本 chunk —— 即便是 tool-only turn 也可能在
                 # finish_reason=tool_calls 之前 emit usage chunk 和空 content。
@@ -1152,6 +1183,11 @@ class OmniOfflineClient:
                 pt = chunk.usage_metadata.get("prompt_tokens")
                 if pt:
                     final_prompt_tokens = pt
+            # Pulse on ANY reasoning chunk (incl. reasoning bundled with a tool
+            # delta / finish_reason on one delta), before the pure-reasoning skip
+            # below — same fix as the main loop (Codex P2).
+            if getattr(chunk, "reasoning_content", None):
+                await self._notify_reasoning_active()
             # 与常规 tool-loop 路径一致：不向下游转发 thinking 模型的纯
             # reasoning chunk（有 reasoning_content、无 content / tool delta /
             # finish / usage）。stream_text 在首个 yield 的 chunk 上记 TTFT，
@@ -1163,8 +1199,6 @@ class OmniOfflineClient:
                 and not chunk.finish_reason
                 and not chunk.usage_metadata
             ):
-                # Same boolean thinking pulse on the forced-finalize path.
-                await self._notify_reasoning_active()
                 continue
             if getattr(chunk, "content", None) and tool_leak_filter is not None:
                 chunk.content = self._filter_tool_leak_content(
@@ -1901,9 +1935,9 @@ class OmniOfflineClient:
             else:
                 return
 
-        # Fresh stream: re-arm the per-stream reasoning-pulse guard so this
-        # turn's first reasoning chunk re-pulses the thinking bubble.
-        self._reasoning_pulsed_this_stream = False
+        # Fresh stream: open a new reasoning-pulse scope (re-arm guard + bump the
+        # ownership seq) so this turn's first reasoning chunk re-pulses the bubble.
+        self._begin_reasoning_stream()
 
         # Check if we need to switch to vision model
         has_images = len(self._pending_images) > 0
@@ -3250,10 +3284,11 @@ class OmniOfflineClient:
         self._last_finish_reason = None
         self._last_block_reason = None
         self._last_prompt_tokens = None
-        # Re-arm the thinking-pulse guard like stream_text does: this turn's first
-        # reasoning chunk should re-pulse, and the finally below must only clear if
-        # THIS turn pulsed.
-        self._reasoning_pulsed_this_stream = False
+        # Open a new reasoning-pulse scope like stream_text does and capture the
+        # ownership token: the finally clear below must fire ONLY for this turn's
+        # own pulse, never for a newer user stream_text that interleaved and
+        # re-pulsed under a fresher seq (Codex P2).
+        _reasoning_owner_seq = self._begin_reasoning_stream()
 
         try:
             self._is_responding = True
@@ -3413,9 +3448,10 @@ class OmniOfflineClient:
             # Clear the thinking bubble if this proactive/greeting/avatar turn
             # pulsed it but committed no visible text — unlike stream_text, there
             # is no external unconditional clear bracketing this call (Codex P2).
-            # No-op when nothing pulsed or it was already cleared on the first
-            # visible token (idempotent).
-            await self._notify_reasoning_done()
+            # Passing the owner seq suppresses the clear when a newer user turn
+            # interleaved and re-pulsed. No-op when nothing pulsed or it was
+            # already cleared on the first visible token (idempotent).
+            await self._notify_reasoning_done(_reasoning_owner_seq)
             # Token usage 由 _AsyncStreamWrapper hook 在流结束时自动记录，
             # 此处不再手动调用 TokenTracker.record() 避免双重计数。
             committed_text = _strip_nonverbal_directives(assistant_message).strip()

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -574,7 +574,7 @@ class OmniOfflineClient:
         voice: str = "",  # Unused for text mode but kept for compatibility
         turn_detection_mode = None,  # Unused for text mode
         on_text_delta: Optional[Callable[[str, bool], Awaitable[None]]] = None,
-        on_thinking_active: Optional[Callable[[], Awaitable[None]]] = None,
+        on_thinking_active: Optional[Callable[[bool], Awaitable[None]]] = None,
         on_audio_delta: Optional[Callable[[bytes], Awaitable[None]]] = None,  # Unused
         on_interrupt: Optional[Callable[[], Awaitable[None]]] = None,  # Unused
         on_input_transcript: Optional[Callable[[str], Awaitable[None]]] = None,
@@ -605,13 +605,18 @@ class OmniOfflineClient:
         self.vision_provider_type = vision_provider_type or provider_type
         self._model_switch_lock = asyncio.Lock()
         self.on_text_delta = on_text_delta
-        # Pulsed once per stream the first time the model emits a reasoning /
-        # thinking chunk (filtered out before it reaches text/TTS — only the
-        # "is thinking" boolean is surfaced). Drives the chat thinking-dots
-        # bubble for ANY turn that actually reasons, decoupled from Focus mode.
+        # Called with True the first time a stream emits a reasoning / thinking
+        # chunk (the text itself is filtered out before it reaches text/TTS —
+        # only the "is thinking" boolean is surfaced), and with False to clear
+        # when that stream ends without an external unconditional clear (see
+        # _notify_reasoning_done). Drives the chat thinking-dots bubble for ANY
+        # turn that actually reasons, decoupled from Focus mode.
         self.on_thinking_active = on_thinking_active
         # Per-stream guard so the three reasoning-filter points (openai loop,
-        # forced-finalize, genai) notify the bubble at most once per stream_text.
+        # forced-finalize, genai) pulse at most once per stream, and so the
+        # end-of-stream clear only fires when this stream actually pulsed.
+        # Re-armed at the top of BOTH stream entry points (stream_text and
+        # prompt_ephemeral).
         self._reasoning_pulsed_this_stream = False
         self.on_input_transcript = on_input_transcript
         self.on_output_transcript = on_output_transcript
@@ -853,9 +858,34 @@ class OmniOfflineClient:
         if cb is None:
             return
         try:
-            await cb()
+            await cb(True)
         except Exception as e:
-            logger.debug("on_thinking_active callback failed (ignored): %s", e)
+            logger.debug("on_thinking_active(True) callback failed (ignored): %s", e)
+
+    async def _notify_reasoning_done(self) -> None:
+        """Symmetric clear for ``_notify_reasoning_active``: if THIS stream pulsed
+        the thinking bubble True, push it back to False. Required for callers
+        without an external unconditional clear — ``prompt_ephemeral``'s
+        proactive / greeting / avatar turns clear the bubble only when a visible
+        token reaches ``send_lanlan_response``; a turn that reasons but commits no
+        text (safety / empty / tool-only) would otherwise leave the bubble stuck
+        on until a later turn (Codex P2). ``stream_text``'s Focus path is cleared
+        by core's own unconditional finally instead (it must also clear the Focus
+        pre-pulse, which fires with no reasoning chunk), so this is wired into
+        ``prompt_ephemeral``'s finally only.
+
+        Resets the guard so it is idempotent. Best-effort; getattr default guards
+        ``__new__`` test stubs that bypass ``__init__``."""
+        if not getattr(self, "_reasoning_pulsed_this_stream", False):
+            return
+        self._reasoning_pulsed_this_stream = False
+        cb = getattr(self, "on_thinking_active", None)
+        if cb is None:
+            return
+        try:
+            await cb(False)
+        except Exception as e:
+            logger.debug("on_thinking_active(False) clear failed (ignored): %s", e)
 
     async def _astream_with_tools(self, messages, **overrides):
         """Polymorphic streaming entry point. Yields ``LLMStreamChunk``
@@ -3220,6 +3250,10 @@ class OmniOfflineClient:
         self._last_finish_reason = None
         self._last_block_reason = None
         self._last_prompt_tokens = None
+        # Re-arm the thinking-pulse guard like stream_text does: this turn's first
+        # reasoning chunk should re-pulse, and the finally below must only clear if
+        # THIS turn pulsed.
+        self._reasoning_pulsed_this_stream = False
 
         try:
             self._is_responding = True
@@ -3376,6 +3410,12 @@ class OmniOfflineClient:
             return False
         finally:
             self._is_responding = False
+            # Clear the thinking bubble if this proactive/greeting/avatar turn
+            # pulsed it but committed no visible text — unlike stream_text, there
+            # is no external unconditional clear bracketing this call (Codex P2).
+            # No-op when nothing pulsed or it was already cleared on the first
+            # visible token (idempotent).
+            await self._notify_reasoning_done()
             # Token usage 由 _AsyncStreamWrapper hook 在流结束时自动记录，
             # 此处不再手动调用 TokenTracker.record() 避免双重计数。
             committed_text = _strip_nonverbal_directives(assistant_message).strip()

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -612,20 +612,24 @@ class OmniOfflineClient:
         # _notify_reasoning_done). Drives the chat thinking-dots bubble for ANY
         # turn that actually reasons, decoupled from Focus mode.
         self.on_thinking_active = on_thinking_active
-        # Per-stream guard so the three reasoning-filter points (openai loop,
-        # forced-finalize, genai) pulse at most once per stream, and so the
-        # end-of-stream clear only fires when this stream actually pulsed.
-        # Re-armed at the top of BOTH stream entry points (stream_text and
-        # prompt_ephemeral) via _begin_reasoning_stream().
-        self._reasoning_pulsed_this_stream = False
-        # Stream-ownership token: a proactive prompt_ephemeral turn can interleave
-        # with a user stream_text on this same client (core drops stale proactive
-        # chunks rather than awaiting the prompt). Each stream entry bumps the seq;
-        # a pulse stamps the pulsing seq; the prompt_ephemeral clear only fires for
-        # ITS OWN seq, so a backgrounded stream's finally can't clear the bubble a
-        # newer foreground stream just pulsed (Codex P2).
+        # Reasoning-pulse ownership. A proactive prompt_ephemeral turn can
+        # interleave with a user stream_text on this SAME client (core drops stale
+        # proactive chunks via the expected-sid guard rather than awaiting the
+        # prompt). Ownership is tracked by a single source of truth — NOT a shared
+        # boolean, which _begin_reasoning_stream would reset out from under an
+        # older still-running stream (Codex P2):
+        #   _reasoning_stream_seq      — monotonic counter, bumped per stream entry
+        #                                (stream_text / prompt_ephemeral) so each
+        #                                stream has a distinct token.
+        #   _reasoning_active_pulse_seq — the seq that currently owns an un-cleared
+        #                                True pulse (None = bubble not lit by us).
+        #                                A pulse stamps it; a clear only fires for
+        #                                the owning seq. Because it is NOT reset on
+        #                                stream entry, a preempted proactive turn
+        #                                still clears its OWN pulse, yet cannot
+        #                                clear a newer stream that already re-pulsed.
         self._reasoning_stream_seq = 0
-        self._reasoning_pulsed_seq: Optional[int] = None
+        self._reasoning_active_pulse_seq: Optional[int] = None
         self.on_input_transcript = on_input_transcript
         self.on_output_transcript = on_output_transcript
         self.handle_connection_error = on_connection_error
@@ -849,20 +853,19 @@ class OmniOfflineClient:
             })
 
     async def _notify_reasoning_active(self) -> None:
-        """Tell the host (once per stream) that the model is emitting reasoning /
-        thinking chunks, so the chat can show a thinking-dots bubble even on a
-        non-Focus turn whose provider reasons internally. The reasoning TEXT is
-        still filtered out at the call site — only this boolean pulse escapes.
-        Idempotent on ``_reasoning_pulsed_this_stream`` so the three filter
-        points can call it blindly. Best-effort: a callback failure must never
-        disturb the stream.
+        """Tell the host that the model is emitting reasoning / thinking chunks, so
+        the chat can show a thinking-dots bubble even on a non-Focus turn whose
+        provider reasons internally. The reasoning TEXT is still filtered out at the
+        call site — only this boolean pulse escapes. Pulses once per stream: it
+        records the current stream's seq as the pulse owner and no-ops while that
+        same seq still owns the pulse, so the three filter points can call it
+        blindly. Best-effort: a callback failure must never disturb the stream.
 
-        getattr default guards ``__new__`` test stubs that bypass ``__init__``
-        (and never set the per-stream guard / callback attributes)."""
-        if getattr(self, "_reasoning_pulsed_this_stream", False):
-            return
-        self._reasoning_pulsed_this_stream = True
-        self._reasoning_pulsed_seq = getattr(self, "_reasoning_stream_seq", 0)
+        getattr defaults guard ``__new__`` test stubs that bypass ``__init__``."""
+        cur = getattr(self, "_reasoning_stream_seq", 0)
+        if getattr(self, "_reasoning_active_pulse_seq", None) == cur:
+            return  # already pulsed for THIS stream
+        self._reasoning_active_pulse_seq = cur
         cb = getattr(self, "on_thinking_active", None)
         if cb is None:
             return
@@ -873,37 +876,40 @@ class OmniOfflineClient:
 
     def _begin_reasoning_stream(self) -> int:
         """Open a new reasoning-pulse scope for one stream and return its ownership
-        token. Bumps the seq (so an older interleaving stream's clear can't fire
-        for this scope) and re-arms the per-stream pulse guard. Called at the top
-        of both stream entry points (stream_text and prompt_ephemeral)."""
+        token. Bumps the seq so this stream's first reasoning chunk re-pulses and
+        so an older interleaving stream's clear can't fire for this scope. Crucially
+        does NOT touch ``_reasoning_active_pulse_seq`` — that single source of truth
+        stays owned by whoever last lit the bubble, so a preempted older stream can
+        still clear its own pulse (Codex P2). Called at the top of both stream entry
+        points (stream_text and prompt_ephemeral)."""
         self._reasoning_stream_seq = getattr(self, "_reasoning_stream_seq", 0) + 1
-        self._reasoning_pulsed_this_stream = False
         return self._reasoning_stream_seq
 
     async def _notify_reasoning_done(self, owner_seq: Optional[int] = None) -> None:
-        """Symmetric clear for ``_notify_reasoning_active``: if THIS stream pulsed
-        the thinking bubble True, push it back to False. Required for callers
-        without an external unconditional clear — ``prompt_ephemeral``'s
-        proactive / greeting / avatar turns clear the bubble only when a visible
-        token reaches ``send_lanlan_response``; a turn that reasons but commits no
-        text (safety / empty / tool-only) would otherwise leave the bubble stuck
-        on until a later turn (Codex P2). ``stream_text``'s Focus path is cleared
-        by core's own unconditional finally instead (it must also clear the Focus
-        pre-pulse, which fires with no reasoning chunk), so this is wired into
-        ``prompt_ephemeral``'s finally only.
+        """Symmetric clear for ``_notify_reasoning_active``: push the bubble back to
+        False when THIS stream still owns the active pulse. Required for callers
+        without an external unconditional clear — ``prompt_ephemeral``'s proactive /
+        greeting / avatar turns clear the bubble only when a visible token reaches
+        ``send_lanlan_response``; a turn that reasons but commits no text (safety /
+        empty / tool-only) would otherwise leave the bubble stuck on (Codex P2).
+        ``stream_text``'s Focus path is cleared by core's own unconditional finally
+        instead (it must also clear the Focus pre-pulse, which fires with no
+        reasoning chunk), so this is wired into ``prompt_ephemeral``'s finally only.
 
-        ``owner_seq`` is the token from this stream's ``_begin_reasoning_stream``:
-        the clear is suppressed when a NEWER interleaving stream has since pulsed
-        (its seq differs), so a backgrounded proactive turn can't clear the bubble
-        a foreground user turn is still reasoning under (Codex P2). Resets the
-        guard so it is idempotent. Best-effort; getattr defaults guard ``__new__``
-        test stubs that bypass ``__init__``."""
-        if not getattr(self, "_reasoning_pulsed_this_stream", False):
+        ``owner_seq`` is the token from this stream's ``_begin_reasoning_stream``.
+        The clear fires only when ``_reasoning_active_pulse_seq`` still equals it:
+          - a NEWER stream that already re-pulsed took ownership (seq differs) → we
+            must NOT clear the bubble it is reasoning under;
+          - but if the newer stream merely STARTED (bumped seq) without pulsing yet,
+            ownership is still ours, so we correctly clear our own pulse rather than
+            leaking it (the bug a shared per-stream boolean would have caused).
+        Idempotent; getattr defaults guard ``__new__`` test stubs."""
+        active = getattr(self, "_reasoning_active_pulse_seq", None)
+        if active is None:
             return
-        if owner_seq is not None and getattr(self, "_reasoning_pulsed_seq", None) != owner_seq:
-            # A newer stream owns the current pulse — don't clear its bubble.
+        if owner_seq is not None and active != owner_seq:
             return
-        self._reasoning_pulsed_this_stream = False
+        self._reasoning_active_pulse_seq = None
         cb = getattr(self, "on_thinking_active", None)
         if cb is None:
             return
@@ -1935,8 +1941,10 @@ class OmniOfflineClient:
             else:
                 return
 
-        # Fresh stream: open a new reasoning-pulse scope (re-arm guard + bump the
-        # ownership seq) so this turn's first reasoning chunk re-pulses the bubble.
+        # Fresh stream: open a new reasoning-pulse scope (bump the ownership seq)
+        # so this turn's first reasoning chunk re-pulses the bubble. stream_text
+        # does not clear via _notify_reasoning_done — core's inline finally clears
+        # unconditionally — so it only needs the bump, not an owner token.
         self._begin_reasoning_stream()
 
         # Check if we need to switch to vision model

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -574,6 +574,7 @@ class OmniOfflineClient:
         voice: str = "",  # Unused for text mode but kept for compatibility
         turn_detection_mode = None,  # Unused for text mode
         on_text_delta: Optional[Callable[[str, bool], Awaitable[None]]] = None,
+        on_thinking_active: Optional[Callable[[], Awaitable[None]]] = None,
         on_audio_delta: Optional[Callable[[bytes], Awaitable[None]]] = None,  # Unused
         on_interrupt: Optional[Callable[[], Awaitable[None]]] = None,  # Unused
         on_input_transcript: Optional[Callable[[str], Awaitable[None]]] = None,
@@ -604,6 +605,14 @@ class OmniOfflineClient:
         self.vision_provider_type = vision_provider_type or provider_type
         self._model_switch_lock = asyncio.Lock()
         self.on_text_delta = on_text_delta
+        # Pulsed once per stream the first time the model emits a reasoning /
+        # thinking chunk (filtered out before it reaches text/TTS — only the
+        # "is thinking" boolean is surfaced). Drives the chat thinking-dots
+        # bubble for ANY turn that actually reasons, decoupled from Focus mode.
+        self.on_thinking_active = on_thinking_active
+        # Per-stream guard so the three reasoning-filter points (openai loop,
+        # forced-finalize, genai) notify the bubble at most once per stream_text.
+        self._reasoning_pulsed_this_stream = False
         self.on_input_transcript = on_input_transcript
         self.on_output_transcript = on_output_transcript
         self.handle_connection_error = on_connection_error
@@ -826,6 +835,28 @@ class OmniOfflineClient:
                 "content": result.output_as_json_string(),
             })
 
+    async def _notify_reasoning_active(self) -> None:
+        """Tell the host (once per stream) that the model is emitting reasoning /
+        thinking chunks, so the chat can show a thinking-dots bubble even on a
+        non-Focus turn whose provider reasons internally. The reasoning TEXT is
+        still filtered out at the call site — only this boolean pulse escapes.
+        Idempotent on ``_reasoning_pulsed_this_stream`` so the three filter
+        points can call it blindly. Best-effort: a callback failure must never
+        disturb the stream.
+
+        getattr default guards ``__new__`` test stubs that bypass ``__init__``
+        (and never set the per-stream guard / callback attributes)."""
+        if getattr(self, "_reasoning_pulsed_this_stream", False):
+            return
+        self._reasoning_pulsed_this_stream = True
+        cb = getattr(self, "on_thinking_active", None)
+        if cb is None:
+            return
+        try:
+            await cb()
+        except Exception as e:
+            logger.debug("on_thinking_active callback failed (ignored): %s", e)
+
     async def _astream_with_tools(self, messages, **overrides):
         """Polymorphic streaming entry point. Yields ``LLMStreamChunk``
         objects (text + finish_reason); tool calls are intercepted and
@@ -1004,6 +1035,9 @@ class OmniOfflineClient:
                     and not chunk.finish_reason
                     and not chunk.usage_metadata
                 ):
+                    # Surface "model is thinking" (boolean only, text stays
+                    # filtered) so the bubble pulses on ANY reasoning turn.
+                    await self._notify_reasoning_active()
                     continue
                 # 永远 yield 文本 chunk —— 即便是 tool-only turn 也可能在
                 # finish_reason=tool_calls 之前 emit usage chunk 和空 content。
@@ -1099,6 +1133,8 @@ class OmniOfflineClient:
                 and not chunk.finish_reason
                 and not chunk.usage_metadata
             ):
+                # Same boolean thinking pulse on the forced-finalize path.
+                await self._notify_reasoning_active()
                 continue
             if getattr(chunk, "content", None) and tool_leak_filter is not None:
                 chunk.content = self._filter_tool_leak_content(
@@ -1223,8 +1259,13 @@ class OmniOfflineClient:
                     cand_content = getattr(cand, "content", None)
                     parts = getattr(cand_content, "parts", None) or []
                     for part in parts:
-                        # Skip thinking parts (Gemini 2.5+ thinking models).
+                        # Skip thinking parts (Gemini 2.5+ thinking models) — but
+                        # surface the boolean "is thinking" pulse first so the
+                        # bubble shows on genai reasoning turns too (dual with the
+                        # OpenAI-compat reasoning_content path). The thought TEXT
+                        # itself is still dropped.
                         if getattr(part, "thought", False):
+                            await self._notify_reasoning_active()
                             continue
                         text = getattr(part, "text", None) or ""
                         fn_call = getattr(part, "function_call", None)
@@ -1829,6 +1870,10 @@ class OmniOfflineClient:
                 text = "请分析这些图片。"
             else:
                 return
+
+        # Fresh stream: re-arm the per-stream reasoning-pulse guard so this
+        # turn's first reasoning chunk re-pulses the thinking bubble.
+        self._reasoning_pulsed_this_stream = False
 
         # Check if we need to switch to vision model
         has_images = len(self._pending_images) > 0

--- a/tests/unit/test_focus_indicator_bridge.py
+++ b/tests/unit/test_focus_indicator_bridge.py
@@ -170,6 +170,27 @@ def test_handle_thinking_active_is_idempotent_within_turn():
     assert _pushed_thinking(stub) == [{"type": "focus_thinking", "active": True}]
 
 
+def test_thinking_callback_scoped_to_live_session():
+    # _make_thinking_active_callback binds the pulse to ONE session so a stale /
+    # pending OmniOfflineClient can't drive the current window's bubble: only the
+    # client that is self.session forwards to _push_focus_thinking (CodeRabbit).
+    stub = _stub()
+    stub.handle_thinking_active = _bind(stub, "handle_thinking_active")
+    make_cb = _bind(stub, "_make_thinking_active_callback")
+
+    live = object()
+    stale = object()
+    stub.session = live
+
+    # Callback bound to the live session forwards.
+    asyncio.run(make_cb(live)(True))
+    assert _pushed_thinking(stub) == [{"type": "focus_thinking", "active": True}]
+
+    # Callback bound to a non-current session is a silent no-op (no extra push).
+    asyncio.run(make_cb(stale)(False))
+    assert _pushed_thinking(stub) == [{"type": "focus_thinking", "active": True}]
+
+
 def test_handle_thinking_active_false_clears_bubble():
     # The same callback clears the bubble (active=False) — this is the end-of-stream
     # clear prompt_ephemeral fires when a proactive/greeting turn reasons but commits

--- a/tests/unit/test_focus_indicator_bridge.py
+++ b/tests/unit/test_focus_indicator_bridge.py
@@ -150,6 +150,26 @@ def test_thinking_message_shape_only_type_and_active():
     assert msg["active"] is True
 
 
+def test_handle_thinking_active_pulses_bubble_on():
+    # handle_thinking_active is the session callback fired when the model emits a
+    # reasoning chunk on ANY turn (Focus or not). It pulses the bubble True via the
+    # idempotent _push_focus_thinking — decoupled from the Focus inline decision.
+    stub = _stub()
+    stub.handle_thinking_active = _bind(stub, "handle_thinking_active")
+    asyncio.run(stub.handle_thinking_active())
+    assert _pushed_thinking(stub) == [{"type": "focus_thinking", "active": True}]
+
+
+def test_handle_thinking_active_is_idempotent_within_turn():
+    # Multiple reasoning chunks in one turn must not spam the bubble — the cached
+    # state in _push_focus_thinking collapses repeated True pulses to one push.
+    stub = _stub()
+    handler = _bind(stub, "handle_thinking_active")
+    asyncio.run(handler())
+    asyncio.run(handler())
+    assert _pushed_thinking(stub) == [{"type": "focus_thinking", "active": True}]
+
+
 def test_thinking_force_re_pushes_for_new_window():
     # resync_focus_for_new_window replays the thinking pulse with force=True so a
     # window opened mid-thinking lands on the current bubble — the idempotent

--- a/tests/unit/test_focus_indicator_bridge.py
+++ b/tests/unit/test_focus_indicator_bridge.py
@@ -170,6 +170,20 @@ def test_handle_thinking_active_is_idempotent_within_turn():
     assert _pushed_thinking(stub) == [{"type": "focus_thinking", "active": True}]
 
 
+def test_handle_thinking_active_false_clears_bubble():
+    # The same callback clears the bubble (active=False) — this is the end-of-stream
+    # clear prompt_ephemeral fires when a proactive/greeting turn reasons but commits
+    # no visible text, so the bubble can't get stuck on (Codex P2).
+    stub = _stub()
+    handler = _bind(stub, "handle_thinking_active")
+    asyncio.run(handler(True))
+    asyncio.run(handler(False))
+    assert _pushed_thinking(stub) == [
+        {"type": "focus_thinking", "active": True},
+        {"type": "focus_thinking", "active": False},
+    ]
+
+
 def test_thinking_force_re_pushes_for_new_window():
     # resync_focus_for_new_window replays the thinking pulse with force=True so a
     # window opened mid-thinking lands on the current bubble — the idempotent

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -571,8 +571,8 @@ async def test_offline_openai_path_pulses_thinking_on_reasoning_chunk():
 
     pulses = []
 
-    async def on_thinking_active():
-        pulses.append(True)
+    async def on_thinking_active(active):
+        pulses.append(active)
 
     client.on_thinking_active = on_thinking_active
 
@@ -580,7 +580,7 @@ async def test_offline_openai_path_pulses_thinking_on_reasoning_chunk():
     async for ch in client._astream_with_tools([{"role": "user", "content": "hi"}]):
         out.append(ch)
 
-    assert len(pulses) == 1, "两个 reasoning chunk 只应 pulse 一次（per-stream 幂等）"
+    assert pulses == [True], "两个 reasoning chunk 只应 pulse 一次 True（per-stream 幂等）"
     # 推理文本仍被过滤，不向下游 yield。
     assert not any(
         getattr(ch, "reasoning_content", None) and not getattr(ch, "content", None)
@@ -608,8 +608,8 @@ async def test_offline_openai_path_no_thinking_pulse_without_reasoning():
 
     pulses = []
 
-    async def on_thinking_active():
-        pulses.append(True)
+    async def on_thinking_active(active):
+        pulses.append(active)
 
     client.on_thinking_active = on_thinking_active
 
@@ -617,6 +617,34 @@ async def test_offline_openai_path_no_thinking_pulse_without_reasoning():
         pass
 
     assert pulses == [], "无 reasoning chunk 时不应 pulse 思考气泡"
+
+
+@pytest.mark.asyncio
+async def test_notify_reasoning_done_clears_only_after_a_pulse():
+    """``_notify_reasoning_done`` is the symmetric clear bracketing prompt_ephemeral:
+    it pushes on_thinking_active(False) IFF this stream actually pulsed True, and is
+    idempotent (a second call is a no-op). Guards the stuck-bubble case where a
+    proactive turn reasons but commits no visible text."""
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client._reasoning_pulsed_this_stream = False
+    pulses = []
+
+    async def on_thinking_active(active):
+        pulses.append(active)
+
+    client.on_thinking_active = on_thinking_active
+
+    # Never pulsed → clear is a no-op.
+    await client._notify_reasoning_done()
+    assert pulses == []
+
+    # Pulse True, then the end-of-stream clear emits exactly one False.
+    await client._notify_reasoning_active()
+    await client._notify_reasoning_done()
+    await client._notify_reasoning_done()  # idempotent
+    assert pulses == [True, False]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -546,6 +546,80 @@ async def test_offline_openai_path_persists_reasoning_content_with_tool_call():
 
 
 @pytest.mark.asyncio
+async def test_offline_openai_path_pulses_thinking_on_reasoning_chunk():
+    """A reasoning-only chunk (thinking model) must fire ``on_thinking_active``
+    exactly ONCE per stream — even on a non-Focus turn — so the chat thinking-dots
+    bubble reflects the real reasoning stream, decoupled from the Focus decision.
+    The reasoning TEXT itself is still filtered out (not yielded downstream)."""
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    chunks = [
+        LLMStreamChunk(content="", reasoning_content="先想想……"),
+        LLMStreamChunk(content="", reasoning_content="再想想……"),
+        LLMStreamChunk(content="答案是 42。", finish_reason="stop"),
+    ]
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.llm = _FakeLLM([chunks])
+    client._tool_definitions = []
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+    client.on_tool_call = None
+    # _astream_with_tools doesn't reset the guard (stream_text does) — arm it here.
+    client._reasoning_pulsed_this_stream = False
+
+    pulses = []
+
+    async def on_thinking_active():
+        pulses.append(True)
+
+    client.on_thinking_active = on_thinking_active
+
+    out = []
+    async for ch in client._astream_with_tools([{"role": "user", "content": "hi"}]):
+        out.append(ch)
+
+    assert len(pulses) == 1, "两个 reasoning chunk 只应 pulse 一次（per-stream 幂等）"
+    # 推理文本仍被过滤，不向下游 yield。
+    assert not any(
+        getattr(ch, "reasoning_content", None) and not getattr(ch, "content", None)
+        for ch in out
+    )
+    assert any(getattr(ch, "content", None) == "答案是 42。" for ch in out)
+
+
+@pytest.mark.asyncio
+async def test_offline_openai_path_no_thinking_pulse_without_reasoning():
+    """非 thinking 端点（delta 全无 reasoning_content）不应触发 on_thinking_active，
+    免得普通轮也莫名其妙弹思考气泡。"""
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    chunks = [LLMStreamChunk(content="直接答。", finish_reason="stop")]
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.llm = _FakeLLM([chunks])
+    client._tool_definitions = []
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+    client.on_tool_call = None
+    client._reasoning_pulsed_this_stream = False
+
+    pulses = []
+
+    async def on_thinking_active():
+        pulses.append(True)
+
+    client.on_thinking_active = on_thinking_active
+
+    async for _ in client._astream_with_tools([{"role": "user", "content": "hi"}]):
+        pass
+
+    assert pulses == [], "无 reasoning chunk 时不应 pulse 思考气泡"
+
+
+@pytest.mark.asyncio
 async def test_offline_openai_path_omits_reasoning_when_absent():
     """非 thinking 端点（delta 不带 reasoning_content）时，assistant tool_calls
     消息不应凭空塞入 reasoning_content 字段，免得污染普通会话 / 触发某些 provider

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -566,8 +566,10 @@ async def test_offline_openai_path_pulses_thinking_on_reasoning_chunk():
     client._use_genai_sdk = False
     client._genai_tools_unsupported = False
     client.on_tool_call = None
-    # _astream_with_tools doesn't reset the guard (stream_text does) — arm it here.
-    client._reasoning_pulsed_this_stream = False
+    # _astream_with_tools doesn't open a stream scope (stream_text does) — seed
+    # the pulse-ownership state here so a fresh stream starts un-pulsed.
+    client._reasoning_stream_seq = 0
+    client._reasoning_active_pulse_seq = None
 
     pulses = []
 
@@ -604,7 +606,7 @@ async def test_offline_openai_path_no_thinking_pulse_without_reasoning():
     client._use_genai_sdk = False
     client._genai_tools_unsupported = False
     client.on_tool_call = None
-    client._reasoning_pulsed_this_stream = False
+    client._reasoning_active_pulse_seq = None
 
     pulses = []
 
@@ -628,7 +630,7 @@ async def test_notify_reasoning_done_clears_only_after_a_pulse():
     from main_logic.omni_offline_client import OmniOfflineClient
 
     client = OmniOfflineClient.__new__(OmniOfflineClient)
-    client._reasoning_pulsed_this_stream = False
+    client._reasoning_active_pulse_seq = None
     pulses = []
 
     async def on_thinking_active(active):
@@ -657,7 +659,7 @@ async def test_notify_reasoning_done_owner_seq_guards_cross_stream_clear():
 
     client = OmniOfflineClient.__new__(OmniOfflineClient)
     client._reasoning_stream_seq = 0
-    client._reasoning_pulsed_this_stream = False
+    client._reasoning_active_pulse_seq = None
     pulses = []
 
     async def on_thinking_active(active):
@@ -681,6 +683,35 @@ async def test_notify_reasoning_done_owner_seq_guards_cross_stream_clear():
 
 
 @pytest.mark.asyncio
+async def test_notify_reasoning_done_clears_own_pulse_after_preemption_without_new_pulse():
+    """A proactive turn that pulsed, then got preempted by a user stream that only
+    STARTED (bumped seq) without pulsing yet, must still clear ITS OWN bubble in
+    finally. The ownership seq is NOT reset by _begin_reasoning_stream, so the
+    older owner stays valid — a shared per-stream boolean would have been reset
+    here, leaking the bubble (Codex P2)."""
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client._reasoning_stream_seq = 0
+    client._reasoning_active_pulse_seq = None
+    pulses = []
+
+    async def on_thinking_active(active):
+        pulses.append(active)
+
+    client.on_thinking_active = on_thinking_active
+
+    s1 = client._begin_reasoning_stream()       # proactive scope
+    await client._notify_reasoning_active()      # proactive pulses → bubble on
+    client._begin_reasoning_stream()             # user stream starts, NO pulse yet
+    assert pulses == [True]
+
+    # Proactive finally: user hasn't pulsed, proactive still owns → clears its own.
+    await client._notify_reasoning_done(s1)
+    assert pulses == [True, False], "被抢占但新流未 pulse 时，旧流必须清掉自己的气泡"
+
+
+@pytest.mark.asyncio
 async def test_offline_openai_path_pulses_when_reasoning_bundled_with_other_signal():
     """A thinking provider can pack reasoning_content onto the SAME delta as a
     visible token / finish_reason (or a tool_call_delta). The pulse must still
@@ -700,7 +731,7 @@ async def test_offline_openai_path_pulses_when_reasoning_bundled_with_other_sign
     client._genai_tools_unsupported = False
     client.on_tool_call = None
     client._reasoning_stream_seq = 0
-    client._reasoning_pulsed_this_stream = False
+    client._reasoning_active_pulse_seq = None
 
     pulses = []
 

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -591,8 +591,8 @@ async def test_offline_openai_path_pulses_thinking_on_reasoning_chunk():
 
 @pytest.mark.asyncio
 async def test_offline_openai_path_no_thinking_pulse_without_reasoning():
-    """非 thinking 端点（delta 全无 reasoning_content）不应触发 on_thinking_active，
-    免得普通轮也莫名其妙弹思考气泡。"""
+    """A non-thinking endpoint (no reasoning_content on any delta) must NOT fire
+    on_thinking_active, so a regular turn never flashes a spurious thinking bubble."""
     from utils.llm_client import LLMStreamChunk
     from main_logic.omni_offline_client import OmniOfflineClient
 

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -648,6 +648,76 @@ async def test_notify_reasoning_done_clears_only_after_a_pulse():
 
 
 @pytest.mark.asyncio
+async def test_notify_reasoning_done_owner_seq_guards_cross_stream_clear():
+    """A backgrounded stream's clear must NOT fire once a newer stream has
+    re-pulsed under a fresher ownership seq — otherwise a preempted proactive
+    turn's finally would clear the bubble a foreground user turn is still
+    reasoning under (Codex P2)."""
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client._reasoning_stream_seq = 0
+    client._reasoning_pulsed_this_stream = False
+    pulses = []
+
+    async def on_thinking_active(active):
+        pulses.append(active)
+
+    client.on_thinking_active = on_thinking_active
+
+    s1 = client._begin_reasoning_stream()          # proactive scope
+    await client._notify_reasoning_active()        # proactive pulses
+    s2 = client._begin_reasoning_stream()          # user stream_text interleaves
+    await client._notify_reasoning_active()        # user pulses under fresher seq
+    assert pulses == [True, True]
+
+    # Proactive finally with its OWN (older) seq must be suppressed.
+    await client._notify_reasoning_done(s1)
+    assert pulses == [True, True], "旧流的 finally 不能清掉新流的气泡"
+
+    # The owning (newer) stream's clear still works.
+    await client._notify_reasoning_done(s2)
+    assert pulses == [True, True, False]
+
+
+@pytest.mark.asyncio
+async def test_offline_openai_path_pulses_when_reasoning_bundled_with_other_signal():
+    """A thinking provider can pack reasoning_content onto the SAME delta as a
+    visible token / finish_reason (or a tool_call_delta). The pulse must still
+    fire — it can't live only inside the pure-reasoning skip, or a reasoning
+    tool-call turn shows no bubble at all (Codex P2)."""
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+
+    # reasoning_content + content + finish_reason all on one chunk → fails the
+    # pure-reasoning skip (has content/finish) yet must still pulse.
+    chunks = [LLMStreamChunk(content="答案", reasoning_content="先想想", finish_reason="stop")]
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.llm = _FakeLLM([chunks])
+    client._tool_definitions = []
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+    client.on_tool_call = None
+    client._reasoning_stream_seq = 0
+    client._reasoning_pulsed_this_stream = False
+
+    pulses = []
+
+    async def on_thinking_active(active):
+        pulses.append(active)
+
+    client.on_thinking_active = on_thinking_active
+
+    out = []
+    async for ch in client._astream_with_tools([{"role": "user", "content": "hi"}]):
+        out.append(ch)
+
+    assert pulses == [True], "reasoning 与可见 token / finish 同 chunk 时仍应 pulse"
+    assert any(getattr(ch, "content", None) == "答案" for ch in out)
+
+
+@pytest.mark.asyncio
 async def test_offline_openai_path_omits_reasoning_when_absent():
     """非 thinking 端点（delta 不带 reasoning_content）时，assistant tool_calls
     消息不应凭空塞入 reasoning_content 字段，免得污染普通会话 / 触发某些 provider


### PR DESCRIPTION
## 原本啥样

聊天历史里的“思考省略号气泡”只跟凝神(Focus)绑定：

- core 在凝神 inline 判定 `_focus_thinking=True` 时，stream 前 pre-pulse `focus_thinking`，`finally` 里 `if _focus_thinking` 才清。regular 轮根本不调。
- thinking 模型吐的 `reasoning_content` chunk 在服务端 stream 里就被过滤掉、**不下发前端**（过滤点：openai 主循环、forced-finalize、genai thought part）。

结果：非凝神轮即便上游 provider 真在内部推理，前端也没有任何“正在思考”的反馈。

## 改成啥样

气泡触发源从“凝神 inline 判定”换成“实际收到 reasoning chunk”，**解耦凝神**：

- `OmniOfflineClient` 新增 `on_thinking_active` 轻量布尔回调 + per-stream 幂等 guard（`_reasoning_pulsed_this_stream`，`stream_text` 开头 re-arm）。三个 reasoning 过滤点在丢弃 reasoning 文本前调一次 `_notify_reasoning_active()`——只外泄“正在思考”布尔 pulse，**reasoning 文本仍然过滤掉**，不进 TTS/前端。
- core 新增 `handle_thinking_active`，挂到主 session 与 pending_session 两个 `OmniOfflineClient` 构造点，内部调 `_push_focus_thinking(True)`。
- **复用现有 `focus_thinking` ws 通道 + 前端气泡组件，前端零改动**（不新增 ws 消息类型、不新增前端 state）。

## 触发与清除

- 凝神轮：保留 stream 前 pre-pulse（即时反馈、幂等无害），气泡第一时间出现。
- 非凝神轮：收到首个 reasoning chunk 时 lazy pulse。
- 两条路径都靠 `_push_focus_thinking` 的幂等性安全叠加。
- **清除改为无条件**：text 路径 `finally` 不再 `if _focus_thinking` 才清。改后非凝神轮也可能 pulse 过 True，gating 会让 tool-only / 空回复 / 出错轮气泡卡住。`_push_focus_thinking` 对缓存状态幂等，没 pulse 时的 clear 是 no-op，无副作用。首个可见 token 的清除（`send_lanlan_response`）保持不变。

## 回归报告

**改动**：核心是给 `OmniOfflineClient` 增 `on_thinking_active` 回调，三个 reasoning 过滤点 pulse 一次布尔信号驱动思考气泡；core 的 text 路径 `finally` 改为无条件清除。

**必要性 / 前后行为**：见上「原本啥样 / 改成啥样」。前：仅凝神轮显示气泡，触发源是 `_focus_inline_decision`；后：任意实际产生 reasoning 的轮都显示气泡，凝神轮保留 pre-pulse 即时反馈。

**潜在回归与缓解**：

- 无条件 `finally` 清除可能影响非凝神轮气泡状态：靠 `_push_focus_thinking` 幂等性保证未 pulse 时 clear 为 no-op；新增 `test_focus_indicator_bridge` 用例覆盖幂等。
- per-stream guard `_reasoning_pulsed_this_stream` 在 `stream_text` 开头 re-arm；`__new__` stub 老测试用 `getattr` 默认值兼容，已复跑通过。
- 多 tool 轮内二次思考不会重复 pulse（once-per-stream），与凝神现状一致，非新增退化。
- 语音 realtime 路径未改动（`OmniRealtimeClient` 不经 `reasoning_content` 流式、无 thinking-on 语义）。
- 仓库内 3 个失败（`test_offline_switch_model_*`×2、`test_focus_mode::test_inline_gate_user_setting_default_on_allows`）经 main 复跑确认为**预存在失败**，与本改动 diff 零交集。

## 测试

主仓库 venv（worktree 无 .venv）跑：

- `test_tool_calling.py`：新增 `test_offline_openai_path_pulses_thinking_on_reasoning_chunk`（非凝神轮两个 reasoning chunk → pulse 恰一次、reasoning 文本仍不下发）、`test_offline_openai_path_no_thinking_pulse_without_reasoning`（无 reasoning 不 pulse）。
- `test_focus_indicator_bridge.py`：新增 `test_handle_thinking_active_pulses_bubble_on`、`test_handle_thinking_active_is_idempotent_within_turn`。
- 相关 reasoning_content 持久化老测试（`__new__` stub）通过 `getattr` 默认值兼容，仍绿。

`test_focus_indicator_bridge.py` 全绿；新增 client 测试全绿。

## 前端

零改动——复用 `focus_thinking` ws 消息类型与现有 ThinkingDots 气泡组件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 聊天中的“thinking”气泡会在模型开始思考时自动激活，并在下一段可见内容或回合结束时正常收起。
  * 同一轮对话中的多次思考脉冲会被合并，避免气泡重复闪烁。

* **Bug 修复**
  * 修复了某些流式输出或异常路径下“thinking”气泡残留不消失的问题。
  * 提升了思考状态在不同模型与流式场景中的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->