### PR TITLE
[codex] fix avatar floating toolbar display

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1879,7 +1879,7 @@
                         el.style.visibility = 'hidden';
                         hiddenFloatingButtonEls.push(el);
                     }
-                    el.style.display = restoreDisplay;
+                    el.style.display = isFloatingButtons ? 'flex' : restoreDisplay;
                 }
                 delete el.dataset.nekoPreHideDisplay;
             });

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1641,13 +1641,16 @@
                 '#live2d-return-button-container, #vrm-return-button-container, #mmd-return-button-container, #pngtuber-return-button-container'
             ).forEach(function (el) {
                 if (!el.dataset.nekoPreHideDisplay) {
+                    var isFloatingButtons = !!(el.id && /-floating-buttons$/.test(el.id));
                     var computedDisplay = '';
                     try {
                         computedDisplay = window.getComputedStyle(el).display || '';
                     } catch (_) {}
-                    el.dataset.nekoPreHideDisplay = computedDisplay && computedDisplay !== 'none'
-                        ? computedDisplay
-                        : (el.style.display || 'none');
+                    el.dataset.nekoPreHideDisplay = isFloatingButtons && !el.style.display && computedDisplay === 'none'
+                        ? 'flex'
+                        : (computedDisplay && computedDisplay !== 'none'
+                            ? computedDisplay
+                            : (el.style.display || 'none'));
                 }
                 el.style.display = 'none';
             });

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -5692,11 +5692,17 @@ const AvatarButtonMixin = {
 
             // 创建包装器
             const btnWrapper = document.createElement('div');
-            btnWrapper.style.position = 'relative';
-            btnWrapper.style.display = 'flex';
-            btnWrapper.style.alignItems = 'center';
-            btnWrapper.style.gap = '8px';
-            btnWrapper.style.pointerEvents = 'auto';
+            Object.assign(btnWrapper.style, {
+                position: 'relative',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                pointerEvents: 'auto',
+                height: '48px',
+                minHeight: '48px',
+                flex: '0 0 48px',
+                boxSizing: 'border-box'
+            });
 
             const stopWrapperEvent = (e) => { e.stopPropagation(); };
             ['pointerdown', 'pointermove', 'pointerup', 'mousedown', 'mousemove', 'mouseup', 'touchstart', 'touchmove', 'touchend'].forEach(evt => {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -497,6 +497,15 @@ button * {
         `{prefix}-return-button-container` / `{prefix}-lock-icon` 三组 ID
         命名约定（live2d / vrm / mmd 各一份）注入到 body，靠属性后缀
         匹配统一收掉，避免漏一个 prefix 留个浮动按钮挡鼠标。 */
+#live2d-floating-buttons,
+#vrm-floating-buttons,
+#mmd-floating-buttons,
+#pngtuber-floating-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 body.neko-game-active #live2d-container,
 body.neko-game-active #vrm-container,
 body.neko-game-active #mmd-container,

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -63,6 +63,20 @@ def test_interpage_restore_keeps_floating_button_containers_in_flex_layout():
     assert "el.style.display = restoreDisplay;" not in restore_block
 
 
+def test_interpage_hide_records_css_fallback_floating_button_display_as_flex():
+    source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+    hide_block = _source_slice_between(
+        source,
+        "document.querySelectorAll(\n                '#live2d-floating-buttons",
+        "el.style.display = 'none';",
+        "interpage floating button hide snapshot block",
+    )
+
+    assert "var isFloatingButtons = !!(el.id && /-floating-buttons$/.test(el.id));" in hide_block
+    assert "isFloatingButtons && !el.style.display && computedDisplay === 'none'" in hide_block
+    assert "? 'flex'" in hide_block
+
+
 def test_css_fallback_keeps_visible_floating_button_containers_as_flex():
     css_source = INDEX_CSS_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_avatar_floating_button_layout_static.py
+++ b/tests/unit/test_avatar_floating_button_layout_static.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+AVATAR_UI_BUTTONS_PATH = PROJECT_ROOT / "static" / "avatar-ui-buttons.js"
+LIVE2D_UI_BUTTONS_PATH = PROJECT_ROOT / "static" / "live2d-ui-buttons.js"
+APP_INTERPAGE_PATH = PROJECT_ROOT / "static" / "app-interpage.js"
+INDEX_CSS_PATH = PROJECT_ROOT / "static" / "css" / "index.css"
+
+
+def _source_slice_between(source, start_marker, end_marker, block_name):
+    start = source.find(start_marker)
+    assert start != -1, f"{block_name} start marker not found: {start_marker}"
+    end = source.find(end_marker, start + len(start_marker))
+    assert end != -1, f"{block_name} end marker not found after start: {end_marker}"
+    assert start < end, f"{block_name} start marker must precede end marker"
+    return source[start:end]
+
+
+def test_avatar_floating_button_rows_keep_fixed_height_when_aux_controls_toggle():
+    avatar_source = AVATAR_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+    live2d_source = LIVE2D_UI_BUTTONS_PATH.read_text(encoding="utf-8")
+
+    wrapper_block = _source_slice_between(
+        avatar_source,
+        "const btnWrapper = document.createElement('div');",
+        "const stopWrapperEvent = (e) => { e.stopPropagation(); };",
+        "floating button wrapper styles",
+    )
+
+    # Live2D positions the toolbar from five 48px rows plus four 12px gaps.
+    # The row wrapper must keep that height even when the mic mute button or
+    # popup trigger is shown, otherwise the vertical toolbar visibly contracts.
+    assert "const baseButtonSize = 48;" in live2d_source
+    assert "const baseGap = 12;" in live2d_source
+    assert "height: '48px'" in wrapper_block
+    assert "minHeight: '48px'" in wrapper_block
+    assert "flex: '0 0 48px'" in wrapper_block
+    assert "boxSizing: 'border-box'" in wrapper_block
+
+    mute_button_block = _source_slice_between(
+        avatar_source,
+        "Object.assign(muteBtn.style, {",
+        "const stopMuteEvent = (e) => { e.stopPropagation(); };",
+        "mic mute button styles",
+    )
+    assert "position: 'absolute'" in mute_button_block
+    assert "top: '50%'" in mute_button_block
+    assert "transform: 'translateY(-50%)'" in mute_button_block
+
+
+def test_interpage_restore_keeps_floating_button_containers_in_flex_layout():
+    source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+    restore_block = _source_slice_between(
+        source,
+        "restoringFloatingEls.forEach(function (el) {",
+        "delete el.dataset.nekoPreHideDisplay;",
+        "interpage floating button restore block",
+    )
+
+    assert "var isFloatingButtons = !!(el.id && /-floating-buttons$/.test(el.id));" in restore_block
+    assert "el.style.display = isFloatingButtons ? 'flex' : restoreDisplay;" in restore_block
+    assert "el.style.display = restoreDisplay;" not in restore_block
+
+
+def test_css_fallback_keeps_visible_floating_button_containers_as_flex():
+    css_source = INDEX_CSS_PATH.read_text(encoding="utf-8")
+
+    fallback_block = _source_slice_between(
+        css_source,
+        "#live2d-floating-buttons,",
+        "body.neko-game-active #live2d-container,",
+        "floating button display fallback css",
+    )
+
+    assert "#vrm-floating-buttons," in fallback_block
+    assert "#mmd-floating-buttons," in fallback_block
+    assert "#pngtuber-floating-buttons" in fallback_block
+    assert "display: flex;" in fallback_block
+    assert "flex-direction: column;" in fallback_block
+    assert "gap: 12px;" in fallback_block


### PR DESCRIPTION
## Summary
- keep avatar floating toolbars in flex layout when inline display is cleared
- restore floating toolbar containers as flex during interpage UI recovery
- add static regression coverage for toolbar row spacing and display recovery

## Root Cause
Clicking the voice control could clear the floating toolbar container's inline `display:flex`. Because the container is a `div`, it fell back to `display:block`, which disabled the column `gap` and made the toolbar visually contract until hover/show logic restored flex.

## Validation
- `uv run pytest tests/unit/test_avatar_floating_button_layout_static.py tests/unit/test_avatar_return_button_idle_tiers_static.py -q`
- `node --check static/app-interpage.js`
- `node --check static/avatar-ui-buttons.js`
- `node --check static/live2d-ui-buttons.js`
- manually reproduced the voice-control click path and confirmed the toolbar remains `display:flex` with 60px row spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化头像浮动按钮样式与尺寸约束，固定行高并保持纵向布局与统一间距。
  * 统一多个浮动按钮容器的纵向弹性布局（列方向）及间距（gap）。
* **Bug 修复**
  * 改善主界面隐藏/恢复后浮动按钮的显示还原策略，避免恢复过程中出现不一致的显示模式。
* **测试**
  * 新增静态用例，覆盖浮动按钮布局与还原显示的回退/分支规则，提升稳定性验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->