### PR TITLE
[codex] 修复羽毛球小游戏对局与道具语音

### DIFF
--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -1035,6 +1035,7 @@
   var NET_CONTACT_IMPULSE = 320;
   var NET_CONTACT_HOLD_MS = 90;
   var PLAYER_MOVE_SPEED = 1040;
+  var PLAYER_POST_SERVE_MOVE_LOCK_MS = 420;
   var PLAYER_JUMP_SPEED = 430;
   var PLAYER_JUMP_GRAVITY = 1350;
   var PLAYER_JUMP_MAX_OFFSET = 82;
@@ -1070,6 +1071,12 @@
   var YUI_RACKET_RESCUE_GATE_REACH_Y = 54;
   var YUI_RACKET_SAVE_REACH_X = 84;
   var YUI_RACKET_SAVE_REACH_Y = 86;
+  var YUI_SHORT_DROP_SAVE_REACH_X = 96;
+  var YUI_SHORT_DROP_SAVE_REACH_Y = 118;
+  var YUI_SHORT_DROP_SAVE_NET_WINDOW_PX = 112;
+  var YUI_SHORT_DROP_SAVE_MAX_Z = 96;
+  var YUI_SHORT_DROP_SAVE_MIN_Z = 4;
+  var YUI_SHORT_DROP_SAVE_POWER_MAX = 32;
   var YUI_SMASH_MIN_SHUTTLE_Z = 64;
   var YUI_SMASH_FULL_SHUTTLE_Z = 138;
   var YUI_CHEAT_RANDOM_CHANCE = 0.72;
@@ -1398,6 +1405,7 @@
   };
   var generatedQuickLines = {};
   var generatedQuickLinesRequestSeq = 0;
+  var gameOverLineSpokenSessionId = '';
   var YUI_PASSIVE_LINES_DUEL = {
     line_in: ['这球压得挺准', '边线都帮你了'],
     net_touch: ['擦网也敢打啊', '这球贴得真险'],
@@ -1405,7 +1413,7 @@
     out: ['就差那么一点', '这球飞太深了'],
     net: ['球网替我拦你', '这拍急了吧'],
     shot_missed: ['别慌，下一拍', '刚刚慢了半拍'],
-    game_over: ['这次先到这儿', '下一局别跑'],
+    game_over: ['这次先到这儿', '下一局别跑', '这局先收着', '比分摆在这儿'],
     long_aim: ['该挥拍了吧', '想太久会僵哦'],
     close_to_record: ['纪录就在拍尖上', '再稳一拍就到了'],
     new_record: ['行吧，这球漂亮', '新纪录先借你'],
@@ -1421,7 +1429,7 @@
     out: ['Missed by a little', 'That one flew too deep'],
     net: ['The net stopped it for me', 'You rushed that swing'],
     shot_missed: ['Stay calm, next shot', 'You were half a beat late'],
-    game_over: ['That is it for now', 'Do not run from the next round'],
+    game_over: ['That is it for now', 'Do not run from the next round', 'We will hold this score', 'The scoreboard remembers'],
     long_aim: ['Time to swing', 'Think too long and you will stiffen'],
     close_to_record: ['The record is on your racket', 'One steadier shot'],
     new_record: ['Fine, that was good', 'You can borrow the new record'],
@@ -1437,7 +1445,7 @@
     out: ['ほんの少し外れたね', '今のは奥まで飛びすぎ'],
     net: ['ネットが私の味方をしたね', 'その一振り、急ぎすぎ'],
     shot_missed: ['落ち着いて、次の一拍', '今のは半拍遅れたね'],
-    game_over: ['今回はここまで', '次のラウンド、逃げないでね'],
+    game_over: ['今回はここまで', '次のラウンド、逃げないでね', 'このスコアは預かっておくね', '点数はちゃんと残ったよ'],
     long_aim: ['そろそろ振ろうか', '考えすぎると固まるよ'],
     close_to_record: ['記録はラケットの先だよ', 'もう一拍だけ安定させて'],
     new_record: ['いいよ、今のはきれい', '新記録、少しだけ貸してあげる'],
@@ -2385,6 +2393,12 @@
     if (primary === 'ja') return YUI_PASSIVE_LINES_DUEL_JA;
     return YUI_PASSIVE_LINES_DUEL_EN;
   }
+  function getNeutralQuickLineFallback(primary) {
+    primary = primary || normalizeRequestLanguagePrimary(getRequestLanguage());
+    if (primary === 'zh') return ['稳一下节奏', '下一拍继续'];
+    if (primary === 'ja') return ['リズムを整えよう', '次の一本に集中しよう'];
+    return ['Settle the rhythm', 'Focus on the next rally'];
+  }
   function isLikelyChineseFallbackLine(line) {
     var text = String(line || '').trim();
     if (!/[\u3400-\u9fff]/.test(text)) return false;
@@ -2453,7 +2467,8 @@
     var source = getQuickLineFallbackSource(primary);
     var defaultFallback = getDefaultQuickLineFallback(primary);
     var scope = 'duel';
-    var fallback = source[key] || defaultFallback[key] || source.game_over || defaultFallback.game_over || ['One more rally.'];
+    var isGameOverKey = key === 'game_over';
+    var fallback = source[key] || defaultFallback[key] || (isGameOverKey ? (source.game_over || defaultFallback.game_over) : null) || getNeutralQuickLineFallback(primary);
     return moodStyleLine(pickLocalizedLine(scope, key, fallback, primary, options), currentMood);
   }
   function getRequestLanguage() {
@@ -2801,9 +2816,10 @@
     var kind = String(event && event.kind || '');
     var label = String(event && event.label || '');
     if (kind === 'game_over' || event && event.is_new_record || kind === 'new_record' || /^streak_(15|20)$/.test(kind)) return 0;
+    if (kind === 'yui_cheat_item') return 0;
+    if (kind === 'yui_cheat_hit') return 0;
+    if (kind === 'yui_cheat_score') return 0;
     if (/^streak_(5|10)$/.test(kind)) return 1;
-    if (kind === 'yui_cheat_item') return 1;
-    if (kind === 'yui_cheat_score') return 1;
     if (label.indexOf('duel') !== -1) return 1;
     if (kind === 'shot_missed' || kind === 'close_to_record') return 2;
     if (kind === 'long_aim' || kind === 'very_long_aim') return 3;
@@ -2852,9 +2868,18 @@
     if (_voiceEntryExpired(entry)) return;
     var pending = voiceArbiter.pending;
     if (_voiceEntryExpired(pending)) pending = voiceArbiter.pending = null;
+    if (shouldInterruptVoiceAudio(entry.event)) {
+      voiceArbiter.pending = entry;
+      _scheduleVoiceArbiterFlush(0);
+      return;
+    }
     if (pending && pending.priority <= entry.priority) return;
     voiceArbiter.pending = entry;
     _scheduleVoiceArbiterFlush(entry.tailWaitMs);
+  }
+  function shouldInterruptVoiceAudio(event) {
+    var kind = String(event && event.kind || '');
+    return kind === 'yui_cheat_item' || kind === 'yui_cheat_hit' || kind === 'yui_cheat_score';
   }
   function _mirrorAndSpeak(entry) {
     if (debugMode && debugVoiceMuted && !debugVoiceMode && !(entry.event && entry.event.force_voice_in_debug)) return Promise.resolve();
@@ -2885,7 +2910,7 @@
       request_id: 'bd-' + entry.id,
       mirror_text: false,
       emit_turn_end: false,
-      interrupt_audio: false,
+      interrupt_audio: shouldInterruptVoiceAudio(entry.event),
       line: entry.line,
       i18n_language: getRequestLanguage(),
       event: payloadEvent
@@ -2893,18 +2918,24 @@
     lastVoiceRequest = speakPayload;
     lastVoiceResult = null;
     lastVoiceFallbackReason = '';
-    return post('/mirror-assistant', mirrorPayload, 2500)
-      .catch(function () {})
-      .then(function () {
-        return post('/speak', speakPayload, 3500).then(function (res) {
-          lastVoiceResult = res || null;
-          return res;
-        }).catch(function () {
-          lastVoiceFallbackReason = 'project_speak_failed';
-          lastVoiceResult = { ok: false, reason: 'project_speak_failed' };
-          return lastVoiceResult;
-        });
+    function requestMirror() {
+      return post('/mirror-assistant', mirrorPayload, 2500).catch(function () {});
+    }
+    function requestSpeak() {
+      return post('/speak', speakPayload, 3500).then(function (res) {
+        lastVoiceResult = res || null;
+        return res;
+      }).catch(function () {
+        lastVoiceFallbackReason = 'project_speak_failed';
+        lastVoiceResult = { ok: false, reason: 'project_speak_failed' };
+        return lastVoiceResult;
       });
+    }
+    if (shouldInterruptVoiceAudio(entry.event)) {
+      void requestMirror();
+      return requestSpeak();
+    }
+    return requestMirror().then(requestSpeak);
   }
   function _requestVoicePlayback(entry) {
     if (!_voiceEntryMatchesCurrentSession(entry)) return Promise.resolve();
@@ -2912,7 +2943,9 @@
     voiceArbiter.inFlight = {
       id: entry.id,
       line: entry.line,
-      expiresAt: Date.now() + holdMs
+      expiresAt: Date.now() + holdMs,
+      isUserReply: !!entry.isUserReply,
+      eventKind: String(entry.event && entry.event.kind || '')
     };
     showBubble(entry.line, entry.control, entry.event);
     return _mirrorAndSpeak(entry).finally(function () {
@@ -2941,6 +2974,12 @@
       return;
     }
     if (voiceArbiter.inFlight && Date.now() < voiceArbiter.inFlight.expiresAt) {
+      if (shouldInterruptVoiceAudio(pending.event) && !voiceArbiter.inFlight.isUserReply) {
+        voiceArbiter.inFlight = null;
+        voiceArbiter.pending = null;
+        void _requestVoicePlayback(pending);
+        return;
+      }
       _scheduleVoiceArbiterFlush(Math.max(80, voiceArbiter.inFlight.expiresAt - Date.now()));
       return;
     }
@@ -2995,7 +3034,7 @@
       label: 'yui_cheat_' + kind,
       item_kind: kind,
       force_voice_in_debug: true,
-      voice_deadline_ms: 3600
+      voice_deadline_ms: 6200
     };
     showBubble(line, control, event);
     speakLine(line, control, event);
@@ -3013,7 +3052,22 @@
       label: 'yui_cheat_score_' + kind,
       item_kind: kind,
       force_voice_in_debug: true,
-      voice_deadline_ms: 5200
+      voice_deadline_ms: 6800
+    };
+    showBubble(line, control, event);
+    speakLine(line, control, event);
+  }
+  function showYuiCheatHitLine(kind) {
+    var line = kind === 'octopus'
+      ? _i18n('toast.yuiCheatInk', 'Yui 扔了墨汁')
+      : _i18n('toast.yuiCheatBananaSlip', '踩到香蕉皮了');
+    var control = { expression: 'tease', intensity: 'medium', mood: 'surprised', bubbleVariant: 'yui-cheat', bubblePriority: 8, bubbleHoldMs: 2800, bubbleDurationMs: 3800 };
+    var event = {
+      kind: 'yui_cheat_hit',
+      label: 'yui_cheat_hit_' + kind,
+      item_kind: kind,
+      force_voice_in_debug: true,
+      voice_deadline_ms: 6200
     };
     showBubble(line, control, event);
     speakLine(line, control, event);
@@ -3095,13 +3149,22 @@
     var label = String(event && event.label || '');
     if (event && (event.force_voice || event.force_voice_in_debug || event.voice_always)) return true;
     if (kind === 'user_reply' || event.isUserReply || event.source === 'user_reply') return true;
-    if (kind === 'yui_cheat_item' || kind === 'yui_cheat_score') return true;
+    if (kind === 'yui_cheat_item' || kind === 'yui_cheat_hit' || kind === 'yui_cheat_score') return true;
     if (kind === 'difficulty_ramp') return true;
     if (event && event.point_winner === 'neko' && label === 'neko_duel_shot') return true;
     if (label.indexOf('duel_difficulty_') === 0) return true;
     return false;
   }
+  function shouldSuppressRepeatedGameOverLine(event) {
+    if (!event || event.kind !== 'game_over') return false;
+    var eventSessionId = String(event.session_id || sessionId || '');
+    if (!eventSessionId) return false;
+    if (gameOverLineSpokenSessionId === eventSessionId) return true;
+    gameOverLineSpokenSessionId = eventSessionId;
+    return false;
+  }
   function speakLine(line, control, event) {
+    if (shouldSuppressRepeatedGameOverLine(event || {})) return;
     line = replaceUnexpectedChineseFallbackLine(line, event);
     if (!shouldReadBadmintonVoice(event, control)) {
       lastVoiceRequest = {
@@ -3160,6 +3223,12 @@
       return;
     }
     if (voiceArbiter.inFlight && Date.now() < voiceArbiter.inFlight.expiresAt && voiceArbiter.inFlight.id !== entry.id) {
+      if (shouldInterruptVoiceAudio(entry.event) && !voiceArbiter.inFlight.isUserReply) {
+        voiceArbiter.inFlight = null;
+        voiceArbiter.pending = null;
+        void _requestVoicePlayback(entry);
+        return;
+      }
       _storeVoicePending(entry);
       return;
     }
@@ -3946,6 +4015,13 @@
     if (event.kind === 'very_long_aim') return 'long_aim';
     return shotTypeLabelKey(event.shot_type) || event.kind;
   }
+  function shouldSuppressChatFallback(res, event) {
+    return !!(res && res.suppress_fallback);
+  }
+  function pickChatFallbackLine(res, event) {
+    if (shouldSuppressChatFallback(res, event)) return '';
+    return pickLine(getFallbackLineKey(event), null, {});
+  }
   function buildBadmintonCurrentStatePayload() {
     var state = {
       game: 'badminton',
@@ -3997,6 +4073,7 @@
     notifyBadmintonEventListeners(event);
     event.i18n_language = getRequestLanguage();
     var shouldCall = shouldCallLLMDuel(event);
+    if (event.local_voice_already_spoken) return;
     if (debugMode) {
       speakLine(pickLine(getFallbackLineKey(event)), {}, event);
       return;
@@ -4028,11 +4105,15 @@
         if (res && res.difficulty) setDuelDifficulty(res.difficulty);
         if (res && res.mood) setMood(res.mood, { reason: 'llm' });
         if (res && res.line) speakLine(moodStyleLine(res.line, currentMood), res.control || {}, event);
-        else speakLine(pickLine(getFallbackLineKey(event)), {}, event);
+        else {
+          var fallbackLine = pickChatFallbackLine(res, event);
+          if (fallbackLine) speakLine(fallbackLine, {}, event);
+        }
       })
       .catch(function () {
         if (event.session_id !== sessionId || event.mode !== currentMode) return;
-        speakLine(pickLine(getFallbackLineKey(event)), {}, event);
+        var fallbackLine = pickChatFallbackLine({ error: 'request_failed' }, event);
+        if (fallbackLine) speakLine(fallbackLine, {}, event);
       });
   }
 
@@ -4264,6 +4345,7 @@
     heldShuttleVisible: true,
     pendingSwing: null,
     shuttleSeq: 0,
+    playerMoveLockedUntil: 0,
     playerCourt: { x: PLAYER_START_X, y: PLAYER_START_Y, targetX: PLAYER_START_X, targetY: PLAYER_START_Y },
     playerJump: { offset: 0, velocity: 0, active: false, cooldownUntil: 0, lastSmashAt: 0 },
     playerCheatEffect: { slowUntil: 0, spinUntil: 0, spinStartedAt: 0, spinAngle: 0 },
@@ -4338,6 +4420,7 @@
     game.playerCourt.y = PLAYER_START_Y;
     game.playerCourt.targetX = PLAYER_START_X;
     game.playerCourt.targetY = PLAYER_START_Y;
+    game.playerMoveLockedUntil = 0;
     resetPlayerJump();
     resetYuiCheats();
     game.yuiCourt.x = YUI_START_X;
@@ -4469,6 +4552,7 @@
       item_kind: item.kind,
       close_score: close,
       duel: buildDuelStatePayload(),
+      local_voice_already_spoken: true,
       voice_deadline_ms: 900
     });
     return true;
