### PR TITLE
修复紧凑聊天导出预览高度塌陷问题，为预览态使用独立最小高度并补充静态契约测试，避免图片/Markdown 预览被压成空白

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2593,7 +2593,7 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
     calc(var(--compact-export-surface-width) * 1.46),
     calc(var(--compact-desktop-workarea-height, 900px) * 0.78)
   );
-  max-height: min(calc(var(--compact-export-surface-width) * 1.46), calc(var(--compact-desktop-workarea-height, 900px) * 0.78));
+  max-height: var(--compact-export-preview-max-height);
 }
 
 .compact-export-history-panel {

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2555,6 +2555,12 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   --compact-export-history-system-bubble-max-ratio: 94%;
   --compact-export-preview-bubble-max-ratio: 90%;
   --compact-export-preview-system-bubble-max-ratio: 95%;
+  --compact-export-preview-min-height: 360px;
+  --compact-export-preview-max-height: 78vh;
+  --compact-export-preview-region-height: min(
+    max(var(--compact-export-history-region-height), var(--compact-export-preview-min-height)),
+    var(--compact-export-preview-max-height)
+  );
   width: var(--compact-export-history-inline-size);
   /* 与 JS getCompactHistorySlotMaxHeight 对齐：高度上限只受屏幕(78vh)约束、不再挂对话条宽度，
      否则窄宽+高屏时 JS 允许的 slot 高 > CSS anchor 高，hit region 会被裁出死区(Codex P2)。 */
@@ -2582,6 +2588,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   );
   --compact-export-history-max-inline-size: calc(
     var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)
+  );
+  --compact-export-preview-max-height: min(
+    calc(var(--compact-export-surface-width) * 1.46),
+    calc(var(--compact-desktop-workarea-height, 900px) * 0.78)
   );
   max-height: min(calc(var(--compact-export-surface-width) * 1.46), calc(var(--compact-desktop-workarea-height, 900px) * 0.78));
 }
@@ -3474,8 +3484,8 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   align-items: stretch;
   gap: 8px;
   width: 100%;
-  height: var(--compact-export-history-region-height);
-  max-height: var(--compact-export-history-region-height);
+  height: var(--compact-export-preview-region-height);
+  max-height: var(--compact-export-preview-region-height);
   border-radius: 18px;
   padding: 9px;
   overflow: hidden;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -2564,7 +2564,7 @@ body.electron-chat-window.subtitle-web-host .compact-chat-surface-shell {
   width: var(--compact-export-history-inline-size);
   /* 与 JS getCompactHistorySlotMaxHeight 对齐：高度上限只受屏幕(78vh)约束、不再挂对话条宽度，
      否则窄宽+高屏时 JS 允许的 slot 高 > CSS anchor 高，hit region 会被裁出死区(Codex P2)。 */
-  max-height: 78vh;
+  max-height: var(--compact-export-preview-max-height);
   transform: translateX(-50%);
   z-index: 100001;
   pointer-events: none;

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -629,8 +629,15 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "calc(var(--compact-export-surface-width) * var(--compact-export-history-width-ratio))" in anchor_block
     assert "width: var(--compact-export-history-inline-size);" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(100vw - var(--compact-export-history-viewport-gutter));" in anchor_block
+    assert "--compact-export-preview-min-height: 360px;" in anchor_block
+    assert "--compact-export-preview-max-height: 78vh;" in anchor_block
+    assert "--compact-export-preview-region-height: min(" in anchor_block
+    assert "max(var(--compact-export-history-region-height), var(--compact-export-preview-min-height))" in anchor_block
+    assert "var(--compact-export-preview-max-height)" in anchor_block
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block
     assert "var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)" in desktop_history_block
+    assert "--compact-export-preview-max-height: min(" in desktop_history_block
+    assert "calc(var(--compact-desktop-workarea-height, 900px) * 0.78)" in desktop_history_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-bubble-max-ratio));" in bubble_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-system-bubble-max-ratio));" in system_bubble_block
     assert "max-width: var(--compact-export-preview-bubble-max-ratio);" in preview_bubble_block
@@ -1801,6 +1808,9 @@ def test_compact_history_layout_contract_avoids_jitter_feedback():
 
     assert "height: calc(var(--compact-export-history-region-height)" in scroll_block
     assert "max-height: calc(var(--compact-export-history-region-height)" in scroll_block
+    assert "height: var(--compact-export-preview-region-height);" in preview_block
+    assert "max-height: var(--compact-export-preview-region-height);" in preview_block
+    assert "height: var(--compact-export-history-region-height);" not in preview_block
     assert "max-height: inherit;" in panel_block
 
 

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -634,6 +634,8 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "--compact-export-preview-region-height: min(" in anchor_block
     assert "max(var(--compact-export-history-region-height), var(--compact-export-preview-min-height))" in anchor_block
     assert "var(--compact-export-preview-max-height)" in anchor_block
+    assert "max-height: var(--compact-export-preview-max-height);" in anchor_block
+    assert "\n  max-height: 78vh;" not in anchor_block
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block
     assert "var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)" in desktop_history_block
     assert "--compact-export-preview-max-height: min(" in desktop_history_block

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -639,7 +639,9 @@ def test_compact_history_size_tokens_are_ratio_based_for_ui_optimization():
     assert "--compact-export-history-max-inline-size: calc(" in desktop_history_block
     assert "var(--compact-desktop-workarea-width, 1440px) - var(--compact-export-history-viewport-gutter)" in desktop_history_block
     assert "--compact-export-preview-max-height: min(" in desktop_history_block
+    assert "calc(var(--compact-export-surface-width) * 1.46)" in desktop_history_block
     assert "calc(var(--compact-desktop-workarea-height, 900px) * 0.78)" in desktop_history_block
+    assert "max-height: var(--compact-export-preview-max-height);" in desktop_history_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-bubble-max-ratio));" in bubble_block
     assert "max-width: var(--compact-history-bubble-max-ratio, var(--compact-export-history-system-bubble-max-ratio));" in system_bubble_block
     assert "max-width: var(--compact-export-preview-bubble-max-ratio);" in preview_bubble_block
@@ -1813,6 +1815,7 @@ def test_compact_history_layout_contract_avoids_jitter_feedback():
     assert "height: var(--compact-export-preview-region-height);" in preview_block
     assert "max-height: var(--compact-export-preview-region-height);" in preview_block
     assert "height: var(--compact-export-history-region-height);" not in preview_block
+    assert "max-height: var(--compact-export-history-region-height);" not in preview_block
     assert "max-height: inherit;" in panel_block
 
 


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复紧凑聊天导出预览高度塌陷问题

## 测试 / Testing

手动测试导出


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化紧凑模式下“导出预览/历史”的预览区域高度控制：新增最小/最大高度约束，并通过统一的高度计算让预览与历史不再强依赖。
  * 更新预览锚点的最大高度策略，改为使用可复用的高度变量与更明确的比例计算逻辑，提升布局稳定性。
* **测试**
  * 加强紧凑历史预览的 CSS 尺寸/高度规则校验，确保不再直接依赖固定的 `78vh` 写法，并验证预览 region 的高度一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->