### PR TITLE
feat(proactive): 主动搭话以屏幕为素材时暂存截图，用户回复前注入对话上下文

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -7053,15 +7053,18 @@ class LLMSessionManager:
         it did. Construction logic in
         ``config.prompts.prompts_proactive.build_proactive_action_note``.
 
-        vision_screenshot_b64: optional; the screen the AI just commented on when
-        this round used the screen as its material. Staged onto the session (NOT
-        committed into history as an image) only on a genuine commit, so the
-        user's NEXT text reply folds it in as leading visual context — the
-        conversation model otherwise sees only the proactive text and can't tell
-        what was on screen. Passing None clears any previously staged screenshot,
-        so a screen-unrelated proactive round never leaves a stale image behind.
-        Staging happens inside the sid-guard below, so a user takeover (sid
-        change → early return) never stages a screenshot for an undelivered turn.
+        vision_screenshot_b64: optional; the screen this proactive round obtained
+        when a vision model was available (the caller passes it whenever a
+        screenshot was captured, regardless of which channel the talk landed on).
+        Staged onto the session (NOT committed into history as an image) only on a
+        genuine commit, so the user's NEXT text reply folds it in as leading
+        visual context — the conversation model otherwise sees only the proactive
+        text and can't tell what was on screen. Passing None clears any previously
+        staged screenshot, so a new proactive round always discards the prior
+        cache (and may fill a fresh one). The session enforces a 2-min TTL on the
+        staged screenshot at injection time. Staging happens inside the sid-guard
+        below, so a user takeover (sid change → early return) never stages a
+        screenshot for an undelivered turn.
 
         Returns True when genuinely persisted, False when skipped due to a sid
         change. The caller uses this to short-circuit downstream side effects
@@ -7104,12 +7107,13 @@ class LLMSessionManager:
                     if note:
                         history_text = f"{full_text}\n{note}" if full_text else note
                 self.session._conversation_history.append(AIMessage(content=history_text))
-                # 本轮以「屏幕」为素材投递时，把那张截图暂存到 session（仅暂存，
-                # 不作为图片写进历史），下一条用户 text 回复经 stream_text 时会把
-                # 它作为前导视觉背景注入——否则对话模型只看到搭话文本，回复时
-                # 完全不知道刚才评论的屏幕长什么样。非 vision 轮传 None 会清掉旧
-                # 截图，避免与屏幕无关的搭话遗留一张陈旧图。set_* 在 sid 校验之后，
-                # 用户接管（sid 变→早 return）时绝不会为未投递的轮次暂存截图。
+                # 本轮拿到截图（有可用 vision 模型）时，把那张截图暂存到 session
+                # （仅暂存，不作为图片写进历史），下一条用户 text 回复经 stream_text
+                # 时会把它作为前导视觉背景注入——否则对话模型只看到搭话文本，回复
+                # 时完全不知道刚才评论的屏幕长什么样。新一轮主动搭话产生即覆盖/清掉
+                # 旧缓存（没拿到截图的轮次传 None 清），session 侧再用 2 分钟 TTL
+                # 兜底过期。set_* 在 sid 校验之后，用户接管（sid 变→早 return）时
+                # 绝不会为未投递的轮次暂存截图。
                 if hasattr(self.session, "set_proactive_screenshot"):
                     self.session.set_proactive_screenshot(vision_screenshot_b64)
                 # LLM 给自己的元数据备忘，不算复读对象。素材推送类 channel（推歌）

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -7031,6 +7031,7 @@ class LLMSessionManager:
         expected_speech_id: str | None = None,
         action_note: str | None = None,
         source_tag: str | None = None,
+        vision_screenshot_b64: str | None = None,
     ) -> bool:
         """Wrap-up after streaming completes: deliver the full text in one shot + record history + TTS/turn end signals.
 
@@ -7051,6 +7052,16 @@ class LLMSessionManager:
         now" the AI isn't clueless — remembering only what it said but not what
         it did. Construction logic in
         ``config.prompts.prompts_proactive.build_proactive_action_note``.
+
+        vision_screenshot_b64: optional; the screen the AI just commented on when
+        this round used the screen as its material. Staged onto the session (NOT
+        committed into history as an image) only on a genuine commit, so the
+        user's NEXT text reply folds it in as leading visual context — the
+        conversation model otherwise sees only the proactive text and can't tell
+        what was on screen. Passing None clears any previously staged screenshot,
+        so a screen-unrelated proactive round never leaves a stale image behind.
+        Staging happens inside the sid-guard below, so a user takeover (sid
+        change → early return) never stages a screenshot for an undelivered turn.
 
         Returns True when genuinely persisted, False when skipped due to a sid
         change. The caller uses this to short-circuit downstream side effects
@@ -7093,7 +7104,14 @@ class LLMSessionManager:
                     if note:
                         history_text = f"{full_text}\n{note}" if full_text else note
                 self.session._conversation_history.append(AIMessage(content=history_text))
-                # 防复读 corpus：只录"被说出口的"那段（full_text），action_note 是
+                # 本轮以「屏幕」为素材投递时，把那张截图暂存到 session（仅暂存，
+                # 不作为图片写进历史），下一条用户 text 回复经 stream_text 时会把
+                # 它作为前导视觉背景注入——否则对话模型只看到搭话文本，回复时
+                # 完全不知道刚才评论的屏幕长什么样。非 vision 轮传 None 会清掉旧
+                # 截图，避免与屏幕无关的搭话遗留一张陈旧图。set_* 在 sid 校验之后，
+                # 用户接管（sid 变→早 return）时绝不会为未投递的轮次暂存截图。
+                if hasattr(self.session, "set_proactive_screenshot"):
+                    self.session.set_proactive_screenshot(vision_screenshot_b64)
                 # LLM 给自己的元数据备忘，不算复读对象。素材推送类 channel（推歌）
                 # 的台词天生模板化，录进 corpus 会污染 FG 窗、漂移其它 channel 的
                 # 复读基线，故按 ANTI_REPEAT_EXEMPT_SOURCE_TAGS 豁免（与出口的

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3692,6 +3692,13 @@ class LLMSessionManager:
         pending_images = getattr(self.session, "_pending_images", None)
         if hasattr(pending_images, "clear"):
             pending_images.clear()
+        # 走 magic-command 等绕过 stream_text 的 text 输入时，主动搭话暂存的屏幕
+        # 截图也不再是"下一条回复的背景"——这些路径不经 stream_text 消费它，残留
+        # 会被注进后续不相关消息。一并清掉（与 _pending_images 同为"用户做了别的
+        # 动作 → 失效待发视觉上下文"的对偶 choke point，Codex P2）。
+        clear_shot = getattr(self.session, "set_proactive_screenshot", None)
+        if callable(clear_shot):
+            clear_shot(None)
 
     async def _publish_openclaw_magic_command(self, command: str) -> None:
         try:

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -240,6 +240,10 @@ _GIBBERISH_PS_RATIO_CEIL = 0.25    # > 25% punct/symbol → emoji/mark spam
 _MAX_TOKENS_SLACK = 20
 _UNLIMITED_BUDGET = 999999  # sentinel set when user picks the slider's "无限制"
 
+# 主动搭话遗留截图的存活上限：暂存后超过这个时长就视为过期、不再注入用户回复
+# （屏幕早变了，旧图反而误导模型）。在注入点惰性判定，无需后台定时器。
+_PROACTIVE_SCREENSHOT_TTL_SECONDS = 120.0
+
 
 def _budget_to_max_tokens(budget: int, summary_mode: bool = False) -> int | None:
     """Convert ``max_response_length`` budget into the LLM API's
@@ -701,8 +705,10 @@ class OmniOfflineClient:
         # 主动搭话以「屏幕」为素材投递后遗留的那张截图，待下一条用户 text 回复
         # 时作为前导视觉背景注入（让对话模型「看到」刚才搭话评论的屏幕）。刻意
         # 与 _pending_images（用户自己的下一帧）隔离：共用会偷走用户的待发帧，
-        # 见 core.py proactive media 注释（Codex P2）。单张、一次性消费。
+        # 见 core.py proactive media 注释（Codex P2）。单张、一次性消费、带 TTL
+        # （_proactive_image_staged_at = 暂存时刻的 monotonic 秒，0.0 = 无暂存）。
         self._proactive_image_to_inject = None
+        self._proactive_image_staged_at = 0.0
 
         # ── Empty-completion 诊断（finish_reason / prompt_tokens / block_reason）──
         # Gemini 在 SAFETY / RECITATION / MAX_TOKENS 等场景会返回 finish_reason
