### PR TITLE
fix(proactive): 剥掉主动搭话泄漏的口吻/回忆线索内部标签

### DIFF
--- a/config/prompts/prompts_activity.py
+++ b/config/prompts/prompts_activity.py
@@ -66,6 +66,8 @@ Nested ``{lang_code: {key: str}}`` tables (resolved via
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 
 # ── Old reflection follow-up memory cues ────────────────────────────
 
@@ -1201,6 +1203,86 @@ ACTIVITY_TONE_QUALITY_BARS: dict[str, dict[str, str]] = {
         "witty": "barra de qualidade: se não houver um momento realmente engraçado / que valha o comentário, não force — responda [PASS] desta vez em vez de soltar uma frase sem graça",
     },
 }
+
+
+# ── Echoable internal-label registry (proactive output leak guard) ──
+#
+# The proactive Phase 2 prompt renders tone-angle seeds and memory-cue
+# labels as "<label>：<description>" bullets / lines (full-width "：" for
+# zh/ja, half-width ": " for en/ko/ru/es/pt). The "<label>" half is an
+# internal mnemonic the model is told to *act on*, never to *speak*. Weak
+# models occasionally echo the bare label as the first line of the reply
+# (e.g. saying the angle name out loud), which the client then splits into
+# its own chat bubble.
+#
+# This registry derives that label set straight from the prompt tables so
+# it stays in lock-step as the tables are edited — no hand-maintained
+# denylist to rot. Consumed by the proactive output stripper in
+# ``main_routers/system_router.py``.
+
+_INTENT_LEAK_LABEL_MAXLEN = 40
+
+
+def _label_before_colon(line: str) -> str | None:
+    """Return the heading label before the first colon in a bullet/line.
+
+    Tries the full-width colon first, then the half-width one, so a
+    half-width colon inside a (zh/ja) description is not mistaken for the
+    separator. Returns None when there is no colon, when nothing precedes
+    it, or when the candidate is implausibly long for a label — a colon
+    that actually lives inside the description.
+    """
+    for sep in ('：', ':'):
+        idx = line.find(sep)
+        if idx <= 0:
+            continue
+        label = line[:idx].strip()
+        if label and '\n' not in label and len(label) <= _INTENT_LEAK_LABEL_MAXLEN:
+            return label
+        return None
+    return None
+
+
+@lru_cache(maxsize=1)
+def get_proactive_intent_leak_labels() -> frozenset[str]:
+    """All internal guidance labels that must never reach spoken output.
+
+    Casefolded for case-insensitive matching. Spans every locale on
+    purpose: the leaked label and the real reply may be in different
+    languages, and matching the union is strictly safer than guessing the
+    round's locale.
+    """
+    labels: set[str] = set()
+
+    def _add_before_colon(text: str) -> None:
+        lab = _label_before_colon(text)
+        if lab:
+            labels.add(lab)
+
+    # Tone-angle seeds: "<label>：<description>" bullets.
+    for per_lang in ACTIVITY_TONE_HINTS.values():
+        for variants in per_lang.values():
+            if isinstance(variants, str):
+                variants = [variants]
+            for bullet in variants:
+                _add_before_colon(bullet)
+
+    # Tone quality bars: "<label>：<description>".
+    for per_lang in ACTIVITY_TONE_QUALITY_BARS.values():
+        for bar in per_lang.values():
+            _add_before_colon(bar)
+
+    # Memory-cue intro: opens with "<label>：…".
+    for intro in TOPIC_MEMORY_CUE_INTROS.values():
+        _add_before_colon(intro)
+
+    # Memory-cue per-item labels: bare labels, no colon.
+    for label in TOPIC_MEMORY_CUE_LABELS.values():
+        label = (label or '').strip()
+        if label:
+            labels.add(label)
+
+    return frozenset(label.casefold() for label in labels if label)
 
 
 # ── Propensity directives (positive instructions, not prohibitions) ─

