### PR TITLE
perf(activity): adaptive backoff for the activity_guess idle burn

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1007,6 +1007,15 @@ EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES = 5           # 或空闲 N 分钟触发
 EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS = 40      # 轮询间隔（与 IDLE_CHECK_INTERVAL 对齐）
 EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS = 30    # Stage-2 LLM rerank 后进 prompt 的 obs 上限（减少 NxM 配对决策点）
 
+# ── activity_guess 自适应退避门控 ──────────────────────────────────────
+# 活动心跳 (main_logic/activity/tracker.py:_activity_guess_loop) 通过 emotion-tier
+# LLM 把"用户在干嘛"叙述出来，只喂 proactive 搭话 prompt。这组旋钮约束「活动没
+# 实质变化时」它多久刷一次——用户在两个 app 间来回切窗口曾让它每 ~40s 烧一次
+# (静默, 无业务日志) 无限持续。详见 main_logic/activity/activity_guess_gate.py。
+ACTIVITY_GUESS_BACKOFF_BASE_SECONDS = 30.0   # 两次调用之间的硬地板 + 首次重述间隔
+ACTIVITY_GUESS_BACKOFF_CAP_SECONDS = 600.0   # 活动稳定后重述间隔的封顶
+ACTIVITY_GUESS_SIG_CACHE_SIZE = 8            # 退避记忆的「不同活动签名」条数
+
 # ── AI-aware Stage-1 (path B) ─────────────────────────────────────────
 # 原 SignalLoop (path A) 只看 user 消息，导致 PR #1346 之后 AI 自我披露 + proactive
 # 引入的屏幕/活动上下文全失明。Path B 走每 N 个 A tick 触发一次的 piggyback