@@ -1955,7 +1961,17 @@ class OmniOfflineClient:
         # Check if we need to switch to vision model. A staged proactive-vision
         # screenshot (the screen she just commented on) counts as an image too,
         # so a text-only user reply still goes multi-modal and the model sees it.
+        # TTL: a screenshot older than the 2-min cap is dropped (the screen has
+        # moved on — a stale frame would mislead more than help).
         proactive_image = self._proactive_image_to_inject
+        if proactive_image and (
+            time.monotonic() - self._proactive_image_staged_at
+            > _PROACTIVE_SCREENSHOT_TTL_SECONDS
+        ):
+            logger.info("Proactive screenshot expired (>%.0fs), dropping", _PROACTIVE_SCREENSHOT_TTL_SECONDS)
+            self._proactive_image_to_inject = None
+            self._proactive_image_staged_at = 0.0
+            proactive_image = None
         has_images = bool(proactive_image) or len(self._pending_images) > 0
         # 就地植入 system_prefix：拼到 user content 的 text 段前缀（watermark
         # 自带，不补 separator 也能区分）。callback 文本随 HumanMessage 一起
@@ -2014,6 +2030,7 @@ class OmniOfflineClient:
             # reply, then cleared so it never re-injects into later turns.
             self._pending_images.clear()
             self._proactive_image_to_inject = None
+            self._proactive_image_staged_at = 0.0
         else:
             # Text-only message（已含 system_prefix watermark 前缀，若有）
             user_message = HumanMessage(content=_user_text_with_prefix)
@@ -3118,11 +3135,17 @@ class OmniOfflineClient:
         SEPARATE single-slot field: sharing ``_pending_images`` would steal the
         user's next frame (see core.py proactive media note / Codex P2).
 
-        Pass ``None`` (e.g. a non-vision proactive round) to clear, so the slot
-        always reflects the most recent committed proactive round's screen and a
-        stale screenshot never trails a later screen-unrelated talk.
+        Pass ``None`` (e.g. a proactive round that obtained no screenshot) to
+        clear, so the slot always reflects the most recent proactive round and a
+        stale screenshot never trails a later talk. The stage timestamp arms the
+        TTL (``_PROACTIVE_SCREENSHOT_TTL_SECONDS``) checked lazily at injection.
         """
-        self._proactive_image_to_inject = image_b64 or None
+        if image_b64:
+            self._proactive_image_to_inject = image_b64
+            self._proactive_image_staged_at = time.monotonic()
+        else:
+            self._proactive_image_to_inject = None
+            self._proactive_image_staged_at = 0.0
 
     def _evict_old_images(self, keep_turns: int = 2) -> None:
         # 只保留最近 keep_turns 个含图 HumanMessage 的图片，更早的剥掉 image_url
@@ -3585,6 +3608,7 @@ class OmniOfflineClient:
         self._conversation_history = []
         self._pending_images.clear()
         self._proactive_image_to_inject = None
+        self._proactive_image_staged_at = 0.0
         if self.llm:
             try:
                 await self.llm.aclose()

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -698,6 +698,11 @@ class OmniOfflineClient:
         self._instructions = ""
         self._stream_task = None
         self._pending_images = []  # Store pending images to send with next text
+        # 主动搭话以「屏幕」为素材投递后遗留的那张截图，待下一条用户 text 回复
+        # 时作为前导视觉背景注入（让对话模型「看到」刚才搭话评论的屏幕）。刻意
+        # 与 _pending_images（用户自己的下一帧）隔离：共用会偷走用户的待发帧，
+        # 见 core.py proactive media 注释（Codex P2）。单张、一次性消费。
+        self._proactive_image_to_inject = None
 
         # ── Empty-completion 诊断（finish_reason / prompt_tokens / block_reason）──
         # Gemini 在 SAFETY / RECITATION / MAX_TOKENS 等场景会返回 finish_reason
@@ -1947,8 +1952,11 @@ class OmniOfflineClient:
         # unconditionally — so it only needs the bump, not an owner token.
         self._begin_reasoning_stream()
 
-        # Check if we need to switch to vision model
-        has_images = len(self._pending_images) > 0
+        # Check if we need to switch to vision model. A staged proactive-vision
+        # screenshot (the screen she just commented on) counts as an image too,
+        # so a text-only user reply still goes multi-modal and the model sees it.
+        proactive_image = self._proactive_image_to_inject
+        has_images = bool(proactive_image) or len(self._pending_images) > 0
         # 就地植入 system_prefix：拼到 user content 的 text 段前缀（watermark
         # 自带，不补 separator 也能区分）。callback 文本随 HumanMessage 一起
         # 落 history，跟 voice mode user-role 注入对偶。
@@ -1969,7 +1977,17 @@ class OmniOfflineClient:
             # Multi-modal message: images + text
             content = []
 
-            # Add images first
+            # Add images first. Temporal order: the proactive screenshot (the
+            # screen she commented on, BEFORE the user spoke) leads, then the
+            # user's own pending frame(s) — so the model doesn't mistake the
+            # earlier screen for what the user just captured.
+            if proactive_image:
+                content.append({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{proactive_image}"
+                    }
+                })
             for img_b64 in self._pending_images:
                 content.append({
                     "type": "image_url",
@@ -1985,10 +2003,17 @@ class OmniOfflineClient:
             })
 
             user_message = HumanMessage(content=content)
-            logger.info(f"Sending multi-modal message with {len(self._pending_images)} images")
+            _img_count = len(self._pending_images) + (1 if proactive_image else 0)
+            logger.info(
+                f"Sending multi-modal message with {_img_count} image(s)"
+                f"{' (incl. proactive screen)' if proactive_image else ''}"
+            )
 
-            # Clear pending images after using them
+            # Clear pending images after using them (content already holds the
+            # data urls). The proactive screenshot is one-shot: consumed by this
+            # reply, then cleared so it never re-injects into later turns.
             self._pending_images.clear()
+            self._proactive_image_to_inject = None
         else:
             # Text-only message（已含 system_prefix watermark 前缀，若有）
             user_message = HumanMessage(content=_user_text_with_prefix)
@@ -3082,6 +3107,23 @@ class OmniOfflineClient:
         """Check if there are pending images waiting to be sent."""
         return len(self._pending_images) > 0
 
+    def set_proactive_screenshot(self, image_b64: str | None) -> None:
+        """Stage (or clear) the proactive-vision screenshot for the user's next reply.
+
+        When proactive chat used the screen as its material, the committed
+        AIMessage carries only text, so the conversation model can't see what
+        was on screen when the user replies. This stashes that screenshot so the
+        NEXT ``stream_text`` folds it in as leading visual context — symmetric
+        with how ``_pending_images`` carries the user's own frame, but kept in a
+        SEPARATE single-slot field: sharing ``_pending_images`` would steal the
+        user's next frame (see core.py proactive media note / Codex P2).
+
+        Pass ``None`` (e.g. a non-vision proactive round) to clear, so the slot
+        always reflects the most recent committed proactive round's screen and a
+        stale screenshot never trails a later screen-unrelated talk.
+        """
+        self._proactive_image_to_inject = image_b64 or None
+
     def _evict_old_images(self, keep_turns: int = 2) -> None:
         # 只保留最近 keep_turns 个含图 HumanMessage 的图片，更早的剥掉 image_url
         # 仅留文本。base64 图片在 vision tokenizer 下约 1.5k~3k tokens/张，
@@ -3542,6 +3584,7 @@ class OmniOfflineClient:
         self._is_responding = False
         self._conversation_history = []
         self._pending_images.clear()
+        self._proactive_image_to_inject = None
         if self.llm:
             try:
                 await self.llm.aclose()

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -707,8 +707,13 @@ class OmniOfflineClient:
         # 与 _pending_images（用户自己的下一帧）隔离：共用会偷走用户的待发帧，
         # 见 core.py proactive media 注释（Codex P2）。单张、一次性消费、带 TTL
         # （_proactive_image_staged_at = 暂存时刻的 monotonic 秒，0.0 = 无暂存）。
+        # _proactive_image_history_len = 暂存那一刻的历史长度：截图只对「紧接它的
+        # 下一条用户回复」有效，若中途又来了别的 AI 轮（greeting / agent 回调走
+        # prompt_ephemeral，不过 finish_proactive_delivery）使历史变长，这张就过时
+        # 了、注入时丢弃——把截图钉死在「最后一条 AI 轮」上（Codex P2）。
         self._proactive_image_to_inject = None
         self._proactive_image_staged_at = 0.0
+        self._proactive_image_history_len = 0
 
         # ── Empty-completion 诊断（finish_reason / prompt_tokens / block_reason）──
         # Gemini 在 SAFETY / RECITATION / MAX_TOKENS 等场景会返回 finish_reason
@@ -1961,17 +1966,30 @@ class OmniOfflineClient:
         # Check if we need to switch to vision model. A staged proactive-vision
         # screenshot (the screen she just commented on) counts as an image too,
         # so a text-only user reply still goes multi-modal and the model sees it.
-        # TTL: a screenshot older than the 2-min cap is dropped (the screen has
-        # moved on — a stale frame would mislead more than help).
+        # The staged screenshot is dropped (not injected) when either:
+        #  - TTL: older than the 2-min cap (the screen has moved on — a stale
+        #    frame would mislead more than help); or
+        #  - superseded: a later AI turn was appended after staging (e.g. a
+        #    greeting / agent callback via prompt_ephemeral), so this reply isn't
+        #    answering the screen-based talk anymore. History only grows by
+        #    appends between staging and this read (the user hasn't been appended
+        #    yet), so a length change means an intervening AI turn (Codex P2).
         proactive_image = self._proactive_image_to_inject
-        if proactive_image and (
-            time.monotonic() - self._proactive_image_staged_at
-            > _PROACTIVE_SCREENSHOT_TTL_SECONDS
-        ):
-            logger.info("Proactive screenshot expired (>%.0fs), dropping", _PROACTIVE_SCREENSHOT_TTL_SECONDS)
-            self._proactive_image_to_inject = None
-            self._proactive_image_staged_at = 0.0
-            proactive_image = None
+        if proactive_image:
+            _expired = (
+                time.monotonic() - self._proactive_image_staged_at
+                > _PROACTIVE_SCREENSHOT_TTL_SECONDS
+            )
+            _superseded = len(self._conversation_history) != self._proactive_image_history_len
+            if _expired or _superseded:
+                logger.info(
+                    "Proactive screenshot dropped (expired=%s superseded=%s)",
+                    _expired, _superseded,
+                )
+                self._proactive_image_to_inject = None
+                self._proactive_image_staged_at = 0.0
+                self._proactive_image_history_len = 0
+                proactive_image = None
         has_images = bool(proactive_image) or len(self._pending_images) > 0
         # 就地植入 system_prefix：拼到 user content 的 text 段前缀（watermark
         # 自带，不补 separator 也能区分）。callback 文本随 HumanMessage 一起
@@ -2031,6 +2049,7 @@ class OmniOfflineClient:
             self._pending_images.clear()
             self._proactive_image_to_inject = None
             self._proactive_image_staged_at = 0.0
+            self._proactive_image_history_len = 0
         else:
             # Text-only message（已含 system_prefix watermark 前缀，若有）
             user_message = HumanMessage(content=_user_text_with_prefix)
@@ -3138,14 +3157,19 @@ class OmniOfflineClient:
         Pass ``None`` (e.g. a proactive round that obtained no screenshot) to
         clear, so the slot always reflects the most recent proactive round and a
         stale screenshot never trails a later talk. The stage timestamp arms the
-        TTL (``_PROACTIVE_SCREENSHOT_TTL_SECONDS``) checked lazily at injection.
+        TTL (``_PROACTIVE_SCREENSHOT_TTL_SECONDS``) checked lazily at injection;
+        the history-length marker pins the screenshot to the AI turn it was staged
+        on, so a later proactive talk delivered through another path (greeting /
+        agent callback via ``prompt_ephemeral``) supersedes it.
         """
         if image_b64:
             self._proactive_image_to_inject = image_b64
             self._proactive_image_staged_at = time.monotonic()
