### PR TITLE
fix(i18n): 更新日志/问卷取语言前先 await i18next ready（#2051 follow-up）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -313,9 +313,13 @@ window.addEventListener('load', async () => {
         // 点完 changelog 弹窗后才读所以躲过，造成"更新日志中文、问卷正常"）。所以先 await
         // i18next ready 再取语言，拿到解析后的权威值（含 getInitialLanguage 不落盘的手动
         // uiLanguage 覆盖）；只有 init 彻底失败/超时才回退 localStorage。
-        // ready 信号：i18next.isInitialized（已就绪直接过）或 i18n-i18next.js 在 finalizeInit
-        // 里派发的 localechange 事件；setTimeout 兜底防 init 卡死时无限挂起。
-        const _ensureI18nReady = (timeoutMs = 5000) => new Promise((resolve) => {
+        // ready 信号：i18next.isInitialized（已就绪直接过）或 i18n-i18next.js 在**所有终态**都会
+        // 派发的 localechange 事件（finalizeInit 成功 / 无 backend 手动加载 / 初始化失败
+        // exportFallbackFunctions 都派发），所以信号一定会来。超时给 12s 是为覆盖 i18n-i18next.js
+        // 自身 bootstrap 的完整窗口：依赖轮询最多 5s + getInitialLanguage 的 Steam 语言查询最多
+        // 2s，外加它 10s 硬安全网强制 init。5s 太短会在 i18next 尚未就绪时提前超时回退（Codex P2），
+        // 12s 覆盖整段窗口后超时只兜「i18n 模块自身彻底卡死」这种极端情况。
+        const _ensureI18nReady = (timeoutMs = 12000) => new Promise((resolve) => {
             if (window.i18next && window.i18next.isInitialized) { resolve(); return; }
             let done = false;
             let timerId;

--- a/static/app.js
+++ b/static/app.js
@@ -318,14 +318,16 @@ window.addEventListener('load', async () => {
         const _ensureI18nReady = (timeoutMs = 5000) => new Promise((resolve) => {
             if (window.i18next && window.i18next.isInitialized) { resolve(); return; }
             let done = false;
+            let timerId;
             const finish = () => {
                 if (done) return;
                 done = true;
+                clearTimeout(timerId);
                 window.removeEventListener('localechange', finish);
                 resolve();
             };
             window.addEventListener('localechange', finish);
-            setTimeout(finish, timeoutMs);
+            timerId = setTimeout(finish, timeoutMs);
         });
         // i18next ready 后 language 即权威值；万一 init 失败/超时，localStorage 的 i18nextLng
         // （getInitialLanguage 在 init 前对 query/steam 值落过盘）作末位兜底，仍比空 lang 强。

--- a/static/app.js
+++ b/static/app.js
@@ -307,16 +307,35 @@ window.addEventListener('load', async () => {
             }
         } catch (_) { }
 
-        // i18next 可能还没 init 完成（init 内部要先 await Steam 语言，window.i18next.language
-        // 这时为空）。此处回退到 localStorage 的 i18nextLng——getInitialLanguage 在 init 之前
-        // 就把解析出的语言落了进去。否则空 lang 传给 /api/changelog 会被后端当中文原文下发：
-        // 更新日志早读（此处）易踩到，问卷在用户点完 changelog 弹窗后才读、时序上 i18next 已就绪
-        // 所以语言正常。与 app-websocket / app-proactive 等处的兜底取法保持一致。
+        // 更新日志/问卷要把 UI 语言传给后端做本地化下发。坑：本启动流程可能早于 i18next
+        // init 完成就跑到这（init 内部要先 await 一次 Steam 语言查询），此时 window.i18next
+        // .language 还是空 → 传 lang='' → 后端按中文原文下发（更新日志早读易踩；问卷在用户
+        // 点完 changelog 弹窗后才读所以躲过，造成"更新日志中文、问卷正常"）。所以先 await
+        // i18next ready 再取语言，拿到解析后的权威值（含 getInitialLanguage 不落盘的手动
+        // uiLanguage 覆盖）；只有 init 彻底失败/超时才回退 localStorage。
+        // ready 信号：i18next.isInitialized（已就绪直接过）或 i18n-i18next.js 在 finalizeInit
+        // 里派发的 localechange 事件；setTimeout 兜底防 init 卡死时无限挂起。
+        const _ensureI18nReady = (timeoutMs = 5000) => new Promise((resolve) => {
+            if (window.i18next && window.i18next.isInitialized) { resolve(); return; }
+            let done = false;
+            const finish = () => {
+                if (done) return;
+                done = true;
+                window.removeEventListener('localechange', finish);
+                resolve();
+            };
+            window.addEventListener('localechange', finish);
+            setTimeout(finish, timeoutMs);
+        });
+        // i18next ready 后 language 即权威值；万一 init 失败/超时，localStorage 的 i18nextLng
+        // （getInitialLanguage 在 init 前对 query/steam 值落过盘）作末位兜底，仍比空 lang 强。
+        // 与 app-websocket / app-proactive 等处的取法保持一致。
         const _resolveUiLang = () => {
             const live = (window.i18next && typeof window.i18next.language === 'string')
                 ? window.i18next.language : '';
             return live || localStorage.getItem('i18nextLng') || '';
         };
+        await _ensureI18nReady();
 
         // 1) 版本更新日志（先讲背景）
         try {


### PR DESCRIPTION
## 背景

[#2051](https://github.com/Project-N-E-K-O/N.E.K.O/pull/2051) 已合并，修了「Steam 切英文但更新日志弹窗仍中文、问卷正常」——根因是启动流程早于 i18next init 完成就 fetch `/api/changelog`，`window.i18next.language` 为空 → 传 `lang=''` → 后端按中文原文下发；问卷因在用户点完更新日志弹窗后才读所以躲过。

#2051 的修法是「`i18next.language` 为空时回退 `localStorage` 的 `i18nextLng`」。Codex 在合并后留了条 P2 指出这**没真正关掉竞态**，独立核验后成立。

## Codex P2（已验证成立）

`getInitialLanguage()`（`static/i18n-i18next.js`）有两个性质，使 localStorage 兜底在 race 期间可能空/旧：

1. **手动 `uiLanguage` 覆盖不落盘**——只对 query/steam 值 `localStorage.setItem`，`uiLanguage` 分支直接 `return` 不持久化；
2. 首启 `init` 设语言**早于** `languageChanged` 持久化 handler 挂上（handler 在 `finalizeInit → exportNormalFunctions` 才注册）。

所以清过 storage、或用 `uiLanguage` 覆盖的用户，race 期间 `localStorage.i18nextLng` 可能为空或是旧 locale，`_resolveUiLang()` 仍返回 `''`/旧值 → 下发错误语言。

## 改法

把 #2051 的「localStorage 兜底」升级为**先 `await` i18next ready 再取语言**：

- 就绪信号 = `i18next.isInitialized`（已就绪直接过）或 `i18n-i18next.js` 在 `finalizeInit` 派发的 `localechange` 事件；
- `5s setTimeout` 兜底，防 init 卡死无限挂起；
- ready 后 `i18next.language` 即解析后的权威值（含 `uiLanguage` 覆盖），`localStorage` 退化为**仅 init 失败/超时**时的末位兜底。

Steam / query / 手动 `uiLanguage` 三条路径都能拿到真值，不再依赖读取时机。

## 验证

属启动时序竞态，preview 无法稳定重放；已逐链追溯根因 + 对齐仓库既有就绪信号（`localechange` / `isInitialized`），`node --check static/app.js` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 启动时在请求更新日志、问卷和待办通知前，会先确保语言国际化已就绪（最多等待 12 秒），避免因初始化未完成导致请求时序异常。
  * 语言值优先取当前国际化语言标识；若仍未就绪，则回退到已保存的备用语言，降低下发空/错误语言造成的显示问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->