--- a/config/prompts/prompts_activity.py
+++ b/config/prompts/prompts_activity.py
@@ -1226,20 +1226,22 @@ _INTENT_LEAK_LABEL_MAXLEN = 40
 def _label_before_colon(line: str) -> str | None:
     """Return the heading label before the first colon in a bullet/line.
 
-    Tries the full-width colon first, then the half-width one, so a
-    half-width colon inside a (zh/ja) description is not mistaken for the
-    separator. Returns None when there is no colon, when nothing precedes
-    it, or when the candidate is implausibly long for a label — a colon
-    that actually lives inside the description.
+    Splits on the *earliest* colon, whether full-width (zh/ja) or half-width
+    (en/ko/ru/es/pt), so the label boundary is found regardless of which
+    colon style a line uses. Returns None when there is no colon, when
+    nothing precedes it, or when the candidate is implausibly long for a
+    label — a colon that actually lives inside the description.
     """
+    sep_idx = -1
     for sep in ('：', ':'):
         idx = line.find(sep)
-        if idx <= 0:
-            continue
-        label = line[:idx].strip()
-        if label and '\n' not in label and len(label) <= _INTENT_LEAK_LABEL_MAXLEN:
-            return label
+        if idx > 0 and (sep_idx == -1 or idx < sep_idx):
+            sep_idx = idx
+    if sep_idx <= 0:
         return None
+    label = line[:sep_idx].strip()
+    if label and '\n' not in label and len(label) <= _INTENT_LEAK_LABEL_MAXLEN:
+        return label
     return None
 
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -7493,6 +7493,10 @@ async def proactive_chat(request: Request):
                 _cleaned, _leak_tag = _strip_proactive_screen_tag_leak(_cleaned)
                 if _leak_tag:
                     regen_source_tag = _leak_tag
+            # 同初稿：把泄漏的内部引导标签从 regen 产出里剥掉，且必须在下面两道
+            # regen 复读复判（score_draft / 字面相似度）**之前**剥——否则带标签前缀
+            # 的复读会稀释分数绕过 drop。_cleaned 在此一次性规范化，复判与投递共用。
+            _cleaned = _strip_proactive_intent_label_leak(_cleaned)
             # regen 输出 [PASS] / 空 → 等价于"模型放弃了"，drop 而不是退回原文。
             # 显式把 ``regen_source_tag == 'PASS'`` 也算 drop（前面剥过 [TAG] 前缀，
             # _cleaned 已不含字面 "[PASS]"，但 regen_source_tag 记下了是 PASS）。
@@ -7571,12 +7575,10 @@ async def proactive_chat(request: Request):
                     )
                 selected_music_link = None
                 music_content = None
-            # 采用 regen 文本接着走下游 source_tag / TTS 投递
+            # 采用 regen 文本接着走下游 source_tag / TTS 投递（_cleaned 已在上方
+            # 落定时剥过泄漏标签，复读复判与投递共用同一份干净文本）。
             response_text = _cleaned
             full_text = _cleaned
-            # regen 产出同样可能带泄漏标签，且它直接走投递 / 录入 corpus（不再过
-            # 上方 dedup），故在此再剥一次。
-            response_text = _strip_proactive_intent_label_leak(response_text)
 
         has_music_topic = 'music' in active_channels
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2001,6 +2001,78 @@ def _strip_proactive_screen_tag_leak(text: str) -> tuple[str, str]:
     return leading + rest, "CHAT"
 
 