+            self._proactive_image_history_len = len(self._conversation_history)
         else:
             self._proactive_image_to_inject = None
             self._proactive_image_staged_at = 0.0
+            self._proactive_image_history_len = 0
 
     def _evict_old_images(self, keep_turns: int = 2) -> None:
         # 只保留最近 keep_turns 个含图 HumanMessage 的图片，更早的剥掉 image_url
@@ -3609,6 +3633,7 @@ class OmniOfflineClient:
         self._pending_images.clear()
         self._proactive_image_to_inject = None
         self._proactive_image_staged_at = 0.0
+        self._proactive_image_history_len = 0
         if self.llm:
             try:
                 await self.llm.aclose()

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -3553,6 +3553,16 @@ class OmniOfflineClient:
             # 此处不再手动调用 TokenTracker.record() 避免双重计数。
             committed_text = _strip_nonverbal_directives(assistant_message).strip()
             content_committed = bool(committed_text)
+            # 一条可见的 ephemeral 回复（greeting / agent 回调 / 戳头像的 quip）是
+            # 用户接下来要回应的「新一条 AI 轮」，它让之前为「下一条用户回复」暂存的
+            # 屏幕截图过时——清掉它。persist_response=False 的回复（如头像 quip）不进
+            # 历史、历史长度不变，stream_text 的 history-len marker 看不到，必须在这条
+            # ephemeral 回复的 choke point 清（Codex P2）。只在真吐了可见文本时清，
+            # 半途 abort / 无文本的尝试不丢一张仍有效的暂存屏。
+            if content_committed:
+                self._proactive_image_to_inject = None
+                self._proactive_image_staged_at = 0.0
+                self._proactive_image_history_len = 0
             # Empty-completion 诊断：和 stream_text 的兜底 warning 对偶。
             # 主动搭话语义上是"静默放弃"，所以不发 status_message，但 INFO
             # 一行 finish_reason 让日志能复盘——上次出问题就是因为没法区分

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -7606,19 +7606,14 @@ async def proactive_chat(request: Request):
             language=proactive_lang,
             master_name=master_name_current,
         )
-        # 本轮是否「以屏幕为素材」投递：必须本轮真的把截图喂给了 vision 模型
-        # (phase2_use_vision) 且最终投递通道就是屏幕/纯聊（primary_channel in
-        # ('chat','vision')）。注意 vision-only 轮没有副作用通道、走 _of_none
-        # 无 tag 模式，source_tag 兜底成 CHAT → primary_channel 是 'chat' 而非
-        # 'vision'（'vision' 只在 MEME 回退那一支出现），所以不能只认 'vision'。
-        # 投递落到 music/web/meme 时屏幕只是顺带喂进去、并非话题，不暂存。
-        # 截图在 finish_proactive_delivery 内 commit 成功后才真正落到 session；
-        # 传 None 会清掉上一轮可能遗留的截图。
-        _stage_vision_screenshot = (
-            screenshot_b64_for_phase2
-            if (phase2_use_vision and primary_channel in ('chat', 'vision'))
-            else None
-        )
+        # 只要本轮后端拿到了截图、且有可用 vision 模型（phase2_use_vision 同时
+        # 蕴含 screenshot_b64_for_phase2 非空），就缓存最后这张主动搭话截图，等
+        # 用户下一条 text 回复时注入——不按最终投递通道筛（哪怕这轮文案落到了
+        # music/web，屏幕仍是这轮看过的画面，留着供用户追问）。截图在
+        # finish_proactive_delivery 内 commit 成功后才真正落 session：新一轮主动
+        # 搭话产生即覆盖/清掉旧缓存（非 vision 轮传 None 清），session 侧再用 2
+        # 分钟 TTL 兜底过期。
+        _stage_vision_screenshot = screenshot_b64_for_phase2 if phase2_use_vision else None
         try:
             await mgr.feed_tts_chunk(response_text, expected_speech_id=proactive_sid)
             committed = await mgr.finish_proactive_delivery(

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -7606,6 +7606,19 @@ async def proactive_chat(request: Request):
             language=proactive_lang,
             master_name=master_name_current,
         )
+        # 本轮是否「以屏幕为素材」投递：必须本轮真的把截图喂给了 vision 模型
+        # (phase2_use_vision) 且最终投递通道就是屏幕/纯聊（primary_channel in
+        # ('chat','vision')）。注意 vision-only 轮没有副作用通道、走 _of_none
+        # 无 tag 模式，source_tag 兜底成 CHAT → primary_channel 是 'chat' 而非
+        # 'vision'（'vision' 只在 MEME 回退那一支出现），所以不能只认 'vision'。
+        # 投递落到 music/web/meme 时屏幕只是顺带喂进去、并非话题，不暂存。
+        # 截图在 finish_proactive_delivery 内 commit 成功后才真正落到 session；
+        # 传 None 会清掉上一轮可能遗留的截图。
+        _stage_vision_screenshot = (
+            screenshot_b64_for_phase2
+            if (phase2_use_vision and primary_channel in ('chat', 'vision'))
+            else None
+        )
         try:
             await mgr.feed_tts_chunk(response_text, expected_speech_id=proactive_sid)
             committed = await mgr.finish_proactive_delivery(
@@ -7613,6 +7626,7 @@ async def proactive_chat(request: Request):
                 expected_speech_id=proactive_sid,
                 action_note=action_note,
                 source_tag=_delivered_tag,
+                vision_screenshot_b64=_stage_vision_screenshot,
             )
         except Exception as exc:
             logger.warning("[%s] buffered proactive delivery failed: %s", lanlan_name, exc)

