### PR TITLE
[codex] 记忆浏览清空与删除粒子消散效果

### DIFF
--- a/static/css/memory_browser.css
+++ b/static/css/memory_browser.css
@@ -1155,6 +1155,31 @@ body.storage-location-memory-modal-open {
     position: relative;
 }
 
+.chat-item.is-dissolving {
+    pointer-events: none;
+    animation: memory-chat-ghost-out 720ms ease forwards;
+}
+
+.chat-item.is-collapsing {
+    overflow: hidden;
+    margin-bottom: 0;
+    padding-top: 0;
+    transition: height 360ms ease, margin 360ms ease, padding 360ms ease;
+}
+
+@keyframes memory-chat-ghost-out {
+    0% {
+        opacity: 1;
+        filter: blur(0);
+        transform: translateY(0) scale(1);
+    }
+    100% {
+        opacity: 0;
+        filter: blur(6px);
+        transform: translateY(-6px) scale(0.985);
+    }
+}
+
 .chat-item + .chat-item {
     padding-top: 18px;
 }
@@ -1412,6 +1437,14 @@ html.neko-window-maximized .chat-item + .chat-item:hover::before {
     transform: translateY(0) scale(0.98);
 }
 
+.memory-particle-canvas {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    pointer-events: none;
+    z-index: 1000;
+}
 
 #save-status {
     font-size: 0.9em;

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -11,6 +11,8 @@
     let memoryParticleContext = null;
     let memoryParticleFrame = 0;
     let memoryParticles = [];
+    let memoryParticleCanvasResizeBound = false;
+    let memoryDissolveRunId = 0;
     let storageLocationState = {
         bootstrap: null,
         blockingReason: '',
@@ -1036,8 +1038,15 @@
             document.body.appendChild(memoryParticleCanvas);
             memoryParticleContext = memoryParticleCanvas.getContext('2d');
         }
+        ensureMemoryParticleResizeListener();
         resizeMemoryParticleCanvas();
         return memoryParticleCanvas;
