### PR TITLE
fix(onboarding): 新手教程上锁前置 pending 信号，修首启选人格与教程并发弹出

### DIFF
--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -203,6 +203,10 @@
         }
 
         async openFromSettings(characterName) {
+            // _tutorialFlowAborted 是 manager 上的持久标志，而 handleHomeTutorialStartupRelease 监听的
+            // startup-greeting-release(released:true) 在教程正常完成/无 round 时也会派发并置位它。设置里的人格
+            // 重选属于独立的一次等待，进等待前清掉上一程教程遗留的 abort，避免越过当前仍在运行的教程锁直接弹出。
+            this._tutorialFlowAborted = false;
             await this.waitForTutorialFlowToSettle();
             this.openReason = 'settings';
             this.currentCharacterName = String(characterName || '').trim() || await this.fetchCurrentCharacterName();

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -23,6 +23,8 @@
     const HOME_TUTORIAL_RESET_EVENT = 'neko:home-tutorial-reset';
     const HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY = 'neko_home_tutorial_reset_event';
     const HOME_TUTORIAL_RESET_CHANNEL = 'neko_tutorial_events';
+    // 与 universal-manager.js / app-websocket.js 同名：教程派发的「启动问候放行」事件。
+    const STARTUP_GREETING_RELEASE_EVENT = 'neko:startup-greeting-release';
 
     function interpolateTemplate(template, options) {
         return String(template || '').replace(/{{\s*(\w+)\s*}}/g, (_, name) => {
@@ -290,6 +292,7 @@
 
             const manager = window.universalTutorialManager || null;
             if (window.isInTutorial === true
+                || window.isNekoHomeTutorialPending === true
                 || (manager && manager.currentPage === 'home' && manager.isTutorialRunning)) {
                 return true;
             }
@@ -640,6 +643,21 @@
                 void this.openIfPending();
             };
 
+            const handleHomeTutorialStartupRelease = (event) => {
+                const detail = event && event.detail;
+                // released:true = 教程已决定不启动（夭折）或已结束（dispatchStartupGreetingRelease），不会再占屏；
+                // released:false 是教程正在启动（clearStartupGreetingRelease），由 isTutorialRunning 接管，跳过。
+                if (!detail || detail.released !== true) {
+                    return;
+                }
+                if (!this.shouldRespectHomeTutorialGate()) {
+                    return;
+                }
+                // 停止等待新手教程、放行选人格。否则在「教程夭折」一类没有 tutorial-completed/skipped 事件的路径上，
+                // pending 被 choke point 清除后 settle 轮询会卡在新用户 observing 态永不 resolve（永远不弹选人格）。
+                this._tutorialFlowAborted = true;
+            };
+
             const resetHomeTutorialCompletedFromStorage = (event) => {
                 if (!event || event.key !== HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY || !event.newValue) {
                     return;
@@ -653,6 +671,7 @@
 
             window.addEventListener(HOME_TUTORIAL_RESET_EVENT, resetHomeTutorialCompleted);
             window.addEventListener('storage', resetHomeTutorialCompletedFromStorage);
+            window.addEventListener(STARTUP_GREETING_RELEASE_EVENT, handleHomeTutorialStartupRelease);
             window.addEventListener('neko:tutorial-started', queueResume);
             window.addEventListener('neko:tutorial-completed', markHomeTutorialCompleted);
             window.addEventListener('neko:tutorial-skipped', markHomeTutorialCompleted);

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -203,10 +203,14 @@
         }
 
         async openFromSettings(characterName) {
-            // _tutorialFlowAborted 是 manager 上的持久标志，而 handleHomeTutorialStartupRelease 监听的
-            // startup-greeting-release(released:true) 在教程正常完成/无 round 时也会派发并置位它。设置里的人格
-            // 重选属于独立的一次等待，进等待前清掉上一程教程遗留的 abort，避免越过当前仍在运行的教程锁直接弹出。
-            this._tutorialFlowAborted = false;
+            // _tutorialFlowAborted 是 manager 上的持久标志，handleHomeTutorialStartupRelease 在教程正常完成/夭折
+            // (released:true) 时也会置位它。设置里的人格重选是独立的一次等待：仅当此刻确有教程占屏(locked)时才清掉
+            // 遗留的 abort 去重新等待（治 Codex 指出的「遗留 abort 让重选越过运行中教程」）；若当前无锁则保留 abort，
+            // 否则清掉后 settle 会在新用户 observing/new 上无限轮询且不会再有 release（Greptile 指出的反向死锁）。
+            // 用可靠的 isHomeTutorialInteractionLocked 判定，而非会被 app-websocket 消费删除的 __NEKO_STARTUP_GREETING_RELEASED__。
+            if (this.isHomeTutorialInteractionLocked()) {
+                this._tutorialFlowAborted = false;
+            }
             await this.waitForTutorialFlowToSettle();
             this.openReason = 'settings';
             this.currentCharacterName = String(characterName || '').trim() || await this.fetchCurrentCharacterName();

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -3049,7 +3049,9 @@ class UniversalTutorialManager {
                 this.startTutorialWhenI18nReady(1500);
             });
         } else if (this.currentPage === 'home') {
-            this.setHomeTutorialPending(true);
+            // 老用户每日教程不置 pending：这里多数天根本没 round（要到 maybeStartAvatarFloatingGuideAutoRound
+            // 之后才知道），且老用户 onboarding 早已完成、选人格不会再 pending，无收益却会在无 round 日白挡门控。
+            // 首启并发的 bug 只发生在上面的新用户 Day1 分支。
             this.waitForFloatingButtons().then((found) => {
                 if (!found) {
                     this.dispatchStartupGreetingRelease('floating-buttons-not-found');

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -489,6 +489,8 @@ class UniversalTutorialManager {
     }
 
     dispatchStartupGreetingRelease(reason, detail = {}) {
+        // 放行启动问候即代表新手教程这一程不会再占屏（夭折未启动，或已结束），结束 pending 窗口。
+        this.setHomeTutorialPending(false);
         const releaseDetail = Object.assign({
             released: true,
             page: this.currentPage,
@@ -507,6 +509,8 @@ class UniversalTutorialManager {
     }
 
     clearStartupGreetingRelease(reason = 'tutorial-started') {
+        // 教程已进入运行态（isTutorialRunning/isInTutorial 已置），由运行锁接管占屏，结束 pending 窗口。
+        this.setHomeTutorialPending(false);
         try {
             const detail = window.__NEKO_STARTUP_GREETING_RELEASED__;
             if (detail && detail.released === true) {
@@ -523,6 +527,16 @@ class UniversalTutorialManager {
         } catch (error) {
             console.warn('[Tutorial] 启动问候放行状态清理失败:', error);
         }
+    }
+
+    setHomeTutorialPending(pending) {
+        // 新手教程「即将运行但尚未上锁」窗口的标志。冷启动加载 Live2D 模型与首句演出期间，
+        // isTutorialRunning / window.isInTutorial 都还没置上、后端 tutorial-prompt 仍是 observing，
+        // 选人格门控（character_personality_onboarding.js 的 isHomeTutorialInteractionLocked）靠这个旗子
+        // 提前知道教程马上要占屏，避免「上锁前的长 await 链超过选人格 15s 超时 → 选人格与新手教程并发弹出」。
+        // 仅由 dispatchStartupGreetingRelease（教程不启动/已结束）与 clearStartupGreetingRelease（教程已上锁接管）
+        // 这对 choke point 收口清除，凡是不启动的出口都必经前者，天然 deadlock-safe。
+        window.isNekoHomeTutorialPending = pending === true;
     }
 
     loadAvatarFloatingGuideState() {
@@ -3023,6 +3037,9 @@ class UniversalTutorialManager {
         const hasSeen = localStorage.getItem(storageKey);
 
         if (!hasSeen && this.currentPage === 'home') {
+            // 新手教程即将启动：先置 pending，让选人格门控在「模型加载/首句演出尚未上锁」这段窗口里
+            // 也把教程视作占屏，避免选人格抢在新手教程之前弹出（上锁前的长 await 链可能超过选人格 15s 超时）。
+            this.setHomeTutorialPending(true);
             this.waitForFloatingButtons().then((found) => {
                 if (!found) {
                     console.warn('[Tutorial] 浮动按钮始终未出现，跳过主页引导');
@@ -3032,6 +3049,7 @@ class UniversalTutorialManager {
                 this.startTutorialWhenI18nReady(1500);
             });
         } else if (this.currentPage === 'home') {
+            this.setHomeTutorialPending(true);
             this.waitForFloatingButtons().then((found) => {
                 if (!found) {
                     this.dispatchStartupGreetingRelease('floating-buttons-not-found');
@@ -3627,6 +3645,8 @@ window.universalTutorialManager = null;
 window.__universalTutorialManagerResizeRetryBound = false;
 
 function dispatchStartupGreetingReleaseWithoutManager(reason, detail = {}) {
+    // 无管理器路径（如移动端禁用教程）同样代表新手教程不会占屏，清除 pending 兜底，避免选人格被永久挡住。
+    window.isNekoHomeTutorialPending = false;
     const releaseDetail = Object.assign({
         released: true,
         page: 'unknown',

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -779,8 +779,9 @@ def test_onboarding_does_not_open_while_home_tutorial_start_is_locked(mock_page:
 
 @pytest.mark.frontend
 def test_onboarding_does_not_open_while_home_tutorial_is_pending(mock_page: Page):
-    """新手教程上锁前的 pending 窗口（冷启动加载模型/首句演出）也应挡住选人格，
-    避免选人格抢在新手教程之前与其并发弹出。即使 15s 超时先到也要继续等。"""
+    """The pre-lock pending window (cold-start model / first-line intro load) must also
+    hold back persona onboarding so it cannot race ahead of the home tutorial; persona
+    keeps waiting even when the 15s settle timeout fires first."""
     _bootstrap_page(mock_page)
     mock_page.evaluate(
         """
@@ -833,9 +834,10 @@ def test_onboarding_does_not_open_while_home_tutorial_is_pending(mock_page: Page
 
 @pytest.mark.frontend
 def test_onboarding_opens_when_pending_home_tutorial_aborts_via_startup_release(mock_page: Page):
-    """死锁安全：新手教程在 pending 后夭折（未启动，无 tutorial-completed/skipped 事件、
-    后端仍是新用户 observing 永不 settle）时，凭教程派发的 startup-greeting-release(released:true)
-    放行选人格，避免选人格被永久挡住。"""
+    """Deadlock safety: when a pending home tutorial aborts (never starts, so there is no
+    tutorial-completed/skipped event and the backend stays new-user 'observing' which never
+    settles), persona onboarding is released by the tutorial's startup-greeting-release
+    (released:true) event instead of being blocked forever."""
     _bootstrap_page(mock_page)
     mock_page.evaluate(
         """

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -887,6 +887,96 @@ def test_onboarding_opens_when_pending_home_tutorial_aborts_via_startup_release(
 
 
 @pytest.mark.frontend
+def test_settings_reselect_does_not_hang_after_tutorial_release_when_unlocked(mock_page: Page):
+    """Greptile P1 / deadlock safety: openFromSettings must NOT reset the persistent
+    _tutorialFlowAborted flag when no tutorial is locked. After a startup-greeting-release
+    (released:true) latched the abort with the backend stuck at new-user 'observing' (which never
+    settles and yields no further release), a reset would make waitForTutorialFlowToSettle poll
+    forever and the settings reselect would hang. Keeping the abort lets it open immediately."""
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__tutorialPromptStatePayload = {
+                status: 'observing',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            // 教程在选人格 settle 之前夭折：abort 标志被监听置位，且当前无任何教程锁。
+            window.dispatchEvent(new CustomEvent('neko:startup-greeting-release', {
+                detail: { released: true, page: 'home', reason: 'floating-buttons-not-found' }
+            }));
+            window.CharacterPersonalityOnboarding.openFromSettings('小天');
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_settings_reselect_waits_for_running_home_tutorial(mock_page: Page):
+    """Codex P2 counterpart: when a tutorial IS locked/running at settings-reselect time, the stale
+    abort flag must be cleared so the reselect waits instead of appearing over the running tutorial."""
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = true;
+            window.__tutorialPromptStatePayload = {
+                status: 'started',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            // 先前教程曾结束并置位过 abort，但现在又有教程在运行。
+            window.CharacterPersonalityOnboarding._tutorialFlowAborted = true;
+            window.CharacterPersonalityOnboarding.openFromSettings('小天');
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(150)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+            window.dispatchEvent(new CustomEvent('neko:tutorial-completed', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
 def test_onboarding_waits_when_default_character_makes_new_user_look_existing(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -778,6 +778,113 @@ def test_onboarding_does_not_open_while_home_tutorial_start_is_locked(mock_page:
 
 
 @pytest.mark.frontend
+def test_onboarding_does_not_open_while_home_tutorial_is_pending(mock_page: Page):
+    """新手教程上锁前的 pending 窗口（冷启动加载模型/首句演出）也应挡住选人格，
+    避免选人格抢在新手教程之前与其并发弹出。即使 15s 超时先到也要继续等。"""
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            const realSetTimeout = window.setTimeout.bind(window);
+            window.setTimeout = (callback, delay, ...args) => {
+                if (delay === 15000) {
+                    return realSetTimeout(callback, 20, ...args);
+                }
+                return realSetTimeout(callback, delay, ...args);
+            };
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.isNekoHomeTutorialPending = true;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: true,
+                manual_home_tutorial_viewed: true,
+                user_cohort: 'existing',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(120)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.isNekoHomeTutorialPending = false;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_onboarding_opens_when_pending_home_tutorial_aborts_via_startup_release(mock_page: Page):
+    """死锁安全：新手教程在 pending 后夭折（未启动，无 tutorial-completed/skipped 事件、
+    后端仍是新用户 observing 永不 settle）时，凭教程派发的 startup-greeting-release(released:true)
+    放行选人格，避免选人格被永久挡住。"""
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            const realSetTimeout = window.setTimeout.bind(window);
+            window.setTimeout = (callback, delay, ...args) => {
+                if (delay === 15000) {
+                    return realSetTimeout(callback, 20, ...args);
+                }
+                return realSetTimeout(callback, delay, ...args);
+            };
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.isNekoHomeTutorialPending = true;
+            window.__tutorialPromptStatePayload = {
+                status: 'observing',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(120)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.isNekoHomeTutorialPending = false;
+            window.dispatchEvent(new CustomEvent('neko:startup-greeting-release', {
+                detail: { released: true, page: 'home', reason: 'floating-buttons-not-found' }
+            }));
+        }
+        """
+    )
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
 def test_onboarding_waits_when_default_character_makes_new_user_look_existing(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(


### PR DESCRIPTION
## 现象

新电脑首启，引导顺序应为 **存储地址 → 新手教程 → 选人格 → 破冰**，但实际是存储地址之后**选人格与新手教程并发弹出**。

## 根因

选人格 `bootstrap()` 的 15s 超时 fallthrough（`character_personality_onboarding.js`）只判断「教程是否已上锁」（`isHomeTutorialInteractionLocked()`）。而新用户教程真正上锁（`isTutorialRunning` / `window.isInTutorial`，`universal-manager.js` 的 `startAvatarFloatingGuideRound`）位于一条长前置 await 链末端：

```
checkAndStartTutorial → waitForFloatingButtons(≤60s, 内含 waitForLive2dModelLoadIdle ~30s)
                      → startTutorialWhenI18nReady(i18n + 固定 1500ms)
                      → startAvatarFloatingGuideRound  ← 此处才上锁
```

冷机首启加载 Live2D 模型常 > 15s。超时触发时教程尚未上锁 → 选人格 `_tutorialFlowAborted=true` 直接 fallthrough `openIfPending()`（首启后端 `initial_personality_prompt.json` 不存在 → status=`pending`）→ 与仍在启动的教程并发。

正常流程靠 settle loop 经后端 status=`completed` resolve，不受影响；坏在「上锁前的冷启动窗口」被 15s 超时挤穿。底层 fallthrough 是既有设计弱点，#2004 把每日开场演出/模型准备拉长后，把它从「极少触发」变成「首启常态触发」。

## 修复

让教程在「决定自动启动新用户教程」时（**进长 await 链之前**）发布早期占屏信号，选人格门控将其视作教程占屏，超时走「继续等」而非 fallthrough：

- **`universal-manager.js`**：新增 `setHomeTutorialPending()`；在 `checkAndStartTutorial` 两个 home 分支（进 `waitForFloatingButtons` 前）置 `window.isNekoHomeTutorialPending=true`；仅由 `dispatchStartupGreetingRelease`（教程不启动/已结束）与 `clearStartupGreetingRelease`（教程已上锁接管）这对 **既有 choke point** 收口清除 —— 凡是不启动的出口都必经前者，天然 deadlock-safe。
- **`character_personality_onboarding.js`**：`isHomeTutorialInteractionLocked()` 纳入 `isNekoHomeTutorialPending`；并监听 `startup-greeting-release(released:true)`，在**教程夭折**（无 `tutorial-completed/skipped` 事件、后端新用户 `observing` 永不 settle）时放行选人格，避免 pending 清除后卡在 observing 轮询把选人格永久挡住。

`released:true` 仅在「运行前不启动」或「运行后结束」派发，绝不在运行中途 → 不会误放行。

## 测试

- `node --check` 两文件通过。
- 新增 frontend 契约：① pending 期间挡住选人格；② 教程经 startup-greeting-release(released:true) 夭折时放行选人格（验证不死锁）。
- `tests/frontend/test_initial_personality_onboarding.py`（57）+ `test_universal_tutorial_manager_static.py` + `test_websocket_home_tutorial_guard.py` 全绿。

> 该 bug 为首启冷机时序竞态（需全新状态 + 冷加载 Live2D > 15s），preview 无法复现，frontend playwright 契约测试为验证路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能/改进**
  * 新增“启动问候放行”事件常量与监听：在满足家园闸门且放行时中断后续教程等待/轮询。
  * 引入家园教程 pending 门控：放行/清理前后会结束 pending 窗口，设置重选入口对中断标记进行条件重置。
* **Bug 修复**
  * 修复 pending 在管理器缺失/教程禁用等情况下可能遗留卡住的问题。
  * 改善角色个性覆盖层在 pending/放行/解锁时序下的显示稳定性与避免等待卡死。
* **测试**
  * 新增 4 条 Playwright 前端用例覆盖 pending 阻止、放行释放、重选不挂起与运行中解锁流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->