### PR TITLE
fix(i18n): 更新日志启动早读语言为空时回退 localStorage，避免误下发中文

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -307,10 +307,21 @@ window.addEventListener('load', async () => {
             }
         } catch (_) { }
 
+        // i18next 可能还没 init 完成（init 内部要先 await Steam 语言，window.i18next.language
+        // 这时为空）。此处回退到 localStorage 的 i18nextLng——getInitialLanguage 在 init 之前
+        // 就把解析出的语言落了进去。否则空 lang 传给 /api/changelog 会被后端当中文原文下发：
+        // 更新日志早读（此处）易踩到，问卷在用户点完 changelog 弹窗后才读、时序上 i18next 已就绪
+        // 所以语言正常。与 app-websocket / app-proactive 等处的兜底取法保持一致。
+        const _resolveUiLang = () => {
+            const live = (window.i18next && typeof window.i18next.language === 'string')
+                ? window.i18next.language : '';
+            return live || localStorage.getItem('i18nextLng') || '';
+        };
+
         // 1) 版本更新日志（先讲背景）
         try {
             const lastVer = localStorage.getItem('neko_last_notified_version') || '';
-            const lang = (window.i18next && window.i18next.language) || '';
+            const lang = _resolveUiLang();
             const cr = await fetch(`/api/changelog?since=${encodeURIComponent(lastVer)}&lang=${encodeURIComponent(lang)}`);
             const cdata = await cr.json();
             let entries = cdata.entries || [];
@@ -361,7 +372,7 @@ window.addEventListener('load', async () => {
         try {
             const _surveyEligibleFor = localStorage.getItem('neko_survey_eligible_for') || '';
             if (_surveyEligibleFor && typeof window.showSurveyModal === 'function') {
-                const surveyLang = (window.i18next && window.i18next.language) || '';
+                const surveyLang = _resolveUiLang();
                 const sr = await fetch(`/api/survey?lang=${encodeURIComponent(surveyLang)}`);
                 const sdata = await sr.json();
                 if (sdata && sdata.has_survey && sdata.survey) {


### PR DESCRIPTION
## 问题

Steam/设置已切英文，**版本问卷语言正常，但更新日志（changelog）弹窗仍是中文**。

## 根因

启动 IIFE 里两处取语言用的是同一句 `(window.i18next && window.i18next.language) || ''`，但时序不同：

- **更新日志**早读（`static/app.js` step 1）：此时 `i18next.init` 还没跑完——init 内部要先 `await getInitialLanguage()`（含一次最多 2s 的 Steam 语言 fetch），所以 `window.i18next.language` 仍为 `undefined` → 传 `lang=''`。后端 `/api/changelog` 收到空 lang 时 `fallback_langs=[]`，直接回中文原文（`main_routers/system_router.py` 的 `_read_localized`）。
- **版本问卷**晚读（step 1.5）：它在 `await Promise.all(changelogPromises)`（用户点完 changelog 弹窗）之后才读语言，此时 i18next 已就绪 → `lang='en'` → 问卷正常。

同样的代码、不同的读取时机，就造成了「更新日志中文、问卷正常」。

## 修复

改为与 `app-websocket.js` / `app-proactive.js` 等处一致的兜底：`i18next.language` 为空时回退 `localStorage` 的 `i18nextLng`（`getInitialLanguage` 在 init 之前就把解析出的语言落进了 localStorage）。changelog 与 survey 两处统一走新的 `_resolveUiLang()`，保持对偶。

## 验证

属启动时序竞态（仅在 changelog fetch 早于 i18next init 完成的窗口内复现），无法在 preview 里稳定重放；已逐链追溯根因、对齐仓库既有同类兜底写法、`node --check static/app.js` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
