### PR TITLE
fix(chat): restore compact meme close hit region

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -861,7 +861,8 @@ describe('App', () => {
       const img = container.querySelector('.compact-meme-overlay img');
       expect(img).not.toBeNull();
       fireEvent.load(img as Element);
-      expect(geometryRefreshes.length).toBeGreaterThan(0);
+      expect(geometryRefreshes.length).toBe(0);
+      await waitFor(() => expect(geometryRefreshes.length).toBeGreaterThan(0));
       geometryRefreshes.length = 0;
 
       fireEvent.click(container.querySelector('.compact-meme-overlay-close') as Element);

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -842,6 +842,36 @@ describe('App', () => {
     expect(container.querySelector('.compact-meme-overlay')).toBeNull();
   });
 
+  it('refreshes compact interaction geometry when the meme close hit region changes', async () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    const meme = parseChatMessage({
+      id: 'meme-close-geometry', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=geometry', alt: 'lol' }], status: 'sent',
+    });
+    const geometryRefreshes: Event[] = [];
+    const handleGeometryRefresh = (event: Event) => geometryRefreshes.push(event);
+    window.addEventListener('neko:compact-interaction-geometry-refresh', handleGeometryRefresh);
+    try {
+      const { container } = render(
+        <App chatSurfaceMode="compact" compactChatState="input" messages={[meme]} />,
+      );
+      await waitFor(() => expect(geometryRefreshes.length).toBeGreaterThan(0));
+      geometryRefreshes.length = 0;
+
+      const img = container.querySelector('.compact-meme-overlay img');
+      expect(img).not.toBeNull();
+      fireEvent.load(img as Element);
+      expect(geometryRefreshes.length).toBeGreaterThan(0);
+      geometryRefreshes.length = 0;
+
+      fireEvent.click(container.querySelector('.compact-meme-overlay-close') as Element);
+      await waitFor(() => expect(geometryRefreshes.length).toBeGreaterThan(0));
+      expect(container.querySelector('.compact-meme-overlay')).toBeNull();
+    } finally {
+      window.removeEventListener('neko:compact-interaction-geometry-refresh', handleGeometryRefresh);
+    }
+  });
+
   it('shows a newer meme even after the previous one was manually closed', () => {
     window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
     const memeA = parseChatMessage({

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2531,6 +2531,37 @@ function CompactChatApp({
     }
     return null;
   }, [messages, isCompactSurface]);
+  const compactMemeOverlayVisible = !!(
+    isCompactSurface
+    && !compactExportHistoryMounted
+    && compactMemeOverlay
+    && compactMemeOverlay.id !== dismissedMemeId
+  );
+  const compactMemeGeometryKey = compactMemeOverlay
+    ? `${compactMemeOverlay.id}:${compactMemeOverlayVisible ? 'visible' : 'hidden'}`
+    : 'none';
+  const lastCompactMemeGeometryKeyRef = useRef<string | null>(null);
+  const requestCompactMemeGeometryRefresh = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(new CustomEvent('neko:compact-interaction-geometry-refresh'));
+  }, []);
+
+  useEffect(() => {
+    if (!isCompactSurface) {
+      lastCompactMemeGeometryKeyRef.current = null;
+      return undefined;
+    }
+    const previousKey = lastCompactMemeGeometryKeyRef.current;
+    lastCompactMemeGeometryKeyRef.current = compactMemeGeometryKey;
+    if (previousKey === compactMemeGeometryKey) return undefined;
+    if (previousKey === null && compactMemeGeometryKey === 'none') return undefined;
+    const frameId = window.requestAnimationFrame(requestCompactMemeGeometryRefresh);
+    return () => window.cancelAnimationFrame(frameId);
+  }, [
+    compactMemeGeometryKey,
+    isCompactSurface,
+    requestCompactMemeGeometryRefresh,
+  ]);
   const compactCaptionPreview = useMemo<CompactMessagePreview | null>(() => {
     if (!compactCaptionState?.turnId || !compactCaptionState.text) {
       return null;
@@ -7055,10 +7086,7 @@ function CompactChatApp({
   // 兜底），不再随历史区收起而隐藏——否则历史默认折叠的 A/B closed 分支会连带看不到主动分享音乐条。
   const compactMusicPlayerVisibility = 'open' as const;
   const closeMemeButtonAriaLabel = i18n('chat.closeMemeAriaLabel', 'Close image');
-  const compactMemeOverlayNode = isCompactSurface
-    && !compactExportHistoryMounted
-    && compactMemeOverlay
-    && compactMemeOverlay.id !== dismissedMemeId ? (
+  const compactMemeOverlayNode = compactMemeOverlayVisible && compactMemeOverlay ? (
     <div
       className="compact-meme-overlay"
       data-compact-meme-overlay="compact-surface"
@@ -7074,7 +7102,14 @@ function CompactChatApp({
             收益（实测 lazy/eager 行为一致，图都会立刻加载），eager 语义更直接、也省掉一层
             IntersectionObserver 判定。注：表情包「常显、不被同轮台词顶掉」靠的是上面 compactMemeOverlay
             的 role 收起逻辑，不是这个属性。 */}
-        <img src={compactMemeOverlay.url} alt={compactMemeOverlay.alt} loading="eager" decoding="async" />
+        <img
+          src={compactMemeOverlay.url}
+          alt={compactMemeOverlay.alt}
+          loading="eager"
+          decoding="async"
+          onLoad={requestCompactMemeGeometryRefresh}
+          onError={requestCompactMemeGeometryRefresh}
+        />
         {/* 关闭叉：overlay 整体 pointer-events:none（点击穿透到桌面/下层），唯独这个按钮 CSS 里单独开
             auto 才接得住点击；点了把当前 meme id 记进 dismissedMemeId（会话级），下一张新 meme 照常显示。
             ⚠️ data-compact-hit-region 必带：overlay 的 data-compact-geometry-hit-scope="children" 让 host

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2541,9 +2541,28 @@ function CompactChatApp({
     ? `${compactMemeOverlay.id}:${compactMemeOverlayVisible ? 'visible' : 'hidden'}`
     : 'none';
   const lastCompactMemeGeometryKeyRef = useRef<string | null>(null);
+  const compactMemeGeometryFrameRef = useRef<number | null>(null);
   const requestCompactMemeGeometryRefresh = useCallback(() => {
     if (typeof window === 'undefined') return;
     window.dispatchEvent(new CustomEvent('neko:compact-interaction-geometry-refresh'));
+  }, []);
+  const scheduleCompactMemeGeometryRefresh = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (compactMemeGeometryFrameRef.current !== null) return;
+    const raf = window.requestAnimationFrame
+      || ((callback: FrameRequestCallback) => window.setTimeout(() => callback(window.performance.now()), 16));
+    compactMemeGeometryFrameRef.current = raf(() => {
+      compactMemeGeometryFrameRef.current = null;
+      requestCompactMemeGeometryRefresh();
+    });
+  }, [requestCompactMemeGeometryRefresh]);
+
+  useEffect(() => () => {
+    if (typeof window === 'undefined') return;
+    if (compactMemeGeometryFrameRef.current === null) return;
+    const cancel = window.cancelAnimationFrame || window.clearTimeout;
+    cancel(compactMemeGeometryFrameRef.current);
+    compactMemeGeometryFrameRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -2555,12 +2574,12 @@ function CompactChatApp({
     lastCompactMemeGeometryKeyRef.current = compactMemeGeometryKey;
     if (previousKey === compactMemeGeometryKey) return undefined;
     if (previousKey === null && compactMemeGeometryKey === 'none') return undefined;
-    const frameId = window.requestAnimationFrame(requestCompactMemeGeometryRefresh);
-    return () => window.cancelAnimationFrame(frameId);
+    scheduleCompactMemeGeometryRefresh();
+    return undefined;
   }, [
     compactMemeGeometryKey,
     isCompactSurface,
-    requestCompactMemeGeometryRefresh,
+    scheduleCompactMemeGeometryRefresh,
   ]);
   const compactCaptionPreview = useMemo<CompactMessagePreview | null>(() => {
     if (!compactCaptionState?.turnId || !compactCaptionState.text) {
@@ -7107,8 +7126,8 @@ function CompactChatApp({
           alt={compactMemeOverlay.alt}
           loading="eager"
           decoding="async"
-          onLoad={requestCompactMemeGeometryRefresh}
-          onError={requestCompactMemeGeometryRefresh}
+          onLoad={scheduleCompactMemeGeometryRefresh}
+          onError={scheduleCompactMemeGeometryRefresh}
         />
         {/* 关闭叉：overlay 整体 pointer-events:none（点击穿透到桌面/下层），唯独这个按钮 CSS 里单独开
             auto 才接得住点击；点了把当前 meme id 记进 dismissedMemeId（会话级），下一张新 meme 照常显示。

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1764,7 +1764,7 @@
                 if (style && Number(style.opacity) <= 0.01) return null;
                 var rect = normalizeCompactDomRect(child.getBoundingClientRect());
                 if (!rect) return null;
-                var clippedRect = kind === 'musicPlayer'
+                var clippedRect = kind === 'musicPlayer' || kind === 'meme'
                     ? rect
                     : (parentRect ? intersectCompactRects(rect, parentRect) : rect);
                 if (!clippedRect) return null;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1602,12 +1602,19 @@ body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"
     pointer-events: none;
 }
 
-/* 主动分享表情包 overlay 是纯被动展示挂件，必须全程点击穿透。它注册了 data-compact-geometry-owner="surface"，
-   会被上面那条把 surface 子树重新开成 auto 的通用规则命中；这里用同优先级、靠后定义的规则把它压回 none
-   （否则表情包显示期间会吞掉它矩形区域的点击）。React styles.css 那条单 class 规则赢不了 host 的 ID 选择器。 */
+/* 主动分享表情包 overlay 的图片区域保持点击穿透；关闭叉是唯一可交互 hit region。
+   它注册了 data-compact-geometry-owner="surface"，会被上面那条把 surface 子树重新开成 auto 的通用规则命中；
+   这里用同优先级、靠后定义的规则把透明包装和图片区压回 none，再单独保留关闭按钮 auto。
+   React styles.css 那条单 class 规则赢不了 host 的 ID 选择器。 */
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-meme-overlay,
-body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-meme-overlay * {
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-meme-overlay img,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-meme-overlay-frame,
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-meme-overlay-close-icon {
     pointer-events: none;
+}
+
+body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-meme-overlay-close {
+    pointer-events: auto;
 }
 
 body.subtitle-web-host #react-chat-window-shell[data-chat-surface-mode="compact"]:not(.is-minimized):not(.is-collapsing):not(.is-expanding) .compact-export-history-bubble,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1100,6 +1100,23 @@ def test_desktop_compact_history_hit_regions_are_clipped_to_visible_parent():
     assert "nativeRect: scrollbarRect" in scrollbar_block
 
 
+def test_compact_meme_close_hit_region_is_collected_as_native_extra_island():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+    app_source = REACT_CHAT_APP_PATH.read_text(encoding="utf-8")
+
+    composite_block = script.split("function collectCompactCompositeGeometryItems(element, kind)", 1)[1].split(
+        "function collectCompactSurfaceGeometryItems()",
+        1,
+    )[0]
+
+    assert 'data-compact-geometry-item="meme"' in app_source
+    assert 'data-compact-geometry-hit-scope="children"' in app_source
+    assert 'data-compact-hit-region-id="meme:close"' in app_source
+    assert "kind === 'musicPlayer' || kind === 'meme'" in composite_block
+    assert "id: child.getAttribute('data-compact-hit-region-id') || (kind + ':hit:' + index)" in composite_block
+    assert "nativeRect: clippedRect" in composite_block
+
+
 def test_compact_geometry_snapshot_separates_base_surface_from_extra_islands():
     script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
 
@@ -2110,6 +2127,19 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
         "    pointer-events: none;\n"
         "}"
     )
+    meme_passthrough_rule = (
+        f'{compact_surface_prefix} .compact-meme-overlay,\n'
+        f'{compact_surface_prefix} .compact-meme-overlay img,\n'
+        f'{compact_surface_prefix} .compact-meme-overlay-frame,\n'
+        f'{compact_surface_prefix} .compact-meme-overlay-close-icon {{\n'
+        "    pointer-events: none;\n"
+        "}"
+    )
+    meme_close_interactive_rule = (
+        f'{compact_surface_prefix} .compact-meme-overlay-close {{\n'
+        "    pointer-events: auto;\n"
+        "}"
+    )
     history_interactive_rule = (
         f'{compact_surface_prefix} .compact-export-history-bubble,\n'
         f'{compact_surface_prefix} .compact-export-history-controls,\n'
@@ -2122,11 +2152,15 @@ def test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_thro
     assert compact_music_interactive_rule in styles
     assert compact_music_hidden_rule in styles
     assert history_passthrough_rule in styles
+    assert meme_passthrough_rule in styles
+    assert meme_close_interactive_rule in styles
     assert history_interactive_rule in styles
     assert styles.index(broad_surface_rule) < styles.index(compact_music_interactive_rule)
     assert styles.index(compact_music_interactive_rule) < styles.index(compact_music_hidden_rule)
     assert styles.index(compact_music_hidden_rule) < styles.index(history_passthrough_rule)
-    assert styles.index(history_passthrough_rule) < styles.index(history_interactive_rule)
+    assert styles.index(history_passthrough_rule) < styles.index(meme_passthrough_rule)
+    assert styles.index(meme_passthrough_rule) < styles.index(meme_close_interactive_rule)
+    assert styles.index(meme_close_interactive_rule) < styles.index(history_interactive_rule)
     assert ".compact-export-history-scroll,\n" in history_passthrough_rule
 
 


### PR DESCRIPTION
## 改动概述 / Summary

这是对 [Project-N-E-K-O/N.E.K.O#2035](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2035) 的后续修复。

修复主动分享表情包右上角关闭叉在实际运行时仍然完全点击穿透的问题：

- 收窄 `subtitle-web-host` 下表情包 overlay 的 host CSS 命中规则，只让图片区域保持点击穿透。
- 单独保留 `.compact-meme-overlay-close` 的 `pointer-events: auto`，确保右上角关闭叉可点击。
- 将 `meme:close` 登记为桌面端 compact extra island 的 `hitRect/nativeRect`，供 NEKO-PC 透明窗口命中区域使用。
- 在表情包显示、隐藏、图片加载成功/失败时刷新 compact interaction geometry，避免桌面端命中区缺失或残留。
- 补充 React 与静态契约测试，防止回归。

## 回归报告 / Regression Report

不适用。本 PR 未触碰 `app/`、`main_logic/`、`memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 改动文件数未超过拆分阈值。

## 测试 / Testing

- `git diff --check`
- `.venv/bin/python -m pytest tests/unit/test_react_chat_window_static.py::test_subtitle_web_host_keeps_compact_history_transparent_wrappers_click_through tests/unit/test_react_chat_window_static.py::test_compact_meme_close_hit_region_is_collected_as_native_extra_island tests/unit/test_react_chat_window_static.py::test_desktop_compact_history_hit_regions_are_clipped_to_visible_parent tests/unit/test_react_chat_window_static.py::test_compact_geometry_snapshot_separates_base_surface_from_extra_islands -q`
- `npm test -- App.test.tsx -t "refreshes compact interaction geometry when the meme close hit region changes"`
- `npm run typecheck`
- `bash build_frontend.sh`
- Playwright 实际运行验证：
  - 按模板顺序加载 `static/css/index.css`、`static/react/neko-chat/neko-chat-window.css`、React IIFE、`static/app-react-chat-window.js`
  - 构造 compact 表情包消息
  - 验证图片区域仍为点击穿透
  - 验证关闭叉 `pointer-events: auto`
  - 验证 geometry 中存在 `meme:close` 的 `hitRect/nativeRect`
  - 实际点击关闭叉后，表情包 overlay 消失，`meme:close` 从 geometry 中移除
  - 在 `bash build_frontend.sh` 后重新执行同一实际点击验证并通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 表情包覆盖层在图片加载成功、加载失败或相关显示状态变化后，会自动刷新交互区域，提升点击响应的准确性。
* **Bug 修复**
  * 优化紧凑模式下表情包覆盖层的点击穿透：关闭按钮成为唯一可交互区域，避免覆盖层其余部分导致的误触或无法点击。
  * 修正表情包在命中区域裁剪规则上的处理，确保关闭按钮命中与关闭流程一致。
* **测试**
  * 新增覆盖层几何刷新与关闭按钮命中的单元测试断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->