### PR TITLE
fix(i18n): 修正 es.json closeSettings 误译 Cerca→Cerrar

### DIFF
--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -945,7 +945,7 @@
         "coreApiProvider": "API principal (chat de voz, solo omnimodal)",
         "assistApiProvider": "API de asistencia (Memoria/Agente/Chat de texto/Voz personalizada)",
         "saveSettings": "Guardar configuración",
-        "closeSettings": "Cerca",
+        "closeSettings": "Cerrar",
         "newbieRecommendTitle": "Recomendación de novato",
         "newbieRecommend": "Si aún no tiene una clave API, puede seleccionar \"Versión gratuita\" en las Opciones avanzadas a continuación para comenzar a usarla sin registrar ninguna cuenta.",
         "advancedOptions": "Opciones avanzadas (opcional)",


### PR DESCRIPTION
## 改动

设置面板「关闭」按钮的西班牙语文案 `closeSettings` 当前值为 `"Cerca"`（意为「附近」），语义错误。应为 `"Cerrar"`（动词「关闭」）。

```diff
-        "closeSettings": "Cerca",
+        "closeSettings": "Cerrar",
```

其余 7 个 locale 的 `closeSettings` 翻译均正确（en `Close` / ja `閉じる` / ko `닫기` / pt `Fechar` / ru `Закрыть` / zh-CN `关闭` / zh-TW `關閉`），不改动。

## ⚠️ i18n-sync 预期红 — 需 maintainer 手工批准

这是一次**单 locale typo 修正**。`check_i18n_sync.py` 对 `static/locales` 下 8 个 locale 文件有 lockstep 约束：每次改动的 diff hunk 行范围必须跨 8 文件对齐。本 PR 只改 `es.json` 第 948 行，会让 es 比其他 7 个 locale 多出一个孤立 hunk，导致 **"Python conventions" job 的 check_i18n_sync 报红**。

这是该项目对一次性单 locale 修正的既定处理方式：**不修改 `check_i18n_sync.py` 的 GROUPS 去绕过**，而是由有 admin 权限的 maintainer 手工 override 合并那次 i18n-sync 红色检查。

