### PR TITLE
feat(focus): 凝神 thinking 轮次给 max_completion_tokens 加 +800 头寸

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1366,6 +1366,22 @@ DIALOG_LLM_STREAM_TIMEOUT_SECONDS = 180
 - 政策：LLM_OUTPUT_BUDGET lint 要求每个 client 构造都带 timeout；本常量是
   主对话流式路径的统一来源。"""
 
+FOCUS_THINKING_EXTRA_TOKENS = 800
+"""凝神（focus / thinking-on）轮次额外放宽的 max_completion_tokens。
+- 背景：thinking 模型（Qwen enable_thinking / GLM·Kimi·Doubao thinking.type /
+  OpenRouter reasoning.effort）的 reasoning token 与正式回复共享同一个
+  max_completion_tokens 预算池（见 docs/design/llm-prompt-budget.md §0），
+  凝神轮一开思考就会从回复额度里扣，把正式回复挤短。
+- 作用：仅在 thinking_on 的那一轮，把 API 端 max_completion_tokens 临时
+  抬高本值，给推理链单独留头寸，不动 Python-side 长度 guard（回复可见
+  长度仍按 max_response_length 收口）。
+- 路由：作为 per-call override 经 _focus_stream_overrides → astream →
+  ChatOpenAI._params 透传，不改 self.llm 实例属性（与 extra_body 同一条
+  per-call 路径，并发安全、下一轮自动复位）。
+- 适用面：Claude 凝神保持 thinking-off（config/providers.py），本加值对其
+  天然 no-op；Gemini thinking_budget 是独立字段（800），本余量也足够覆盖。
+- 取值：扁平 800，不按 provider 分叉——只在真正开思考的轮次生效。"""
+
 # ---- Memory: refine (Phase A-3) — MemoryRefineEngine 的 cron 参数 ----
 # 通用 cosine 聚类 + LLM 决议管道，复用在 PERSONA_REFINE 和
 # REFLECTION_REFINE 两条 cron 上。fact 不可变（只能作 merge/modify
@@ -2443,6 +2459,7 @@ __all__ = [
     'PERSONA_VERSION_HISTORY_MAX',
     'MEMORY_LLM_HARD_TIMEOUT_SECONDS',
     'DIALOG_LLM_STREAM_TIMEOUT_SECONDS',
+    'FOCUS_THINKING_EXTRA_TOKENS',
     'LLM_OUTPUT_GUARD_MAX_TOKENS',
     'MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS',
     'MEMORY_REFINE_COSINE_THRESHOLD',

--- a/docs/design/llm-prompt-budget.md
+++ b/docs/design/llm-prompt-budget.md
@@ -244,8 +244,11 @@ callback（`enqueue_agent_callback`）会经 `_build_callback_instruction`（文
 | 翻译输出 | `TRANSLATION_OUTPUT_MAX_TOKENS` | 1000 |
 | ComputerUse 主调用 | `COMPUTER_USE_MAX_TOKENS` | 6000 |
 | 变长输出 runaway guard | `LLM_OUTPUT_GUARD_MAX_TOKENS` | 4096 |
+| 凝神 thinking 额外头寸（叠加，非上限） | `FOCUS_THINKING_EXTRA_TOKENS` | 800 |
 
 > 注：变长结构化 JSON 输出（memory reflection/recall/persona/facts/refine、deduper、card-assist 等）没有紧的 task-specific budget，统一用 `LLM_OUTPUT_GUARD_MAX_TOKENS`（generous runaway guard，不会误截）作上限。见 §0。
+
+> 注：`FOCUS_THINKING_EXTRA_TOKENS` 不是一个独立 cap，而是**叠加值**——仅在凝神（thinking-on）轮次，把主对话当前的 `max_completion_tokens`（`max_response_length + slack`，含 summary-mode 抬升）再 +800，给 reasoning 链单独留头寸。thinking 模型（Qwen / GLM / Kimi / Doubao / OpenRouter）的 reasoning token 与正式回复共用同一预算池（见 §0），不留头寸会把回复挤短。作为 per-call override 经 `_focus_stream_overrides` → `astream` → `_params` 透传（与 `extra_body` 同一条路），不改 `self.llm` 实例属性；base 为 `None`（无限制预算）时省略字段。Python-side 长度 guard 仍按 `max_response_length` 收口可见回复。Claude 凝神保持 thinking-off 故对其 no-op；Gemini `thinking_budget` 是独立字段（800），本余量也覆盖。
 
 **timeout 索引（部分）**：
 

--- a/docs/design/llm-prompt-budget.md
+++ b/docs/design/llm-prompt-budget.md
@@ -247,8 +247,8 @@ callback（`enqueue_agent_callback`）会经 `_build_callback_instruction`（文
 | 凝神 thinking 额外头寸（叠加，非上限） | `FOCUS_THINKING_EXTRA_TOKENS` | 800 |
 
 > 注：变长结构化 JSON 输出（memory reflection/recall/persona/facts/refine、deduper、card-assist 等）没有紧的 task-specific budget，统一用 `LLM_OUTPUT_GUARD_MAX_TOKENS`（generous runaway guard，不会误截）作上限。见 §0。
-
-> 注：`FOCUS_THINKING_EXTRA_TOKENS` 不是一个独立 cap，而是**叠加值**——仅在凝神（thinking-on）轮次，把主对话当前的 `max_completion_tokens`（`max_response_length + slack`，含 summary-mode 抬升）再 +800，给 reasoning 链单独留头寸。thinking 模型（Qwen / GLM / Kimi / Doubao / OpenRouter）的 reasoning token 与正式回复共用同一预算池（见 §0），不留头寸会把回复挤短。作为 per-call override 经 `_focus_stream_overrides` → `astream` → `_params` 透传（与 `extra_body` 同一条路），不改 `self.llm` 实例属性；base 为 `None`（无限制预算）时省略字段。Python-side 长度 guard 仍按 `max_response_length` 收口可见回复。Claude 凝神保持 thinking-off 故对其 no-op；Gemini `thinking_budget` 是独立字段（800），本余量也覆盖。
+>
+> 注：`FOCUS_THINKING_EXTRA_TOKENS` 不是一个独立 cap，而是**叠加值**——仅在凝神**且该 provider 真正被翻开思考**的轮次，把主对话当前的 `max_completion_tokens`（`max_response_length + slack`，含 summary-mode 抬升）再 +800，给 reasoning 链单独留头寸。thinking 模型（Qwen / GLM / Kimi / Doubao / OpenRouter）的 reasoning token 与正式回复共用同一预算池（见 §0），不留头寸会把回复挤短。是否"真正开思考"用 `focus_extra_body(model) != get_extra_body(model)` 判：相等即 focus 形态与常规（关思考）形态一致（Claude 保持 disabled、未知模型为 None、非 thinking provider 只是保留自身非思考 extra），此时**不加** +800（避免给没有 reasoning 的轮次白抬上限、逼近 provider 输出上限）。作为 per-call override 经 `_focus_stream_overrides` → `astream` → `_params` 透传（与 `extra_body` 同一条路），不改 `self.llm` 实例属性；base 为 `None`（无限制预算）时省略字段。Python-side 长度 guard 仍按 `max_response_length` 收口可见回复。原生 Gemini（genai SDK 路径）的 `thinking_budget` 是独立字段、不占 `max_output_tokens`，没有"共享池挤占"问题，故该路径不参与本叠加（且 focus extra_body 在 genai 路径本就被忽略，是另一独立话题）。
 
 **timeout 索引（部分）**：
 

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -33,7 +33,11 @@ from utils.llm_client import (
 from openai import APIConnectionError, AuthenticationError, InternalServerError, RateLimitError
 from utils.frontend_utils import calculate_text_similarity
 from utils.tokenize import count_tokens, truncate_to_tokens
-from config import OMNI_RECENT_RESPONSES_MAX, DIALOG_LLM_STREAM_TIMEOUT_SECONDS
+from config import (
+    OMNI_RECENT_RESPONSES_MAX,
+    DIALOG_LLM_STREAM_TIMEOUT_SECONDS,
+    FOCUS_THINKING_EXTRA_TOKENS,
+)
 from main_logic.tool_calling import (
     OnToolCallCallback,
     ToolCall,
@@ -1868,7 +1872,9 @@ class OmniOfflineClient:
         return summary
 
     @staticmethod
-    def _focus_stream_overrides(thinking_on: bool, model: str) -> dict:
+    def _focus_stream_overrides(
+        thinking_on: bool, model: str, base_max_tokens: int | None = None,
+    ) -> dict:
         """Per-call streaming overrides for a Focus turn.
 
         When thinking-on, override extra_body with ``focus_extra_body(model)`` —
