### PR TITLE
修复紧凑聊天框历史收起时，表情包图片尚未加载完成就提前显示关闭叉的问题；关闭按钮现在会等图片加载或失败后再渲染，并补充对应测试

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -879,6 +879,69 @@ describe('App', () => {
     }
   });
 
+  it('renders the meme overlay close button after the image fails to load', async () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    const meme = parseChatMessage({
+      id: 'meme-error-geometry', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=error', alt: 'lol' }], status: 'sent',
+    });
+    const geometryRefreshes: Event[] = [];
+    const handleGeometryRefresh = (event: Event) => geometryRefreshes.push(event);
+    window.addEventListener('neko:compact-interaction-geometry-refresh', handleGeometryRefresh);
+    try {
+      const { container } = render(
+        <App chatSurfaceMode="compact" compactChatState="input" messages={[meme]} />,
+      );
+      await waitFor(() => expect(geometryRefreshes.length).toBeGreaterThan(0));
+      geometryRefreshes.length = 0;
+
+      const img = container.querySelector('.compact-meme-overlay img');
+      expect(img).not.toBeNull();
+      expect(container.querySelector('.compact-meme-overlay-close')).toBeNull();
+      fireEvent.error(img as Element);
+      expect(geometryRefreshes.length).toBe(0);
+      await waitFor(() => expect(geometryRefreshes.length).toBeGreaterThan(0));
+      expect(container.querySelector('.compact-meme-overlay-close')).not.toBeNull();
+    } finally {
+      window.removeEventListener('neko:compact-interaction-geometry-refresh', handleGeometryRefresh);
+    }
+  });
+
+  it('does not reuse a loaded meme overlay close button after history remounts the same image', async () => {
+    window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
+    const meme = parseChatMessage({
+      id: 'meme-history-remount', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
+      blocks: [{ type: 'image', url: '/api/meme/proxy-image?url=history-remount', alt: 'lol' }], status: 'sent',
+    });
+    vi.useFakeTimers();
+    try {
+      const { container } = render(
+        <App chatSurfaceMode="compact" compactChatState="input" messages={[meme]} />,
+      );
+
+      const firstImage = container.querySelector('.compact-meme-overlay img');
+      fireEvent.load(firstImage as Element);
+      expect(container.querySelector('.compact-meme-overlay-close')).not.toBeNull();
+
+      fireEvent.click(container.querySelector<HTMLButtonElement>('.compact-history-visibility-handle')!);
+      expect(container.querySelector('.compact-meme-overlay')).toBeNull();
+
+      fireEvent.click(container.querySelector<HTMLButtonElement>('.compact-history-visibility-handle')!);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(COMPACT_EXPORT_HISTORY_VISIBILITY_ANIMATION_MS);
+      });
+
+      const remountedImage = container.querySelector('.compact-meme-overlay img');
+      expect(remountedImage).toHaveAttribute('src', '/api/meme/proxy-image?url=history-remount');
+      expect(container.querySelector('.compact-meme-overlay-close')).toBeNull();
+
+      fireEvent.load(remountedImage as Element);
+      expect(container.querySelector('.compact-meme-overlay-close')).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('shows a newer meme even after the previous one was manually closed', () => {
     window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
     const memeA = parseChatMessage({

--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -822,7 +822,7 @@ describe('App', () => {
     expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=t1');
   });
 
-  it('renders a close button on the meme overlay and hides the overlay when clicked', () => {
+  it('renders the meme overlay close button after the image loads and hides the overlay when clicked', async () => {
     window.localStorage.setItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY, 'false');
     const meme = parseChatMessage({
       id: 'meme-closeme', role: 'assistant', author: 'Neko', time: '10:00', createdAt: 1,
@@ -831,12 +831,16 @@ describe('App', () => {
     const { container } = render(
       <App chatSurfaceMode="compact" compactChatState="input" messages={[meme]} />,
     );
+    const img = container.querySelector('.compact-meme-overlay img');
+    expect(img).toHaveAttribute('src', '/api/meme/proxy-image?url=close');
+    expect(container.querySelector('.compact-meme-overlay-close')).toBeNull();
+
+    fireEvent.load(img as Element);
+    await waitFor(() => expect(container.querySelector('.compact-meme-overlay-close')).not.toBeNull());
     const closeButton = container.querySelector('.compact-meme-overlay-close');
-    expect(closeButton).not.toBeNull();
     // ⚠️ host 只把带 data-compact-hit-region 的子元素登记成 native 可交互区；漏了它 Electron
     // pass-through 窗口里点击会穿到桌面（见 app-react-chat-window.js collectCompactCompositeGeometryItems）。
     expect(closeButton).toHaveAttribute('data-compact-hit-region', 'true');
-    expect(container.querySelector('.compact-meme-overlay img')).toHaveAttribute('src', '/api/meme/proxy-image?url=close');
 
     fireEvent.click(closeButton as Element);
     expect(container.querySelector('.compact-meme-overlay')).toBeNull();
@@ -860,9 +864,11 @@ describe('App', () => {
 
       const img = container.querySelector('.compact-meme-overlay img');
       expect(img).not.toBeNull();
+      expect(container.querySelector('.compact-meme-overlay-close')).toBeNull();
       fireEvent.load(img as Element);
       expect(geometryRefreshes.length).toBe(0);
       await waitFor(() => expect(geometryRefreshes.length).toBeGreaterThan(0));
+      expect(container.querySelector('.compact-meme-overlay-close')).not.toBeNull();
       geometryRefreshes.length = 0;
 
       fireEvent.click(container.querySelector('.compact-meme-overlay-close') as Element);
@@ -882,6 +888,9 @@ describe('App', () => {
     const { container, rerender } = render(
       <App chatSurfaceMode="compact" compactChatState="input" messages={[memeA]} />,
     );
+    const memeAImage = container.querySelector('.compact-meme-overlay img');
+    fireEvent.load(memeAImage as Element);
+    expect(container.querySelector('.compact-meme-overlay-close')).not.toBeNull();
     fireEvent.click(container.querySelector('.compact-meme-overlay-close') as Element);
     expect(container.querySelector('.compact-meme-overlay')).toBeNull();
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2568,7 +2568,7 @@ function CompactChatApp({
     scheduleCompactMemeGeometryRefresh();
   }, [compactMemeOverlayLoadKey, scheduleCompactMemeGeometryRefresh]);
   const handleCompactMemeOverlayImageRef = useCallback((node: HTMLImageElement | null) => {
-    if (!node?.complete || node.naturalWidth <= 0) return;
+    if (!node?.complete) return;
     markCompactMemeOverlayImageSettled();
   }, [markCompactMemeOverlayImageSettled]);
 

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -2572,6 +2572,15 @@ function CompactChatApp({
     markCompactMemeOverlayImageSettled();
   }, [markCompactMemeOverlayImageSettled]);
 
+  useLayoutEffect(() => {
+    setLoadedMemeOverlayKey(current => {
+      if (!compactMemeOverlayVisible || compactMemeOverlayLoadKey === null) {
+        return current === null ? current : null;
+      }
+      return current === compactMemeOverlayLoadKey ? current : null;
+    });
+  }, [compactMemeOverlayLoadKey, compactMemeOverlayVisible]);
+
   useEffect(() => () => {
     if (typeof window === 'undefined') return;
     if (compactMemeGeometryFrameRef.current === null) return;

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1745,6 +1745,7 @@ function CompactChatApp({
   // 用户手动叉掉的表情包 id（会话级，不持久化）：overlay 的 meme id 命中即隐藏。下一张新 meme 是不同
   // id，自然重新显示；刷新后状态重置（与 compactCaptionState 等紧凑挂件一致，均为 ephemeral state）。
   const [dismissedMemeId, setDismissedMemeId] = useState<string | null>(null);
+  const [loadedMemeOverlayKey, setLoadedMemeOverlayKey] = useState<string | null>(null);
   const [compactAssistantStreamingGap, setCompactAssistantStreamingGap] = useState<{
     turnId: string;
     acceptStreaming: boolean;
@@ -2540,6 +2541,11 @@ function CompactChatApp({
   const compactMemeGeometryKey = compactMemeOverlay
     ? `${compactMemeOverlay.id}:${compactMemeOverlayVisible ? 'visible' : 'hidden'}`
     : 'none';
+  const compactMemeOverlayLoadKey = compactMemeOverlay
+    ? `${compactMemeOverlay.id}:${compactMemeOverlay.url}`
+    : null;
+  const compactMemeOverlayImageSettled = compactMemeOverlayLoadKey !== null
+    && loadedMemeOverlayKey === compactMemeOverlayLoadKey;
   const lastCompactMemeGeometryKeyRef = useRef<string | null>(null);
   const compactMemeGeometryFrameRef = useRef<number | null>(null);
   const requestCompactMemeGeometryRefresh = useCallback(() => {
@@ -2556,6 +2562,15 @@ function CompactChatApp({
       requestCompactMemeGeometryRefresh();
     });
   }, [requestCompactMemeGeometryRefresh]);
+  const markCompactMemeOverlayImageSettled = useCallback(() => {
+    if (compactMemeOverlayLoadKey === null) return;
+    setLoadedMemeOverlayKey(compactMemeOverlayLoadKey);
+    scheduleCompactMemeGeometryRefresh();
+  }, [compactMemeOverlayLoadKey, scheduleCompactMemeGeometryRefresh]);
+  const handleCompactMemeOverlayImageRef = useCallback((node: HTMLImageElement | null) => {
+    if (!node?.complete || node.naturalWidth <= 0) return;
+    markCompactMemeOverlayImageSettled();
+  }, [markCompactMemeOverlayImageSettled]);
 
   useEffect(() => () => {
     if (typeof window === 'undefined') return;
@@ -7126,43 +7141,46 @@ function CompactChatApp({
           alt={compactMemeOverlay.alt}
           loading="eager"
           decoding="async"
-          onLoad={scheduleCompactMemeGeometryRefresh}
-          onError={scheduleCompactMemeGeometryRefresh}
+          ref={handleCompactMemeOverlayImageRef}
+          onLoad={markCompactMemeOverlayImageSettled}
+          onError={markCompactMemeOverlayImageSettled}
         />
         {/* 关闭叉：overlay 整体 pointer-events:none（点击穿透到桌面/下层），唯独这个按钮 CSS 里单独开
             auto 才接得住点击；点了把当前 meme id 记进 dismissedMemeId（会话级），下一张新 meme 照常显示。
             ⚠️ data-compact-hit-region 必带：overlay 的 data-compact-geometry-hit-scope="children" 让 host
             只把带该标记的子元素登记成 native 可交互区（见 app-react-chat-window.js collectCompactCompositeGeometryItems）。
             漏了它，Electron pass-through 窗口会把按钮当穿透区、点击穿到桌面（普通浏览器窗口测不出，对齐音乐条）。 */}
-        <button
-          type="button"
-          className="compact-meme-overlay-close"
-          data-compact-hit-region="true"
-          data-compact-hit-region-id="meme:close"
-          data-compact-hit-region-kind="meme-close"
-          aria-label={closeMemeButtonAriaLabel}
-          title={closeMemeButtonAriaLabel}
-          onClick={(event) => {
-            event.stopPropagation();
-            setDismissedMemeId(compactMemeOverlay.id);
-          }}
-        >
-          <svg
-            className="compact-meme-overlay-close-icon"
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            focusable="false"
+        {compactMemeOverlayImageSettled ? (
+          <button
+            type="button"
+            className="compact-meme-overlay-close"
+            data-compact-hit-region="true"
+            data-compact-hit-region-id="meme:close"
+            data-compact-hit-region-kind="meme-close"
+            aria-label={closeMemeButtonAriaLabel}
+            title={closeMemeButtonAriaLabel}
+            onClick={(event) => {
+              event.stopPropagation();
+              setDismissedMemeId(compactMemeOverlay.id);
+            }}
           >
-            <path
-              d="M4.5 4.5 11.5 11.5 M11.5 4.5 4.5 11.5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
+            <svg
+              className="compact-meme-overlay-close-icon"
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                d="M4.5 4.5 11.5 11.5 M11.5 4.5 4.5 11.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        ) : null}
       </div>
     </div>
   ) : null;


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复紧凑聊天框历史收起时，表情包图片尚未加载完成就提前显示关闭叉的问题；关闭按钮现在会等图片加载或失败后再渲染，并补充对应测试

## 测试 / Testing

手动测试表情包搭话


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 主动表情包（meme overlay）的关闭按钮仅在图片加载/结算完成后显示，提升误触防护。
  * 图片结算后会触发布局几何刷新，增强紧凑视图交互稳定性。
* **Bug 修复**
  * 修复关闭按钮显示时序不稳定：加载前不出现，加载/失败后按正确时机出现。
  * 修复历史区复挂同图时关闭按钮复用问题；重新加载后才可用。
  * 修复手动关闭后切换新表情包时关闭按钮可用性问题。
* **Tests**
  * 更新并扩展相关测试场景与断言顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->