### PR TITLE
fix(build): CI 打全本地化角色种子目录 + 应用内引导文档

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -119,14 +119,10 @@ jobs:
         run: |
           python -c "
           import json, os
+          # 本地化角色种子在 config/characters/<locale>.json（已入库的目录，PR #1282），
+          # 不需在此生成；只补 git 不跟踪的运行时文件，让构建有可读的基准配置。
           configs = {
             'config/characters.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.en.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.ja.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.ko.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.ru.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.zh-CN.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.zh-TW.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
             'config/core_config.json': {},
             'config/user_preferences.json': [],
           }
@@ -236,12 +232,10 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/__init__.py=config/__init__.py"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/api_providers.json=config/api_providers.json"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.json=config/characters.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.en.json=config/characters.en.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.ja.json=config/characters.ja.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.ko.json=config/characters.ko.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.ru.json=config/characters.ru.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.zh-CN.json=config/characters.zh-CN.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.zh-TW.json=config/characters.zh-TW.json"
+          # 本地化角色种子在 config/characters/<locale>.json（PR #1282 后），ConfigManager.
+          # _get_localized_characters_source 按 locale 读该目录；打整个目录，别再引用已不存在的
+          # 根级 config/characters.<locale>.json（旧路径，会静默丢失全部本地化种子）。
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=config/characters=config/characters"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/core_config.json=config/core_config.json"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/user_preferences.json=config/user_preferences.json"
           # changelog/.md 与 survey/.json 是纯数据文件，--include-package=config 只编 .py
@@ -271,6 +265,9 @@ jobs:
             NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/embedding_models=data/embedding_models"
           fi
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=static=static"
+          # 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
+          # 是纯数据目录，--include-package 不带，漏了引导页内容/图片打包后 404。
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=docs/zh-CN/guide=docs/zh-CN/guide"
 
           # Packages
           NUITKA_OPTS="$NUITKA_OPTS --include-package=uvicorn"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -458,8 +458,9 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/__init__.py=config/__init__.py
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/api_providers.json=config/api_providers.json
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.json=config/characters.json
-          rem 本地化角色种子在 config/characters/<locale>.json（PR #1282 后），按 locale 读该目录；
-          rem 打整个目录，别再引用已不存在的根级 config/characters.<locale>.json 旧路径。
+          rem 本地化角色种子是 config/characters 目录下按 locale 命名的 json（en.json 等，PR #1282 后）；
+          rem 打整个目录，别再引用 PR #1282 前已不存在的根级 config.characters.locale.json 旧路径。
+          rem （cmd 的 rem 行会把尖括号当重定向解析，注释里一律不用尖括号）
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=config/characters=config/characters
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/core_config.json=config/core_config.json
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/user_preferences.json=config/user_preferences.json

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -128,14 +128,10 @@ jobs:
         run: |
           python -c "
           import json, os
+          # 本地化角色种子在 config/characters/<locale>.json（已入库的目录，PR #1282），
+          # 不需在此生成；只补 git 不跟踪的运行时文件，让构建有可读的基准配置。
           configs = {
             'config/characters.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.en.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.ja.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.ko.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.ru.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.zh-CN.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
-            'config/characters.zh-TW.json': {'主人': {'档案名': '', '性别': '', '昵称': ''}, '猫娘': {}, '当前猫娘': ''},
             'config/core_config.json': {},
             'config/user_preferences.json': [],
           }
@@ -285,12 +281,10 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/__init__.py=config/__init__.py"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/api_providers.json=config/api_providers.json"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.json=config/characters.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.en.json=config/characters.en.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.ja.json=config/characters.ja.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.ko.json=config/characters.ko.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.ru.json=config/characters.ru.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.zh-CN.json=config/characters.zh-CN.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.zh-TW.json=config/characters.zh-TW.json"
+          # 本地化角色种子在 config/characters/<locale>.json（PR #1282 后），ConfigManager.
+          # _get_localized_characters_source 按 locale 读该目录；打整个目录，别再引用已不存在的
+          # 根级 config/characters.<locale>.json（旧路径，会静默丢失全部本地化种子）。
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=config/characters=config/characters"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/core_config.json=config/core_config.json"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/user_preferences.json=config/user_preferences.json"
           # changelog/.md 与 survey/.json 是纯数据文件，--include-package=config 只编 .py
@@ -324,6 +318,9 @@ jobs:
             NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=data/embedding_models=data/embedding_models"
           fi
           NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=static=static"
+          # 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
+          # 是纯数据目录，--include-package 不带，漏了引导页内容/图片打包后 404。
+          NUITKA_OPTS="$NUITKA_OPTS --include-data-dir=docs/zh-CN/guide=docs/zh-CN/guide"
 
           # Packages
           NUITKA_OPTS="$NUITKA_OPTS --include-package=uvicorn"
@@ -461,12 +458,9 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/__init__.py=config/__init__.py
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/api_providers.json=config/api_providers.json
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.json=config/characters.json
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.en.json=config/characters.en.json
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.ja.json=config/characters.ja.json
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.ko.json=config/characters.ko.json
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.ru.json=config/characters.ru.json
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.zh-CN.json=config/characters.zh-CN.json
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.zh-TW.json=config/characters.zh-TW.json
+          rem 本地化角色种子在 config/characters/<locale>.json（PR #1282 后），按 locale 读该目录；
+          rem 打整个目录，别再引用已不存在的根级 config/characters.<locale>.json 旧路径。
+          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=config/characters=config/characters
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/core_config.json=config/core_config.json
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/user_preferences.json=config/user_preferences.json
           rem changelog/.md 与 survey/.json 是纯数据，--include-package=config 不带，须显式打包
