### PR TITLE
修复完整聊天窗口 /chat_full 会重复弹出更新内容的问题，将其纳入聊天页启动提示跳过逻辑，并补充回归测试，确保更新弹窗只在主窗口显示

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -263,7 +263,10 @@ async function waitForStorageLocationStartupBarrierInternal() {
 window.addEventListener('load', async () => {
     await waitForStorageLocationStartupBarrierInternal();
 
-    const _isChatPage = window.location.pathname === '/chat';
+    const _isChatPage = window.location.pathname === '/chat'
+        || window.location.pathname === '/chat/'
+        || window.location.pathname === '/chat_full'
+        || window.location.pathname === '/chat_full/';
 
     setTimeout(() => {
         if (_isChatPage) return;

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 
 APP_REACT_CHAT_WINDOW_PATH = Path(__file__).resolve().parents[2] / "static" / "app-react-chat-window.js"
+APP_JS_PATH = Path(__file__).resolve().parents[2] / "static" / "app.js"
 APP_BUTTONS_PATH = Path(__file__).resolve().parents[2] / "static" / "app-buttons.js"
 APP_CHAT_EXPORT_PATH = Path(__file__).resolve().parents[2] / "static" / "app-chat-export.js"
 APP_INTERPAGE_PATH = Path(__file__).resolve().parents[2] / "static" / "app-interpage.js"
@@ -316,6 +317,20 @@ def test_chat_full_is_reserved_from_character_page_config_routing():
     assert "'web_chat_compact'" in source
     assert "RESERVED_PAGE_PATHS.has(pathParts[0])" in source
     assert "isReservedPagePath(window.location.pathname)" in source
+
+
+def test_chat_full_skips_startup_prominent_notice_queue():
+    source = APP_JS_PATH.read_text(encoding="utf-8")
+    load_block = source.split("window.addEventListener('load'", 1)[1].split(
+        "// 监听 voice_id",
+        1,
+    )[0]
+
+    assert "window.location.pathname === '/chat'" in load_block
+    assert "window.location.pathname === '/chat/'" in load_block
+    assert "window.location.pathname === '/chat_full'" in load_block
+    assert "window.location.pathname === '/chat_full/'" in load_block
+    assert "if (_isChatPage) return;" in load_block
 
 
 def test_web_chat_compact_is_allowed_during_main_limited_mode():


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复完整聊天窗口 /chat_full 会重复弹出更新内容的问题，将其纳入聊天页启动提示跳过逻辑，并补充回归测试，确保更新弹窗只在主窗口显示

## 测试 / Testing

手动回退版本测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 扩展了聊天独立窗口的页面识别范围，支持更多聊天路径。
  * 在聊天全屏/独立窗口页面中，启动提示和后续通知/问卷流程会按预期跳过，减少不必要的弹窗干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->