### PR TITLE
fix(chat): refine compact meme overlay lifecycle

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -684,6 +684,7 @@ describe('App', () => {
   });
 
   it('keeps the proactive meme overlay through the same-turn assistant caption that follows it', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
     // 回归：主动分享是「发表情包 + 说台词」，台词是 assistant 消息、紧随 meme 落地。
     // 旧逻辑「有新消息就收起」会让图一瞬间被台词顶掉（线上实测：图闪一下就没）。
     const meme = parseChatMessage({
@@ -716,6 +717,7 @@ describe('App', () => {
   });
 
   it('collapses the meme overlay once the user speaks again', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
     const meme = parseChatMessage({
       id: 'meme-abc123', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
       blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=x', alt: 'lol' }], status: 'sent',
@@ -734,6 +736,7 @@ describe('App', () => {
   });
 
   it('keeps the meme overlay alongside a music card from the same share (independent widgets)', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
     const meme = parseChatMessage({
       id: 'meme-xyz', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
       blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=y', alt: 'lol' }], status: 'sent',
@@ -749,6 +752,7 @@ describe('App', () => {
   });
 
   it('keeps the meme overlay even when a much later music-only turn arrives (no user message)', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
     // 表情包是独立挂件，不被猫娘后续的音乐分享收起；只有用户开口才换场。
     const meme = parseChatMessage({
       id: 'meme-old', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1000,
@@ -762,6 +766,28 @@ describe('App', () => {
       <App chatSurfaceMode="compact" compactChatState="input" messages={[meme, laterMusic]} />,
     );
     expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=z');
+  });
+
+  it('hides the proactive meme overlay while compact history is open', () => {
+    const meme = parseChatMessage({
+      id: 'meme-visible-in-history',
+      role: 'assistant',
+      author: 'Neko',
+      time: '10:00',
+      createdAt: 1,
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=history', alt: 'history meme' }],
+      status: 'sent',
+    });
+
+    const { container } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" messages={[meme]} />,
+    );
+
+    expect(container.querySelector('.compact-meme-overlay')).toBeNull();
+    const historyImage = container.querySelector(
+      '[data-compact-export-history-message-id="meme-visible-in-history"] .message-block-image img',
+    );
+    expect(historyImage).toHaveAttribute('src', '/api/meme/proxy-image?url=history');
   });
 
   it('defaults compact history open and preserves history controls through visibility toggles', async () => {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -7034,7 +7034,7 @@ function CompactChatApp({
   // 音乐条可见性与「聊天历史折叠」解耦：只要有音乐内容就常显（空态由 CSS `:empty { display:none }`
   // 兜底），不再随历史区收起而隐藏——否则历史默认折叠的 A/B closed 分支会连带看不到主动分享音乐条。
   const compactMusicPlayerVisibility = 'open' as const;
-  const compactMemeOverlayNode = isCompactSurface && compactMemeOverlay ? (
+  const compactMemeOverlayNode = isCompactSurface && !compactExportHistoryMounted && compactMemeOverlay ? (
     <div
       className="compact-meme-overlay"
       data-compact-meme-overlay="compact-surface"
@@ -7042,7 +7042,8 @@ function CompactChatApp({
       data-compact-geometry-item="meme"
       data-compact-geometry-hit-scope="children"
     >
-      {/* 被动弹出的单图挂件，一渲染就 fixed 钉在视口内，没有「视口外延迟加载」的场景——lazy 对它零
+      {/* 被动弹出的单图挂件仅在历史区收起后显示；历史打开时由历史列表承载同一条图片消息，避免重复展示。
+          一渲染就 fixed 钉在视口内，没有「视口外延迟加载」的场景——lazy 对它零
           收益（实测 lazy/eager 行为一致，图都会立刻加载），eager 语义更直接、也省掉一层
           IntersectionObserver 判定。注：表情包「常显、不被同轮台词顶掉」靠的是上面 compactMemeOverlay
           的 role 收起逻辑，不是这个属性。 */}


### PR DESCRIPTION
## 改动概览

修复紧凑聊天框中主动搭话表情包 overlay 的生命周期问题。

打开历史对话时，不再额外显示悬浮在对话框上方中间的表情包图片，避免与历史列表里的同一条图片消息重复展示。历史收起后，仍保留原有的主动表情包预览能力。

## 问题原因

主动搭话表情包会作为 `meme-` 前缀的图片消息进入 React 消息流。此前 compact 模式会额外从消息列表中抽取最新表情包，渲染为独立的 `compact-meme-overlay`。

这个 overlay 的生命周期只受“用户是否发言”影响，没有考虑历史对话区域是否打开，导致历史已显示该图片消息时，中间仍额外悬浮一张重复表情包。

## 修复内容

- 历史对话打开或处于关闭动画挂载期间，不渲染额外的表情包 overlay。
- 历史对话关闭后，保留原有表情包 overlay 行为。
- 保留同轮 assistant 台词、音乐卡不会顶掉表情包的既有逻辑。
- 保留用户发言后收起表情包 overlay 的既有逻辑。
- 新增回归测试覆盖历史打开时 overlay 隐藏、历史列表仍显示图片消息的场景。

## 验证

- `npm test`
- `bash build_frontend.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了紧凑界面下表情包叠层的显示逻辑，避免在历史面板打开时重复显示或干扰页面展示。
  * 当紧凑导出历史面板处于打开状态时，表情包会隐藏叠层并正确显示在历史消息中，提升可见性与一致性。
  * 补充了相关测试覆盖，确保不同面板状态下的展示行为符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->