@@ -2422,6 +2431,9 @@ __all__ = [
     'EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS',
     'EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS',
     'EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS',
+    'ACTIVITY_GUESS_BACKOFF_BASE_SECONDS',
+    'ACTIVITY_GUESS_BACKOFF_CAP_SECONDS',
+    'ACTIVITY_GUESS_SIG_CACHE_SIZE',
     'PERSONA_RENDER_MAX_TOKENS',
     'REFLECTION_RENDER_MAX_TOKENS',
     'PERSONA_RENDER_ENCODING',

--- a/main_logic/activity/activity_guess_gate.py
+++ b/main_logic/activity/activity_guess_gate.py
@@ -32,7 +32,9 @@ re-describes the same two activities over and over.
 
 What this gate changes
 ----------------------
-The refresh interval becomes *adaptive to how novel the activity is*:
+The refresh interval becomes *adaptive to how novel the activity is*. Everything
+the gate tracks is keyed PER SIGNATURE so a one-off excursion never disturbs a
+separate signature's state:
 
 * **Coarsened signature** — callers pass ``(state, window-category)`` instead of
   the exact app, so flicking between two same-category apps is a no-op and even
@@ -43,29 +45,33 @@ The refresh interval becomes *adaptive to how novel the activity is*:
   already-narrated signatures therefore decays from "every BASE" toward "every
   CAP", and a one-off new activity does NOT reset the backoff a separate,
   still-oscillating signature has accumulated.
-* **Novelty bypass** — a signature not in the small recently-narrated cache, or a
-  new conversation turn (``conv_seq`` advanced), fires immediately and restarts
-  that signature's backoff. Switching to a genuinely different activity
-  (work → game) re-narrates at once; only re-describing the *same* activity backs
-  off.
+* **Novelty / freshness bypass** — a signature not in the small recently-narrated
+  cache, or one whose cached narration was built under an OLDER conversation turn
+  (``conv_seq``), fires immediately and restarts that signature's backoff. The
+  conversation seq is stored per signature, so a new turn refreshes *every*
+  cached activity when it is next visited — not just the first one re-narrated.
+  Switching to a genuinely different (or conversation-stale) activity re-narrates
+  at once; only re-describing the *same* activity under the *same* conversation
+  backs off.
 
 Per-signature narration cache
 -----------------------------
-The gate also stores the last narration (scores + guess text) **per signature**,
-not as one global slot. This is what keeps "staleness never makes it wrong"
-honest: when the backoff suppresses a re-narration, the consumer asks
-``cached(current_signature)`` and gets the narration for *the activity the user
-is in right now* — never a leftover narration for whichever signature happened to
-fire last. (Within a coarse bucket the narration stays at category granularity by
-design — two same-category apps share one entry; the exact app/title is carried
-by other snapshot fields, not this hint.)
+The gate also stores the last narration (scores + guess text) **per signature**.
+This is what keeps "staleness never makes it wrong" honest: when the backoff
+suppresses a re-narration, the consumer asks ``cached(current_signature)`` and
+gets the narration for *the activity the user is in right now* — never a leftover
+narration for whichever signature happened to fire last. (Within a coarse bucket
+the narration stays at category granularity by design — two same-category apps
+share one entry; the exact app/title is carried by other snapshot fields, not
+this hint.)
 
 The hard ``BASE`` floor is always respected (no two calls closer than ``BASE``),
-preserving the old anti-thrash guarantee during rapid flicker. The novelty check
-deliberately sits *above* the backoff interval so a genuinely new activity is
-never delayed by a grown interval — the cap only governs re-narrating something
-already seen. ``record_fired`` is called only after a narration LLM call actually
-succeeds, so failed/discarded calls do not advance the backoff or the cache.
+preserving the old anti-thrash guarantee during rapid flicker. The novelty/
+freshness checks deliberately sit *above* the backoff interval so a genuinely new
+or conversation-stale activity is never delayed by a grown interval — the cap
+only governs re-narrating something already seen under the current conversation.
+``record_fired`` is called only after a narration LLM call actually succeeds, so
+failed/discarded calls do not advance the backoff or the cache.
 """
 
 from __future__ import annotations
@@ -101,14 +107,15 @@ class ActivityGuessGate:
         # base <= 0 would zero out the floor and the ``2**streak`` interval.)
         self._cap = max(float(cap_seconds), self._base)
         self._cache_size = max(1, int(cache_size))
-        # signature -> (last_fire_ts, streak, scores, guess), LRU (most-recently
-        # fired at the end). The streak AND the narration are stored PER
-        # SIGNATURE: a one-off novel activity never resets a separate signature's
-        # backoff, and the consumer always reads the narration matching the
-        # current activity rather than whichever signature fired last.
-        self._narrated: "OrderedDict[Hashable, tuple[float, int, dict, str]]" = OrderedDict()
+        # signature -> (last_fire_ts, streak, conv_seq, scores, guess), LRU
+        # (most-recently fired at the end). Streak, the conversation seq, AND the
+        # narration are all stored PER SIGNATURE: a one-off novel activity (or a
+        # new conversation turn consumed by another signature) never disturbs a
+        # separate signature's backoff, freshness, or cached guess.
+        self._narrated: "OrderedDict[Hashable, tuple[float, int, int, dict, str]]" = OrderedDict()
+        # Global only for the hard anti-thrash floor (no two LLM calls closer
+        # than BASE, regardless of which signature).
         self._last_fire_ts: float | None = None
-        self._last_fire_conv_seq: int | None = None
         # Cap the per-signature streak so ``base * 2**streak`` can't grow without
         # bound — once the interval reaches CAP, a larger streak changes nothing.
         self._max_streak = 0
@@ -117,13 +124,6 @@ class ActivityGuessGate:
             eff *= 2
             self._max_streak += 1
 
-    def _conv_advanced(self, conv_seq: int) -> bool:
-        """A new conversation turn since the last fire is itself fresh context."""
-        return (
-            self._last_fire_conv_seq is not None
-            and conv_seq != self._last_fire_conv_seq
-        )
-
     def should_fire(self, sig: Hashable, conv_seq: int, now: float) -> bool:
         # Hard floor: never two calls closer than BASE — even on novelty or a new
         # conversation turn (preserves the old anti-thrash behaviour during rapid
@@ -131,11 +131,12 @@ class ActivityGuessGate:
         if self._last_fire_ts is not None and now - self._last_fire_ts < self._base:
             return False
         rec = self._narrated.get(sig)
-        if rec is None or self._conv_advanced(conv_seq):
-            # Genuinely new activity, or new conversation → refresh immediately,
+        if rec is None or rec[2] != conv_seq:
+            # Genuinely new activity, or this signature's cached narration was
+            # built under an older conversation turn → refresh immediately,
             # bypassing whatever backoff this signature had accumulated.
             return True
-        # Same activity, no new conversation → re-narrate only after this
+        # Same activity, same conversation → re-narrate only after this
         # signature's own grown interval has elapsed.
         last_ts, streak = rec[0], rec[1]
         return (now - last_ts) >= min(self._base * (2 ** streak), self._cap)
@@ -148,21 +149,20 @@ class ActivityGuessGate:
         scores: dict | None = None,
         guess: str = '',
     ) -> None:
-        """Record a *successful* narration; advances THIS signature's backoff
-        and stores its narration (scores + guess) for ``cached`` to serve."""
+        """Record a *successful* narration; advances THIS signature's backoff,
+        stamps its conversation seq, and stores its narration for ``cached``."""
         rec = self._narrated.get(sig)
-        if rec is None or self._conv_advanced(conv_seq):
+        if rec is None or rec[2] != conv_seq:
             # New signature (or evicted), or fresh conversation context → restart
             # this signature's backoff at streak 0. Other signatures are untouched.
             streak = 0
         else:
             streak = min(rec[1] + 1, self._max_streak)
-        self._narrated[sig] = (now, streak, scores if scores is not None else {}, guess)
+        self._narrated[sig] = (now, streak, conv_seq, scores if scores is not None else {}, guess)
         self._narrated.move_to_end(sig)
         while len(self._narrated) > self._cache_size:
             self._narrated.popitem(last=False)
         self._last_fire_ts = now
-        self._last_fire_conv_seq = conv_seq
 
     def cached(self, sig: Hashable) -> tuple[dict, str]:
         """The last narration recorded for ``sig`` as ``(scores, guess)``.
@@ -174,4 +174,4 @@ class ActivityGuessGate:
         rec = self._narrated.get(sig)
         if rec is None:
             return {}, ''
-        return rec[2], rec[3]
+        return rec[3], rec[4]

--- a/main_logic/activity/activity_guess_gate.py
+++ b/main_logic/activity/activity_guess_gate.py
@@ -1,0 +1,138 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adaptive-backoff gate for the ``activity_guess`` emotion-tier loop.
+
+Pure decision logic, extracted from ``UserActivityTracker._activity_guess_loop``
+so the firing policy can be unit-tested without spinning up the tracker, the
+collector, or a live LLM (same split rationale as ``focus_scorer.py``).
+
+Problem it solves
+-----------------
+The activity heartbeat re-narrates "what the user is doing" via an emotion-tier
+LLM call, consumed only by the proactive-chat prompt. The narration is silent
+(no business log), so the only visible trace is an httpx POST every ~40s. The
+old gate fired whenever the ``(state, exact-app, subcategory)`` signature
+changed, throttled solely by a flat 30s floor. A user flicking between two apps
+(e.g. an IM window and a browser) flips that signature on every switch, so the
+floor lets one LLM call through every ~40s indefinitely — pure idle burn that
+re-describes the same two activities over and over.
+
+What this gate changes
+----------------------
+The refresh interval becomes *adaptive to how novel the activity is*:
+
+* **Coarsened signature** — callers pass ``(state, window-category)`` instead of
+  the exact app, so flicking between two same-category apps is a no-op and even
+  cross-category flicker only registers at the category level.
+* **Per-signature exponential backoff** — each distinct signature is re-narrated
+  on an interval that grows while the recent activity set stays stable (no
+  genuinely new signature): ``BASE → 2·BASE → …`` capped at ``CAP``. Oscillating
+  between already-narrated signatures therefore decays from "every BASE" toward
+  "every CAP".
+* **Novelty bypass** — a signature not in the small recently-narrated cache, or a
+  new conversation turn (``conv_seq`` advanced), fires immediately and resets the
+  backoff. Switching to a genuinely different activity (work → game) re-narrates
+  at once; only re-describing the *same* activities backs off. Because staleness
+  only ever accrues on an activity that hasn't changed, the proactive prompt
+  never reads a narration that is wrong — just one that is unchanged.
+
+The hard ``BASE`` floor is always respected (no two calls closer than ``BASE``),
+preserving the old anti-thrash guarantee during rapid flicker. The novelty check
+deliberately sits *above* the backoff interval so a genuinely new activity is
+never delayed by a grown interval — the cap only governs re-narrating something
+already seen.
+
+This object is **decision-only**: it owns no clock and performs no I/O. The
+tracker passes ``now`` (monotonic-ish wall time) and calls ``record_fired`` only
+after a narration LLM call actually succeeds, so failed/discarded calls do not
+advance the backoff.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Hashable
+
+
+class ActivityGuessGate:
+    """Decide whether the activity_guess loop should issue an LLM call this tick.
+
+    Usage (per tick, after the loop's privacy/away/proactive/goodbye bails)::
+
+        if not gate.should_fire(sig, conv_seq, now):
+            continue
+        ... run the emotion-tier LLM, guard against conv_seq advancing ...
+        gate.record_fired(sig, conv_seq, now)   # only on success
+    """
+
+    def __init__(self, *, base_seconds: float, cap_seconds: float, cache_size: int):
+        if base_seconds <= 0:
+            raise ValueError('base_seconds must be > 0')
+        self._base = float(base_seconds)
+        # A cap below base is meaningless; clamp so the interval is always >= base.
+        self._cap = max(float(cap_seconds), self._base)
+        self._cache_size = max(1, int(cache_size))
+        # signature -> last fire timestamp (LRU; most-recently fired at the end).
+        self._narrated: "OrderedDict[Hashable, float]" = OrderedDict()
+        # Consecutive non-novel fires; grows the backoff interval, reset by novelty.
+        self._streak = 0
+        self._last_fire_ts: float | None = None
+        self._last_fire_conv_seq: int | None = None
+        # Cap the streak so ``base * 2**streak`` can't grow without bound — once
+        # the interval reaches CAP, a larger streak changes nothing.
+        self._max_streak = 0
+        eff = self._base
+        while eff < self._cap and self._max_streak < 32:
+            eff *= 2
+            self._max_streak += 1
+
+    def _conv_advanced(self, conv_seq: int) -> bool:
+        """A new conversation turn since the last fire is itself fresh context."""
+        return (
+            self._last_fire_conv_seq is not None
+            and conv_seq != self._last_fire_conv_seq
+        )
+
+    def _effective_interval(self) -> float:
+        return min(self._base * (2 ** self._streak), self._cap)
+
+    def should_fire(self, sig: Hashable, conv_seq: int, now: float) -> bool:
+        # Hard floor: never two calls closer than BASE — even on novelty or a new
+        # conversation turn (preserves the old anti-thrash behaviour during rapid
+        # window flicker).
+        if self._last_fire_ts is not None and now - self._last_fire_ts < self._base:
+            return False
+        last_ts = self._narrated.get(sig)
+        if last_ts is None or self._conv_advanced(conv_seq):
+            # Genuinely new activity, or new conversation → refresh immediately,
+            # bypassing whatever backoff the stable period had accumulated.
+            return True
+        # Same activity, no new conversation → re-narrate only after the grown
+        # interval has elapsed for this signature.
+        return (now - last_ts) >= self._effective_interval()
+
+    def record_fired(self, sig: Hashable, conv_seq: int, now: float) -> None:
+        """Record a *successful* narration; advances backoff + the LRU cache."""
+        is_novel = (sig not in self._narrated) or self._conv_advanced(conv_seq)
+        if is_novel:
+            self._streak = 0
+        else:
+            self._streak = min(self._streak + 1, self._max_streak)
+        self._narrated[sig] = now
+        self._narrated.move_to_end(sig)
+        while len(self._narrated) > self._cache_size:
+            self._narrated.popitem(last=False)
+        self._last_fire_ts = now
+        self._last_fire_conv_seq = conv_seq

--- a/main_logic/activity/activity_guess_gate.py
+++ b/main_logic/activity/activity_guess_gate.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Adaptive-backoff gate for the ``activity_guess`` emotion-tier loop.
+"""Adaptive-backoff gate + per-signature narration cache for ``activity_guess``.
 
-Pure decision logic, extracted from ``UserActivityTracker._activity_guess_loop``
+Pure data/decision logic, extracted from ``UserActivityTracker._activity_guess_loop``
 so the firing policy can be unit-tested without spinning up the tracker, the
-collector, or a live LLM (same split rationale as ``focus_scorer.py``).
+collector, or a live LLM (same split rationale as ``focus_scorer.py``). It owns
+no clock and performs no I/O — the tracker passes ``now``.
 
 Problem it solves
 -----------------
@@ -36,28 +37,35 @@ The refresh interval becomes *adaptive to how novel the activity is*:
 * **Coarsened signature** — callers pass ``(state, window-category)`` instead of
   the exact app, so flicking between two same-category apps is a no-op and even
   cross-category flicker only registers at the category level.
-* **Per-signature exponential backoff** — each distinct signature is re-narrated
-  on an interval that grows while the recent activity set stays stable (no
-  genuinely new signature): ``BASE → 2·BASE → …`` capped at ``CAP``. Oscillating
-  between already-narrated signatures therefore decays from "every BASE" toward
-  "every CAP".
+* **Per-signature exponential backoff** — each distinct signature carries its
+  OWN streak and is re-narrated on an interval that grows with each of *its*
+  re-narrations: ``BASE → 2·BASE → …`` capped at ``CAP``. Oscillating between
+  already-narrated signatures therefore decays from "every BASE" toward "every
+  CAP", and a one-off new activity does NOT reset the backoff a separate,
+  still-oscillating signature has accumulated.
 * **Novelty bypass** — a signature not in the small recently-narrated cache, or a
-  new conversation turn (``conv_seq`` advanced), fires immediately and resets the
-  backoff. Switching to a genuinely different activity (work → game) re-narrates
-  at once; only re-describing the *same* activities backs off. Because staleness
-  only ever accrues on an activity that hasn't changed, the proactive prompt
-  never reads a narration that is wrong — just one that is unchanged.
+  new conversation turn (``conv_seq`` advanced), fires immediately and restarts
+  that signature's backoff. Switching to a genuinely different activity
+  (work → game) re-narrates at once; only re-describing the *same* activity backs
+  off.
+
+Per-signature narration cache
+-----------------------------
+The gate also stores the last narration (scores + guess text) **per signature**,
+not as one global slot. This is what keeps "staleness never makes it wrong"
+honest: when the backoff suppresses a re-narration, the consumer asks
+``cached(current_signature)`` and gets the narration for *the activity the user
+is in right now* — never a leftover narration for whichever signature happened to
+fire last. (Within a coarse bucket the narration stays at category granularity by
+design — two same-category apps share one entry; the exact app/title is carried
+by other snapshot fields, not this hint.)
 
 The hard ``BASE`` floor is always respected (no two calls closer than ``BASE``),
 preserving the old anti-thrash guarantee during rapid flicker. The novelty check
 deliberately sits *above* the backoff interval so a genuinely new activity is
 never delayed by a grown interval — the cap only governs re-narrating something
-already seen.
-
-This object is **decision-only**: it owns no clock and performs no I/O. The
-tracker passes ``now`` (monotonic-ish wall time) and calls ``record_fired`` only
-after a narration LLM call actually succeeds, so failed/discarded calls do not
-advance the backoff.
+already seen. ``record_fired`` is called only after a narration LLM call actually
+succeeds, so failed/discarded calls do not advance the backoff or the cache.
 """
 
 from __future__ import annotations
@@ -67,31 +75,42 @@ from collections.abc import Hashable
 
 
 class ActivityGuessGate:
-    """Decide whether the activity_guess loop should issue an LLM call this tick.
+    """Per-signature activity-narration cache with adaptive backoff.
 
     Usage (per tick, after the loop's privacy/away/proactive/goodbye bails)::
 
         if not gate.should_fire(sig, conv_seq, now):
             continue
-        ... run the emotion-tier LLM, guard against conv_seq advancing ...
-        gate.record_fired(sig, conv_seq, now)   # only on success
+        result = await run_emotion_tier_llm(...)         # guard conv_seq advance
+        gate.record_fired(sig, conv_seq, now, scores, guess)   # only on success
+
+    and at snapshot time the consumer reads the narration for the *current*
+    activity::
+
+        scores, guess = gate.cached(current_sig)
     """
 
     def __init__(self, *, base_seconds: float, cap_seconds: float, cache_size: int):
         if base_seconds <= 0:
             raise ValueError('base_seconds must be > 0')
         self._base = float(base_seconds)
-        # A cap below base is meaningless; clamp so the interval is always >= base.
+        # ``cap`` is a soft ceiling, not load-bearing like ``base``: a bad value
+        # (0 / negative / below base) is clamped up to ``base`` rather than
+        # raising, so a misconfigured config knob degrades to "no backoff beyond
+        # base" instead of crashing tracker/session init. (``base`` must raise —
+        # base <= 0 would zero out the floor and the ``2**streak`` interval.)
         self._cap = max(float(cap_seconds), self._base)
         self._cache_size = max(1, int(cache_size))
-        # signature -> last fire timestamp (LRU; most-recently fired at the end).
-        self._narrated: "OrderedDict[Hashable, float]" = OrderedDict()
-        # Consecutive non-novel fires; grows the backoff interval, reset by novelty.
-        self._streak = 0
+        # signature -> (last_fire_ts, streak, scores, guess), LRU (most-recently
+        # fired at the end). The streak AND the narration are stored PER
+        # SIGNATURE: a one-off novel activity never resets a separate signature's
+        # backoff, and the consumer always reads the narration matching the
+        # current activity rather than whichever signature fired last.
+        self._narrated: "OrderedDict[Hashable, tuple[float, int, dict, str]]" = OrderedDict()
         self._last_fire_ts: float | None = None
         self._last_fire_conv_seq: int | None = None
-        # Cap the streak so ``base * 2**streak`` can't grow without bound — once
-        # the interval reaches CAP, a larger streak changes nothing.
+        # Cap the per-signature streak so ``base * 2**streak`` can't grow without
+        # bound — once the interval reaches CAP, a larger streak changes nothing.
         self._max_streak = 0
         eff = self._base
         while eff < self._cap and self._max_streak < 32:
@@ -105,34 +124,54 @@ class ActivityGuessGate:
             and conv_seq != self._last_fire_conv_seq
         )
 
-    def _effective_interval(self) -> float:
-        return min(self._base * (2 ** self._streak), self._cap)
-
     def should_fire(self, sig: Hashable, conv_seq: int, now: float) -> bool:
         # Hard floor: never two calls closer than BASE — even on novelty or a new
         # conversation turn (preserves the old anti-thrash behaviour during rapid
         # window flicker).
         if self._last_fire_ts is not None and now - self._last_fire_ts < self._base:
             return False
-        last_ts = self._narrated.get(sig)
-        if last_ts is None or self._conv_advanced(conv_seq):
+        rec = self._narrated.get(sig)
+        if rec is None or self._conv_advanced(conv_seq):
             # Genuinely new activity, or new conversation → refresh immediately,
-            # bypassing whatever backoff the stable period had accumulated.
+            # bypassing whatever backoff this signature had accumulated.
             return True
-        # Same activity, no new conversation → re-narrate only after the grown
-        # interval has elapsed for this signature.
-        return (now - last_ts) >= self._effective_interval()
+        # Same activity, no new conversation → re-narrate only after this
+        # signature's own grown interval has elapsed.
+        last_ts, streak = rec[0], rec[1]
+        return (now - last_ts) >= min(self._base * (2 ** streak), self._cap)
 
-    def record_fired(self, sig: Hashable, conv_seq: int, now: float) -> None:
-        """Record a *successful* narration; advances backoff + the LRU cache."""
-        is_novel = (sig not in self._narrated) or self._conv_advanced(conv_seq)
-        if is_novel:
-            self._streak = 0
+    def record_fired(
+        self,
+        sig: Hashable,
+        conv_seq: int,
+        now: float,
+        scores: dict | None = None,
+        guess: str = '',
+    ) -> None:
+        """Record a *successful* narration; advances THIS signature's backoff
+        and stores its narration (scores + guess) for ``cached`` to serve."""
+        rec = self._narrated.get(sig)
+        if rec is None or self._conv_advanced(conv_seq):
+            # New signature (or evicted), or fresh conversation context → restart
+            # this signature's backoff at streak 0. Other signatures are untouched.
+            streak = 0
         else:
-            self._streak = min(self._streak + 1, self._max_streak)
-        self._narrated[sig] = now
+            streak = min(rec[1] + 1, self._max_streak)
+        self._narrated[sig] = (now, streak, scores if scores is not None else {}, guess)
         self._narrated.move_to_end(sig)
         while len(self._narrated) > self._cache_size:
             self._narrated.popitem(last=False)
         self._last_fire_ts = now
         self._last_fire_conv_seq = conv_seq
+
+    def cached(self, sig: Hashable) -> tuple[dict, str]:
+        """The last narration recorded for ``sig`` as ``(scores, guess)``.
+
+        Returns ``({}, '')`` when this signature has never been narrated (or was
+        evicted) — an honest "no narration yet" rather than a leftover narration
+        for a different activity. The caller should copy ``scores`` before
+        exposing it (the stored dict is shared)."""
+        rec = self._narrated.get(sig)
+        if rec is None:
+            return {}, ''
+        return rec[2], rec[3]

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -265,14 +265,14 @@ class UserActivityTracker:
         self._open_threads_computed_at_seq: int = -1
         self._open_threads_task: asyncio.Task | None = None
 
-        # activity_guess cache + adaptive-backoff gate. The gate decides when
-        # the heartbeat may pay for an emotion-tier narration call: a coarse
-        # (state, window-category) signature with per-signature exponential
-        # backoff and a novelty bypass (see ActivityGuessGate). Replaces the
-        # old flat 30s floor + exact-app signature, which let window flicker
-        # burn one (silent) call every ~40s. The caches hold the last result.
-        self._activity_scores_cache: dict[str, float] = {}
-        self._activity_guess_cache: str = ''
+        # adaptive-backoff gate + per-signature narration cache. The gate
+        # decides when the heartbeat may pay for an emotion-tier narration call
+        # (coarse (state, window-category) signature, per-signature exponential
+        # backoff, novelty bypass — see ActivityGuessGate) AND stores the last
+        # narration per signature, so get_snapshot always serves the narration
+        # for the activity the user is in right now. Replaces the old flat 30s
+        # floor + exact-app signature + single global narration cache, which let
+        # window flicker burn one (silent) call every ~40s.
         self._activity_guess_gate = ActivityGuessGate(
             base_seconds=ACTIVITY_GUESS_BACKOFF_BASE_SECONDS,
             cap_seconds=ACTIVITY_GUESS_BACKOFF_CAP_SECONDS,
@@ -549,10 +549,18 @@ class UserActivityTracker:
         # Patch in emotion-tier enrichment caches. ``snap`` is a frozen
         # dataclass; ``replace`` returns a new instance without mutating
         # the original. Callers always get a self-consistent snapshot.
+        # Serve the narration for the activity the user is in RIGHT NOW, not
+        # whichever signature fired last: with the per-signature backoff a
+        # re-narration can be suppressed, so a single global slot could hand the
+        # proactive prompt a narration for a different activity. cached() returns
+        # ('', {}) for a not-yet-narrated signature — honest, not stale-wrong.
+        cur_scores, cur_guess = self._activity_guess_gate.cached(
+            self._coarse_activity_sig(snap)
+        )
         return dc_replace(
             snap,
-            activity_scores=dict(self._activity_scores_cache),
-            activity_guess=self._activity_guess_cache,
+            activity_scores=dict(cur_scores),
+            activity_guess=cur_guess,
             open_threads=list(self._open_threads_cache),
             work_break_pending=self._build_work_break_pending(),
             anti_slack_pending=self._build_anti_slack_pending(),
@@ -590,10 +598,18 @@ class UserActivityTracker:
                 work_break_pending=None,
                 anti_slack_pending=None,
             )
+        # Serve the narration for the activity the user is in RIGHT NOW, not
+        # whichever signature fired last: with the per-signature backoff a
+        # re-narration can be suppressed, so a single global slot could hand the
+        # proactive prompt a narration for a different activity. cached() returns
+        # ('', {}) for a not-yet-narrated signature — honest, not stale-wrong.
+        cur_scores, cur_guess = self._activity_guess_gate.cached(
+            self._coarse_activity_sig(snap)
+        )
         return dc_replace(
             snap,
-            activity_scores=dict(self._activity_scores_cache),
-            activity_guess=self._activity_guess_cache,
+            activity_scores=dict(cur_scores),
+            activity_guess=cur_guess,
             open_threads=list(self._open_threads_cache),
             work_break_pending=self._build_work_break_pending(),
             anti_slack_pending=self._build_anti_slack_pending(),
@@ -1065,6 +1081,21 @@ class UserActivityTracker:
 
     # ── activity_guess background loop ──────────────────────────
 
+    @staticmethod
+    def _coarse_activity_sig(snap: ActivitySnapshot) -> tuple:
+        """Coarse ``(state, window-category)`` key for the activity_guess gate.
+
+        Deliberately coarser than the exact app: flicking between two
+        same-category apps (two IM clients, two browsers) is the same activity
+        as far as the narration is concerned, so it must not re-narrate. Shared
+        by the heartbeat loop (deciding when to fire) and ``get_snapshot``
+        (reading the narration for the current activity), so both agree on the
+        key for the same snapshot."""
+        return (
+            snap.state,
+            snap.active_window.category if snap.active_window else None,
+        )
+
     async def _activity_guess_loop(self) -> None:
         """20s tick. Recomputes activity_guess when the activity is fresh.
 
@@ -1178,11 +1209,7 @@ class UserActivityTracker:
                 # fires now. The narration only describes *what* the user is
                 # doing, so a stale narration of an unchanged activity is still
                 # accurate — staleness never makes it wrong. See ActivityGuessGate.
-                coarse_sig = (
-                    rule_snap.state,
-                    (rule_snap.active_window.category
-                        if rule_snap.active_window else None),
-                )
+                coarse_sig = self._coarse_activity_sig(rule_snap)
                 if not self._activity_guess_gate.should_fire(
                     coarse_sig, self._conv_seq, ts,
                 ):
@@ -1215,9 +1242,11 @@ class UserActivityTracker:
                         self.lanlan_name, seen_conv_seq, self._conv_seq,
                     )
                     continue
-                self._activity_scores_cache = result.get('scores', {}) or {}
-                self._activity_guess_cache = result.get('guess', '') or ''
-                self._activity_guess_gate.record_fired(coarse_sig, seen_conv_seq, ts)
+                self._activity_guess_gate.record_fired(
+                    coarse_sig, seen_conv_seq, ts,
+                    scores=result.get('scores', {}) or {},
+                    guess=result.get('guess', '') or '',
+                )
             except asyncio.CancelledError:
                 return
             except Exception as e:

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -65,6 +65,12 @@ from main_logic.activity.system_signals import (
     SystemSignalCollector, SystemSnapshot, get_system_signal_collector,
 )
 from utils.activity_config import get_activity_preferences
+from main_logic.activity.activity_guess_gate import ActivityGuessGate
+from config import (
+    ACTIVITY_GUESS_BACKOFF_BASE_SECONDS,
+    ACTIVITY_GUESS_BACKOFF_CAP_SECONDS,
+    ACTIVITY_GUESS_SIG_CACHE_SIZE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +85,9 @@ _CONV_BUFFER_MAXLEN = 12
 # up when activity is actually shifting.
 _ACTIVITY_GUESS_TICK_SECONDS = 20.0
 
-# After computing activity_guess, suppress recompute for at least this
-# long even if signature changes — protects against thrashing during
-# rapid window flicker (a 30s minimum interval between LLM calls).
-_ACTIVITY_GUESS_MIN_REFRESH_SECONDS = 30.0
+# The per-call minimum-interval floor + adaptive re-narrate backoff now live in
+# ActivityGuessGate (configured via ACTIVITY_GUESS_BACKOFF_* in config); see
+# main_logic/activity/activity_guess_gate.py. The old flat 30s floor is gone.
 
 # Frontend-pushed external signals are considered fresh for this many
 # seconds. After that the tracker falls back to the local collector
@@ -260,14 +265,19 @@ class UserActivityTracker:
         self._open_threads_computed_at_seq: int = -1
         self._open_threads_task: asyncio.Task | None = None
 
-        # activity_guess cache. Stale check uses a state-signature tuple
-        # (state, active app, idle bucket) — when unchanged for a tick
-        # AND we recently computed, the loop short-circuits before
-        # paying the LLM cost.
+        # activity_guess cache + adaptive-backoff gate. The gate decides when
+        # the heartbeat may pay for an emotion-tier narration call: a coarse
+        # (state, window-category) signature with per-signature exponential
+        # backoff and a novelty bypass (see ActivityGuessGate). Replaces the
+        # old flat 30s floor + exact-app signature, which let window flicker
+        # burn one (silent) call every ~40s. The caches hold the last result.
         self._activity_scores_cache: dict[str, float] = {}
         self._activity_guess_cache: str = ''
-        self._activity_guess_state_sig: tuple | None = None
-        self._activity_guess_at: float = 0.0
+        self._activity_guess_gate = ActivityGuessGate(
+            base_seconds=ACTIVITY_GUESS_BACKOFF_BASE_SECONDS,
+            cap_seconds=ACTIVITY_GUESS_BACKOFF_CAP_SECONDS,
+            cache_size=ACTIVITY_GUESS_SIG_CACHE_SIZE,
+        )
         self._activity_guess_loop_task: asyncio.Task | None = None
         self._topic_candidate_task: asyncio.Task | None = None
 
@@ -1056,19 +1066,19 @@ class UserActivityTracker:
     # ── activity_guess background loop ──────────────────────────
 
     async def _activity_guess_loop(self) -> None:
-        """20s tick. Recomputes activity_guess on state change.
+        """20s tick. Recomputes activity_guess when the activity is fresh.
 
-        Skip rules (in order of cheapness):
-          1. State signature unchanged AND user hasn't said anything
-             new since last compute → skip.
-          2. ``state == 'away'`` → no point describing absence.
-          3. Last LLM call < ``_ACTIVITY_GUESS_MIN_REFRESH_SECONDS`` ago
-             → skip even if signature changed (anti-thrash).
+        Cheap bails first: privacy mode, ``state == 'away'`` (nothing to
+        narrate), proactive-chat disabled, narration suppressed. Whatever
+        survives is handed to ``ActivityGuessGate.should_fire`` — a coarse
+        ``(state, window-category)`` signature with a per-signature exponential
+        backoff (BASE → CAP) and a novelty / new-conversation bypass — so
+        flicking between the same apps stops re-narrating while a genuinely new
+        activity still refreshes at once.
 
         Failures are silent — the previous cache stays in place until
         the next tick succeeds.
         """
-        last_conv_seq = -1
         while True:
             try:
                 await asyncio.sleep(_ACTIVITY_GUESS_TICK_SECONDS)
@@ -1159,33 +1169,23 @@ class UserActivityTracker:
                 if rule_snap.state == 'away':
                     continue
 
-                # Anti-thrash: respect the minimum refresh interval.
-                if (
-                    self._activity_guess_at
-                    and ts - self._activity_guess_at < _ACTIVITY_GUESS_MIN_REFRESH_SECONDS
-                ):
-                    continue
-
-                # State signature: which "kind of activity" the rule
-                # machine sees right now. Deliberately does NOT include the
-                # idle-seconds bucket: idle time grows monotonically while a
-                # user is AFK, so bucketing it (idle // 30) flips the signature
-                # every ~30s even when nothing about "what the user is doing"
-                # changed — defeating dedup and burning one emotion-tier call
-                # every ~40s during pure idle. The activity narration describes
-                # *what* the user is doing, and the only idle transitions worth
-                # re-narrating (active → idle → away) already show up in
-                # ``state`` (away itself bails above). Finer idle gradations add
-                # no narration value, so excluding the bucket lets a stable
-                # state + window + no-new-turn settle into a permanent skip.
-                sig = (
+                # Adaptive-backoff gate. Coarse (state, window-category)
+                # signature so flicking between two same-category apps is a
+                # no-op; per-signature exponential backoff (BASE → CAP) so
+                # oscillating between already-narrated activities decays toward
+                # CAP instead of burning one (silent) call every ~40s; a novel
+                # signature or a new conversation turn bypasses the backoff and
+                # fires now. The narration only describes *what* the user is
+                # doing, so a stale narration of an unchanged activity is still
+                # accurate — staleness never makes it wrong. See ActivityGuessGate.
+                coarse_sig = (
                     rule_snap.state,
-                    (rule_snap.active_window.canonical
-                        if rule_snap.active_window else None),
-                    (rule_snap.active_window.subcategory
+                    (rule_snap.active_window.category
                         if rule_snap.active_window else None),
                 )
-                if sig == self._activity_guess_state_sig and self._conv_seq == last_conv_seq:
+                if not self._activity_guess_gate.should_fire(
+                    coarse_sig, self._conv_seq, ts,
+                ):
                     continue
 
                 # In-flight guard — capture conv_seq + buffer snapshots
@@ -1217,9 +1217,7 @@ class UserActivityTracker:
                     continue
                 self._activity_scores_cache = result.get('scores', {}) or {}
                 self._activity_guess_cache = result.get('guess', '') or ''
-                self._activity_guess_state_sig = sig
-                self._activity_guess_at = ts
-                last_conv_seq = seen_conv_seq
+                self._activity_guess_gate.record_fired(coarse_sig, seen_conv_seq, ts)
             except asyncio.CancelledError:
                 return
             except Exception as e:

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1019,6 +1019,8 @@ def test_activity_guess_signature_excludes_idle_bucket():
     """
     from main_logic.activity.tracker import UserActivityTracker
 
+    from types import SimpleNamespace
+
     loop_source = inspect.getsource(UserActivityTracker._activity_guess_loop)
     sig_source = inspect.getsource(UserActivityTracker._coarse_activity_sig)
     # idle_bucket 是旧签名里按 idle 秒数分桶的那个变量名（空烧根因），断言它
@@ -1027,12 +1029,27 @@ def test_activity_guess_signature_excludes_idle_bucket():
     # signals 仍在 _snapshot_signals_for_llm 这个独立方法里用到它）。
     assert "idle_bucket" not in loop_source
     assert "idle_bucket" not in sig_source
-    # The coarse signature keys on (state, window-category) — not the exact app
-    # (canonical) / subcategory, and not idle seconds.
-    assert "category" in sig_source
-    assert "canonical" not in sig_source
-    assert "subcategory" not in sig_source
     assert "self._activity_guess_gate.should_fire(" in loop_source
+    # Behaviour (not just the comment): the coarse key is (state, category) —
+    # different category → different key; same category but different
+    # canonical/subcategory → SAME key (coarsening), so window flicker within a
+    # category does not re-narrate.
+    work = SimpleNamespace(
+        state='focused_work',
+        active_window=SimpleNamespace(category='work', canonical='IDE', subcategory='code'),
+    )
+    chat = SimpleNamespace(
+        state='focused_work',
+        active_window=SimpleNamespace(category='chat', canonical='IM', subcategory='dm'),
+    )
+    same_bucket = SimpleNamespace(
+        state='focused_work',
+        active_window=SimpleNamespace(category='work', canonical='Browser', subcategory='docs'),
+    )
+    assert (UserActivityTracker._coarse_activity_sig(work)
+            != UserActivityTracker._coarse_activity_sig(chat))
+    assert (UserActivityTracker._coarse_activity_sig(work)
+            == UserActivityTracker._coarse_activity_sig(same_bucket))
 
 
 def test_conversation_turn_dispatcher_does_not_purge_topic_signals_for_redacted_turns():

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1008,14 +1008,14 @@ def test_activity_guess_loop_skips_llm_when_narration_suppressed():
 
 
 def test_activity_guess_signature_excludes_idle_bucket():
-    """idle seconds growing must not flip the dedup signature.
+    """The activity_guess gate must not key on monotonically-growing idle time.
 
-    While AFK, system_idle_seconds keeps climbing; the old code folded
-    idle//30 into the signature, flipping it every ~30s, defeating dedup
-    and burning one emotion-tier LLM call every ~40s during pure idle.
-    The signature now keys only on "what the user is doing" (state +
-    window + subcategory); the active->idle->away transition is still
-    caught by state (away bails anyway).
+    While AFK, system_idle_seconds keeps climbing; an earlier version folded
+    idle//30 into the dedup signature, flipping it every ~30s and burning one
+    emotion-tier LLM call every ~40s during pure idle. The gate now keys on a
+    coarse ``(state, window-category)`` signature handed to ActivityGuessGate
+    (per-signature backoff + novelty bypass); idle seconds never enter it. The
+    active->idle->away transition is still caught by state (away bails anyway).
     """
     from main_logic.activity.tracker import UserActivityTracker
 
@@ -1025,7 +1025,8 @@ def test_activity_guess_signature_excludes_idle_bucket():
     # 约束目标更宽，会误伤将来 loop 里对 idle 秒数的其它无害引用（喂 LLM 的
     # signals 仍在 _snapshot_signals_for_llm 这个独立方法里用到它）。
     assert "idle_bucket" not in source
-    assert "sig = (" in source
+    assert "coarse_sig = (" in source
+    assert "self._activity_guess_gate.should_fire(" in source
 
 
 def test_conversation_turn_dispatcher_does_not_purge_topic_signals_for_redacted_turns():

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1019,14 +1019,20 @@ def test_activity_guess_signature_excludes_idle_bucket():
     """
     from main_logic.activity.tracker import UserActivityTracker
 
-    source = inspect.getsource(UserActivityTracker._activity_guess_loop)
+    loop_source = inspect.getsource(UserActivityTracker._activity_guess_loop)
+    sig_source = inspect.getsource(UserActivityTracker._coarse_activity_sig)
     # idle_bucket 是旧签名里按 idle 秒数分桶的那个变量名（空烧根因），断言它
     # 不回归即精准守住该行为。不断言 "system_idle_seconds" not in source：那比
     # 约束目标更宽，会误伤将来 loop 里对 idle 秒数的其它无害引用（喂 LLM 的
     # signals 仍在 _snapshot_signals_for_llm 这个独立方法里用到它）。
-    assert "idle_bucket" not in source
-    assert "coarse_sig = (" in source
-    assert "self._activity_guess_gate.should_fire(" in source
+    assert "idle_bucket" not in loop_source
+    assert "idle_bucket" not in sig_source
+    # The coarse signature keys on (state, window-category) — not the exact app
+    # (canonical) / subcategory, and not idle seconds.
+    assert "category" in sig_source
+    assert "canonical" not in sig_source
+    assert "subcategory" not in sig_source
+    assert "self._activity_guess_gate.should_fire(" in loop_source
 
 
 def test_conversation_turn_dispatcher_does_not_purge_topic_signals_for_redacted_turns():

--- a/tests/unit/test_activity_guess_gate.py
+++ b/tests/unit/test_activity_guess_gate.py
@@ -1,0 +1,136 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``ActivityGuessGate`` — the activity_guess adaptive backoff.
+
+Small base/cap/cache values keep the arithmetic obvious:
+``base=10, cap=80`` → re-narrate intervals for a stable signature climb
+10 → 20 → 40 → 80 (capped). ``cache=3`` makes LRU eviction easy to drive.
+"""
+
+from main_logic.activity.activity_guess_gate import ActivityGuessGate
+
+
+def _gate(base=10.0, cap=80.0, cache=3):
+    return ActivityGuessGate(base_seconds=base, cap_seconds=cap, cache_size=cache)
+
+
+def _fire_times(gate, sig, *, conv_seq, start, end, step):
+    """Drive should_fire/record_fired across a clock and return the fire times."""
+    fired = []
+    now = start
+    while now <= end:
+        if gate.should_fire(sig, conv_seq, now):
+            gate.record_fired(sig, conv_seq, now)
+            fired.append(now)
+        now += step
+    return fired
+
+
+def test_first_call_always_fires():
+    gate = _gate()
+    assert gate.should_fire('A', conv_seq=0, now=0.0) is True
+
+
+def test_hard_floor_blocks_within_base_even_for_novel_sig():
+    gate = _gate()
+    assert gate.should_fire('A', 0, 0.0) is True
+    gate.record_fired('A', 0, 0.0)
+    # A brand-new signature 'B' would normally fire (novel), but the hard floor
+    # forbids two calls closer than BASE.
+    assert gate.should_fire('B', 0, 5.0) is False
+    # Once BASE has elapsed, the novel signature fires.
+    assert gate.should_fire('B', 0, 10.0) is True
+
+
+def test_novel_signature_bypasses_grown_backoff():
+    gate = _gate()
+    # Let 'A' grow its backoff over several re-narrations.
+    _fire_times(gate, 'A', conv_seq=0, start=0.0, end=200.0, step=5.0)
+    # A genuinely different activity 'Z' must fire on the next floor-clear tick,
+    # not wait out A's (now large) interval.
+    now = 205.0
+    assert gate.should_fire('Z', 0, now) is True
+
+
+def test_same_signature_backoff_is_exponential_then_capped():
+    gate = _gate(base=10.0, cap=80.0)
+    fired = _fire_times(gate, 'A', conv_seq=0, start=0.0, end=400.0, step=5.0)
+    # Intervals between consecutive fires: 10, 20, 40, 80, 80, ... (cap=80).
+    intervals = [b - a for a, b in zip(fired, fired[1:])]
+    assert intervals[:4] == [10.0, 20.0, 40.0, 80.0]
+    assert all(iv == 80.0 for iv in intervals[4:])  # never exceeds the cap
+    # Fire schedule: 0, 10, 30, 70, 150, 230, 310, 390.
+    assert fired[:5] == [0.0, 10.0, 30.0, 70.0, 150.0]
+
+
+def test_oscillation_between_two_sigs_decays():
+    """The user's bug: flicking A<->B used to fire ~every BASE forever."""
+    gate = _gate(base=10.0, cap=80.0)
+    fired = []
+    now = 0.0
+    i = 0
+    while now <= 600.0:
+        sig = 'A' if i % 2 == 0 else 'B'
+        if gate.should_fire(sig, 0, now):
+            gate.record_fired(sig, 0, now)
+            fired.append(now)
+        now += 5.0
+        i += 1
+    # Old behaviour: a fire roughly every other 5s tick over 600s ≈ 60. The
+    # backoff must cut that to a small bounded count and stretch the cadence.
+    assert len(fired) < 25
+    intervals = [b - a for a, b in zip(fired, fired[1:])]
+    # Late cadence has clearly backed off well above the BASE (10s) floor
+    # (converges to ~25s combined for two capped signatures).
+    assert intervals[-1] >= 20.0
+
+
+def test_new_conversation_turn_resets_backoff():
+    gate = _gate(base=10.0, cap=80.0)
+    # Grow A's streak so its interval is large.
+    _fire_times(gate, 'A', conv_seq=0, start=0.0, end=200.0, step=5.0)
+    # A new conversation turn (conv_seq advances) is fresh context: it fires on
+    # the next floor-clear tick and resets the backoff to BASE.
+    assert gate.should_fire('A', conv_seq=1, now=205.0) is True
+    gate.record_fired('A', conv_seq=1, now=205.0)
+    # Streak reset → next re-narration of the same (still conv_seq=1) activity is
+    # due again after just BASE, not the grown interval.
+    assert gate.should_fire('A', conv_seq=1, now=215.0) is True
+
+
+def test_lru_eviction_makes_old_signature_novel_again():
+    gate = _gate(base=10.0, cap=80.0, cache=3)
+    # Fire four distinct signatures, each novel, spaced past the floor.
+    for k, sig in enumerate(['A', 'B', 'C', 'D']):
+        t = k * 10.0
+        assert gate.should_fire(sig, 0, t) is True
+        gate.record_fired(sig, 0, t)
+    # cache=3 → 'A' (oldest) was evicted when 'D' landed. It is therefore novel
+    # again and fires immediately on the next floor-clear tick.
+    assert gate.should_fire('A', 0, 40.0) is True
+
+
+def test_cap_below_base_is_clamped():
+    # A misconfigured cap < base must not make the interval shorter than base.
+    gate = ActivityGuessGate(base_seconds=30.0, cap_seconds=5.0, cache_size=4)
+    fired = _fire_times(gate, 'A', conv_seq=0, start=0.0, end=200.0, step=5.0)
+    intervals = [b - a for a, b in zip(fired, fired[1:])]
+    assert all(iv >= 30.0 for iv in intervals)
+
+
+def test_rejects_nonpositive_base():
+    import pytest
+    with pytest.raises(ValueError):
+        ActivityGuessGate(base_seconds=0.0, cap_seconds=600.0, cache_size=8)

--- a/tests/unit/test_activity_guess_gate.py
+++ b/tests/unit/test_activity_guess_gate.py
@@ -90,11 +90,11 @@ def test_oscillation_between_two_sigs_decays():
         i += 1
     # Old behaviour: a fire roughly every other 5s tick over 600s ≈ 60. The
     # backoff must cut that to a small bounded count and stretch the cadence.
-    assert len(fired) < 25
-    intervals = [b - a for a, b in zip(fired, fired[1:])]
-    # Late cadence has clearly backed off well above the BASE (10s) floor
-    # (converges to ~25s combined for two capped signatures).
-    assert intervals[-1] >= 20.0
+    assert len(fired) < 30
+    # Cadence clearly decays: fewer fires in a late window than in an early one.
+    early = sum(1 for t in fired if t < 150.0)
+    late = sum(1 for t in fired if t >= 450.0)
+    assert late < early
 
 
 def test_new_conversation_turn_resets_backoff():
@@ -134,3 +134,37 @@ def test_rejects_nonpositive_base():
     import pytest
     with pytest.raises(ValueError):
         ActivityGuessGate(base_seconds=0.0, cap_seconds=600.0, cache_size=8)
+
+
+def test_novel_sig_does_not_reset_other_sigs_backoff():
+    """Per-signature streak: a one-off new activity must not re-open the backoff
+    that a separate, still-oscillating signature has accumulated."""
+    gate = _gate(base=10.0, cap=80.0, cache=8)
+    # Grow 'A' to its CAP interval (80) via repeated re-narration.
+    _fire_times(gate, 'A', conv_seq=0, start=0.0, end=400.0, step=5.0)
+    # 'A' last fired at 390. A one-off NEW activity 'C' fires (past the floor).
+    assert gate.should_fire('C', 0, 405.0) is True
+    gate.record_fired('C', 0, 405.0)
+    # 'A' must still be on its grown (CAP) interval — NOT reset to BASE. With a
+    # single global streak, C's fire would have reset it and A would fire here.
+    assert gate.should_fire('A', 0, 415.0) is False   # 415-390=25 < CAP(80)
+    assert gate.should_fire('A', 0, 475.0) is True     # 475-390=85 >= 80
+
+
+def test_cached_serves_per_signature_narration():
+    """The narration is stored per signature, so a suppressed re-narration never
+    leaves the consumer reading another activity's guess (Codex P2)."""
+    gate = _gate()
+    gate.record_fired('work', 0, 0.0, scores={'focused_work': 0.9}, guess='deep in code')
+    gate.record_fired('chat', 0, 30.0, scores={'chatting': 0.8}, guess='chatting on IM')
+    # 'chat' fired last, but asking for 'work' returns work's own narration.
+    assert gate.cached('work') == ({'focused_work': 0.9}, 'deep in code')
+    assert gate.cached('chat') == ({'chatting': 0.8}, 'chatting on IM')
+
+
+def test_cached_unknown_signature_is_empty():
+    gate = _gate()
+    assert gate.cached('never-seen') == ({}, '')
+    gate.record_fired('A', 0, 0.0, scores={'x': 1.0}, guess='g')
+    # A different, not-yet-narrated signature stays empty (honest, not stale).
+    assert gate.cached('B') == ({}, '')

--- a/tests/unit/test_activity_guess_gate.py
+++ b/tests/unit/test_activity_guess_gate.py
@@ -168,3 +168,20 @@ def test_cached_unknown_signature_is_empty():
     gate.record_fired('A', 0, 0.0, scores={'x': 1.0}, guess='g')
     # A different, not-yet-narrated signature stays empty (honest, not stale).
     assert gate.cached('B') == ({}, '')
+
+
+def test_new_conversation_freshness_is_per_signature():
+    """A new turn must refresh EVERY cached activity when next visited, not just
+    the first one re-narrated. With a single global last-fired conv seq, the
+    first re-narration would consume the turn and leave the rest looking fresh.
+    """
+    gate = _gate(base=10.0, cap=80.0)
+    # Grow 'B' to its CAP interval under conv_seq=0; last fire at 390.
+    _fire_times(gate, 'B', conv_seq=0, start=0.0, end=400.0, step=5.0)
+    # New conversation turn (0 -> 1); a DIFFERENT activity 'A' is narrated first.
+    assert gate.should_fire('A', 1, 405.0) is True
+    gate.record_fired('A', 1, 405.0)
+    # 'B' was last narrated under conv_seq=0, so its guess predates the turn. It
+    # must refresh on revisit even though 'A' already consumed the new turn and
+    # B's own grown interval (CAP=80) has NOT elapsed (415 - 390 = 25 < 80).
+    assert gate.should_fire('B', 1, 415.0) is True


### PR DESCRIPTION
## 回归报告

### 改动

把 `activity_guess`（活动心跳的 emotion-tier 叙述调用）的触发门控，从「精细签名 `(state, 精确app, subcategory)` + 平直 30s 地板 + 单个全局叙述缓存」换成新的 `ActivityGuessGate`（`main_logic/activity/activity_guess_gate.py`，纯数据/逻辑、无时钟无 I/O）：

- 签名粗化为 `(state, window-category)`（共用 `_coarse_activity_sig` helper，loop 与 get_snapshot 同 key）；
- **per-signature** 指数退避重述（每个签名各自 `(last_ts, streak)`，`BASE → CAP`）；
- **新签名 / 新对话轮**绕过退避立即刷新并只重置该签名的退避；
- 叙述（scores + guess）**按签名缓存在 gate 里**；`get_snapshot` 按「当前活动签名」取叙述，永远拿到当前活动的叙述（没叙述过则空），不会串到别的活动。

常量进 config 可调：`ACTIVITY_GUESS_BACKOFF_BASE_SECONDS=30` / `ACTIVITY_GUESS_BACKOFF_CAP_SECONDS=600` / `ACTIVITY_GUESS_SIG_CACHE_SIZE=8`。

### 理由 / 必要性

活动心跳通过**静默**的 emotion-tier LLM 调用叙述「用户在干嘛」（只喂 proactive 搭话 prompt，成功不打业务日志，唯一痕迹是 httpx POST）。旧门控只要 `(state, 精确app, subcategory)` 签名一变就放行、仅靠 30s 地板节流——用户在两个 app 间来回切窗口时，签名每切必变，于是每 ~40s 烧一次 LLM、无限重复描述同样两个活动。实机受控复现确认这正是「空闲期每 ~41s 静默 POST 循环」的根因。

### 前后行为

- **前**：QQ↔Chrome 来回切 → activity_guess 每 ~41s 一次 LLM 调用，持续不衰减（受控复现实测：`22:55:51 / 22:56:34 / 22:57:15 / 22:57:56`，间隔 41/41/43s）。
- **后**：同样振荡 → 每签名退避 `30s → 60 → 120 → … → 600s`；单测 600s 窗内放行从 ~60 次降到 <30 次且「早密晚疏」；真切去新活动（如打游戏）仍**立即**刷新。叙述按签名缓存→质量中性且**不会错**：切回 work 时拿到 work 叙述（或空），绝不会拿到 chat 叙述。

### 潜在回归

- 纯门控逻辑单测 `tests/unit/test_activity_guess_gate.py`（12 例：首发 / 硬地板 / novelty 绕过 / 指数退避+封顶 / 振荡衰减 / 新对话重置 / LRU 复活 / **per-sig 退避隔离** / **per-sig 叙述按签名取** / **未知签名空** / cap<base 钳制 / 非法参数）——全过。
- 既有 `_activity_guess_loop` 内省测试随新 `_coarse_activity_sig` helper 更新；`tests/test_activity_tracker_followup.py` 整文件 **99 passed**（合计 111 passed）。ruff lint 全过。
- **消费端 `get_snapshot` / `get_snapshot_sync` 有改动**：叙述从「单全局缓存」改为「按当前活动签名取」。私有模式早返回（清空叙述）不变；外部消费者（`snapshot.py` 渲染、`system_router`）读的是快照字段、不直接碰缓存，无需改动。
- 未触及 `_activity_guess_loop` 前置的 privacy / away / proactive-disabled / narration-suppressed bail（顺序与行为不变，内省测试守住）；硬 `BASE` 地板保留旧 anti-thrash 语义。
- 影响面仅限 activity_guess 的刷新节奏与叙述取用（消费方 = proactive Phase 2 叙述）。其余后台循环（memory signal loop / topic / master_emotion）不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 优化了活动猜测的触发节奏，系统会更智能地控制刷新频率，减少重复更新。
  * 改进了按当前活动状态读取结果的方式，显示内容更贴近用户此刻正在进行的活动。

* **Bug Fixes**
  * 减少了不同活动之间的结果串用问题，避免旧内容影响当前展示。
  * 提升了在活动频繁切换时的稳定性，触发与缓存行为更一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->