### PR TITLE
fix: handle string content in recent history endpoint

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -4179,7 +4179,8 @@ async def get_recent_history(lanlan_name: str):
         if i.type == 'system':
             result += content + "\n"
         else:
-            result += f"{name_mapping[i.type]} | {content}\n"
+            speaker = name_mapping.get(i.type, i.type)
+            result += f"{speaker} | {content}\n"
     return result
 
 @app.get("/search_for_memory/{lanlan_name}/{query}")

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -4171,12 +4171,15 @@ async def get_recent_history(lanlan_name: str):
     name_mapping['ai'] = lanlan_name
     result = _loc(RECENT_HISTORY_INTRO, _lang).format(name=lanlan_name)
     for i in history:
-        if i.type == 'system':
-            result += i.content + "\n"
+        if isinstance(i.content, str):
+            content = i.content
         else:
-            texts = [j['text'] for j in i.content if j['type']=='text']
-            joined = "\n".join(texts)
-            result += f"{name_mapping[i.type]} | {joined}\n"
+            texts = [j['text'] for j in i.content if isinstance(j, dict) and j.get('type') == 'text']
+            content = "\n".join(texts)
+        if i.type == 'system':
+            result += content + "\n"
+        else:
+            result += f"{name_mapping[i.type]} | {content}\n"
     return result
 
 @app.get("/search_for_memory/{lanlan_name}/{query}")

--- a/tests/unit/test_memory_server_recent_history_endpoint.py
+++ b/tests/unit/test_memory_server_recent_history_endpoint.py
@@ -80,3 +80,35 @@ async def test_get_recent_history_keeps_text_part_content():
 
     assert "Master | part one\npart two" in result
     assert "ignored" not in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_recent_history_uses_type_as_unknown_speaker():
+    from app import memory_server
+
+    fake_config = SimpleNamespace(
+        aload_characters=AsyncMock(return_value={"猫娘": {"test_char": {}}}),
+        aget_character_data=AsyncMock(return_value=(
+            "master",
+            None,
+            None,
+            None,
+            {"human": "Master", "ai": "Catgirl", "system": "System"},
+            None,
+            None,
+            None,
+            None,
+        )),
+    )
+    fake_recent = SimpleNamespace(
+        aget_recent_history=AsyncMock(return_value=[
+            SimpleNamespace(type="tool", content="tool result"),
+        ])
+    )
+
+    with patch.object(memory_server, "_config_manager", fake_config), \
+         patch.object(memory_server, "recent_history_manager", fake_recent):
+        result = await memory_server.get_recent_history("test_char")
+
+    assert "tool | tool result" in result

--- a/tests/unit/test_memory_server_recent_history_endpoint.py
+++ b/tests/unit/test_memory_server_recent_history_endpoint.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_recent_history_accepts_string_content():
+    from app import memory_server
+
+    fake_config = SimpleNamespace(
+        aload_characters=AsyncMock(return_value={"猫娘": {"test_char": {}}}),
+        aget_character_data=AsyncMock(return_value=(
+            "master",
+            None,
+            None,
+            None,
+            {"human": "Master", "ai": "Catgirl", "system": "System"},
+            None,
+            None,
+            None,
+            None,
+        )),
+    )
+    fake_recent = SimpleNamespace(
+        aget_recent_history=AsyncMock(return_value=[
+            SimpleNamespace(type="system", content="session note"),
+            SimpleNamespace(type="human", content="plain user history"),
+            SimpleNamespace(type="ai", content="plain ai history"),
+        ])
+    )
+
+    with patch.object(memory_server, "_config_manager", fake_config), \
+         patch.object(memory_server, "recent_history_manager", fake_recent):
+        result = await memory_server.get_recent_history("test_char")
+
+    assert "session note" in result
+    assert "Master | plain user history" in result
+    assert "test_char | plain ai history" in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_recent_history_keeps_text_part_content():
+    from app import memory_server
+
+    fake_config = SimpleNamespace(
+        aload_characters=AsyncMock(return_value={"猫娘": {"test_char": {}}}),
+        aget_character_data=AsyncMock(return_value=(
+            "master",
+            None,
+            None,
+            None,
+            {"human": "Master", "ai": "Catgirl", "system": "System"},
+            None,
+            None,
+            None,
+            None,
+        )),
+    )
+    fake_recent = SimpleNamespace(
+        aget_recent_history=AsyncMock(return_value=[
+            SimpleNamespace(
+                type="human",
+                content=[
+                    {"type": "text", "text": "part one"},
+                    {"type": "image_url", "image_url": "ignored"},
+                    {"type": "text", "text": "part two"},
+                ],
+            ),
+        ])
+    )
+
+    with patch.object(memory_server, "_config_manager", fake_config), \
+         patch.object(memory_server, "recent_history_manager", fake_recent):
+        result = await memory_server.get_recent_history("test_char")
+
+    assert "Master | part one\npart two" in result
+    assert "ignored" not in result


### PR DESCRIPTION
## 改动概述 / Summary
- Handle recent history entries whose message content is already a plain string.
- Preserve the existing list-of-content-parts behavior by rendering text parts and ignoring non-text parts.
- Prevent the legacy `/get_recent_history/{lanlan_name}` endpoint from raising `TypeError` when review/update paths write string content.

## 回归报告 / Regression Report
- Changed the legacy recent history rendering path in `app/memory_server.py` so string content is rendered directly and list content still renders only text parts.
- This is necessary because recent history entries can be written back with `content` as a plain string, while the legacy endpoint previously assumed every non-system message used `list[dict]` content.
- Before this change, `/get_recent_history/{lanlan_name}` could raise `TypeError: string indices must be integers, not 'str'` when it iterated a string as content. After this change, string content is emitted as the message text and mixed content parts still ignore non-text entries such as images.
- Potential regression surface is limited to the legacy recent history endpoint output formatting. It was covered with targeted tests for string content and list-of-text-parts content, plus ruff and whitespace checks.

## 不拆分理由 / Why Not Split
Not applicable. This PR changes one runtime file and one focused unit test file for the same compatibility fix.

## 测试 / Testing
- `uv run --project D:\AI\N.E.K.O\N.E.K.O python -m pytest tests\unit\test_memory_server_recent_history_endpoint.py -q`
- `uv run --project D:\AI\N.E.K.O\N.E.K.O ruff check app\memory_server.py tests\unit\test_memory_server_recent_history_endpoint.py`
- `git diff --check upstream/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化最近历史上下文的拼接逻辑，兼容纯文本和分段内容，减少因消息格式不同导致的历史记录生成异常。
  * 统一处理系统消息与普通消息的内容格式，并更好地保留非标准消息类型的前缀显示。

* **Tests**
  * 新增单元测试，覆盖字符串内容、分段文本内容以及非人类/AI消息类型的历史输出场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->