### PR TITLE
Cover compact tool wheel viewport-fit hidden slots

### DIFF
--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -968,6 +968,19 @@ def test_compact_tool_fan_viewport_fit_hidden_slots_stay_on_reversed_arc():
             '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden"] {'
         ),
     )
+    hidden_block = css_block(
+        styles,
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden"] {'
+        ),
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden-forward"] {'
+        ),
+    )
     hidden_forward_block = css_block(
         styles,
         (
@@ -994,12 +1007,29 @@ def test_compact_tool_fan_viewport_fit_hidden_slots_stay_on_reversed_arc():
             '.compact-input-tool-item[data-compact-tool-wheel-slot="-2"],'
         ),
     )
+    extra_hidden_block = css_block(
+        styles,
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="-2"] {'
+        ),
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="-1"] {'
+        ),
+    )
 
     assert "transition: none;" in hidden_slots_block
+    assert "rotate(calc(-140deg + var(--compact-tool-wheel-drag-angle)))" in hidden_block
+    assert "rotate(calc(140deg + var(--compact-tool-wheel-drag-counter-angle)))" in hidden_block
     assert "rotate(calc(-50deg + var(--compact-tool-wheel-drag-angle)))" in hidden_forward_block
     assert "rotate(calc(50deg + var(--compact-tool-wheel-drag-counter-angle)))" in hidden_forward_block
     assert "rotate(calc(-230deg + var(--compact-tool-wheel-drag-angle)))" in hidden_backward_block
     assert "rotate(calc(230deg + var(--compact-tool-wheel-drag-counter-angle)))" in hidden_backward_block
+    assert "rotate(calc(-200deg + var(--compact-tool-wheel-drag-angle)))" in extra_hidden_block
+    assert "rotate(calc(200deg + var(--compact-tool-wheel-drag-counter-angle)))" in extra_hidden_block
 
 
 def test_compact_tool_fan_labels_are_plain_noninteractive_tags():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -952,6 +952,56 @@ def test_compact_tool_fan_uses_shell_local_anchor_not_fixed_viewport_position():
     assert "id: index === 0 ? 'toolFan:native' : 'toolFan:native:' + index" in script
 
 
+def test_compact_tool_fan_viewport_fit_hidden_slots_stay_on_reversed_arc():
+    styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
+
+    hidden_slots_block = css_block(
+        styles,
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden"],'
+        ),
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden"] {'
+        ),
+    )
+    hidden_forward_block = css_block(
+        styles,
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden-forward"] {'
+        ),
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden-backward"] {'
+        ),
+    )
+    hidden_backward_block = css_block(
+        styles,
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="hidden-backward"] {'
+        ),
+        (
+            '.compact-input-tool-fan[data-compact-input-tool-fan-open="true"]'
+            '[data-compact-tool-wheel-layout="viewport-fit"] '
+            '.compact-input-tool-item[data-compact-tool-wheel-slot="-2"],'
+        ),
+    )
+
+    assert "transition: none;" in hidden_slots_block
+    assert "rotate(calc(-50deg + var(--compact-tool-wheel-drag-angle)))" in hidden_forward_block
+    assert "rotate(calc(50deg + var(--compact-tool-wheel-drag-counter-angle)))" in hidden_forward_block
+    assert "rotate(calc(-230deg + var(--compact-tool-wheel-drag-angle)))" in hidden_backward_block
+    assert "rotate(calc(230deg + var(--compact-tool-wheel-drag-counter-angle)))" in hidden_backward_block
+
+
 def test_compact_tool_fan_labels_are_plain_noninteractive_tags():
     styles = REACT_CHAT_STYLES_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- keep the upstream React Vitest styles.css?raw fix intact
- add Python static coverage for viewport-fit hidden compact tool wheel slots
- keep the PR test-only with no package, tsconfig, or runtime changes

## Testing
- uv run pytest tests/unit/test_react_chat_window_static.py -k viewport_fit_hidden_slots
- npm run test -- src/App.test.tsx -t "viewport-fit hidden compact tool wheel slots"
- local git merge-tree conflict scan against upstream/main
