### PR TITLE
[codex] 为角色卡删除添加粒子消散效果

### DIFF
--- a/docs/design/memory-browser-particle-dissolve.md
+++ b/docs/design/memory-browser-particle-dissolve.md
@@ -12,9 +12,9 @@
 ## 相关文件
 
 - `static/js/memory_browser.js`
-  - `executeDissolveAction`
-  - `bindMemoryDissolveButton`
   - `dissolveChatItems`
+  - `deleteChat`
+  - `#clear-memory-btn` 的点击绑定
   - `addMemoryItemParticles`、`sampleMemoryElementParticles`、`startMemoryParticles`
   - `teardownMemoryParticleCanvas`
 - `static/css/memory_browser.css`
@@ -26,99 +26,81 @@
 
 删除和清空不再直接执行 DOM 删除，而是走“先动画、后重渲染”流程：
 
-1. 根据按钮配置拿到目标元素列表；
+1. 删除入口拿到目标元素列表；
 2. 修改 `chatData` 数据源；
-3. 调用统一溶解入口执行粒子动画；
+3. 调用 `dissolveChatItems` 执行粒子动画；
 4. 动画完成后回调刷新列表（`renderChatEdit`）；
 5. 最后恢复按钮状态。
 
-这个流程避免了各按钮重复维护动画时序和状态开关。
+这个流程把动画时序集中在 `dissolveChatItems`，删除入口只负责找到目标、修改数据和传入完成回调。
 
-## 通用方法（已抽象）
+## 现有入口
 
-### `executeDissolveAction(config)`
+### `dissolveChatItems(items, onComplete)`
 
-该方法接收一个配置对象 `config`，并按统一流程执行。
+这是当前记忆浏览器的粒子消散入口。它接收要消散的 `.chat-item` 列表，并在动画结束后执行 `onComplete`。
 
-字段说明：
+当前职责：
 
-- `getTargets`：返回当前操作的 DOM 列表（例如单条 `.chat-item`）
-- `mutateData`：在动画前执行数据变更（例如 `chatData.splice`、过滤）
-- `onComplete`：动画完成后的回调（一般用于 `renderChatEdit`）
-- `onEmpty`：无目标项时的兜底回调
+- 检查 `prefers-reduced-motion` 和目标数量；
+- 设置 `memoryDissolveInProgress`，禁用清空和单条删除按钮；
+- 为目标元素错峰添加粒子和 `.is-dissolving`；
+- 调用 `collapseMemoryItem` 收起元素高度；
+- 在收尾时执行 `onComplete` 并恢复按钮状态。
 
 执行顺序：
 
-1. 先检查 `memoryDissolveInProgress`，防止并发重入；
-2. 组装并过滤目标；
-3. 目标为空则触发 `onEmpty` 并返回；
-4. 执行 `mutateData`；
-5. 调 `dissolveChatItems(targets, onComplete)`。
-
-### `bindMemoryDissolveButton(button, config)`
-
-统一按钮绑定入口。传入任意按钮 DOM 与配置即可完成点击绑定。
-
-伪码：
-
-```js
-bindMemoryDissolveButton(btn, {
-  getTargets,
-  mutateData,
-  onComplete,
-  onEmpty
-});
-```
+1. 过滤空目标；
+2. reduced-motion 或目标过多时直接执行完成回调；
+3. 启动粒子画布和逐项消散动画；
+4. 动画结束后执行完成回调。
 
 ## 现有接入方式
 
 ### 单条删除
 
-每个 `.delete-btn` 仍由渲染逻辑绑定到 `deleteChat(i)`，内部通过通用入口执行：
+每个 `.delete-btn` 由渲染逻辑绑定到 `deleteChat(i)`，内部按真实 DOM 和数据索引执行：
 
-- `getTargets`：当前 `data-chat-index` 对应 `.chat-item`
-- `mutateData`：`chatData.splice(idx, 1)`
-- `onComplete`：`renderChatEdit`
+- 通过 `data-chat-index` 找到当前 `.chat-item`；
+- 执行 `chatData.splice(idx, 1)`；
+- 调用 `dissolveChatItems([item], renderChatEdit)`。
 
 ### 清空按钮
 