@@ -482,6 +476,9 @@ jobs:
           if exist "data\tiktoken_cache" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/tiktoken_cache=data/tiktoken_cache
           if exist "data\embedding_models" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=data/embedding_models=data/embedding_models
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=static=static
+          rem 应用内 OpenClaw 引导文档 + 图片，由 agent_router 经 /api/agent/openclaw/guide/* 提供；
+          rem 纯数据目录，漏了引导页内容/图片打包后 404。
+          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=docs/zh-CN/guide=docs/zh-CN/guide
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=uvicorn
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=fastapi
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=starlette

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -489,7 +489,7 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=config
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=plugin
           rem Built-in plugins are imported at runtime via their dotted entry path
-          rem (plugin.plugins.<name>:Class in plugin.toml), so they must be compiled
+          rem (plugin.plugins.[name]:Class in plugin.toml), so they must be compiled
           rem into the binary; --include-data-dir alone drops the .py. Synced with
           rem build_nuitka.bat. training/ is offline-only (torch) so carve it out.
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=plugin.plugins

--- a/scripts/check_nuitka_dist.py
+++ b/scripts/check_nuitka_dist.py
@@ -57,12 +57,17 @@ _REQUIRED_ASSETS: tuple[tuple[str, str | None], ...] = (
     # 守 dist 里确有它们，否则 /api/changelog、/api/survey（Steam-only）打包后读空。
     ("config/changelog", None),
     ("config/surveys", None),
+    # 本地化角色种子目录 config/characters/<locale>.json（PR #1282）。--include-package=config
+    # 只编 .py 不带；守该目录里至少有一份 locale json，否则非默认语言用户的角色种子回退错语言。
+    ("config/characters", "*.json"),
     ("static", None),
     ("templates", None),
     ("assets", None),
     ("data/browser_use_prompts", None),
     ("frontend/plugin-manager/dist", "index.html"),
     ("plugin/plugins", None),
+    # 应用内 OpenClaw 引导文档 + 图片，agent_router 经 /api/agent/openclaw/guide/* 提供；纯数据目录。
+    ("docs/zh-CN/guide", None),
 )
 
 # 内置插件目录里每一个子目录都必须有 plugin.toml；用来抓 ``plugin/plugins``


### PR DESCRIPTION
## 背景

排查"打包后版本问卷（survey）不触发"时，对 Nuitka 资产打包做了一次三方对账（本地 `build_nuitka.bat` / CI `build-desktop.yml` / 校验脚本 `check_nuitka_dist.py`），顺带发现 CI 这侧两个会进产物的真实漏打。

> 注：survey 本身那个 bug 出在**本地** `build_nuitka.bat`（gitignore，未入库，已在本地修好）——仓库里 CI 的 `build-desktop.yml` 本来就有 `config/surveys`，所以本 PR 不含 survey 改动。

## 问题

**1. 本地化角色种子打成空（静默回退错语言）**
`build-desktop.yml` 的 Nuitka 步骤一直 `--include-data-files` 六个**根级** `config/characters.<locale>.json`。PR #1282 已把本地化角色种子挪进 `config/characters/` 目录，这些根路径**早已不存在**；同时**漏打了真正的 `config/characters/` 目录**。
"生成默认 config" 步骤又临时造出这些 dummy 根文件，把 Nuitka 的 missing-file 警告也盖掉了，所以一直没人发现 → CI 产物里非默认语言用户的角色种子回退成 base，拿到错语言。
（运行时读取：`ConfigManager._get_localized_characters_source` 按 locale 读 `config/characters/<locale>.json`。）

**2. 应用内引导文档 404**
`docs/zh-CN/guide` 只在本地 `build_nuitka.bat` 里打包，CI 的 Unix + Windows 两段都漏 → CI 产物的 OpenClaw 引导页 `/api/agent/openclaw/guide/*` 内容和图片全部 404。
（运行时读取：`main_routers/agent_router.py` 的 `_load_openclaw_guide_markdown` / `openclaw_guide_asset`。）

## 改动（Unix + Windows 两段对称）

- 用 `--include-data-dir=config/characters=config/characters` 打整个目录，删掉 6 个死路径 include 和配套的 dummy 生成；
- 补 `--include-data-dir=docs/zh-CN/guide=docs/zh-CN/guide`；
- `check_nuitka_dist.py` 增 `("config/characters", "*.json")` 与 `("docs/zh-CN/guide", None)` 两道守门，防再次静默回归。

## 验证

- `config/characters/`（8 个 locale）与 `docs/zh-CN/guide/`（15 个文件）均为 git 跟踪、未被 ignore，CI fresh checkout 必有，新守门项不会误红。
- `check_nuitka_dist.py` 无单测，新增必需项不影响现有测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 桌面构建包现在内置本地化角色资源：会随安装携带 `config/characters` 目录，并以基准 `config/characters.json` 作为回退依据，支持按语言加载本地化数据。
  * 安装后 OpenClaw 引导页的文档与图片可在应用内正常访问。
* **Bug 修复**
  * 修复打包后引导页内容/图片缺失的问题。
  * 更新打包产物资源校验，确保本地化角色目录与指南资源存在，避免静默缺失导致回退异常。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->