### PR TITLE
修正模型管理中 Live3D 动作/表情下拉默认项与文案，并避免下拉选项文字左侧描边被裁切

### DIFF
--- a/static/css/model_manager.css
+++ b/static/css/model_manager.css
@@ -27,6 +27,8 @@
     /* 描边颜色 */
     --button-text-stroke-width: 2px;
     /* 描边宽度（视觉上的） */
+    --dropdown-text-stroke-safe-inset: 4px;
+    /* 下拉项文字左侧描边安全区，防止阴影描边被 overflow 裁掉 */
     --dropdown-text-max-width: 200px;
     /* 下拉菜单项文字最大宽度，超出显示省略号 */
     --model-manager-control-width: 270px;
@@ -2878,9 +2880,9 @@ body.model-manager-page #pngtuber-container .pngtuber-image {
 .dropdown-item-text::before {
     content: attr(data-text);
     position: absolute;
-    left: 0;
+    left: var(--dropdown-text-stroke-safe-inset);
     top: 0;
-    width: 100%;
+    width: calc(100% - var(--dropdown-text-stroke-safe-inset));
     height: 100%;
     z-index: -1;
     color: var(--button-text-stroke-color);
@@ -2912,9 +2914,9 @@ body.model-manager-page #pngtuber-container .pngtuber-image {
 .dropdown-item-text::after {
     content: attr(data-text);
     position: absolute;
-    left: 0;
+    left: var(--dropdown-text-stroke-safe-inset);
     top: 0;
-    width: 100%;
+    width: calc(100% - var(--dropdown-text-stroke-safe-inset));
     height: 100%;
     z-index: 10;
     background: linear-gradient(to bottom, #96e8ff, #e3f4ff, #ffffff);

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2282,6 +2282,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const userModelList = document.getElementById('user-model-list');
     const playVrmAnimationBtn = document.getElementById('play-vrm-animation-btn');
     let isVrmAnimationPlaying = false; // 跟踪VRM动作播放状态
+    let lastVrmAnimationSelection = '_no_motion_';
     let isVrmExpressionPlaying = false; // 跟踪VRM表情播放状态
     let isMmdAnimationPlaying = false; // 跟踪MMD手动预览动画播放状态
     let isMmdIdlePlaying = false; // 跟踪MMD待机动画播放状态（与手动预览分离）
@@ -5341,12 +5342,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             vrmAnimations = (data.success && data.animations) ? data.animations : [];
 
             if (vrmAnimationSelect) {
-                // 始终保留"无动作"选项，让用户能清空已保存的动作配置
-                vrmAnimationSelect.innerHTML = `<option value="">${t('live2d.selectMotion', '选择动作')}</option>`;
+                const previousValue = vrmAnimationSelect.value;
+                vrmAnimationSelect.innerHTML = '';
                 const noMotionOption = document.createElement('option');
                 noMotionOption.value = '_no_motion_';
                 noMotionOption.textContent = t('live2d.noMotion', '无动作');
                 vrmAnimationSelect.appendChild(noMotionOption);
+
+                const addAnimationOption = document.createElement('option');
+                addAnimationOption.value = '';
+                addAnimationOption.textContent = t('live2d.vrmAnimation.addAnimation', '添加动作');
+                vrmAnimationSelect.appendChild(addAnimationOption);
 
                 if (vrmAnimations.length > 0) {
                     vrmAnimations.forEach(anim => {
@@ -5369,6 +5375,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                         vrmAnimationSelect.appendChild(option);
                     });
                 }
+                const hasPreviousValue = previousValue && Array.from(vrmAnimationSelect.options)
+                    .some(option => option.value === previousValue);
+                vrmAnimationSelect.value = hasPreviousValue ? previousValue : '_no_motion_';
+                lastVrmAnimationSelection = vrmAnimationSelect.value || '_no_motion_';
                 vrmAnimationSelect.disabled = false;
                 if (vrmAnimationSelectBtn) {
                     vrmAnimationSelectBtn.disabled = false;
@@ -5441,20 +5451,24 @@ document.addEventListener('DOMContentLoaded', async () => {
         vrmAnimationSelect.addEventListener('change', async (e) => {
             const selectedValue = e.target.value;
 
-            // 如果选择的是第一个选项（空值，即"增加动作"），触发文件选择器
+            // 如果选择的是"添加动作"入口，触发文件选择器
             if (selectedValue === '') {
                 const vrmAnimationFileUpload = document.getElementById('vrm-animation-file-upload');
                 if (vrmAnimationFileUpload) {
                     vrmAnimationFileUpload.click();
                 }
-                // 重置选择器到第一个选项（保持显示"选择动作"）
-                e.target.value = '';
-                updateVRMAnimationSelectButtonText(); // 更新按钮文字为"选择动作"
+                const restoreValue = Array.from(vrmAnimationSelect.options)
+                    .some(option => option.value === lastVrmAnimationSelection)
+                    ? lastVrmAnimationSelection
+                    : '_no_motion_';
+                e.target.value = restoreValue;
+                updateVRMAnimationSelectButtonText();
                 return;
             }
 
             // 无动作选项：停止当前播放的 VRM 动作
             if (selectedValue === '_no_motion_') {
+                lastVrmAnimationSelection = '_no_motion_';
                 if (vrmManager) {
                     vrmManager.stopVRMAAnimation();
                     isVrmAnimationPlaying = false;
@@ -5463,9 +5477,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
                 if (playVrmAnimationBtn) playVrmAnimationBtn.disabled = true;
                 stopIdleRotation('vrm');
+                updateVRMAnimationSelectButtonText();
                 return;
             }
 
+            lastVrmAnimationSelection = selectedValue;
             updateVRMAnimationSelectButtonText();
             const animationPath = e.target.value;
             if (animationPath && playVrmAnimationBtn) {
@@ -5528,7 +5544,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // 播放/暂停 VRM 动作（切换功能）
     if (playVrmAnimationBtn) {
         playVrmAnimationBtn.addEventListener('click', async () => {
-            if (!vrmManager || !vrmAnimationSelect || !vrmAnimationSelect.value) {
+            if (!vrmManager || !vrmAnimationSelect || !vrmAnimationSelect.value || vrmAnimationSelect.value === '_no_motion_') {
                 showStatus(t('live2d.vrmAnimation.selectAnimationFirst', '请先选择动作'), 2000);
                 return;
             }
@@ -6472,7 +6488,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const expressions = vrmManager.expression.getExpressionList();
 
-        vrmExpressionSelect.innerHTML = `<option value="">${t('live2d.selectExpression', '选择表情')}</option>`;
+        vrmExpressionSelect.innerHTML = '';
         const noExpressionOption = document.createElement('option');
         noExpressionOption.value = '_no_expression_';
         noExpressionOption.textContent = t('live2d.noExpression', '无表情');
@@ -6491,6 +6507,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             // 播放按钮保持禁用，直到用户选择一个表情
             if (triggerVrmExpressionBtn) triggerVrmExpressionBtn.disabled = true;
+            vrmExpressionSelect.value = '_no_expression_';
             updateVRMExpressionDropdown();
             updateVRMExpressionSelectButtonText();
         } else {
@@ -6543,12 +6560,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         vrmExpressionSelect.addEventListener('change', async (e) => {
             const selectedValue = e.target.value;
 
-            // 如果选择的是第一个选项（空值，即"选择表情"），显示提示（VRM表情通常是内置的）
+            // 空值仅作为无可用表情/异常状态兜底；正常列表不再提供"选择表情"选项。
             if (selectedValue === '') {
                 showStatus(t('live2d.vrmExpression.builtInOnly', 'VRM表情通常是模型内置的，无法单独上传'), 3000);
-                // 重置选择器到第一个选项（保持显示"选择表情"）
-                e.target.value = '';
-                updateVRMExpressionSelectButtonText(); // 更新按钮文字为"选择表情"
+                e.target.value = '_no_expression_';
+                updateVRMExpressionSelectButtonText();
                 // 禁用播放按钮
                 if (triggerVrmExpressionBtn) {
                     triggerVrmExpressionBtn.disabled = true;
@@ -6615,7 +6631,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (triggerVrmExpressionBtn) {
         triggerVrmExpressionBtn.addEventListener('click', () => {
             const name = vrmExpressionSelect.value;
-            if (!name) {
+            if (!name || name === '_no_expression_') {
                 showStatus(t('live2d.vrmExpression.selectFirst', '请先选择一个表情'));
                 return;
             }

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "VRM Animation Preview:",
             "selectAnimation": "Animation",
+            "addAnimation": "Add Animation",
             "noAnimations": "No animation files found",
             "loading": "Loading animation list...",
             "animationListLoaded": "Animation list loaded successfully",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "Vista previa de la animación VRM:",
             "selectAnimation": "Animación",
+            "addAnimation": "Agregar animación",
             "noAnimations": "No se encontraron archivos de animación",
             "loading": "Cargando lista de animaciones...",
             "animationListLoaded": "Lista de animaciones cargada correctamente.",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "VRMアニメーションプレビュー:",
             "selectAnimation": "アニメーション",
+            "addAnimation": "アニメーションを追加",
             "noAnimations": "アニメーションファイルなし",
             "loading": "リスト読み込み中...",
             "animationListLoaded": "リスト読み込み成功",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "VRM 애니메이션 미리보기:",
             "selectAnimation": "애니메이션",
+            "addAnimation": "애니메이션 추가",
             "noAnimations": "애니메이션 파일을 찾을 수 없습니다.",
             "loading": "애니메이션 목록 로드 중...",
             "animationListLoaded": "애니메이션 목록이 성공적으로 로드되었습니다.",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "Pré-visualização da animação VRM:",
             "selectAnimation": "Animação",
+            "addAnimation": "Adicionar animação",
             "noAnimations": "Nenhum arquivo de animação encontrado",
             "loading": "Carregando lista de animações...",
             "animationListLoaded": "Lista de animações carregada com sucesso",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "Предпросмотр анимации VRM:",
             "selectAnimation": "Анимация",
+            "addAnimation": "Добавить анимацию",
             "noAnimations": "Файлы анимации не найдены",
             "loading": "Загрузка списка анимаций...",
             "animationListLoaded": "Список анимаций загружен",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "VRM动作预览:",
             "selectAnimation": "选择动作",
+            "addAnimation": "添加动作",
             "noAnimations": "未找到动作文件",
             "loading": "正在加载动作列表...",
             "animationListLoaded": "动作列表加载成功",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1373,6 +1373,7 @@
         "vrmAnimation": {
             "title": "VRM動作預覽:",
             "selectAnimation": "選擇動作",
+            "addAnimation": "新增動作",
             "noAnimations": "未找到動作文件",
             "loading": "正在加載動作列表...",
             "animationListLoaded": "動作列表加載成功",

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -165,10 +165,10 @@
                 <div id="vrm-animation-select-wrapper" style="position: relative; display: flex; flex: 1;">
                     <button id="vrm-animation-select-btn" class="btn btn-primary" type="button" disabled data-i18n-title="live2d.vrmAnimation.selectAnimation">
                         <img src="/static/icons/motion_select_icon.png?v=1" data-i18n-alt="live2d.vrmAnimation.selectAnimation" class="vrm-animation-select-icon" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;">
-                        <span class="round-stroke-text" id="vrm-animation-select-text" data-i18n="live2d.vrmAnimation.selectAnimation" data-text="Select Animation">选择动作</span>
+                        <span class="round-stroke-text" id="vrm-animation-select-text" data-i18n="live2d.noMotion" data-text="No Motion">无动作</span>
                     </button>
                     <select id="vrm-animation-select" class="control-select" style="display: none;" disabled>
-                        <option value="" data-i18n="live2d.vrmAnimation.selectAnimation">选择动作</option>
+                        <option value="_no_motion_" data-i18n="live2d.noMotion">无动作</option>
                     </select>
                     <div id="vrm-animation-dropdown" class="vrm-animation-dropdown" style="display: none;">
                         <!-- 下拉菜单项将动态生成 -->
@@ -184,10 +184,10 @@
                 <div id="vrm-expression-select-wrapper" style="position: relative; display: flex; flex: 1;">
                     <button id="vrm-expression-select-btn" class="btn btn-primary" type="button" disabled data-i18n-title="live2d.vrmExpression.selectExpression">
                         <img src="/static/icons/expression_chosen.png?v=1" data-i18n-alt="live2d.vrmExpression.selectExpression" class="vrm-expression-select-icon" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;">
-                        <span class="round-stroke-text" id="vrm-expression-select-text" data-i18n="live2d.vrmExpression.selectExpression" data-text="Select Expression">选择表情</span>
+                        <span class="round-stroke-text" id="vrm-expression-select-text" data-i18n="live2d.noExpression" data-text="No Expression">无表情</span>
                     </button>
                     <select id="vrm-expression-select" class="control-select" style="display: none;" disabled>
-                        <option value="" data-i18n="live2d.vrmExpression.selectExpression">选择表情</option>
+                        <option value="_no_expression_" data-i18n="live2d.noExpression">无表情</option>
                     </select>
                     <div id="vrm-expression-dropdown" class="vrm-expression-dropdown" style="display: none;">
                         <!-- 下拉菜单项将动态生成 -->


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

去除模型管理中live3d的表情选项中选择表情的选项，并将动作选项默认显示无动作选项，选择动作选项改为添加动作
顺便修复下拉选项中文字左侧会被截断的问题

## 测试 / Testing

手动测试模型管理UI

## UI改动对比
之前:
<img width="133" height="430" alt="image" src="https://github.com/user-attachments/assets/36bf0e9a-a192-48b3-99b0-e0a08af997e4" />

之后:
<img width="60" height="432" alt="image" src="https://github.com/user-attachments/assets/111f7579-0b54-4bde-8e31-0dfedf6491cc" />