### PR TITLE
fix(agent): prevent plugin/utils from shadowing root utils in spawned child processes

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -21,7 +21,7 @@ _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # sub-packages.  The check ``not in`` is deliberately removed: ``_repo_root``
 # may already exist later in sys.path (e.g. via .venv site-packages), but
 # that position loses to ``plugin/`` which is inserted at index 1 by
-# ``_ensure_user_plugin_server``.
+# ``_start_embedded_user_plugin_server`` (L747).
 if sys.path[0:1] != [_repo_root]:
     sys.path.insert(0, _repo_root)
 

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -16,7 +16,13 @@
 import sys
 import os
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _repo_root not in sys.path:
+# Always insert at position 0 so project-root ``utils/`` (and ``config/``,
+# etc.) are found *before* ``plugin/`` which may contain identically-named
+# sub-packages.  The check ``not in`` is deliberately removed: ``_repo_root``
+# may already exist later in sys.path (e.g. via .venv site-packages), but
+# that position loses to ``plugin/`` which is inserted at index 1 by
+# ``_ensure_user_plugin_server``.
+if sys.path[0:1] != [_repo_root]:
     sys.path.insert(0, _repo_root)
 
 # Wire DI bindings explicitly — direct script invocation

--- a/app/main_server.py
+++ b/app/main_server.py
@@ -19,7 +19,7 @@ import os
 # (python app/main_server.py). Under launcher.py the path is already set
 # up; the insert below is then a no-op.
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _repo_root not in sys.path:
+if sys.path[0:1] != [_repo_root]:
     sys.path.insert(0, _repo_root)
 
 # Wire DI bindings (config._runtime resolvers ← utils.language_utils /

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -16,7 +16,7 @@
 import sys
 import os
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _repo_root not in sys.path:
+if sys.path[0:1] != [_repo_root]:
     sys.path.insert(0, _repo_root)
 
 # Wire DI bindings explicitly — direct script invocation

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -16,6 +16,7 @@
 import sys
 import os
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Force project root to sys.path[0] — see agent_server.py top for rationale.
 if sys.path[0:1] != [_repo_root]:
     sys.path.insert(0, _repo_root)
 

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -15,6 +15,7 @@
 
 import sys, os
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Force project root to sys.path[0] — see agent_server.py top for rationale.
 if sys.path[0:1] != [_repo_root]:
     sys.path.insert(0, _repo_root)
 

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -15,7 +15,7 @@
 
 import sys, os
 _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _repo_root not in sys.path:
+if sys.path[0:1] != [_repo_root]:
     sys.path.insert(0, _repo_root)
 
 # Wire DI bindings explicitly — direct script invocation


### PR DESCRIPTION
## 改动概述 / Summary

- 修复直接运行 `uv run python app/agent_server.py` 并开启用户插件时，multiprocessing 子进程报 `ModuleNotFoundError: No module named 'utils.logger_config'` 的问题

## 回归报告 / Regression Report

**改动了什么：** `app/agent_server.py` 顶部的 `sys.path` 修复逻辑，将 `if _repo_root not in sys.path` 改为 `if sys.path[0:1] != [_repo_root]`。

**理由 / 必要性：** `_start_embedded_user_plugin_server`（本文件 L735）在运行时会 `sys.path.insert(1, plugin_dir)`（L747），当 multiprocessing spawn 子进程继承父进程的 `sys.path` 时，`plugin/` 已在索引 1。由于 `.venv` site-packages 已将 `_repo_root` 放在更后面的索引，原 `not in` 判断跳过了 insert，导致 `plugin/utils/` 先于项目根 `utils/` 被找到并注册到 `sys.modules`。

**改动前后对比：**
- 改动前：`uv run python app/agent_server.py` → 开启插件 → 子进程崩溃（`ModuleNotFoundError`）
- 改动后：子进程 `_repo_root` 始终在 `sys.path[0]`，`import utils` 正确解析到项目根 `utils/`

**潜在回归点：** 通过 launcher.py 启动的路径不受影响。`sys.path[0]` 重复插入的开销可忽略。

## 不拆分理由 / Why Not Split

不适用（仅改动 1 个文件）。

## 测试 / Testing

- 手动验证：`uv run python app/agent_server.py` → 访问 `localhost:48911` → 开启用户插件，不再崩溃
- 手动验证：`uv run python launcher.py` 启动流程无回归

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了应用启动时的模块搜索顺序，确保项目根目录始终优先于其他路径。
  * 减少了路径重复或顺序不一致带来的导入异常，提升了运行稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->