### PR TITLE
fix(model_manager): 恢复 VRM 单动作下拉选中态，避免无关保存静默清空已存动作

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -5375,9 +5375,24 @@ document.addEventListener('DOMContentLoaded', async () => {
                         vrmAnimationSelect.appendChild(option);
                     });
                 }
-                const hasPreviousValue = previousValue && Array.from(vrmAnimationSelect.options)
-                    .some(option => option.value === previousValue);
-                vrmAnimationSelect.value = hasPreviousValue ? previousValue : '_no_motion_';
+                // 选中态优先级：会话内已有选择（previousValue，如上传新动作后重载列表）
+                // > 角色已保存的单动作（reserved vrm.animation）> 无动作。
+                // 不恢复已保存值就会默认落在 _no_motion_，而 saveModelToCharacter 把 _no_motion_
+                // 映射成 vrm_animation:''，后端据此清空保留字段——于是任何无关保存都会静默抹掉已存动作。
+                let resolvedValue = '_no_motion_';
+                if (previousValue && Array.from(vrmAnimationSelect.options)
+                        .some(option => option.value === previousValue)) {
+                    resolvedValue = previousValue;
+                } else {
+                    // previousValue 匹配不上（典型：首次进入页面，select 尚无选中值）→ 回退到已保存动作
+                    const savedAnimation = await getSavedVrmAnimationUrl();
+                    if (savedAnimation) {
+                        const matched = Array.from(vrmAnimationSelect.options).find(option =>
+                            option.value === savedAnimation || option.getAttribute('data-path') === savedAnimation);
+                        if (matched) resolvedValue = matched.value;
+                    }
+                }
+                vrmAnimationSelect.value = resolvedValue;
                 lastVrmAnimationSelection = vrmAnimationSelect.value || '_no_motion_';
                 vrmAnimationSelect.disabled = false;
                 if (vrmAnimationSelectBtn) {
@@ -7488,6 +7503,24 @@ document.addEventListener('DOMContentLoaded', async () => {
             setSelectedIdleAnimations('vrm-idle-animation-multiselect', vrmIdleAnimation);
         } catch (error) {
             console.error('[VRM] 恢复待机动作失败:', error);
+        }
+    }
+
+    // 读取角色已保存的单个 VRM 动作（reserved vrm.animation）。
+    // 与 restoreVrmIdleAnimation 对偶：后者恢复待机动作多选，本函数为 loadVRMAnimations
+    // 提供单动作下拉的恢复值，避免首次进入页面时下拉默认落在 _no_motion_。
+    async function getSavedVrmAnimationUrl() {
+        try {
+            const lanlanName = await getLanlanName();
+            if (!lanlanName) return null;
+
+            const data = await RequestHelper.fetchJson('/api/characters');
+            const charData = data['猫娘']?.[lanlanName];
+            const saved = charData?.vrm_animation;
+            return (typeof saved === 'string' && saved) ? saved : null;
+        } catch (error) {
+            console.error('[VRM] 读取已保存动作失败:', error);
+            return null;
         }
     }
 

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -5375,16 +5375,19 @@ document.addEventListener('DOMContentLoaded', async () => {
                         vrmAnimationSelect.appendChild(option);
                     });
                 }
-                // 选中态优先级：会话内已有选择（previousValue，如上传新动作后重载列表）
+                // 选中态优先级：会话内用户主动选的真实动作（previousValue）
                 // > 角色已保存的单动作（reserved vrm.animation）> 无动作。
-                // 不恢复已保存值就会默认落在 _no_motion_，而 saveModelToCharacter 把 _no_motion_
-                // 映射成 vrm_animation:''，后端据此清空保留字段——于是任何无关保存都会静默抹掉已存动作。
+                // 关键：模板给 select 预置了 value=_no_motion_ 的初始 option（见 model_manager.html），
+                // 首次进页面 previousValue 就是这个 sentinel——必须把它排除在「会话内选择」外，
+                // 否则恢复分支永远走不到，下拉停在 _no_motion_，无关保存又把 vrm_animation 清成 ''
+                // （即本次要修的回归）。不恢复已保存值时，saveModelToCharacter 会把 _no_motion_
+                // 映射成 vrm_animation:''，后端据此清空保留字段。
                 let resolvedValue = '_no_motion_';