@@ -4520,6 +4604,7 @@
     markYuiCheatHit('banana');
     badmintonGameAudio.playSfx('yuiCheat.bananaSlip', { volumeMultiplier: 0.9 });
     showAssistHint(_i18n('toast.yuiCheatBananaSlip', '踩到香蕉皮了'));
+    showYuiCheatHitLine('banana');
     setPlayerAction('react-disappointed', 560);
     sendGameEvent({
       kind: 'yui_cheat_hit',
@@ -4528,6 +4613,7 @@
       item_kind: 'banana',
       item_id: item && item.id,
       duel: buildDuelStatePayload(),
+      local_voice_already_spoken: true,
       voice_deadline_ms: 900
     });
   }
@@ -4736,8 +4822,25 @@
   function getYuiRacketSaveRangeState(incomingBall) {
     return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);
   }
+  function getYuiShortDropSaveRangeState(incomingBall) {
+    return getYuiRacketRangeState(incomingBall, YUI_SHORT_DROP_SAVE_REACH_X, YUI_SHORT_DROP_SAVE_REACH_Y);
+  }
   function isYuiSmashSaveReachable(incomingBall) {
     return !!(incomingBall && incomingBall.isSmash) && getYuiRacketRescueGateState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;
+  }
+  function isYuiShortDropSaveReachable(incomingBall) {
+    if (!incomingBall || incomingBall.isSmash || incomingBall.hitNet) return false;
+    if (incomingBall.shooter !== 'player' || incomingBall.direction !== 1 || !incomingBall.crossedNet) return false;
+    var shuttleRadius = incomingBall.radius || BALL_R;
+    var shuttleCourtY = getShuttleCourtY(incomingBall, false);
+    var nearNetLeft = BADMINTON.netX + shuttleRadius * 0.5;
+    var nearNetRight = nearNetLeft + YUI_SHORT_DROP_SAVE_NET_WINDOW_PX;
+    if (shuttleCourtY < nearNetLeft || shuttleCourtY > nearNetRight) return false;
+    var shuttleZ = getShuttleCourtZ(incomingBall, false);
+    if (shuttleZ < YUI_SHORT_DROP_SAVE_MIN_Z || shuttleZ > YUI_SHORT_DROP_SAVE_MAX_Z) return false;
+    var shotPower = Number.isFinite(incomingBall.power) ? incomingBall.power : ((incomingBall.swingForce || 0) * 100);
+    if (shotPower > YUI_SHORT_DROP_SAVE_POWER_MAX) return false;
+    return getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiShortDropSaveRangeState(incomingBall).normalized <= 1;
   }
   function getYuiSmashHeightQuality(incomingBall) {
     if (!incomingBall) return 0;
@@ -5134,13 +5237,16 @@
     if (isPlayerReceivingReturn()) return canPlayerReturnIncomingShuttle();
     return !isPositionTransitioning;
   }