+# Decoration a model may wrap a leaked label in (markdown bold/heading/bullet,
+# CJK + ASCII brackets). Stripped from both ends before matching so e.g.
+# "**屏幕细节轻问**" / "【回忆线索】" still resolve to the bare label.
+_INTENT_LABEL_DECOR = '*-•◦·#`_~【】「」[]《》（）() \t'
+
+
+def _strip_proactive_intent_label_leak(text: str) -> str:
+    """Strip an internal guidance label echoed as a leading heading.
+
+    Weak models sometimes copy a tone-angle seed or memory-cue label from
+    the proactive Phase 2 prompt and emit the bare label as the first line
+    of the reply; the client then splits it into its own chat bubble. Such
+    labels are pure scaffolding and must never be spoken.
+
+    Removes, from the START of ``text`` only and repeating to peel stacked
+    labels:
+    - a standalone first line that exactly matches a known label (optional
+      decoration / trailing colon), when real content follows on a later
+      line;
+    - a leading ``<label>:`` / ``<label>：`` prefix on the first line,
+      keeping the rest of that line as content.
+
+    Exact (decoration-trimmed, casefolded) matching against the derived
+    label set keeps generic words from being scrubbed out of normal speech.
+    Returns ``text`` unchanged when the leading segment is not a known label.
+    """
+    if not text:
+        return text
+    from config.prompts.prompts_activity import get_proactive_intent_leak_labels
+    labels = get_proactive_intent_leak_labels()
+    if not labels:
+        return text
+
+    def _norm(segment: str) -> str:
+        out = segment.strip().strip(_INTENT_LABEL_DECOR)
+        out = out.rstrip('：:').strip(_INTENT_LABEL_DECOR)
+        return out.strip()
+
+    # Bounded peel — a handful of stacked labels at most; never loop the body.
+    for _ in range(4):
+        body = text.lstrip()
+        if not body:
+            break
+        nl = body.find('\n')
+        first = body if nl == -1 else body[:nl]
+        rest = '' if nl == -1 else body[nl + 1:]
+
+        # Case 1: the whole first line is a label, with real content after it.
+        if rest.strip() and _norm(first).casefold() in labels:
+            text = rest
+            continue
+
+        # Case 2: "<label>：<content>" sharing one line.
+        sep_idx = -1
+        for sep in ('：', ':'):
+            idx = first.find(sep)
+            if idx > 0:
+                sep_idx = idx
+                break
+        if sep_idx > 0:
+            cand = _norm(first[:sep_idx]).casefold()
+            after = first[sep_idx + 1:].strip()
+            if cand in labels and (after or rest.strip()):
+                if after:
+                    text = after + ('\n' + rest if rest else '')
+                else:
+                    text = rest
+                continue
+        break
+    return text
+
+
 def _lookup_link_by_title(title: str, all_links: list[dict]) -> dict | None:
     """
     Look up the link matching a Phase 1 output title in all_web_links.
@@ -7614,6 +7686,11 @@ async def proactive_chat(request: Request):
         # 搭话产生即覆盖/清掉旧缓存（非 vision 轮传 None 清），session 侧再用 2
         # 分钟 TTL 兜底过期。
         _stage_vision_screenshot = screenshot_b64_for_phase2 if phase2_use_vision else None
+        # 输出侧兜底：剥掉模型偶尔把活动状态里的「口吻 / 回忆线索」等内部引导标签当成
+        # 首行小标题念出来的泄漏（前端 realistic 模式会把它按换行切成单独一个气泡）。
+        # 这些标签纯属脚手架，绝不该进 TTS / 历史。response_text 同时喂 TTS 与 finish
+        # 历史写入，故在投递前一次性清掉即可覆盖 tagless / tagged / BM25-regen 全部路径。
+        response_text = _strip_proactive_intent_label_leak(response_text)
         try:
             await mgr.feed_tts_chunk(response_text, expected_speech_id=proactive_sid)
             committed = await mgr.finish_proactive_delivery(

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2053,13 +2053,16 @@ def _strip_proactive_intent_label_leak(text: str) -> str:
             text = rest
             continue
 
-        # Case 2: "<label>：<content>" sharing one line.
+        # Case 2: "<label>：<content>" sharing one line. Take the EARLIEST
+        # colon (full- or half-width), not full-width-first — otherwise a
+        # half-width separator followed by a full-width colon in the body
+        # (e.g. "Memory cues: ...：...") would split on the wrong colon and
+        # leave the leading label unstripped.
         sep_idx = -1
         for sep in ('：', ':'):
             idx = first.find(sep)
-            if idx > 0:
+            if idx > 0 and (sep_idx == -1 or idx < sep_idx):
                 sep_idx = idx
-                break
         if sep_idx > 0:
             cand = _norm(first[:sep_idx]).casefold()
             after = first[sep_idx + 1:].strip()
@@ -7291,6 +7294,11 @@ async def proactive_chat(request: Request):
         if _leak_tag and not source_tag:
             source_tag = _leak_tag
         response_text = full_text.strip()
+        # 剥掉模型偶尔把活动状态里的「口吻 / 回忆线索」等内部引导标签当成首行小标题
+        # 念出来的泄漏（前端 realistic 模式会按换行切成单独一个气泡）。必须在下方
+        # 重复度 / BM25 防复读判定**之前**剥：否则被泄漏标签做前缀的复读句会因前缀
+        # 稀释相似度而绕过 dedup。这些标签纯脚手架，绝不该进 TTS / 历史。
+        response_text = _strip_proactive_intent_label_leak(response_text)
         # 不要把 proactive 原文写进 logger（会进日志文件 / 遥测）；只记元数据。
         # 完整原文通过 print 给开发者本地查看。
         logger.debug(f"[{lanlan_name}] Phase 2 流式完成 (vision={phase2_use_vision}, len={len(response_text)} chars)")
@@ -7566,6 +7574,9 @@ async def proactive_chat(request: Request):
             # 采用 regen 文本接着走下游 source_tag / TTS 投递
             response_text = _cleaned
             full_text = _cleaned
+            # regen 产出同样可能带泄漏标签，且它直接走投递 / 录入 corpus（不再过
+            # 上方 dedup），故在此再剥一次。
+            response_text = _strip_proactive_intent_label_leak(response_text)
 
         has_music_topic = 'music' in active_channels
 
@@ -7686,11 +7697,6 @@ async def proactive_chat(request: Request):
         # 搭话产生即覆盖/清掉旧缓存（非 vision 轮传 None 清），session 侧再用 2
         # 分钟 TTL 兜底过期。
         _stage_vision_screenshot = screenshot_b64_for_phase2 if phase2_use_vision else None
-        # 输出侧兜底：剥掉模型偶尔把活动状态里的「口吻 / 回忆线索」等内部引导标签当成
-        # 首行小标题念出来的泄漏（前端 realistic 模式会把它按换行切成单独一个气泡）。
-        # 这些标签纯属脚手架，绝不该进 TTS / 历史。response_text 同时喂 TTS 与 finish
-        # 历史写入，故在投递前一次性清掉即可覆盖 tagless / tagged / BM25-regen 全部路径。
-        response_text = _strip_proactive_intent_label_leak(response_text)
         try:
             await mgr.feed_tts_chunk(response_text, expected_speech_id=proactive_sid)
             committed = await mgr.finish_proactive_delivery(

--- a/tests/unit/test_proactive_intent_label_leak.py
+++ b/tests/unit/test_proactive_intent_label_leak.py
@@ -93,6 +93,14 @@ def test_strip_latin_label_case_insensitive() -> None:
     ) == "that trip you mentioned?"
 
 
+def test_strip_same_line_mixed_colon_takes_earliest() -> None:
+    # Half-width separator, full-width colon later in the body: must split on
+    # the EARLIEST colon, else the leading label is mis-parsed and survives.
+    assert _strip_proactive_intent_label_leak(
+        "Memory cues: that trip：mentioned?"
+    ) == "that trip：mentioned?"
+
+
 # ── False-positive guard ────────────────────────────────────────────
 
 

--- a/tests/unit/test_proactive_intent_label_leak.py
+++ b/tests/unit/test_proactive_intent_label_leak.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Output-side guard: leaked internal guidance labels never reach spoken text.
+
+The proactive Phase 2 prompt feeds the model tone-angle seeds and memory-cue
+labels shaped as ``<label>：<description>``. Weak models sometimes echo the bare
+``<label>`` as the first line of the reply, which the client splits into its own
+chat bubble — the reported screenshot leak (``屏幕细节轻问`` followed by the real
+line) and the older ``回忆 / 线索`` leak. ``_strip_proactive_intent_label_leak``
+removes such a leading label before delivery. These tests pin both the derived
+registry and the stripping behaviour, including the false-positive guard that
+keeps the label words from being scrubbed when they occur in normal speech.
+"""  # noqa: DOCSTRING_CJK
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from config.prompts.prompts_activity import get_proactive_intent_leak_labels
+from main_routers.system_router import _strip_proactive_intent_label_leak
+
+
+# ── Registry derivation ─────────────────────────────────────────────
+
+
+def test_registry_covers_reported_cjk_labels() -> None:
+    labels = get_proactive_intent_leak_labels()
+    for lab in ('屏幕细节轻问', '回忆线索', '较久前的回忆线索', '质量闸',
+                '体察式关心', '纯存在感', '主动关心'):
+        assert lab.casefold() in labels, f"registry missing {lab!r}"
+
+
+def test_registry_covers_latin_labels() -> None:
+    labels = get_proactive_intent_leak_labels()
+    for lab in ('one screen-detail beat', 'pure presence', 'Memory cues',
+                'Older memory cue', 'quality bar', 'between-the-beats soft aside'):
+        assert lab.casefold() in labels, f"registry missing {lab!r}"
+
+
+def test_registry_skips_colonless_sentence_bullets() -> None:
+    # The hushed 2nd bullet is a full sentence with no "<label>：" shape; it must
+    # NOT become a denylist entry (would be an over-broad, sentence-long label).
+    labels = get_proactive_intent_leak_labels()
+    assert '几乎不出声，让存在感和氛围本身兜住这一轮'.casefold() not in labels
+
+
+# ── Stripping behaviour ─────────────────────────────────────────────
+
+
+def test_strip_reported_screenshot_case() -> None:
+    leaked = "屏幕细节轻问\n主人你在合成终端做的这个东西要用来干嘛呀喵"
+    assert _strip_proactive_intent_label_leak(leaked) == \
+        "主人你在合成终端做的这个东西要用来干嘛呀喵"
+
+
+def test_strip_memory_cue_label_standalone_line() -> None:
+    assert _strip_proactive_intent_label_leak("回忆线索\n今天过得怎么样呀") == "今天过得怎么样呀"
+
+
+def test_strip_same_line_label_colon_content() -> None:
+    assert _strip_proactive_intent_label_leak("屏幕细节轻问：你在写什么代码呀") == "你在写什么代码呀"
+    assert _strip_proactive_intent_label_leak("回忆线索：上次说的旅行呢") == "上次说的旅行呢"
+
+
+def test_strip_stacked_labels() -> None:
+    assert _strip_proactive_intent_label_leak("屏幕细节轻问\n回忆线索\n主人在干嘛") == "主人在干嘛"
+
+
+def test_strip_decorated_label() -> None:
+    assert _strip_proactive_intent_label_leak("【屏幕细节轻问】\n你在看啥") == "你在看啥"
+    assert _strip_proactive_intent_label_leak("**屏幕细节轻问**\n你在看啥") == "你在看啥"
+    assert _strip_proactive_intent_label_leak("- 屏幕细节轻问\n你在看啥") == "你在看啥"
+
+
+def test_strip_latin_label_case_insensitive() -> None:
+    assert _strip_proactive_intent_label_leak(
+        "One Screen-Detail Beat\nHey, what are you working on?"
+    ) == "Hey, what are you working on?"
+    assert _strip_proactive_intent_label_leak(
+        "Memory cues: that trip you mentioned?"
+    ) == "that trip you mentioned?"
+
+
+# ── False-positive guard ────────────────────────────────────────────
+
+
+def test_no_strip_when_first_line_not_a_label() -> None:
+    txt = "你在看这个啊？看起来挺有意思的\n是新项目吗"
+    assert _strip_proactive_intent_label_leak(txt) == txt
+
+
+def test_no_strip_label_only_no_following_content() -> None:
+    # Degenerate: only the label, nothing to keep — leave as-is rather than
+    # deliver an empty string.
+    assert _strip_proactive_intent_label_leak("屏幕细节轻问") == "屏幕细节轻问"
+
+
+def test_no_strip_label_words_inside_natural_sentence() -> None:
+    # The label words appearing mid-sentence (not as a heading) must survive.
+    txt = "我刚刚也在想这个屏幕细节，问你一句话哦"
+    assert _strip_proactive_intent_label_leak(txt) == txt
+
+
+def test_empty_input_safe() -> None:
+    assert _strip_proactive_intent_label_leak("") == ""
+    assert _strip_proactive_intent_label_leak("   ") == "   "


