### PR TITLE
chore(chat): lower compact wheel sfx volume

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1238,7 +1238,7 @@ function getCompactToolWheelAudioSystem(): NekoGameAudioSystemInstance | null {
       config: {
         audioMix: {
           sfx: {
-            baseVolume: 1,
+            baseVolume: 0.5,
             maxVolume: 1,
           },
         },

--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -867,7 +867,7 @@ function getCompactToolWheelAudioSystem(): NekoGameAudioSystemInstance | null {
       config: {
         audioMix: {
           sfx: {
-            baseVolume: 1,
+            baseVolume: 0.5,
             maxVolume: 1,
           },
         },


### PR DESCRIPTION
## Summary
- Lower the compact tool wheel SFX base volume from 1.0 to 0.5.
- Keep the compact App surface and FullChatSurface audio settings aligned.

## Test plan
- `npm test -- src/App.test.tsx` (203 tests passed; existing React act/jsdom media warnings remain)
- `npm run typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 降低紧凑工具轮盘的交互音效基础音量，使手势和齿轮等声音更柔和、不那么突兀。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->