### PR TITLE
feat(activity): feed a recent-window trail into the activity_guess narration

### DIFF
--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -583,6 +583,37 @@ class ActivityStateMachine:
             self._current_window_started_at = ts
             self._window_history.append(_WindowEntry(timestamp=ts, observation=obs))
 
+    def recent_window_trail(
+        self, *, now: float, limit: int = 3, max_age_seconds: float | None = None,
+    ) -> list[tuple[str, float]]:
+        """Recent foreground windows as ``(canonical_name, dwell_seconds)``, oldest
+        first and the still-active current window last.
+
+        Built from ``_window_history`` (one entry per genuine window change). Each
+        entry's dwell is the time until the *next* change, or ``now`` for the
+        current window. Lets a caller describe activity FLOW ("coded, then
+        browsed, now chatting") instead of only the instantaneous window.
+
+        Canonical app names only — never window titles — so this widens the
+        sensitive surface no further than the single ``active_window`` already
+        does. Entries without a canonical name are skipped; ``max_age_seconds``
+        (when set) drops windows whose switch is older than that. Because the
+        history is time-ordered, both filters keep a contiguous recent tail, so
+        each surviving entry's dwell stays correct.
+        """
+        entries = [
+            e for e in self._window_history
+            if e.observation is not None and e.observation.canonical
+        ]
+        if max_age_seconds is not None:
+            entries = [e for e in entries if now - e.timestamp <= max_age_seconds]
+        entries = entries[-limit:] if limit > 0 else []
+        trail: list[tuple[str, float]] = []
+        for i, entry in enumerate(entries):
+            end = entries[i + 1].timestamp if i + 1 < len(entries) else now
+            trail.append((entry.observation.canonical, max(0.0, end - entry.timestamp)))
+        return trail
+
     def update_system(self, sys_snap: SystemSnapshot) -> None:
         """Cache the latest system snapshot (idle / CPU)."""
         self._latest_system = sys_snap

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -590,29 +590,36 @@ class ActivityStateMachine:
         first and the still-active current window last.
 
         Built from ``_window_history`` (one entry per genuine window change). Each