### PR DESCRIPTION
## 问题

截图：主动搭话先冒出一条单独的「屏幕细节轻问」气泡（00:28:28），紧接才是真正台词（00:28:30）。此前也有用户遇到第一句被加上「回忆 / 线索」。

**根因**：主动搭话 Phase 2 prompt 把活动状态里的「口吻角度种子」「记忆线索标签」按 `<标签>：<描述>` 渲染给模型看——标签只是内部助记、让模型据此发挥，绝不该说出口。弱模型偶尔把裸标签当首行小标题念出来，`full_text` = `屏幕细节轻问\n<真台词>`，前端 realistic 模式按 `\n` 硬分句 → 切成两个气泡、各自时间戳、~2s 间隔。

**为什么没被现有防护拦住**：已有两道脚手架防护——#1512（缺合法来源标签 → drop/regen）和 #1556（`_strip_proactive_screen_tag_leak` 剥 `[Screen]` 泄漏标签）——都只在「带来源标签」通道（web/music/meme）生效。屏幕轻聊走 `_of_none` 纯文本档（`_expects_source_tag=False`），两道全跳过，泄漏标签直达 TTS。且 `_strip_proactive_screen_tag_leak` 只匹配 `[方括号]`，对裸标签词无效。

## 方案（纯输出侧兜底）