--- a/tests/unit/test_proactive_vision_screenshot_staging.py
+++ b/tests/unit/test_proactive_vision_screenshot_staging.py
@@ -262,6 +262,41 @@ def test_stream_text_drops_screenshot_superseded_by_later_ai_turn():
     c.switch_model.assert_not_awaited()
 
 
+def test_proactive_injected_image_evicts_through_normal_keep_turns():
+    """Once injected, the proactive screenshot is a normal list-content image turn
+    and occupies a history image slot governed by the SAME _evict_old_images
+    (keep_turns=2) as user frames — no special-casing, no exemption. With two
+    newer image turns, the proactive turn's image is stripped (text kept) just
+    like any older user image would be."""
+    c = _bare_offline()
+
+    def _img_turn(url_tag: str, text: str) -> HumanMessage:
+        return HumanMessage(content=[
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{url_tag}"}},
+            {"type": "text", "text": text},
+        ])
+
+    # Oldest image turn = the proactive-injected reply (image leads, then text),
+    # exactly the shape stream_text builds. Then two newer user image turns.
+    proactive_turn = _img_turn("PROACTIVE", "这是什么")
+    c._conversation_history = [
+        SystemMessage(content="sys"),
+        proactive_turn,
+        AIMessage(content="ai-1"),
+        _img_turn("USER1", "看这个"),
+        AIMessage(content="ai-2"),
+        _img_turn("USER2", "还有这个"),
+    ]
+
+    c._evict_old_images()  # keep_turns=2 → keep the two newest image turns
+
+    # Proactive turn is the oldest image turn → image stripped, collapses to text.
+    assert c._conversation_history[1].content == "这是什么"
+    # The two newer image turns keep their images.
+    assert _image_urls(c._conversation_history[3].content) == ["data:image/jpeg;base64,USER1"]
+    assert _image_urls(c._conversation_history[5].content) == ["data:image/jpeg;base64,USER2"]
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 2b. prompt_ephemeral —— a visible ephemeral reply supersedes the staged screen
 #     (covers persist_response=False replies the history-len marker can't see)

--- a/tests/unit/test_proactive_vision_screenshot_staging.py
+++ b/tests/unit/test_proactive_vision_screenshot_staging.py
@@ -1,27 +1,38 @@
-"""主动搭话「以屏幕为素材」截图暂存 + 用户回复前注入 测试。
+"""Proactive-vision screenshot staging + inject-before-user-reply tests.
 
-原本：主动搭话用 vision 模型看屏幕生成台词后，``finish_proactive_delivery``
-只把纯文本 AIMessage 写进历史，那张截图当场丢弃——用户回复时对话模型完全
-不知道刚才评论的屏幕长什么样。
+Before: a proactive round used the vision model to look at the screen, but
+``finish_proactive_delivery`` committed only the text AIMessage and dropped the
+screenshot — so when the user replied, the conversation model had no idea what
+was on screen.
 
-本特性：把那张截图暂存到一个**独立单槽** ``_proactive_image_to_inject``，
-下一条用户 text 回复经 ``stream_text`` 时作为*前导* image_url 折叠进该用户
-HumanMessage（"用户说话前加入对话上下文"）。
+Now: that screenshot is stashed in a dedicated single slot
+``_proactive_image_to_inject`` and the next user text reply folds it in via
+``stream_text`` as the LEADING image of that user HumanMessage.
 
-三层契约：
-1. ``OmniOfflineClient.set_proactive_screenshot``：写/清独立单槽，绝不碰用户
-   自己的 ``_pending_images``（共用会偷走用户下一帧，Codex P2）。
-2. ``OmniOfflineClient.stream_text``：暂存截图排在用户自己的帧*之前*（时间序），
-   消费后一次性清空；无暂存时行为与原来完全一致（纯文本消息）。
-3. ``LLMSessionManager.finish_proactive_delivery(vision_screenshot_b64=...)``：
-   仅在 commit 成功（sid 未被用户抢占）时才暂存；传 ``None`` 清掉旧截图；
-   sid 不匹配（用户接管）时整轮短路，绝不为未投递的轮次暂存截图。
+Caching policy (latest spec): cache the last screenshot whenever the backend
+obtained one AND a vision model is available; a new proactive round overwrites /
+clears the prior cache; the cache has a 2-minute TTL and expired frames are not
+injected.
+
+Contracts under test:
+1. ``OmniOfflineClient.set_proactive_screenshot``: write/clear the isolated slot
+   + timestamp; never touch the user's own ``_pending_images`` (sharing it would
+   steal the user's next frame — Codex P2).
+2. ``OmniOfflineClient.stream_text``: the staged screenshot leads the user's own
+   frame(s) (temporal order) and is consumed one-shot; with nothing staged the
+   behavior is byte-for-byte the old text-only path.
+3. TTL: a screenshot older than ``_PROACTIVE_SCREENSHOT_TTL_SECONDS`` (120s) is
+   dropped lazily at injection.
+4. ``LLMSessionManager.finish_proactive_delivery(vision_screenshot_b64=...)``:
+   stage only on a genuine commit (sid not preempted); ``None`` clears the prior
+   cache; a sid mismatch (user took over) short-circuits and never stages a
+   screenshot for an undelivered turn.
 """
 import asyncio
 import os
 import sys
+import time
 from queue import Queue
-from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -35,14 +46,15 @@ from main_logic.session_state import SessionStateMachine
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 1. set_proactive_screenshot —— 独立单槽语义 + 与 _pending_images 隔离
+# 1. set_proactive_screenshot —— isolated single slot + 与 _pending_images 隔离
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _bare_offline() -> OmniOfflineClient:
-    """__new__ 绕过 __init__，仅装上槽相关字段。"""
+    """__new__ past __init__; wire up only the slot-related fields."""
     c = OmniOfflineClient.__new__(OmniOfflineClient)
     c._pending_images = []
     c._proactive_image_to_inject = None
+    c._proactive_image_staged_at = 0.0
     return c
 
 
@@ -50,6 +62,8 @@ def test_set_proactive_screenshot_stores_in_isolated_slot():
     c = _bare_offline()
     c.set_proactive_screenshot("SHOT_B64")
     assert c._proactive_image_to_inject == "SHOT_B64"
+    # 暂存即打上时间戳，给 TTL 用。
+    assert c._proactive_image_staged_at > 0.0
     # 关键隔离：绝不污染用户自己的待发帧队列（守住 Codex P2 约束）。
     assert c._pending_images == []
 
@@ -57,8 +71,10 @@ def test_set_proactive_screenshot_stores_in_isolated_slot():
 def test_set_proactive_screenshot_none_and_empty_clear_slot():
     c = _bare_offline()
     c._proactive_image_to_inject = "OLD"
+    c._proactive_image_staged_at = 123.0
     c.set_proactive_screenshot(None)
     assert c._proactive_image_to_inject is None
+    assert c._proactive_image_staged_at == 0.0  # 时间戳一并清
     # 空串也按"清空"处理（image_b64 or None），不会把空字符串当成一张图。
     c._proactive_image_to_inject = "OLD"
     c.set_proactive_screenshot("")
@@ -66,34 +82,38 @@ def test_set_proactive_screenshot_none_and_empty_clear_slot():
 
 
 def test_close_clears_proactive_slot():
-    """close() 必须把槽与 _pending_images 一并清掉，不跨实例泄漏。"""
+    """close() must clear slot + timestamp + _pending_images (no cross-instance leak)."""
     c = _bare_offline()
     c._conversation_history = []
     c._is_responding = False
     c._proactive_image_to_inject = "SHOT"
+    c._proactive_image_staged_at = 123.0
     c.llm = None
     c._genai_client = None
 
     asyncio.run(OmniOfflineClient.close(c))
     assert c._proactive_image_to_inject is None
+    assert c._proactive_image_staged_at == 0.0
     assert c._pending_images == []
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 2. stream_text —— 暂存截图作为前导 image 注入用户回复
+# 2. stream_text —— stage the screenshot as the leading image of the user reply
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _make_offline_for_stream(*, vision_model: str = "vm") -> tuple[OmniOfflineClient, list]:
-    """装一个能跑到 stream_text 消息构建 + 首次 astream 调用的最小 client。
+    """Minimal client that reaches stream_text's message build + first astream call.
 
-    ``_astream_visible_with_tools`` 被替换成一个捕获 messages 后立刻 raise 的
-    桩——构建好的用户 HumanMessage 在 raise 前已 append 进历史并作为第一个参数
-    传给它，所以能拿到它做断言；raise 走通用 except 直接 break（不重试、不 sleep）。
+    ``_astream_visible_with_tools`` is replaced by a stub that captures the
+    messages and immediately raises — the built user HumanMessage is appended to
+    history and passed to it before the raise, so we can assert on it; the raise
+    hits the generic except → break (no retry, no sleep).
     """
     c = OmniOfflineClient.__new__(OmniOfflineClient)
     c._conversation_history = [SystemMessage(content="sys")]
     c._pending_images = []
     c._proactive_image_to_inject = None
