### PR TITLE
优化 PNGTuber 说话和分层动画表现

### DIFF
--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -198,8 +198,16 @@
             return 'mmd';
         }
 
+        var pngtuberContainer = document.getElementById('pngtuber-container');
+        if (pngtuberContainer && pngtuberContainer.style.display !== 'none' && !pngtuberContainer.classList.contains('hidden')) {
+            return 'pngtuber';
+        }
+
         var cfg = window.lanlan_config || {};
         var modelType = String(cfg.model_type || '').toLowerCase();
+        if (modelType === 'pngtuber') {
+            return 'pngtuber';
+        }
         if (modelType === 'live3d') {
             var subType = String(cfg.live3d_sub_type || '').toLowerCase();
             if (subType === 'vrm' || subType === 'mmd') {
@@ -662,6 +670,11 @@
                 console.log('[Audio] MMD 口型同步已停止');
             }
             S.lipSyncActive = false;
+        } else if (activeModelType === 'pngtuber' && window.pngtuberManager) {
+            if (typeof window.pngtuberManager.stopLipSync === 'function') {
+                window.pngtuberManager.stopLipSync();
+            }
+            S.lipSyncActive = false;
         } else if (window.LanLan1 && window.LanLan1.live2dModel) {
             stopLipSync(window.LanLan1.live2dModel);
         } else {
@@ -1038,6 +1051,12 @@
                                 window.mmdManager.animationModule.startLipSync(S.globalAnalyser);
                                 S.lipSyncActive = true;
                                 console.log('[Audio] MMD 口型同步已启动');
+                            }
+                        } else if (activeModelType === 'pngtuber' && window.pngtuberManager) {
+                            if (typeof window.pngtuberManager.startLipSync === 'function') {
+                                window.pngtuberManager.startLipSync(S.globalAnalyser);
+                                S.lipSyncActive = true;
+                                console.log('[Audio] PNGTuber lip sync started');
                             }
                         } else if (window.LanLan1 && window.LanLan1.live2dModel) {
                             startLipSync(window.LanLan1.live2dModel, S.globalAnalyser);

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -110,6 +110,8 @@
             this.layeredStateReturnTimer = null;
             this.layeredAnimationFrame = null;
             this.layeredAnimationStart = 0;
+            this.layeredBreathingFrame = null;
+            this.layeredBreathingStart = 0;
             this._boundLayeredHotkey = (event) => this.handleLayeredHotkey(event);
             this._boundLayeredPlayEvent = (event) => this.handleLayeredPlayEvent(event);
             this._layeredHotkeysAttached = false;
@@ -125,6 +127,16 @@
             this.speakingBounceAmplitude = 0;
             this.speakingBounceSquish = 0;
             this.lastSpeakingBounceAt = 0;
+            this.lipSyncFrame = null;
+            this.lipSyncMouthOpen = 0;
+            this.lipSyncMouthState = false;
+            this.lipSyncLastStateChangeAt = 0;
+            this.lipSyncNextPulseAt = 0;
+            this.lipSyncPulseCloseAt = 0;
+            this.talkingHopFrame = null;
+            this.talkingHopStart = 0;
+            this.talkingHopAmplitude = 0;
+            this.talkingHopPeriodMs = 0;
             this.clickTimer = null;
             this._suppressNextClick = false;
             this._boundSpeechStart = () => this.setSpeaking(true);
@@ -274,6 +286,7 @@
 
         clearLayeredTimers() {
             this.stopLayeredAnimationLoop();
+            this.stopLayeredBreathingLoop();
             if (this.layeredBlinkTimer) {
                 clearTimeout(this.layeredBlinkTimer);
                 this.layeredBlinkTimer = null;
@@ -543,12 +556,26 @@
             return states[this.layeredStateIndex] || layer.state || {};
         }
 
+        layeredRuntimeFeatureEnabled(featureName) {
+            const features = this.layeredMetadata && this.layeredMetadata.runtime_features;
+            if (!features || typeof features !== 'object') return false;
+            return features[featureName] === true;
+        }
+
         stateHasMotion(layerState) {
-            const hasXMotion = Math.abs(Number(layerState.xAmp) || 0) > 0.0001 && Math.abs(Number(layerState.xFrq) || 0) > 0.0001;
-            const hasYMotion = Math.abs(Number(layerState.yAmp) || 0) > 0.0001 && Math.abs(Number(layerState.yFrq) || 0) > 0.0001;
-            const hasWiggleMotion = Math.abs(Number(layerState.wiggle_amp) || 0) > 0.0001
+            const layerMotionEnabled = this.layeredRuntimeFeatureEnabled('layer_motion');
+            const hasXMotion = layerMotionEnabled
+                && Math.abs(Number(layerState.xAmp) || 0) > 0.0001
+                && Math.abs(Number(layerState.xFrq) || 0) > 0.0001;
+            const hasYMotion = layerMotionEnabled
+                && Math.abs(Number(layerState.yAmp) || 0) > 0.0001
+                && Math.abs(Number(layerState.yFrq) || 0) > 0.0001;
+            const hasWiggleMotion = layerMotionEnabled
+                && Math.abs(Number(layerState.wiggle_amp) || 0) > 0.0001
                 && Math.abs(Number(layerState.wiggle_freq || layerState.rot_frq) || 0) > 0.0001;
-            return hasXMotion || hasYMotion || hasWiggleMotion || this.stateHasFrameAnimation(layerState);
+            const hasFrameAnimation = this.layeredRuntimeFeatureEnabled('sprite_sheet_animation')
+                && this.stateHasFrameAnimation(layerState);
+            return hasXMotion || hasYMotion || hasWiggleMotion || hasFrameAnimation;
         }
 
         stateFrameInfo(layer, layerState, img, timestamp = performance.now()) {
@@ -579,7 +606,8 @@
             const legacyFullSheetY = hasSheet && !explicitFrameHeight && layerHeight >= imageHeight;
             let frame = Math.max(0, Math.floor(Number(layerState.frame) || 0));
             const speed = Math.max(0, Number(layerState.animation_speed) || Number(layer.animation_speed) || 0);
-            const canAnimate = frames > 1
+            const canAnimate = this.layeredRuntimeFeatureEnabled('sprite_sheet_animation')
+                && frames > 1
                 && speed > 0
                 && hasSheet
                 && layerState.non_animated_sheet !== true;
@@ -622,6 +650,7 @@
 
         restartLayeredAnimationLoop() {
             this.stopLayeredAnimationLoop();
+            this.startLayeredBreathingLoop();
             if (!this.isLayeredActive() || !this.hasMotionLayersForCurrentState()) return;
             this.layeredAnimationStart = performance.now();
             const tick = (timestamp) => {
@@ -633,6 +662,53 @@
                 this.layeredAnimationFrame = requestAnimationFrame(tick);
             };
             this.layeredAnimationFrame = requestAnimationFrame(tick);
+        }
+
+        layeredBreathingEnabled() {
+            if (!this.isLayeredActive()) return false;
+            const features = this.layeredMetadata && this.layeredMetadata.runtime_features;
+            if (features && typeof features === 'object' && features.layered_breathing === false) return false;
+            return this.isLayeredActive();
+        }
+
+        currentLayeredBreathingTransform(timestamp = performance.now()) {
+            if (!this.layeredBreathingEnabled()) return { y: 0, scaleX: 1, scaleY: 1 };
+            if (!this.layeredBreathingStart) {
+                this.layeredBreathingStart = timestamp;
+            }
+            const elapsedSeconds = Math.max(0, (timestamp - this.layeredBreathingStart) / 1000);
+            const wave = (Math.sin(elapsedSeconds * Math.PI * 2 * 0.32) + 1) / 2;
+            return {
+                y: -2.6 * wave,
+                scaleX: 1 + 0.004 * wave,
+                scaleY: 1 + 0.009 * wave
+            };
+        }
+
+        startLayeredBreathingLoop() {
+            if (this.layeredBreathingFrame || !this.layeredBreathingEnabled()) return;
+            this.layeredBreathingStart = this.layeredBreathingStart || performance.now();
+            const tick = (timestamp) => {
+                if (!this.layeredBreathingEnabled() || !this.container || this.container.style.display === 'none') {
+                    this.stopLayeredBreathingLoop();
+                    return;
+                }
+                this.applyTransform(timestamp);
+                this.updateLockIconPosition();
+                if (typeof this.updateFloatingButtonsPosition === 'function') {
+                    this.updateFloatingButtonsPosition();
+                }
+                this.layeredBreathingFrame = requestAnimationFrame(tick);
+            };
+            this.layeredBreathingFrame = requestAnimationFrame(tick);
+        }
+
+        stopLayeredBreathingLoop() {
+            if (this.layeredBreathingFrame) {
+                cancelAnimationFrame(this.layeredBreathingFrame);
+                this.layeredBreathingFrame = null;
+            }
+            this.layeredBreathingStart = 0;
         }
 
         motionValue(amplitude, frequency, timestamp, phase = 0) {
@@ -651,6 +727,7 @@
             if (!ctx) return false;
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             const layers = Array.isArray(this.layeredMetadata.layers) ? this.layeredMetadata.layers : [];
+            const layerMotionEnabled = this.layeredRuntimeFeatureEnabled('layer_motion');
             layers
                 .filter((layer) => this.shouldRenderLayer(layer, stateName))
                 .sort((a, b) => {
@@ -666,9 +743,9 @@
                     const frame = this.stateFrameInfo(layer, layerState, img, timestamp);
                     const baseX = (Number(layerState.x ?? layer.x) || 0) + frame.legacyOffsetX;
                     const baseY = (Number(layerState.y ?? layer.y) || 0) + frame.legacyOffsetY;
-                    const x = baseX + this.motionValue(layerState.xAmp, layerState.xFrq, timestamp, Number(layer.order || 0) * 0.17);
-                    const y = baseY + this.motionValue(layerState.yAmp, layerState.yFrq, timestamp, Number(layer.order || 0) * 0.23);
-                    const wiggleDegrees = this.motionValue(layerState.wiggle_amp, layerState.wiggle_freq || layerState.rot_frq, timestamp, Number(layer.order || 0) * 0.11);
+                    const x = baseX + (layerMotionEnabled ? this.motionValue(layerState.xAmp, layerState.xFrq, timestamp, Number(layer.order || 0) * 0.17) : 0);
+                    const y = baseY + (layerMotionEnabled ? this.motionValue(layerState.yAmp, layerState.yFrq, timestamp, Number(layer.order || 0) * 0.23) : 0);
+                    const wiggleDegrees = layerMotionEnabled ? this.motionValue(layerState.wiggle_amp, layerState.wiggle_freq || layerState.rot_frq, timestamp, Number(layer.order || 0) * 0.11) : 0;
                     const rotation = (Number(layerState.rotation) || 0) + wiggleDegrees * Math.PI / 180;
                     const rawScale = Array.isArray(layerState.scale) ? layerState.scale : [1, 1];
                     const baseScale = Array.isArray(layer.base_scale) ? layer.base_scale : [1, 1];
@@ -729,14 +806,16 @@
             this.setState(this.state || 'idle');
         }
 
-        applyTransform() {
+        applyTransform(timestamp = performance.now()) {
             if (!this.image) return;
             const bounce = this.currentSpeakingBounceTransform();
+            const breathing = this.currentLayeredBreathingTransform(timestamp);
+            const talkingHop = this.currentTalkingHopTransform(timestamp);
             const placement = this.getActivePlacement();
             const renderPlacement = this.getRenderPlacement(placement);
             const scaleX = this.config.mirror ? -renderPlacement.scale : renderPlacement.scale;
-            const finalScaleX = scaleX * bounce.scaleX;
-            const finalScaleY = renderPlacement.scale * bounce.scaleY;
+            const finalScaleX = scaleX * bounce.scaleX * breathing.scaleX * talkingHop.scaleX;
+            const finalScaleY = renderPlacement.scale * bounce.scaleY * breathing.scaleY * talkingHop.scaleY;
             const modelManagerPage = isModelManagerPage();
             const pointerEvents = this.isLocked ? 'none' : 'auto';
             if (this.container) {
@@ -759,7 +838,7 @@
             const anchorTranslate = modelManagerPage
                 ? 'translate(-50%, -50%)'
                 : 'translate(-100%, -100%)';
-            this.image.style.transform = `${anchorTranslate} translate(${renderPlacement.offsetX}px, ${renderPlacement.offsetY + bounce.y}px) scale(${finalScaleX}, ${finalScaleY})`;
+            this.image.style.transform = `${anchorTranslate} translate(${renderPlacement.offsetX}px, ${renderPlacement.offsetY + bounce.y + breathing.y + talkingHop.y}px) scale(${finalScaleX}, ${finalScaleY})`;
         }
 
         getActiveLayoutFields() {
@@ -1226,12 +1305,14 @@
             return this.config[emotionKey] || this.config.idle_image || DEFAULT_PLACEHOLDER;
         }
 
-        setState(state) {
+        setState(state, options = {}) {
             this.state = state || 'idle';
             this.ensureContainer();
             if (this.isLayeredActive()) {
                 this.drawLayeredState(this.state);
-                this.restartLayeredAnimationLoop();
+                if (options.restartLayeredAnimation !== false) {
+                    this.restartLayeredAnimationLoop();
+                }
                 this.applyTransform();
                 this.updateLockIconPosition();
                 return;
@@ -1251,6 +1332,7 @@
         }
 
         speakingBounceConfig() {
+            if (this.isLayeredActive()) return null;
             const settings = this.layeredMetadata && this.layeredMetadata.settings;
             const stateSettings = this.currentRemixStateSettings();
             const mouthAnimation = String(stateSettings.current_mo_anim || '').toLowerCase();
@@ -1330,29 +1412,160 @@
             this.speakingBounceFrame = requestAnimationFrame(tick);
         }
 
+        currentTalkingHopTransform(timestamp = performance.now()) {
+            if (!this.talkingHopStart || !this.talkingHopAmplitude || !this.talkingHopPeriodMs) {
+                return { y: 0, scaleX: 1, scaleY: 1 };
+            }
+            const elapsed = Math.max(0, timestamp - this.talkingHopStart);
+            const progress = (elapsed % this.talkingHopPeriodMs) / this.talkingHopPeriodMs;
+            const wave = Math.sin(progress * Math.PI);
+            return {
+                y: -this.talkingHopAmplitude * wave,
+                scaleX: 1,
+                scaleY: 1 + 0.004 * wave
+            };
+        }
+
+        startTalkingHopAnimation() {
+            if (this.talkingHopFrame || !this.isSpeaking) return;
+            this.talkingHopStart = performance.now();
+            this.talkingHopAmplitude = 4.5;
+            this.talkingHopPeriodMs = 260;
+            const tick = (timestamp = performance.now()) => {
+                if (!this.isSpeaking || !this.container || this.container.style.display === 'none') {
+                    this.stopTalkingHopAnimation();
+                    return;
+                }
+                this.applyTransform(timestamp);
+                this.updateLockIconPosition();
+                if (typeof this.updateFloatingButtonsPosition === 'function') {
+                    this.updateFloatingButtonsPosition();
+                }
+                this.talkingHopFrame = requestAnimationFrame(tick);
+            };
+            this.talkingHopFrame = requestAnimationFrame(tick);
+        }
+
+        stopTalkingHopAnimation() {
+            if (this.talkingHopFrame) {
+                cancelAnimationFrame(this.talkingHopFrame);
+                this.talkingHopFrame = null;
+            }
+            this.talkingHopStart = 0;
+            this.talkingHopAmplitude = 0;
+            this.talkingHopPeriodMs = 0;
+            this.applyTransform();
+        }
+
+        applyLipSyncMouthState(open) {
+            if (this.lipSyncMouthState === open && this.speakingMouthOpen === open) return;
+            this.lipSyncMouthState = open;
+            this.speakingMouthOpen = open;
+            if (open) {
+                this.startSpeakingBounceAnimation();
+            }
+            this.setState(open ? 'talking' : 'idle', { restartLayeredAnimation: false });
+        }
+
+        startLipSync(analyser) {
+            if (!analyser || typeof analyser.getByteTimeDomainData !== 'function') {
+                this.startSpeakingMouthAnimation();
+                return false;
+            }
+            if (this.lipSyncFrame) {
+                cancelAnimationFrame(this.lipSyncFrame);
+                this.lipSyncFrame = null;
+            }
+            if (this.speakingMouthTimer) {
+                clearTimeout(this.speakingMouthTimer);
+                this.speakingMouthTimer = null;
+            }
+            this.isSpeaking = true;
+            this.startTalkingHopAnimation();
+            this.lipSyncMouthOpen = 0;
+            this.lipSyncMouthState = !!this.speakingMouthOpen;
+            this.lipSyncLastStateChangeAt = performance.now();
+            this.lipSyncNextPulseAt = this.lipSyncLastStateChangeAt;
+            this.lipSyncPulseCloseAt = 0;
+            const sampleSize = Math.max(32, Number(analyser.fftSize || analyser.frequencyBinCount) || 2048);
+            const dataArray = new Uint8Array(sampleSize);
+            const tick = (timestamp = performance.now()) => {
+                if (!this.isSpeaking || !analyser || typeof analyser.getByteTimeDomainData !== 'function') {
+                    this.stopLipSync();
+                    return;
+                }
+                analyser.getByteTimeDomainData(dataArray);
+                let sum = 0;
+                for (let i = 0; i < dataArray.length; i += 1) {
+                    const value = (dataArray[i] - 128) / 128;
+                    sum += value * value;
+                }
+                const rms = Math.sqrt(sum / dataArray.length);
+                const targetOpen = Math.min(1, rms * 10);
+                this.lipSyncMouthOpen = this.lipSyncMouthOpen * 0.55 + targetOpen * 0.45;
+                const activeThreshold = 0.16;
+                const quietThreshold = 0.07;
+                const pulseOpenMs = Math.max(42, Math.min(72, 42 + this.lipSyncMouthOpen * 34));
+                const pulseGapMs = Math.max(45, Math.min(135, 135 - this.lipSyncMouthOpen * 90));
+                if (this.lipSyncMouthState && timestamp >= this.lipSyncPulseCloseAt) {
+                    this.applyLipSyncMouthState(false);
+                    this.lipSyncNextPulseAt = timestamp + pulseGapMs;
+                } else if (!this.lipSyncMouthState && this.lipSyncMouthOpen >= activeThreshold && timestamp >= this.lipSyncNextPulseAt) {
+                    this.applyLipSyncMouthState(true);
+                    this.lipSyncPulseCloseAt = timestamp + pulseOpenMs;
+                } else if (this.lipSyncMouthState && this.lipSyncMouthOpen <= quietThreshold) {
+                    this.applyLipSyncMouthState(false);
+                    this.lipSyncNextPulseAt = timestamp + pulseGapMs;
+                }
+                this.lipSyncFrame = requestAnimationFrame(tick);
+            };
+            this.lipSyncFrame = requestAnimationFrame(tick);
+            return true;
+        }
+
+        stopLipSync() {
+            if (this.lipSyncFrame) {
+                cancelAnimationFrame(this.lipSyncFrame);
+                this.lipSyncFrame = null;
+            }
+            this.lipSyncMouthOpen = 0;
+            this.lipSyncMouthState = false;
+            this.lipSyncLastStateChangeAt = 0;
+            this.lipSyncNextPulseAt = 0;
+            this.lipSyncPulseCloseAt = 0;
+            this.stopTalkingHopAnimation();
+            if (this.speakingMouthOpen) {
+                this.speakingMouthOpen = false;
+                this.setState('idle', { restartLayeredAnimation: false });
+            }
+        }
+
         scheduleSpeakingMouthFrame() {
             if (!this.isSpeaking) return;
+            if (this.lipSyncFrame) return;
             const nextDelay = this.speakingMouthOpen
                 ? 80 + Math.random() * 90
                 : 55 + Math.random() * 95;
             this.speakingMouthTimer = setTimeout(() => {
                 this.speakingMouthTimer = null;
-                if (!this.isSpeaking) return;
+                if (!this.isSpeaking || this.lipSyncFrame) return;
                 this.speakingMouthOpen = !this.speakingMouthOpen;
                 if (this.speakingMouthOpen) {
                     this.startSpeakingBounceAnimation();
                 }
-                this.setState(this.speakingMouthOpen ? 'talking' : 'idle');
+                this.setState(this.speakingMouthOpen ? 'talking' : 'idle', { restartLayeredAnimation: false });
                 this.scheduleSpeakingMouthFrame();
             }, nextDelay);
         }
 
         startSpeakingMouthAnimation() {
             this.isSpeaking = true;
+            this.startTalkingHopAnimation();
+            if (this.lipSyncFrame) return;
             if (this.speakingMouthTimer) return;
             this.speakingMouthOpen = true;
             this.startSpeakingBounceAnimation();
-            this.setState('talking');
+            this.setState('talking', { restartLayeredAnimation: false });
             this.scheduleSpeakingMouthFrame();
         }
 
@@ -1363,6 +1576,8 @@
                 clearTimeout(this.speakingMouthTimer);
                 this.speakingMouthTimer = null;
             }
+            this.stopLipSync();
+            this.stopTalkingHopAnimation();
             this.stopSpeakingBounceAnimation();
         }
 
@@ -1446,6 +1661,8 @@
                 timers: {
                     mouthTimer: !!this.speakingMouthTimer,
                     bounceFrame: !!this.speakingBounceFrame,
+                    lipSyncFrame: !!this.lipSyncFrame,
+                    talkingHopFrame: !!this.talkingHopFrame,
                     blinkTimer: !!this.layeredBlinkTimer,
                     blinkEndTimer: !!this.layeredBlinkEndTimer,
                     returnIdleTimer: !!this.returnIdleTimer,

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -137,6 +137,7 @@
             this.talkingHopStart = 0;
             this.talkingHopAmplitude = 0;
             this.talkingHopPeriodMs = 0;
+            this.lastOverlayPositionUpdateAt = 0;
             this.clickTimer = null;
             this._suppressNextClick = false;
             this._boundSpeechStart = () => this.setSpeaking(true);
@@ -671,6 +672,16 @@
             return this.isLayeredActive();
         }
 
+        updateOverlayPositionsForAnimation(timestamp = performance.now()) {
+            const minIntervalMs = 120;
+            if (this.lastOverlayPositionUpdateAt && timestamp - this.lastOverlayPositionUpdateAt < minIntervalMs) return;
+            this.lastOverlayPositionUpdateAt = timestamp;
+            this.updateLockIconPosition();
+            if (typeof this.updateFloatingButtonsPosition === 'function') {
+                this.updateFloatingButtonsPosition();
+            }
+        }
+
         currentLayeredBreathingTransform(timestamp = performance.now()) {
             if (!this.layeredBreathingEnabled()) return { y: 0, scaleX: 1, scaleY: 1 };
             if (!this.layeredBreathingStart) {
@@ -694,10 +705,7 @@
                     return;
                 }
                 this.applyTransform(timestamp);
-                this.updateLockIconPosition();
-                if (typeof this.updateFloatingButtonsPosition === 'function') {
-                    this.updateFloatingButtonsPosition();
-                }
+                this.updateOverlayPositionsForAnimation(timestamp);
                 this.layeredBreathingFrame = requestAnimationFrame(tick);
             };
             this.layeredBreathingFrame = requestAnimationFrame(tick);
@@ -1394,19 +1402,16 @@
                 cancelAnimationFrame(this.speakingBounceFrame);
                 this.speakingBounceFrame = null;
             }
-            const tick = () => {
-                const progress = (performance.now() - this.speakingBounceStart) / this.speakingBounceDuration;
+            const tick = (timestamp = performance.now()) => {
+                const progress = (timestamp - this.speakingBounceStart) / this.speakingBounceDuration;
                 if (progress >= 1 || !this.container || this.container.style.display === 'none') {
                     this.speakingBounceFrame = null;
                     this.speakingBounceStart = 0;
                     this.applyTransform();
                     return;
                 }
-                this.applyTransform();
-                this.updateLockIconPosition();
-                if (typeof this.updateFloatingButtonsPosition === 'function') {
-                    this.updateFloatingButtonsPosition();
-                }
+                this.applyTransform(timestamp);
+                this.updateOverlayPositionsForAnimation(timestamp);
                 this.speakingBounceFrame = requestAnimationFrame(tick);
             };
             this.speakingBounceFrame = requestAnimationFrame(tick);
@@ -1437,10 +1442,7 @@
                     return;
                 }
                 this.applyTransform(timestamp);
-                this.updateLockIconPosition();
-                if (typeof this.updateFloatingButtonsPosition === 'function') {
-                    this.updateFloatingButtonsPosition();
-                }
+                this.updateOverlayPositionsForAnimation(timestamp);
                 this.talkingHopFrame = requestAnimationFrame(tick);
             };
             this.talkingHopFrame = requestAnimationFrame(tick);

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -643,17 +643,22 @@
                 && layerState.non_animated_sheet !== true;
         }
 
-        hasMotionLayersForCurrentState() {
+        hasMotionLayersForCurrentState(stateName = this.state || 'idle') {
             if (!this.isLayeredActive()) return false;
             const layers = Array.isArray(this.layeredMetadata.layers) ? this.layeredMetadata.layers : [];
-            return layers.some((layer) => this.stateHasMotion(this.layerStateForCurrentIndex(layer)));
+            return layers.some((layer) => (
+                this.shouldRenderLayer(layer, stateName)
+                && this.stateHasMotion(this.layerStateForCurrentIndex(layer))
+            ));
         }
 
-        restartLayeredAnimationLoop() {
-            this.stopLayeredAnimationLoop();
+        startLayeredAnimationLoop(options = {}) {
             this.startLayeredBreathingLoop();
+            if (this.layeredAnimationFrame) return;
             if (!this.isLayeredActive() || !this.hasMotionLayersForCurrentState()) return;
-            this.layeredAnimationStart = performance.now();
+            if (!options.preserveTimeline || !this.layeredAnimationStart) {
+                this.layeredAnimationStart = performance.now();
+            }
             const tick = (timestamp) => {
                 if (!this.isLayeredActive()) {
                     this.stopLayeredAnimationLoop();
@@ -663,6 +668,11 @@
                 this.layeredAnimationFrame = requestAnimationFrame(tick);
             };
             this.layeredAnimationFrame = requestAnimationFrame(tick);
+        }
+
+        restartLayeredAnimationLoop() {
+            this.stopLayeredAnimationLoop();
+            this.startLayeredAnimationLoop();
         }
 
         layeredBreathingEnabled() {
@@ -1320,6 +1330,8 @@
                 this.drawLayeredState(this.state);
                 if (options.restartLayeredAnimation !== false) {
                     this.restartLayeredAnimationLoop();
+                } else if (!this.layeredAnimationFrame && this.hasMotionLayersForCurrentState()) {
+                    this.startLayeredAnimationLoop({ preserveTimeline: true });
                 }
                 this.applyTransform();
                 this.updateLockIconPosition();

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -138,6 +138,7 @@
             this.talkingHopAmplitude = 0;
             this.talkingHopPeriodMs = 0;
             this.lastOverlayPositionUpdateAt = 0;
+            this.lastAnimationTransformAt = 0;
             this.clickTimer = null;
             this._suppressNextClick = false;
             this._boundSpeechStart = () => this.setSpeaking(true);
@@ -692,11 +693,15 @@
             }
         }
 
+        applyAnimationTransform(timestamp = performance.now()) {
+            if (this.lastAnimationTransformAt === timestamp) return;
+            this.lastAnimationTransformAt = timestamp;
+            this.applyTransform(timestamp);
+        }
+
         currentLayeredBreathingTransform(timestamp = performance.now()) {
             if (!this.layeredBreathingEnabled()) return { y: 0, scaleX: 1, scaleY: 1 };
-            if (!this.layeredBreathingStart) {
-                this.layeredBreathingStart = timestamp;
-            }
+            if (!this.layeredBreathingStart) return { y: 0, scaleX: 1, scaleY: 1 };
             const elapsedSeconds = Math.max(0, (timestamp - this.layeredBreathingStart) / 1000);
             const wave = (Math.sin(elapsedSeconds * Math.PI * 2 * 0.32) + 1) / 2;
             return {
@@ -714,7 +719,7 @@
                     this.stopLayeredBreathingLoop();
                     return;
                 }
-                this.applyTransform(timestamp);
+                this.applyAnimationTransform(timestamp);
                 this.updateOverlayPositionsForAnimation(timestamp);
                 this.layeredBreathingFrame = requestAnimationFrame(tick);
             };
@@ -1422,7 +1427,7 @@
                     this.applyTransform();
                     return;
                 }
-                this.applyTransform(timestamp);
+                this.applyAnimationTransform(timestamp);
                 this.updateOverlayPositionsForAnimation(timestamp);
                 this.speakingBounceFrame = requestAnimationFrame(tick);
             };
@@ -1444,7 +1449,7 @@
         }
 
         startTalkingHopAnimation() {
-            if (this.talkingHopFrame || !this.isSpeaking) return;
+            if (this.talkingHopFrame || !this.isSpeaking || !this.isLayeredActive()) return;
             this.talkingHopStart = performance.now();
             this.talkingHopAmplitude = 4.5;
             this.talkingHopPeriodMs = 260;
@@ -1453,7 +1458,7 @@
                     this.stopTalkingHopAnimation();
                     return;
                 }
-                this.applyTransform(timestamp);
+                this.applyAnimationTransform(timestamp);
                 this.updateOverlayPositionsForAnimation(timestamp);
                 this.talkingHopFrame = requestAnimationFrame(tick);
             };
@@ -1501,7 +1506,7 @@
             this.lipSyncLastStateChangeAt = performance.now();
             this.lipSyncNextPulseAt = this.lipSyncLastStateChangeAt;
             this.lipSyncPulseCloseAt = 0;
-            const sampleSize = Math.max(32, Number(analyser.fftSize || analyser.frequencyBinCount) || 2048);
+            const sampleSize = Math.max(32, Number(analyser.fftSize) || 2048);
             const dataArray = new Uint8Array(sampleSize);
             const tick = (timestamp = performance.now()) => {
                 if (!this.isSpeaking || !analyser || typeof analyser.getByteTimeDomainData !== 'function') {

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -131,8 +131,8 @@ def test_pngtuber_mouth_flap_does_not_restart_layered_motion_timeline():
         source.index("setState(state"):
         source.index("        currentRemixStateSettings()")
     ]
-    restart_block = source[
-        source.index("restartLayeredAnimationLoop()"):
+    animation_loop_block = source[
+        source.index("startLayeredAnimationLoop(options = {})"):
         source.index("        motionValue(")
     ]
     schedule_block = source[
@@ -146,7 +146,8 @@ def test_pngtuber_mouth_flap_does_not_restart_layered_motion_timeline():
 
     assert "restartLayeredAnimation !== false" in set_state_block
     assert source.count("this.layeredAnimationStart = performance.now();") == 1
-    assert "this.layeredAnimationStart = performance.now();" in restart_block
+    assert "this.layeredAnimationStart = performance.now();" in animation_loop_block
+    assert "if (!options.preserveTimeline || !this.layeredAnimationStart)" in animation_loop_block
     assert "layeredAnimationStart = performance.now()" not in set_state_block
     assert "layeredAnimationStart = performance.now()" not in schedule_block
     assert "layeredAnimationStart = performance.now()" not in start_block
@@ -154,6 +155,8 @@ def test_pngtuber_mouth_flap_does_not_restart_layered_motion_timeline():
     assert (
         "if (options.restartLayeredAnimation !== false) {\n"
         "                    this.restartLayeredAnimationLoop();\n"
+        "                } else if (!this.layeredAnimationFrame && this.hasMotionLayersForCurrentState()) {\n"
+        "                    this.startLayeredAnimationLoop({ preserveTimeline: true });\n"
         "                }"
     ) in set_state_block
     assert "this.restartLayeredAnimationLoop();" not in schedule_block
@@ -188,6 +191,10 @@ def test_layered_pngtuber_motion_requires_explicit_runtime_feature_flags():
         source.index("stateHasMotion(layerState)"):
         source.index("        stateFrameInfo(")
     ]
+    current_motion_block = source[
+        source.index("hasMotionLayersForCurrentState("):
+        source.index("        startLayeredAnimationLoop(")
+    ]
     frame_block = source[
         source.index("stateFrameInfo(layer, layerState, img"):
         source.index("        stateHasFrameAnimation(")
@@ -198,6 +205,8 @@ def test_layered_pngtuber_motion_requires_explicit_runtime_feature_flags():
     ]
 
     assert "return features[featureName] === true;" in feature_block
+    assert "hasMotionLayersForCurrentState(stateName = this.state || 'idle')" in current_motion_block
+    assert "this.shouldRenderLayer(layer, stateName)" in current_motion_block
     assert "this.layeredRuntimeFeatureEnabled('layer_motion')" in state_motion_block
     assert "this.layeredRuntimeFeatureEnabled('sprite_sheet_animation')" in state_motion_block
     assert "this.layeredRuntimeFeatureEnabled('sprite_sheet_animation')" in frame_block
@@ -221,6 +230,10 @@ def test_layered_pngtuber_keeps_stable_breathing_without_raw_layer_motion():
         source.index("restartLayeredAnimationLoop()"):
         source.index("        motionValue(")
     ]
+    animation_loop_block = source[
+        source.index("startLayeredAnimationLoop(options = {})"):
+        source.index("        layeredBreathingEnabled()")
+    ]
     breathing_enabled_block = source[
         source.index("layeredBreathingEnabled()"):
         source.index("        currentLayeredBreathingTransform(")
@@ -241,7 +254,8 @@ def test_layered_pngtuber_keeps_stable_breathing_without_raw_layer_motion():
     assert "this.layeredBreathingFrame = null;" in constructor_block
     assert "this.layeredBreathingStart = 0;" in constructor_block
     assert "this.stopLayeredBreathingLoop();" in timers_block
-    assert "this.startLayeredBreathingLoop();" in restart_block
+    assert "this.startLayeredAnimationLoop();" in restart_block
+    assert "this.startLayeredBreathingLoop();" in animation_loop_block
     assert "features.layered_breathing === false" in breathing_enabled_block
     assert "return this.isLayeredActive();" in breathing_enabled_block
     assert "scaleY" in breathing_transform_block

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -417,3 +417,39 @@ def test_pngtuber_talking_hop_moves_whole_avatar_while_speaking():
     assert "this.startTalkingHopAnimation();" in lip_sync_block
     assert "this.stopTalkingHopAnimation();" in stop_speaking_block
     assert "talkingHopFrame: !!this.talkingHopFrame" in debug_block
+
+
+def test_pngtuber_animation_loops_throttle_overlay_position_updates():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    constructor_block = source[
+        source.index("constructor(containerId = 'pngtuber-container')"):
+        source.index("        ensureContainer()")
+    ]
+    helper_block = source[
+        source.index("updateOverlayPositionsForAnimation("):
+        source.index("        currentLayeredBreathingTransform(")
+    ]
+    breathing_loop_block = source[
+        source.index("        startLayeredBreathingLoop() {"):
+        source.index("        stopLayeredBreathingLoop()")
+    ]
+    bounce_loop_block = source[
+        source.index("        startSpeakingBounceAnimation() {"):
+        source.index("        currentTalkingHopTransform(")
+    ]
+    hop_loop_block = source[
+        source.index("        startTalkingHopAnimation() {"):
+        source.index("        stopTalkingHopAnimation()")
+    ]
+
+    assert "this.lastOverlayPositionUpdateAt = 0;" in constructor_block
+    assert "const minIntervalMs = 120;" in helper_block
+    assert "timestamp - this.lastOverlayPositionUpdateAt < minIntervalMs" in helper_block
+    assert "this.updateLockIconPosition();" in helper_block
+    assert "this.updateFloatingButtonsPosition();" in helper_block
+    assert "this.updateOverlayPositionsForAnimation(timestamp);" in breathing_loop_block
+    assert "this.updateOverlayPositionsForAnimation(timestamp);" in bounce_loop_block
+    assert "this.updateOverlayPositionsForAnimation(timestamp);" in hop_loop_block
+    assert "this.updateLockIconPosition();" not in breathing_loop_block
+    assert "this.updateLockIconPosition();" not in bounce_loop_block
+    assert "this.updateLockIconPosition();" not in hop_loop_block

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PNGTUBER_CORE_PATH = PROJECT_ROOT / "static" / "pngtuber-core.js"
+APP_AUDIO_PLAYBACK_PATH = PROJECT_ROOT / "static" / "app-audio-playback.js"
 APP_INTERPAGE_PATH = PROJECT_ROOT / "static" / "app-interpage.js"
 APP_UI_PATH = PROJECT_ROOT / "static" / "app-ui.js"
 INDEX_CSS_PATH = PROJECT_ROOT / "static" / "css" / "index.css"
@@ -122,3 +123,297 @@ def test_pngtuber_container_pointer_events_stay_passthrough_on_restore_paths():
     assert "pngtuberContainer.style.pointerEvents = 'none';" in interpage_source
     assert "pngtuberContainer.style.setProperty('pointer-events', 'none', 'important');" in app_ui_source
     assert "pngtuberContainer.style.setProperty('pointer-events', 'auto', 'important');" not in app_ui_source
+
+
+def test_pngtuber_mouth_flap_does_not_restart_layered_motion_timeline():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    set_state_block = source[
+        source.index("setState(state"):
+        source.index("        currentRemixStateSettings()")
+    ]
+    restart_block = source[
+        source.index("restartLayeredAnimationLoop()"):
+        source.index("        motionValue(")
+    ]
+    schedule_block = source[
+        source.index("scheduleSpeakingMouthFrame()"):
+        source.index("        startSpeakingMouthAnimation()")
+    ]
+    start_block = source[
+        source.index("startSpeakingMouthAnimation()"):
+        source.index("        stopSpeakingMouthAnimation()")
+    ]
+
+    assert "restartLayeredAnimation !== false" in set_state_block
+    assert source.count("this.layeredAnimationStart = performance.now();") == 1
+    assert "this.layeredAnimationStart = performance.now();" in restart_block
+    assert "layeredAnimationStart = performance.now()" not in set_state_block
+    assert "layeredAnimationStart = performance.now()" not in schedule_block
+    assert "layeredAnimationStart = performance.now()" not in start_block
+    assert set_state_block.count("this.restartLayeredAnimationLoop();") == 1
+    assert (
+        "if (options.restartLayeredAnimation !== false) {\n"
+        "                    this.restartLayeredAnimationLoop();\n"
+        "                }"
+    ) in set_state_block
+    assert "this.restartLayeredAnimationLoop();" not in schedule_block
+    assert "this.restartLayeredAnimationLoop();" not in start_block
+    assert "this.setState(this.speakingMouthOpen ? 'talking' : 'idle', { restartLayeredAnimation: false });" in schedule_block
+    assert "this.setState('talking', { restartLayeredAnimation: false });" in start_block
+
+
+def test_layered_pngtuber_speaking_bounce_does_not_transform_whole_canvas():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    bounce_config_block = source[
+        source.index("speakingBounceConfig()"):
+        source.index("        currentSpeakingBounceTransform(")
+    ]
+    apply_transform_block = source[
+        source.index("applyTransform(timestamp = performance.now())"):
+        source.index("        getActiveLayoutFields()")
+    ]
+
+    assert "if (this.isLayeredActive()) return null;" in bounce_config_block
+    assert "const bounce = this.currentSpeakingBounceTransform();" in apply_transform_block
+    assert "this.image.style.transform" in apply_transform_block
+
+
+def test_layered_pngtuber_motion_requires_explicit_runtime_feature_flags():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    feature_block = source[
+        source.index("layeredRuntimeFeatureEnabled("):
+        source.index("        stateHasMotion(")
+    ]
+    state_motion_block = source[
+        source.index("stateHasMotion(layerState)"):
+        source.index("        stateFrameInfo(")
+    ]
+    frame_block = source[
+        source.index("stateFrameInfo(layer, layerState, img"):
+        source.index("        stateHasFrameAnimation(")
+    ]
+    draw_block = source[
+        source.index("drawLayeredState(stateName"):
+        source.index("        showTransientImage(")
+    ]
+
+    assert "return features[featureName] === true;" in feature_block
+    assert "this.layeredRuntimeFeatureEnabled('layer_motion')" in state_motion_block
+    assert "this.layeredRuntimeFeatureEnabled('sprite_sheet_animation')" in state_motion_block
+    assert "this.layeredRuntimeFeatureEnabled('sprite_sheet_animation')" in frame_block
+    assert "const layerMotionEnabled = this.layeredRuntimeFeatureEnabled('layer_motion');" in draw_block
+    assert "layerMotionEnabled ? this.motionValue(layerState.xAmp, layerState.xFrq" in draw_block
+    assert "layerMotionEnabled ? this.motionValue(layerState.yAmp, layerState.yFrq" in draw_block
+    assert "layerMotionEnabled ? this.motionValue(layerState.wiggle_amp, layerState.wiggle_freq || layerState.rot_frq" in draw_block
+
+
+def test_layered_pngtuber_keeps_stable_breathing_without_raw_layer_motion():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    constructor_block = source[
+        source.index("constructor(containerId = 'pngtuber-container')"):
+        source.index("        ensureContainer()")
+    ]
+    timers_block = source[
+        source.index("clearLayeredTimers()"):
+        source.index("        attachLayeredHotkeys()")
+    ]
+    restart_block = source[
+        source.index("restartLayeredAnimationLoop()"):
+        source.index("        motionValue(")
+    ]
+    breathing_enabled_block = source[
+        source.index("layeredBreathingEnabled()"):
+        source.index("        currentLayeredBreathingTransform(")
+    ]
+    breathing_transform_block = source[
+        source.index("currentLayeredBreathingTransform("):
+        source.index("        startLayeredBreathingLoop(")
+    ]
+    breathing_loop_block = source[
+        source.index("        startLayeredBreathingLoop("):
+        source.index("        motionValue(")
+    ]
+    apply_transform_block = source[
+        source.index("applyTransform(timestamp = performance.now())"):
+        source.index("        getActiveLayoutFields()")
+    ]
+
+    assert "this.layeredBreathingFrame = null;" in constructor_block
+    assert "this.layeredBreathingStart = 0;" in constructor_block
+    assert "this.stopLayeredBreathingLoop();" in timers_block
+    assert "this.startLayeredBreathingLoop();" in restart_block
+    assert "features.layered_breathing === false" in breathing_enabled_block
+    assert "return this.isLayeredActive();" in breathing_enabled_block
+    assert "scaleY" in breathing_transform_block
+    assert "scaleX" in breathing_transform_block
+    assert "this.applyTransform(timestamp);" in breathing_loop_block
+    assert "const breathing = this.currentLayeredBreathingTransform(timestamp);" in apply_transform_block
+    assert "bounce.y + breathing.y" in apply_transform_block
+    assert "bounce.scaleX * breathing.scaleX" in apply_transform_block
+    assert "bounce.scaleY * breathing.scaleY" in apply_transform_block
+
+
+def test_audio_playback_routes_lip_sync_to_pngtuber_when_active():
+    source = APP_AUDIO_PLAYBACK_PATH.read_text(encoding="utf-8")
+    model_type_block = source[
+        source.index("function getActiveAvatarModelType()"):
+        source.index("    function clearPendingAudioMetaStallTimer()")
+    ]
+    stop_block = source[
+        source.index("function stopActiveLipSync()"):
+        source.index("    function maybeFinalizeAssistantSpeech(")
+    ]
+    schedule_block = source[
+        source.index("function scheduleAudioChunks()"):
+        source.index("                    var scheduledStartTime = S.nextChunkTime;")
+    ]
+
+    assert "pngtuber-container" in model_type_block
+    assert "modelType === 'pngtuber'" in model_type_block
+    assert "return 'pngtuber';" in model_type_block
+    assert "activeModelType === 'pngtuber'" in schedule_block
+    assert "typeof window.pngtuberManager.startLipSync === 'function'" in schedule_block
+    assert "window.pngtuberManager.startLipSync(S.globalAnalyser)" in schedule_block
+    assert "S.lipSyncActive = true;" in schedule_block
+    assert "activeModelType === 'pngtuber'" in stop_block
+    assert "typeof window.pngtuberManager.stopLipSync === 'function'" in stop_block
+    assert "window.pngtuberManager.stopLipSync()" in stop_block
+    assert "S.lipSyncActive = false;" in stop_block
+
+
+def test_pngtuber_analyser_lip_sync_uses_hysteresis_and_timer_mutex():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    constructor_block = source[
+        source.index("constructor(containerId = 'pngtuber-container')"):
+        source.index("        ensureContainer()")
+    ]
+    lip_sync_block = source[
+        source.index("startLipSync(analyser)"):
+        source.index("        stopLipSync()")
+    ]
+    stop_lip_sync_block = source[
+        source.index("stopLipSync()"):
+        source.index("        scheduleSpeakingMouthFrame()")
+    ]
+    schedule_block = source[
+        source.index("scheduleSpeakingMouthFrame()"):
+        source.index("        startSpeakingMouthAnimation()")
+    ]
+
+    assert "this.lipSyncFrame = null;" in constructor_block
+    assert "this.lipSyncMouthOpen = 0;" in constructor_block
+    assert "this.lipSyncMouthState = false;" in constructor_block
+    assert "this.lipSyncLastStateChangeAt = 0;" in constructor_block
+    assert "this.lipSyncNextPulseAt = 0;" in constructor_block
+    assert "this.lipSyncPulseCloseAt = 0;" in constructor_block
+    assert "clearTimeout(this.speakingMouthTimer);" in lip_sync_block
+    assert "this.startSpeakingMouthAnimation();" in lip_sync_block
+    assert "analyser.getByteTimeDomainData(dataArray);" in lip_sync_block
+    assert "Math.sqrt(sum / dataArray.length)" in lip_sync_block
+    assert "const activeThreshold = 0.16;" in lip_sync_block
+    assert "const quietThreshold = 0.07;" in lip_sync_block
+    assert "const pulseOpenMs = Math.max(42, Math.min(72, 42 + this.lipSyncMouthOpen * 34));" in lip_sync_block
+    assert "const pulseGapMs = Math.max(45, Math.min(135, 135 - this.lipSyncMouthOpen * 90));" in lip_sync_block
+    assert "timestamp >= this.lipSyncPulseCloseAt" in lip_sync_block
+    assert "timestamp >= this.lipSyncNextPulseAt" in lip_sync_block
+    assert "this.lipSyncPulseCloseAt = timestamp + pulseOpenMs;" in lip_sync_block
+    assert "this.lipSyncNextPulseAt = timestamp + pulseGapMs;" in lip_sync_block
+    assert "this.applyLipSyncMouthState(true);" in lip_sync_block
+    assert "this.applyLipSyncMouthState(false);" in lip_sync_block
+    assert "this.lipSyncFrame = requestAnimationFrame(tick);" in lip_sync_block
+    assert "cancelAnimationFrame(this.lipSyncFrame);" in stop_lip_sync_block
+    assert "this.lipSyncFrame = null;" in stop_lip_sync_block
+    assert "this.lipSyncMouthOpen = 0;" in stop_lip_sync_block
+    assert "this.lipSyncNextPulseAt = 0;" in stop_lip_sync_block
+    assert "this.lipSyncPulseCloseAt = 0;" in stop_lip_sync_block
+    assert "if (this.lipSyncFrame) return;" in schedule_block
+    assert "if (!this.isSpeaking || this.lipSyncFrame) return;" in schedule_block
+
+
+def test_pngtuber_lip_sync_state_changes_use_layered_safe_mouth_pulses():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    helper_block = source[
+        source.index("applyLipSyncMouthState(open)"):
+        source.index("        startLipSync(analyser)")
+    ]
+
+    assert "if (this.lipSyncMouthState === open && this.speakingMouthOpen === open) return;" in helper_block
+    assert "this.lipSyncMouthState = open;" in helper_block
+    assert "this.speakingMouthOpen = open;" in helper_block
+    assert "this.startSpeakingBounceAnimation();" in helper_block
+    assert "this.setState(open ? 'talking' : 'idle', { restartLayeredAnimation: false });" in helper_block
+
+
+def test_pngtuber_debug_state_exposes_lip_sync_timer():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    debug_block = source[
+        source.index("getDebugState()"):
+        source.index("        setSpeaking(isSpeaking)")
+    ]
+
+    assert "lipSyncFrame: !!this.lipSyncFrame" in debug_block
+
+
+def test_pngtuber_talking_hop_moves_whole_avatar_while_speaking():
+    source = PNGTUBER_CORE_PATH.read_text(encoding="utf-8")
+    constructor_block = source[
+        source.index("constructor(containerId = 'pngtuber-container')"):
+        source.index("        ensureContainer()")
+    ]
+    hop_transform_block = source[
+        source.index("currentTalkingHopTransform("):
+        source.index("        startTalkingHopAnimation(")
+    ]
+    hop_loop_block = source[
+        source.index("startTalkingHopAnimation("):
+        source.index("        applyLipSyncMouthState(open)")
+    ]
+    stop_block = source[
+        source.index("stopTalkingHopAnimation()"):
+        source.index("        applyLipSyncMouthState(open)")
+    ]
+    apply_transform_block = source[
+        source.index("applyTransform(timestamp = performance.now())"):
+        source.index("        getActiveLayoutFields()")
+    ]
+    start_block = source[
+        source.index("startSpeakingMouthAnimation()"):
+        source.index("        stopSpeakingMouthAnimation()")
+    ]
+    lip_sync_block = source[
+        source.index("startLipSync(analyser)"):
+        source.index("        stopLipSync()")
+    ]
+    stop_speaking_block = source[
+        source.index("stopSpeakingMouthAnimation()"):
+        source.index("        renderedLayerCountForState(")
+    ]
+    debug_block = source[
+        source.index("getDebugState()"):
+        source.index("        setSpeaking(isSpeaking)")
+    ]
+
+    assert "this.talkingHopFrame = null;" in constructor_block
+    assert "this.talkingHopStart = 0;" in constructor_block
+    assert "this.talkingHopAmplitude = 0;" in constructor_block
+    assert "this.talkingHopPeriodMs = 0;" in constructor_block
+    assert "return { y: 0, scaleX: 1, scaleY: 1 };" in hop_transform_block
+    assert "const wave = Math.sin(progress * Math.PI);" in hop_transform_block
+    assert "y: -this.talkingHopAmplitude * wave" in hop_transform_block
+    assert "scaleY: 1 + 0.004 * wave" in hop_transform_block
+    assert "if (this.talkingHopFrame || !this.isSpeaking) return;" in hop_loop_block
+    assert "this.talkingHopAmplitude = 4.5;" in hop_loop_block
+    assert "this.talkingHopPeriodMs = 260;" in hop_loop_block
+    assert "this.applyTransform(timestamp);" in hop_loop_block
+    assert "this.talkingHopFrame = requestAnimationFrame(tick);" in hop_loop_block
+    assert "cancelAnimationFrame(this.talkingHopFrame);" in stop_block
+    assert "this.talkingHopFrame = null;" in stop_block
+    assert "this.talkingHopStart = 0;" in stop_block
+    assert "const talkingHop = this.currentTalkingHopTransform(timestamp);" in apply_transform_block
+    assert "bounce.y + breathing.y + talkingHop.y" in apply_transform_block
+    assert "bounce.scaleX * breathing.scaleX * talkingHop.scaleX" in apply_transform_block
+    assert "bounce.scaleY * breathing.scaleY * talkingHop.scaleY" in apply_transform_block
+    assert "this.startTalkingHopAnimation();" in start_block
+    assert "this.startTalkingHopAnimation();" in lip_sync_block
+    assert "this.stopTalkingHopAnimation();" in stop_speaking_block
+    assert "talkingHopFrame: !!this.talkingHopFrame" in debug_block

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -258,9 +258,11 @@ def test_layered_pngtuber_keeps_stable_breathing_without_raw_layer_motion():
     assert "this.startLayeredBreathingLoop();" in animation_loop_block
     assert "features.layered_breathing === false" in breathing_enabled_block
     assert "return this.isLayeredActive();" in breathing_enabled_block
+    assert "if (!this.layeredBreathingStart) return { y: 0, scaleX: 1, scaleY: 1 };" in breathing_transform_block
+    assert "this.layeredBreathingStart = timestamp;" not in breathing_transform_block
     assert "scaleY" in breathing_transform_block
     assert "scaleX" in breathing_transform_block
-    assert "this.applyTransform(timestamp);" in breathing_loop_block
+    assert "this.applyAnimationTransform(timestamp);" in breathing_loop_block
     assert "const breathing = this.currentLayeredBreathingTransform(timestamp);" in apply_transform_block
     assert "bounce.y + breathing.y" in apply_transform_block
     assert "bounce.scaleX * breathing.scaleX" in apply_transform_block
@@ -322,6 +324,8 @@ def test_pngtuber_analyser_lip_sync_uses_hysteresis_and_timer_mutex():
     assert "this.lipSyncPulseCloseAt = 0;" in constructor_block
     assert "clearTimeout(this.speakingMouthTimer);" in lip_sync_block
     assert "this.startSpeakingMouthAnimation();" in lip_sync_block
+    assert "const sampleSize = Math.max(32, Number(analyser.fftSize) || 2048);" in lip_sync_block
+    assert "frequencyBinCount" not in lip_sync_block
     assert "analyser.getByteTimeDomainData(dataArray);" in lip_sync_block
     assert "Math.sqrt(sum / dataArray.length)" in lip_sync_block
     assert "const activeThreshold = 0.16;" in lip_sync_block
@@ -415,10 +419,10 @@ def test_pngtuber_talking_hop_moves_whole_avatar_while_speaking():
     assert "const wave = Math.sin(progress * Math.PI);" in hop_transform_block
     assert "y: -this.talkingHopAmplitude * wave" in hop_transform_block
     assert "scaleY: 1 + 0.004 * wave" in hop_transform_block
-    assert "if (this.talkingHopFrame || !this.isSpeaking) return;" in hop_loop_block
+    assert "if (this.talkingHopFrame || !this.isSpeaking || !this.isLayeredActive()) return;" in hop_loop_block
     assert "this.talkingHopAmplitude = 4.5;" in hop_loop_block
     assert "this.talkingHopPeriodMs = 260;" in hop_loop_block
-    assert "this.applyTransform(timestamp);" in hop_loop_block
+    assert "this.applyAnimationTransform(timestamp);" in hop_loop_block
     assert "this.talkingHopFrame = requestAnimationFrame(tick);" in hop_loop_block
     assert "cancelAnimationFrame(this.talkingHopFrame);" in stop_block
     assert "this.talkingHopFrame = null;" in stop_block
@@ -457,10 +461,18 @@ def test_pngtuber_animation_loops_throttle_overlay_position_updates():
     ]
 
     assert "this.lastOverlayPositionUpdateAt = 0;" in constructor_block
+    assert "this.lastAnimationTransformAt = 0;" in constructor_block
     assert "const minIntervalMs = 120;" in helper_block
     assert "timestamp - this.lastOverlayPositionUpdateAt < minIntervalMs" in helper_block
     assert "this.updateLockIconPosition();" in helper_block
     assert "this.updateFloatingButtonsPosition();" in helper_block
+    assert "applyAnimationTransform(timestamp = performance.now())" in helper_block
+    assert "if (this.lastAnimationTransformAt === timestamp) return;" in helper_block
+    assert "this.lastAnimationTransformAt = timestamp;" in helper_block
+    assert "this.applyTransform(timestamp);" in helper_block
+    assert "this.applyAnimationTransform(timestamp);" in breathing_loop_block
+    assert "this.applyAnimationTransform(timestamp);" in bounce_loop_block
+    assert "this.applyAnimationTransform(timestamp);" in hop_loop_block
     assert "this.updateOverlayPositionsForAnimation(timestamp);" in breathing_loop_block
     assert "this.updateOverlayPositionsForAnimation(timestamp);" in bounce_loop_block
     assert "this.updateOverlayPositionsForAnimation(timestamp);" in hop_loop_block


### PR DESCRIPTION
﻿## 改动概览

这个 PR 解决 PNGTuber 在分层模型下的两个体验问题：一是嘴型切换和分层动画时间轴互相干扰，导致从猫猫形态切回或说话过程中出现空白、抖动、动画重启；二是 PNGTuber 说话表现太机械，缺少跟随真实音频的活泼反馈。

改动后，分层模型的原始逐层 motion 和 spritesheet 运行时动画默认不再直接启用，只有 metadata 显式声明 runtime feature 时才会使用。默认表现改为整体 breathing，避免各身体部件独立位移造成抖动。说话时，音频播放层会把 analyser lip-sync 分支路由到 PNGTuber，由 PNGTuber 根据真实音频强度触发短促嘴型开合，并在讲话期间让整个 PNGTuber 做轻微上下跳动。

## 技术决策

分层 PNGTuber 的稳定性优先级高于复用旧的逐层 motion 参数。之前的抖动来自多个身体部件各自按 x/y/wiggle 参数运动，以及嘴型开合反复重启分层动画时间轴；因此这次没有重新打开 layer motion，而是把呼吸和讲话跳动都做在整体 transform 层。

音频同步也没有沿用 Live2D 那种“音量越高嘴巴越持续张开”的参数口型。PNGTuber 只有 idle/talking 这类离散状态时，持续张嘴会显得不自然，所以 analyser 只负责判断发声强弱和 pulse 密度，最终呈现为短促张闭。讲话期间的整体上下跳动同样使用独立 RAF 和 transform 叠加，不修改模型位置配置，也不影响单个分层部件。

## 风险与边界

这个 PR 只覆盖 PNGTuber 前端运行时和对应静态契约测试，不改后端角色配置、导入器、模型文件格式，也不新增多嘴型资产支持。两态 PNGTuber 仍然只能在 idle/talking 间切换；更细的口型层级需要后续模型资产和 metadata 约定支持。

音频层只新增 PNGTuber 的窄分支，不改变 VRM、MMD、Live2D 的 lip-sync 路径。分层模型仍默认关闭逐层 runtime motion，因此不会把此前的身体部件抖动路径重新打开。讲话 hop 和 breathing 都是整体 transform 叠加，主要风险是视觉幅度需要继续按实际角色观感微调。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增对 PNGTuber 模型的识别；音频播放将自动切换到对应的口型同步流程。
  * 分层角色新增呼吸循环，并增强说话表现（说话弹跳/跳动与口型联动）。
* **改进**
  * 口型/说话/变换统一由音频分析驱动，并根据启用能力进行门控，避免未启用时误触发动画位移与变换叠加。
  * 调试信息新增口型与跳动帧状态，便于定位表现差异。
* **测试**
  * 扩展静态契约测试，覆盖分层呼吸、说话联动、口型时序与音频路由。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->