### PR TITLE
拖文件给猫娘时透传 avatar-drop 来源标记，并在猫爪 analyzer 入口跳过该类回合，避免文件拖拽被误判为 Agent 任务触发

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3724,7 +3724,14 @@ class LLMSessionManager:
                 "details": {"command": command},
             }))
 
-    async def handle_input_transcript(self, transcript: str, *, is_voice_source: bool = True):
+    async def handle_input_transcript(
+        self,
+        transcript: str,
+        *,
+        is_voice_source: bool = True,
+        source: str | None = None,
+        metadata: dict | None = None,
+    ):
         """Sync transcript text into queues/cache and push it to the frontend.
 
         ``is_voice_source`` defaults to True for the realtime-client
@@ -3844,6 +3851,11 @@ class LLMSessionManager:
 
         # 推送到同步消息队列
         user_message = {"input_type": "transcript", "data": record_transcript_text}
+        source_value = str(source or "").strip()
+        if source_value:
+            user_message["source"] = source_value
+        if isinstance(metadata, dict) and metadata:
+            user_message["metadata"] = metadata
         if not is_voice_source and self._active_text_request_id:
             user_message["request_id"] = self._active_text_request_id
         self.sync_message_queue.put({"type": "user", "data": user_message})
@@ -9447,6 +9459,7 @@ class LLMSessionManager:
                 # 文本模式：直接发送文本
                 if isinstance(data, str):
                     memory_text = self._clean_frontend_memory_text(message.get("memory_text"))
+                    message_source = str(message.get("source") or "").strip()
                     record_data = memory_text or data
                     # 更新用户活动时间戳（与 handle_input_transcript / _record_external_user_input
                     # 对偶）。idle reset loop 依赖该字段判断静默时长，文本路径不补的话
@@ -9582,8 +9595,21 @@ class LLMSessionManager:
                     _focus_thinking = await self._focus_inline_decision(record_data)
                     input_transcript_callback = None
                     if memory_text:
-                        async def input_transcript_callback(_transcript: str, *, _memory_text: str = memory_text) -> None:
-                            await self.handle_input_transcript(_memory_text, is_voice_source=False)
+                        transcript_metadata = {"source": message_source} if message_source else None
+
+                        async def input_transcript_callback(
+                            _transcript: str,
+                            *,
+                            _memory_text: str = memory_text,
+                            _message_source: str = message_source,
+                            _transcript_metadata: dict | None = transcript_metadata,
+                        ) -> None:
+                            await self.handle_input_transcript(
+                                _memory_text,
+                                is_voice_source=False,
+                                source=_message_source,
+                                metadata=_transcript_metadata,
+                            )
 
                     stream_text_kwargs = {
                         "system_prefix": _agent_cb_ctx or None,
@@ -9789,6 +9815,9 @@ class LLMSessionManager:
                                 "has_image": True,
                                 "mime_type": "image/jpeg",
                             }
+                            message_source = str(message.get("source") or "").strip()
+                            if message_source:
+                                image_message["source"] = message_source
                             if message.get("request_id"):
                                 image_message["request_id"] = message.get("request_id")
                             self.sync_message_queue.put({

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -134,6 +134,7 @@ from main_logic.mirror_meta import (
 )
 
 _USER_IMAGE_INPUT_TYPES = frozenset({"screen", "camera", "avatar_drop_image", "user_image"})
+AVATAR_DROP_SOURCE = "avatar-drop"
 
 
 def merge_unsynced_tail_assistants(chat_history, last_synced_index):
@@ -230,19 +231,96 @@ def _should_persist_avatar_interaction_memory(
     return True
 
 
+def _iter_source_values(value: object) -> list[str]:
+    if isinstance(value, str):
+        source = value.strip()
+        return [source] if source else []
+    if isinstance(value, (list, tuple, set, frozenset)):
+        values: list[str] = []
+        for item in value:
+            values.extend(_iter_source_values(item))
+        return values
+    return []
+
+
+def _message_has_source(message: dict, source: str) -> bool:
+    if not isinstance(message, dict):
+        return False
+    expected = str(source or "").strip()
+    if not expected:
+        return False
+
+    if expected in _iter_source_values(message.get("source")):
+        return True
+
+    for metadata_key in ("metadata", "meta"):
+        metadata = message.get(metadata_key)
+        if not isinstance(metadata, dict):
+            continue
+        if expected in _iter_source_values(metadata.get("source")):
+            return True
+        if expected in _iter_source_values(metadata.get("sources")):
+            return True
+
+    attachments = message.get("attachments")
+    if isinstance(attachments, list):
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            if expected in _iter_source_values(attachment.get("source")):
+                return True
+            if expected == AVATAR_DROP_SOURCE and str(attachment.get("input_type") or "") == "avatar_drop_image":
+                return True
+
+    return False
+
+
+def _latest_user_message_has_source(messages: list[dict], source: str) -> bool:
+    for message in reversed(messages or []):
+        if isinstance(message, dict) and message.get("role") == "user":
+            return _message_has_source(message, source)
+    return False
+
+
+def _append_user_input_cache_to_history(chat_history: list, text: object, sources: set[str]) -> bool:
+    user_text = str(text or "")
+    if not user_text:
+        sources.clear()
+        return False
+
+    item = {'role': 'user', 'content': [{"type": "text", "text": user_text}]}
+    normalized_sources = sorted({source for source in sources if source})
+    if normalized_sources:
+        item["metadata"] = {"sources": normalized_sources}
+        if len(normalized_sources) == 1:
+            item["source"] = normalized_sources[0]
+    chat_history.append(item)
+    sources.clear()
+    return True
+
+
 def _normalize_pending_user_attachments(pending_user_images: list) -> list[dict]:
     attachments = []
     for raw in pending_user_images or []:
+        input_type = ""
+        source = ""
         if isinstance(raw, dict):
             url = str(raw.get("data") or raw.get("url") or "").strip()
+            input_type = str(raw.get("input_type") or "").strip()
+            source = str(raw.get("source") or "").strip()
         else:
             url = str(raw or "").strip()
         if not url:
             continue
-        attachments.append({
+        attachment = {
             "type": "image_url",
             "url": url,
-        })
+        }
+        if input_type:
+            attachment["input_type"] = input_type
+        if source:
+            attachment["source"] = source
+        attachments.append(attachment)
     return attachments
 
 
@@ -251,6 +329,8 @@ def _append_pending_user_image(
     data: object,
     request_id: object,
     input_type: object = None,
+    *,
+    source: object = None,
 ) -> bool:
     """Append a real user image entry and return whether one was queued.
 
