### PR TITLE
fix: reset tutorial prompt for home day resets

### DIFF
--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -498,9 +498,17 @@
         return response.json();
     }
 
+    async function resetHomeTutorialPromptState(reason) {
+        if (window.universalTutorialManager && typeof window.universalTutorialManager.resetHomeTutorialPromptState === 'function') {
+            return window.universalTutorialManager.resetHomeTutorialPromptState(reason);
+        }
+        return resetHomeTutorialPromptStateViaApi(reason);
+    }
+
     async function resetSelectedTutorial() {
         const selection = resolveSelectedTutorialReset();
         if (selection.type === 'home-day') {
+            await resetHomeTutorialPromptState('memory_browser_home_day_reset');
             if (window.AvatarFloatingGuideReset && typeof window.AvatarFloatingGuideReset.resetAvatarFloatingGuideDay === 'function') {
                 await window.AvatarFloatingGuideReset.resetAvatarFloatingGuideDay(selection.day, {
                     source: 'memory_browser_reset_select',
@@ -526,11 +534,7 @@
                     source: 'memory_browser_reset_home_all',
                 });
             }
-            if (window.universalTutorialManager && typeof window.universalTutorialManager.resetHomeTutorialPromptState === 'function') {
-                await window.universalTutorialManager.resetHomeTutorialPromptState('memory_browser_home_all_reset');
-            } else {
-                await resetHomeTutorialPromptStateViaApi('memory_browser_home_all_reset');
-            }
+            await resetHomeTutorialPromptState('memory_browser_home_all_reset');
             alert(getTutorialHomeAllResetSuccessMessage());
             return;
         }

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -508,7 +508,6 @@
     async function resetSelectedTutorial() {
         const selection = resolveSelectedTutorialReset();
         if (selection.type === 'home-day') {
-            await resetHomeTutorialPromptState('memory_browser_home_day_reset');
             if (window.AvatarFloatingGuideReset && typeof window.AvatarFloatingGuideReset.resetAvatarFloatingGuideDay === 'function') {
                 await window.AvatarFloatingGuideReset.resetAvatarFloatingGuideDay(selection.day, {
                     source: 'memory_browser_reset_select',
@@ -522,6 +521,7 @@
                     source: 'memory_browser_reset_select',
                 });
             }
+            await resetHomeTutorialPromptState('memory_browser_home_day_reset');
             return;
         }
         if (selection.type === 'home-all') {

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -459,6 +459,45 @@ def test_memory_browser_home_day_reset_also_resets_prompt_backend_without_manage
 
 
 @pytest.mark.frontend
+def test_memory_browser_home_day_reset_uses_manager_after_avatar_day_reset(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector(".tutorial-cascader-trigger", timeout=10000)
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialResetCalls = [];
+            window.AvatarFloatingGuideReset = Object.assign({}, window.AvatarFloatingGuideReset || {}, {
+                resetAvatarFloatingGuideDay: async (day, options) => {
+                    window.__tutorialResetCalls.push({ type: 'avatar-day', day, options });
+                }
+            });
+            window.universalTutorialManager = Object.assign({}, window.universalTutorialManager || {}, {
+                resetHomeTutorialPromptState: async (reason) => {
+                    window.__tutorialResetCalls.push({ type: 'prompt', reason });
+                }
+            });
+        }
+        """
+    )
+
+    mock_page.locator(".tutorial-cascader-trigger").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-page='home']").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-day='1']").click()
+    mock_page.locator("#tutorial-reset-btn").click()
+
+    mock_page.wait_for_function("window.__tutorialResetCalls.length === 2")
+    assert mock_page.evaluate("window.__tutorialResetCalls") == [
+        {"type": "avatar-day", "day": 1, "options": {"source": "memory_browser_reset_select"}},
+        {"type": "prompt", "reason": "memory_browser_home_day_reset"},
+    ]
+
+
+@pytest.mark.frontend
 def test_memory_browser_tutorial_cascader_localizes_home_day_labels_for_english(
     mock_page: Page,
     running_server: str,

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -465,6 +465,14 @@ def test_memory_browser_home_day_reset_uses_manager_after_avatar_day_reset(
     seed_memory_file,
 ):
     _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    prompt_reset_requests = []
+
+    def handle_prompt_reset(route):
+        prompt_reset_requests.append(_request_json(route))
+        route.fulfill(status=200, content_type="application/json", json={"ok": True})
+
+    mock_page.route("**/api/tutorial-prompt/reset", handle_prompt_reset)
+
     mock_page.goto(f"{running_server}/memory_browser")
     mock_page.wait_for_selector(".tutorial-cascader-trigger", timeout=10000)
     mock_page.evaluate(
@@ -495,6 +503,7 @@ def test_memory_browser_home_day_reset_uses_manager_after_avatar_day_reset(
         {"type": "avatar-day", "day": 1, "options": {"source": "memory_browser_reset_select"}},
         {"type": "prompt", "reason": "memory_browser_home_day_reset"},
     ]
+    assert prompt_reset_requests == []
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -415,6 +415,50 @@ def test_memory_browser_home_all_reset_falls_back_to_prompt_reset_api_without_ma
 
 
 @pytest.mark.frontend
+def test_memory_browser_home_day_reset_also_resets_prompt_backend_without_manager(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    prompt_reset_payloads = []
+
+    def handle_prompt_reset(route):
+        prompt_reset_payloads.append(_request_json(route))
+        route.fulfill(status=200, content_type="application/json", json={"ok": True})
+
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.route("**/api/tutorial-prompt/reset", handle_prompt_reset)
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector(".tutorial-cascader-trigger", timeout=10000)
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialResetCalls = [];
+            window.AvatarFloatingGuideReset = Object.assign({}, window.AvatarFloatingGuideReset || {}, {
+                resetAvatarFloatingGuideDay: async (day, options) => {
+                    window.__tutorialResetCalls.push({ type: 'avatar-day', day, options });
+                }
+            });
+            delete window.universalTutorialManager;
+        }
+        """
+    )
+
+    mock_page.locator(".tutorial-cascader-trigger").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-page='home']").click()
+    mock_page.locator(".tutorial-cascader-option[data-tutorial-day='1']").click()
+
+    with mock_page.expect_response("**/api/tutorial-prompt/reset"):
+        mock_page.locator("#tutorial-reset-btn").click()
+
+    mock_page.wait_for_function("window.__tutorialResetCalls.length === 1")
+    assert mock_page.evaluate("window.__tutorialResetCalls") == [
+        {"type": "avatar-day", "day": 1, "options": {"source": "memory_browser_reset_select"}},
+    ]
+    assert prompt_reset_payloads == [{"reason": "memory_browser_home_day_reset"}]
+
+
+@pytest.mark.frontend
 def test_memory_browser_tutorial_cascader_localizes_home_day_labels_for_english(
     mock_page: Page,
     running_server: str,

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -891,14 +891,14 @@ def test_home_tutorial_reset_also_resets_day1_icebreaker_state():
         "if (selection.type === 'home-all'",
         1,
     )[0]
-    prompt_reset_helper = memory_browser_source.split("async function resetHomeTutorialPromptState(reason)", 1)[1].split(
+    prompt_reset_helper = memory_browser_source.split("async function resetHomeTutorialPromptState(", 1)[1].split(
         "async function resetSelectedTutorial()",
         1,
     )[0]
     assert "resetHomeTutorialPromptState('memory_browser_home_day_reset')" in home_day_block
     assert "resetHomeTutorialPromptState('memory_browser_home_all_reset')" in home_all_block
-    assert "window.universalTutorialManager.resetHomeTutorialPromptState(reason)" in prompt_reset_helper
-    assert "resetHomeTutorialPromptStateViaApi(reason)" in prompt_reset_helper
+    assert "window.universalTutorialManager.resetHomeTutorialPromptState(" in prompt_reset_helper
+    assert "resetHomeTutorialPromptStateViaApi(" in prompt_reset_helper
     assert "'/api/tutorial-prompt/reset'" in memory_browser_source
 
 

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -887,8 +887,18 @@ def test_home_tutorial_reset_also_resets_day1_icebreaker_state():
         "if (selection.type === 'page'",
         1,
     )[0]
+    home_day_block = memory_browser_source.split("if (selection.type === 'home-day') {", 1)[1].split(
+        "if (selection.type === 'home-all'",
+        1,
+    )[0]
+    prompt_reset_helper = memory_browser_source.split("async function resetHomeTutorialPromptState(reason)", 1)[1].split(
+        "async function resetSelectedTutorial()",
+        1,
+    )[0]
+    assert "resetHomeTutorialPromptState('memory_browser_home_day_reset')" in home_day_block
     assert "resetHomeTutorialPromptState('memory_browser_home_all_reset')" in home_all_block
-    assert "resetHomeTutorialPromptStateViaApi('memory_browser_home_all_reset')" in home_all_block
+    assert "window.universalTutorialManager.resetHomeTutorialPromptState(reason)" in prompt_reset_helper
+    assert "resetHomeTutorialPromptStateViaApi(reason)" in prompt_reset_helper
     assert "'/api/tutorial-prompt/reset'" in memory_browser_source
 
 


### PR DESCRIPTION
## 改动概述 / Summary
- 修复记忆浏览器里“主页 / 第 N 天”教程重置只重置浮动引导、不重置后端 tutorial prompt 状态的问题。
- 抽出主页教程 prompt reset helper，让 home-day 和 home-all 共用 manager 优先、API fallback 的逻辑。
- 补充前端回归测试和静态契约测试，防止按天重置再次漏掉 `/api/tutorial-prompt/reset`。

## 回归报告 / Regression Report
- 变更内容：`memory_browser.js` 的主页按天重置流程现在会先调用 tutorial prompt reset，再执行对应天数的 avatar floating guide reset。
- 必要性：用户在重置教程后刷新页面仍读到后端已完成状态，导致教程没有真正重新生效。
- 变更前：home-day 只清理前端/本地 avatar day 状态；后端 durable prompt state 仍可能保持 completed。
- 变更后：home-day 与 home-all 都会清理后端 tutorial prompt 状态，刷新后不会继续沿用 completed 状态。
- 潜在回归点：教程重置弹窗、home-all 重置、无 universalTutorialManager 时的 API fallback。
- 验证：新增/更新的 memory browser 前端测试覆盖 home-day、home-all、fallback；unit/static contract 覆盖后端 reset 契约和静态调用链。

## 不拆分理由 / Why Not Split
不适用。PR 只涉及 3 个文件，属于同一个教程重置 bug 的最小修复。

## 测试 / Testing
- `.venv/bin/python -m pytest tests/frontend/test_memory_browser.py::test_memory_browser_home_day_reset_also_resets_prompt_backend_without_manager tests/frontend/test_memory_browser.py::test_memory_browser_home_all_reset_restarts_avatar_guide_from_day_one tests/frontend/test_memory_browser.py::test_memory_browser_home_all_reset_falls_back_to_prompt_reset_api_without_manager tests/unit/test_tutorial_prompt_state.py::test_reset_tutorial_prompt_state_clears_completed_home_prompt_state tests/unit/test_tutorial_prompt_router.py::test_tutorial_prompt_reset_route_clears_completed_state tests/unit/test_new_user_icebreaker_static_contracts.py::test_home_tutorial_reset_also_resets_day1_icebreaker_state -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化新手引导提示重置：为“主页 / 第 1 天”和“主页 / 全部”统一重置入口，优先使用管理器能力；缺失时自动回退到备用方式，确保状态稳定更新。
  * 统一触发逻辑与原因标识，确保头像浮层重置与教程提示重置按预期生效。  
* **Tests**
  * 新增并扩展前端端到端用例与单元合约断言，覆盖 `home-day` 与 `home-all` 的重置行为，并校验后端请求 `reason`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->