### PR TITLE
fix(chat): 紧凑表情包 overlay 生命周期（按轮换场 + 手动关闭叉）

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -805,6 +805,23 @@ describe('App', () => {
     expect(container.querySelector('.compact-meme-overlay')).toBeNull();
   });
 
+  it('keeps the meme overlay when a non-assistant (tool/system) message with a different turnId follows', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    // 只有「不同 turnId 的助手发言」算换场；tool/system 不是发言，不该顶掉图。
+    const meme = parseChatMessage({
+      id: 'meme-turn1', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1, turnId: 'turn-1',
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=t1', alt: 'lol' }], status: 'sent',
+    });
+    const toolMsg = parseChatMessage({
+      id: 'tool-x', role: 'tool', author: 'Tool', time: '10:01', createdAt: 2, turnId: 'turn-2',
+      blocks: [{ type: 'text', text: 'tool result' }], status: 'sent',
+    });
+    const { container } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" messages={[meme, toolMsg]} />,
+    );
+    expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=t1');
+  });
+
   it('hides the proactive meme overlay while compact history is open', () => {
     const meme = parseChatMessage({
       id: 'meme-visible-in-history',

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -768,6 +768,43 @@ describe('App', () => {
     expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=z');
   });
 
+  it('keeps the meme overlay through a same-turn caption that shares its turnId', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    // host 给主动分享 meme 打上它所属轮的 turnId（与同轮台词相同）；同轮台词不该顶掉图。
+    const meme = parseChatMessage({
+      id: 'meme-turn1', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1, turnId: 'turn-1',
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=t1', alt: 'lol' }], status: 'sent',
+    });
+    const sameTurnCaption = parseChatMessage({
+      id: 'assistant-caption', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 2, turnId: 'turn-1',
+      blocks: [{ type: 'text', text: '给你看个图～' }], status: 'sent',
+    });
+    const { container } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" messages={[meme, sameTurnCaption]} />,
+    );
+    expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=t1');
+  });
+
+  it('collapses the meme overlay once a new assistant turn (different turnId) arrives', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    // 真正的新一轮回复/主动搭话（不同 turnId）应顶掉旧图，即便用户没开口。
+    const meme = parseChatMessage({
+      id: 'meme-turn1', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1, turnId: 'turn-1',
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=t1', alt: 'lol' }], status: 'sent',
+    });
+    const { container, rerender } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" messages={[meme]} />,
+    );
+    expect(container.querySelector('.compact-meme-overlay')).not.toBeNull();
+
+    const newTurnReply = parseChatMessage({
+      id: 'assistant-newturn', role: 'assistant', author: 'Neko', time: '10:05', createdAt: 2, turnId: 'turn-2',
+      blocks: [{ type: 'text', text: '在干嘛呀～' }], status: 'sent',
+    });
+    rerender(<App chatSurfaceMode="compact" compactChatState="input" messages={[meme, newTurnReply]} />);
+    expect(container.querySelector('.compact-meme-overlay')).toBeNull();
+  });
+
   it('hides the proactive meme overlay while compact history is open', () => {
     const meme = parseChatMessage({
       id: 'meme-visible-in-history',

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -822,6 +822,47 @@ describe('App', () => {
     expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=t1');
   });
 
+  it('renders a close button on the meme overlay and hides the overlay when clicked', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    const meme = parseChatMessage({
+      id: 'meme-closeme', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=close', alt: 'lol' }], status: 'sent',
+    });
+    const { container } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" messages={[meme]} />,
+    );
+    const closeButton = container.querySelector('.compact-meme-overlay-close');
+    expect(closeButton).not.toBeNull();
+    // ⚠️ host 只把带 data-compact-hit-region 的子元素登记成 native 可交互区；漏了它 Electron
+    // pass-through 窗口里点击会穿到桌面（见 app-react-chat-window.js collectCompactCompositeGeometryItems）。
+    expect(closeButton).toHaveAttribute('data-compact-hit-region', 'true');
+    expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=close');
+
+    fireEvent.click(closeButton as Element);
+    expect(container.querySelector('.compact-meme-overlay')).toBeNull();
+  });
+
+  it('shows a newer meme even after the previous one was manually closed', () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    const memeA = parseChatMessage({
+      id: 'meme-A', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=A', alt: 'A' }], status: 'sent',
+    });
+    const { container, rerender } = render(
+      <App chatSurfaceMode="compact" compactChatState="input" messages={[memeA]} />,
+    );
+    fireEvent.click(container.querySelector('.compact-meme-overlay-close') as Element);
+    expect(container.querySelector('.compact-meme-overlay')).toBeNull();
+
+    // 叉掉旧图后，来一张新表情包（不同 id）应照常显示——dismiss 只钉旧 id。
+    const memeB = parseChatMessage({
+      id: 'meme-B', role: 'assistant', author: 'Neko', time: '10:05', createdAt: 2,
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=B', alt: 'B' }], status: 'sent',
+    });
+    rerender(<App chatSurfaceMode="compact" compactChatState="input" messages={[memeA, memeB]} />);
+    expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=B');
+  });
+
   it('hides the proactive meme overlay while compact history is open', () => {
     const meme = parseChatMessage({
       id: 'meme-visible-in-history',

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2511,7 +2511,15 @@ function CompactChatApp({
     for (let i = memeIdx + 1; i < messages.length; i += 1) {
       const later = messages[i];
       if (later?.role === 'user') return null;
-      if (memeTurnId && typeof later?.turnId === 'string' && later.turnId && later.turnId !== memeTurnId) {
+      // 仅「不同 turnId 的助手发言」算新一轮换场；tool/system 不是发言、且通常与 assistant 同轮，
+      // 不参与收起（更新的表情包另由上面「从尾部取最新 meme」自然替换，不走这里）。
+      if (
+        later?.role === 'assistant'
+        && memeTurnId
+        && typeof later.turnId === 'string'
+        && later.turnId
+        && later.turnId !== memeTurnId
+      ) {
         return null;
       }
     }

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1742,6 +1742,9 @@ function CompactChatApp({
   const compactCapsuleEntryLocked = compactTextEntryLocked;
   const [speechPlaybackState, setSpeechPlaybackState] = useState<SpeechPlaybackState | null>(null);
   const [compactCaptionState, setCompactCaptionState] = useState<CompactCaptionState | null>(null);
+  // 用户手动叉掉的表情包 id（会话级，不持久化）：overlay 的 meme id 命中即隐藏。下一张新 meme 是不同
+  // id，自然重新显示；刷新后状态重置（与 compactCaptionState 等紧凑挂件一致，均为 ephemeral state）。
+  const [dismissedMemeId, setDismissedMemeId] = useState<string | null>(null);
   const [compactAssistantStreamingGap, setCompactAssistantStreamingGap] = useState<{
     turnId: string;
     acceptStreaming: boolean;
@@ -2492,7 +2495,7 @@ function CompactChatApp({
   // 主动分享的表情包是 image-only 消息（id 以 'meme-' 开头），原本只活在会折叠的历史里。把「最新一条
   // 若是表情包」抽成一个独立 overlay 显示（仿音乐条），常显到「用户开口」或「新一轮助手发言」出现即收起
   // （换场规则详见下方 memo 注释）。
-  const compactMemeOverlay = useMemo<{ url: string; alt: string } | null>(() => {
+  const compactMemeOverlay = useMemo<{ id: string; url: string; alt: string } | null>(() => {
     if (!isCompactSurface) return null;
     let memeIdx = -1;
     for (let i = messages.length - 1; i >= 0; i -= 1) {
@@ -2524,7 +2527,7 @@ function CompactChatApp({
       }
     }
     for (const block of meme.blocks ?? []) {
-      if (block.type === 'image') return { url: block.url, alt: block.alt || 'Meme' };
+      if (block.type === 'image') return { id: meme.id, url: block.url, alt: block.alt || 'Meme' };
     }
     return null;
   }, [messages, isCompactSurface]);
@@ -7051,7 +7054,11 @@ function CompactChatApp({
   // 音乐条可见性与「聊天历史折叠」解耦：只要有音乐内容就常显（空态由 CSS `:empty { display:none }`
   // 兜底），不再随历史区收起而隐藏——否则历史默认折叠的 A/B closed 分支会连带看不到主动分享音乐条。
   const compactMusicPlayerVisibility = 'open' as const;
-  const compactMemeOverlayNode = isCompactSurface && !compactExportHistoryMounted && compactMemeOverlay ? (
+  const closeMemeButtonAriaLabel = i18n('chat.closeMemeAriaLabel', 'Close image');
+  const compactMemeOverlayNode = isCompactSurface
+    && !compactExportHistoryMounted
+    && compactMemeOverlay
+    && compactMemeOverlay.id !== dismissedMemeId ? (
     <div
       className="compact-meme-overlay"
       data-compact-meme-overlay="compact-surface"
@@ -7059,12 +7066,50 @@ function CompactChatApp({
       data-compact-geometry-item="meme"
       data-compact-geometry-hit-scope="children"
     >
-      {/* 被动弹出的单图挂件仅在历史区收起后显示；历史打开时由历史列表承载同一条图片消息，避免重复展示。
-          一渲染就 fixed 钉在视口内，没有「视口外延迟加载」的场景——lazy 对它零
-          收益（实测 lazy/eager 行为一致，图都会立刻加载），eager 语义更直接、也省掉一层
-          IntersectionObserver 判定。注：表情包「常显、不被同轮台词顶掉」靠的是上面 compactMemeOverlay
-          的 role 收起逻辑，不是这个属性。 */}
-      <img src={compactMemeOverlay.url} alt={compactMemeOverlay.alt} loading="eager" decoding="async" />
+      {/* frame 收紧到图片实际尺寸，让关闭叉贴在「图片」右上角而非更宽的 overlay 右上角（图片在 overlay
+          里居中、常比 overlay 窄）。 */}
+      <div className="compact-meme-overlay-frame">
+        {/* 被动弹出的单图挂件仅在历史区收起后显示；历史打开时由历史列表承载同一条图片消息，避免重复展示。
+            一渲染就 fixed 钉在视口内，没有「视口外延迟加载」的场景——lazy 对它零
+            收益（实测 lazy/eager 行为一致，图都会立刻加载），eager 语义更直接、也省掉一层
+            IntersectionObserver 判定。注：表情包「常显、不被同轮台词顶掉」靠的是上面 compactMemeOverlay
+            的 role 收起逻辑，不是这个属性。 */}
+        <img src={compactMemeOverlay.url} alt={compactMemeOverlay.alt} loading="eager" decoding="async" />
+        {/* 关闭叉：overlay 整体 pointer-events:none（点击穿透到桌面/下层），唯独这个按钮 CSS 里单独开
+            auto 才接得住点击；点了把当前 meme id 记进 dismissedMemeId（会话级），下一张新 meme 照常显示。
+            ⚠️ data-compact-hit-region 必带：overlay 的 data-compact-geometry-hit-scope="children" 让 host
+            只把带该标记的子元素登记成 native 可交互区（见 app-react-chat-window.js collectCompactCompositeGeometryItems）。
+            漏了它，Electron pass-through 窗口会把按钮当穿透区、点击穿到桌面（普通浏览器窗口测不出，对齐音乐条）。 */}
+        <button
+          type="button"
+          className="compact-meme-overlay-close"
+          data-compact-hit-region="true"
+          data-compact-hit-region-id="meme:close"
+          data-compact-hit-region-kind="meme-close"
+          aria-label={closeMemeButtonAriaLabel}
+          title={closeMemeButtonAriaLabel}
+          onClick={(event) => {
+            event.stopPropagation();
+            setDismissedMemeId(compactMemeOverlay.id);
+          }}
+        >
+          <svg
+            className="compact-meme-overlay-close-icon"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              d="M4.5 4.5 11.5 11.5 M11.5 4.5 4.5 11.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   ) : null;
   const compactMusicPlayerMountNode = isCompactSurface ? (

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2490,7 +2490,8 @@ function CompactChatApp({
   const surfaceModeClassName = `chat-surface-mode-${chatSurfaceMode}`;
   const compactMessagePreviewFromMessages = useMemo(() => getCompactMessagePreview(messages), [messages]);
   // 主动分享的表情包是 image-only 消息（id 以 'meme-' 开头），原本只活在会折叠的历史里。把「最新一条
-  // 若是表情包」抽成一个独立 overlay 显示（仿音乐条），常显到下一条新消息出现（最新消息不再是表情包）即收起。
+  // 若是表情包」抽成一个独立 overlay 显示（仿音乐条），常显到「用户开口」或「新一轮助手发言」出现即收起
+  // （换场规则详见下方 memo 注释）。
   const compactMemeOverlay = useMemo<{ url: string; alt: string } | null>(() => {
     if (!isCompactSurface) return null;
     let memeIdx = -1;
@@ -2499,12 +2500,20 @@ function CompactChatApp({
     }
     if (memeIdx < 0) return null;
     const meme = messages[memeIdx];
-    // 表情包是「仿音乐条」的独立常显挂件：发出后一直挂着，直到用户开口（出现下一条 role==='user'
-    // 的消息）才收起。猫娘同一轮、乃至后续若干轮的台词(assistant)和音乐卡都不算「对话换场」，
-    // 不收起——否则主动分享时紧随表情包落地的台词消息会在一瞬间把图顶掉。下一张新表情包由上面
-    // 「从尾部取最新 meme」自然替换，无需在这里显式清掉旧图。
+    // 表情包是「仿音乐条」的独立常显挂件，换场规则：
+    //  1) 用户开口（出现 role==='user' 的消息）→ 收起；
+    //  2) 出现「不同 turnId 的助手发言」→ 收起（host 给 meme 打了它所属主动搭话轮的 turnId，
+    //     见 app-proactive.js `_showMemeBubbles`）。这样真正的新一轮回复/主动搭话会顶掉旧图。
+    // 同一轮紧随表情包落地的台词(assistant)与 meme 共享 turnId，不算换场、不收起——否则图会一瞬间
+    // 被台词顶掉(#2031 回归)。turnId 缺失（meme 或后续消息任一方无 turnId，如纯音乐卡）时退化为只看
+    // 规则 1，保持旧行为。下一张新表情包由上面「从尾部取最新 meme」自然替换。
+    const memeTurnId = typeof meme.turnId === 'string' && meme.turnId ? meme.turnId : null;
     for (let i = memeIdx + 1; i < messages.length; i += 1) {
-      if (messages[i]?.role === 'user') return null;
+      const later = messages[i];
+      if (later?.role === 'user') return null;
+      if (memeTurnId && typeof later?.turnId === 'string' && later.turnId && later.turnId !== memeTurnId) {
+        return null;
+      }
     }
     for (const block of meme.blocks ?? []) {
       if (block.type === 'image') return { url: block.url, alt: block.alt || 'Meme' };

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -3052,7 +3052,10 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   width: min(calc(var(--compact-meme-surface-width) - 16px), 240px, calc(100vw - 24px));
   transform: translateX(-50%);
   z-index: 8;
-  /* 被动展示，不接收指针事件——让点击穿透到桌面/下层，且不被 Electron pass-through 当可交互 island。 */
+  /* 居中 inline-block 的 frame（frame 收紧到图片尺寸，让关闭叉贴图片角）。 */
+  text-align: center;
+  /* 被动展示，不接收指针事件——让点击穿透到桌面/下层，且不被 Electron pass-through 当可交互 island。
+     注：pointer-events 会继承给子元素，所以图片区也穿透；唯独关闭叉按钮单独开 auto 才可点。 */
   pointer-events: none;
   -webkit-app-region: no-drag;
 }
@@ -3072,6 +3075,54 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
   object-fit: contain;
   border-radius: 12px;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+}
+
+/* 关闭叉的定位框：inline-block 收紧到图片实际尺寸，叉子绝对定位到框右上角＝图片右上角。
+   pointer-events 继承 overlay 的 none（图片区继续穿透），只有下面的按钮单独开 auto。 */
+.compact-meme-overlay-frame {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.compact-meme-overlay-close {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  line-height: 0;
+  cursor: pointer;
+  /* overlay 整体 pointer-events:none（含图片区，点击穿透）；唯独这个按钮开 auto 才接得住点击。 */
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+  opacity: 0.85;
+  transition: opacity 0.16s ease, background 0.16s ease, transform 0.16s ease;
+  z-index: 1;
+}
+
+.compact-meme-overlay-close:hover {
+  background: rgba(0, 0, 0, 0.68);
+  opacity: 1;
+  transform: scale(1.06);
+}
+
+.compact-meme-overlay-close:active {
+  transform: scale(0.96);
+}
+
+.compact-meme-overlay-close-icon {
+  display: block;
+  width: 12px;
+  height: 12px;
+  pointer-events: none;
 }
 
 #music-player-mount.compact-music-player-mount[data-compact-music-player-visibility="closing"],

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -1632,6 +1632,14 @@
             return;
         }
 
+        // 表情包绑定它所属主动搭话轮的 turn_id（与同轮台词共享同一个值：flush 条件是
+        // realisticGeminiCurrentTurnId === captureTurnId，而台词的 turnId 也是 String(turn_id)）。
+        // compact overlay 靠它判定「新一轮发言才换场、同轮台词不顶掉」。turn_id 缺失（'fallback'/空）
+        // 时留 undefined，React 侧回退到旧的「只有用户开口才收起」逻辑。
+        var memeTurnId = (targetTurnId !== undefined && targetTurnId !== null
+            && targetTurnId !== '' && targetTurnId !== 'fallback')
+            ? String(targetTurnId) : undefined;
+
         // 优先通过 React 聊天窗口 API 显示表情包
         var host = window.reactChatWindowHost;
         if (host && typeof host.appendMessage === 'function') {
@@ -1662,6 +1670,7 @@
                         author: assistantName,
                         time: timeStr,
                         createdAt: Date.now(),
+                        turnId: memeTurnId,
                         avatarLabel: assistantName.trim().slice(0, 1).toUpperCase(),
                         avatarUrl: avatarUrl || undefined,
                         blocks: [{ type: 'image', url: proxyUrl, alt: meme.title || 'Meme' }],

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "Pending images",
         "pendingImageAlt": "Image {{index}}",
         "removePendingImage": "Remove image",
+        "closeMemeAriaLabel": "Close image",
         "emojiButtonAriaLabel": "Emoji",
         "toolIconsAriaLabel": "Tool icons",
         "toolLollipop": "Lollipop",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "Imágenes pendientes",
         "pendingImageAlt": "Imagen {{index}}",
         "removePendingImage": "Quitar imagen",
+        "closeMemeAriaLabel": "Cerrar imagen",
         "emojiButtonAriaLabel": "emojis",
         "toolIconsAriaLabel": "Iconos de herramientas",
         "toolLollipop": "Chupete",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "送信待ち画像",
         "pendingImageAlt": "画像 {{index}}",
         "removePendingImage": "画像を削除",
+        "closeMemeAriaLabel": "画像を閉じる",
         "emojiButtonAriaLabel": "絵文字",
         "toolIconsAriaLabel": "ツールアイコン",
         "toolLollipop": "キャンディー",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "전송 대기 이미지",
         "pendingImageAlt": "이미지 {{index}}",
         "removePendingImage": "이미지 제거",
+        "closeMemeAriaLabel": "이미지 닫기",
         "emojiButtonAriaLabel": "이모지",
         "toolIconsAriaLabel": "도구 아이콘",
         "toolLollipop": "막대사탕",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "Imagens pendentes",
         "pendingImageAlt": "Imagem {{index}}",
         "removePendingImage": "Remover imagem",
+        "closeMemeAriaLabel": "Fechar imagem",
         "emojiButtonAriaLabel": "Emoji",
         "toolIconsAriaLabel": "Ícones de ferramentas",
         "toolLollipop": "Pirulito",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "Изображения к отправке",
         "pendingImageAlt": "Изображение {{index}}",
         "removePendingImage": "Удалить изображение",
+        "closeMemeAriaLabel": "Закрыть изображение",
         "emojiButtonAriaLabel": "Эмодзи",
         "toolIconsAriaLabel": "Значки инструментов",
         "toolLollipop": "Леденец",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "待发送图片",
         "pendingImageAlt": "图片 {{index}}",
         "removePendingImage": "移除图片",
+        "closeMemeAriaLabel": "关闭图片",
         "emojiButtonAriaLabel": "表情",
         "toolIconsAriaLabel": "工具图标",
         "toolLollipop": "棒棒糖",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -776,6 +776,7 @@
         "pendingImagesAriaLabel": "待發送圖片",
         "pendingImageAlt": "圖片 {{index}}",
         "removePendingImage": "移除圖片",
+        "closeMemeAriaLabel": "關閉圖片",
         "emojiButtonAriaLabel": "表情",
         "toolIconsAriaLabel": "工具圖示",
         "toolLollipop": "棒棒糖",


### PR DESCRIPTION
紧凑（compact）态主动表情包 overlay 的生命周期改进，三部分：

## 1. 按对话轮换场（原始改动）

#2031 后 overlay 收起只认「用户开口」，猫娘后续若干轮台词/主动搭话都顶不掉旧图。本 PR：
- host（`static/app-proactive.js _showMemeBubbles`）给 meme 消息补它所属主动搭话轮的 `turnId`（与同轮台词共享同一个 `response.turn_id`，原本 meme 绕开 adapter 没 turnId）。
- `App.tsx compactMemeOverlay` 收起规则从「仅用户开口」扩为「用户开口 **或** 出现不同 turnId 的**助手发言**」。同轮台词共享 turnId 不被秒掉（保 #2031）；真正新一轮回复/主动搭话顶掉旧图；Electron 重载后历史里有新轮也不复活。
- turnId 缺失（如纯音乐卡）退化为旧的「仅用户开口」逻辑。

## 2. 换场仅认 assistant 发言（回应 CodeRabbit）

turnId rule 2 补 `role === 'assistant'` 门控，`tool`/`system` 消息不再误把图顶掉，代码与注释一致。

## 3. 右上角手动关闭叉（新增机制）

历史收起时，overlay 右上角出现小叉，点了即可叉掉当前图：
- 会话级 `dismissedMemeId` 状态：命中当前 meme id 即隐藏；下一张新 meme（不同 id）照常显示；不持久化、刷新重置（与其余紧凑挂件一致）。
- 图片外包 inline-block frame 收紧到图片尺寸，叉子贴**图片**右上角而非更宽的 overlay 角（图片居中、常比 overlay 窄）。
- overlay 整体 `pointer-events:none`（点击穿透桌面/下层），唯独叉子单独 `auto`；并带 `data-compact-hit-region` 让 host 登记成 **native 可交互区**——否则 Electron pass-through 窗口里点击会穿到桌面（普通浏览器窗口测不出，对齐 `music_ui.js` 音乐条做法）。
- aria-label/title 走 `chat.closeMemeAriaLabel`，补齐 8 个 locale。

## 验证

- `react-neko-chat` `npm test`：209 passed（含 turnId 换场、assistant 门控、tool/system 不收起、关闭叉渲染/点击隐藏/新图重显/hit-region 等用例）。
- `tsc --noEmit` 通过；`check_i18n_sync` + `check_i18n` 全绿（8 locale 各 3928 key）。
- vite dev 真浏览器实测：frame 贴合图片(132×200)、叉子贴图片右上角、`elementFromPoint` 命中按钮、真点叉掉 overlay、手机宽度同样可点。
- 几何 hit-region 修复经「读 host `collectCompactCompositeGeometryItems` 确认机制 + 对齐音乐条成熟模式 + 单测锁契约」三重验证；端到端 native 命中需完整 Electron 环境。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 支持在紧凑态表情包悬浮层中新增关闭按钮（叉号），点击即可隐藏；当出现新表情包时会自动恢复显示。
  * 增加“关闭图片/表情包”的无障碍 aria 文案。
* **Bug Fixes**
  * 优化悬浮层收起时机：基于表情包关联的轮次信息判断同轮不误收起，跨轮（或进入新一轮助手回复）会正确收起。
* **Tests**
  * 重写并新增覆盖同轮/跨轮与非助手消息、关闭按钮交互及 dismiss 行为的用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->