-                if (previousValue && Array.from(vrmAnimationSelect.options)
+                if (previousValue && previousValue !== '_no_motion_' && Array.from(vrmAnimationSelect.options)
                         .some(option => option.value === previousValue)) {
                     resolvedValue = previousValue;
                 } else {
-                    // previousValue 匹配不上（典型：首次进入页面，select 尚无选中值）→ 回退到已保存动作
+                    // previousValue 是 _no_motion_ sentinel 或空（典型：首次进入页面）→ 回退到已保存动作
                     const savedAnimation = await getSavedVrmAnimationUrl();
                     if (savedAnimation) {
                         const matched = Array.from(vrmAnimationSelect.options).find(option =>

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -5390,9 +5390,22 @@ document.addEventListener('DOMContentLoaded', async () => {
                     // previousValue 是 _no_motion_ sentinel 或空（典型：首次进入页面）→ 回退到已保存动作
                     const savedAnimation = await getSavedVrmAnimationUrl();
                     if (savedAnimation) {
-                        const matched = Array.from(vrmAnimationSelect.options).find(option =>
+                        let matched = Array.from(vrmAnimationSelect.options).find(option =>
                             option.value === savedAnimation || option.getAttribute('data-path') === savedAnimation);
-                        if (matched) resolvedValue = matched.value;
+                        if (!matched) {
+                            // saved 不在当前动作列表（文件被删，或 /api/model/vrm/animations 端点临时遗漏）。
+                            // 若就此回落 _no_motion_，下次无关保存会把 vrm_animation 清成 '' 静默丢数据，
+                            // 故注入一个选项保留选中态——下拉如实反映已存动作，保存走设值分支原样回传。
+                            let label = savedAnimation.split('/').pop() || savedAnimation;
+                            try { label = decodeURIComponent(label); } catch { /* 解码失败则保留原始串 */ }
+                            matched = document.createElement('option');
+                            matched.value = savedAnimation;
+                            matched.setAttribute('data-path', savedAnimation);
+                            matched.setAttribute('data-filename', label);
+                            matched.textContent = label;
+                            vrmAnimationSelect.appendChild(matched);
+                        }
+                        resolvedValue = matched.value;
                     }
                 }
                 vrmAnimationSelect.value = resolvedValue;

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -249,6 +249,41 @@ async def test_switching_live3d_subtypes_preserves_inactive_model_config(
 
 
 @pytest.mark.asyncio
+async def test_vrm_save_omitting_animation_preserves_saved_animation(monkeypatch):
+    # 不带 vrm_animation 字段的保存不得动到已存的单动作。
+    # 这是前端动作下拉恢复机制（restore -> 下拉显示已存动作 -> 保存回传原值）依赖的契约：
+    # 若契约破坏，无关保存会静默清空已存动作。
+    response, _body, saved = await _call_update(
+        monkeypatch,
+        {
+            'model_type': 'live3d',
+            'vrm': '/user_vrm/models/hero.vrm',
+        },
+    )
+
+    assert response.status_code == 200
+    catgirl = saved['猫娘']['测试角色']
+    assert get_reserved(catgirl, 'avatar', 'vrm', 'animation') == '/user_vrm/animation/pose.vrma'
+
+
+@pytest.mark.asyncio
+async def test_vrm_save_empty_animation_clears_saved_animation(monkeypatch):
+    # 只有显式传 vrm_animation='' 才清空，对应用户主动选择"无动作"(_no_motion_)。
+    response, _body, saved = await _call_update(
+        monkeypatch,
+        {
+            'model_type': 'live3d',
+            'vrm': '/user_vrm/models/hero.vrm',
+            'vrm_animation': '',
+        },
+    )
+
+    assert response.status_code == 200
+    catgirl = saved['猫娘']['测试角色']
+    assert get_reserved(catgirl, 'avatar', 'vrm', 'animation') is None
+
+
+@pytest.mark.asyncio
 async def test_switching_workshop_origin_character_to_local_live3d_model_updates_current_asset_source_only(monkeypatch):
     characters = _build_characters_fixture()
     catgirl = characters['猫娘']['测试角色']

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -253,7 +253,7 @@ async def test_vrm_save_omitting_animation_preserves_saved_animation(monkeypatch
     # 不带 vrm_animation 字段的保存不得动到已存的单动作。
     # 这是前端动作下拉恢复机制（restore -> 下拉显示已存动作 -> 保存回传原值）依赖的契约：
     # 若契约破坏，无关保存会静默清空已存动作。
-    response, _body, saved = await _call_update(
+    response, body, saved = await _call_update(
         monkeypatch,
         {
             'model_type': 'live3d',
@@ -262,14 +262,15 @@ async def test_vrm_save_omitting_animation_preserves_saved_animation(monkeypatch
     )
 
     assert response.status_code == 200
-    catgirl = saved['猫娘']['测试角色']
+    assert body['success'] is True
+    catgirl = _single_saved_catgirl(saved)
     assert get_reserved(catgirl, 'avatar', 'vrm', 'animation') == '/user_vrm/animation/pose.vrma'
 
 
 @pytest.mark.asyncio
 async def test_vrm_save_empty_animation_clears_saved_animation(monkeypatch):
     # 只有显式传 vrm_animation='' 才清空，对应用户主动选择"无动作"(_no_motion_)。
-    response, _body, saved = await _call_update(
+    response, body, saved = await _call_update(
         monkeypatch,
         {
             'model_type': 'live3d',
@@ -279,7 +280,8 @@ async def test_vrm_save_empty_animation_clears_saved_animation(monkeypatch):
     )
 
     assert response.status_code == 200
-    catgirl = saved['猫娘']['测试角色']
+    assert body['success'] is True
+    catgirl = _single_saved_catgirl(saved)
     assert get_reserved(catgirl, 'avatar', 'vrm', 'animation') is None
 
 


### PR DESCRIPTION
## 改动概述 / Summary

修 #2010 引入的一处静默丢数据回归（Codex P2）。

#2010 把 VRM 动作下拉的默认项从空值改成 `_no_motion_`（"无动作"）。但**单个动作字段（reserved `vrm.animation`）一直没有回填进下拉的路径**（待机动作有 `restoreVrmIdleAnimation`，单动作没有对偶）。于是首次进页面下拉永远停在 `_no_motion_`，而 `saveModelToCharacter` 把 `_no_motion_` 映射成 `vrm_animation:''`，后端据此**清空**该保留字段。结果：用户给 VRM 存过单动作后，只要在 VRM 模式下做任何无关保存（调灯光/位置等），已存动作就被静默抹掉。

#2010 之前默认是空值，`saveModelToCharacter` 会让该字段从 payload 省略，后端 `'vrm_animation' not in data` 原样保留——所以这是回归。

### 修法

- `loadVRMAnimations` 选中态决策加一级回退：`previousValue`（会话内已有选择，如上传新动作后重载列表）> 角色已保存的 `vrm.animation` > `_no_motion_`。只在 `previousValue` 匹配不上时（典型即首次进页面）才去 fetch 保存值，不给上传动作等高频路径加请求。
- 新增 `getSavedVrmAnimationUrl()`，与 `restoreVrmIdleAnimation` 对偶。
- 这样：进页面下拉正确反映已存动作（顺带补上 #2010 想做的"显示正确默认项"语义）；不碰动作时保存回传原值 → 保留；用户**主动**选 `_no_motion_` 才清空（符合本意）。

格式一致性：`/api/model/vrm/animations` 返回的 `url` 是相对路径（`/user_vrm/animation/...` 或 `/static/vrm/animation/...`），前端 `vrmToUrl` 对 `/` 开头原样返回 → `option.value` 同格式；保存进后端、`config_manager` 原样读回 `charData.vrm_animation`。两端格式一致，`option.value === savedAnimation` 必命中（另有 `data-path` 兜底）。

## 测试 / Testing

- 新增 2 个回归测试，钉死后端契约（`tests/unit/test_characters_router_model_settings.py`，全文件 19 passed）：
  - `test_vrm_save_omitting_animation_preserves_saved_animation`：缺省 `vrm_animation` 字段 → 保留已存动作。
  - `test_vrm_save_empty_animation_clears_saved_animation`：显式 `vrm_animation:''` → 清空（对应用户主动选"无动作"）。
- 前端恢复逻辑为源码层验证：fetch 复用生产已在跑的 `restoreVrmIdleAnimation` 模式、存储值与下拉 `option.value` 格式逐一核对一致、`select.value` 赋值为浏览器原生、时序确认（在选项填充完成后才设值）。**未做浏览器端到端**——需把当前 live2d 角色临时切成 VRM 并加载 WebGL 模型渲染，环境成本与不确定性偏高；如需要可补。

## 回归报告 / Regression Report

不适用（未改动 `app/` | `main_logic/` | `memory/` 下的 Python）。

## 不拆分理由

不适用（计入上限的改动文件 1 个）。
