### PR TITLE
fix(ui): 修复首页锁图标刚启动点不动（pointer-events 兜底）

### DIFF
--- a/static/avatar-ui-drag.js
+++ b/static/avatar-ui-drag.js
@@ -27,9 +27,10 @@
             'body.' + DRAGGING_CLASS + ' [id^="vrm-btn-"],',
             'body.' + DRAGGING_CLASS + ' .mmd-floating-btn,',
             'body.' + DRAGGING_CLASS + ' [id^="mmd-btn-"],',
-            'body.' + DRAGGING_CLASS + ' #live2d-lock-icon,',
-            'body.' + DRAGGING_CLASS + ' #vrm-lock-icon,',
-            'body.' + DRAGGING_CLASS + ' #mmd-lock-icon,',
+            // 四种模型的锁图标统一按 id 后缀匹配（含 pngtuber-lock-icon），与
+            // index.css 的 [id$="-lock-icon"]{pointer-events:auto} 兜底对偶；少一个 prefix
+            // 就会让该模型拖拽时锁仍可点而粘手。
+            'body.' + DRAGGING_CLASS + ' [id$="-lock-icon"],',
             'body.' + DRAGGING_CLASS + ' #live2d-floating-buttons,',
             'body.' + DRAGGING_CLASS + ' #live2d-floating-buttons *,',
             'body.' + DRAGGING_CLASS + ' #vrm-floating-buttons,',

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -514,6 +514,18 @@ body.neko-game-active [id$="-lock-icon"] {
     pointer-events: none !important;
 }
 
+/* 锁图标的 pointer-events 兜底。
+   整页以 html,body{pointer-events:none} 作点击穿透底，锁图标本应自行 opt-in auto。
+   锁创建时（avatar-ui-buttons / live2d-ui-buttons 等）设的是 inline pointer-events:auto，
+   但 showLive2d / restoreYuiGuideLive2DPreparingControls 等「恢复」函数会对它
+   removeProperty('pointer-events') 来清掉 !important 残留，连带把那份 auto 也抹掉，
+   于是锁掉回继承的 none、永久点不动（直到一次 goodbye→return 重新设上 auto）。
+   这条兜底把锁的静止态钉成可点；拖拽屏蔽（body.neko-model-dragging …!important）、
+   游戏态隐藏、教程 preparing 隐藏（均用 !important none）仍能正常压住它。 */
+[id$="-lock-icon"] {
+    pointer-events: auto;
+}
+
 /* Goodbye 后的 return 入口 Phase 2 改为 CAT1 占位表现，但继续复用原有
    DOM/ID/事件协议与拖拽逻辑。 */
 .neko-idle-return-button-container {


### PR DESCRIPTION
## 现象
首页（index.html）刚启动时锁图标可见但点不动，无法锁定角色；点「请她离开」再「请她回来」之后就能点了。Live2D，网页端和 Electron 都复现。

## 根因
index.html 整页以 `html,body { pointer-events: none }` 作点击穿透底，锁图标靠创建时设的 inline `pointer-events:auto` 自行 opt-in 才可点。但 `showLive2d` / `restoreYuiGuideLive2DPreparingControls` 等「恢复」函数会对锁 `removeProperty('pointer-events')`（本意是清掉教程隐藏留下的 `!important` 残留），连带把锁创建时那份 `auto` 也一起抹掉 → 锁继承 body 的 `none`，刚启动就永久点不动。只有 goodbye→return 走的 `restoreLive2DDisplaySurface` 链路最后会重新把锁设回可点，所以「请她回来」后能点。

## 修复
给 `[id$="-lock-icon"]` 加一条 CSS 兜底 `pointer-events: auto`，把锁的静止态钉成可点，一条覆盖 live2d/vrm/mmd/pngtuber 四种模型。沿用本文件已有先例（`.neko-idle-return-button-container { pointer-events: auto }`，同样是在穿透底页上给交互元素 opt-in）。拖拽屏蔽（`body.neko-model-dragging …!important`）、游戏态隐藏、教程 preparing 隐藏（均 `!important none`）仍能正常压住它。

## 验证（浏览器实测）
- 修复前：刚启动 `getComputedStyle(lock).pointerEvents === 'none'`，锁不可点
- 修复后：刚启动 `=== 'auto'`，`elementFromPoint` 命中锁本体，真实点击（遵守 pointer-events + 层叠）令 `isLocked` false→true
- 回归：拖拽期 `body.neko-model-dragging` 下锁仍为 `none`（`!important` 压住，不粘手），拖拽结束回 `auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化“锁图标”在全局禁用交互规则生效时的点击可用性：对以 `-lock-icon` 结尾的元素增加兜底交互样式。
  * 改进拖拽过程中“锁图标”按钮的交互屏蔽/恢复逻辑：统一覆盖所有 `-lock-icon` 后缀图标，避免拖拽经过时仍可能错误可点击。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->