### PR TITLE
fix: 修复 PNGTuber 从猫猫形态返回后空白

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -2113,7 +2113,7 @@
                     pngtuberContainer.style.visibility = 'visible';
                 }
 
-                const modelReturnEnterRect = consumeModelReturnEnterRect();
+                const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;
                 if (pngtuberContainer) {
                     prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });
                     if (modelReturnEnterRect) {

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -2113,13 +2113,19 @@
                     pngtuberContainer.style.visibility = 'visible';
                 }
 
+                const modelReturnEnterRect = consumeModelReturnEnterRect();
                 if (pngtuberContainer) {
-                    prepareModelReturnContainer(pngtuberContainer, consumeModelReturnEnterRect(), { clearPointerEvents: true });
-                    pngtuberContainer.style.setProperty('pointer-events', 'none', 'important');
-                    const pngtuberImage = pngtuberContainer.querySelector('.pngtuber-image');
-                    if (pngtuberImage) {
-                        pngtuberImage.style.setProperty('pointer-events', 'auto', 'important');
+                    prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });
+                    if (modelReturnEnterRect) {
+                        playModelReturnEnter(pngtuberContainer, modelReturnEnterRect);
                     }
+                    pngtuberContainer.style.setProperty('pointer-events', 'none', 'important');
+                    pngtuberContainer.querySelectorAll('.pngtuber-image').forEach((pngtuberImage) => {
+                        pngtuberImage.style.removeProperty('transition');
+                        pngtuberImage.style.removeProperty('opacity');
+                        pngtuberImage.style.setProperty('visibility', 'visible', 'important');
+                        pngtuberImage.style.setProperty('pointer-events', 'auto', 'important');
+                    });
                 }
 
                 const live2dContainerPngtuber = document.getElementById('live2d-container');

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -415,9 +415,9 @@ def test_pngtuber_return_replays_model_enter_animation_after_preparing_container
         source.index("const live2dContainerPngtuber = document.getElementById('live2d-container');")
     ]
 
-    assert "const modelReturnEnterRect = consumeModelReturnEnterRect();" in branch
+    assert "const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;" in branch
     assert branch.count("consumeModelReturnEnterRect()") == 1
-    assert branch.index("await window.loadPNGTuberAvatar(pngtuberConfig);") < branch.index("const modelReturnEnterRect = consumeModelReturnEnterRect();")
+    assert branch.index("await window.loadPNGTuberAvatar(pngtuberConfig);") < branch.index("const modelReturnEnterRect = pngtuberContainer ? consumeModelReturnEnterRect() : null;")
     assert "prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });" in branch
     assert "if (modelReturnEnterRect) {" in branch
     assert "playModelReturnEnter(pngtuberContainer, modelReturnEnterRect);" in branch

--- a/tests/unit/test_avatar_return_button_idle_tiers_static.py
+++ b/tests/unit/test_avatar_return_button_idle_tiers_static.py
@@ -398,10 +398,30 @@ def test_pngtuber_return_restores_pointer_events():
         source.index("const live2dContainerPngtuber = document.getElementById('live2d-container');")
     ]
 
-    assert "prepareModelReturnContainer(pngtuberContainer, consumeModelReturnEnterRect(), { clearPointerEvents: true });" in branch
+    assert "prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });" in branch
     assert "pngtuberContainer.style.setProperty('pointer-events', 'none', 'important');" in branch
+    assert "pngtuberContainer.querySelectorAll('.pngtuber-image').forEach((pngtuberImage) => {" in branch
+    assert "pngtuberImage.style.removeProperty('transition');" in branch
+    assert "pngtuberImage.style.removeProperty('opacity');" in branch
+    assert "pngtuberImage.style.setProperty('visibility', 'visible', 'important');" in branch
     assert "pngtuberImage.style.setProperty('pointer-events', 'auto', 'important');" in branch
     assert "pngtuberContainer.style.setProperty('pointer-events', 'auto', 'important');" not in branch
+
+
+def test_pngtuber_return_replays_model_enter_animation_after_preparing_container():
+    source = APP_UI_PATH.read_text(encoding="utf-8")
+    branch = source[
+        source.index("} else if (effectiveModelType === 'pngtuber') {"):
+        source.index("const live2dContainerPngtuber = document.getElementById('live2d-container');")
+    ]
+
+    assert "const modelReturnEnterRect = consumeModelReturnEnterRect();" in branch
+    assert branch.count("consumeModelReturnEnterRect()") == 1
+    assert branch.index("await window.loadPNGTuberAvatar(pngtuberConfig);") < branch.index("const modelReturnEnterRect = consumeModelReturnEnterRect();")
+    assert "prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });" in branch
+    assert "if (modelReturnEnterRect) {" in branch
+    assert "playModelReturnEnter(pngtuberContainer, modelReturnEnterRect);" in branch
+    assert branch.index("prepareModelReturnContainer(pngtuberContainer, modelReturnEnterRect, { clearPointerEvents: true });") < branch.index("playModelReturnEnter(pngtuberContainer, modelReturnEnterRect);")
 
 
 def test_return_button_idle_tier_styles_are_present():


### PR DESCRIPTION
﻿## 改动概述

修复 PNGTuber 从猫猫形态返回后可能显示空白的问题。返回流程现在会在 PNGTuber 重新加载成功后复用模型返回入场动画，并清理 PNGTuber 图片/分层画布上残留的透明度状态。

## 问题与根因

猫猫形态返回时会记录返回锚点，并通过 `prepareModelReturnContainer` 按锚点预置模型容器。Live2D、VRM、MMD 分支随后会执行返回入场动画，把容器从预置状态恢复为可见；但 PNGTuber 分支只做了预置，没有补上 `playModelReturnEnter`，因此容器可能停留在透明或缩放状态，表现为模型已经加载但画面空白。

分层 PNGTuber 还可能在离场视觉效果后留下画布透明度，返回时即使容器恢复，也会继续显示为空。

## 风险与边界

本轮只调整 PNGTuber 从猫猫形态返回时的前端显示恢复逻辑，并补充对应静态回归覆盖。Live2D、VRM、MMD 和普通模型切换流程继续沿用原有路径。

返回锚点会在 PNGTuber 加载成功后再消费；如果加载失败并走其他模型回退路径，返回动画锚点不会提前丢失。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 PNGtuber 返回交互：返回时先缓存位置结果，再用于容器准备与进入动画播放，提升过渡一致性。
  * 交互恢复从仅处理单张图片调整为遍历容器内所有图片：重置 transition/opacity/visibility，并将点击事件正确回启到每个图片元素。
* **Tests**
  * 强化 PNGtuber 返回相关断言，逐项验证 transition/opacity/visibility 及 pointer-events（含 `important`）恢复效果。
  * 新增用例覆盖“准备容器后重放进入动画”、且确保位置结果仅消费一次的时序与调用顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->