@@ -1876,6 +1882,17 @@ class OmniOfflineClient:
         dialect) while PRESERVING non-thinking provider extras (e.g. step-2-mini's
         built-in web_search), which a blunt ``extra_body=None`` would drop.
         Returns ``{}`` (instance default, thinking off) otherwise.
+
+        Also bumps ``max_completion_tokens`` by ``FOCUS_THINKING_EXTRA_TOKENS``
+        on a thinking-on turn: thinking models (Qwen / GLM / Kimi / Doubao /
+        OpenRouter) bill reasoning tokens against the SAME budget as the visible
+        reply, so without headroom the chain-of-thought squeezes the answer
+        short. The bump is layered on ``base_max_tokens`` (the live instance
+        ceiling, already reflecting summary-mode lift / vision-model switch),
+        so it composes with both. ``base_max_tokens=None`` (unlimited budget)
+        omits the field — the request stays uncapped. The Python-side length
+        guard still caps the visible reply at ``max_response_length``; this only
+        gives reasoning its own slack on the API side.
 
         Vision-model turns are included: Focus runs thinking-on regardless of
         whether the turn carries images. The inline streaming timeout
@@ -1886,7 +1903,10 @@ class OmniOfflineClient:
         if not thinking_on:
             return {}
         from config.providers import focus_extra_body