@@ -265,6 +345,9 @@ def _append_pending_user_image(
     }
     if input_type:
         entry["input_type"] = input_type
+    source_value = str(source or "").strip()
+    if source_value:
+        entry["source"] = source_value
     pending_user_images.append(entry)
     if len(pending_user_images) > PENDING_USER_IMAGES_MAX:
         del pending_user_images[:-PENDING_USER_IMAGES_MAX]
@@ -347,7 +430,12 @@ def _build_recent_analyze_messages(
         txt = str(txt or '')
         if txt == '':
             continue
-        recent.append({'role': item.get('role'), 'content': txt})
+        recent_item = {'role': item.get('role'), 'content': txt}
+        if item.get("source"):
+            recent_item["source"] = item.get("source")
+        if isinstance(item.get("metadata"), dict) and item.get("metadata"):
+            recent_item["metadata"] = item.get("metadata")
+        recent.append(recent_item)
         if item.get('role') == 'user':
             last_user_idx = len(recent) - 1
             last_user_source_idx = source_idx
@@ -689,6 +777,7 @@ async def run_sync_connector(
         )
 
     user_input_cache = ''
+    user_input_sources: set[str] = set()
     text_output_cache = ''  # lanlan的当前消息
     text_output_request_id = None
     current_turn = 'user'
@@ -727,7 +816,7 @@ async def run_sync_connector(
                             if current_turn == 'user':  # assistant new message starts
                                 had_user_input_this_turn = bool(user_input_cache)
                                 if user_input_cache:
-                                    chat_history.append({'role': 'user', 'content': [{"type": "text", "text": user_input_cache}]})
+                                    _append_user_input_cache_to_history(chat_history, user_input_cache, user_input_sources)
                                     user_input_cache = ''
                                 current_turn = 'assistant'
                                 text_output_request_id = message["data"].get("request_id")
@@ -768,6 +857,15 @@ async def run_sync_connector(
                     elif message["type"] == "user":  # 准备转录
                         data = message["data"].get("data")
                         input_type = message["data"].get("input_type")
+                        if input_type == "transcript":
+                            for source_value in _iter_source_values(message["data"].get("source")):
+                                user_input_sources.add(source_value)
+                            transcript_metadata = message["data"].get("metadata")
+                            if isinstance(transcript_metadata, dict):
+                                for source_value in _iter_source_values(transcript_metadata.get("source")):
+                                    user_input_sources.add(source_value)
+                                for source_value in _iter_source_values(transcript_metadata.get("sources")):
+                                    user_input_sources.add(source_value)
                         if input_type == "transcript": # 暂时只处理语音，后续还需要记录图片
                             if user_input_cache == '':
                                 await _try_send_json(sync_slot, {'type': 'user_activity'})  # 用于打断前端声音播放
@@ -793,6 +891,7 @@ async def run_sync_connector(
                                 data,
                                 message["data"].get("request_id") or "",
                                 input_type,
+                                source=message["data"].get("source"),
                             )
                             if not appended_image and message["data"].get("has_image"):
                                 await _try_send_json(sync_slot, {'type': 'user_activity'})
@@ -819,7 +918,7 @@ async def run_sync_connector(
                                 
                                 # 先处理未完成的用户输入缓存（如果有）
                                 if user_input_cache:
-                                    chat_history.append({'role': 'user', 'content': [{"type": "text", "text": user_input_cache}]})
+                                    _append_user_input_cache_to_history(chat_history, user_input_cache, user_input_sources)
                                     user_input_cache = ''
                                 
                                 # 再处理未完成的输出缓存（如果有）
@@ -1030,13 +1129,20 @@ async def run_sync_connector(
                                             allow_attach_to_last_user=had_user_input_this_turn,
                                         )
                                         has_user = any(m.get('role') == 'user' for m in recent)
+                                        latest_user_is_avatar_drop = _latest_user_message_has_source(
+                                            recent,
+                                            AVATAR_DROP_SOURCE,
+                                        )
                                         logger.info(
                                             f"[{lanlan_name}] turn_end analyze check: "
                                             f"history={len(chat_history)} recent={len(recent)} "
                                             f"has_user={has_user} had_input={had_user_input_this_turn} "
-                                            f"agent_callback_turn={is_agent_callback_turn_end}"
+                                            f"agent_callback_turn={is_agent_callback_turn_end} "
+                                            f"avatar_drop_turn={latest_user_is_avatar_drop}"
                                         )
-                                        if recent and not is_agent_callback_turn_end:
+                                        if recent and latest_user_is_avatar_drop:
+                                            logger.info(f"[{lanlan_name}] analyze_request skipped (avatar_drop turn_end), messages={len(recent)}")
+                                        elif recent and not is_agent_callback_turn_end:
                                             sent = await _publish_analyze_request_with_fallback(
                                                 lanlan_name=lanlan_name,
                                                 trigger="turn_end",
@@ -1100,7 +1206,7 @@ async def run_sync_connector(
                                 
                                 # 先处理未完成的用户输入缓存（如果有）
                                 if user_input_cache:
-                                    chat_history.append({'role': 'user', 'content': [{"type": "text", "text": user_input_cache}]})
+                                    _append_user_input_cache_to_history(chat_history, user_input_cache, user_input_sources)
                                     user_input_cache = ''
                                 
                                 # 再处理未完成的输出缓存（如果有）
@@ -1129,7 +1235,13 @@ async def run_sync_connector(
                                             allow_attach_to_last_user=had_user_input_this_turn,
                                         )
                                         has_user = any(m.get('role') == 'user' for m in recent)
-                                        if recent and has_user:
+                                        latest_user_is_avatar_drop = _latest_user_message_has_source(
+                                            recent,
+                                            AVATAR_DROP_SOURCE,
+                                        )
+                                        if recent and has_user and latest_user_is_avatar_drop:
+                                            logger.info(f"[{lanlan_name}] analyze_request skipped (avatar_drop session_end), messages={len(recent)}")
+                                        elif recent and has_user:
                                             sent = await _publish_analyze_request_with_fallback(
                                                 lanlan_name=lanlan_name,
                                                 trigger="session_end",

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -434,7 +434,7 @@ def _build_recent_analyze_messages(
         if item.get("source"):
             recent_item["source"] = item.get("source")
         if isinstance(item.get("metadata"), dict) and item.get("metadata"):
-            recent_item["metadata"] = item.get("metadata")
+            recent_item["metadata"] = item.get("metadata").copy()
         recent.append(recent_item)
         if item.get('role') == 'user':
             last_user_idx = len(recent) - 1
@@ -857,7 +857,7 @@ async def run_sync_connector(
                     elif message["type"] == "user":  # 准备转录
                         data = message["data"].get("data")
                         input_type = message["data"].get("input_type")
-                        if input_type == "transcript":
+                        if input_type == "transcript": # 暂时只处理语音，后续还需要记录图片
                             for source_value in _iter_source_values(message["data"].get("source")):
                                 user_input_sources.add(source_value)
                             transcript_metadata = message["data"].get("metadata")
@@ -866,7 +866,6 @@ async def run_sync_connector(
                                     user_input_sources.add(source_value)
                                 for source_value in _iter_source_values(transcript_metadata.get("sources")):
                                     user_input_sources.add(source_value)
-                        if input_type == "transcript": # 暂时只处理语音，后续还需要记录图片
                             if user_input_cache == '':
                                 await _try_send_json(sync_slot, {'type': 'user_activity'})  # 用于打断前端声音播放
                             user_input_cache += data

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -1139,7 +1139,7 @@ async def run_sync_connector(
                                             f"agent_callback_turn={is_agent_callback_turn_end} "
                                             f"avatar_drop_turn={latest_user_is_avatar_drop}"
                                         )
-                                        if recent and latest_user_is_avatar_drop:
+                                        if recent and has_user and latest_user_is_avatar_drop:
                                             logger.info(f"[{lanlan_name}] analyze_request skipped (avatar_drop turn_end), messages={len(recent)}")
                                         elif recent and not is_agent_callback_turn_end:
                                             sent = await _publish_analyze_request_with_fallback(

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2558,6 +2558,9 @@
             window._lastSubmittedText = typeof options.rollbackText === 'string' ? options.rollbackText : text;
             window._lastSubmittedRequestId = window._lastSubmittedText ? requestId : '';
             var isReactWindowSource = options.source === 'react-chat-window';
+            var messageSource = (typeof options.source === 'string' && options.source.trim())
+                ? options.source.trim()
+                : '';
             var reactOptimisticMessageId = '';
             var reactOptimisticMessageAppended = null;
             var sentUserContent = false;
@@ -2756,12 +2759,16 @@
                         for (var extraIndex = 0; extraIndex < extraImageDataUrls.length; extraIndex += 1) {
                             var extraUrl = extraImageDataUrls[extraIndex];
                             sentImageUrls.push(extraUrl);
-                            S.socket.send(JSON.stringify({
+                            var extraMessage = {
                                 action: 'stream_data',
                                 data: extraUrl,
                                 input_type: 'avatar_drop_image',
                                 request_id: requestId
-                            }));
+                            };
+                            if (messageSource) {
+                                extraMessage.source = messageSource;
+                            }
+                            S.socket.send(JSON.stringify(extraMessage));
                         }
 
                         sentUserContent = true;
@@ -2791,6 +2798,9 @@
                         };
                         if (memoryText) {
                             textMessage.memory_text = memoryText;
+                        }
+                        if (messageSource) {
+                            textMessage.source = messageSource;
                         }
                         S.socket.send(JSON.stringify(textMessage));
 

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2558,9 +2558,7 @@
             window._lastSubmittedText = typeof options.rollbackText === 'string' ? options.rollbackText : text;
             window._lastSubmittedRequestId = window._lastSubmittedText ? requestId : '';
             var isReactWindowSource = options.source === 'react-chat-window';
-            var messageSource = (typeof options.source === 'string' && options.source.trim())
-                ? options.source.trim()
-                : '';
+            var messageSource = typeof options.source === 'string' ? options.source.trim() : '';
             var reactOptimisticMessageId = '';
             var reactOptimisticMessageAppended = null;
             var sentUserContent = false;

--- a/tests/unit/test_avatar_drop_frontend_static.py
+++ b/tests/unit/test_avatar_drop_frontend_static.py
@@ -181,7 +181,7 @@ def test_avatar_drop_payload_sends_full_prompt_but_records_memory_summary_only()
     assert "memoryText: prompt" not in send_payload
     assert "extraImageDataUrls: imageDataUrls" in send_payload
     assert "input_type: 'avatar_drop_image',\n                                request_id: requestId" in source
-    assert "var messageSource = (typeof options.source === 'string' && options.source.trim())" in source
+    assert "var messageSource = typeof options.source === 'string' ? options.source.trim() : '';" in source
     assert "extraMessage.source = messageSource" in source
     assert "textMessage.source = messageSource" in source
     assert "forceReactOptimisticMessage: true" in send_payload

--- a/tests/unit/test_avatar_drop_frontend_static.py
+++ b/tests/unit/test_avatar_drop_frontend_static.py
@@ -181,6 +181,9 @@ def test_avatar_drop_payload_sends_full_prompt_but_records_memory_summary_only()
     assert "memoryText: prompt" not in send_payload
     assert "extraImageDataUrls: imageDataUrls" in send_payload
     assert "input_type: 'avatar_drop_image',\n                                request_id: requestId" in source
+    assert "var messageSource = (typeof options.source === 'string' && options.source.trim())" in source
+    assert "extraMessage.source = messageSource" in source
+    assert "textMessage.source = messageSource" in source
     assert "forceReactOptimisticMessage: true" in send_payload
     assert "ignoreComposerAttachments: true" in send_payload
 

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -1134,12 +1134,13 @@ def test_cross_server_avatar_drop_image_queue_skips_metadata_only_entries():
 @pytest.mark.unit
 def test_avatar_drop_recent_message_marks_latest_user_for_analyzer_skip():
     """Avatar Drop handoff turns are chat content, not Agent task requests."""
+    metadata = {"sources": [cross_server_module.AVATAR_DROP_SOURCE]}
     recent = cross_server_module._build_recent_analyze_messages(
         [{
             "role": "user",
             "content": [{"type": "text", "text": "Handed over: note.txt"}],
             "source": cross_server_module.AVATAR_DROP_SOURCE,
-            "metadata": {"sources": [cross_server_module.AVATAR_DROP_SOURCE]},
+            "metadata": metadata,
         }],
         [{
             "data": "data:image/png;base64,current",
@@ -1162,6 +1163,7 @@ def test_avatar_drop_recent_message_marks_latest_user_for_analyzer_skip():
             "source": cross_server_module.AVATAR_DROP_SOURCE,
         }],
     }]
+    assert recent[0]["metadata"] is not metadata
     assert cross_server_module._latest_user_message_has_source(
         recent,
         cross_server_module.AVATAR_DROP_SOURCE,

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -32,12 +32,27 @@ class _FakeState:
     def __init__(self):
         self.preempt_marked = False
         self.events = []
+        self.mode = core_module.CognitionMode.REGULAR
 
     def mark_user_input_preempt(self):
         self.preempt_marked = True
 
     async def fire(self, event, **kwargs):
         self.events.append((event, kwargs))
+
+    async def update_focus(self, *_args, **_kwargs):
+        self.mode = core_module.CognitionMode.REGULAR
+        return self.mode
+
+    async def clear_focus(self):
+        self.mode = core_module.CognitionMode.REGULAR
+
+    def snapshot(self):
+        return {
+            "focus_charge": 0.0,
+            "focus_charge_at": 0.0,
+            "focus_episode_id": None,
+        }
 
 
 class _FakeQueue:
@@ -131,6 +146,11 @@ def _make_manager():
     mgr._magic_command_image_drop_request_order = deque()
     mgr._pending_turn_meta = None
     mgr._current_ai_turn_text = ""
+    mgr._focus_indicator_active = False
+    mgr._focus_thinking_active = False
+    mgr._focus_artifacts_pending = False
+    mgr._focus_artifacts_history_start = None
+    mgr._focus_emotion_reading = None
     mgr._recent_ai_voice_echo_text = ""
     mgr._recent_ai_voice_echo_at = 0.0
     mgr._pending_ai_voice_echo_text = ""
@@ -667,7 +687,12 @@ async def test_text_mode_avatar_drop_image_is_metadata_only_in_analyzer_queue(mo
 
     await core_module.LLMSessionManager._process_stream_data_internal(
         mgr,
-        {"input_type": "avatar_drop_image", "data": "raw-image", "request_id": "req-img"},
+        {
+            "input_type": "avatar_drop_image",
+            "data": "raw-image",
+            "request_id": "req-img",
+            "source": "avatar-drop",
+        },
     )
 
     mgr.session.stream_image.assert_awaited_once_with("img-b64")
@@ -679,6 +704,32 @@ async def test_text_mode_avatar_drop_image_is_metadata_only_in_analyzer_queue(mo
             "has_image": True,
             "mime_type": "image/jpeg",
             "request_id": "req-img",
+            "source": "avatar-drop",
+        },
+    }]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_non_voice_transcript_reuse_preserves_avatar_drop_source():
+    """Text-mode Avatar Drop memory summaries must keep their source tag."""
+    mgr = _make_transcript_manager()
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr,
+        "Handed over: note.txt",
+        is_voice_source=False,
+        source="avatar-drop",
+        metadata={"source": "avatar-drop"},
+    )
+
+    assert mgr.sync_message_queue.messages == [{
+        "type": "user",
+        "data": {
+            "input_type": "transcript",
+            "data": "Handed over: note.txt",
+            "source": "avatar-drop",
+            "metadata": {"source": "avatar-drop"},
         },
     }]
 
@@ -1078,6 +1129,62 @@ def test_cross_server_avatar_drop_image_queue_skips_metadata_only_entries():
         "request_id": "req-current",
         "input_type": "user_image",
     }]
+
+
+@pytest.mark.unit
+def test_avatar_drop_recent_message_marks_latest_user_for_analyzer_skip():
+    """Avatar Drop handoff turns are chat content, not Agent task requests."""
+    recent = cross_server_module._build_recent_analyze_messages(
+        [{
+            "role": "user",
+            "content": [{"type": "text", "text": "Handed over: note.txt"}],
+            "source": cross_server_module.AVATAR_DROP_SOURCE,
+            "metadata": {"sources": [cross_server_module.AVATAR_DROP_SOURCE]},
+        }],
+        [{
+            "data": "data:image/png;base64,current",
+            "request_id": "req-current",
+            "input_type": "avatar_drop_image",
+            "source": cross_server_module.AVATAR_DROP_SOURCE,
+        }],
+        allow_attach_to_last_user=True,
+    )
+
+    assert recent == [{
+        "role": "user",
+        "content": "Handed over: note.txt",
+        "source": cross_server_module.AVATAR_DROP_SOURCE,
+        "metadata": {"sources": [cross_server_module.AVATAR_DROP_SOURCE]},
+        "attachments": [{
+            "type": "image_url",
+            "url": "data:image/png;base64,current",
+            "input_type": "avatar_drop_image",
+            "source": cross_server_module.AVATAR_DROP_SOURCE,
+        }],
+    }]
+    assert cross_server_module._latest_user_message_has_source(
+        recent,
+        cross_server_module.AVATAR_DROP_SOURCE,
+    ) is True
+
+
+@pytest.mark.unit
+def test_avatar_drop_source_on_older_user_message_does_not_skip_latest_normal_user():
+    """Only the latest user turn controls the analyzer skip decision."""
+    recent = [
+        {
+            "role": "user",
+            "content": "Handed over: note.txt",
+            "source": cross_server_module.AVATAR_DROP_SOURCE,
+        },
+        {"role": "assistant", "content": "Got it."},
+        {"role": "user", "content": "Now help me open settings."},
+    ]
+
+    assert cross_server_module._latest_user_message_has_source(
+        recent,
+        cross_server_module.AVATAR_DROP_SOURCE,
+    ) is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复“将文件拖给猫娘”时可能误触发猫爪 Agent 的问题。
拖拽文件发送时透传 `source: "avatar-drop"`，后端保留该来源标记，并在 `cross_server` 向猫爪 analyzer 发送 `turn_end/session_end` 分析请求前判断：如果最新用户回合来源是 `avatar-drop`，则跳过本次 Agent 分析。

## 回归报告 / Regression Report

<!--
仅当本 PR 触碰 app/、main_logic/、memory/ 时必填。请逐项说明：
  - 改动了什么
  - 理由 / 必要性
  - 改动前后的表现对比
  - 潜在回归点（影响哪些链路、怎么验证的）
未触碰这三个模块：写「不适用」或删除本节。
-->
- 改动了什么
  - 前端发送拖拽文件文本/图片时带上 `source`。
  - `main_logic/core.py` 将文本 transcript 和拖拽图片 metadata 的 `source` 写入 sync queue。
  - `main_logic/cross_server.py` 在构造 analyzer recent messages 时保留来源，并对最新用户回合为 `avatar-drop` 的回合跳过猫爪分析。

- 理由 / 必要性
  - 拖文件给猫娘属于内容交互，不是用户请求 Agent 执行任务。
  - 原逻辑里拖拽消息进入普通文本回合，猫娘回复后可能被 analyzer 误判为猫爪任务触发。

- 改动前后的表现对比
  - 改动前：拖文件后，猫娘围绕文件内容的回复可能进入猫爪 analyzer 并误触发 Agent。
  - 改动后：该回合会正常给猫娘处理和回复，但不会进入猫爪任务分析。
  - 用户后续正常输入不受影响，例如拖完文件后再说“帮我打开设置”，仍会照常进入猫爪判断。

- 潜在回归点
  - 文本发送链路：验证普通文本仍会发送到模型。
  - 图片/截图链路：验证普通截图、聊天框图片不被 `avatar-drop` 跳过逻辑误伤。
  - session end 链路：验证拖拽文件后结束会话不会补发 analyzer 请求。
  - sync/analyzer 摘要链路：验证 `source/metadata` 只作为内部标记，不改变用户可见内容和记忆文本。

## 测试 / Testing

手动测试拖拽


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 用户转写与文本/图片输入现在可携带“来源（source）”与附加元信息（metadata），并在前端与后端通信中统一透传。
  * 前端发送文本与额外图片时会写入并校验 `messageSource`（自动去除首尾空格）。
* **Bug 修复**
  * 优化“Avatar Drop”相关的分析触发：当最近用户消息命中该来源时跳过后续分析请求，且只影响最新用户消息判定。
* **测试**
  * 新增并更新单元测试，覆盖来源字段透传与分析跳过判定逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->