### PR TITLE
fix: sync icebreaker compact caption

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -2524,8 +2524,16 @@
         batch.forEach(function (action) {
             try {
                 if (action.type === 'append' && action.message) {
-                    host.appendMessage(action.message);
                     shouldOpenHost = true;
+                    return Promise.resolve(host.appendMessage(action.message)).then(function (result) {
+                        if (!result) return result;
+                        return waitForIcebreakerChatHostMounted(host).then(function () {
+                            syncIcebreakerAssistantCompactCaption(action.message);
+                            return result;
+                        });
+                    }).catch(function (error) {
+                        console.warn('[NewUserIcebreaker] Failed to append bridge message:', error);
+                    });
                 } else if (action.type === 'set_prompt' && action.prompt && typeof host.setIcebreakerChoicePrompt === 'function') {
                     host.setIcebreakerChoicePrompt(action.prompt);
                     shouldOpenHost = true;
@@ -2558,6 +2566,62 @@
     function clearIcebreakerChoicePromptFromBroadcast(sessionId) {
         if (!isStandaloneChatPage()) return;
         queueIcebreakerBridgeAction({ type: 'clear_prompt', sessionId: String(sessionId || '') });
+    }
+
+    // Also defined in new-user-icebreaker.js for the local chat host path.
+    function getIcebreakerMessageText(message) {
+        var blocks = message && Array.isArray(message.blocks) ? message.blocks : [];
+        for (var i = 0; i < blocks.length; i++) {
+            if (blocks[i] && blocks[i].type === 'text') {
+                var text = String(blocks[i].text || '').trim();
+                if (text) return text;
+            }
+        }
+        return '';
+    }
+
+    function syncIcebreakerAssistantCompactCaption(message) {
+        if (!isStandaloneChatPage() || !message || message.role !== 'assistant') return;
+        var line = getIcebreakerMessageText(message);
+        if (!line) return;
+        var turnId = String(message.turnId || message.id || ('icebreaker-turn-' + Date.now()));
+        try {
+            window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+                detail: {
+                    turnId: turnId,
+                    source: 'new_user_icebreaker'
+                }
+            }));
+            window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+                detail: {
+                    turnId: turnId,
+                    segmentId: turnId + ':icebreaker',
+                    text: line,
+                    source: 'new_user_icebreaker'
+                }
+            }));
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] compact caption sync failed:', error);
+        }
+    }
+
+    function waitForIcebreakerChatHostMounted(host) {
+        return new Promise(function (resolve) {
+            var attempts = 0;
+            function checkMounted() {
+                var isMounted = false;
+                try {
+                    isMounted = !!(host && typeof host.isMounted === 'function' && host.isMounted());
+                } catch (_) {}
+                if (isMounted || attempts >= 100) {
+                    yuiGuideInterpageResources.setTimeout(resolve, 0);
+                    return;
+                }
+                attempts += 1;
+                yuiGuideInterpageResources.setTimeout(checkMounted, 50);
+            }
+            checkMounted();
+        });
     }
 
     function isIcebreakerBridgeAction(action) {

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -546,31 +546,61 @@
         });
     }
 