-        return {"extra_body": focus_extra_body(model)}
+        overrides: dict = {"extra_body": focus_extra_body(model)}
+        if base_max_tokens is not None:
+            overrides["max_completion_tokens"] = base_max_tokens + FOCUS_THINKING_EXTRA_TOKENS
+        return overrides
 
     async def stream_text(
         self,
@@ -2155,8 +2175,15 @@ class OmniOfflineClient:
                         # instance's thinking-off extra_body applies. Routed
                         # through the visible (tool-leak-filtered) variant,
                         # which forwards **overrides to ``_astream_with_tools``.
+                        # Also threads a ``max_completion_tokens`` bump
+                        # (+FOCUS_THINKING_EXTRA_TOKENS) so reasoning gets its
+                        # own headroom instead of eating the reply's budget;
+                        # base is the live instance ceiling (already reflects
+                        # summary-mode lift / vision switch), ``None`` stays
+                        # uncapped.
                         _focus_overrides = self._focus_stream_overrides(
                             thinking_on, self.model,
+                            base_max_tokens=self.llm.max_completion_tokens if self.llm else None,
                         )
                         # Focus 凝神: leak-prone models (qwen3.5/3.6/3.7 hybrids)
                         # stream their chain-of-thought into ``content`` ending in

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1884,15 +1884,21 @@ class OmniOfflineClient:
         Returns ``{}`` (instance default, thinking off) otherwise.
 
         Also bumps ``max_completion_tokens`` by ``FOCUS_THINKING_EXTRA_TOKENS``
-        on a thinking-on turn: thinking models (Qwen / GLM / Kimi / Doubao /
-        OpenRouter) bill reasoning tokens against the SAME budget as the visible
-        reply, so without headroom the chain-of-thought squeezes the answer
-        short. The bump is layered on ``base_max_tokens`` (the live instance
-        ceiling, already reflecting summary-mode lift / vision-model switch),
-        so it composes with both. ``base_max_tokens=None`` (unlimited budget)
-        omits the field — the request stays uncapped. The Python-side length
-        guard still caps the visible reply at ``max_response_length``; this only
-        gives reasoning its own slack on the API side.
+        — but ONLY when this turn actually flips thinking ON for the provider:
+        thinking models (Qwen / GLM / Kimi / Doubao / OpenRouter) bill reasoning
+        tokens against the SAME budget as the visible reply, so without headroom
+        the chain-of-thought squeezes the answer short. "Actually on" is detected
+        by ``focus_extra_body(model) != get_extra_body(model)`` — when the focus
+        form equals the regular (thinking-off) extra_body (Claude kept disabled,
+        unknown models → None, non-thinking providers only preserving their
+        non-thinking extras) there is no reasoning to reserve for, and a needless
+        +800 could push a request past a model's output ceiling near the cap /
+        summary floor. The bump is layered on ``base_max_tokens`` (the live
+        instance ceiling, already reflecting summary-mode lift / vision-model
+        switch), so it composes with both. ``base_max_tokens=None`` (unlimited
+        budget) omits the field — the request stays uncapped. The Python-side
+        length guard still caps the visible reply at ``max_response_length``;
+        this only gives reasoning its own slack on the API side.
 
         Vision-model turns are included: Focus runs thinking-on regardless of
         whether the turn carries images. The inline streaming timeout
@@ -1902,9 +1908,21 @@ class OmniOfflineClient:
         """
         if not thinking_on:
             return {}
-        from config.providers import focus_extra_body
-        overrides: dict = {"extra_body": focus_extra_body(model)}
-        if base_max_tokens is not None:
+        from config.providers import focus_extra_body, get_extra_body
+        fb = focus_extra_body(model)
+        overrides: dict = {"extra_body": fb}
+        # Headroom only when Focus actually enables thinking for this provider:
+        # ``fb is None`` ⇒ no thinking-enable override at all (unknown model);
+        # ``fb == get_extra_body(model)`` ⇒ focus form equals the regular
+        # (thinking-off) form (Claude kept disabled, non-thinking providers only
+        # preserving their own extras). Either way there's no reasoning to
+        # reserve for, and a needless +800 could push a request past a model's
+        # output ceiling.
+        if (
+            base_max_tokens is not None
+            and fb is not None
+            and fb != get_extra_body(model)
+        ):
             overrides["max_completion_tokens"] = base_max_tokens + FOCUS_THINKING_EXTRA_TOKENS
         return overrides
 

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -547,6 +547,11 @@ async def test_focus_override_threads_through_visible_stream():
     captured = []
 
     class _FakeLLM:
+        # Mirror the real ChatOpenAI contract: the stream_text call site reads
+        # ``self.llm.max_completion_tokens`` to compute the Focus token bump's
+        # base, so the fake must carry it (else a full-path test AttributeErrors).
+        max_completion_tokens = 500
+
         async def astream(self, messages, **overrides):
             captured.append(overrides)
             return
@@ -576,10 +581,15 @@ async def test_focus_override_threads_through_visible_stream():
     assert "extra_body" not in captured[-1]
 
     # focus turn with a base ceiling: the max_completion_tokens bump must reach
-    # astream too (same per-call path as extra_body)
+    # astream too (same per-call path as extra_body). Read the base off the llm
+    # the SAME way the stream_text call site does, so this also exercises the
+    # ``self.llm.max_completion_tokens`` wiring (not just the helper in isolation).
     from config import FOCUS_THINKING_EXTRA_TOKENS
     c3 = _make_client()
-    overrides3 = OmniOfflineClient._focus_stream_overrides(True, c3.model, base_max_tokens=500)
+    overrides3 = OmniOfflineClient._focus_stream_overrides(
+        True, c3.model,
+        base_max_tokens=c3.llm.max_completion_tokens if c3.llm else None,
+    )
     await _drain(c3._astream_visible_with_tools(["m"], **overrides3))
     assert captured[-1]["max_completion_tokens"] == 500 + FOCUS_THINKING_EXTRA_TOKENS
 

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -476,6 +476,20 @@ def test_focus_stream_overrides_decision():
     # thinking off → no override (vision no longer gates thinking)
     assert _C._focus_stream_overrides(False, "step-2-mini") == {}
 
+    # ── max_completion_tokens bump (reasoning headroom) ──
+    from config import FOCUS_THINKING_EXTRA_TOKENS
+    # thinking-on WITH a base ceiling → bump layered on top, extra_body untouched
+    assert _C._focus_stream_overrides(True, "qwen-flash", base_max_tokens=500) == {
+        "extra_body": {"enable_thinking": True},
+        "max_completion_tokens": 500 + FOCUS_THINKING_EXTRA_TOKENS,
+    }
+    # base None (unlimited budget) → field omitted, request stays uncapped
+    assert "max_completion_tokens" not in _C._focus_stream_overrides(
+        True, "qwen-flash", base_max_tokens=None,
+    )
+    # thinking off → base ignored, no bump (and no extra_body)
+    assert _C._focus_stream_overrides(False, "qwen-flash", base_max_tokens=500) == {}
+
 
 def test_focus_extra_body_provider_dialects():
     """focus_extra_body flips each provider's thinking knob to its ENABLED form
@@ -560,6 +574,14 @@ async def test_focus_override_threads_through_visible_stream():
     c2 = _make_client()
     await _drain(c2._astream_visible_with_tools(["m"], **OmniOfflineClient._focus_stream_overrides(False, c2.model)))
     assert "extra_body" not in captured[-1]
+
+    # focus turn with a base ceiling: the max_completion_tokens bump must reach
+    # astream too (same per-call path as extra_body)
+    from config import FOCUS_THINKING_EXTRA_TOKENS
+    c3 = _make_client()
+    overrides3 = OmniOfflineClient._focus_stream_overrides(True, c3.model, base_max_tokens=500)
+    await _drain(c3._astream_visible_with_tools(["m"], **overrides3))
+    assert captured[-1]["max_completion_tokens"] == 500 + FOCUS_THINKING_EXTRA_TOKENS
 
 
 # ── 6. caller-level Focus gates: charge hygiene + privacy-independence ─────

--- a/tests/unit/test_focus_mode.py
+++ b/tests/unit/test_focus_mode.py
@@ -489,6 +489,15 @@ def test_focus_stream_overrides_decision():
     )
     # thinking off → base ignored, no bump (and no extra_body)
     assert _C._focus_stream_overrides(False, "qwen-flash", base_max_tokens=500) == {}
