### PR TITLE
fix: preserve follow API model IDs

### DIFF
--- a/tests/unit/test_config_manager_follow_urls.py
+++ b/tests/unit/test_config_manager_follow_urls.py
@@ -57,6 +57,68 @@ def test_follow_assist_uses_resolved_provider_url_instead_of_stale_saved_url():
         shutil.rmtree(config_dir, ignore_errors=True)
 
 
+def test_follow_assist_uses_saved_model_id_for_text_tiers():
+    """follow_assist keeps saved text model IDs while following URL and key."""
+    config_dir = _make_workspace_temp_dir()
+    try:
+        cm = _manager_with_core_config(config_dir, {
+            "coreApiKey": "free-access",
+            "coreApi": "free",
+            "assistApi": "deepseek",
+            "assistApiKeyDeepseek": "sk-deepseek",
+            "enableCustomApi": True,
+            "conversationModelProvider": "follow_assist",
+            "conversationModelUrl": "https://api.deepseek.com/v1",
+            "conversationModelId": "deepseek-v4-flash",
+            "conversationModelApiKey": "sk-deepseek",
+            "correctionModelProvider": "follow_assist",
+            "correctionModelUrl": "https://api.deepseek.com/v1",
+            "correctionModelId": "deepseek-v4-flash",
+            "correctionModelApiKey": "sk-deepseek",
+            "agentModelProvider": "follow_assist",
+            "agentModelUrl": "https://api.deepseek.com/v1",
+            "agentModelId": "deepseek-v4-flash",
+            "agentModelApiKey": "sk-deepseek",
+        })
+
+        assert cm.get_model_api_config("conversation")["model"] == "deepseek-v4-flash"
+        assert cm.get_model_api_config("correction")["model"] == "deepseek-v4-flash"
+        assert cm.get_model_api_config("agent")["model"] == "deepseek-v4-flash"
+    finally:
+        shutil.rmtree(config_dir, ignore_errors=True)
+
+
+def test_follow_core_uses_saved_model_id_for_text_tiers():
+    """follow_core keeps saved text model IDs while following URL and key."""
+    config_dir = _make_workspace_temp_dir()
+    try:
+        cm = _manager_with_core_config(config_dir, {
+            "coreApi": "deepseek",
+            "coreApiKeyDeepseek": "sk-deepseek",
+            "assistApi": "free",
+            "assistApiKey": "free-access",
+            "enableCustomApi": True,
+            "conversationModelProvider": "follow_core",
+            "conversationModelUrl": "https://api.deepseek.com/v1",
+            "conversationModelId": "deepseek-v4-flash",
+            "conversationModelApiKey": "sk-deepseek",
+            "correctionModelProvider": "follow_core",
+            "correctionModelUrl": "https://api.deepseek.com/v1",
+            "correctionModelId": "deepseek-v4-flash",
+            "correctionModelApiKey": "sk-deepseek",
+            "agentModelProvider": "follow_core",
+            "agentModelUrl": "https://api.deepseek.com/v1",
+            "agentModelId": "deepseek-v4-flash",
+            "agentModelApiKey": "sk-deepseek",
+        })
+
+        assert cm.get_model_api_config("conversation")["model"] == "deepseek-v4-flash"
+        assert cm.get_model_api_config("correction")["model"] == "deepseek-v4-flash"
+        assert cm.get_model_api_config("agent")["model"] == "deepseek-v4-flash"
+    finally:
+        shutil.rmtree(config_dir, ignore_errors=True)
+
+
 def test_follow_core_non_omni_still_uses_core_provider_http_url():
     """非 omni 的 follow_core 仍应解析为核心 provider 对应的 HTTP 兼容地址。"""
     config_dir = _make_workspace_temp_dir()

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -4210,9 +4210,9 @@ class ConfigManager:
                 # 其他 model type（conversation/summary/correction/emotion/vision/agent）
                 # 走 chat completion REST，没有 'local' 分支；跳 URL 反而会改变它们的
                 # follow_* 路由（详见 PR #1084 review thread），故仅对 omni/tts 跳。
-                # 注：follow_* 下用户填的 modelId 当前在 get_model_api_config fallback
-                # 路径里读不到（fallback 用 CORE_MODEL，不是 REALTIME_MODEL/TTS_MODEL），
-                # 那是另一个层面的问题，下个 PR 跟进。
+                # 注：follow_* 下 omni/tts 仍不能依赖 get_model_api_config fallback
+                # 读取用户填的 modelId（fallback 用 CORE_MODEL，不是 REALTIME_MODEL/TTS_MODEL），
+                # 因此这些特殊前缀继续走既有 follow 解析。
                 is_follow = provider in ('follow_core', 'follow_assist', 'follow_conversation', 'follow_summary')
                 # GSV 启用时 ttsModelUrl 是 GPT-SoVITS server URL，不是 follow_*
                 # 联动出来的 LLM URL。即便 ttsModelProvider 仍是默认 follow_assist，
@@ -4245,9 +4245,16 @@ class ConfigManager:
                 elif provider == 'follow_summary':
                     config[model_key] = config.get('SUMMARY_MODEL', '')
                 elif provider in ('follow_core', 'follow_assist'):
-                    followed_model = _resolve_game_follow_model_id(prefix, provider)
-                    if followed_model:
-                        config[model_key] = followed_model
+                    if (
+                        prefix not in ('gameMain', 'gameSummary', 'omni', 'tts')
+                        and isinstance(cfg_model, str)
+                        and cfg_model.strip()
+                    ):
+                        config[model_key] = cfg_model.strip()
+                    else:
+                        followed_model = _resolve_game_follow_model_id(prefix, provider)
+                        if followed_model:
+                            config[model_key] = followed_model
                 elif cfg_model is not None:
                     config[model_key] = cfg_model or config.get(model_key, '')
 


### PR DESCRIPTION
## 改动概述 / Summary
- 修复自定义 API 设置中 `follow_core` / `follow_assist` 的文本模型配置解析，保留设置页保存的模型 ID。
- 避免普通文本模型槽位在已填写自定义模型 ID 时，实际聊天链路回退到 provider 默认模型。
- 该修复覆盖所有走 `follow_core` / `follow_assist` 的普通文本模型槽位，不针对单一 provider 做特判。
- 保持 `gameMain` / `gameSummary` / `omni` / `tts` 的既有跟随模型解析逻辑不变。

## 回归报告 / Regression Report
不适用。本 PR 未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split
不适用。变更只包含一个配置解析修复和对应单测。

## 测试 / Testing
- `/Users/stg-mba003/.local/bin/uv run pytest tests/unit/test_config_manager_follow_urls.py -q`
- `/Users/stg-mba003/.local/bin/uv run pytest tests/unit/test_api_config_manager.py::TestCustomApiToggle::test_game_follow_assist_derives_model_id_from_assist_profile tests/unit/test_api_config_manager.py::TestCustomApiToggle::test_game_follow_core_derives_model_id_from_core_profile tests/unit/test_api_config_manager.py::TestFollowProviderNotLocal::test_non_omni_follow_core_url_not_skipped -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复自定义 API 启用后，当使用辅助联动 API（follow_core / follow_assist）时，文本类配置可能错误覆盖已保存的模型 ID 的问题。
  * 对会话/纠错/代理等文本场景，会优先保留已保存的模型标识；仅在需要时才回填联动解析结果。
* **Tests**
  * 新增回归测试：分别验证 follow_assist 与 follow_core 在文本类场景下均正确使用已保存的模型 ID（并覆盖会话/纠错/代理三类配置）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