+    c._proactive_image_staged_at = 0.0
     c.model = "m"
     c.vision_model = vision_model
     c.max_response_rerolls = 0
@@ -120,7 +140,7 @@ def _make_offline_for_stream(*, vision_model: str = "vm") -> tuple[OmniOfflineCl
 
 
 def _last_user_message(captured: list) -> HumanMessage:
-    assert captured, "astream 从未被调用——消息没构建到位"
+    assert captured, "astream never called — message did not get built"
     msg = captured[0][-1]
     assert isinstance(msg, HumanMessage)
     return msg
@@ -154,8 +174,9 @@ def test_stream_text_injects_proactive_screenshot_before_user_text():
 
 
 def test_stream_text_orders_proactive_before_user_frame():
-    """暂存截图（她评论过的屏幕）排在用户自己的帧之前——时间序，避免模型把
-    旧屏当成用户刚拍的。两者消费后都清空。"""
+    """Staged screenshot (the screen she commented on) leads the user's own
+    frame — temporal order, so the model doesn't read the earlier screen as the
+    user's just-captured frame. Both cleared after consume."""
     c, captured = _make_offline_for_stream()
     c._pending_images = ["USER_FRAME_B64"]
     c.set_proactive_screenshot("PROACTIVE_B64")
@@ -173,7 +194,8 @@ def test_stream_text_orders_proactive_before_user_frame():
 
 
 def test_stream_text_without_staging_is_text_only():
-    """无暂存截图、无用户帧 → 纯文本消息，行为与改动前完全一致（无回归）。"""
+    """Nothing staged, no user frame → plain-text message, identical to the
+    pre-change path (no regression)."""
     c, captured = _make_offline_for_stream()
 
     asyncio.run(c.stream_text("普通一句话"))
@@ -183,12 +205,42 @@ def test_stream_text_without_staging_is_text_only():
     c.switch_model.assert_not_awaited()
 
 
+def test_stream_text_drops_expired_screenshot():
+    """Staged > 2-min TTL → not injected, plain-text reply, expired slot cleared."""
+    from main_logic.omni_offline_client import _PROACTIVE_SCREENSHOT_TTL_SECONDS
+
+    c, captured = _make_offline_for_stream()
+    c.set_proactive_screenshot("STALE_B64")
+    # 把暂存时刻倒拨到 TTL 之外，模拟用户隔了很久才回。
+    c._proactive_image_staged_at = time.monotonic() - (_PROACTIVE_SCREENSHOT_TTL_SECONDS + 5)
+
+    asyncio.run(c.stream_text("现在才回你"))
+
+    msg = _last_user_message(captured)
+    assert msg.content == "现在才回你"  # 过期 → 纯文本，无图
+    assert c._proactive_image_to_inject is None
+    assert c._proactive_image_staged_at == 0.0
+    c.switch_model.assert_not_awaited()
+
+
+def test_stream_text_injects_within_ttl():
+    """Within TTL (just staged) → injected. Dual of the expiry case, pinning both
+    sides of the TTL boundary."""
+    c, captured = _make_offline_for_stream()
+    c.set_proactive_screenshot("FRESH_B64")  # staged_at = now
+
+    asyncio.run(c.stream_text("马上回你"))
+
+    msg = _last_user_message(captured)
+    assert _image_urls(msg.content) == ["data:image/jpeg;base64,FRESH_B64"]
+
+
 # ─────────────────────────────────────────────────────────────────────────────
-# 3. finish_proactive_delivery(vision_screenshot_b64=...) —— commit 成功才暂存
+# 3. finish_proactive_delivery(vision_screenshot_b64=...) —— stage only on commit
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _make_mgr() -> LLMSessionManager:
-    """复用 test_proactive_action_note.py 的最小 manager 装配。"""
+    """Minimal manager assembly reused from test_proactive_action_note.py."""
     mgr = LLMSessionManager.__new__(LLMSessionManager)
     mgr.use_tts = True
     mgr.tts_cache_lock = asyncio.Lock()
@@ -217,18 +269,20 @@ def _make_mgr() -> LLMSessionManager:
 
 
 def _real_session() -> OmniOfflineClient:
-    """真实 OmniOfflineClient（__new__）当 session：用真的 set_proactive_screenshot
-    + 真的 _proactive_image_to_inject 槽，断言才有意义。"""
+    """Real OmniOfflineClient (__new__) as the session, so the assertions exercise
+    the real set_proactive_screenshot + _proactive_image_to_inject slot."""
     sess = OmniOfflineClient.__new__(OmniOfflineClient)
     sess._conversation_history = []
     sess._pending_images = []
     sess._proactive_image_to_inject = None
+    sess._proactive_image_staged_at = 0.0
     return sess
 
 
 @pytest.mark.asyncio
 async def test_finish_stages_vision_screenshot_on_commit():
-    """本轮以屏幕为素材投递 + commit 成功 → 截图落到独立槽，等下一条用户回复注入。"""
+    """Screenshot obtained + commit succeeds → it lands in the isolated slot,
+    ready for the next user reply to inject."""
     mgr = _make_mgr()
     mgr.current_speech_id = "s"
     mgr.session = _real_session()
@@ -248,8 +302,8 @@ async def test_finish_stages_vision_screenshot_on_commit():
 
 @pytest.mark.asyncio
 async def test_finish_clears_stale_screenshot_when_none():
-    """非 vision 轮（传 None）→ 清掉上一轮可能遗留的截图，避免与屏幕无关的
-    搭话拖着一张陈旧图。"""
+    """A round with no screenshot (passes None) discards any prior cache, so a
+    later screen-unrelated talk never trails a stale image."""
     mgr = _make_mgr()
     mgr.current_speech_id = "s"
     mgr.session = _real_session()
@@ -265,8 +319,9 @@ async def test_finish_clears_stale_screenshot_when_none():
 
 @pytest.mark.asyncio
 async def test_finish_does_not_stage_on_sid_mismatch():
-    """sid 不匹配（用户已接管本轮）→ finish 短路返回 False，截图绝不暂存，
-    旧槽值也不被这条未投递的孤儿轮次篡改。"""
+    """sid mismatch (user already took over this turn) → finish short-circuits
+    and returns False; the screenshot is never staged and the prior slot value is
+    not mutated by this orphan undelivered turn."""
     mgr = _make_mgr()
     mgr.current_speech_id = "s_user"
     mgr.session = _real_session()

--- a/tests/unit/test_proactive_vision_screenshot_staging.py
+++ b/tests/unit/test_proactive_vision_screenshot_staging.py
@@ -1,0 +1,283 @@
+"""主动搭话「以屏幕为素材」截图暂存 + 用户回复前注入 测试。
+
+原本：主动搭话用 vision 模型看屏幕生成台词后，``finish_proactive_delivery``
+只把纯文本 AIMessage 写进历史，那张截图当场丢弃——用户回复时对话模型完全
+不知道刚才评论的屏幕长什么样。
+
+本特性：把那张截图暂存到一个**独立单槽** ``_proactive_image_to_inject``，
+下一条用户 text 回复经 ``stream_text`` 时作为*前导* image_url 折叠进该用户
+HumanMessage（"用户说话前加入对话上下文"）。
+
+三层契约：
+1. ``OmniOfflineClient.set_proactive_screenshot``：写/清独立单槽，绝不碰用户
+   自己的 ``_pending_images``（共用会偷走用户下一帧，Codex P2）。
+2. ``OmniOfflineClient.stream_text``：暂存截图排在用户自己的帧*之前*（时间序），
+   消费后一次性清空；无暂存时行为与原来完全一致（纯文本消息）。
+3. ``LLMSessionManager.finish_proactive_delivery(vision_screenshot_b64=...)``：
+   仅在 commit 成功（sid 未被用户抢占）时才暂存；传 ``None`` 清掉旧截图；
+   sid 不匹配（用户接管）时整轮短路，绝不为未投递的轮次暂存截图。
+"""
+import asyncio
+import os
+import sys
+from queue import Queue
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from utils.llm_client import HumanMessage, SystemMessage
+from main_logic.core import LLMSessionManager
+from main_logic.omni_offline_client import OmniOfflineClient
+from main_logic.session_state import SessionStateMachine
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. set_proactive_screenshot —— 独立单槽语义 + 与 _pending_images 隔离
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _bare_offline() -> OmniOfflineClient:
+    """__new__ 绕过 __init__，仅装上槽相关字段。"""
+    c = OmniOfflineClient.__new__(OmniOfflineClient)
+    c._pending_images = []
+    c._proactive_image_to_inject = None
+    return c
+
+
+def test_set_proactive_screenshot_stores_in_isolated_slot():
+    c = _bare_offline()
+    c.set_proactive_screenshot("SHOT_B64")
+    assert c._proactive_image_to_inject == "SHOT_B64"
+    # 关键隔离：绝不污染用户自己的待发帧队列（守住 Codex P2 约束）。
+    assert c._pending_images == []
+
+
+def test_set_proactive_screenshot_none_and_empty_clear_slot():
+    c = _bare_offline()
+    c._proactive_image_to_inject = "OLD"
+    c.set_proactive_screenshot(None)
+    assert c._proactive_image_to_inject is None
+    # 空串也按"清空"处理（image_b64 or None），不会把空字符串当成一张图。
+    c._proactive_image_to_inject = "OLD"
+    c.set_proactive_screenshot("")
+    assert c._proactive_image_to_inject is None
+
+
+def test_close_clears_proactive_slot():
+    """close() 必须把槽与 _pending_images 一并清掉，不跨实例泄漏。"""
+    c = _bare_offline()
+    c._conversation_history = []
+    c._is_responding = False
+    c._proactive_image_to_inject = "SHOT"
+    c.llm = None
+    c._genai_client = None
+
+    asyncio.run(OmniOfflineClient.close(c))
+    assert c._proactive_image_to_inject is None
+    assert c._pending_images == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. stream_text —— 暂存截图作为前导 image 注入用户回复
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_offline_for_stream(*, vision_model: str = "vm") -> tuple[OmniOfflineClient, list]:
+    """装一个能跑到 stream_text 消息构建 + 首次 astream 调用的最小 client。
+
+    ``_astream_visible_with_tools`` 被替换成一个捕获 messages 后立刻 raise 的
+    桩——构建好的用户 HumanMessage 在 raise 前已 append 进历史并作为第一个参数
+    传给它，所以能拿到它做断言；raise 走通用 except 直接 break（不重试、不 sleep）。
+    """
+    c = OmniOfflineClient.__new__(OmniOfflineClient)
+    c._conversation_history = [SystemMessage(content="sys")]
+    c._pending_images = []
+    c._proactive_image_to_inject = None
+    c.model = "m"
+    c.vision_model = vision_model
+    c.max_response_rerolls = 0
+    c.max_response_length = 2000
+    c._prefix_buffer_size = 0
+    c.on_input_transcript = None
+    c.on_text_delta = AsyncMock()
+    c.on_status_message = None
+    c.on_response_discarded = None
+    c.on_response_done = None
+    c._begin_reasoning_stream = MagicMock()
+    c.switch_model = AsyncMock()
+
+    captured: list = []
+
+    async def _fake_astream_visible(messages, **overrides):
+        # messages 此刻 = self._conversation_history，末尾就是刚构建的用户消息。
+        captured.append(list(messages))
+        raise RuntimeError("stop-after-construction")
+        yield  # pragma: no cover —— 标记为 async generator
+
+    c._astream_visible_with_tools = _fake_astream_visible
+    return c, captured
+
+
+def _last_user_message(captured: list) -> HumanMessage:
+    assert captured, "astream 从未被调用——消息没构建到位"
+    msg = captured[0][-1]
+    assert isinstance(msg, HumanMessage)
+    return msg
+
+
+def _image_urls(content: list) -> list[str]:
+    return [
+        item["image_url"]["url"]
+        for item in content
+        if isinstance(item, dict) and item.get("type") == "image_url"
+    ]
+
+
+def test_stream_text_injects_proactive_screenshot_before_user_text():
+    c, captured = _make_offline_for_stream()
+    c.set_proactive_screenshot("PROACTIVE_B64")
+
+    asyncio.run(c.stream_text("这是什么呀"))
+
+    msg = _last_user_message(captured)
+    assert isinstance(msg.content, list)
+    urls = _image_urls(msg.content)
+    assert urls == ["data:image/jpeg;base64,PROACTIVE_B64"]
+    # 图在前、文本在后（"用户说话前加入"）。
+    assert msg.content[0].get("type") == "image_url"
+    assert msg.content[-1] == {"type": "text", "text": "这是什么呀"}
+    # 一次性消费：消费后槽清空，绝不再注入后续轮次。
+    assert c._proactive_image_to_inject is None
+    # 有图 → 切 vision 模型（让对话模型真能看见这张屏）。
+    c.switch_model.assert_awaited_once()
+
+
+def test_stream_text_orders_proactive_before_user_frame():
+    """暂存截图（她评论过的屏幕）排在用户自己的帧之前——时间序，避免模型把
+    旧屏当成用户刚拍的。两者消费后都清空。"""
+    c, captured = _make_offline_for_stream()
+    c._pending_images = ["USER_FRAME_B64"]
+    c.set_proactive_screenshot("PROACTIVE_B64")
+
+    asyncio.run(c.stream_text("看看这个"))
+
+    msg = _last_user_message(captured)
+    urls = _image_urls(msg.content)
+    assert urls == [
+        "data:image/jpeg;base64,PROACTIVE_B64",
+        "data:image/jpeg;base64,USER_FRAME_B64",
+    ]
+    assert c._proactive_image_to_inject is None
+    assert c._pending_images == []
+
+
+def test_stream_text_without_staging_is_text_only():
+    """无暂存截图、无用户帧 → 纯文本消息，行为与改动前完全一致（无回归）。"""
+    c, captured = _make_offline_for_stream()
+
+    asyncio.run(c.stream_text("普通一句话"))
+
+    msg = _last_user_message(captured)
+    assert msg.content == "普通一句话"  # 纯字符串，非多模态列表
+    c.switch_model.assert_not_awaited()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. finish_proactive_delivery(vision_screenshot_b64=...) —— commit 成功才暂存
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_mgr() -> LLMSessionManager:
+    """复用 test_proactive_action_note.py 的最小 manager 装配。"""
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.use_tts = True
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.lock = asyncio.Lock()
+    mgr._proactive_write_lock = asyncio.Lock()
+    mgr.tts_pending_chunks = []
+    mgr.tts_request_queue = Queue()
+    mgr.tts_response_queue = Queue()
+    mgr.tts_thread = MagicMock()
+    mgr.tts_thread.is_alive.return_value = True
+    mgr.tts_ready = True
+    mgr.current_speech_id = None
+    mgr._tts_done_queued_for_turn = False
+    mgr.lanlan_name = "Test"
+    mgr.session = None
+    mgr.websocket = None
+    mgr.sync_message_queue = Queue()
+    mgr._enqueue_tts_text_chunk = MagicMock()
+    mgr._respawn_tts_worker = MagicMock()
+    mgr._tts_norm_speech_id = None
+    mgr.send_lanlan_response = AsyncMock()
+    mgr.state = SessionStateMachine(lanlan_name="Test")
+    mgr._activity_tracker = MagicMock()
+    mgr._current_ai_turn_text = ''
+    return mgr
+
+
+def _real_session() -> OmniOfflineClient:
+    """真实 OmniOfflineClient（__new__）当 session：用真的 set_proactive_screenshot
+    + 真的 _proactive_image_to_inject 槽，断言才有意义。"""
+    sess = OmniOfflineClient.__new__(OmniOfflineClient)
+    sess._conversation_history = []
+    sess._pending_images = []
+    sess._proactive_image_to_inject = None
+    return sess
+
+
+@pytest.mark.asyncio
+async def test_finish_stages_vision_screenshot_on_commit():
+    """本轮以屏幕为素材投递 + commit 成功 → 截图落到独立槽，等下一条用户回复注入。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s"
+    mgr.session = _real_session()
+
+    result = await LLMSessionManager.finish_proactive_delivery(
+        mgr, "你这屏幕上的图好好看～", expected_speech_id="s",
+        vision_screenshot_b64="SHOT_B64",
+    )
+
+    assert result is True
+    assert mgr.session._proactive_image_to_inject == "SHOT_B64"
+    # 截图只进独立槽，绝不混进用户的 _pending_images。
+    assert mgr.session._pending_images == []
+    # 历史里仍只有纯文本 AIMessage（截图不作为图片写历史）。
+    assert mgr.session._conversation_history[0].content == "你这屏幕上的图好好看～"
+
+
+@pytest.mark.asyncio
+async def test_finish_clears_stale_screenshot_when_none():
+    """非 vision 轮（传 None）→ 清掉上一轮可能遗留的截图，避免与屏幕无关的
+    搭话拖着一张陈旧图。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s"
+    mgr.session = _real_session()
+    mgr.session._proactive_image_to_inject = "STALE_OLD_SHOT"
+
+    await LLMSessionManager.finish_proactive_delivery(
+        mgr, "我突然想起件事", expected_speech_id="s",
+        vision_screenshot_b64=None,
+    )
+
+    assert mgr.session._proactive_image_to_inject is None
+
+
+@pytest.mark.asyncio
+async def test_finish_does_not_stage_on_sid_mismatch():
+    """sid 不匹配（用户已接管本轮）→ finish 短路返回 False，截图绝不暂存，
+    旧槽值也不被这条未投递的孤儿轮次篡改。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"
+    mgr.session = _real_session()
+    mgr.session._proactive_image_to_inject = "PREEXISTING"
+
+    result = await LLMSessionManager.finish_proactive_delivery(
+        mgr, "孤儿 proactive", expected_speech_id="s_proactive",
+        vision_screenshot_b64="SHOULD_NOT_STAGE",
+    )
+
+    assert result is False
+    # 既不写新截图，也不清旧值——整轮在 sid 校验处早 return。
+    assert mgr.session._proactive_image_to_inject == "PREEXISTING"
+    assert mgr.session._conversation_history == []

--- a/tests/unit/test_proactive_vision_screenshot_staging.py
+++ b/tests/unit/test_proactive_vision_screenshot_staging.py
@@ -35,6 +35,7 @@ import os
 import sys
 import time
 from queue import Queue
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -259,6 +260,73 @@ def test_stream_text_drops_screenshot_superseded_by_later_ai_turn():
     assert c._proactive_image_to_inject is None
     assert c._proactive_image_history_len == 0
     c.switch_model.assert_not_awaited()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2b. prompt_ephemeral —— a visible ephemeral reply supersedes the staged screen
+#     (covers persist_response=False replies the history-len marker can't see)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_offline_for_ephemeral():
+    """Minimal client to drive prompt_ephemeral up to its finally block."""
+    c = OmniOfflineClient.__new__(OmniOfflineClient)
+    c._conversation_history = [SystemMessage(content="sys")]
+    c._pending_images = []
+    c._proactive_image_to_inject = None
+    c._proactive_image_staged_at = 0.0
+    c._proactive_image_history_len = 0
+    c.model = "m"
+    c.vision_model = ""  # no images here, keep model switch out of the path
+    c._is_responding = False
+    c._prefix_buffer_size = 0
+    c.master_name = "M"
+    c.lanlan_name = "L"
+    c.on_text_delta = AsyncMock()
+    c.on_status_message = None
+    c.on_response_done = AsyncMock()
+    c._begin_reasoning_stream = MagicMock(return_value=1)
+    c._notify_reasoning_done = AsyncMock()
+
+    def _set_chunks(chunks):
+        async def _fake(messages):
+            for ch in chunks:
+                yield ch
+        c._astream_visible_with_tools = _fake
+
+    return c, _set_chunks
+
+
+def test_prompt_ephemeral_visible_reply_supersedes_staged_screenshot():
+    """The avatar-tap path: a visible persist_response=False reply leaves history
+    length unchanged (the marker can't see it), so prompt_ephemeral itself must
+    clear the staged screenshot when it commits visible text (Codex P2)."""
+    c, set_chunks = _make_offline_for_ephemeral()
+    c.set_proactive_screenshot("SCREEN_B64")
+    set_chunks([SimpleNamespace(content="戳你一下喵~")])
+
+    committed = asyncio.run(
+        c.prompt_ephemeral("======戳头像======", completion_mode="response", persist_response=False)
+    )
+
+    assert committed is True
+    assert c._proactive_image_to_inject is None
+    assert c._proactive_image_staged_at == 0.0
+    assert c._proactive_image_history_len == 0
+
+
+def test_prompt_ephemeral_no_visible_text_keeps_staged_screenshot():
+    """An aborted / no-text ephemeral attempt must NOT drop a still-valid staged
+    screen (the user saw no new reply)."""
+    c, set_chunks = _make_offline_for_ephemeral()
+    c.set_proactive_screenshot("SCREEN_B64")
+    set_chunks([])  # nothing emitted → content_committed is False
+
+    committed = asyncio.run(
+        c.prompt_ephemeral("======戳头像======", completion_mode="response", persist_response=False)
+    )
+
+    assert committed is False
+    assert c._proactive_image_to_inject == "SCREEN_B64"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_proactive_vision_screenshot_staging.py
+++ b/tests/unit/test_proactive_vision_screenshot_staging.py
@@ -412,6 +412,23 @@ async def test_finish_clears_stale_screenshot_when_none():
     assert mgr.session._proactive_image_to_inject is None
 
 
+def test_clear_text_pending_images_also_clears_proactive_slot():
+    """Magic-command bypasses (OpenClaw/Qwenpaw) go through _clear_text_pending_images
+    instead of stream_text, so that hook must also drop the staged screenshot —
+    otherwise it survives and injects into a later unrelated message (Codex P2)."""
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.session = _real_session()
+    mgr.session._pending_images = ["user-frame"]
+    mgr.session.set_proactive_screenshot("SCREEN_B64")
+    assert mgr.session._proactive_image_to_inject == "SCREEN_B64"
+
+    LLMSessionManager._clear_text_pending_images(mgr)
+
+    assert mgr.session._pending_images == []
+    assert mgr.session._proactive_image_to_inject is None
+    assert mgr.session._proactive_image_staged_at == 0.0
+
+
 @pytest.mark.asyncio
 async def test_finish_does_not_stage_on_sid_mismatch():
     """sid mismatch (user already took over this turn) → finish short-circuits

--- a/tests/unit/test_proactive_vision_screenshot_staging.py
+++ b/tests/unit/test_proactive_vision_screenshot_staging.py
@@ -21,8 +21,10 @@ Contracts under test:
 2. ``OmniOfflineClient.stream_text``: the staged screenshot leads the user's own
    frame(s) (temporal order) and is consumed one-shot; with nothing staged the
    behavior is byte-for-byte the old text-only path.
-3. TTL: a screenshot older than ``_PROACTIVE_SCREENSHOT_TTL_SECONDS`` (120s) is
-   dropped lazily at injection.
+3. TTL + supersede: a screenshot older than ``_PROACTIVE_SCREENSHOT_TTL_SECONDS``
+   (120s), OR one whose AI turn was superseded by a later AI message appended
+   through another path (greeting / agent callback via ``prompt_ephemeral``), is
+   dropped lazily at injection (Codex P2).
 4. ``LLMSessionManager.finish_proactive_delivery(vision_screenshot_b64=...)``:
    stage only on a genuine commit (sid not preempted); ``None`` clears the prior
    cache; a sid mismatch (user took over) short-circuits and never stages a
@@ -39,7 +41,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
-from utils.llm_client import HumanMessage, SystemMessage
+from utils.llm_client import AIMessage, HumanMessage, SystemMessage
 from main_logic.core import LLMSessionManager
 from main_logic.omni_offline_client import OmniOfflineClient
 from main_logic.session_state import SessionStateMachine
@@ -52,9 +54,11 @@ from main_logic.session_state import SessionStateMachine
 def _bare_offline() -> OmniOfflineClient:
     """__new__ past __init__; wire up only the slot-related fields."""
     c = OmniOfflineClient.__new__(OmniOfflineClient)
+    c._conversation_history = []
     c._pending_images = []
     c._proactive_image_to_inject = None
     c._proactive_image_staged_at = 0.0
+    c._proactive_image_history_len = 0
     return c
 
 
@@ -82,18 +86,19 @@ def test_set_proactive_screenshot_none_and_empty_clear_slot():
 
 
 def test_close_clears_proactive_slot():
-    """close() must clear slot + timestamp + _pending_images (no cross-instance leak)."""
+    """close() must clear slot + timestamp + marker + _pending_images (no leak)."""
     c = _bare_offline()
-    c._conversation_history = []
     c._is_responding = False
     c._proactive_image_to_inject = "SHOT"
     c._proactive_image_staged_at = 123.0
+    c._proactive_image_history_len = 5
     c.llm = None
     c._genai_client = None
 
     asyncio.run(OmniOfflineClient.close(c))
     assert c._proactive_image_to_inject is None
     assert c._proactive_image_staged_at == 0.0
+    assert c._proactive_image_history_len == 0
     assert c._pending_images == []
 
 
@@ -114,6 +119,7 @@ def _make_offline_for_stream(*, vision_model: str = "vm") -> tuple[OmniOfflineCl
     c._pending_images = []
     c._proactive_image_to_inject = None
     c._proactive_image_staged_at = 0.0
+    c._proactive_image_history_len = 0
     c.model = "m"
     c.vision_model = vision_model
     c.max_response_rerolls = 0
@@ -235,6 +241,26 @@ def test_stream_text_injects_within_ttl():
     assert _image_urls(msg.content) == ["data:image/jpeg;base64,FRESH_B64"]
 
 
+def test_stream_text_drops_screenshot_superseded_by_later_ai_turn():
+    """A later AI turn after staging (e.g. greeting / agent callback via
+    prompt_ephemeral, NOT finish_proactive_delivery) supersedes the screenshot —
+    it's no longer tied to the last AI turn, so injection drops it. Pins Codex P2:
+    another delivery path not clearing the slot still can't leak a stale screen
+    into the user's reply."""
+    c, captured = _make_offline_for_stream()
+    c.set_proactive_screenshot("SCREEN_TALK_B64")  # marker = len([Sys]) = 1
+    # 模拟随后一条 prompt_ephemeral 投递的 AI 轮把历史变长（不经 set_*）。
+    c._conversation_history.append(AIMessage(content="顺便说，记得喝水哦"))
+
+    asyncio.run(c.stream_text("好的"))
+
+    msg = _last_user_message(captured)
+    assert msg.content == "好的"  # 陈旧屏被丢弃 → 纯文本
+    assert c._proactive_image_to_inject is None
+    assert c._proactive_image_history_len == 0
+    c.switch_model.assert_not_awaited()
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 3. finish_proactive_delivery(vision_screenshot_b64=...) —— stage only on commit
 # ─────────────────────────────────────────────────────────────────────────────
@@ -276,6 +302,7 @@ def _real_session() -> OmniOfflineClient:
     sess._pending_images = []
     sess._proactive_image_to_inject = None
     sess._proactive_image_staged_at = 0.0
+    sess._proactive_image_history_len = 0
     return sess
 
 


### PR DESCRIPTION
## 背景 / 原本啥样

主动搭话（proactive chat）以「屏幕」为素材时，Phase 2 会把当下截图喂给 vision 模型生成台词，但 `finish_proactive_delivery` 落库时**只写纯文本 AIMessage，截图当场丢弃**。结果：用户回复这条搭话时，对话模型（text model）只看到搭话文本，完全不知道刚才评论的屏幕长什么样，答非所问。

## 改动核心

把那张截图**暂存**到一个独立单槽，等用户**下一条 text 回复**时，作为前导 `image_url` 折叠进该用户消息（"用户说话前加入对话上下文"），让对话模型能"看到"刚才讨论的屏幕。

**缓存策略**：只要本轮后端拿到了截图且有可用 vision 模型（`phase2_use_vision`）就缓存最后这张（不按最终投递通道筛）；新一轮主动搭话产生即覆盖/清掉旧缓存；缓存带 **2 分钟 TTL** + **superseded 失效**（钉死在「最后一条 AI 轮」）。

- `OmniOfflineClient`：`_proactive_image_to_inject`（独立单槽）+ `_proactive_image_staged_at`（TTL）+ `_proactive_image_history_len`（暂存时历史长度）+ `set_proactive_screenshot()`。**与用户自己的 `_pending_images` 严格隔离**——共用会偷走用户下一帧（既有 Codex P2 约束）。
- `stream_text`：暂存截图排在用户帧**之前**（时间序），一次性消费后清空；TTL 过期或 superseded（中途有别的 AI 轮 append）则丢弃；无暂存时行为与原来逐字节一致（无回归）。
- `finish_proactive_delivery(vision_screenshot_b64=...)`：sid-guard 之后落槽（仅 commit 成功才暂存）；传 `None` 清旧。
- 路由 gate：`_stage_vision_screenshot = screenshot_b64_for_phase2 if phase2_use_vision else None`。
  > ⚠️ vision-only 轮走 `_of_none` 无 tag 模式 → `source_tag` 兜底成 CHAT → `primary_channel == 'chat'`（`'vision'` 只在 MEME 回退出现），所以不能只认 `'vision'`。

**Supersede 多路覆盖**（避免旧屏注给"回复那条不相关后续轮"）：
- history-len marker：catch 任何「进历史」的后续 AI 轮（path-agnostic）。
- `prompt_ephemeral` finally 清槽：catch greeting / agent 回调 / 头像 quip 等可见 ephemeral 回复（含 `persist_response=False`，marker 看不到）。
- `_clear_text_pending_images` 清槽：catch OpenClaw/Qwenpaw magic-command 等绕过 stream_text 的输入。

## 不处理语音回复（架构隔离）

voice session 是独立 realtime 连接，不继承 text session 的 `_conversation_history`，也无历史回放机制。截图槽是 `OmniOfflineClient`(text) 专属，用户转语音时新建 `OmniRealtimeClient` 读不到该槽，随旧 client `close()` 自然丢弃。

## 回归报告

**改了什么**：`main_logic/omni_offline_client.py`（新增暂存槽+TTL+supersede+注入）、`main_logic/core.py`（`finish_proactive_delivery` 新增 `vision_screenshot_b64` 参数 + 落槽；`_clear_text_pending_images` 清槽）、`main_routers/system_router.py`（proactive 端点按 `phase2_use_vision` 决定传图/传 None）。新增 `tests/unit/test_proactive_vision_screenshot_staging.py`。

**为什么必要**：屏幕类主动搭话的截图当场丢弃，用户回复时对话模型对刚评论的屏幕一无所知，导致答非所问——这是该特性的核心断点。

**前后行为**：
- 之前：屏幕类主动搭话 → 用户回复 → 对话模型只见文本，看不到屏幕。
- 之后：截图暂存 → 用户下一条 text 回复前导注入该截图 → 模型能看到（2 分钟内、未被更晚的 AI 轮 supersede）。
- **关键不变量**：没有暂存截图时，`stream_text` 走与改动前完全相同的纯文本路径（`proactive_image` 为 None → 新逻辑整体短路）。激活条件窄：vision 开 + 屏幕类主动搭话 + 2 分钟内 text 回复 + 中途无别的 AI 轮。

**潜在回归**：
1. **（最值得盯）注入截图会把该 text session 永久切到 vision 模型**——既有架构（`stream_text` 一旦 `has_images` 即 `switch_model`，且图留在历史无法切回；用户分享屏幕 / proactive media 早已如此），本 PR 新增「屏幕类主动搭话被回复」这一触发点。若 vision 模型在纯聊场景更慢/更贵/更弱，命中后该 session 后续轮会受影响。
2. 宽 gate 下，若本轮投递落到 music/web（屏幕只是顺带喂进去），用户回复仍会被注入该屏幕——可能是离题上下文（已知取舍）。
3. 注入的是「当时那张」最长 2 分钟前的屏幕，TTL 兜底。
4. 多个 `finish_proactive_delivery` 调用方（mini-game 邀请 / icebreaker / game postgame）现在 commit 时会 `set_proactive_screenshot(None)` 清槽——符合「新主动搭话产生即丢弃」，且 `hasattr` guard 兜底非 OmniOfflineClient session。
5. 已知 TTL-bounded 边界（narrow，degraded-not-crash）：hot-swap 提升 pending_session 时暂存槽（在旧 session 上）丢失；以及中途被用户打断的 ephemeral quip 可能误清一张仍有效的暂存屏。两者均 ≤2min 失效、不致崩。

**验证**：本特性单测 15 例全绿；相关 proactive / ephemeral / 截图套件无回归（`test_core_game_route_memory_contract` 的 2 个 openclaw 失败为 base 既有红，已 stash 验证与本 PR 无关）。`DOCSTRING_CJK` / ruff / 各 convention lint 本地+CI 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