+  function isPlayerPostServeMoveLocked() {
+    return performance.now() < (game.playerMoveLockedUntil || 0);
+  }
   function canPlayerMoveCourt() {
     if (isBadmintonLoadingActive()) return false;
     var incomingYuiBall = game.ball && game.ball.shooter === 'neko' && game.ball.direction === -1 && !game.ball.resolved;
     var playerShotInFlight = game.ball && game.ball.shooter === 'player' && game.ball.direction === 1 && !game.ball.resolved;
     var yuiTurnActive = game.state === 'neko_thinking' || game.duel.activeShooter === 'neko';
     var yuiSwinging = game.pendingSwing && game.pendingSwing.shooter === 'neko';
-    return isDuelMode() && (isPlayerServeSetup() || canPlayerControlShot() || playerShotInFlight || yuiTurnActive || incomingYuiBall || yuiSwinging);
+    return isDuelMode() && (isPlayerServeSetup() || canPlayerControlShot() || (playerShotInFlight && !isPlayerPostServeMoveLocked()) || yuiTurnActive || incomingYuiBall || yuiSwinging);
   }
   function isPlayerServeSetup() {
     return isDuelMode() && game.state === 'ready' && isPlayerTurn() && game.heldShuttleVisible && !game.ball && !game.pendingSwing;
@@ -5450,6 +5556,7 @@
   function resetGame() {
     clearTimeout(resultTimer);
     resultTimer = 0;
+    gameOverLineSpokenSessionId = '';
     netContactEffects = [];
     if (debugMode && window.__badmintonNetEffectDebug) {
       window.__badmintonNetEffectDebug = {
@@ -5771,6 +5878,9 @@
     };
     game.pendingSwing = swing;
     game.heldShuttleVisible = false;
+    if (shotShooter === 'player' && !incomingBall) {
+      game.playerMoveLockedUntil = performance.now() + SWING_IMPACT_DELAY_MS + PLAYER_POST_SERVE_MOVE_LOCK_MS;
+    }
     if (game.ball && game.ball.shooter !== shotShooter && !incomingBall) game.ball = null;
     game.charging = false;
     game.state = 'swinging';
@@ -5942,8 +6052,8 @@
     ball.vy = Math.max(Math.abs(ball.vy || 0) * 0.10 + (carriesToTargetSide ? 132 : 150), carriesToTargetSide ? 132 : 150);
     syncShuttleCourtCoordinates(ball);
   }
-  function checkShuttleLanding(ball) {
-    if (!ball || ball.resolved) return;
+  function updateShuttleNetCrossing(ball) {
+    if (!ball || ball.resolved) return false;
     var direction = ball.direction === -1 ? -1 : 1;
     var crossedNet = didShuttleCrossMidcourtNet(ball, direction);
     if (!ball.crossedNet && crossedNet) {
@@ -5951,9 +6061,15 @@
       var netCrossing = getMidcourtNetCrossing(ball);
       if (isShuttleInsideNetZ(ball, netCrossing)) {
         applyMidcourtNetContact(ball, netCrossing);
-        return;
+        return true;
       }
     }
+    return false;
+  }
+  function checkShuttleLanding(ball) {
+    if (!ball || ball.resolved) return;
+    var direction = ball.direction === -1 ? -1 : 1;
+    if (updateShuttleNetCrossing(ball)) return;
     var ballRadius = ball.radius || BALL_R;
     if (ball.y >= FLOOR_Y - ballRadius * 0.25) {
       if (ball.netContactHoldUntil && performance.now() < ball.netContactHoldUntil) return;
@@ -6007,8 +6123,9 @@
     var inYuiReach = crossesYuiReach
       && shuttleZ <= yuiContactTopZ
       && shuttleZ >= yuiContactBottomZ;
-    if (!inYuiReach) return false;
-    var yuiSave = isYuiSmashSaveReachable(ball);
+    var yuiShortDropSave = isYuiShortDropSaveReachable(ball);
+    if (!inYuiReach && !yuiShortDropSave) return false;
+    var yuiSave = isYuiSmashSaveReachable(ball) || yuiShortDropSave;
     if (!isYuiRacketHitInRange(ball) && !yuiSave) return false;
     game.duel.activeShooter = 'neko';
     game.duel.rallyHits += 1;
@@ -6638,9 +6755,10 @@
         b.prevCourtY = getShuttleCourtY(b, false);
         b.prevZ = getShuttleCourtZ(b, false);
         stepBallPhysics(b, subDt);
+        updateShuttleNetCrossing(b);
+        if (!b.hitNet && maybeYuiReturnIncomingShuttle(b)) break;
         checkShuttleLanding(b);
         if (!b.hitNet) {
-          if (maybeYuiReturnIncomingShuttle(b)) break;
           if (maybePlayerReceiveIncomingShuttle(b)) break;
         }
         updateNetPhysics(subDt);
@@ -9643,6 +9761,7 @@
           incomingReturnInReach: canPlayerReturnIncomingShuttle(),
           positionTransitioning: isPositionTransitioning,
           playerCourt: Object.assign({}, game.playerCourt),
+          playerMoveLockRemainingMs: Math.max(0, Math.round((game.playerMoveLockedUntil || 0) - performance.now())),
           courtServiceLines: getCourtServiceLinePositions(BADMINTON),
           playerServeX: PLAYER_START_X,
           playerFootY: getPlayerFootY(),

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -1681,6 +1681,11 @@
     return z >= getNetBottomZ() - shuttleRadius * 0.18
       && z <= getNetTopZ() + shuttleRadius * 0.12;
   }
+  function didShuttleLegallyClearNet(shuttle, crossing) {
+    var shuttleRadius = (shuttle && shuttle.radius) || BALL_R;
+    var z = crossing ? crossing.z : getShuttleCourtZ(shuttle, false);
+    return z > getNetTopZ() + shuttleRadius * 0.12;
+  }
   function getCourtDistanceMark(key) {
     for (var i = 0; i < COURT_DISTANCE_MARKS.length; i++) {
       if (COURT_DISTANCE_MARKS[i].key === key) return COURT_DISTANCE_MARKS[i];
@@ -4785,7 +4790,6 @@
     return clamp(heightQuality * timingQuality * contactQuality, 0, 1);
   }
   function isPlayerSmashReady(incomingBall) {
-    if (isPlayerServeSetup()) return false;
     return getPlayerSmashQuality(incomingBall) >= 0.22;
   }
   function getYuiNeutralRacketContactPoint() {
@@ -5517,10 +5521,10 @@
     var netTopZ = getNetTopZ();
     var forwardSpeed = Math.abs(ball.vCourtY || ball.vx || 0);
     var risingSpeed = Math.max(0, ball.vz || -(ball.vy || 0));
-    var highOnTape = z >= netTopZ - shuttleRadius * 0.72;
+    var clearsTape = z >= netTopZ - shuttleRadius * 0.26;
     var hasCarry = forwardSpeed >= 115 || risingSpeed >= 36;
-    var barelyOverTape = z >= netTopZ - shuttleRadius * 0.26;
-    return highOnTape && (hasCarry || barelyOverTape);
+    var aboveTape = z >= netTopZ;
+    return clearsTape && (hasCarry || aboveTape);
   }
   function spawnNetContactEffect(ball, crossing) {
     var lightweight = shouldUseLightweightNetContactEffects();
@@ -5847,6 +5851,8 @@
     shuttle.forceScore = false;
     shuttle.crossedNet = false;
     shuttle.hitNet = false;
+    shuttle.legalNetClearance = false;
+    shuttle.netCarryToTargetSide = false;
     shuttle.netContactAt = 0;
     shuttle.netContactHoldUntil = 0;
     shuttle.awaitingReturnBy = '';
@@ -5969,7 +5975,14 @@
   function stepAwaitingPlayerReturn(dt) {
     var ball = game.ball;
     if (!ball || ball.awaitingReturnBy !== 'player') return false;
-    if (performance.now() > ball.returnDeadlineAt) {
+    if (ball.resolved) {
+      if (performance.now() >= ball.resolveAt) {
+        finishShot(ball.pendingScored, ball.pendingShotType, ball);
+        return true;
+      }
+      return false;
+    }
+    if (!ball.hitNet && performance.now() > ball.returnDeadlineAt) {
       ball.shooter = 'player';
       finishShot(false, 'out', ball);
       return true;
@@ -6040,6 +6053,7 @@
     ball.hitNet = true;
     ball.netTouched = true;
     ball.netCarryToTargetSide = carriesToTargetSide;
+    ball.legalNetClearance = false;
     ball.crossedNet = carriesToTargetSide;
     ball.netContactAt = performance.now();
     ball.netContactHoldUntil = ball.netContactAt + NET_CONTACT_HOLD_MS;
@@ -6058,12 +6072,13 @@
     var direction = ball.direction === -1 ? -1 : 1;
     var crossedNet = didShuttleCrossMidcourtNet(ball, direction);
     if (!ball.crossedNet && crossedNet) {
-      ball.crossedNet = true;
       var netCrossing = getMidcourtNetCrossing(ball);
-      if (isShuttleInsideNetZ(ball, netCrossing)) {
+      if (!didShuttleLegallyClearNet(ball, netCrossing)) {
         applyMidcourtNetContact(ball, netCrossing);
         return true;
       }
+      ball.crossedNet = true;
+      ball.legalNetClearance = true;
     }
     return false;
   }
@@ -6082,15 +6097,17 @@
       var inTargetY = ball.y >= BADMINTON.targetTop && ball.y <= BADMINTON.courtBottom + ballRadius;
       var landedOnTargetSide = direction > 0 ? landingCourtY >= targetLeft : landingCourtY <= targetRight;
       if (ball.hitNet) {
-        var netScored = landedOnTargetSide && inTargetX && inTargetY;
-        var netShotType = !landedOnTargetSide ? 'net' : (netScored ? 'net_touch' : 'out');
+        var netCarriedOver = ball.netCarryToTargetSide === true;
+        var netScored = netCarriedOver && landedOnTargetSide && inTargetX && inTargetY;
+        var netShotType = (!netCarriedOver || !landedOnTargetSide) ? 'net' : (netScored ? 'net_touch' : 'out');
         queueShotResolution(ball, netScored, netShotType, netScored ? 140 : 80);
         ball.vx *= 0.18;
         ball.vy = -Math.abs(ball.vy) * 0.08;
         return;
       }
-      var scored = ball.crossedNet && inTargetX && inTargetY;
-      var shotType = (!ball.crossedNet || !landedOnTargetSide) ? 'net' : 'out';
+      var legallyOverNet = ball.legalNetClearance === true;
+      var scored = legallyOverNet && inTargetX && inTargetY;
+      var shotType = (!legallyOverNet || !landedOnTargetSide) ? 'net' : 'out';
       if (scored) {
         var nearBaseline = direction > 0 ? ball.x > targetRight - 34 : ball.x < targetLeft + 34;
         var nearNet = direction > 0 ? ball.x < targetLeft + 34 : ball.x > targetRight - 34;
@@ -9643,6 +9660,7 @@
       shooter: 'neko',
       direction: -1,
       crossedNet: true,
+      legalNetClearance: true,
       resolved: false,
       awaitingReturnBy: 'player',
       returnDeadlineAt: performance.now() + 2400,
@@ -9690,6 +9708,7 @@
       shooter: 'player',
       direction: 1,
       crossedNet: true,
+      legalNetClearance: true,
       resolved: false,
       awaitingReturnBy: '',
       hitNet: false,
@@ -9839,6 +9858,8 @@
             trail: getShuttleTrailPoints(game.ball),
             awaitingReturnBy: game.ball.awaitingReturnBy || '',
             crossedNet: !!game.ball.crossedNet,
+            legalNetClearance: game.ball.legalNetClearance === true,
+            netCarryToTargetSide: game.ball.netCarryToTargetSide === true,
             hitNet: !!game.ball.hitNet
           } : null,
           difficulty: getDuelDifficultyName(),

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -4015,11 +4015,11 @@
     if (event.kind === 'very_long_aim') return 'long_aim';
     return shotTypeLabelKey(event.shot_type) || event.kind;
   }
-  function shouldSuppressChatFallback(res, event) {
+  function shouldSuppressChatFallback(res) {
     return !!(res && res.suppress_fallback);
   }
   function pickChatFallbackLine(res, event) {
-    if (shouldSuppressChatFallback(res, event)) return '';
+    if (shouldSuppressChatFallback(res)) return '';
     return pickLine(getFallbackLineKey(event), null, {});
   }
   function buildBadmintonCurrentStatePayload() {
@@ -6070,6 +6070,7 @@
   function checkShuttleLanding(ball) {
     if (!ball || ball.resolved) return;
     var direction = ball.direction === -1 ? -1 : 1;
+    // This is a no-op after the main physics loop, but required by stepAwaitingPlayerReturn.
     if (updateShuttleNetCrossing(ball)) return;
     var ballRadius = ball.radius || BALL_R;
     if (ball.y >= FLOOR_Y - ballRadius * 0.25) {

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -4796,38 +4796,43 @@
     var contact = getYuiShotOrigin();
     return { x: contact.x, y: contact.y, source: 'neutral-racket-anchor' };
   }
+  function getYuiRacketRangeStateForPoint(incomingBall, racket, reachX, reachY) {
+    var contact = racket || getYuiNeutralRacketContactPoint();
+    var ballX = incomingBall && Number.isFinite(incomingBall.x) ? incomingBall.x : contact.x;
+    var ballY = incomingBall && Number.isFinite(incomingBall.y) ? incomingBall.y : contact.y;
+    var dx = Math.abs(ballX - contact.x);
+    var dy = Math.abs(ballY - contact.y);
+    var normalized = Math.pow(dx / reachX, 2) + Math.pow(dy / reachY, 2);
+    return { dx: dx, dy: dy, normalized: normalized, racket: contact, source: contact.source || '' };
+  }
   function getYuiRacketRangeState(incomingBall, reachX, reachY) {
     var neutral = getYuiNeutralRacketContactPoint();
     var visible = getYuiVisibleRacketContactPoint();
-    var ballX = incomingBall && Number.isFinite(incomingBall.x) ? incomingBall.x : neutral.x;
-    var ballY = incomingBall && Number.isFinite(incomingBall.y) ? incomingBall.y : neutral.y;
-    function stateFor(racket) {
-      var dx = Math.abs(ballX - racket.x);
-      var dy = Math.abs(ballY - racket.y);
-      var normalized = Math.pow(dx / reachX, 2) + Math.pow(dy / reachY, 2);
-      return { dx: dx, dy: dy, normalized: normalized, racket: racket, source: racket.source || '' };
-    }
-    var best = stateFor(neutral);
+    var best = getYuiRacketRangeStateForPoint(incomingBall, neutral, reachX, reachY);
     if (visible) {
-      var visibleState = stateFor(visible);
+      var visibleState = getYuiRacketRangeStateForPoint(incomingBall, visible, reachX, reachY);
       if (visibleState.normalized < best.normalized) best = visibleState;
     }
     return best;
   }
+  function getYuiVisibleOrNeutralRacketRangeState(incomingBall, reachX, reachY) {
+    var visible = getYuiVisibleRacketContactPoint();
+    return getYuiRacketRangeStateForPoint(incomingBall, visible || getYuiNeutralRacketContactPoint(), reachX, reachY);
+  }
   function getYuiRacketHitRangeState(incomingBall) {
-    return getYuiRacketRangeState(incomingBall, YUI_RACKET_HIT_REACH_X, YUI_RACKET_HIT_REACH_Y);
+    return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_RACKET_HIT_REACH_X, YUI_RACKET_HIT_REACH_Y);
   }
   function isYuiRacketHitInRange(incomingBall) {
     return getYuiRacketHitRangeState(incomingBall).normalized <= 1;
   }
   function getYuiRacketRescueGateState(incomingBall) {
-    return getYuiRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);
+    return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);
   }
   function getYuiRacketSaveRangeState(incomingBall) {
-    return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);
+    return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);
   }
   function getYuiShortDropSaveRangeState(incomingBall) {
-    return getYuiRacketRangeState(incomingBall, YUI_SHORT_DROP_SAVE_REACH_X, YUI_SHORT_DROP_SAVE_REACH_Y);
+    return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_SHORT_DROP_SAVE_REACH_X, YUI_SHORT_DROP_SAVE_REACH_Y);
   }
   function isYuiSmashSaveReachable(incomingBall) {
     return !!(incomingBall && incomingBall.isSmash) && getYuiRacketRescueGateState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;
@@ -6137,15 +6142,17 @@
     var shuttleRadius = ball.radius || BALL_R;
     var yuiReachLeft = BADMINTON.netX + shuttleRadius * 0.5;
     var yuiReachRight = BADMINTON.courtRight - shuttleRadius * 0.5;
+    var yuiRacketHitState = getYuiRacketHitRangeState(ball);
+    var yuiRacketHitInRange = yuiRacketHitState.normalized <= 1;
     var crossesYuiReach = Math.max(previousShuttleCourtY, shuttleCourtY) >= yuiReachLeft
       && Math.min(previousShuttleCourtY, shuttleCourtY) <= yuiReachRight;
-    var inYuiReach = crossesYuiReach
+    var inYuiReach = yuiRacketHitInRange || (crossesYuiReach
       && shuttleZ <= yuiContactTopZ
-      && shuttleZ >= yuiContactBottomZ;
+      && shuttleZ >= yuiContactBottomZ);
     var yuiShortDropSave = isYuiShortDropSaveReachable(ball);
-    if (!inYuiReach && !yuiShortDropSave) return false;
     var yuiSave = isYuiSmashSaveReachable(ball) || yuiShortDropSave;
-    if (!isYuiRacketHitInRange(ball) && !yuiSave) return false;
+    if (!inYuiReach && !yuiSave) return false;
+    if (!yuiRacketHitInRange && !yuiSave) return false;
     game.duel.activeShooter = 'neko';
     game.duel.rallyHits += 1;
     maybeTriggerYuiCheat('rally_return');
@@ -9064,6 +9071,8 @@
     var contact = getRacketContactPoint('player');
     var yui = getYuiShotOrigin();
     if (!ball || !contact || !yui) return;
+    var canReturnNow = canPlayerReturnIncomingShuttle();
+    if (!canReturnNow) return;
     var dx = yui.x - contact.x;
     var dy = yui.y - contact.y;
     var len = Math.max(1, Math.sqrt(dx * dx + dy * dy));
@@ -9081,11 +9090,10 @@
     var controlY = ball.y + uy * 2 + ny * 24;
     var endX = ball.x + ux * 38 + nx * 7;
     var endY = ball.y + uy * 38 + ny * 7;
-    var canReturnNow = canPlayerReturnIncomingShuttle();
-    var cueAlpha = canReturnNow ? 1 : 0.46;
+    var cueAlpha = 1;
 
     aimingCtx.save();
-    aimingCtx.strokeStyle = canReturnNow ? 'rgba(255,236,168,.075)' : 'rgba(114,216,255,.055)';
+    aimingCtx.strokeStyle = 'rgba(255,236,168,.075)';
     aimingCtx.lineWidth = 5.8 + pulse * 0.8;
     aimingCtx.lineCap = 'round';
     aimingCtx.globalAlpha = cueAlpha;
@@ -9094,7 +9102,7 @@
     aimingCtx.quadraticCurveTo(controlX, controlY, endX, endY);
     aimingCtx.stroke();
 
-    aimingCtx.strokeStyle = canReturnNow ? 'rgba(255,210,96,.30)' : 'rgba(114,216,255,.25)';
+    aimingCtx.strokeStyle = 'rgba(255,210,96,.30)';
     aimingCtx.lineWidth = 1.5 + pulse * 0.35;
     aimingCtx.beginPath();
     aimingCtx.moveTo(startX, startY);

--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -4837,7 +4837,8 @@
     var nearNetRight = nearNetLeft + YUI_SHORT_DROP_SAVE_NET_WINDOW_PX;
     if (shuttleCourtY < nearNetLeft || shuttleCourtY > nearNetRight) return false;
     var shuttleZ = getShuttleCourtZ(incomingBall, false);
-    if (shuttleZ < YUI_SHORT_DROP_SAVE_MIN_Z || shuttleZ > YUI_SHORT_DROP_SAVE_MAX_Z) return false;
+    var minSaveZ = Math.max(YUI_SHORT_DROP_SAVE_MIN_Z, shuttleRadius * 0.25 + 0.5);
+    if (shuttleZ <= minSaveZ || shuttleZ > YUI_SHORT_DROP_SAVE_MAX_Z) return false;
     var shotPower = Number.isFinite(incomingBall.power) ? incomingBall.power : ((incomingBall.swingForce || 0) * 100);
     if (shotPower > YUI_SHORT_DROP_SAVE_POWER_MAX) return false;
     return getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiShortDropSaveRangeState(incomingBall).normalized <= 1;

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -139,6 +139,25 @@ def _force_shot_result(page: Page, scored: bool = True) -> None:
     )
 
 
+def _wait_for_badminton_speak_payload(
+    page: Page, speak_payloads: list[dict], event_kind: str, timeout_ms: int = 3000
+) -> dict:
+    deadline = time.time() + timeout_ms / 1000
+    while time.time() < deadline:
+        payload = next(
+            (
+                payload
+                for payload in reversed(speak_payloads)
+                if payload.get("event", {}).get("kind") == event_kind
+            ),
+            None,
+        )
+        if payload:
+            return payload
+        page.wait_for_timeout(50)
+    pytest.fail(f"Timed out waiting for badminton speak event: {event_kind}")
+
+
 @pytest.mark.e2e
 def test_badminton_legacy_modes_fall_back_to_duel(mock_page: Page, running_server: str):
     page = mock_page
@@ -1399,14 +1418,13 @@ def test_badminton_yui_banana_cheat_warns_player_with_bubble(mock_page: Page, ru
     assert page.evaluate(
         """() => window.getComputedStyle(document.getElementById('neko-bubble')).backgroundColor"""
     ) == "rgb(207, 234, 255)"
-    page.wait_for_timeout(500)
-    assert speak_payloads
-    assert re.search(r"香蕉皮|踩到|这一步|跳过去", speak_payloads[-1]["line"])
-    assert speak_payloads[-1]["event"]["kind"] == "yui_cheat_item"
-    assert speak_payloads[-1]["event"]["label"] == "yui_cheat_banana"
-    assert speak_payloads[-1]["event"]["item_kind"] == "banana"
-    assert speak_payloads[-1]["event"]["force_voice_in_debug"] is True
-    assert speak_payloads[-1]["event"]["voice_deadline_ms"] == 3600
+    item_payload = _wait_for_badminton_speak_payload(page, speak_payloads, "yui_cheat_item")
+    assert re.search(r"香蕉皮|踩到|这一步|跳过去", item_payload["line"])
+    assert item_payload["event"]["label"] == "yui_cheat_banana"
+    assert item_payload["event"]["item_kind"] == "banana"
+    assert item_payload["event"]["force_voice_in_debug"] is True
+    assert item_payload["event"]["voice_deadline_ms"] == 6200
+    assert item_payload["interrupt_audio"] is True
     page.evaluate("window.BadmintonDemo.showBubble('普通回合台词', { mood: 'happy' })")
     page.wait_for_timeout(120)
     expect(page.locator("#neko-bubble")).to_contain_text(re.compile("香蕉皮|踩到|这一步|跳过去"))
@@ -1470,6 +1488,62 @@ def test_badminton_yui_voice_defer_releases_stuck_playback_state(
 
     assert speak_payloads
     assert speak_payloads[-1]["event"]["kind"] == "yui_cheat_item"
+    assert speak_payloads[-1]["interrupt_audio"] is True
+
+
+@pytest.mark.e2e
+def test_badminton_yui_cheat_voice_does_not_wait_for_mirror_assistant(
+    mock_page: Page, running_server: str
+):
+    page = mock_page
+    speak_payloads = []
+    page.add_init_script(
+        """
+        (() => {
+          const originalFetch = window.fetch.bind(window);
+          window.__badmintonBlockedMirrorAssistant = 0;
+          window.fetch = (input, init) => {
+            const url = String(input && input.url ? input.url : input || '');
+            if (url.indexOf('/api/game/badminton/mirror-assistant') !== -1) {
+              window.__badmintonBlockedMirrorAssistant += 1;
+              return new Promise(() => {});
+            }
+            return originalFetch(input, init);
+          };
+        })();
+        """
+    )
+
+    def capture_speak(route):
+        speak_payloads.append(json.loads(route.request.post_data or "{}"))
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok":true,"audio_sent":true,"speech_id":"e2e-yui-cheat-no-mirror-wait"}',
+        )
+
+    page.route("**/api/game/badminton/speak", capture_speak)
+    _goto_badminton(page, running_server, "duel", debug=True, debug_voice=False)
+
+    page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    page.evaluate(
+        """() => {
+          const state = window.BadmintonDemo.getState();
+          window.BadmintonDemo._debugSpawnYuiCheat('banana', {
+            x: state.playerCourt.x + 92,
+            y: state.playerFootY
+          });
+        }"""
+    )
+
+    deadline = time.time() + 3
+    while time.time() < deadline and not speak_payloads:
+        page.wait_for_timeout(25)
+
+    assert page.evaluate("window.__badmintonBlockedMirrorAssistant") >= 1
+    assert speak_payloads
+    assert speak_payloads[-1]["event"]["kind"] == "yui_cheat_item"
+    assert speak_payloads[-1]["interrupt_audio"] is True
 
 
 @pytest.mark.e2e
@@ -1663,6 +1737,25 @@ def test_badminton_voice_selection_mutes_ordinary_hint_but_keeps_bubble(
 @pytest.mark.e2e
 def test_badminton_banana_peel_flips_and_slows_grounded_player(mock_page: Page, running_server: str):
     page = mock_page
+    speak_payloads = []
+
+    def capture_speak(route):
+        speak_payloads.append(json.loads(route.request.post_data or "{}"))
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok":true,"audio_sent":true,"speech_id":"e2e-yui-cheat-hit"}',
+        )
+
+    page.route(
+        "**/api/game/badminton/mirror-assistant",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok":true}',
+        ),
+    )
+    page.route("**/api/game/badminton/speak", capture_speak)
     _goto_badminton(page, running_server, "duel")
 
     page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
@@ -1724,6 +1817,10 @@ def test_badminton_banana_peel_flips_and_slows_grounded_player(mock_page: Page, 
     assert movement["afterInput"]["playerCourt"]["targetX"] > before["targetX"] + 16
     assert movement["afterInput"]["yuiCheat"]["player_effect"]["slipping"] is True
     assert movement["afterInput"]["yuiCheat"]["player_effect"]["speed_multiplier"] == pytest.approx(0.22)
+    hit_payload = _wait_for_badminton_speak_payload(page, speak_payloads, "yui_cheat_hit")
+    assert hit_payload["event"]["label"] == "yui_cheat_hit_banana"
+    assert hit_payload["event"]["item_kind"] == "banana"
+    assert hit_payload["interrupt_audio"] is True
     assert max(movement["spinSamples"]) > 5.2
     slow_distance = state["playerCourt"]["x"] - before["x"]
     expected_slow_distance = (
@@ -1844,6 +1941,25 @@ def test_badminton_player_can_jump_over_banana_peel(mock_page: Page, running_ser
 @pytest.mark.e2e
 def test_badminton_octopus_ink_covers_player_screen(mock_page: Page, running_server: str):
     page = mock_page
+    speak_payloads = []
+
+    def capture_speak(route):
+        speak_payloads.append(json.loads(route.request.post_data or "{}"))
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok":true,"audio_sent":true,"speech_id":"e2e-yui-cheat-octopus"}',
+        )
+
+    page.route(
+        "**/api/game/badminton/mirror-assistant",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok":true}',
+        ),
+    )
+    page.route("**/api/game/badminton/speak", capture_speak)
     _goto_badminton(page, running_server, "duel")
 
     page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
@@ -1863,6 +1979,10 @@ def test_badminton_octopus_ink_covers_player_screen(mock_page: Page, running_ser
     assert state["yuiCheat"]["last_used_kind"] == "octopus"
     assert state["yuiCheat"]["ink"]["active"] is True
     assert state["yuiCheat"]["ink"]["alpha"] >= 0.75
+    item_payload = _wait_for_badminton_speak_payload(page, speak_payloads, "yui_cheat_item")
+    assert item_payload["event"]["label"] == "yui_cheat_octopus"
+    assert item_payload["event"]["item_kind"] == "octopus"
+    assert item_payload["interrupt_audio"] is True
 
 
 @pytest.mark.e2e
@@ -1933,25 +2053,14 @@ def test_badminton_yui_taunts_after_cheat_hit_scores_point(
         timeout=2000,
     )
 
-    deadline = time.time() + 6
-    score_payload = None
-    while time.time() < deadline:
-        score_payload = next(
-            (
-                payload
-                for payload in reversed(speak_payloads)
-                if payload.get("event", {}).get("kind") == "yui_cheat_score"
-            ),
-            None,
-        )
-        if score_payload:
-            break
-        page.wait_for_timeout(50)
-    assert score_payload
+    score_payload = _wait_for_badminton_speak_payload(
+        page, speak_payloads, "yui_cheat_score", timeout_ms=6000
+    )
     event = score_payload["event"]
     assert event["kind"] == "yui_cheat_score"
     assert event["label"] == f"yui_cheat_score_{kind}"
     assert event["item_kind"] == kind
+    assert score_payload["interrupt_audio"] is True
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -101,7 +101,24 @@ def test_badminton_start_tutorial_memory_and_never_prompt(mock_page: Page, runni
     page.locator("#badminton-start-button").click()
     expect(page.locator("#badminton-start-overlay")).not_to_be_visible(timeout=3000)
     page.wait_for_function("window.BadmintonDemo.getState().canControlShot === true", timeout=5000)
-    assert page.evaluate("localStorage.getItem('bd_start_tutorial_dismissed')") == "1"
+    tutorial_key = page.evaluate(
+        """() => {
+          const rawName = String(
+            (window.lanlan_config && window.lanlan_config.lanlan_name)
+              || new URLSearchParams(window.location.search).get('lanlan_name')
+              || 'default'
+          ).trim();
+          let scope = 'default';
+          if (rawName) {
+            scope = encodeURIComponent(rawName.toLowerCase())
+              .replace(/%/g, '~')
+              .replace(/[^a-z0-9_~-]+/g, '_') || 'default';
+          }
+          return `bd:${scope}:bd_start_tutorial_dismissed`;
+        }"""
+    )
+    assert page.evaluate("(key) => localStorage.getItem(key)", tutorial_key) == "1"
+    assert page.evaluate("localStorage.getItem('bd_start_tutorial_dismissed')") is None
 
     page.reload()
     page.wait_for_function(
@@ -347,6 +364,13 @@ def test_badminton_space_jump_turns_air_swing_into_smash(mock_page: Page, runnin
     )
     page.wait_for_function(
         """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          return state && state.playerJump && state.playerJump.active && state.playerJump.offset > 0;
+        }""",
+        timeout=2000,
+    )
+    page.wait_for_function(
+        """() => {
           const api = window.BadmintonDemo;
           const state = api && api.getState();
           if (!state || !state.playerJump || !state.playerJump.smashReady || !state.canControlShot) return false;
@@ -354,7 +378,7 @@ def test_badminton_space_jump_turns_air_swing_into_smash(mock_page: Page, runnin
           api.shoot();
           return true;
         }""",
-        timeout=2000,
+        timeout=3500,
     )
     jumping = page.evaluate("window.__badmintonSmashReadySnapshot")
     assert jumping["smashReady"] is True
@@ -1030,6 +1054,220 @@ def test_badminton_yui_awaiting_return_still_hits_midcourt_net(mock_page: Page, 
             && window.__badmintonNetEffectDebug.count === 0;
         }"""
     )
+
+
+@pytest.mark.e2e
+def test_badminton_yui_close_net_hit_below_tape_scores_for_player(mock_page: Page, running_server: str):
+    page = mock_page
+    _goto_badminton(page, running_server, "duel")
+
+    page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    page.evaluate(
+        """() => {
+          window.BadmintonDemo._debugSetAwaitingPlayerReturnBall({
+            id: 905,
+            x: 466,
+            y: 346,
+            prevX: 470,
+            prevY: 346,
+            courtY: 466,
+            prevCourtY: 470,
+            z: 104,
+            prevZ: 104,
+            vx: -360,
+            vy: 0,
+            vCourtY: -360,
+            vz: 0,
+            radius: 18,
+            shooter: 'neko',
+            direction: -1,
+            crossedNet: false,
+            resolved: false,
+            awaitingReturnBy: 'player',
+            returnDeadlineAt: performance.now() + 2400,
+            groundedReturnAt: 0,
+            angle: 43,
+            power: 52,
+            trail: []
+          });
+        }"""
+    )
+
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          if (!state || !state.currentShuttle || !state.currentShuttle.hitNet) return false;
+          window.__bdYuiCloseNetHitSample = {
+            hitNet: state.currentShuttle.hitNet,
+            crossedNet: state.currentShuttle.crossedNet,
+            netCarryToTargetSide: state.currentShuttle.netCarryToTargetSide,
+            y: state.currentShuttle.y,
+            z: state.currentShuttle.z
+          };
+          return true;
+        }""",
+        timeout=2000,
+    )
+    netted = page.evaluate("window.__bdYuiCloseNetHitSample")
+    assert netted["hitNet"] is True
+    assert netted["crossedNet"] is False
+    assert netted["netCarryToTargetSide"] is False
+    assert netted["z"] < 116
+
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          return state && state.attemptsResults.length > 0;
+        }""",
+        timeout=3500,
+    )
+    resolved = page.evaluate("window.BadmintonDemo.getState()")
+    result = resolved["attemptsResults"][-1]
+    assert result["shooter"] == "neko"
+    assert result["shot_type"] == "net"
+    assert result["point_winner"] == "player"
+    assert resolved["duel"]["player_score"] == 1
+    assert resolved["duel"]["neko_score"] == 0
+    assert resolved["duel"]["neko_misses"] == 1
+    assert resolved["duel"]["player_misses"] == 0
+
+
+@pytest.mark.e2e
+def test_badminton_yui_low_midcourt_blocked_shot_scores_for_player(mock_page: Page, running_server: str):
+    page = mock_page
+    _goto_badminton(page, running_server, "duel")
+
+    page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    page.evaluate(
+        """() => {
+          window.BadmintonDemo._debugSetAwaitingPlayerReturnBall({
+            id: 906,
+            x: 466,
+            y: 406,
+            prevX: 470,
+            prevY: 406,
+            courtY: 466,
+            prevCourtY: 470,
+            z: 44,
+            prevZ: 44,
+            vx: -360,
+            vy: 0,
+            vCourtY: -360,
+            vz: 0,
+            radius: 18,
+            shooter: 'neko',
+            direction: -1,
+            crossedNet: false,
+            legalNetClearance: false,
+            resolved: false,
+            awaitingReturnBy: 'player',
+            returnDeadlineAt: performance.now() + 2400,
+            groundedReturnAt: 0,
+            angle: 32,
+            power: 52,
+            trail: []
+          });
+        }"""
+    )
+
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          if (!state || !state.currentShuttle || !state.currentShuttle.hitNet) return false;
+          window.__bdYuiLowBlockedNetSample = {
+            hitNet: state.currentShuttle.hitNet,
+            crossedNet: state.currentShuttle.crossedNet,
+            legalNetClearance: state.currentShuttle.legalNetClearance,
+            netCarryToTargetSide: state.currentShuttle.netCarryToTargetSide,
+            z: state.currentShuttle.z
+          };
+          return true;
+        }""",
+        timeout=2000,
+    )
+    netted = page.evaluate("window.__bdYuiLowBlockedNetSample")
+    assert netted["hitNet"] is True
+    assert netted["crossedNet"] is False
+    assert netted["legalNetClearance"] is False
+    assert netted["netCarryToTargetSide"] is False
+
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          return state && state.attemptsResults.length > 0;
+        }""",
+        timeout=3500,
+    )
+    resolved = page.evaluate("window.BadmintonDemo.getState()")
+    result = resolved["attemptsResults"][-1]
+    assert result["shooter"] == "neko"
+    assert result["shot_type"] == "net"
+    assert result["point_winner"] == "player"
+    assert resolved["duel"]["player_score"] == 1
+    assert resolved["duel"]["neko_score"] == 0
+    assert resolved["duel"]["neko_misses"] == 1
+    assert resolved["duel"]["player_misses"] == 0
+
+
+@pytest.mark.e2e
+def test_badminton_yui_net_hit_cannot_become_player_timeout_point(mock_page: Page, running_server: str):
+    page = mock_page
+    _goto_badminton(page, running_server, "duel")
+
+    page.wait_for_function("window.BadmintonDemo.getState().state === 'ready'")
+    page.evaluate(
+        """() => {
+          window.BadmintonDemo._debugSetAwaitingPlayerReturnBall({
+            id: 907,
+            x: 466,
+            y: 406,
+            prevX: 470,
+            prevY: 406,
+            courtY: 466,
+            prevCourtY: 470,
+            z: 44,
+            prevZ: 44,
+            vx: -360,
+            vy: 0,
+            vCourtY: -360,
+            vz: 0,
+            radius: 18,
+            shooter: 'neko',
+            direction: -1,
+            crossedNet: false,
+            legalNetClearance: false,
+            resolved: false,
+            awaitingReturnBy: 'player',
+            returnDeadlineAt: performance.now() + 35,
+            groundedReturnAt: 0,
+            angle: 32,
+            power: 52,
+            trail: []
+          });
+        }"""
+    )
+
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          return state && state.currentShuttle && state.currentShuttle.hitNet;
+        }""",
+        timeout=2000,
+    )
+    page.wait_for_function(
+        """() => {
+          const state = window.BadmintonDemo && window.BadmintonDemo.getState();
+          return state && state.attemptsResults.length > 0;
+        }""",
+        timeout=3500,
+    )
+    resolved = page.evaluate("window.BadmintonDemo.getState()")
+    result = resolved["attemptsResults"][-1]
+    assert result["shooter"] == "neko"
+    assert result["shot_type"] == "net"
+    assert result["point_winner"] == "player"
+    assert resolved["duel"]["player_score"] == 1
+    assert resolved["duel"]["neko_score"] == 0
 
 
 @pytest.mark.e2e
@@ -2116,6 +2354,7 @@ def test_badminton_player_net_touch_landing_on_yui_side_scores_for_player(mock_p
             shooter: 'player',
             direction: 1,
             crossedNet: true,
+            netCarryToTargetSide: true,
             hitNet: true,
             netTouched: true,
             netContactHoldUntil: 0,

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -1482,13 +1482,8 @@ def test_badminton_yui_voice_defer_releases_stuck_playback_state(
         timeout=1500,
     )
 
-    deadline = time.time() + 3
-    while time.time() < deadline and not speak_payloads:
-        page.wait_for_timeout(50)
-
-    assert speak_payloads
-    assert speak_payloads[-1]["event"]["kind"] == "yui_cheat_item"
-    assert speak_payloads[-1]["interrupt_audio"] is True
+    item_payload = _wait_for_badminton_speak_payload(page, speak_payloads, "yui_cheat_item")
+    assert item_payload["interrupt_audio"] is True
 
 
 @pytest.mark.e2e
@@ -1536,14 +1531,9 @@ def test_badminton_yui_cheat_voice_does_not_wait_for_mirror_assistant(
         }"""
     )
 
-    deadline = time.time() + 3
-    while time.time() < deadline and not speak_payloads:
-        page.wait_for_timeout(25)
-
+    item_payload = _wait_for_badminton_speak_payload(page, speak_payloads, "yui_cheat_item")
     assert page.evaluate("window.__badmintonBlockedMirrorAssistant") >= 1
-    assert speak_payloads
-    assert speak_payloads[-1]["event"]["kind"] == "yui_cheat_item"
-    assert speak_payloads[-1]["interrupt_audio"] is True
+    assert item_payload["interrupt_audio"] is True
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -3285,7 +3285,8 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     short_drop_save_section = html[short_drop_save_start:html.index("function getYuiSmashHeightQuality(incomingBall)", short_drop_save_start)]
     assert "var nearNetRight = nearNetLeft + YUI_SHORT_DROP_SAVE_NET_WINDOW_PX;" in short_drop_save_section
     assert "var shuttleZ = getShuttleCourtZ(incomingBall, false);" in short_drop_save_section
-    assert "if (shuttleZ < YUI_SHORT_DROP_SAVE_MIN_Z || shuttleZ > YUI_SHORT_DROP_SAVE_MAX_Z) return false;" in short_drop_save_section
+    assert "var minSaveZ = Math.max(YUI_SHORT_DROP_SAVE_MIN_Z, shuttleRadius * 0.25 + 0.5);" in short_drop_save_section
+    assert "if (shuttleZ <= minSaveZ || shuttleZ > YUI_SHORT_DROP_SAVE_MAX_Z) return false;" in short_drop_save_section
     assert "if (shotPower > YUI_SHORT_DROP_SAVE_POWER_MAX) return false;" in short_drop_save_section
     assert "return getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiShortDropSaveRangeState(incomingBall).normalized <= 1;" in short_drop_save_section
     assert "var YUI_SMASH_MIN_SHUTTLE_Z = 64;" in html

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -1735,7 +1735,7 @@ def test_badminton_reset_game_clears_game_over_line_gate():
 @pytest.mark.unit
 def test_badminton_chat_empty_or_inactive_response_uses_safe_fallback():
     html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
-    helper_start = html.index("function shouldSuppressChatFallback(res, event) {")
+    helper_start = html.index("function shouldSuppressChatFallback(res) {")
     helper_section = html[helper_start:html.index("function buildBadmintonCurrentStatePayload()", helper_start)]
     send_event_start = html.index("function sendGameEvent(")
     send_event = html[send_event_start:html.index("function loadLocalLeaderboard(", send_event_start)]
@@ -1746,9 +1746,9 @@ def test_badminton_chat_empty_or_inactive_response_uses_safe_fallback():
     assert "reason === 'route_not_active'" not in helper_section
     assert "reason === 'client_timeout'" not in helper_section
     assert "function pickChatFallbackLine(res, event) {" in helper_section
-    assert "if (shouldSuppressChatFallback(res, event)) return '';" in helper_section
+    assert "if (shouldSuppressChatFallback(res)) return '';" in helper_section
     assert "return pickLine(getFallbackLineKey(event), null, {});" in helper_section
-    assert helper_section.index("if (shouldSuppressChatFallback(res, event)) return '';") < helper_section.index("return pickLine(getFallbackLineKey(event), null, {});")
+    assert helper_section.index("if (shouldSuppressChatFallback(res)) return '';") < helper_section.index("return pickLine(getFallbackLineKey(event), null, {});")
     assert "if (res && res.line) speakLine(moodStyleLine(res.line, currentMood), res.control || {}, event);" in send_event
     assert "var fallbackLine = pickChatFallbackLine(res, event);" in send_event
     assert "if (fallbackLine) speakLine(fallbackLine, {}, event);" in send_event

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -2473,13 +2473,15 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "function didShuttleCrossMidcourtNet(shuttle, direction) {" in html
     assert "function getMidcourtNetCrossing(shuttle) {" in html
     assert "function isShuttleInsideNetZ(shuttle, crossing) {" in html
+    assert "function didShuttleLegallyClearNet(shuttle, crossing) {" in html
     assert "shuttle.courtY = origin.x;" in html
     assert "shuttle.z = screenYToCourtZ(origin.y);" in html
     assert "shuttle.vCourtY = shuttle.vx;" in html
     assert "shuttle.vz = -(shuttle.vy || 0);" in html
     assert "var crossedNet = didShuttleCrossMidcourtNet(ball, direction);" in html
     assert "var netCrossing = getMidcourtNetCrossing(ball);" in html
-    assert "if (isShuttleInsideNetZ(ball, netCrossing)) {" in html
+    assert "if (!didShuttleLegallyClearNet(ball, netCrossing)) {" in html
+    assert "ball.legalNetClearance = true;" in html
     assert "z >= getNetBottomZ() - shuttleRadius * 0.18" in html
     assert "z <= getNetTopZ() + shuttleRadius * 0.12" in html
     assert "function applyNetContactImpulse(ball, crossing) {" in html
@@ -2488,13 +2490,16 @@ def test_badminton_scene_uses_compact_avatars_and_net():
     assert "node.vx += recoilX;" in html
     assert "node.vy += rippleY;" in html
     assert "function doesNetTouchCarryToTargetSide(ball, crossing) {" in html
-    assert "var highOnTape = z >= netTopZ - shuttleRadius * 0.72;" in html
+    assert "var clearsTape = z >= netTopZ - shuttleRadius * 0.26;" in html
     assert "var hasCarry = forwardSpeed >= 115 || risingSpeed >= 36;" in html
+    assert "var aboveTape = z >= netTopZ;" in html
+    assert "return clearsTape && (hasCarry || aboveTape);" in html
     assert "function applyMidcourtNetContact(ball, crossing) {" in html
     assert "ball.x = crossing.screenX;" in html
     assert "ball.y = crossing.screenY;" in html
     assert "ball.netTouched = true;" in html
     assert "ball.netCarryToTargetSide = carriesToTargetSide;" in html
+    assert "ball.legalNetClearance = false;" in html
     assert "ball.crossedNet = carriesToTargetSide;" in html
     assert "ball.netContactHoldUntil = ball.netContactAt + NET_CONTACT_HOLD_MS;" in html
     assert "applyNetContactImpulse(ball, crossing);" in html
@@ -3336,8 +3341,16 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     net_crossing_start = html.index("function updateShuttleNetCrossing(ball) {")
     net_crossing_section = html[net_crossing_start:html.index("function checkShuttleLanding(ball) {", net_crossing_start)]
     assert "var crossedNet = didShuttleCrossMidcourtNet(ball, direction);" in net_crossing_section
-    assert "if (isShuttleInsideNetZ(ball, netCrossing)) {" in net_crossing_section
+    assert "if (!didShuttleLegallyClearNet(ball, netCrossing)) {" in net_crossing_section
     assert "applyMidcourtNetContact(ball, netCrossing);" in net_crossing_section
+    assert "ball.legalNetClearance = true;" in net_crossing_section
+    awaiting_return_start = html.index("function stepAwaitingPlayerReturn(dt) {")
+    awaiting_return_section = html[awaiting_return_start:html.index("function queueShotResolution(ball, scored, shotType, delayMs) {", awaiting_return_start)]
+    assert "if (ball.resolved) {" in awaiting_return_section
+    assert "finishShot(ball.pendingScored, ball.pendingShotType, ball);" in awaiting_return_section
+    assert "if (!ball.hitNet && performance.now() > ball.returnDeadlineAt) {" in awaiting_return_section
+    assert awaiting_return_section.index("if (ball.resolved) {") < awaiting_return_section.index("if (!ball.hitNet && performance.now() > ball.returnDeadlineAt) {")
+    assert "if (ball.hitNet) {\n      ball.awaitingReturnBy = '';" not in awaiting_return_section
     landing_start = html.index("function checkShuttleLanding(ball) {")
     landing_section = html[landing_start:html.index("function maybeYuiReturnIncomingShuttle(ball)", landing_start)]
     assert "returnedFromShuttleId" not in landing_section
@@ -3349,14 +3362,16 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "var inTargetX = ball.x >= targetLeft && ball.x <= targetRight;" not in landing_section
     assert "var landedOnTargetSide = direction > 0 ? ball.x >= targetLeft : ball.x <= targetRight;" not in landing_section
     assert "if (ball.hitNet) {" in landing_section
-    assert "var netScored = landedOnTargetSide && inTargetX && inTargetY;" in landing_section
-    assert "var netShotType = !landedOnTargetSide ? 'net' : (netScored ? 'net_touch' : 'out');" in landing_section
+    assert "var netCarriedOver = ball.netCarryToTargetSide === true;" in landing_section
+    assert "var netScored = netCarriedOver && landedOnTargetSide && inTargetX && inTargetY;" in landing_section
+    assert "var netShotType = (!netCarriedOver || !landedOnTargetSide) ? 'net' : (netScored ? 'net_touch' : 'out');" in landing_section
     assert "queueShotResolution(ball, netScored, netShotType, netScored ? 140 : 80);" in landing_section
-    assert "var scored = ball.crossedNet && inTargetX && inTargetY;" in landing_section
-    assert "var shotType = (!ball.crossedNet || !landedOnTargetSide) ? 'net' : 'out';" in landing_section
+    assert "var legallyOverNet = ball.legalNetClearance === true;" in landing_section
+    assert "var scored = legallyOverNet && inTargetX && inTargetY;" in landing_section
+    assert "var shotType = (!legallyOverNet || !landedOnTargetSide) ? 'net' : 'out';" in landing_section
     assert "shotType = ball.hitNet ? 'net_touch' : (nearBaseline ? 'line_in' : (nearNet ? 'net_touch' : 'zone_in'));" in landing_section
     assert "var scored = !ball.hitNet && ball.crossedNet && inTargetX && inTargetY;" not in landing_section
-    net_contact_start = net_crossing_section.index("if (isShuttleInsideNetZ(ball, netCrossing)) {")
+    net_contact_start = net_crossing_section.index("if (!didShuttleLegallyClearNet(ball, netCrossing)) {")
     net_contact_section = net_crossing_section[
         net_contact_start:
         net_crossing_section.index("return false;", net_contact_start)
@@ -3492,7 +3507,7 @@ def test_badminton_player_can_receive_and_return_yui_shuttle():
     awaiting_section = html[awaiting_start:html.index("function queueShotResolution", awaiting_start)]
     assert awaiting_section.index("stepBallPhysics(ball, subDt);") < awaiting_section.index("checkShuttleLanding(ball);")
     assert awaiting_section.index("checkShuttleLanding(ball);") < awaiting_section.index("updateNetPhysics(subDt);")
-    assert "if (performance.now() > ball.returnDeadlineAt) {" in html
+    assert "if (!ball.hitNet && performance.now() > ball.returnDeadlineAt) {" in html
     assert "if (!ball.groundedReturnAt) ball.groundedReturnAt = performance.now();" in html
     assert "if (performance.now() - ball.groundedReturnAt < 1100) continue;" in html
     assert "finishShot(false, 'out', ball);" in html
@@ -3577,7 +3592,8 @@ def test_badminton_space_jump_enables_air_smash():
         html.index("function isPlayerSmashReady(incomingBall) {"):
         html.index("function getYuiRacketHitRangeState(incomingBall) {")
     ]
-    assert "if (isPlayerServeSetup()) return false;" in smash_ready_section
+    assert "if (isPlayerServeSetup()) return false;" not in smash_ready_section
+    assert "return getPlayerSmashQuality(incomingBall) >= 0.22;" in smash_ready_section
     assert "function getYuiSmashQuality(incomingBall, shot) {" in html
     assert "function getYuiSmashHeightQuality(incomingBall) {" in html
     assert "function shouldYuiSmashReturn(incomingBall, shot, quality) {" in html

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -3261,16 +3261,22 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "return getYuiVisibleRacketContactPoint() || getYuiShotOrigin();" in html
     assert "function getYuiNeutralRacketContactPoint() {" in html
     assert "source: 'neutral-racket-anchor'" in html
+    assert "function getYuiRacketRangeStateForPoint(incomingBall, racket, reachX, reachY) {" in html
+    assert "var contact = racket || getYuiNeutralRacketContactPoint();" in html
     assert "function getYuiRacketRangeState(incomingBall, reachX, reachY) {" in html
     assert "var neutral = getYuiNeutralRacketContactPoint();" in html
     assert "var visible = getYuiVisibleRacketContactPoint();" in html
+    assert "var best = getYuiRacketRangeStateForPoint(incomingBall, neutral, reachX, reachY);" in html
+    assert "var visibleState = getYuiRacketRangeStateForPoint(incomingBall, visible, reachX, reachY);" in html
     assert "if (visibleState.normalized < best.normalized) best = visibleState;" in html
+    assert "function getYuiVisibleOrNeutralRacketRangeState(incomingBall, reachX, reachY) {" in html
+    assert "return getYuiRacketRangeStateForPoint(incomingBall, visible || getYuiNeutralRacketContactPoint(), reachX, reachY);" in html
     assert "function getYuiRacketHitRangeState(incomingBall) {" in html
-    assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_HIT_REACH_X, YUI_RACKET_HIT_REACH_Y);" in html
+    assert "return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_RACKET_HIT_REACH_X, YUI_RACKET_HIT_REACH_Y);" in html
     assert "function isYuiRacketHitInRange(incomingBall) {" in html
     assert "return getYuiRacketHitRangeState(incomingBall).normalized <= 1;" in html
     assert "function getYuiRacketRescueGateState(incomingBall) {" in html
-    assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);" in html
+    assert "return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);" in html
     assert "var YUI_RACKET_SAVE_REACH_X = 84;" in html
     assert "var YUI_RACKET_SAVE_REACH_Y = 86;" in html
     assert "var YUI_SHORT_DROP_SAVE_REACH_X = 96;" in html
@@ -3280,9 +3286,9 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "var YUI_SHORT_DROP_SAVE_MIN_Z = 4;" in html
     assert "var YUI_SHORT_DROP_SAVE_POWER_MAX = 32;" in html
     assert "function getYuiRacketSaveRangeState(incomingBall) {" in html
-    assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);" in html
+    assert "return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);" in html
     assert "function getYuiShortDropSaveRangeState(incomingBall) {" in html
-    assert "return getYuiRacketRangeState(incomingBall, YUI_SHORT_DROP_SAVE_REACH_X, YUI_SHORT_DROP_SAVE_REACH_Y);" in html
+    assert "return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_SHORT_DROP_SAVE_REACH_X, YUI_SHORT_DROP_SAVE_REACH_Y);" in html
     assert "function isYuiSmashSaveReachable(incomingBall) {" in html
     assert "return !!(incomingBall && incomingBall.isSmash) && getYuiRacketRescueGateState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;" in html
     assert "function isYuiShortDropSaveReachable(incomingBall) {" in html
@@ -3305,15 +3311,17 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "headY: racketHead.y," in html
     assert "var yuiReachLeft = BADMINTON.netX + shuttleRadius * 0.5;" in html
     assert "var yuiReachRight = BADMINTON.courtRight - shuttleRadius * 0.5;" in html
+    assert "var yuiRacketHitState = getYuiRacketHitRangeState(ball);" in html
+    assert "var yuiRacketHitInRange = yuiRacketHitState.normalized <= 1;" in html
     assert "var crossesYuiReach = Math.max(previousShuttleCourtY, shuttleCourtY) >= yuiReachLeft" in html
     assert "&& Math.min(previousShuttleCourtY, shuttleCourtY) <= yuiReachRight;" in html
-    assert "var inYuiReach = crossesYuiReach" in html
+    assert "var inYuiReach = yuiRacketHitInRange || (crossesYuiReach" in html
     assert "&& shuttleZ <= yuiContactTopZ" in html
-    assert "&& shuttleZ >= yuiContactBottomZ" in html
+    assert "&& shuttleZ >= yuiContactBottomZ);" in html
     assert "var yuiShortDropSave = isYuiShortDropSaveReachable(ball);" in html
-    assert "if (!inYuiReach && !yuiShortDropSave) return false;" in html
     assert "var yuiSave = isYuiSmashSaveReachable(ball) || yuiShortDropSave;" in html
-    assert "if (!isYuiRacketHitInRange(ball) && !yuiSave) return false;" in html
+    assert "if (!inYuiReach && !yuiSave) return false;" in html
+    assert "if (!yuiRacketHitInRange && !yuiSave) return false;" in html
     assert "game.duel.activeShooter = 'neko';" in html
     assert "game.duel.rallyHits += 1;" in html
     assert "var returnPressureBoost = Math.min(5, game.duel.rallyHits * 0.30);" in html
@@ -3523,9 +3531,10 @@ def test_badminton_player_can_receive_and_return_yui_shuttle():
     assert "function drawPlayerChargeMeter(" in draw_section
     assert "drawPlayerChargeMeter(game.charging && canPlayerChargeShot() ? clamp(game.power, 0, 100) : 0, t);" in draw_section
     assert "if (!isIncomingPlayerReturnCandidate()) return;" in draw_section
-    assert "if (!canReturnNow) return;" not in draw_section
-    assert "var cueAlpha = canReturnNow ? 1 : 0.46;" in draw_section
-    assert "'rgba(114,216,255,.055)'" in draw_section
+    assert "if (!canReturnNow) return;" in draw_section
+    assert "var cueAlpha = 1;" in draw_section
+    assert "'rgba(114,216,255,.055)'" not in draw_section
+    assert "'rgba(114,216,255,.25)'" not in draw_section
     assert "var returnPercent = clamp(returnDeadlineMs / 2400 * 100, 0, 100);" not in draw_section
     assert "drawReturnChargeTrace" not in draw_section
 

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -3294,7 +3294,10 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "function isYuiShortDropSaveReachable(incomingBall) {" in html
     short_drop_save_start = html.index("function isYuiShortDropSaveReachable(incomingBall) {")
     short_drop_save_section = html[short_drop_save_start:html.index("function getYuiSmashHeightQuality(incomingBall)", short_drop_save_start)]
+    assert "var shuttleCourtY = getShuttleCourtY(incomingBall, false);" in short_drop_save_section
+    assert "var nearNetLeft = BADMINTON.netX + shuttleRadius * 0.5;" in short_drop_save_section
     assert "var nearNetRight = nearNetLeft + YUI_SHORT_DROP_SAVE_NET_WINDOW_PX;" in short_drop_save_section
+    assert "if (shuttleCourtY < nearNetLeft || shuttleCourtY > nearNetRight) return false;" in short_drop_save_section
     assert "var shuttleZ = getShuttleCourtZ(incomingBall, false);" in short_drop_save_section
     assert "var minSaveZ = Math.max(YUI_SHORT_DROP_SAVE_MIN_Z, shuttleRadius * 0.25 + 0.5);" in short_drop_save_section
     assert "if (shuttleZ <= minSaveZ || shuttleZ > YUI_SHORT_DROP_SAVE_MAX_Z) return false;" in short_drop_save_section

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -1691,6 +1691,71 @@ def test_badminton_non_chinese_static_quick_line_fallbacks_are_not_chinese():
 
 
 @pytest.mark.unit
+def test_badminton_unknown_quick_line_key_does_not_fallback_to_game_over():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+    pick_line = html[html.index("function pickLine(key, primary, options) {"):html.index("function getRequestLanguage()", html.index("function pickLine(key, primary, options) {"))]
+
+    assert "function getNeutralQuickLineFallback(primary) {" in html
+    assert "var isGameOverKey = key === 'game_over';" in pick_line
+    assert "var fallback = source[key] || defaultFallback[key] || (isGameOverKey ? (source.game_over || defaultFallback.game_over) : null) || getNeutralQuickLineFallback(primary);" in pick_line
+    assert "(isGameOverKey ? (source.game_over || defaultFallback.game_over) : null)" in pick_line
+    assert "source[key] || defaultFallback[key] || source.game_over" not in pick_line
+    assert "|| source.game_over || defaultFallback.game_over" not in pick_line
+    assert "|| getNeutralQuickLineFallback(primary)" in pick_line
+
+
+@pytest.mark.unit
+def test_badminton_game_over_line_is_suppressed_after_first_session_fallback():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+    suppress_start = html.index("function shouldSuppressRepeatedGameOverLine(event) {")
+    suppress_section = html[suppress_start:html.index("function speakLine(line, control, event) {", suppress_start)]
+    speak_start = html.index("function speakLine(line, control, event) {")
+    speak_section = html[speak_start:html.index("function getActiveAvatarContainer()", speak_start)]
+
+    assert "var gameOverLineSpokenSessionId = '';" in html
+    assert "if (!event || event.kind !== 'game_over') return false;" in suppress_section
+    assert "var eventSessionId = String(event.session_id || sessionId || '');" in suppress_section
+    assert "if (gameOverLineSpokenSessionId === eventSessionId) return true;" in suppress_section
+    assert "gameOverLineSpokenSessionId = eventSessionId;" in suppress_section
+    assert "if (shouldSuppressRepeatedGameOverLine(event || {})) return;" in speak_section
+    assert speak_section.index("if (shouldSuppressRepeatedGameOverLine(event || {})) return;") < speak_section.index("line = replaceUnexpectedChineseFallbackLine(line, event);")
+    assert speak_section.index("if (shouldSuppressRepeatedGameOverLine(event || {})) return;") < speak_section.index("if (!shouldReadBadmintonVoice(event, control)) {")
+
+
+@pytest.mark.unit
+def test_badminton_reset_game_clears_game_over_line_gate():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+    reset_start = html.index("function resetGame() {")
+    reset_section = html[reset_start:html.index("game.state = 'ready';", reset_start)]
+
+    assert "gameOverLineSpokenSessionId = '';" in reset_section
+    assert reset_section.index("gameOverLineSpokenSessionId = '';") < reset_section.index("sessionId = createBadmintonSessionId();")
+
+
+@pytest.mark.unit
+def test_badminton_chat_empty_or_inactive_response_uses_safe_fallback():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+    helper_start = html.index("function shouldSuppressChatFallback(res, event) {")
+    helper_section = html[helper_start:html.index("function buildBadmintonCurrentStatePayload()", helper_start)]
+    send_event_start = html.index("function sendGameEvent(")
+    send_event = html[send_event_start:html.index("function loadLocalLeaderboard(", send_event_start)]
+
+    assert "return !!(res && res.suppress_fallback);" in helper_section
+    assert "reason === 'rate_limited'" not in helper_section
+    assert "reason === 'route_inactive'" not in helper_section
+    assert "reason === 'route_not_active'" not in helper_section
+    assert "reason === 'client_timeout'" not in helper_section
+    assert "function pickChatFallbackLine(res, event) {" in helper_section
+    assert "if (shouldSuppressChatFallback(res, event)) return '';" in helper_section
+    assert "return pickLine(getFallbackLineKey(event), null, {});" in helper_section
+    assert helper_section.index("if (shouldSuppressChatFallback(res, event)) return '';") < helper_section.index("return pickLine(getFallbackLineKey(event), null, {});")
+    assert "if (res && res.line) speakLine(moodStyleLine(res.line, currentMood), res.control || {}, event);" in send_event
+    assert "var fallbackLine = pickChatFallbackLine(res, event);" in send_event
+    assert "if (fallbackLine) speakLine(fallbackLine, {}, event);" in send_event
+    assert "var fallbackLine = pickChatFallbackLine({ error: 'request_failed' }, event);" in send_event
+
+
+@pytest.mark.unit
 def test_badminton_speak_line_guards_non_chinese_from_chinese_fallback_text():
     html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
 
@@ -2024,6 +2089,15 @@ def test_badminton_debug_voice_mode_allows_tts_when_debugging():
     assert "hasProjectVoicePlaybackBridge" not in mirror_section
     assert "missing_project_voice_playback_bridge" not in mirror_section
     assert "lastVoiceRequest = speakPayload;" in mirror_section
+    assert "function shouldInterruptVoiceAudio(event) {" in html
+    assert "return kind === 'yui_cheat_item' || kind === 'yui_cheat_hit' || kind === 'yui_cheat_score';" in html
+    assert "interrupt_audio: shouldInterruptVoiceAudio(entry.event)," in mirror_section
+    assert "function requestMirror() {" in mirror_section
+    assert "function requestSpeak() {" in mirror_section
+    assert "if (shouldInterruptVoiceAudio(entry.event)) {" in mirror_section
+    assert "void requestMirror();" in mirror_section
+    assert "return requestSpeak();" in mirror_section
+    assert "return requestMirror().then(requestSpeak);" in mirror_section
     assert "reason: 'project_speak_failed'" in mirror_section
     assert "return post('/speak', speakPayload, 3500).then(function (res) {" in mirror_section
 
@@ -2037,7 +2111,7 @@ def test_badminton_voice_selection_reads_only_high_value_yui_lines():
     speak_section = html[speak_start:html.index("function getActiveAvatarContainer()", speak_start)]
 
     assert "if (event && (event.force_voice || event.force_voice_in_debug || event.voice_always)) return true;" in selector_section
-    assert "kind === 'yui_cheat_item' || kind === 'yui_cheat_score'" in selector_section
+    assert "kind === 'yui_cheat_item' || kind === 'yui_cheat_hit' || kind === 'yui_cheat_score'" in selector_section
     assert "kind === 'difficulty_ramp'" in selector_section
     assert "kind === 'game_over' && (event.duel_outcome === 'neko_win' || event.point_winner === 'neko')" not in selector_section
     assert "event.point_winner === 'neko' && label === 'neko_duel_shot'" in selector_section
@@ -2696,7 +2770,9 @@ def test_badminton_mouse_input_is_gated_to_player_controlled_shots():
     assert "var playerShotInFlight = game.ball && game.ball.shooter === 'player' && game.ball.direction === 1 && !game.ball.resolved;" in html
     assert "var yuiTurnActive = game.state === 'neko_thinking' || game.duel.activeShooter === 'neko';" in html
     assert "var yuiSwinging = game.pendingSwing && game.pendingSwing.shooter === 'neko';" in html
-    assert "return isDuelMode() && (isPlayerServeSetup() || canPlayerControlShot() || playerShotInFlight || yuiTurnActive || incomingYuiBall || yuiSwinging);" in html
+    assert "function isPlayerPostServeMoveLocked() {" in html
+    assert "return performance.now() < (game.playerMoveLockedUntil || 0);" in html
+    assert "return isDuelMode() && (isPlayerServeSetup() || canPlayerControlShot() || (playerShotInFlight && !isPlayerPostServeMoveLocked()) || yuiTurnActive || incomingYuiBall || yuiSwinging);" in html
     assert "function isIncomingPlayerShuttleInReach(ball) {" in html
     assert "var PLAYER_RETURN_REACH_X = 84;" in html
     assert "var PLAYER_RETURN_REACH_Y = 108;" in html
@@ -2738,6 +2814,25 @@ def test_badminton_mouse_input_is_gated_to_player_controlled_shots():
     assert "if (game.charging && returnIncomingPlayerShuttle()) return;" in mouseup
     assert "if (game.charging && canPlayerControlShot()) shoot();" in mouseup
     assert "game.charging = false;" in mouseup
+
+
+@pytest.mark.unit
+def test_badminton_player_serve_briefly_locks_court_movement():
+    html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
+    queue_start = html.index("function queueRacketSwing(angle, power, shooter, options) {")
+    queue_section = html[queue_start:html.index("function returnIncomingPlayerShuttle()", queue_start)]
+    return_start = html.index("function returnIncomingPlayerShuttle() {")
+    return_section = html[return_start:html.index("function shoot()", return_start)]
+    reset_start = html.index("function resetCourtMovement() {")
+    reset_section = html[reset_start:html.index("function resetYuiCheats()", reset_start)]
+
+    assert "var PLAYER_POST_SERVE_MOVE_LOCK_MS = 420;" in html
+    assert "playerMoveLockedUntil: 0," in html
+    assert "if (shotShooter === 'player' && !incomingBall) {" in queue_section
+    assert "game.playerMoveLockedUntil = performance.now() + SWING_IMPACT_DELAY_MS + PLAYER_POST_SERVE_MOVE_LOCK_MS;" in queue_section
+    assert "queueRacketSwing(playerReturnAngle, returnPower, 'player', { incomingBall: game.ball });" in return_section
+    assert "game.playerMoveLockedUntil" not in return_section
+    assert "game.playerMoveLockedUntil = 0;" in reset_section
 
 
 @pytest.mark.unit
@@ -3057,6 +3152,7 @@ def test_badminton_yui_cheat_items_warn_player_with_bubble_lines():
     spawn_section = html[spawn_start:html.index("function maybeTriggerYuiCheat(reason) {", spawn_start)]
 
     assert "function showYuiCheatLine(kind) {" in html
+    assert "function showYuiCheatHitLine(kind) {" in html
     assert "function showYuiCheatScoreLine(kind) {" in html
     assert "function markYuiCheatHit(kind) {" in html
     assert "function getYuiCheatScoreTauntKind(pointWinner) {" in html
@@ -3082,13 +3178,28 @@ def test_badminton_yui_cheat_items_warn_player_with_bubble_lines():
     assert "label: 'yui_cheat_' + kind," in html
     assert "item_kind: kind," in html
     assert "force_voice_in_debug: true," in html
-    assert "voice_deadline_ms: 3600" in html
-    assert "voice_deadline_ms: 5200" in html
-    assert "if (kind === 'yui_cheat_item') return 1;" in html
-    assert "if (kind === 'yui_cheat_score') return 1;" in html
+    assert "voice_deadline_ms: 6200" in html
+    assert "voice_deadline_ms: 6800" in html
+    assert "if (kind === 'yui_cheat_item') return 0;" in html
+    assert "if (kind === 'yui_cheat_hit') return 0;" in html
+    assert "if (kind === 'yui_cheat_score') return 0;" in html
+    assert "if (shouldInterruptVoiceAudio(entry.event)) {" in html
+    assert "if (shouldInterruptVoiceAudio(entry.event) && !voiceArbiter.inFlight.isUserReply) {" in html
+    assert "if (shouldInterruptVoiceAudio(pending.event) && !voiceArbiter.inFlight.isUserReply) {" in html
+    assert "voiceArbiter.inFlight = null;" in html
+    assert "void _requestVoicePlayback(entry);" in html
+    assert "void _requestVoicePlayback(pending);" in html
+    assert "eventKind: String(entry.event && entry.event.kind || '')" in html
+    assert "local_voice_already_spoken: true," in html
+    send_event_start = html.index("function sendGameEvent(event) {")
+    send_event = html[send_event_start:html.index("function loadLocalLeaderboard(", send_event_start)]
+    assert "if (event.local_voice_already_spoken) return;" in send_event
+    assert send_event.index("if (event.local_voice_already_spoken) return;") < send_event.index("if (debugMode) {")
     assert "showYuiCheatLine('octopus');" in ink_section
     assert "showYuiCheatLine('banana');" in spawn_section
     assert "markYuiCheatHit('banana');" in html
+    assert "showYuiCheatHitLine('banana');" in html
+    assert "kind: 'yui_cheat_hit'," in html
     finish_start = html.index("function finishDuelShot(scored, shotType, ball) {")
     finish_section = html[finish_start:html.index("function finishShot(scored, shotType, ball) {", finish_start)]
     assert "var cheatScoreTauntKind = getYuiCheatScoreTauntKind(pointWinner);" in finish_section
@@ -3157,10 +3268,26 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);" in html
     assert "var YUI_RACKET_SAVE_REACH_X = 84;" in html
     assert "var YUI_RACKET_SAVE_REACH_Y = 86;" in html
+    assert "var YUI_SHORT_DROP_SAVE_REACH_X = 96;" in html
+    assert "var YUI_SHORT_DROP_SAVE_REACH_Y = 118;" in html
+    assert "var YUI_SHORT_DROP_SAVE_NET_WINDOW_PX = 112;" in html
+    assert "var YUI_SHORT_DROP_SAVE_MAX_Z = 96;" in html
+    assert "var YUI_SHORT_DROP_SAVE_MIN_Z = 4;" in html
+    assert "var YUI_SHORT_DROP_SAVE_POWER_MAX = 32;" in html
     assert "function getYuiRacketSaveRangeState(incomingBall) {" in html
     assert "return getYuiRacketRangeState(incomingBall, YUI_RACKET_SAVE_REACH_X, YUI_RACKET_SAVE_REACH_Y);" in html
+    assert "function getYuiShortDropSaveRangeState(incomingBall) {" in html
+    assert "return getYuiRacketRangeState(incomingBall, YUI_SHORT_DROP_SAVE_REACH_X, YUI_SHORT_DROP_SAVE_REACH_Y);" in html
     assert "function isYuiSmashSaveReachable(incomingBall) {" in html
     assert "return !!(incomingBall && incomingBall.isSmash) && getYuiRacketRescueGateState(incomingBall).normalized > 1 && getYuiRacketSaveRangeState(incomingBall).normalized <= 1;" in html
+    assert "function isYuiShortDropSaveReachable(incomingBall) {" in html
+    short_drop_save_start = html.index("function isYuiShortDropSaveReachable(incomingBall) {")
+    short_drop_save_section = html[short_drop_save_start:html.index("function getYuiSmashHeightQuality(incomingBall)", short_drop_save_start)]
+    assert "var nearNetRight = nearNetLeft + YUI_SHORT_DROP_SAVE_NET_WINDOW_PX;" in short_drop_save_section
+    assert "var shuttleZ = getShuttleCourtZ(incomingBall, false);" in short_drop_save_section
+    assert "if (shuttleZ < YUI_SHORT_DROP_SAVE_MIN_Z || shuttleZ > YUI_SHORT_DROP_SAVE_MAX_Z) return false;" in short_drop_save_section
+    assert "if (shotPower > YUI_SHORT_DROP_SAVE_POWER_MAX) return false;" in short_drop_save_section
+    assert "return getYuiRacketHitRangeState(incomingBall).normalized > 1 && getYuiShortDropSaveRangeState(incomingBall).normalized <= 1;" in short_drop_save_section
     assert "var YUI_SMASH_MIN_SHUTTLE_Z = 64;" in html
     assert "var YUI_SMASH_FULL_SHUTTLE_Z = 138;" in html
     assert "function getYuiSmashHeightQuality(incomingBall) {" in html
@@ -3177,7 +3304,9 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "var inYuiReach = crossesYuiReach" in html
     assert "&& shuttleZ <= yuiContactTopZ" in html
     assert "&& shuttleZ >= yuiContactBottomZ" in html
-    assert "var yuiSave = isYuiSmashSaveReachable(ball);" in html
+    assert "var yuiShortDropSave = isYuiShortDropSaveReachable(ball);" in html
+    assert "if (!inYuiReach && !yuiShortDropSave) return false;" in html
+    assert "var yuiSave = isYuiSmashSaveReachable(ball) || yuiShortDropSave;" in html
     assert "if (!isYuiRacketHitInRange(ball) && !yuiSave) return false;" in html
     assert "game.duel.activeShooter = 'neko';" in html
     assert "game.duel.rallyHits += 1;" in html
@@ -3199,13 +3328,19 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "stepBallPhysics(b, subDt);" in update_section
     assert "if (b.resolved && canonicalShotType(b.pendingShotType) === 'net') {" in update_section
     assert update_section.index("if (b.resolved && canonicalShotType(b.pendingShotType) === 'net') {") < update_section.index("stepBallPhysics(b, subDt);")
-    assert "if (maybeYuiReturnIncomingShuttle(b)) break;" in update_section
-    assert update_section.index("checkShuttleLanding(b);") < update_section.index("if (maybeYuiReturnIncomingShuttle(b)) break;")
-    assert update_section.index("if (maybeYuiReturnIncomingShuttle(b)) break;") < update_section.index("if (maybePlayerReceiveIncomingShuttle(b)) break;")
+    assert "if (!b.hitNet && maybeYuiReturnIncomingShuttle(b)) break;" in update_section
+    assert update_section.index("updateShuttleNetCrossing(b);") < update_section.index("if (!b.hitNet && maybeYuiReturnIncomingShuttle(b)) break;")
+    assert update_section.index("if (!b.hitNet && maybeYuiReturnIncomingShuttle(b)) break;") < update_section.index("checkShuttleLanding(b);")
+    assert update_section.index("if (!b.hitNet && maybeYuiReturnIncomingShuttle(b)) break;") < update_section.index("if (maybePlayerReceiveIncomingShuttle(b)) break;")
+    net_crossing_start = html.index("function updateShuttleNetCrossing(ball) {")
+    net_crossing_section = html[net_crossing_start:html.index("function checkShuttleLanding(ball) {", net_crossing_start)]
+    assert "var crossedNet = didShuttleCrossMidcourtNet(ball, direction);" in net_crossing_section
+    assert "if (isShuttleInsideNetZ(ball, netCrossing)) {" in net_crossing_section
+    assert "applyMidcourtNetContact(ball, netCrossing);" in net_crossing_section
     landing_start = html.index("function checkShuttleLanding(ball) {")
     landing_section = html[landing_start:html.index("function maybeYuiReturnIncomingShuttle(ball)", landing_start)]
     assert "returnedFromShuttleId" not in landing_section
-    assert "if (isShuttleInsideNetZ(ball, netCrossing)) {" in landing_section
+    assert "if (updateShuttleNetCrossing(ball)) return;" in landing_section
     assert "if (ball.netContactHoldUntil && performance.now() < ball.netContactHoldUntil) return;" in landing_section
     assert "var landingCourtY = getShuttleCourtY(ball, false);" in landing_section
     assert "var inTargetX = landingCourtY >= targetLeft && landingCourtY <= targetRight;" in landing_section
@@ -3220,9 +3355,10 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "var shotType = (!ball.crossedNet || !landedOnTargetSide) ? 'net' : 'out';" in landing_section
     assert "shotType = ball.hitNet ? 'net_touch' : (nearBaseline ? 'line_in' : (nearNet ? 'net_touch' : 'zone_in'));" in landing_section
     assert "var scored = !ball.hitNet && ball.crossedNet && inTargetX && inTargetY;" not in landing_section
-    net_contact_section = landing_section[
-        landing_section.index("if (isShuttleInsideNetZ(ball, netCrossing)) {"):
-        landing_section.index("var ballRadius = ball.radius || BALL_R;")
+    net_contact_start = net_crossing_section.index("if (isShuttleInsideNetZ(ball, netCrossing)) {")
+    net_contact_section = net_crossing_section[
+        net_contact_start:
+        net_crossing_section.index("return false;", net_contact_start)
     ]
     assert "applyMidcourtNetContact(ball, netCrossing);" in net_contact_section
     assert "queueShotResolution(ball, false, 'net'" not in net_contact_section
@@ -3234,6 +3370,7 @@ def test_badminton_duel_avatars_move_to_receive_shuttles():
     html = BADMINTON_TEMPLATE.read_text(encoding="utf-8")
 
     assert "var PLAYER_MOVE_SPEED = 1040;" in html
+    assert "var PLAYER_POST_SERVE_MOVE_LOCK_MS = 420;" in html
     assert "var YUI_MOVE_SPEED = 360;" in html
     assert "var YUI_RETURN_CHASE_SPEED = 720;" in html
     assert "var YUI_RETURN_CHASE_Y_SPEED = 540;" in html
@@ -3241,6 +3378,7 @@ def test_badminton_duel_avatars_move_to_receive_shuttles():
     assert "transition: opacity .24s ease;" in html
     assert "transition: transform .3s ease, opacity .24s ease;" not in html
     assert "playerCourt: { x: PLAYER_START_X, y: PLAYER_START_Y, targetX: PLAYER_START_X, targetY: PLAYER_START_Y }," in html
+    assert "playerMoveLockedUntil: 0," in html
     assert "yuiCourt: { x: YUI_START_X, y: YUI_START_Y, targetX: YUI_START_X, targetY: YUI_START_Y }," in html
     assert "function updatePlayerCourtTarget(clientX, clientY) {" in html
     assert "var normX = clamp(clientX / Math.max(1, window.innerWidth), 0, 1);" in html
@@ -3280,12 +3418,14 @@ def test_badminton_duel_avatars_move_to_receive_shuttles():
     assert "game.yuiCourt.y = moveToward(game.yuiCourt.y, game.yuiCourt.targetY, yuiChaseSpeedY, dt);" in html
     assert "function canPlayerMoveCourt() {" in html
     assert "if (isBadmintonLoadingActive()) return false;" in html
-    assert "return isDuelMode() && (isPlayerServeSetup() || canPlayerControlShot()" in html
+    assert "function isPlayerPostServeMoveLocked() {" in html
+    assert "return isDuelMode() && (isPlayerServeSetup() || canPlayerControlShot() || (playerShotInFlight && !isPlayerPostServeMoveLocked())" in html
     assert "var incomingYuiBall = game.ball && game.ball.shooter === 'neko' && game.ball.direction === -1 && !game.ball.resolved;" in html
     assert "var canMoveCourt = canPlayerMoveCourt();" in html
     assert "if (canMoveCourt) updatePlayerCourtTarget(ev.clientX, ev.clientY);" in html
     assert "if (isDuelMode()) updateCourtMovement(dt);" in html
     assert "playerCourt: Object.assign({}, game.playerCourt)," in html
+    assert "playerMoveLockRemainingMs: Math.max(0, Math.round((game.playerMoveLockedUntil || 0) - performance.now()))," in html
     assert "var playerRacketContact = getRacketContactPoint('player');" in html
     assert "playerRacketContact: playerRacketContact ? {" in html
     assert "source: playerRacketContact.source || 'fallback'" in html


### PR DESCRIPTION
## 改动概述
修复羽毛球小游戏里几条对局体验问题：结束台词不再被未知 fallback 反复刷出，玩家发球后会有短暂移动锁，Yui 能在近网最小力度短球落地前尝试救球，道具使用、命中和得分嘲讽都会走明确的项目语音链路。

## 技术决策
将 game over 台词抑制和普通兜底台词拆开，避免 `/chat` 异常时误把所有台词静音；把羽毛球过网状态更新前置，让 Yui 接球判定先于落地结算；为近网低力度短球增加窄范围救球条件，保留玩家正常吊球得分空间。

道具语音改为本地道具台词直接进入 `speakLine`，并让 `yui_cheat_item`、`yui_cheat_hit`、`yui_cheat_score` 都以高优先级和 `interrupt_audio` 进入 `/speak`。道具语音不再等待 `/mirror-assistant`，上报事件通过 `local_voice_already_spoken` 避免重复排第二条语音。

## 风险与边界
本轮只调整羽毛球小游戏模板和对应测试，不修改核心后端、路由、记忆或主语音管线。近网救球只覆盖已过网、非扣杀、低高度、低力度且普通击球够不到的短球，不改变普通落点判分。真实出声仍依赖项目 TTS 管线可用；前端侧已保证道具场景会发出正确的 `/speak` 请求并携带打断标记。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 发球后挥拍引入短暂移动锁定，并提供剩余锁定时间（便于状态观察）。
  * 扩展 Yui “短吊救球”策略与可达性判定。
  * 语音播报支持按会话去重与更细粒度的事件打断，并新增香蕉踩滑落相关提示。
* **Bug 修复**
  * 优化触网穿越与落点/救球判定，减少边界误判；聊天兜底更稳健，避免空白或重复播报。
* **测试**
  * 强化端到端与模板契约测试，覆盖语音打断、兜底与网判定等关键场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->