### PR TITLE
fix(memory): 容忍 LLM 输出容器间缺逗号，修复历史审阅 Expecting ',' delimiter

### DIFF
--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -402,3 +402,55 @@ def test_inner_quotes_transform_is_noop_on_valid_json():
     """已合法的 JSON（含已转义引号）不应被这步动到。"""  # noqa: DOCSTRING_CJK
     raw = '{"a": "say \\"hi\\" loud", "b": ["x", "y"]}'
     assert robust_json_loads(raw) == {"a": 'say "hi" loud', "b": ["x", "y"]}
+
+
+# ── 容器元素间缺逗号 `}{`→`},{`（记忆审阅 correction 模型最高频失败） ────────
+
+
+@pytest.mark.unit
+def test_missing_comma_between_array_objects():
+    """实测案例：记忆审阅模型在 corrected_dialogue 两个对象间漏逗号。
+    `} {` 在合法 JSON 中永不出现 → 补 `},{` 零歧义。"""  # noqa: DOCSTRING_CJK
+    raw = (
+        '{"explanation": "去重",'
+        ' "corrected_dialogue": ['
+        '{"role": "user", "content": "你好"}'
+        ' {"role": "ai", "content": "嗨"}'
+        ']}'
+    )
+    parsed = robust_json_loads(raw)
+    assert [m["content"] for m in parsed["corrected_dialogue"]] == ["你好", "嗨"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # 对象数组缺逗号（含换行 / 缩进，pretty-printed 场景）
+        ('[{"a":1}\n{"b":2}]', [{"a": 1}, {"b": 2}]),
+        # 数组套数组缺逗号
+        ('[[1]\n[2]]', [[1], [2]]),
+        ('[{"a":1} [2]]', [{"a": 1}, [2]]),
+        ('[[1] {"b":2}]', [[1], {"b": 2}]),
+        # 连续多个缺口
+        ('[{"a":1} {"b":2} {"c":3}]', [{"a": 1}, {"b": 2}, {"c": 3}]),
+    ],
+)
+def test_missing_structural_comma_various(raw, expected):
+    assert robust_json_loads(raw) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # 嵌套闭合后立刻开新容器是合法的（中间有逗号）→ 不应再插
+        '{"a": {"b": 1}, "c": [1, 2]}',
+        '[[1], [2]]',
+        # 字符串值里的 `}{` 不是结构 token → 不许动
+        '{"s": "code: }{ here", "t": "arr ][ x"}',
+    ],
+)
+def test_missing_structural_comma_noop_on_valid(raw):
+    """补逗号 transform 在合法 JSON（含字符串内的 `}{`）上必须是 no-op。"""  # noqa: DOCSTRING_CJK
+    assert robust_json_loads(raw) == json.loads(raw)

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -454,3 +454,14 @@ def test_missing_structural_comma_various(raw, expected):
 def test_missing_structural_comma_noop_on_valid(raw):
     """补逗号 transform 在合法 JSON（含字符串内的 `}{`）上必须是 no-op。"""  # noqa: DOCSTRING_CJK
     assert robust_json_loads(raw) == json.loads(raw)
+
+
+@pytest.mark.unit
+def test_missing_comma_repair_runs_after_inner_quote_escape():
+    """关键回归（Codex P2）：补逗号必须排在内引号转义之后。
+
+    内容里有未转义英文引号（奇数个）会翻转串解析奇偶，使字面 `}{` 落在
+    “串外”。若补逗号先跑，会把内容里的 `{a}{b}` 误判为结构边界插逗号，
+    静默篡改成 `{a},{b}`。先转义内引号、串边界稳了，才不会误插。"""  # noqa: DOCSTRING_CJK
+    raw = '{"c": "他说"后写 {a}{b}"}'
+    assert robust_json_loads(raw) == {"c": '他说"后写 {a}{b}'}

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -479,10 +479,13 @@ def robust_json_loads(raw: str) -> Any:
         _normalize_quotes,
         # 清掉 `,결{` 类结构 token 间幻觉污染；自身已双引号感知
         _strip_stray_chars_between_tokens,
-        # 容器元素间缺逗号 `}{`→`},{`；自身串感知，仅补结构 close→open（零歧义）
-        _insert_missing_structural_commas,
-        # 最后才动、最激进：转义字符串值内未转义的英文双引号（qwen 等模型常犯）
+        # 转义字符串值内未转义的英文双引号（qwen 等模型常犯）
         _escape_inner_quotes,
+        # 容器元素间缺逗号 `}{`→`},{`；自身串感知，仅补结构 close→open（零歧义）。
+        # 必须排在 _escape_inner_quotes **之后**：未转义内引号会翻转串解析奇偶，
+        # 让内容里的字面 `}{` 被误判为结构边界而插入逗号（静默篡改）。先把内引号
+        # 转义干净，串边界才稳，本步的 close→open 判定才可信（Codex P2）。
+        _insert_missing_structural_commas,
     )
     s = raw
     for transform in transforms:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -252,6 +252,60 @@ def _escape_inner_quotes(s: str) -> str:
     return ''.join(out)
 
 