- 新增 `get_proactive_intent_leak_labels()`：从 `ACTIVITY_TONE_HINTS` / `ACTIVITY_TONE_QUALITY_BARS` / `TOPIC_MEMORY_CUE_*` **运行时派生**标签集（全角「：」与半角「: 」都处理、跨 7 语言、`lru_cache`），随表自动同步，不维护硬编码 denylist。
- 新增 `_strip_proactive_intent_label_leak()`：投递前在 `response_text` 上剥掉首行精确匹配的泄漏标签（独立成行，或「标签：正文」同行）。**句首精确匹配**避免误杀正文里偶现的标签词。对偶既有的 `_strip_proactive_screen_tag_leak`。
- 在 Phase 2 投递 choke point（`feed_tts_chunk` 前）调用一次即覆盖 tagless / tagged / BM25-regen 全部路径——`response_text` 同时喂 TTS 与 `finish_proactive_delivery` 历史写入。

prompt 文案只读不改；不动口吻菜单渲染、不动前端分句器（按拍板只做输出侧过滤）。

## 回归报告

**改动文件**
- `config/prompts/prompts_activity.py`（+82）：新增 `_label_before_colon()` + `get_proactive_intent_leak_labels()`，**纯新增**，不改任何现有表 / 渲染逻辑。
- `main_routers/system_router.py`（+77）：新增 `_strip_proactive_intent_label_leak()`，并在 Phase 2 投递前调用一次。
- `tests/unit/test_proactive_intent_label_leak.py`（新增测试，不计入 counted files）。