-`#clear-memory-btn` 直接使用 `bindMemoryDissolveButton` 绑定：
+`#clear-memory-btn` 使用现有点击处理器直接接入：
 
-- `getTargets`：所有 human/ai 消息节点；
-- `mutateData`：过滤 `chatData`，仅保留 `system`；
-- `onComplete`：`renderChatEdit` + 提示文案；
-- `onEmpty`：无对话可清时直接提示。
+- 查询所有 human/ai 消息节点；
+- 无可清空项时直接提示；
+- 过滤 `chatData`，仅保留非 human/ai 的消息（例如 system 备忘录）；
+- 调用 `dissolveChatItems(itemsToDissolve, callback)`；
+- 在回调中执行 `renderChatEdit()` 并展示清空提示。
 
-这意味着后续新增“删除某类消息”按钮时无需改动画代码，只需提供一组配置。
+这意味着后续新增“删除某类消息”按钮时，应沿用同样模式：入口先收集 DOM 目标并修改 `chatData`，然后把目标列表和完成回调交给 `dissolveChatItems`。
 
 ## 使用新功能的接入模板（新增按钮）
 
 ```js
-bindMemoryDissolveButton(
-  document.getElementById('btn-delete-ai-only'),
-  {
-    getTargets: function () {
-      return Array.from(
-        document.querySelectorAll('#memory-chat-edit .chat-item[data-role="ai"]')
-      );
-    },
-    mutateData: function () {
-      chatData = chatData.filter(function (item) {
-        return item && item.role !== 'ai';
-      });
-    },
-    onEmpty: function () {
-      showSaveStatus('当前没有 AI 消息可删除', false);
-    },
-    onComplete: function () {
-      renderChatEdit();
-      showSaveStatus('已删除 AI 消息', false);
-    }
+document.getElementById('btn-delete-ai-only').onclick = function () {
+  if (memoryDissolveInProgress) return;
+  const itemsToDissolve = Array.from(
+    document.querySelectorAll('#memory-chat-edit .chat-item[data-role="ai"]')
+  );
+  if (!itemsToDissolve.length) {
+    showSaveStatus('当前没有 AI 消息可删除', false);
+    return;
   }
-);
+
+  chatData = chatData.filter(function (item) {
+    return item && item.role !== 'ai';
+  });
+  dissolveChatItems(itemsToDissolve, function () {
+    renderChatEdit();
+    showSaveStatus('已删除 AI 消息', false);
+  });
+};
 ```
 
-> 建议：`getTargets` 必须与 `mutateData` 语义一致。否则会出现“动画了却没删/删了但动画不对上”的问题。
+> 建议：DOM 目标查询必须与 `chatData` 过滤语义一致。否则会出现“动画了却没删/删了但动画不对上”的问题。
 
 ## 关键状态与并发控制
 