+def _insert_missing_structural_commas(s: str) -> str:
+    """Insert a missing comma between two adjacent JSON containers.
+
+    LLMs frequently drop the separator between array / object elements, e.g.
+    ``[{"role": "user", ...} {"role": "ai", ...}]`` — ``json.loads`` then raises
+    ``Expecting ',' delimiter`` at the second ``{``. This was the single most
+    common unhandled failure observed in the memory-review (``correction`` model)
+    path, whose output is exactly an array of ``{role, content}`` objects.
+
+    Stateful scan (string + backslash aware so braces inside string values are
+    ignored). Whenever a structural close ``}`` / ``]`` is immediately followed —
+    only whitespace between — by a structural open ``{`` / ``[`` outside any
+    string, insert a ``,`` between them.
+
+    Deliberately scoped to the **close → open** boundary only: ``}{`` / ``}[`` /
+    ``]{`` / ``][`` are never valid JSON, so inserting a comma there cannot
+    silently corrupt a legitimate document (on valid input this is a no-op). The
+    riskier siblings — a missing comma after a *string* value (``"a" "b"``, where
+    the leading ``"`` might be an inner content quote rather than a real
+    terminator) — are left to fail loudly, consistent with this module's bias
+    against silent corruption.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    in_string = False
+    escape = False
+    while i < n:
+        c = s[i]
+        out.append(c)
+        if in_string:
+            if escape:
+                escape = False
+            elif c == '\\':
+                escape = True
+            elif c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+            i += 1
+            continue
+        if c in '}]':
+            # 向前看：跳过空白后若紧跟另一个容器起始（{ 或 [）→ 缺分隔逗号
+            j = i + 1
+            while j < n and s[j].isspace():
+                j += 1
+            if j < n and s[j] in '{[':
+                out.append(',')
+        i += 1
+    return ''.join(out)
+
+
 def _try_json_loads(s: str) -> tuple[Any, bool]:
     try:
         return json.loads(s), True
@@ -397,7 +451,8 @@ def robust_json_loads(raw: str) -> Any:
 
     Handles: unquoted keys, trailing commas, ``{{ }}``, Python ``True/False/None``,
     single-quoted strings (including mixed-quote scenarios), stray hallucinated
-    chars between structural tokens (e.g. ``,결{`` → ``,{``), unescaped English
+    chars between structural tokens (e.g. ``,결{`` → ``,{``), missing commas
+    between adjacent containers (e.g. ``}{`` → ``},{``), unescaped English
     double-quotes inside string values (e.g. ``"他说"晚安"走了"``), and over-escaped
     ``---`` memo dividers in string values.
     """  # noqa: DOCSTRING_CJK
@@ -424,6 +479,8 @@ def robust_json_loads(raw: str) -> Any:
         _normalize_quotes,
         # 清掉 `,결{` 类结构 token 间幻觉污染；自身已双引号感知
         _strip_stray_chars_between_tokens,
+        # 容器元素间缺逗号 `}{`→`},{`；自身串感知，仅补结构 close→open（零歧义）
+        _insert_missing_structural_commas,
         # 最后才动、最激进：转义字符串值内未转义的英文双引号（qwen 等模型常犯）
         _escape_inner_quotes,
     )


### PR DESCRIPTION
## 问题

记忆审阅（`correction` 模型）路径反复报错（生产日志一天内多次）：

```
N.E.K.O.Memory - ERROR - ❌ 历史记录审阅失败：Expecting ',' delimiter: line 4 column 199 ...
  File ".../memory/recent.py", line 754, in review_history
  File ".../utils/file_utils.py", line 314, in robust_json_loads
```

`review_history` 让 correction 模型返回 `{"explanation":..., "corrected_dialogue":[{"role":..,"content":..}, {..}, ...]}`，再用 `robust_json_loads` 解析。报错既不是网络也不是内引号——是**模型在两个对话对象之间漏写逗号**（`} {` 应为 `}, {`），这是对象数组最高频的 LLM JSON 错误。整批审阅因此作废（返回 `('failed', None)`，3 次重试也救不回）。

`robust_json_loads` 现有兜底覆盖了无引号 key / 尾逗号 / `{{}}` / Python 字面量 / 单引号 / 结构 token 间幻觉污染 / 字符串内未转义引号 / over-escape 分隔符——唯独**只删尾逗号、从不补缺失逗号**，所以这条 `Expecting ',' delimiter` 漏网。

## 改动

新增 `_insert_missing_structural_commas`（`utils/file_utils.py`）：串感知 + 反斜杠转义感知扫描，**仅**在结构性 close（`}`/`]`）紧跟结构性 open（`{`/`[`）时补一个逗号。放在 `_escape_inner_quotes` 之前。

零歧义、零静默篡改风险：`}{` / `}[` / `]{` / `][` 在合法 JSON 中永不相邻，所以
- 合法 JSON 上是 no-op（实测语义完全不变）；
- 字符串值里的 `}{` 因串感知被跳过，不会误动。

符合本模块"宁可显式抛错也不静默篡改"的契约。

**故意不在范围内**：字符串值后缺逗号（`"x" "y"`，首引号可能是内容引号而非真收尾）这类有歧义的情形仍留给它显式失败——避免把 `_escape_inner_quotes` 已知的 comma 歧义风险再扩大。

## 验证

`tests/unit/test_robust_json_loads.py`：61 原有 + 9 新增（数组对象缺逗号 / 嵌套数组缺逗号 / 连续多缺口 / 合法 JSON no-op / 字符串内 `}{` 不误动）全过：

```
70 passed in 0.10s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 提升 `robust_json_loads` 的兜底修复能力：当相邻容器之间缺少逗号（如 `}{` → `},{`）时，自动补齐分隔符。
  * 覆盖对象数组、数组嵌套、以及多处连续缺口等场景；在合法 JSON 情况下保持不变，并减少误判字符串片段的风险。
* **Tests**
  * 新增回归测试，验证缺逗号修复与字符串边界/转义场景的正确顺序与稳定性。
* **Documentation**
  * 更新相关处理说明，明确支持该缺逗号场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->