+    # Headroom only when Focus actually flips thinking ON: Claude is kept
+    # disabled (focus form == regular) → base provided but NO bump…
+    assert _C._focus_stream_overrides(True, "claude-opus-4-7", base_max_tokens=500) == {
+        "extra_body": {"thinking": {"type": "disabled"}}
+    }
+    # …and an unknown model (focus form == regular == None) likewise no bump
+    assert "max_completion_tokens" not in _C._focus_stream_overrides(
+        True, "test-model", base_max_tokens=500,
+    )
 
 
 def test_focus_extra_body_provider_dialects():
@@ -584,8 +593,11 @@ async def test_focus_override_threads_through_visible_stream():
     # astream too (same per-call path as extra_body). Read the base off the llm
     # the SAME way the stream_text call site does, so this also exercises the
     # ``self.llm.max_completion_tokens`` wiring (not just the helper in isolation).
+    # Use a real thinking model (qwen-flash) so the bump is actually emitted —
+    # "test-model" resolves to a no-op focus form and (by design) gets no bump.
     from config import FOCUS_THINKING_EXTRA_TOKENS
     c3 = _make_client()
+    c3.model = "qwen-flash"
     overrides3 = OmniOfflineClient._focus_stream_overrides(
         True, c3.model,
         base_max_tokens=c3.llm.max_completion_tokens if c3.llm else None,


### PR DESCRIPTION
## 背景

凝神（focus / thinking-on）轮次会在主对话那次 LLM 调用上开启 provider 的 thinking。但 thinking 模型（Qwen `enable_thinking` / GLM·Kimi·Doubao `thinking.type` / OpenRouter `reasoning.effort`）的 reasoning token **与正式回复共用同一个 `max_completion_tokens` 预算池**（见 `docs/design/llm-prompt-budget.md` §0），一开思考就从回复额度里扣，把正式回复挤短。

此前 `_focus_stream_overrides` 只翻了 `extra_body`（thinking 开关），没给推理链留头寸。

## 改动

仅在 `thinking_on` 的那一轮，把 API 端 `max_completion_tokens` 在**当前实例上限**（`max_response_length + slack`，已含 summary-mode 抬升 / vision 切模型后的值）基础上 `+FOCUS_THINKING_EXTRA_TOKENS(800)`，给 reasoning 单独留头寸。

- **路由**：作为 per-call override 经 `_focus_stream_overrides` → `astream` → `ChatOpenAI._params` 透传（与 `extra_body` 同一条 per-call 路径），**不改 `self.llm` 实例属性**——并发安全、下一轮不传自动复位，避免 summary-mode 那种 snapshot/restore 风险。
- **可见回复长度不变**：Python-side 长度 guard 仍按 `max_response_length` 收口，+800 只在 API 侧给推理留空间。
- **无限制预算**（base 为 `None`）时省略字段，请求保持无上限。

## 适用面

- **Claude**：凝神保持 thinking-off（`config/providers.py`），本加值天然 no-op。
- **Gemini**：`thinking_budget` 是独立字段（focus 下 800），本余量也覆盖；genai 原生路径读实例属性、不经 per-call override，留它对的（focus 在那本就 no-op）。
- 语音/realtime（`OmniRealtimeClient`）无 focus thinking，未触及。

## 回归报告

**改动内容**：新增 `config.FOCUS_THINKING_EXTRA_TOKENS=800`；`OmniOfflineClient._focus_stream_overrides` 增加 `base_max_tokens` 参数，在 `thinking_on` 且 base 非 `None` 时往返回的 per-call override dict 里加 `max_completion_tokens = base + 800`；调用点（`stream_text` 主对话循环）传入 `self.llm.max_completion_tokens` 活上限。

**理由/必要性**：凝神 thinking-on 的轮次里，reasoning token 与正式回复共享 `max_completion_tokens` 预算（OpenAI-compat thinking 模型），导致思考越多正式回复被截得越短——这是用户实际反馈的体感问题。给 thinking 单独留 800 token 头寸即可缓解。

**改动前后行为**：
- 改动前：凝神轮 `max_completion_tokens = max_response_length + 20(slack)`，reasoning 与回复抢同一池子。
- 改动后：凝神轮 `max_completion_tokens = (max_response_length + 20) + 800`，仅 API 侧抬高；可见回复仍由 Python-side 长度 guard 按 `max_response_length` 收口，长度不变，只是回复不再被 thinking 挤掉。
- 非凝神轮、Claude（thinking 保持 off）、无限制预算（base=None）三种情况均与改动前**逐字节一致**。

**潜在回归**：
- per-call override 经既有 `**overrides` 链透传到 `astream`/`_params`（已有单测覆盖），不碰 `self.llm` 实例属性，无并发污染、无需 snapshot/restore，下一轮不传即复位。
- 与 summary-mode 抬升正交：读的是 `self.llm` 活上限，summary 抬升后 base 已含抬升值，+800 叠加其上，不冲突。
- genai 原生路径（`_astream_genai_with_tools`）读实例属性、不消费 per-call override，故该路径行为不变（且 focus 对 genai 本就 no-op，Gemini thinking_budget 独立且 ≤800）；如未来想给 genai 也留头寸需单独处理。
- 风险面仅限单次 stream_text 调用的输出上限，不影响输入 budget / 归档 / 工具循环 / TTS 链路。

## 文件

- `config/__init__.py` §3.7：新增 `FOCUS_THINKING_EXTRA_TOKENS=800` + `__all__`
- `main_logic/omni_offline_client.py`：`_focus_stream_overrides` 加 `base_max_tokens` 参数 + token bump，调用点传 `self.llm` 活上限
- `tests/unit/test_focus_mode.py`：补 +800 行为断言 + astream 透传断言
- `docs/design/llm-prompt-budget.md` §5：登记叠加值说明

## 验证

- `pytest tests/unit/test_focus_mode.py`：新增 3 处断言全过（既有失败 `test_inline_gate_user_setting_default_on_allows` 与本 PR 无关，在干净 HEAD 上同样失败，疑似已由 origin/main 领先的提交修复）
- `scripts/check_llm_budget.py`：无违规（per-call override 本就豁免）
- `scripts/check_docstring_no_cjk.py`：exit 0
- `test_focus_indicator_bridge.py` + `test_check_llm_budget.py`：34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 凝神/思考模式下会自动预留额外的输出预算，减少推理过程挤占正常回复长度的问题。
* **Bug 修复**
  * 在不同调用场景中，更准确地沿用当前回复预算，避免输出长度异常受限。
  * 关闭思考模式时，不再额外应用这部分预算调整。
* **文档**
  * 更新了相关预算说明，补充不同模型与模式下的行为差异。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->