@@ -133,7 +115,7 @@ bindMemoryDissolveButton(
 
 ## 粒子与动效参数
 
-- 默认触发粒子时长约束：
+- 默认粒子数量与项目上限：
   - `maxParticleItems = 40`：超过该数量时走无粒子快速路径（直接完成）；
   - `maxStaggeredItems = 6`：分摊最多 6 个元素的错峰时间，避免长列表时整体等待过长；
   - `prefers-reduced-motion` 时直接跳过粒子与折叠动画，保持可访问性友好。
@@ -158,7 +140,7 @@ bindMemoryDissolveButton(
 2. 清空所有消息（含无消息时）；
 3. `prefers-reduced-motion: reduce` 用户下点击按钮行为；
 4. 动画中关闭弹层（`pagehide`）后无残留节点和按钮卡死；
-5. 后续新增按钮只需配置三四个回调，无需改 `dissolveChatItems`。
+5. 后续新增按钮只需复用“查询目标、修改 `chatData`、调用 `dissolveChatItems`”的接入模式。
 
 ## 与现有工作流关系
 

--- a/docs/design/memory-browser-particle-dissolve.md
+++ b/docs/design/memory-browser-particle-dissolve.md
@@ -1,0 +1,165 @@
+# 记忆浏览器：粒子消散功能开发说明
+
+## 目的
+
+这份文档描述“记忆浏览器聊天记录删除/清空”的粒子消散动效实现，目标是：
+
+- 保证用户看到自然的消失动画；
+- 统一删除流程，后续可复用到更多按钮；
+- 避免页面关闭、重复点击等场景下卡死或状态异常；
+- 降低删除/清空操作对主流程的侵入性。
+
+## 相关文件
+
+- `static/js/memory_browser.js`
+  - `executeDissolveAction`
+  - `bindMemoryDissolveButton`
+  - `dissolveChatItems`
+  - `addMemoryItemParticles`、`sampleMemoryElementParticles`、`startMemoryParticles`
+  - `teardownMemoryParticleCanvas`
+- `static/css/memory_browser.css`
+  - `.is-dissolving`、`.is-collapsing`、`#memory-particle-canvas` 动画与样式
+- `tests/frontend/test_memory_browser.py`
+  - 涵盖动画、`prefers-reduced-motion`、`pagehide` 清理的回归场景
+
+## 核心行为概述
+
+删除和清空不再直接执行 DOM 删除，而是走“先动画、后重渲染”流程：
+
+1. 根据按钮配置拿到目标元素列表；
+2. 修改 `chatData` 数据源；
+3. 调用统一溶解入口执行粒子动画；
+4. 动画完成后回调刷新列表（`renderChatEdit`）；
+5. 最后恢复按钮状态。
+
+这个流程避免了各按钮重复维护动画时序和状态开关。
+
+## 通用方法（已抽象）
+
+### `executeDissolveAction(config)`
+
+该方法接收一个配置对象 `config`，并按统一流程执行。
+
+字段说明：
+
+- `getTargets`：返回当前操作的 DOM 列表（例如单条 `.chat-item`）
+- `mutateData`：在动画前执行数据变更（例如 `chatData.splice`、过滤）
+- `onComplete`：动画完成后的回调（一般用于 `renderChatEdit`）
+- `onEmpty`：无目标项时的兜底回调
+
+执行顺序：
+
+1. 先检查 `memoryDissolveInProgress`，防止并发重入；
+2. 组装并过滤目标；
+3. 目标为空则触发 `onEmpty` 并返回；
+4. 执行 `mutateData`；
+5. 调 `dissolveChatItems(targets, onComplete)`。
+
+### `bindMemoryDissolveButton(button, config)`
+
+统一按钮绑定入口。传入任意按钮 DOM 与配置即可完成点击绑定。
+
+伪码：
+
+```js
+bindMemoryDissolveButton(btn, {
+  getTargets,
+  mutateData,
+  onComplete,
+  onEmpty
+});
+```
+
+## 现有接入方式
+
+### 单条删除
+
+每个 `.delete-btn` 仍由渲染逻辑绑定到 `deleteChat(i)`，内部通过通用入口执行：
+
+- `getTargets`：当前 `data-chat-index` 对应 `.chat-item`
+- `mutateData`：`chatData.splice(idx, 1)`
+- `onComplete`：`renderChatEdit`
+
+### 清空按钮
+
+`#clear-memory-btn` 直接使用 `bindMemoryDissolveButton` 绑定：
+
+- `getTargets`：所有 human/ai 消息节点；
+- `mutateData`：过滤 `chatData`，仅保留 `system`；
+- `onComplete`：`renderChatEdit` + 提示文案；
+- `onEmpty`：无对话可清时直接提示。
+
+这意味着后续新增“删除某类消息”按钮时无需改动画代码，只需提供一组配置。
+
+## 使用新功能的接入模板（新增按钮）
+
+```js
+bindMemoryDissolveButton(
+  document.getElementById('btn-delete-ai-only'),
+  {
+    getTargets: function () {
+      return Array.from(
+        document.querySelectorAll('#memory-chat-edit .chat-item[data-role="ai"]')
+      );
+    },
+    mutateData: function () {
+      chatData = chatData.filter(function (item) {
+        return item && item.role !== 'ai';
+      });
+    },
+    onEmpty: function () {
+      showSaveStatus('当前没有 AI 消息可删除', false);
+    },
+    onComplete: function () {
+      renderChatEdit();
+      showSaveStatus('已删除 AI 消息', false);
+    }
+  }
+);
+```
+
+> 建议：`getTargets` 必须与 `mutateData` 语义一致。否则会出现“动画了却没删/删了但动画不对上”的问题。
+
+## 关键状态与并发控制
+
+### `memoryDissolveInProgress`
+
+在动画期间禁用清空和单条删除入口，避免重复触发导致 UI 与数据错位。
+
+### `memoryDissolveRunId`
+
+每次 `dissolveChatItems` 开始前自增，用于 `setTimeout` 回调中的并发防护。
+防止新一轮交互触发后，旧定时器仍然回写旧回调，导致按钮错位或重复渲染。
+
+## 粒子与动效参数
+
+- 默认触发粒子时长约束：
+  - `maxParticleItems = 40`：超过该数量时走无粒子快速路径（直接完成）；
+  - `maxStaggeredItems = 6`：分摊最多 6 个元素的错峰时间，避免长列表时整体等待过长；
+  - `prefers-reduced-motion` 时直接跳过粒子与折叠动画，保持可访问性友好。
+- `collapseMemoryItem` 使用 `offsetHeight` 捕获高度，避免 `transform` 带来的快照误差。
+
+## 生命周期与清理
+
+粒子画布统一通过 `ensureMemoryParticleCanvas` 与 `teardownMemoryParticleCanvas` 管理，并在以下场景触发清理：
+
+- 组件关闭（`closeMemoryBrowser`）；
+- `pagehide`；
+- `beforeunload`；
+- 溶解收尾（内部兜底）。
+
+清理时会移除 `resize` 监听、清空动画上下文、移除全屏画布，并恢复操作按钮，避免再次进入页面后按钮残留禁用。
+
+## 回归点（建议）
+
+新增接入前建议按以下场景验证：
+
+1. 单条删除动画 + 完成后重渲染；
+2. 清空所有消息（含无消息时）；
+3. `prefers-reduced-motion: reduce` 用户下点击按钮行为；
+4. 动画中关闭弹层（`pagehide`）后无残留节点和按钮卡死；
+5. 后续新增按钮只需配置三四个回调，无需改 `dissolveChatItems`。
+
+## 与现有工作流关系
+
+该功能是前端展示/交互层增强，不改写数据持久化约定。若要在后端或接口层新增“按条件物理删除”能力，应继续保留现有数据通道，前端动画层仅负责 UX 表达与节奏控制。

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -4579,7 +4579,7 @@ margin-top: 10px;
 .chara-card-item.is-dissolving,
 .chara-list-item.is-dissolving {
     pointer-events: none;
-    animation: chara-card-ghost-out 680ms ease forwards;
+    animation: var(--chara-card-dissolve-animation, chara-card-ghost-out 680ms ease forwards);
 }
 
 .chara-card-particle-canvas {
@@ -4601,6 +4601,14 @@ margin-top: 10px;
         opacity: 0;
         filter: blur(6px);
         transform: translateY(-6px) scale(0.985);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .chara-card-item.is-dissolving,
+    .chara-list-item.is-dissolving {
+        --chara-card-dissolve-animation: none;
+        animation: none;
     }
 }
 

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -4576,6 +4576,34 @@ margin-top: 10px;
     transform: translateY(-1px);
 }
 
+.chara-card-item.is-dissolving,
+.chara-list-item.is-dissolving {
+    pointer-events: none;
+    animation: chara-card-ghost-out 680ms ease forwards;
+}
+
+.chara-card-particle-canvas {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    pointer-events: none;
+    z-index: 9999;
+}
+
+@keyframes chara-card-ghost-out {
+    0% {
+        opacity: 1;
+        filter: blur(0);
+        transform: translateY(0) scale(1);
+    }
+    100% {
+        opacity: 0;
+        filter: blur(6px);
+        transform: translateY(-6px) scale(0.985);
+    }
+}
+
 /* ===== 角色卡详情面板 ===== */
 .catgirl-panel-overlay {
     position: fixed;

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -17,6 +17,16 @@ const FRONTEND_FORCE_HIDDEN_FIELDS = [
     'mmd_idle_animations',
 ];
 
+let charaCardParticleCanvas = null;
+let charaCardParticleContext = null;
+let charaCardParticleFrame = 0;
+let charaCardParticles = [];
+let charaCardParticleResizeBound = false;
+let charaCardParticleResizeHandler = null;
+let charaCardDissolveRunId = 0;
+const CHARA_CARD_DISSOLVE_PARTICLE_LIMIT = 144;
+const CHARA_CARD_DISSOLVE_DURATION = 680;
+
 function _safeArray(value) {
     return ReservedFieldsUtils._safeArray(value);
 }
@@ -4441,6 +4451,190 @@ function renderCharaCardsView() {
     document.getElementById('chara-view-list-btn')?.classList.toggle('active', charaCardsViewMode === 'list');
 }
 
+function _ensureCharaCardParticleCanvas() {
+    if (charaCardParticleCanvas) return;
+    charaCardParticleCanvas = document.createElement('canvas');
+    charaCardParticleCanvas.id = 'chara-card-particle-canvas';
+    charaCardParticleCanvas.className = 'chara-card-particle-canvas';
+    charaCardParticleCanvas.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(charaCardParticleCanvas);
+    charaCardParticleContext = charaCardParticleCanvas.getContext('2d');
+
+    if (!charaCardParticleResizeBound) {
+        charaCardParticleResizeHandler = function () {
+            if (!charaCardParticleCanvas || !charaCardParticleContext) return;
+            const dpr = window.devicePixelRatio || 1;
+            charaCardParticleCanvas.width = Math.max(1, Math.floor(window.innerWidth * dpr));
+            charaCardParticleCanvas.height = Math.max(1, Math.floor(window.innerHeight * dpr));
+            charaCardParticleCanvas.style.width = `${window.innerWidth}px`;
+            charaCardParticleCanvas.style.height = `${window.innerHeight}px`;
+            charaCardParticleContext.setTransform(dpr, 0, 0, dpr, 0, 0);
+        };
+        window.addEventListener('resize', charaCardParticleResizeHandler);
+        charaCardParticleResizeBound = true;
+        charaCardParticleResizeHandler();
+    }
+}
+
+function _teardownCharaCardParticleCanvas() {
+    if (!charaCardParticleCanvas) return;
+    if (charaCardParticleResizeBound && charaCardParticleResizeHandler) {
+        window.removeEventListener('resize', charaCardParticleResizeHandler);
+    }
+    window.cancelAnimationFrame(charaCardParticleFrame);
+    charaCardParticleFrame = 0;
+    if (charaCardParticleContext) {
+        charaCardParticleContext.clearRect(0, 0, window.innerWidth, window.innerHeight);
+    }
+    if (charaCardParticleCanvas.parentNode) {
+        charaCardParticleCanvas.parentNode.removeChild(charaCardParticleCanvas);
+    }
+    charaCardParticleCanvas = null;
+    charaCardParticleContext = null;
+    charaCardParticles = [];
+    charaCardParticleResizeBound = false;
+    charaCardParticleResizeHandler = null;
+}
+
+function _randomBetween(min, max) {
+    return min + Math.random() * (max - min);
+}
+
+function _createCharaCardParticle(x, y, color, delay) {
+    const angle = _randomBetween(-Math.PI * 0.9, -Math.PI * 0.1);
+    const speed = _randomBetween(1, 3.8);
+    charaCardParticles.push({
+        x,
+        y,
+        vx: Math.cos(angle) * speed + _randomBetween(-0.4, 0.4),
+        vy: Math.sin(angle) * speed - _randomBetween(0.2, 1.2),
+        rotation: _randomBetween(0, Math.PI),
+        spin: _randomBetween(-0.18, 0.18),
+        size: _randomBetween(2.8, 6.4),
+        life: 0,
+        maxLife: _randomBetween(42, 76),
+        delay: delay || 0,
+        color,
+        alpha: 1,
+    });
+}
+
+function _spawnCharaCardParticles(target) {
+    const rect = target.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+
+    const palette = ['#40c5f1', '#7fd9ff', '#ffffff', '#ff9eb5', '#ff6f8b', '#e3f4ff'];
+    const particleCount = Math.min(CHARA_CARD_DISSOLVE_PARTICLE_LIMIT, Math.max(18, Math.floor(rect.width * rect.height / 180)));
+
+    for (let i = 0; i < particleCount; i++) {
+        _createCharaCardParticle(
+            _randomBetween(rect.left + rect.width * 0.07, rect.right - rect.width * 0.07),
+            _randomBetween(rect.top + rect.height * 0.05, rect.bottom - rect.height * 0.05),
+            palette[Math.floor(Math.random() * palette.length)],
+            _randomBetween(0, 22)
+        );
+    }
+}
+
+function _animateCharaCardParticles() {
+    if (!charaCardParticleContext) return;
+    charaCardParticleContext.clearRect(0, 0, window.innerWidth, window.innerHeight);
+
+    charaCardParticles = charaCardParticles.filter(particle => {
+        if (particle.delay > 0) {
+            particle.delay -= 1;
+            return true;
+        }
+
+        particle.life += 1;
+        const progress = particle.life / particle.maxLife;
+        particle.vy += 0.018;
+        particle.vx *= 0.992;
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+        particle.rotation += particle.spin;
+        particle.alpha = Math.max(0, 1 - progress);
+
+        charaCardParticleContext.save();
+        charaCardParticleContext.globalAlpha = particle.alpha;
+        charaCardParticleContext.translate(particle.x, particle.y);
+        charaCardParticleContext.rotate(particle.rotation);
+        charaCardParticleContext.fillStyle = particle.color;
+        charaCardParticleContext.shadowColor = 'rgba(64, 197, 241, 0.35)';
+        charaCardParticleContext.shadowBlur = 7 * particle.alpha;
+        charaCardParticleContext.fillRect(-particle.size / 2, -particle.size / 2, particle.size, particle.size);
+        charaCardParticleContext.restore();
+
+        return particle.life < particle.maxLife;
+    });
+
+    if (charaCardParticles.length) {
+        charaCardParticleFrame = requestAnimationFrame(_animateCharaCardParticles);
+    } else {
+        cancelAnimationFrame(charaCardParticleFrame);
+        charaCardParticleFrame = 0;
+        if (!charaCardParticles.length) {
+            _teardownCharaCardParticleCanvas();
+        }
+    }
+}
+
+function _startCharaCardParticles() {
+    if (!charaCardParticleCanvas) _ensureCharaCardParticleCanvas();
+    if (!charaCardParticleFrame) {
+        charaCardParticleFrame = requestAnimationFrame(_animateCharaCardParticles);
+    }
+}
+
+function _wait(duration) {
+    return new Promise(resolve => window.setTimeout(resolve, duration));
+}
+
+async function _dissolveCharaCardElement(target) {
+    if (!(target && target.classList)) {
+        return;
+    }
+    const runId = ++charaCardDissolveRunId;
+    const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    target.style.pointerEvents = 'none';
+    target.classList.add('is-dissolving');
+
+    if (!reduceMotion) {
+        _ensureCharaCardParticleCanvas();
+        _spawnCharaCardParticles(target);
+        _startCharaCardParticles();
+    }
+
+    await _wait(CHARA_CARD_DISSOLVE_DURATION);
+    if (runId !== charaCardDissolveRunId) {
+        target.classList.remove('is-dissolving');
+        target.style.opacity = '0';
+        target.style.visibility = 'hidden';
+        target.style.pointerEvents = 'none';
+        return;
+    }
+    target.classList.remove('is-dissolving');
+    target.style.opacity = '0';
+    target.style.visibility = 'hidden';
+    target.style.pointerEvents = '';
+}
+
+async function _deleteCharaCardWithParticle(name, targetCardElement, triggerButton) {
+    const deleted = await workshopDeleteCatgirl(name, { skipReload: true });
+    if (!deleted) {
+        if (triggerButton) triggerButton.disabled = false;
+        return false;
+    }
+
+    if (targetCardElement) {
+        await _dissolveCharaCardElement(targetCardElement);
+    }
+
+    await loadCharacterCards();
+    return true;
+}
+
 // 卡片视图渲染
 function renderCharaCardsGrid(container, cards, currentCatgirl, hiddenKeys) {
     const grid = document.createElement('div');
@@ -4544,9 +4738,12 @@ function renderCharaCardsGrid(container, cards, currentCatgirl, hiddenKeys) {
         deleteBtn.title = window.t ? window.t('character.deleteCard') : '删除角色卡';
         deleteBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>'
             + '<span>' + (window.t ? window.t('character.deleteCard') : '删除角色卡') + '</span>';
-        deleteBtn.onclick = function (e) {
+        deleteBtn.onclick = async function (e) {
             e.stopPropagation();
-            workshopDeleteCatgirl(name);
+            if (deleteBtn.disabled) return;
+            deleteBtn.disabled = true;
+            const deleted = await _deleteCharaCardWithParticle(name, item, deleteBtn);
+            if (!deleted) deleteBtn.disabled = false;
         };
         actionsRow.appendChild(deleteBtn);
 
@@ -4644,9 +4841,12 @@ function renderCharaCardsList(container, cards, currentCatgirl, hiddenKeys) {
         deleteBtn.title = window.t ? window.t('character.deleteCard') : '删除角色卡';
         deleteBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>'
             + '<span class="list-action-label">' + (window.t ? window.t('character.deleteCard') : '删除角色卡') + '</span>';
-        deleteBtn.onclick = function (e) {
+        deleteBtn.onclick = async function (e) {
             e.stopPropagation();
-            workshopDeleteCatgirl(name);
+            if (deleteBtn.disabled) return;
+            deleteBtn.disabled = true;
+            const deleted = await _deleteCharaCardWithParticle(name, item, deleteBtn);
+            if (!deleted) deleteBtn.disabled = false;
         };
         actions.appendChild(deleteBtn);
 
@@ -7079,7 +7279,8 @@ async function workshopSwitchCatgirl(name) {
 
 // 删除猫娘
 // 返回值约定：成功删除返回 true；任何早退/失败/用户取消都返回 false——给调用方据此决定是否关面板
-async function workshopDeleteCatgirl(name) {
+async function workshopDeleteCatgirl(name, options = {}) {
+    const shouldReload = options && options.skipReload ? false : true;
     // 先做语音态预检并拿到权威当前角色名，避免别窗口切换后本地缓存失效
     const guard = await ensureCanModifyCardsOutsideVoiceMode();
     if (!guard.ok) {
@@ -7146,8 +7347,10 @@ async function workshopDeleteCatgirl(name) {
             await showAlertDialog(msg, { type: 'error' });
             return false;
         }
-        // 重新加载角色卡列表
-        await loadCharacterCards();
+        if (shouldReload) {
+            // 重新加载角色卡列表
+            await loadCharacterCards();
+        }
         return true;
     } catch (error) {
         console.error('删除猫娘失败:', error);

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -4573,9 +4573,7 @@ function _animateCharaCardParticles() {
     } else {
         cancelAnimationFrame(charaCardParticleFrame);
         charaCardParticleFrame = 0;
-        if (!charaCardParticles.length) {
-            _teardownCharaCardParticleCanvas();
-        }
+        _teardownCharaCardParticleCanvas();
     }
 }
 
@@ -4598,13 +4596,17 @@ async function _dissolveCharaCardElement(target) {
     const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     target.style.pointerEvents = 'none';
-    target.classList.add('is-dissolving');
 
-    if (!reduceMotion) {
-        _ensureCharaCardParticleCanvas();
-        _spawnCharaCardParticles(target);
-        _startCharaCardParticles();
+    if (reduceMotion) {
+        target.style.opacity = '0';
+        target.style.visibility = 'hidden';
+        return;
     }
+
+    target.classList.add('is-dissolving');
+    _ensureCharaCardParticleCanvas();
+    _spawnCharaCardParticles(target);
+    _startCharaCardParticles();
 
     await _wait(CHARA_CARD_DISSOLVE_DURATION);
     if (runId !== charaCardDissolveRunId) {
@@ -4621,18 +4623,33 @@ async function _dissolveCharaCardElement(target) {
 }
 
 async function _deleteCharaCardWithParticle(name, targetCardElement, triggerButton) {
-    const deleted = await workshopDeleteCatgirl(name, { skipReload: true });
-    if (!deleted) {
+    try {
+        const deleted = await workshopDeleteCatgirl(name, { skipReload: true });
+        if (!deleted) {
+            if (triggerButton) triggerButton.disabled = false;
+            return false;
+        }
+
+        if (targetCardElement) {
+            await _dissolveCharaCardElement(targetCardElement);
+        }
+
+        try {
+            await loadCharacterCards();
+        } catch (error) {
+            console.error('刷新角色卡列表失败:', error);
+            if (targetCardElement && targetCardElement.parentNode) {
+                targetCardElement.parentNode.removeChild(targetCardElement);
+            } else if (triggerButton) {
+                triggerButton.disabled = false;
+            }
+        }
+        return true;
+    } catch (error) {
+        console.error('删除角色卡粒子消散流程失败:', error);
         if (triggerButton) triggerButton.disabled = false;
         return false;
     }
-
-    if (targetCardElement) {
-        await _dissolveCharaCardElement(targetCardElement);
-    }
-
-    await loadCharacterCards();
-    return true;
 }
 
 // 卡片视图渲染


### PR DESCRIPTION
## 背景
角色卡列表里的“删除角色卡”之前是删除成功后直接刷新列表，视觉上比较突兀。近期记忆浏览已经接入了粒子消散删除效果，这次把同类体验扩展到角色卡删除，并处理消散结束后卡片短暂闪现的问题。

## 改了什么

**角色卡删除粒子消散**
- 为卡片视图和列表视图的“删除角色卡”按钮接入粒子消散动画。
- 删除成功后改为先播放目标卡片/列表项的消散效果，再刷新角色卡列表。
- 删除按钮在处理期间会临时禁用，避免重复点击导致状态错位。

**消散动画收尾修复**
- 在动画结束后显式锁定目标元素为隐藏态，避免移除动画类时浏览器回退样式导致卡片短暂闪现。
- 支持 `prefers-reduced-motion`，减少动效用户会跳过粒子生成但保持删除流程可用。

**文档补充**
- 新增 `docs/design/memory-browser-particle-dissolve.md`，记录记忆浏览粒子消散的通用入口、接入方式、并发控制与回归点，方便后续绑定更多删除按钮。

## 验证
- `node --check static/js/character_card_manager.js`
- `git diff --check`
- `uv run pytest tests/frontend/test_chara_settings.py -q`：2 passed，存在项目已有依赖/框架 deprecation warnings。

## 不拆分理由
本 PR 的代码改动都围绕“删除项粒子消散体验”展开：角色卡删除接入、动效样式、闪现收尾修复属于同一条交互链路；文档则记录同类粒子消散功能的复用方式。拆开会让 review 需要在多个 PR 间来回对照交互时序，因此合在一起更便于验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 角色卡删除时新增“粒子溶解/消散”过渡动效，提升视觉反馈与交互体验。
* **改进**
  * 删除流程采用“先动效、后刷新”的呈现方式；同时加强删除按钮状态控制，避免重复点击与异常时的恢复体验。
  * 在“减少动态效果”模式下自动降级为简洁淡出，兼顾性能与可访问性。
* **文档**
  * 补充记忆浏览器聊天记录删除/清空的粒子消散动效实现与回归验证说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->