### PR TITLE
修复PNGTuber单文件工程导入

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -9038,6 +9038,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         closePNGTuberUploadChoice();
     }
 
+    function handlePNGTuberUploadChoiceKeydown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closePNGTuberUploadChoice();
+            if (uploadBtn) uploadBtn.focus();
+        }
+    }
+
+    function handlePNGTuberUploadChoiceFocusout(event) {
+        const nextTarget = event.relatedTarget;
+        if (!pngtuberUploadChoiceMenu) return;
+        if (nextTarget && (pngtuberUploadChoiceMenu.contains(nextTarget) || uploadBtn.contains(nextTarget))) return;
+        closePNGTuberUploadChoice();
+    }
+
     function createPNGTuberUploadChoiceItem(label, onSelect) {
         const item = document.createElement('div');
         item.className = 'dropdown-item';
@@ -9077,14 +9092,24 @@ document.addEventListener('DOMContentLoaded', async () => {
         menu.style.top = `${rect.bottom + window.scrollY + 4}px`;
         menu.style.minWidth = `${Math.max(rect.width, 270)}px`;
         menu.style.zIndex = '3000';
-        menu.appendChild(createPNGTuberUploadChoiceItem('导入工程文件', () => {
-            pngtuberPackageUpload.click();
-        }));
-        menu.appendChild(createPNGTuberUploadChoiceItem('导入文件夹', () => {
-            pngtuberModelUpload.click();
-        }));
+        menu.addEventListener('keydown', handlePNGTuberUploadChoiceKeydown);
+        menu.addEventListener('focusout', handlePNGTuberUploadChoiceFocusout);
+        menu.appendChild(createPNGTuberUploadChoiceItem(
+            (window.t && window.t('live2d.pngtuberImportProjectFile')) || '导入工程文件',
+            () => {
+                pngtuberPackageUpload.click();
+            }
+        ));
+        menu.appendChild(createPNGTuberUploadChoiceItem(
+            (window.t && window.t('live2d.pngtuberImportFolder')) || '导入文件夹',
+            () => {
+                pngtuberModelUpload.click();
+            }
+        ));
         document.body.appendChild(menu);
         pngtuberUploadChoiceMenu = menu;
+        const firstItem = menu.querySelector('.dropdown-item');
+        if (firstItem) firstItem.focus({ preventScroll: true });
         setTimeout(() => {
             document.addEventListener('mousedown', handlePNGTuberUploadChoiceOutsideClick, true);
         }, 0);

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2088,6 +2088,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const uploadBtn = document.getElementById('upload-btn');
     const modelUpload = document.getElementById('model-upload');
     const pngtuberModelUpload = document.getElementById('pngtuber-model-upload');
+    const pngtuberPackageUpload = document.getElementById('pngtuber-package-upload');
     const pngtuberPreviewGroup = document.getElementById('pngtuber-preview-group');
     const pngtuberBasicPreviewSection = document.getElementById('pngtuber-basic-preview-section');
     const pngtuberTalkPreviewBtn = document.getElementById('pngtuber-talk-preview-btn');
@@ -9021,10 +9022,78 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     // 上传模型功能
+    let pngtuberUploadChoiceMenu = null;
+
+    function closePNGTuberUploadChoice() {
+        if (pngtuberUploadChoiceMenu) {
+            pngtuberUploadChoiceMenu.remove();
+            pngtuberUploadChoiceMenu = null;
+            document.removeEventListener('mousedown', handlePNGTuberUploadChoiceOutsideClick, true);
+        }
+    }
+
+    function handlePNGTuberUploadChoiceOutsideClick(event) {
+        if (!pngtuberUploadChoiceMenu) return;
+        if (pngtuberUploadChoiceMenu.contains(event.target) || uploadBtn.contains(event.target)) return;
+        closePNGTuberUploadChoice();
+    }
+
+    function createPNGTuberUploadChoiceItem(label, onSelect) {
+        const item = document.createElement('div');
+        item.className = 'dropdown-item';
+        item.setAttribute('role', 'button');
+        item.tabIndex = 0;
+        item.innerHTML = `<span class="dropdown-item-text" data-text="${label}">${label}</span>`;
+        const select = () => {
+            closePNGTuberUploadChoice();
+            onSelect();
+        };
+        item.addEventListener('click', select);
+        item.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                select();
+            }
+        });
+        return item;
+    }
+
+    function showPNGTuberUploadChoice() {
+        if (!pngtuberPackageUpload) {
+            pngtuberModelUpload.click();
+            return;
+        }
+        if (pngtuberUploadChoiceMenu) {
+            closePNGTuberUploadChoice();
+            return;
+        }
+
+        const rect = uploadBtn.getBoundingClientRect();
+        const menu = document.createElement('div');
+        menu.className = 'model-type-dropdown';
+        menu.style.display = 'block';
+        menu.style.position = 'absolute';
+        menu.style.left = `${rect.left + window.scrollX}px`;
+        menu.style.top = `${rect.bottom + window.scrollY + 4}px`;
+        menu.style.minWidth = `${Math.max(rect.width, 270)}px`;
+        menu.style.zIndex = '3000';
+        menu.appendChild(createPNGTuberUploadChoiceItem('导入工程文件', () => {
+            pngtuberPackageUpload.click();
+        }));
+        menu.appendChild(createPNGTuberUploadChoiceItem('导入文件夹', () => {
+            pngtuberModelUpload.click();
+        }));
+        document.body.appendChild(menu);
+        pngtuberUploadChoiceMenu = menu;
+        setTimeout(() => {
+            document.addEventListener('mousedown', handlePNGTuberUploadChoiceOutsideClick, true);
+        }, 0);
+    }
+
     uploadBtn.addEventListener('click', () => {
         // 根据当前模型类型选择不同的文件选择器
         if (currentModelType === 'pngtuber') {
-            pngtuberModelUpload.click();
+            showPNGTuberUploadChoice();
         } else if (currentModelType !== 'live2d') {
             vrmFileUpload.click();
         } else {
@@ -9447,56 +9516,74 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
-    if (pngtuberModelUpload) {
-        pngtuberModelUpload.addEventListener('change', async (e) => {
-            const files = Array.from(e.target.files);
-            if (files.length === 0) return;
+    async function uploadPNGTuberFiles(files) {
+        if (!files || files.length === 0) return;
 
-            uploadStatus.textContent = '正在上传PNGTuber模型...';
-            uploadStatus.style.color = '#4f8cff';
-            uploadBtn.disabled = true;
+        uploadStatus.textContent = '正在上传PNGTuber模型...';
+        uploadStatus.style.color = '#4f8cff';
+        uploadBtn.disabled = true;
 
-            try {
-                const formData = new FormData();
-                for (const file of files) {
-                    formData.append('files', file, file.webkitRelativePath || file.name);
-                }
+        try {
+            const formData = new FormData();
+            for (const file of files) {
+                formData.append('files', file, file.webkitRelativePath || file.name);
+            }
 
-                const response = await fetch('/api/model/pngtuber/upload_model', {
-                    method: 'POST',
-                    body: formData
-                });
-                const result = await response.json();
+            const response = await fetch('/api/model/pngtuber/upload_model', {
+                method: 'POST',
+                body: formData
+            });
+            const result = await response.json();
 
-                if (result.success) {
-                    uploadStatus.textContent = `✓ ${result.message}`;
-                    uploadStatus.style.color = '#28a745';
-                    await loadPNGTuberModels();
-                    if (result.folder && modelSelect) {
-                        const option = Array.from(modelSelect.options).find(opt =>
-                            opt.value === result.folder || opt.getAttribute('data-folder') === result.folder
-                        );
-                        if (option) {
-                            modelSelect.value = option.value;
-                            modelSelect.dispatchEvent(new Event('change', { bubbles: true }));
-                        } else if (result.pngtuber && window.loadPNGTuberAvatar) {
-                            await window.loadPNGTuberAvatar(result.pngtuber);
-                        }
+            if (result.success) {
+                uploadStatus.textContent = `✓ ${result.message}`;
+                uploadStatus.style.color = '#28a745';
+                await loadPNGTuberModels();
+                if (result.folder && modelSelect) {
+                    const option = Array.from(modelSelect.options).find(opt =>
+                        opt.value === result.folder || opt.getAttribute('data-folder') === result.folder
+                    );
+                    if (option) {
+                        modelSelect.value = option.value;
+                        modelSelect.dispatchEvent(new Event('change', { bubbles: true }));
+                    } else if (result.pngtuber && window.loadPNGTuberAvatar) {
+                        await window.loadPNGTuberAvatar(result.pngtuber);
                     }
-                    setTimeout(() => { uploadStatus.textContent = ''; }, 3000);
-                } else {
-                    uploadStatus.textContent = `✗ ${result.error}`;
-                    uploadStatus.style.color = '#dc3545';
-                    setTimeout(() => { uploadStatus.textContent = ''; }, 5000);
                 }
-            } catch (error) {
-                console.error('上传PNGTuber模型失败:', error);
-                uploadStatus.textContent = `✗ 上传失败: ${error.message}`;
+                setTimeout(() => { uploadStatus.textContent = ''; }, 3000);
+            } else {
+                uploadStatus.textContent = `✗ ${result.error}`;
                 uploadStatus.style.color = '#dc3545';
                 setTimeout(() => { uploadStatus.textContent = ''; }, 5000);
+            }
+        } catch (error) {
+            console.error('上传PNGTuber模型失败:', error);
+            uploadStatus.textContent = `✗ 上传失败: ${error.message}`;
+            uploadStatus.style.color = '#dc3545';
+            setTimeout(() => { uploadStatus.textContent = ''; }, 5000);
+        } finally {
+            uploadBtn.disabled = false;
+        }
+    }
+
+    if (pngtuberModelUpload) {
+        pngtuberModelUpload.addEventListener('change', async (e) => {
+            if (e.target.files.length === 0) return;
+            try {
+                await uploadPNGTuberFiles(Array.from(e.target.files));
             } finally {
-                uploadBtn.disabled = false;
                 pngtuberModelUpload.value = '';
+            }
+        });
+    }
+
+    if (pngtuberPackageUpload) {
+        pngtuberPackageUpload.addEventListener('change', async (e) => {
+            if (e.target.files.length === 0) return;
+            try {
+                await uploadPNGTuberFiles(Array.from(e.target.files));
+            } finally {
+                pngtuberPackageUpload.value = '';
             }
         });
     }

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "Cannot delete the model currently in use",
         "modelInUse": "In use",
         "pngtuberTalkPreview": "Test Talking",
-        "pngtuberStatePreview": "State Preview"
+        "pngtuberStatePreview": "State Preview",
+        "pngtuberImportProjectFile": "Import Project File",
+        "pngtuberImportFolder": "Import Folder"
     },
     "voice": {
         "title": "Voice Registration",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "No se puede eliminar el modelo en uso",
         "modelInUse": "En uso",
         "pngtuberTalkPreview": "Probar habla",
-        "pngtuberStatePreview": "Vista previa de estado"
+        "pngtuberStatePreview": "Vista previa de estado",
+        "pngtuberImportProjectFile": "Importar archivo de proyecto",
+        "pngtuberImportFolder": "Importar carpeta"
     },
     "voice": {
         "title": "Registro de voz",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "現在使用中のモデルは削除できません",
         "modelInUse": "使用中",
         "pngtuberTalkPreview": "発話をテスト",
-        "pngtuberStatePreview": "状態プレビュー"
+        "pngtuberStatePreview": "状態プレビュー",
+        "pngtuberImportProjectFile": "プロジェクトファイルをインポート",
+        "pngtuberImportFolder": "フォルダーをインポート"
     },
     "voice": {
         "title": "ボイス登録",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "현재 사용 중인 모델은 삭제할 수 없습니다",
         "modelInUse": "사용 중",
         "pngtuberTalkPreview": "말하기 테스트",
-        "pngtuberStatePreview": "상태 미리보기"
+        "pngtuberStatePreview": "상태 미리보기",
+        "pngtuberImportProjectFile": "프로젝트 파일 가져오기",
+        "pngtuberImportFolder": "폴더 가져오기"
     },
     "voice": {
         "title": "음성 등록",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "Não é possível excluir o modelo em uso",
         "modelInUse": "Em uso",
         "pngtuberTalkPreview": "Testar fala",
-        "pngtuberStatePreview": "Prévia de estado"
+        "pngtuberStatePreview": "Prévia de estado",
+        "pngtuberImportProjectFile": "Importar arquivo de projeto",
+        "pngtuberImportFolder": "Importar pasta"
     },
     "voice": {
         "title": "Registro de voz",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "Нельзя удалить модель, которая сейчас используется",
         "modelInUse": "Используется",
         "pngtuberTalkPreview": "Проверить речь",
-        "pngtuberStatePreview": "Предпросмотр состояния"
+        "pngtuberStatePreview": "Предпросмотр состояния",
+        "pngtuberImportProjectFile": "Импорт файла проекта",
+        "pngtuberImportFolder": "Импорт папки"
     },
     "voice": {
         "title": "Регистрация голоса",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "无法删除当前正在使用的模型",
         "modelInUse": "使用中",
         "pngtuberTalkPreview": "测试说话",
-        "pngtuberStatePreview": "状态预览"
+        "pngtuberStatePreview": "状态预览",
+        "pngtuberImportProjectFile": "导入工程文件",
+        "pngtuberImportFolder": "导入文件夹"
     },
     "voice": {
         "title": "音色注册",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1543,7 +1543,9 @@
         "cannotDeleteBoundModel": "無法刪除目前正在使用的模型",
         "modelInUse": "使用中",
         "pngtuberTalkPreview": "測試說話",
-        "pngtuberStatePreview": "狀態預覽"
+        "pngtuberStatePreview": "狀態預覽",
+        "pngtuberImportProjectFile": "導入工程檔案",
+        "pngtuberImportFolder": "導入資料夾"
     },
     "voice": {
         "title": "音色注冊",

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -37,6 +37,7 @@
         <div class="control-group">
             <input type="file" id="model-upload" webkitdirectory directory multiple style="display: none;">
             <input type="file" id="pngtuber-model-upload" webkitdirectory directory multiple style="display: none;">
+            <input type="file" id="pngtuber-package-upload" accept=".pngRemix,.pngremix,.save,.veadomini,.veado" style="display: none;">
             <input type="file" id="vrm-file-upload" accept=".vrm,.zip" style="display: none;">
             <input type="file" id="mmd-file-upload" accept=".pmx,.pmd,.zip" style="display: none;">
             <input type="file" id="mmd-animation-file-upload" accept=".vmd" style="display: none;">

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -37,7 +37,7 @@
         <div class="control-group">
             <input type="file" id="model-upload" webkitdirectory directory multiple style="display: none;">
             <input type="file" id="pngtuber-model-upload" webkitdirectory directory multiple style="display: none;">
-            <input type="file" id="pngtuber-package-upload" accept=".pngRemix,.pngremix,.save,.veadomini,.veado" style="display: none;">
+            <input type="file" id="pngtuber-package-upload" accept=".pngRemix,.pngremix,.save" style="display: none;">
             <input type="file" id="vrm-file-upload" accept=".vrm,.zip" style="display: none;">
             <input type="file" id="mmd-file-upload" accept=".pmx,.pmd,.zip" style="display: none;">
             <input type="file" id="mmd-animation-file-upload" accept=".vmd" style="display: none;">

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -7,6 +7,7 @@ CARD_MAKER_JS = PROJECT_ROOT / "static" / "js" / "card_maker.js"
 CARD_MAKER_CSS = PROJECT_ROOT / "static" / "css" / "card_maker.css"
 CHARACTER_CARD_MANAGER_JS = PROJECT_ROOT / "static" / "js" / "character_card_manager.js"
 MODEL_MANAGER_JS = PROJECT_ROOT / "static" / "js" / "model_manager.js"
+MODEL_MANAGER_TEMPLATE = PROJECT_ROOT / "templates" / "model_manager.html"
 WINDOW_CONTROLS_JS = PROJECT_ROOT / "static" / "js" / "window_controls.js"
 CARD_MAKER_TEMPLATE = PROJECT_ROOT / "templates" / "card_maker.html"
 LOCALE_DIR = PROJECT_ROOT / "static" / "locales"
@@ -87,6 +88,19 @@ def test_model_manager_pngtuber_save_preserves_stored_placement():
         script.index("if (currentModelType === 'pngtuber')") :
         script.index("['adapter', 'layered_metadata', 'source_format', 'source_type']", script.index("if (currentModelType === 'pngtuber')"))
     ]
+
+
+def test_model_manager_pngtuber_upload_supports_project_file_without_removing_folder_upload():
+    script = MODEL_MANAGER_JS.read_text(encoding="utf-8")
+    template = MODEL_MANAGER_TEMPLATE.read_text(encoding="utf-8")
+
+    assert 'id="pngtuber-model-upload" webkitdirectory directory multiple' in template
+    assert 'id="pngtuber-package-upload" accept=".pngRemix,.pngremix,.save,.veadomini,.veado"' in template
+    assert "const pngtuberPackageUpload = document.getElementById('pngtuber-package-upload');" in script
+    assert "showPNGTuberUploadChoice()" in script
+    assert "uploadPNGTuberFiles(Array.from(e.target.files));" in script
+    assert "pngtuberPackageUpload.click();" in script
+    assert "pngtuberModelUpload.click();" in script
 
 
 def test_card_maker_rejects_remote_pngtuber_assets_before_export():

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -95,10 +95,17 @@ def test_model_manager_pngtuber_upload_supports_project_file_without_removing_fo
     template = MODEL_MANAGER_TEMPLATE.read_text(encoding="utf-8")
 
     assert 'id="pngtuber-model-upload" webkitdirectory directory multiple' in template
-    assert 'id="pngtuber-package-upload" accept=".pngRemix,.pngremix,.save,.veadomini,.veado"' in template
+    assert 'id="pngtuber-package-upload" accept=".pngRemix,.pngremix,.save"' in template
+    assert ".veadomini" not in template
+    assert ".veado" not in template
     assert "const pngtuberPackageUpload = document.getElementById('pngtuber-package-upload');" in script
     assert "showPNGTuberUploadChoice()" in script
     assert "uploadPNGTuberFiles(Array.from(e.target.files));" in script
+    assert "menu.addEventListener('keydown', handlePNGTuberUploadChoiceKeydown);" in script
+    assert "menu.addEventListener('focusout', handlePNGTuberUploadChoiceFocusout);" in script
+    assert "event.key === 'Escape'" in script
+    assert "window.t('live2d.pngtuberImportProjectFile')" in script
+    assert "window.t('live2d.pngtuberImportFolder')" in script
     assert "pngtuberPackageUpload.click();" in script
     assert "pngtuberModelUpload.click();" in script
 

--- a/tests/unit/test_i18n_locale_keys.py
+++ b/tests/unit/test_i18n_locale_keys.py
@@ -36,6 +36,17 @@ PNG_TUBER_PREVIEW_LABELS = {
     "pt.json": ("Testar fala", "Prévia de estado"),
 }
 
+PNG_TUBER_UPLOAD_LABELS = {
+    "zh-CN.json": ("导入工程文件", "导入文件夹"),
+    "zh-TW.json": ("導入工程檔案", "導入資料夾"),
+    "en.json": ("Import Project File", "Import Folder"),
+    "ja.json": ("プロジェクトファイルをインポート", "フォルダーをインポート"),
+    "ko.json": ("프로젝트 파일 가져오기", "폴더 가져오기"),
+    "ru.json": ("Импорт файла проекта", "Импорт папки"),
+    "es.json": ("Importar archivo de proyecto", "Importar carpeta"),
+    "pt.json": ("Importar arquivo de projeto", "Importar pasta"),
+}
+
 
 @pytest.fixture(scope="session", autouse=True)
 def mock_memory_server():
@@ -132,6 +143,23 @@ def test_pngtuber_preview_labels_are_localized():
         actual = (
             live2d.get("pngtuberTalkPreview") if isinstance(live2d, dict) else None,
             live2d.get("pngtuberStatePreview") if isinstance(live2d, dict) else None,
+        )
+        if actual != expected:
+            mismatches[locale_name] = actual
+
+    assert mismatches == {}
+
+
+@pytest.mark.unit
+def test_pngtuber_upload_choice_labels_are_localized():
+    mismatches: dict[str, tuple[str | None, str | None]] = {}
+
+    for locale_name, expected in PNG_TUBER_UPLOAD_LABELS.items():
+        data = json.loads((LOCALES_DIR / locale_name).read_text(encoding="utf-8"))
+        live2d = data.get("live2d") if isinstance(data, dict) else None
+        actual = (
+            live2d.get("pngtuberImportProjectFile") if isinstance(live2d, dict) else None,
+            live2d.get("pngtuberImportFolder") if isinstance(live2d, dict) else None,
         )
         if actual != expected:
             mismatches[locale_name] = actual


### PR DESCRIPTION
## 改动概述 / Summary

修复 PNGTuber 模式下【导入模型】只能打开文件夹选择器的问题。

- 新增 PNGTuber 单文件工程上传入口，支持选择 `.pngRemix`、`.save`、`.veadomini`、`.veado`。
- PNGTuber 导入按钮现在提供「导入工程文件」和「导入文件夹」两种入口。
- 原有 PNGTuber 文件夹导入继续保留，Live2D / VRM / MMD 的导入路径不变。
- 单文件和文件夹最终仍复用现有 `/api/model/pngtuber/upload_model` 后端接口。

## 回归报告 / Regression Report

不适用。本 PR 未修改 `app/`、`main_logic/`、`main_routers/`、`memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 只涉及模型管理页模板、前端脚本和对应静态契约测试，计入上限的文件数未超过 20。

## 测试 / Testing

- `.venv/bin/python -m pytest tests/unit/test_card_maker_static_contracts.py`
- `/Users/mac/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check static/js/model_manager.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * PNGTuber 上传新增二选一入口，可选择“导入工程文件”或“导入文件夹”。
  * 工程文件上传已加筛选，仅显示支持的扩展名文件类型；上传后自动刷新模型列表并尝试定位新内容。
* **Bug 修复**
  * 统一了 PNGTuber 上传处理流程，避免不同上传方式之间互相干扰；定位失败时会回退到自动加载对应头像。
* **测试**
  * 补充了上传界面与本地化文案的单元测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->