**理由**：见上「根因 / 方案」。

**前后对比**
- 前：模型输出 `屏幕细节轻问\n主人你在合成终端做的这个东西要用来干嘛呀喵` → 两个气泡（标签 + 台词）。
- 后：剥成 `主人你在合成终端做的这个东西要用来干嘛呀喵` → 一个气泡。`回忆线索\n…` 同理。

**回归范围 / 验证**
- 新增 13 条单测：派生表（CJK + 拉丁 + 跳过无冒号的句子型 bullet）、截图复现、记忆线索族、同行 `标签：正文`、堆叠多标签、`【】`/`**`/`- ` 装饰包裹、拉丁大小写不敏感；误杀守卫（首行非标签 / 仅标签无后续内容 / 标签词出现在句子中段）。
- 既有回归全绿（**445 passed**）：`test_proactive_phase1_pass`、`test_proactive_delivery`、`test_proactive_text_does_not_dehumanize`、`test_anti_repeat`、`test_proactive_material_dedup`、`test_topic_delivery`、`test_activity_tracker_followup`、`test_proactive_sm_integration`。
- 守门脚本全过：`check_docstring_no_cjk` / `check_prompt_hygiene` / `check_module_layering`。
- 唯一失败 `test_focus_mode::test_inline_gate_user_setting_default_on_allows` 经 `git stash` 验证为 **base 既有失败**，与本改动无关（focus 关键词打分，未触及）。

**未覆盖 / 取舍**
- 只派生「口吻」+「记忆线索」两族（对应截图两个症状）。活动状态段其它标题（`未收尾话题` / `评估` / `叙述`）与决策段引用名暂未纳入：部分是常用词（`tone`/`scores`），硬拦有误杀风险，且非本次症状；如需可后续扩 denylist 来源。
- 截图第二条里模型自己说出「主人」是**另一个无输出侧防护**的泄漏类（`test_proactive_text_does_not_dehumanize` 只查模板不查输出）。本 PR 按拍板暂不处理，留作独立项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化主动搭话输出清理，减少内部意图/标签前缀在展示、朗读与历史记录中的泄漏。
  * 扩展清理识别范围：支持中英文冒号（含全角）、装饰/列表等前缀，以及首行多层堆叠的剥离。
  * 增强误伤防护：仅在疑似标签形式匹配时裁剪，非标签句子与空输入保持原样。
* **Tests**
  * 新增单元测试，覆盖标签注册提取与文本清理的边界场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->