-        entry's dwell is the time until the *next* change, or ``now`` for the
+        window's dwell is the time until the *next* change, or ``now`` for the
         current window. Lets a caller describe activity FLOW ("coded, then
         browsed, now chatting") instead of only the instantaneous window.
 
-        Canonical app names only — never window titles — so this widens the
-        sensitive surface no further than the single ``active_window`` already
-        does. Entries without a canonical name are skipped; ``max_age_seconds``
-        (when set) drops windows whose switch is older than that. Because the
-        history is time-ordered, both filters keep a contiguous recent tail, so
-        each surviving entry's dwell stays correct.
+        Two kinds of window are excluded from the OUTPUT: those with no canonical
+        name, and ``private``-category ones. The loop's private-mode bail is
+        downstream of ``update_window``, so private windows still land in the
+        history and would otherwise resurface here after the user leaves private
+        mode. App names only — never window titles — so the sensitive surface is
+        no wider than the single ``active_window`` already exposes.
+
+        Dwell boundaries come from the RAW history order, computed *before* those
+        exclusions: a skipped window in the middle of the sequence drops its own
+        time instead of folding it into the previous app's dwell.
         """
-        entries = [
-            e for e in self._window_history
-            if e.observation is not None and e.observation.canonical
-        ]
+        # max_age trims old switches off the front (which never affects a newer
+        # window's boundary); then walk the raw history in order so each kept
+        # window's dwell stops at the next RAW switch, not the next *kept* one.
+        raw_entries = list(self._window_history)
         if max_age_seconds is not None:
-            entries = [e for e in entries if now - e.timestamp <= max_age_seconds]
-        entries = entries[-limit:] if limit > 0 else []
+            raw_entries = [e for e in raw_entries if now - e.timestamp <= max_age_seconds]
+        if limit <= 0:
+            return []
         trail: list[tuple[str, float]] = []
-        for i, entry in enumerate(entries):
-            end = entries[i + 1].timestamp if i + 1 < len(entries) else now
-            trail.append((entry.observation.canonical, max(0.0, end - entry.timestamp)))
-        return trail
+        for i, entry in enumerate(raw_entries):
+            end = raw_entries[i + 1].timestamp if i + 1 < len(raw_entries) else now
+            obs = entry.observation
+            if obs is not None and obs.canonical and obs.category != 'private':
+                trail.append((obs.canonical, max(0.0, end - entry.timestamp)))
+        return trail[-limit:]
 
     def update_system(self, sys_snap: SystemSnapshot) -> None:
         """Cache the latest system snapshot (idle / CPU)."""

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -89,6 +89,13 @@ _ACTIVITY_GUESS_TICK_SECONDS = 20.0
 # ActivityGuessGate (configured via ACTIVITY_GUESS_BACKOFF_* in config); see
 # main_logic/activity/activity_guess_gate.py. The old flat 30s floor is gone.
 
+# How many recent foreground windows (with dwell) to feed the activity_guess LLM
+# so its narration can describe the user's activity FLOW ("coded, then browsed,
+# now chatting"), not just the instantaneous window. Canonical app names only —
+# never window titles — see ActivityStateMachine.recent_window_trail.
+_ACTIVITY_GUESS_WINDOW_TRAIL_LIMIT = 3
+_ACTIVITY_GUESS_WINDOW_TRAIL_MAX_AGE_SECONDS = 600.0
+
 # Frontend-pushed external signals are considered fresh for this many
 # seconds. After that the tracker falls back to the local collector
 # (which on remote deployments will be in degraded mode) — better to
@@ -1225,7 +1232,7 @@ class UserActivityTracker:
                 seen_conv_seq = self._conv_seq
                 user_msgs_snapshot = list(self._user_msg_buffer)
                 ai_msgs_snapshot = list(self._ai_msg_buffer)
-                signals = self._snapshot_signals_for_llm(rule_snap)
+                signals = self._snapshot_signals_for_llm(rule_snap, now=ts)
                 from main_logic.activity.llm_enrichment import call_activity_guess
                 result = await call_activity_guess(
                     snapshot_signals=signals,
@@ -1325,14 +1332,17 @@ class UserActivityTracker:
             return ext
         return self._collector.snapshot()
 
-    @staticmethod
-    def _snapshot_signals_for_llm(snap: ActivitySnapshot) -> dict:
+    def _snapshot_signals_for_llm(self, snap: ActivitySnapshot, *, now: float) -> dict:
         """Pick the structured fields worth feeding into the prompt.
 
         Trimmed deliberately — full snapshot has many cross-references
         and timing fields the LLM doesn't need. We pass what's
         observably "what is the user doing on screen + how recent is
         activity", and leave the rest as state-machine internals.
+
+        ``recent_windows`` adds a short trail of the last few foreground apps
+        (canonical names + dwell, no titles) so the narration can describe the
+        user's activity FLOW rather than only the instantaneous window.
         """
         win = snap.active_window
         return {
@@ -1342,12 +1352,33 @@ class UserActivityTracker:
                 if win and win.canonical else None
             ),
             'window_title': win.title if win else None,
+            'recent_windows': self._format_window_trail(now=now),
             'system_idle_seconds': int(snap.system_idle_seconds),
             'cpu_avg_30s': round(snap.cpu_avg_30s, 1),
             'window_switch_rate_5min': snap.window_switch_rate_5min,
             'voice_mode_active': snap.voice_mode_active,
             'time_period': snap.period,
         }
+
+    def _format_window_trail(self, *, now: float) -> str | None:
+        """One compact line of the recent foreground-app trail, or None.
+
+        Returns None for a single window (it adds nothing over ``active_window``),
+        so the line only appears when there's an actual flow to describe. App
+        names only — no titles. Example: ``VS Code 6min -> Chrome 2min -> Slack 40s``.
+        """
+        trail = self._sm.recent_window_trail(
+            now=now,
+            limit=_ACTIVITY_GUESS_WINDOW_TRAIL_LIMIT,
+            max_age_seconds=_ACTIVITY_GUESS_WINDOW_TRAIL_MAX_AGE_SECONDS,
+        )
+        if len(trail) < 2:
+            return None
+
+        def _dwell(seconds: float) -> str:
+            return f'{int(seconds)}s' if seconds < 90 else f'{int(seconds / 60)}min'
+
+        return ' -> '.join(f'{name} {_dwell(d)}' for name, d in trail)
 
     # ── internals ──────────────────────────────────────────────
 

--- a/tests/unit/test_recent_window_trail.py
+++ b/tests/unit/test_recent_window_trail.py
@@ -99,3 +99,40 @@ def test_format_window_trail_omits_single_and_renders_flow():
     line = fmt(fake, now=t0 + 480)
     assert line == 'VS Code 6min -> Chrome 2min'
     assert 'secret' not in line  # app names only, never titles
+
+
+def test_recent_window_trail_excludes_private_entries():
+    """A 'private' window recorded in history (the loop's private bail is
+    downstream of update_window) must NOT resurface in the trail after the user
+    leaves private mode — even though the observation carries a canonical."""
+    sm = _sm()
+    t0 = 1000.0
+    sm.update_window(_win('VS Code', 'work', 'ide'), now=t0)
+    sm.update_window(
+        WindowObservation(
+            process_name=None, title='secret-bank', category='private',
+            subcategory=None, canonical='[private]', is_browser=False,
+        ),
+        now=t0 + 60,
+    )
+    sm.update_window(_win('Chrome', 'entertainment', 'browser'), now=t0 + 120)
+    assert [n for n, _ in sm.recent_window_trail(now=t0 + 180, limit=5)] == ['VS Code', 'Chrome']
+
+
+def test_recent_window_trail_dwell_not_inflated_by_noncanonical_gap():
+    """A canonical-less window sandwiched between two named ones drops its own
+    time rather than folding it into the previous app's dwell."""
+    sm = _sm()
+    t0 = 1000.0
+    sm.update_window(_win('A', 'work', 'ide'), now=t0)
+    sm.update_window(
+        WindowObservation(
+            process_name='unknown.exe', title='secret-unknown', category='unknown',
+            subcategory=None, canonical=None, is_browser=False,
+        ),
+        now=t0 + 50,
+    )
+    sm.update_window(_win('B', 'communication', 'im'), now=t0 + 100)
+    trail = sm.recent_window_trail(now=t0 + 130, limit=5)
+    assert trail[0] == ('A', 50.0)   # not 100.0 — the gap's 50s is dropped, not added
+    assert trail[1] == ('B', 30.0)

--- a/tests/unit/test_recent_window_trail.py
+++ b/tests/unit/test_recent_window_trail.py
@@ -1,0 +1,101 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the recent-window trail fed into the activity_guess LLM.
+
+``ActivityStateMachine.recent_window_trail`` turns the window-change history into
+``(canonical, dwell)`` pairs; ``UserActivityTracker._format_window_trail`` renders
+the compact prompt line. Both are exercised hermetically — windows are hand-built
+``WindowObservation``s fed at controlled timestamps, no polling / no prefs I/O.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from main_logic.activity.snapshot import WindowObservation
+from main_logic.activity.state_machine import ActivityStateMachine
+from main_logic.activity.tracker import UserActivityTracker
+from utils.activity_config import ActivityPreferences
+
+
+def _win(canonical: str, category: str, sub: str) -> WindowObservation:
+    """A WindowObservation with a distinct canonical and a *sensitive* title, so
+    tests can assert the title never leaks into the trail."""
+    return WindowObservation(
+        process_name=f'{canonical}.exe',
+        title=f'secret-{canonical}-document',
+        category=category,
+        subcategory=sub,
+        canonical=canonical,
+        is_browser=(category == 'entertainment'),
+    )
+
+
+def _sm() -> ActivityStateMachine:
+    return ActivityStateMachine(prefs=ActivityPreferences())
+
+
+def test_recent_window_trail_canonical_dwell_and_no_titles():
+    """Oldest-first, current-last; dwell = time until the next change (or `now`
+    for the still-active current window); window titles never leak."""
+    sm = _sm()
+    t0 = 1000.0
+    sm.update_window(_win('VS Code', 'work', 'ide'), now=t0)
+    sm.update_window(_win('Chrome', 'entertainment', 'browser'), now=t0 + 360)
+    sm.update_window(_win('Slack', 'communication', 'im'), now=t0 + 480)
+
+    trail = sm.recent_window_trail(now=t0 + 520, limit=3)
+    assert [name for name, _ in trail] == ['VS Code', 'Chrome', 'Slack']
+    assert [dwell for _, dwell in trail] == [360.0, 120.0, 40.0]
+    assert all('secret' not in name for name, _ in trail)
+
+
+def test_recent_window_trail_limit_and_max_age():
+    sm = _sm()
+    t0 = 1000.0
+    sm.update_window(_win('A', 'work', 'ide'), now=t0)
+    sm.update_window(_win('B', 'entertainment', 'browser'), now=t0 + 100)
+    sm.update_window(_win('C', 'communication', 'im'), now=t0 + 200)
+    sm.update_window(_win('D', 'work', 'ide'), now=t0 + 300)
+    now = t0 + 350
+
+    # limit keeps only the newest N.
+    assert [n for n, _ in sm.recent_window_trail(now=now, limit=2)] == ['C', 'D']
+    # max_age drops windows whose switch is older than the cutoff: only D's switch
+    # (t0+300) is within 120s of now (t0+350).
+    assert [n for n, _ in sm.recent_window_trail(now=now, limit=5, max_age_seconds=120)] == ['D']
+
+
+def test_recent_window_trail_single_window_kept_as_one_entry():
+    sm = _sm()
+    sm.update_window(_win('VS Code', 'work', 'ide'), now=1000.0)
+    assert sm.recent_window_trail(now=1100.0, limit=3) == [('VS Code', 100.0)]
+
+
+def test_format_window_trail_omits_single_and_renders_flow():
+    """The tracker renders a trail line only when there's an actual flow (>= 2
+    windows); a lone current window adds nothing over ``active_window``."""
+    sm = _sm()
+    fake = SimpleNamespace(_sm=sm)  # _format_window_trail only touches self._sm
+    fmt = UserActivityTracker._format_window_trail
+
+    t0 = 1000.0
+    sm.update_window(_win('VS Code', 'work', 'ide'), now=t0)
+    assert fmt(fake, now=t0 + 60) is None  # single window → no flow → omitted
+
+    sm.update_window(_win('Chrome', 'entertainment', 'browser'), now=t0 + 360)
+    line = fmt(fake, now=t0 + 480)
+    assert line == 'VS Code 6min -> Chrome 2min'
+    assert 'secret' not in line  # app names only, never titles


### PR DESCRIPTION
## 回归报告

Follow-up to #2021（独立 PR——改的是 `activity_guess` 的 **LLM 输入**，跟 #2021 的退避**门控正交**）。

### 改动

给 `activity_guess`（emotion-tier 活动叙述 LLM）的**输入**加一条「最近窗口流水」，让叙述能讲活动流而不只是当前窗口：

- 新增 `ActivityStateMachine.recent_window_trail(now, limit, max_age_seconds)`：从既有 `_window_history` 取最近 N 个前台 app，返回 `(canonical, dwell_seconds)`，最旧在前、当前在末；dwell = 到下一次切换（当前窗口用 `now`）。
- `_snapshot_signals_for_llm` 新增 `recent_windows` 信号行（如 `VS Code 6min -> Chrome 2min -> Slack 40s`），**单窗口时省略**（相对 `active_window` 无增量）。该方法由 `@staticmethod` 改实例方法（要读状态机历史），唯一调用方传 `now=ts`。
- 常量 `_ACTIVITY_GUESS_WINDOW_TRAIL_LIMIT=3` / `_ACTIVITY_GUESS_WINDOW_TRAIL_MAX_AGE_SECONDS=600`。

### 理由 / 必要性

之前 `_snapshot_signals_for_llm` 只喂**当前**活跃窗口 + 一个切换频率数字，看不到用户刚才开过哪些 app。叙述只能写「在 Chrome」，写不出「刚从 VS Code 切到 Chrome 查资料」。proactive 搭话开场白能据此更贴活动流。

### 前后行为

- **前**：LLM 输入只有 `active_window`（当前）+ `window_switch_rate_5min`（数字）。
- **后**：多一条 `recent_windows: VS Code 6min -> Chrome 2min -> Slack 40s`（≥2 个窗口才出现）。无窗口流水时该行省略（`_format_signals` 自动跳过 None 值）。叙述未变 prompt（信号行自描述，LLM 据「基于系统信号」的既有指令使用）；若后续发现叙述没用上，再考虑显式 prompt 提示（涉及 7 语言 i18n，故本 PR 先不动）。

### 潜在回归

- ⚠️ **隐私**：只喂 **canonical（app 名）+ dwell**，**绝不喂 window title**——敏感面不比已有的单个 `active_window` 更宽；private 态 tick 在 loop 入口就 bail、根本不进叙述。单测断言 title 不泄漏。
- `_snapshot_signals_for_llm` 改实例方法：唯一调用方（loop 内）已同步传 `now=ts`，grep 确认无其它调用方。
- 单测 `tests/unit/test_recent_window_trail.py`（4 例：canonical+dwell+无 title 泄漏 / limit+max_age / 单窗口一条目 / 格式化省略单窗口+渲染流水）；`test_activity_tracker_followup.py`(99) + gate(13) 全过，合计 **116 passed**，ruff 绿。
- 影响面仅限 activity_guess 的 LLM **输入**；不碰 memory / topic / master_emotion / 退避门控。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 活动识别现在会基于最近的前台窗口切换轨迹生成更连贯的上下文描述。
  * 轨迹结果以时间顺序汇总最近使用的应用，并附带每段停留时长信息。

* **改进**
  * 引入更精细的时间裁剪与显示规则，提升行为连续性的可读性与稳定性。
  * 确保只呈现应用名称，避免展示敏感窗口标题信息。

* **测试**
  * 新增单元测试，覆盖轨迹顺序、停留时长计算、过滤规则与内容安全性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->