+    }
+
+    function ensureMemoryParticleResizeListener() {
+        if (memoryParticleCanvasResizeBound) return;
+        window.addEventListener('resize', resizeMemoryParticleCanvas);
+        memoryParticleCanvasResizeBound = true;
     }
 
     function resizeMemoryParticleCanvas() {
@@ -1048,6 +1057,26 @@
         memoryParticleCanvas.style.width = window.innerWidth + 'px';
         memoryParticleCanvas.style.height = window.innerHeight + 'px';
         memoryParticleContext.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    function teardownMemoryParticleCanvas() {
+        if (memoryParticleCanvasResizeBound) {
+            window.removeEventListener('resize', resizeMemoryParticleCanvas);
+            memoryParticleCanvasResizeBound = false;
+        }
+        cancelAnimationFrame(memoryParticleFrame);
+        memoryParticleFrame = 0;
+        memoryParticles = [];
+        memoryDissolveInProgress = false;
+        memoryDissolveRunId++;
+        if (memoryParticleContext) {
+            memoryParticleContext.clearRect(0, 0, window.innerWidth, window.innerHeight);
+        }
+        if (memoryParticleCanvas && memoryParticleCanvas.parentNode) {
+            memoryParticleCanvas.parentNode.removeChild(memoryParticleCanvas);
+        }
+        memoryParticleCanvas = null;
+        memoryParticleContext = null;
     }
 
     function randomBetween(min, max) {
@@ -1223,7 +1252,7 @@
     }
 
     function collapseMemoryItem(item) {
-        const height = item.getBoundingClientRect().height;
+        const height = item.offsetHeight;
         item.style.height = height + 'px';
         item.classList.add('is-collapsing');
         requestAnimationFrame(() => {
@@ -1245,8 +1274,18 @@
             if (typeof onComplete === 'function') onComplete();
             return;
         }
+        const reduceMotion = window.matchMedia
+            && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const maxStaggeredItems = 6;
+        const maxParticleItems = 40;
+
+        if (reduceMotion || targets.length > maxParticleItems) {
+            if (typeof onComplete === 'function') onComplete();
+            return;
+        }
 
         memoryDissolveInProgress = true;
+        const dissolveRunId = ++memoryDissolveRunId;
         setChatActionButtonsEnabled(false);
         memoryParticles = [];
         cancelAnimationFrame(memoryParticleFrame);
@@ -1254,18 +1293,23 @@
 
         targets.forEach((item, sequence) => {
             window.setTimeout(() => {
+                if (dissolveRunId !== memoryDissolveRunId) return;
                 addMemoryItemParticles(item, sequence);
                 item.classList.add('is-dissolving');
                 startMemoryParticles();
-                window.setTimeout(() => collapseMemoryItem(item), 620);
-            }, sequence * 145);
+                window.setTimeout(() => {
+                    if (dissolveRunId !== memoryDissolveRunId) return;
+                    collapseMemoryItem(item);
+                }, 620);
+            }, Math.min(sequence, maxStaggeredItems) * 145);
         });
 
         window.setTimeout(() => {
+            if (dissolveRunId !== memoryDissolveRunId) return;
             if (typeof onComplete === 'function') onComplete();
             memoryDissolveInProgress = false;
             setChatActionButtonsEnabled(true);
-        }, 1120 + targets.length * 145);
+        }, 1120 + Math.min(targets.length, maxStaggeredItems) * 145);
     }
 
     async function loadMemoryFileList() {
@@ -1694,6 +1738,7 @@
     }
     function closeMemoryBrowser() {
         teardownMemoryChatPanelHeightSync();
+        teardownMemoryParticleCanvas();
         if (window.opener) {
             // 如果是通过 window.open() 打开的，直接关闭
             window.close();
@@ -1720,9 +1765,14 @@
     }
     // 将函数暴露到全局作用域，供 HTML onclick 调用
     window.closeMemoryBrowser = closeMemoryBrowser;
-    window.addEventListener('pagehide', teardownMemoryChatPanelHeightSync);
-    window.addEventListener('beforeunload', teardownMemoryChatPanelHeightSync);
-    window.addEventListener('resize', resizeMemoryParticleCanvas);
+    window.addEventListener('pagehide', function () {
+        teardownMemoryChatPanelHeightSync();
+        teardownMemoryParticleCanvas();
+    });
+    window.addEventListener('beforeunload', function () {
+        teardownMemoryChatPanelHeightSync();
+        teardownMemoryParticleCanvas();
+    });
     // 页面加载时隐藏保存按钮
     document.addEventListener('DOMContentLoaded', async function () {
         initMemoryChatPanelHeightSync();

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -1077,6 +1077,7 @@
         }
         memoryParticleCanvas = null;
         memoryParticleContext = null;
+        setChatActionButtonsEnabled(true);
     }
 
     function randomBetween(min, max) {

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -6,6 +6,11 @@
     let chatData = [];
     let currentCatName = '';
     let memoryFileRequestId = 0;
+    let memoryDissolveInProgress = false;
+    let memoryParticleCanvas = null;
+    let memoryParticleContext = null;
+    let memoryParticleFrame = 0;
+    let memoryParticles = [];
     let storageLocationState = {
         bootstrap: null,
         blockingReason: '',
@@ -1022,6 +1027,247 @@
         return String(c);
     }
 
+    function ensureMemoryParticleCanvas() {
+        if (!memoryParticleCanvas) {
+            memoryParticleCanvas = document.createElement('canvas');
+            memoryParticleCanvas.id = 'memory-particle-canvas';
+            memoryParticleCanvas.className = 'memory-particle-canvas';
+            memoryParticleCanvas.setAttribute('aria-hidden', 'true');
+            document.body.appendChild(memoryParticleCanvas);
+            memoryParticleContext = memoryParticleCanvas.getContext('2d');
+        }
+        resizeMemoryParticleCanvas();
+        return memoryParticleCanvas;
+    }
+
+    function resizeMemoryParticleCanvas() {
+        if (!memoryParticleCanvas || !memoryParticleContext) return;
+        const dpr = window.devicePixelRatio || 1;
+        memoryParticleCanvas.width = Math.max(1, Math.floor(window.innerWidth * dpr));
+        memoryParticleCanvas.height = Math.max(1, Math.floor(window.innerHeight * dpr));
+        memoryParticleCanvas.style.width = window.innerWidth + 'px';
+        memoryParticleCanvas.style.height = window.innerHeight + 'px';
+        memoryParticleContext.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    function randomBetween(min, max) {
+        return min + Math.random() * (max - min);
+    }
+
+    function createMemoryParticle(x, y, color, delay) {
+        const angle = randomBetween(-Math.PI * 0.92, -Math.PI * 0.08);
+        const speed = randomBetween(0.8, 4.2);
+        memoryParticles.push({
+            x,
+            y,
+            vx: Math.cos(angle) * speed + randomBetween(-0.65, 0.65),
+            vy: Math.sin(angle) * speed - randomBetween(0.2, 1.2),
+            rotation: randomBetween(0, Math.PI),
+            spin: randomBetween(-0.16, 0.16),
+            size: randomBetween(2.2, 5.8),
+            life: 0,
+            maxLife: randomBetween(48, 86),
+            delay: delay || 0,
+            color,
+            alpha: 1
+        });
+    }
+
+    function roundedRectPath(context, x, y, width, height, radius) {
+        const r = Math.min(radius, width / 2, height / 2);
+        context.beginPath();
+        context.moveTo(x + r, y);
+        context.arcTo(x + width, y, x + width, y + height, r);
+        context.arcTo(x + width, y + height, x, y + height, r);
+        context.arcTo(x, y + height, x, y, r);
+        context.arcTo(x, y, x + width, y, r);
+        context.closePath();
+    }
+
+    function wrapParticleText(context, text, x, y, maxWidth, lineHeight) {
+        const chars = Array.from(String(text || ''));
+        let line = '';
+        let cursorY = y;
+        for (const char of chars) {
+            const testLine = line + char;
+            if (line && context.measureText(testLine).width > maxWidth) {
+                context.fillText(line, x, cursorY);
+                line = char;
+                cursorY += lineHeight;
+            } else {
+                line = testLine;
+            }
+        }
+        if (line) {
+            context.fillText(line, x, cursorY);
+        }
+    }
+
+    function sampleMemoryElementParticles(element, role, delay) {
+        const rect = element.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return;
+
+        const offscreen = document.createElement('canvas');
+        const scale = 0.7;
+        offscreen.width = Math.max(1, Math.ceil(rect.width * scale));
+        offscreen.height = Math.max(1, Math.ceil(rect.height * scale));
+        const off = offscreen.getContext('2d');
+        if (!off) return;
+        off.scale(scale, scale);
+
+        const computed = window.getComputedStyle(element);
+        const foreground = computed.color || '#40c5f1';
+        const isBubble = element.classList.contains('chat-bubble');
+        const isDelete = element.classList.contains('delete-btn');
+        const palette = role === 'ai'
+            ? ['#40c5f1', '#96e8ff', '#f0f9ff', '#ffffff']
+            : ['#40c5f1', '#e3f4ff', '#ffffff', '#b3e5fc'];
+
+        if (isBubble || isDelete) {
+            roundedRectPath(off, 1, 1, rect.width - 2, rect.height - 2, isDelete ? 999 : 20);
+            off.fillStyle = computed.backgroundColor || (isDelete ? '#ff5252' : '#f0f9ff');
+            off.fill();
+            off.strokeStyle = isDelete ? 'rgba(255,255,255,0.2)' : '#e3f4ff';
+            off.lineWidth = isDelete ? 0 : 2;
+            if (!isDelete) off.stroke();
+        }
+
+        off.fillStyle = foreground;
+        off.font = `${computed.fontWeight} ${computed.fontSize} ${computed.fontFamily}`;
+        off.textBaseline = 'top';
+        const startX = isBubble ? 18 : 0;
+        const startY = isBubble ? 12 : 0;
+        const maxWidth = Math.max(40, rect.width - (isBubble ? 36 : 0));
+        const lineHeight = parseFloat(computed.lineHeight) || parseFloat(computed.fontSize) * 1.55;
+        wrapParticleText(off, element.textContent || '', startX, startY, maxWidth, lineHeight);
+
+        const image = off.getImageData(0, 0, offscreen.width, offscreen.height);
+        const step = isBubble ? 5 : 4;
+        for (let y = 0; y < image.height; y += step) {
+            for (let x = 0; x < image.width; x += step) {
+                const alpha = image.data[(y * image.width + x) * 4 + 3];
+                if (alpha > 16 && Math.random() > 0.46) {
+                    const color = isDelete
+                        ? (Math.random() > 0.42 ? '#ff8a8a' : '#ffffff')
+                        : palette[Math.floor(Math.random() * palette.length)];
+                    createMemoryParticle(rect.left + x / scale, rect.top + y / scale, color, delay + randomBetween(0, 12));
+                }
+            }
+        }
+    }
+
+    function addMemoryItemParticles(item, sequence) {
+        ensureMemoryParticleCanvas();
+        const delay = (sequence || 0) * 7;
+        const role = item.getAttribute('data-role') || '';
+        item.querySelectorAll('.chat-speaker, .chat-bubble, .chat-time, .delete-btn').forEach(node => {
+            sampleMemoryElementParticles(node, role, delay);
+        });
+
+        const rect = item.getBoundingClientRect();
+        if (rect.width > 0) {
+            for (let i = 0; i < 28; i++) {
+                createMemoryParticle(
+                    randomBetween(rect.left + rect.width * 0.08, rect.right - rect.width * 0.1),
+                    rect.top + randomBetween(0, 4),
+                    i % 2 ? '#b3e5fc' : '#40c5f1',
+                    delay + randomBetween(0, 16)
+                );
+            }
+        }
+    }
+
+    function animateMemoryParticles() {
+        if (!memoryParticleContext) return;
+        memoryParticleContext.clearRect(0, 0, window.innerWidth, window.innerHeight);
+        memoryParticles = memoryParticles.filter(particle => {
+            if (particle.delay > 0) {
+                particle.delay -= 1;
+                return true;
+            }
+
+            particle.life += 1;
+            const progress = particle.life / particle.maxLife;
+            particle.vy += 0.018;
+            particle.vx *= 0.992;
+            particle.x += particle.vx;
+            particle.y += particle.vy;
+            particle.rotation += particle.spin;
+            particle.alpha = Math.max(0, 1 - progress);
+
+            memoryParticleContext.save();
+            memoryParticleContext.globalAlpha = particle.alpha;
+            memoryParticleContext.translate(particle.x, particle.y);
+            memoryParticleContext.rotate(particle.rotation);
+            memoryParticleContext.fillStyle = particle.color;
+            memoryParticleContext.shadowColor = 'rgba(64, 197, 241, 0.38)';
+            memoryParticleContext.shadowBlur = 9 * particle.alpha;
+            memoryParticleContext.fillRect(-particle.size / 2, -particle.size / 2, particle.size, particle.size);
+            memoryParticleContext.restore();
+
+            return particle.life < particle.maxLife;
+        });
+
+        if (memoryParticles.length) {
+            memoryParticleFrame = requestAnimationFrame(animateMemoryParticles);
+        } else {
+            cancelAnimationFrame(memoryParticleFrame);
+            memoryParticleFrame = 0;
+        }
+    }
+
+    function startMemoryParticles() {
+        if (!memoryParticleFrame) {
+            memoryParticleFrame = requestAnimationFrame(animateMemoryParticles);
+        }
+    }
+
+    function collapseMemoryItem(item) {
+        const height = item.getBoundingClientRect().height;
+        item.style.height = height + 'px';
+        item.classList.add('is-collapsing');
+        requestAnimationFrame(() => {
+            item.style.height = '0px';
+        });
+    }
+
+    function setChatActionButtonsEnabled(enabled) {
+        const clearBtn = document.getElementById('clear-memory-btn');
+        if (clearBtn) clearBtn.disabled = !enabled;
+        document.querySelectorAll('#memory-chat-edit .delete-btn').forEach(btn => {
+            btn.disabled = !enabled;
+        });
+    }
+
+    function dissolveChatItems(items, onComplete) {
+        const targets = (items || []).filter(Boolean);
+        if (!targets.length) {
+            if (typeof onComplete === 'function') onComplete();
+            return;
+        }
+
+        memoryDissolveInProgress = true;
+        setChatActionButtonsEnabled(false);
+        memoryParticles = [];
+        cancelAnimationFrame(memoryParticleFrame);
+        memoryParticleFrame = 0;
+
+        targets.forEach((item, sequence) => {
+            window.setTimeout(() => {
+                addMemoryItemParticles(item, sequence);
+                item.classList.add('is-dissolving');
+                startMemoryParticles();
+                window.setTimeout(() => collapseMemoryItem(item), 620);
+            }, sequence * 145);
+        });
+
+        window.setTimeout(() => {
+            if (typeof onComplete === 'function') onComplete();
+            memoryDissolveInProgress = false;
+            setChatActionButtonsEnabled(true);
+        }, 1120 + targets.length * 145);
+    }
+
     async function loadMemoryFileList() {
         const ul = document.getElementById('memory-file-list');
         ul.innerHTML = `<li style="color:#888; padding: 8px;">${window.t ? window.t('memory.loading') : '加载中...'}</li>`;
@@ -1086,6 +1332,8 @@
         chatData.forEach((msg, i) => {
             const container = document.createElement('div');
             container.className = 'chat-item';
+            container.setAttribute('data-chat-index', String(i));
+            container.setAttribute('data-role', msg.role || '');
 
             if (msg.role === 'system') {
                 let text = msg.text;
@@ -1223,8 +1471,11 @@
     }
 
     function deleteChat(idx) {
+        if (memoryDissolveInProgress) return;
+        const item = document.querySelector(`#memory-chat-edit .chat-item[data-chat-index="${idx}"]`);
+        if (!item || idx < 0 || idx >= chatData.length) return;
         chatData.splice(idx, 1);
-        renderChatEdit();
+        dissolveChatItems([item], renderChatEdit);
     }
     // 新增：AI输入框内容变更时，自动拼接时间戳
     function updateAIContent(idx, value) {
@@ -1418,10 +1669,20 @@
         }
     };
     document.getElementById('clear-memory-btn').onclick = function () {
+        if (memoryDissolveInProgress) return;
+        const itemsToDissolve = Array.from(
+            document.querySelectorAll('#memory-chat-edit .chat-item[data-role="human"], #memory-chat-edit .chat-item[data-role="ai"]')
+        );
+        if (!itemsToDissolve.length) {
+            showSaveStatus(window.t ? window.t('memory.clearedChatKeptMemo') : '已清空对话记录，备忘录已保留（未保存）', false);
+            return;
+        }
         // 只清空对话轮次（用户 / AI）；system＝先前对话的备忘录，一律保留
         chatData = chatData.filter(msg => msg && msg.role !== 'human' && msg.role !== 'ai');
-        renderChatEdit();
-        showSaveStatus(window.t ? window.t('memory.clearedChatKeptMemo') : '已清空对话记录，备忘录已保留（未保存）', false);
+        dissolveChatItems(itemsToDissolve, function () {
+            renderChatEdit();
+            showSaveStatus(window.t ? window.t('memory.clearedChatKeptMemo') : '已清空对话记录，备忘录已保留（未保存）', false);
+        });
     };
     function showSaveStatus(msg, success) {
         const el = document.getElementById('save-status');
@@ -1461,6 +1722,7 @@
     window.closeMemoryBrowser = closeMemoryBrowser;
     window.addEventListener('pagehide', teardownMemoryChatPanelHeightSync);
     window.addEventListener('beforeunload', teardownMemoryChatPanelHeightSync);
+    window.addEventListener('resize', resizeMemoryParticleCanvas);
     // 页面加载时隐藏保存按钮
     document.addEventListener('DOMContentLoaded', async function () {
         initMemoryChatPanelHeightSync();

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -461,6 +461,50 @@ def test_memory_browser_select_file(mock_page: Page, running_server: str, seed_m
     expect(mock_page.locator("#save-row")).to_be_visible()
 
 
+@pytest.mark.frontend
+def test_memory_browser_clear_all_dissolves_chat_items_before_removing(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    """The Clear button should animate human/AI rows away and keep the system memo."""
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-chat-edit .chat-item", timeout=5000)
+    expect(mock_page.locator("#memory-chat-edit .chat-item")).to_have_count(3)
+
+    mock_page.locator("#clear-memory-btn").click()
+
+    expect(mock_page.locator("#memory-chat-edit .chat-item.is-dissolving")).to_have_count(2)
+    expect(mock_page.locator("#memory-particle-canvas")).to_have_count(1)
+    expect(mock_page.locator("#memory-chat-edit .chat-item")).to_have_count(1, timeout=3000)
+    expect(mock_page.locator("#memory-chat-edit .memo-textarea").first).to_have_value("这是测试备忘录内容。")
+    expect(mock_page.locator("#save-status")).to_contain_text("已清空对话记录，备忘录已保留")
+
+
+@pytest.mark.frontend
+def test_memory_browser_delete_single_chat_item_dissolves_before_removing(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    """Per-row delete should use the same particle dissolve instead of vanishing instantly."""
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-chat-edit .delete-btn", timeout=5000)
+    expect(mock_page.locator("#memory-chat-edit .chat-item")).to_have_count(3)
+
+    mock_page.locator("#memory-chat-edit .delete-btn").first.click()
+
+    expect(mock_page.locator("#memory-chat-edit .chat-item.is-dissolving")).to_have_count(1)
+    expect(mock_page.locator("#memory-particle-canvas")).to_have_count(1)
+    expect(mock_page.locator("#memory-chat-edit .chat-item")).to_have_count(2, timeout=3000)
+    expect(mock_page.locator("#memory-chat-edit")).not_to_contain_text("你好，测试猫娘！")
+    expect(mock_page.locator("#memory-chat-edit")).to_contain_text("你好主人！我是测试猫娘喵~")
+
+
 _BODY_SENTENCE = "博士正在和小猫娘一起挖铁矿，刚找到一批可以做铁镐。"
 _OLDER_SENTENCE = "几天前两人养过一株窗台幼苗，并烤了草莓蛋糕。"
 

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -505,6 +505,46 @@ def test_memory_browser_delete_single_chat_item_dissolves_before_removing(
     expect(mock_page.locator("#memory-chat-edit")).to_contain_text("你好主人！我是测试猫娘喵~")
 
 
+@pytest.mark.frontend
+def test_memory_browser_clear_respects_reduced_motion(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    """Reduced-motion users should not wait for the particle canvas animation."""
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.emulate_media(reduced_motion="reduce")
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-chat-edit .chat-item", timeout=5000)
+    expect(mock_page.locator("#memory-chat-edit .chat-item")).to_have_count(3)
+
+    mock_page.locator("#clear-memory-btn").click()
+
+    expect(mock_page.locator("#memory-chat-edit .chat-item")).to_have_count(1)
+    expect(mock_page.locator("#memory-particle-canvas")).to_have_count(0)
+    expect(mock_page.locator("#save-status")).to_contain_text("已清空对话记录，备忘录已保留")
+
+
+@pytest.mark.frontend
+def test_memory_browser_particle_canvas_is_removed_on_pagehide(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    """The temporary particle canvas should not linger when the page unloads."""
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-chat-edit .delete-btn", timeout=5000)
+    mock_page.locator("#memory-chat-edit .delete-btn").first.click()
+    expect(mock_page.locator("#memory-particle-canvas")).to_have_count(1)
+
+    mock_page.evaluate("window.dispatchEvent(new Event('pagehide'))")
+
+    expect(mock_page.locator("#memory-particle-canvas")).to_have_count(0)
+
+
 _BODY_SENTENCE = "博士正在和小猫娘一起挖铁矿，刚找到一批可以做铁镐。"
 _OLDER_SENTENCE = "几天前两人养过一株窗台幼苗，并烤了草莓蛋糕。"
 


### PR DESCRIPTION
## 改动概述 / Summary

- 为记忆浏览页的【清空】和单条【删除】加入粒子消散动画。
- 动画会作用在聊天气泡、说话人、时间和删除按钮上，随后再移除对应记录。
- 补充了前端回归测试，覆盖清空全部和单条删除的消散流程。

## 回归报告 / Regression Report

不适用。

## 不拆分理由 / Why Not Split

不适用。

## 测试 / Testing

- `./.venv/bin/pytest tests/frontend/test_memory_browser.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为记忆浏览器“删除/清空”加入消息溶解过渡，并显示粒子背景动画，增强交互反馈。
* **改进**
  * 删除单条或清空时，先播放溶解效果再移除内容；动画期间会禁用对应操作以避免重复触发。
  * 在减少动态效果或消息较多时自动跳过粒子过程并直接完成；页面卸载时清理粒子画布。
* **测试**
  * 新增前端用例覆盖溶解/粒子边界状态、减少动态效果、以及页面卸载清理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->