-    function finalizeIcebreakerAssistantSubtitle(text) {
-        var line = String(text || '').trim();
+    // Also defined in app-interpage.js for the standalone chat bridge path.
+    function getIcebreakerMessageText(message) {
+        var blocks = message && Array.isArray(message.blocks) ? message.blocks : [];
+        for (var i = 0; i < blocks.length; i++) {
+            if (blocks[i] && blocks[i].type === 'text') {
+                var text = String(blocks[i].text || '').trim();
+                if (text) return text;
+            }
+        }
+        return '';
+    }
+
+    function syncIcebreakerAssistantCompactCaption(role, message) {
+        if (role !== 'assistant') return;
+        var line = getIcebreakerMessageText(message);
         if (!line) return;
+        var turnId = String((message && (message.turnId || message.id)) || makeMessageId('icebreaker-turn'));
+        var detail = {
+            turnId: turnId,
+            segmentId: turnId + ':icebreaker',
+            text: line,
+            source: SOURCE
+        };
         try {
-            var bridge = window.subtitleBridge;
-            if (!bridge || typeof bridge.finalizeTurnWithTranslation !== 'function') {
-                return;
-            }
-            if (typeof bridge.beginTurn === 'function') {
-                bridge.beginTurn({ latch: false });
-            }
-            var result = bridge.finalizeTurnWithTranslation(line);
-            if (result && typeof result.catch === 'function') {
-                result.catch(function (error) {
-                    console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
-                });
-            }
+            window.dispatchEvent(new CustomEvent('neko-assistant-turn-start', {
+                detail: {
+                    turnId: turnId,
+                    source: SOURCE
+                }
+            }));
+            window.dispatchEvent(new CustomEvent('neko-compact-caption-update', {
+                detail: detail
+            }));
         } catch (error) {
-            console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
+            console.warn('[NewUserIcebreaker] compact caption sync failed:', error);
         }
     }
 
-    function syncIcebreakerAssistantSubtitle(role, contextOk, text) {
-        if (role !== 'assistant' || contextOk !== true) return;
-        finalizeIcebreakerAssistantSubtitle(text);
+    function waitForIcebreakerChatHostMounted(host) {
+        return new Promise(function (resolve) {
+            var attempts = 0;
+            function checkMounted() {
+                var isMounted = false;
+                try {
+                    isMounted = !!(host && typeof host.isMounted === 'function' && host.isMounted());
+                } catch (_) {}
+                if (isMounted || attempts >= 100) {
+                    window.setTimeout(resolve, 0);
+                    return;
+                }
+                attempts += 1;
+                window.setTimeout(checkMounted, 50);
+            }
+            checkMounted();
+        });
     }
 
     function appendChatMessage(role, text, meta) {
@@ -591,19 +621,25 @@
             icebreaker: Object.assign({ source: SOURCE }, meta || {})
         };
         broadcastIcebreakerAppendMessage(message);
-        return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {
+        return appendLlmContext(role, messageText, meta || {}).then(function () {
             if (!shouldRenderIcebreakerOnLocalChatHost()) {
-                syncIcebreakerAssistantSubtitle(role, contextOk, messageText);
+                // The standalone /chat page applies both append and compact caption sync
+                // from the broadcast receiver in app-interpage.js.
                 return message;
             }
+            var chatHost = null;
             return waitForChatHost(30000).then(function (host) {
+                chatHost = host;
                 if (typeof host.openWindow === 'function') {
                     host.openWindow();
                 }
                 return host.appendMessage(message);
             }).then(function (result) {
-                syncIcebreakerAssistantSubtitle(role, contextOk, messageText);
-                return result;
+                if (!result) return result;
+                return waitForIcebreakerChatHostMounted(chatHost).then(function () {
+                    syncIcebreakerAssistantCompactCaption(role, message);
+                    return result;
+                });
             });
         }).catch(function (error) {
             console.warn('[NewUserIcebreaker] append message failed:', error);

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -15,6 +15,7 @@ APP_WEBSOCKET_PATH = ROOT / "static" / "app-websocket.js"
 APP_PROACTIVE_PATH = ROOT / "static" / "app-proactive.js"
 APP_PROMPT_PATH = ROOT / "static" / "tutorial" / "core" / "app-prompt.js"
 UNIVERSAL_TUTORIAL_MANAGER_PATH = ROOT / "static" / "tutorial" / "core" / "universal-manager.js"
+APP_INTERPAGE_PATH = ROOT / "static" / "app-interpage.js"
 INDEX_TEMPLATE_PATH = ROOT / "templates" / "index.html"
 WEBSOCKET_ROUTER_PATH = ROOT / "main_routers" / "websocket_router.py"
 GAME_ROUTER_PATH = ROOT / "main_routers" / "game_router.py"
@@ -374,7 +375,7 @@ def test_icebreaker_context_appends_are_serialized_before_chat_progression():
         "function speakViaProjectTts",
         1,
     )[0]
-    context_then = "return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {"
+    context_then = "return appendLlmContext(role, messageText, meta || {}).then(function () {"
     assert context_then in append_message_block
     assert "broadcastIcebreakerAppendMessage(message);" in append_message_block
     assert append_message_block.index("broadcastIcebreakerAppendMessage(message);") < append_message_block.index(
@@ -388,7 +389,7 @@ def test_icebreaker_context_appends_are_serialized_before_chat_progression():
 def test_icebreaker_context_append_requires_successful_json_payload():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
     append_context_block = runtime.split("function appendLlmContext(role, text, meta)", 1)[1].split(
-        "function finalizeIcebreakerAssistantSubtitle(text)",
+        "function getIcebreakerMessageText(message)",
         1,
     )[0]
 
@@ -410,36 +411,49 @@ def test_icebreaker_context_append_requires_successful_json_payload():
     assert "return true;" not in append_context_block
 
 
-def test_icebreaker_assistant_messages_finalize_subtitle_translation_like_normal_chat():
+def test_icebreaker_assistant_messages_update_compact_caption_like_normal_chat():
     runtime = RUNTIME_PATH.read_text(encoding="utf-8")
-    subtitle_runtime = SUBTITLE_PATH.read_text(encoding="utf-8")
+    interpage_runtime = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
 
-    assert "function finalizeIcebreakerAssistantSubtitle(text)" in runtime
-    subtitle_block = runtime.split("function finalizeIcebreakerAssistantSubtitle(text)", 1)[1].split(
+    assert "function syncIcebreakerAssistantCompactCaption(role, message)" in runtime
+    assert "function waitForIcebreakerChatHostMounted(host)" in runtime
+    sync_block = runtime.split("function syncIcebreakerAssistantCompactCaption(role, message)", 1)[1].split(
         "function appendChatMessage(role, text, meta)",
         1,
     )[0]
-    assert "window.subtitleBridge" in subtitle_block
-    assert "bridge.beginTurn({ latch: false })" in subtitle_block
-    assert "bridge.beginTurn()" not in subtitle_block
-    assert "bridge.finalizeTurnWithTranslation(line)" in subtitle_block
-    assert "console.warn('[NewUserIcebreaker] subtitle translation failed:'" in subtitle_block
-    begin_turn_block = subtitle_runtime.split("function beginSubtitleTurn(", 1)[1].split(
-        "function onAssistantTurnStart()",
-        1,
-    )[0]
-    assert "options && options.latch === false" in begin_turn_block
-    assert "turnBoundaryLatched = !skipLatch;" in begin_turn_block
-
-    sync_block = runtime.split("function syncIcebreakerAssistantSubtitle(role, contextOk, text)", 1)[1].split(
-        "function appendChatMessage(role, text, meta)",
-        1,
-    )[0]
-    assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
+    assert "if (role !== 'assistant') return;" in sync_block
+    assert "window.dispatchEvent(new CustomEvent('neko-assistant-turn-start'" in sync_block
+    assert "window.dispatchEvent(new CustomEvent('neko-compact-caption-update'" in sync_block
+    assert "window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable'" not in sync_block
+    assert "window.dispatchEvent(new CustomEvent('neko-assistant-turn-end'" not in sync_block
+    assert "segmentId: turnId + ':icebreaker'" in sync_block
+    assert "source: SOURCE" in sync_block
     assert "openSubtitleTranslationForIcebreakerAssistantMessage()" not in sync_block
     assert "setSubtitleEnabled(true" not in sync_block
     assert "setTranslateEnabled(true" not in sync_block
-    assert "finalizeIcebreakerAssistantSubtitle(text);" in sync_block
+    assert "subtitleBridge" not in sync_block
+    assert "finalizeTurnWithTranslation" not in sync_block
+
+    assert "function syncIcebreakerAssistantCompactCaption(message)" in interpage_runtime
+    assert "function waitForIcebreakerChatHostMounted(host)" in interpage_runtime
+    interpage_compact_block = interpage_runtime.split(
+        "function syncIcebreakerAssistantCompactCaption(message)", 1
+    )[1].split("function isIcebreakerBridgeAction", 1)[0]
+    assert "if (!isStandaloneChatPage() || !message || message.role !== 'assistant') return;" in interpage_compact_block
+    assert "window.dispatchEvent(new CustomEvent('neko-assistant-turn-start'" in interpage_compact_block
+    assert "window.dispatchEvent(new CustomEvent('neko-compact-caption-update'" in interpage_compact_block
+    assert "window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable'" not in interpage_compact_block
+    assert "window.dispatchEvent(new CustomEvent('neko-assistant-turn-end'" not in interpage_compact_block
+    assert "return Promise.resolve(host.appendMessage(action.message)).then(function (result) {" in interpage_runtime
+    assert "return waitForIcebreakerChatHostMounted(host).then(function () {" in interpage_runtime
+    assert "syncIcebreakerAssistantCompactCaption(action.message);" in interpage_runtime
+    assert interpage_runtime.index("return Promise.resolve(host.appendMessage(action.message)).then(function (result) {") < interpage_runtime.index(
+        "return waitForIcebreakerChatHostMounted(host).then(function () {"
+    ) < interpage_runtime.index(
+        "syncIcebreakerAssistantCompactCaption(action.message);"
+    )
+    assert "icebreaker_assistant_subtitle" not in runtime
+    assert "icebreaker_assistant_subtitle" not in interpage_runtime
 
 
 def test_icebreaker_assistant_message_does_not_auto_open_subtitle_translation_panel():
@@ -457,24 +471,28 @@ def test_icebreaker_assistant_message_does_not_auto_open_subtitle_translation_pa
     assert "setSubtitleEnabled(true" not in start_block
     assert "setTranslateEnabled(true" not in start_block
 
-    sync_block = runtime.split("function syncIcebreakerAssistantSubtitle(role, contextOk, text)", 1)[1].split(
+    sync_block = runtime.split("function syncIcebreakerAssistantCompactCaption(role, message)", 1)[1].split(
         "function appendChatMessage(role, text, meta)",
         1,
     )[0]
-    assert "if (role !== 'assistant' || contextOk !== true) return;" in sync_block
+    assert "if (role !== 'assistant') return;" in sync_block
     assert "setSubtitleEnabled(true" not in sync_block
     assert "setTranslateEnabled(true" not in sync_block
-    assert "finalizeIcebreakerAssistantSubtitle(text);" in sync_block
+    assert "subtitleBridge" not in sync_block
+    assert "finalizeTurnWithTranslation" not in sync_block
 
     append_message_block = runtime.split("function appendChatMessage(role, text, meta)", 1)[1].split(
         "function speakViaProjectTts",
         1,
     )[0]
-    assert "return appendLlmContext(role, messageText, meta || {}).then(function (contextOk) {" in append_message_block
+    assert "return appendLlmContext(role, messageText, meta || {}).then(function () {" in append_message_block
     assert "return host.appendMessage(message);" in append_message_block
-    assert "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);" in append_message_block
-    assert append_message_block.index("return host.appendMessage(message);") < append_message_block.rindex(
-        "syncIcebreakerAssistantSubtitle(role, contextOk, messageText);"
+    assert "return waitForIcebreakerChatHostMounted(chatHost).then(function () {" in append_message_block
+    assert "syncIcebreakerAssistantCompactCaption(role, message);" in append_message_block
+    assert append_message_block.index("return host.appendMessage(message);") < append_message_block.index(
+        "return waitForIcebreakerChatHostMounted(chatHost).then(function () {"
+    ) < append_message_block.rindex(
+        "syncIcebreakerAssistantCompactCaption(role, message);"
     )
 
 


### PR DESCRIPTION
## 改动概述 / Summary
- 修复破冰 assistant 文案已进入 React 聊天记录，但底部 compact 气泡不刷新或只显示空框的问题。
- 复用现有 `neko-compact-caption-update` 事件链路；不主动宣告 `neko-assistant-speech-unavailable`，无语音场景继续交给 React compact 气泡既有 fallback timer 处理，避免干扰真实 TTS 播放态。
- caption 事件会等 React Chat host mounted 后再派发，避免首次打开聊天框时 listener 尚未注册导致事件丢失。
- 将 UI 显示从 `/api/icebreaker/context` 写入结果中解耦；context 写入失败不再阻断气泡显示，记忆/上下文写入逻辑本身不变。

## 回归报告 / Regression Report
不适用。本 PR 未修改 `app/`、`main_logic/` 或 `memory/`，只调整破冰前端静态脚本与对应静态契约测试。

## 不拆分理由 / Why Not Split
不适用。

## 测试 / Testing
- [x] `uv run pytest tests/unit/test_new_user_icebreaker_static_contracts.py -q`
- [x] `node --check static/tutorial/icebreaker/new-user-icebreaker.js`
- [x] `node --check static/app-interpage.js`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 助手消息新增紧凑字幕/标题同步：在独立聊天场景提取助手文本并触发更新事件，完成追加后自动刷新。
  * 跨页面追加的助手消息同步更可靠：在完成消息追加并等待聊天宿主就绪后再触发紧凑字幕更新。
* **变更**
  * 移除了基于字幕/翻译桥接的紧凑字幕同步链路，改为紧凑字幕事件驱动同步。
* **测试**
  * 更新前端契约测试：调整上下文追加回调校验，并将字幕翻译相关断言替换为紧凑字幕同步与事件触发/顺序验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->