### PR TITLE
perf(activity): 主动叙述断连即止 + 同活动退避 4×/900s

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1012,8 +1012,13 @@ EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS = 30    # Stage-2 LLM rerank 后进 pro
 # LLM 把"用户在干嘛"叙述出来，只喂 proactive 搭话 prompt。这组旋钮约束「活动没
 # 实质变化时」它多久刷一次——用户在两个 app 间来回切窗口曾让它每 ~40s 烧一次
 # (静默, 无业务日志) 无限持续。详见 main_logic/activity/activity_guess_gate.py。
+# 同一活动每被重述一次，下次重述间隔就 ×MULTIPLIER 增长，封顶 CAP：30→120→480→900。
+# CAP 选 900s 对齐 AWAY_IDLE_SECONDS（state_machine.py，挂机 15min 进 away 后心跳硬 bail），
+# 这样稳定活动退避到地板时差不多也该转 away 了。消费端 get_snapshot 读 cache 无 TTL
+# 守卫，所以 CAP 放大不会让 proactive 拿到“过期”叙述（叙述只描述“在干嘛”，旧 = 仍准）。
 ACTIVITY_GUESS_BACKOFF_BASE_SECONDS = 30.0   # 两次调用之间的硬地板 + 首次重述间隔
-ACTIVITY_GUESS_BACKOFF_CAP_SECONDS = 600.0   # 活动稳定后重述间隔的封顶
+ACTIVITY_GUESS_BACKOFF_MULTIPLIER = 4.0      # 每次重述后退避间隔的增长倍数（必须 > 1）
+ACTIVITY_GUESS_BACKOFF_CAP_SECONDS = 900.0   # 活动稳定后重述间隔的封顶（对齐 AWAY_IDLE 15min）
 ACTIVITY_GUESS_SIG_CACHE_SIZE = 8            # 退避记忆的「不同活动签名」条数
 
 # ── AI-aware Stage-1 (path B) ─────────────────────────────────────────
@@ -2448,6 +2453,7 @@ __all__ = [
     'EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS',
     'EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS',
     'ACTIVITY_GUESS_BACKOFF_BASE_SECONDS',
+    'ACTIVITY_GUESS_BACKOFF_MULTIPLIER',
     'ACTIVITY_GUESS_BACKOFF_CAP_SECONDS',
     'ACTIVITY_GUESS_SIG_CACHE_SIZE',
     'PERSONA_RENDER_MAX_TOKENS',

--- a/main_logic/activity/activity_guess_gate.py
+++ b/main_logic/activity/activity_guess_gate.py
@@ -40,11 +40,11 @@ separate signature's state:
   the exact app, so flicking between two same-category apps is a no-op and even
   cross-category flicker only registers at the category level.
 * **Per-signature exponential backoff** — each distinct signature carries its
-  OWN streak and is re-narrated on an interval that grows with each of *its*
-  re-narrations: ``BASE → 2·BASE → …`` capped at ``CAP``. Oscillating between
-  already-narrated signatures therefore decays from "every BASE" toward "every
-  CAP", and a one-off new activity does NOT reset the backoff a separate,
-  still-oscillating signature has accumulated.
+  OWN streak and is re-narrated on an interval that grows by ``MULTIPLIER`` with
+  each of *its* re-narrations: ``BASE → MULTIPLIER·BASE → MULTIPLIER²·BASE → …``
+  capped at ``CAP``. Oscillating between already-narrated signatures therefore
+  decays from "every BASE" toward "every CAP", and a one-off new activity does
+  NOT reset the backoff a separate, still-oscillating signature has accumulated.
 * **Novelty / freshness bypass** — a signature not in the small recently-narrated
   cache, or one whose cached narration was built under an OLDER conversation turn
   (``conv_seq``), fires immediately and restarts that signature's backoff. The
@@ -96,15 +96,26 @@ class ActivityGuessGate:
         scores, guess = gate.cached(current_sig)
     """
 
-    def __init__(self, *, base_seconds: float, cap_seconds: float, cache_size: int):
+    def __init__(
+        self, *, base_seconds: float, cap_seconds: float, cache_size: int,
+        backoff_multiplier: float = 2.0,
+    ):
         if base_seconds <= 0:
             raise ValueError('base_seconds must be > 0')
+        # The multiplier must actually grow the interval. A value <= 1 would
+        # degrade the backoff to "re-narrate every BASE" — i.e. the original
+        # idle burn this gate exists to kill. So, unlike ``cap`` (a soft ceiling
+        # that clamps), the multiplier is load-bearing like ``base`` and a
+        # misconfig raises rather than silently re-introducing the burn.
+        if backoff_multiplier <= 1.0:
+            raise ValueError('backoff_multiplier must be > 1')
         self._base = float(base_seconds)
+        self._mult = float(backoff_multiplier)
         # ``cap`` is a soft ceiling, not load-bearing like ``base``: a bad value
         # (0 / negative / below base) is clamped up to ``base`` rather than
         # raising, so a misconfigured config knob degrades to "no backoff beyond
         # base" instead of crashing tracker/session init. (``base`` must raise —
-        # base <= 0 would zero out the floor and the ``2**streak`` interval.)
+        # base <= 0 would zero out the floor and the ``mult**streak`` interval.)
         self._cap = max(float(cap_seconds), self._base)
         self._cache_size = max(1, int(cache_size))
         # signature -> (last_fire_ts, streak, conv_seq, scores, guess), LRU
@@ -116,12 +127,14 @@ class ActivityGuessGate:
         # Global only for the hard anti-thrash floor (no two LLM calls closer
         # than BASE, regardless of which signature).
         self._last_fire_ts: float | None = None
-        # Cap the per-signature streak so ``base * 2**streak`` can't grow without
-        # bound — once the interval reaches CAP, a larger streak changes nothing.
+        # Cap the per-signature streak so ``base * mult**streak`` can't grow
+        # without bound — once the interval reaches CAP, a larger streak changes
+        # nothing. ``mult > 1`` (enforced above) guarantees ``eff`` strictly
+        # grows, so this loop terminates well before the 32 backstop.
         self._max_streak = 0
         eff = self._base
         while eff < self._cap and self._max_streak < 32:
-            eff *= 2
+            eff *= self._mult
             self._max_streak += 1
 
     def should_fire(self, sig: Hashable, conv_seq: int, now: float) -> bool:
@@ -139,7 +152,7 @@ class ActivityGuessGate:
         # Same activity, same conversation → re-narrate only after this
         # signature's own grown interval has elapsed.
         last_ts, streak = rec[0], rec[1]
-        return (now - last_ts) >= min(self._base * (2 ** streak), self._cap)
+        return (now - last_ts) >= min(self._base * (self._mult ** streak), self._cap)
 
     def record_fired(
         self,

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -68,6 +68,7 @@ from utils.activity_config import get_activity_preferences
 from main_logic.activity.activity_guess_gate import ActivityGuessGate
 from config import (
     ACTIVITY_GUESS_BACKOFF_BASE_SECONDS,
+    ACTIVITY_GUESS_BACKOFF_MULTIPLIER,
     ACTIVITY_GUESS_BACKOFF_CAP_SECONDS,
     ACTIVITY_GUESS_SIG_CACHE_SIZE,
 )
@@ -277,6 +278,7 @@ class UserActivityTracker:
             base_seconds=ACTIVITY_GUESS_BACKOFF_BASE_SECONDS,
             cap_seconds=ACTIVITY_GUESS_BACKOFF_CAP_SECONDS,
             cache_size=ACTIVITY_GUESS_SIG_CACHE_SIZE,
+            backoff_multiplier=ACTIVITY_GUESS_BACKOFF_MULTIPLIER,
         )
         self._activity_guess_loop_task: asyncio.Task | None = None
         self._topic_candidate_task: asyncio.Task | None = None
@@ -951,12 +953,14 @@ class UserActivityTracker:
     ) -> None:
         """Inject the predicate that decides whether activity_guess narration has a live consumer.
 
-        ``predicate()`` returns True when narration is currently pointless — the
-        only consumer (proactive Phase 2) will bail at its ``goodbye_silent``
-        guard, so computing the emotion-tier guess just burns an LLM call with
-        nobody to read it. The 20s heartbeat keeps ticking the rule-based
-        break-reminder / context-prompt logic regardless; only the LLM
-        narration step is skipped. Pass None to clear (never suppress).
+        ``predicate()`` returns True when narration currently has no consumer —
+        the sole reader (proactive Phase 2) won't act, so computing the
+        emotion-tier guess just burns an LLM call with nobody to read it. The
+        injector owns the exact conditions (today: the catgirl is in
+        goodbye-silence, OR no client is connected to deliver a proactive turn
+        to); the tracker treats the predicate as opaque. The 20s heartbeat keeps
+        ticking the rule-based break-reminder / context-prompt logic regardless;
+        only the LLM narration step is skipped. Pass None to clear (never suppress).
         """
         self._narration_suppressed_check = predicate
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1167,11 +1167,18 @@ class LLMSessionManager:
                 )
         self._activity_tracker.set_context_prompt_callback(_push_activity_context_prompt)
 
-        # activity_guess narration 的「下游消费方」门控：会话 goodbye_silent（猫娘挂机
-        # 静默）时，proactive Phase 2 一进门就 bail，narration 没人读。把 is_goodbye_silent
-        # 注入 tracker，让 20s 心跳在静默期跳过昂贵的 emotion-tier LLM 外呼（规则心跳照跑）。
-        # tracker 跨 session 长存、心跳不随 End Session 取消，否则挂机后会一直空烧 LLM。
-        self._activity_tracker.set_narration_suppressed_check(self.is_goodbye_silent)
+        # activity_guess narration 的「下游消费方」门控：narration 只喂 proactive
+        # Phase 2，Phase 2 在两种情况下都没人读 → 这次昂贵的 emotion-tier 外呼纯属空烧：
+        #   ① goodbye_silent（猫娘挂机静默）—— Phase 2 一进门就 bail；
+        #   ② 没有在线 WebSocket（普通断连 / End Session 后）—— proactive 没法送达。
+        # tracker 跨 session 长存、心跳不随 End Session 取消（break-reminder / 情境弹窗这些
+        # 规则心跳要继续跑），所以必须靠这个门控在「无消费方」时跳过 LLM；否则用户关掉页面
+        # 后整段挂机会一直空烧（cap 只是把间隔退避到 ~900s，不会停）。重连 / 退出静默后
+        # 每签名 cache 还在，narration 在该签名退避间隔走完时恢复（conv_seq 变化或间隔已
+        # 在挂起期间走完则下一 tick 立刻恢复）。
+        self._activity_tracker.set_narration_suppressed_check(
+            self._should_suppress_activity_narration
+        )
 
         # AI 当前轮文本 buffer：每个 send_lanlan_response chunk 累加，turn end
         # 时作为一个 conversation turn 发给 dispatcher。activity sink 用末尾
@@ -2192,6 +2199,30 @@ class LLMSessionManager:
             return websocket.client_state == websocket.client_state.CONNECTED
         except Exception:
             return False
+
+    def _should_suppress_activity_narration(self) -> bool:
+        """Whether the activity_guess emotion-tier narration has no live consumer.
+
+        Injected into the tracker as the narration suppressed-check (see where
+        ``set_narration_suppressed_check`` is wired). The narration only feeds
+        proactive Phase 2's state_section, and Phase 2 is a no-op in two cases —
+        paying for the LLM call then is pure idle burn:
+
+          * ``is_goodbye_silent()`` — cat-mode silence; Phase 2 bails at its
+            goodbye guard.
+          * no connected WebSocket — after a plain disconnect / End Session the
+            tracker heartbeat keeps ticking (it outlives the session so the
+            rule-based break-reminder / context-prompt logic still runs), but a
+            proactive turn has no client to reach. Without this, closing the page
+            leaves the loop re-narrating at the backoff cap (~900s) all night.
+
+        Both conditions recover on their own: the per-signature narration cache
+        stays warm across the suppressed window, so reconnecting (or leaving
+        goodbye-silence) resumes narration once that signature's backoff interval
+        elapses — on the next tick if a new turn advanced conv_seq or the interval
+        already passed during the gap, otherwise after the remaining interval.
+        """
+        return self.is_goodbye_silent() or not self._has_connected_websocket()
 
     def _can_preserve_tts_ready_for_session_start(self) -> bool:
         """A live, previously-ready TTS worker will not emit __ready__ again."""

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -961,6 +961,29 @@ def test_activity_guess_loop_kicks_topic_candidates_before_private_bail():
     assert source.index("if rule_snap.state == 'private':") < source.index("if not _proactive_chat_enabled():")
 
 
+def test_activity_guess_gate_wired_with_production_backoff_knobs():
+    """config → tracker → gate wiring carries the user-tuned faster-decay
+    schedule: 4x growth per re-narration, capped at 900s (aligned with the
+    15-min away threshold)."""
+    from main_logic.activity.tracker import UserActivityTracker
+    from config import (
+        ACTIVITY_GUESS_BACKOFF_BASE_SECONDS,
+        ACTIVITY_GUESS_BACKOFF_MULTIPLIER,
+        ACTIVITY_GUESS_BACKOFF_CAP_SECONDS,
+    )
+
+    tracker = UserActivityTracker('test_lanlan')
+    gate = tracker._activity_guess_gate
+    assert gate._base == ACTIVITY_GUESS_BACKOFF_BASE_SECONDS
+    assert gate._mult == ACTIVITY_GUESS_BACKOFF_MULTIPLIER
+    assert gate._cap == max(
+        ACTIVITY_GUESS_BACKOFF_CAP_SECONDS, ACTIVITY_GUESS_BACKOFF_BASE_SECONDS,
+    )
+    # Pin the user's headline ask so a silent revert to the old 2x/600s is caught.
+    assert ACTIVITY_GUESS_BACKOFF_MULTIPLIER == 4.0
+    assert ACTIVITY_GUESS_BACKOFF_CAP_SECONDS == 900.0
+
+
 def test_narration_suppressed_check_defaults_and_injection():
     from main_logic.activity.tracker import UserActivityTracker
 

--- a/tests/unit/test_activity_guess_gate.py
+++ b/tests/unit/test_activity_guess_gate.py
@@ -19,6 +19,8 @@ Small base/cap/cache values keep the arithmetic obvious:
 10 → 20 → 40 → 80 (capped). ``cache=3`` makes LRU eviction easy to drive.
 """
 
+import pytest
+
 from main_logic.activity.activity_guess_gate import ActivityGuessGate
 
 
@@ -131,7 +133,6 @@ def test_cap_below_base_is_clamped():
 
 
 def test_rejects_nonpositive_base():
-    import pytest
     with pytest.raises(ValueError):
         ActivityGuessGate(base_seconds=0.0, cap_seconds=600.0, cache_size=8)
 
@@ -211,7 +212,6 @@ def test_multiplier_must_exceed_one():
     anything strictly above 1 is accepted. Asserting both sides locks the ``> 1``
     boundary so a mutation that wrongly tightens the check (e.g. ``< 2.0``,
     rejecting a legitimate 1.5) can't slip through."""
-    import pytest
     for bad in (1.0, 0.5, 0.0, -2.0):
         with pytest.raises(ValueError):
             ActivityGuessGate(

--- a/tests/unit/test_activity_guess_gate.py
+++ b/tests/unit/test_activity_guess_gate.py
@@ -170,6 +170,61 @@ def test_cached_unknown_signature_is_empty():
     assert gate.cached('B') == ({}, '')
 
 
+def test_default_multiplier_is_two():
+    """Omitting ``backoff_multiplier`` preserves the historical 2x schedule, so
+    callers that predate the knob (and these tests' ``_gate`` helper) are
+    unaffected."""
+    gate = ActivityGuessGate(base_seconds=10.0, cap_seconds=80.0, cache_size=3)
+    fired = _fire_times(gate, 'A', conv_seq=0, start=0.0, end=400.0, step=5.0)
+    intervals = [b - a for a, b in zip(fired, fired[1:])]
+    assert intervals[:4] == [10.0, 20.0, 40.0, 80.0]
+
+
+def test_custom_multiplier_grows_faster_then_caps():
+    """A larger multiplier reaches the cap in fewer re-narrations. base=10,
+    mult=4, cap=160 → a stable signature's intervals climb 10 → 40 → 160 (capped),
+    i.e. two re-narrations instead of four to settle at the floor."""
+    gate = ActivityGuessGate(
+        base_seconds=10.0, cap_seconds=160.0, cache_size=3, backoff_multiplier=4.0,
+    )
+    fired = _fire_times(gate, 'A', conv_seq=0, start=0.0, end=1000.0, step=1.0)
+    intervals = [b - a for a, b in zip(fired, fired[1:])]
+    assert intervals[:2] == [10.0, 40.0]
+    assert all(iv == 160.0 for iv in intervals[2:])  # never exceeds the cap
+
+
+def test_production_4x_900_schedule():
+    """The user-tuned production schedule: base=30, mult=4, cap=900 → a stable
+    activity decays 30 → 120 → 480 → 900 (capped) — to the floor in 3 steps."""
+    gate = ActivityGuessGate(
+        base_seconds=30.0, cap_seconds=900.0, cache_size=8, backoff_multiplier=4.0,
+    )
+    fired = _fire_times(gate, 'A', conv_seq=0, start=0.0, end=4000.0, step=1.0)
+    intervals = [b - a for a, b in zip(fired, fired[1:])]
+    assert intervals[:3] == [30.0, 120.0, 480.0]
+    assert all(iv == 900.0 for iv in intervals[3:])
+
+
+def test_multiplier_must_exceed_one():
+    """A multiplier <= 1 would degrade the backoff to 'every BASE' (the original
+    idle burn), so it is rejected at construction like a non-positive base;
+    anything strictly above 1 is accepted. Asserting both sides locks the ``> 1``
+    boundary so a mutation that wrongly tightens the check (e.g. ``< 2.0``,
+    rejecting a legitimate 1.5) can't slip through."""
+    import pytest
+    for bad in (1.0, 0.5, 0.0, -2.0):
+        with pytest.raises(ValueError):
+            ActivityGuessGate(
+                base_seconds=10.0, cap_seconds=80.0, cache_size=3,
+                backoff_multiplier=bad,
+            )
+    # Just-above-boundary value must construct without raising.
+    ActivityGuessGate(
+        base_seconds=10.0, cap_seconds=80.0, cache_size=3,
+        backoff_multiplier=1.0001,
+    )
+
+
 def test_new_conversation_freshness_is_per_signature():
     """A new turn must refresh EVERY cached activity when next visited, not just
     the first one re-narrated. With a single global last-fired conv seq, the

--- a/tests/unit/test_activity_narration_suppression.py
+++ b/tests/unit/test_activity_narration_suppression.py
@@ -1,0 +1,95 @@
+# Copyright 2025-2026 Project N.E.K.O. Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``LLMSessionManager._should_suppress_activity_narration``.
+
+The activity_guess emotion-tier narration only feeds proactive Phase 2. The
+tracker heartbeat outlives a session (so the rule-based break-reminder /
+context-prompt logic keeps ticking), so without a "no consumer" gate the loop
+would keep paying for the LLM call after the user closed the page. This
+predicate is that gate; it must suppress when EITHER goodbye-silence is in
+effect OR no client WebSocket is connected.
+
+Construction of the real ``LLMSessionManager`` is heavy, so — following
+``tests/unit/test_focus_indicator_bridge.py`` — we bind the unbound methods onto
+a tiny ``SimpleNamespace`` stub that exposes only the attributes the predicate
+touches.
+"""
+
+from __future__ import annotations
+
+import types
+
+from main_logic.core import LLMSessionManager
+
+
+def _mgr(*, goodbye_silent: bool, connected: bool):
+    """Stub manager exposing only what the suppress predicate reads."""
+    stub = types.SimpleNamespace()
+    stub.goodbye_silent = goodbye_silent
+
+    # ``_has_connected_websocket`` compares ``websocket.client_state`` against
+    # ``client_state.CONNECTED``. Make the fake client_state equal to its own
+    # ``.CONNECTED`` iff we want "connected".
+    cs = types.SimpleNamespace()
+    cs.CONNECTED = cs if connected else object()
+    stub.websocket = types.SimpleNamespace(client_state=cs)
+
+    for name in (
+        'is_goodbye_silent',
+        '_has_connected_websocket',
+        '_should_suppress_activity_narration',
+    ):
+        setattr(
+            stub, name,
+            getattr(LLMSessionManager, name).__get__(stub, LLMSessionManager),
+        )
+    return stub
+
+
+def test_suppress_when_goodbye_silent():
+    # Even with a live connection, goodbye-silence means Phase 2 bails → suppress.
+    assert _mgr(goodbye_silent=True, connected=True)._should_suppress_activity_narration() is True
+
+
+def test_suppress_when_no_connected_websocket():
+    # The headline fix (A): a plain disconnect with NO goodbye_silent must still
+    # suppress — otherwise the heartbeat burns the LLM at the backoff cap all
+    # night after the user closes the page.
+    assert _mgr(goodbye_silent=False, connected=False)._should_suppress_activity_narration() is True
+
+
+def test_not_suppressed_when_connected_and_not_goodbye():
+    # The only case with a real consumer: live connection, not silenced.
+    assert _mgr(goodbye_silent=False, connected=True)._should_suppress_activity_narration() is False
+
+
+def test_suppress_when_both_conditions_hold():
+    assert _mgr(goodbye_silent=True, connected=False)._should_suppress_activity_narration() is True
+
+
+def test_suppress_when_websocket_is_none():
+    stub = types.SimpleNamespace()
+    stub.goodbye_silent = False
+    stub.websocket = None
+    for name in (
+        'is_goodbye_silent',
+        '_has_connected_websocket',
+        '_should_suppress_activity_narration',
+    ):
+        setattr(
+            stub, name,
+            getattr(LLMSessionManager, name).__get__(stub, LLMSessionManager),
+        )
+    assert stub._should_suppress_activity_narration() is True


### PR DESCRIPTION
## 背景

`activity_guess`（proactive 搭话用的「用户在干嘛」emotion-tier 叙述）成功时不打业务日志，对外只是 httpx POST。日志里整夜挂机仍每 ~10min 空烧一次 LLM。逐层定位为两个独立问题。

## 改动

**A — 断连即止空烧**
`tracker` 心跳刻意跨 session 长存（规则类 break-reminder / 情境弹窗要继续 tick），但原抑制开关只挂 `is_goodbye_silent`。普通 WebSocket 断连 / 关页面不会设 goodbye_silent，于是叙述在「无任何消费方」（proactive 需在线连接才能送达）时仍按 backoff cap 间隔整夜空烧。改为新谓词 `_should_suppress_activity_narration = is_goodbye_silent() or not _has_connected_websocket()`，断连即跳过昂贵的 emotion-tier 外呼；规则心跳照跑；重连后每签名 cache 还在，退避间隔走完自然恢复。

**B — 同活动更快退避**
退避增长倍数从写死的 `2` 改为可配置（新增 `ACTIVITY_GUESS_BACKOFF_MULTIPLIER=4.0`），`CAP` 600→900（对齐 `AWAY_IDLE_SECONDS=900`，稳定活动退避到地板时差不多也该转 away 被硬 bail）。稳定活动重述间隔 `30→120→480→900`，3 步到地板（旧 ×2/600 需 5 步）。`mult≤1` 直接 raise，避免退化回每 30s 空烧。当时拍板（PR #2021）记下的「消费端 get_snapshot 读 cache 无 TTL 守卫」背书了 CAP 放大安全。

## 回归报告

**改动文件（watched）**：`main_logic/core.py`、`main_logic/activity/activity_guess_gate.py`、`main_logic/activity/tracker.py`（+ `config/__init__.py`、3 个测试文件）。

**改动点 / 理由**
- `activity_guess_gate.py`：退避倍数参数化（`backoff_multiplier`，默认 2.0 保向后兼容），`<=1` 校验 raise；`should_fire` 与 `_max_streak` 里的 `2` 换成 `self._mult`。理由 = 让同活动退避更快。
- `tracker.py`：import + 透传 `ACTIVITY_GUESS_BACKOFF_MULTIPLIER`；泛化 `set_narration_suppressed_check` docstring（不再把 goodbye_silent 写成唯一抑制原因）。
- `core.py`：新增 `_should_suppress_activity_narration`，替换 narration 抑制接线。
- `config/__init__.py`：新增 `ACTIVITY_GUESS_BACKOFF_MULTIPLIER=4.0`、`CAP` 600→900、补 `__all__` 导出。

**前后行为**
- 前：断连后叙述按 600s cap 整夜空烧；同活动退避 ×2 到 600s（5 步）。
- 后：断连/无在线 WebSocket 即跳过叙述 LLM；同活动退避 ×4 到 900s（3 步）。
- 规则心跳（break-reminder / 情境弹窗 / topic 候选）不受影响，照常 tick。
- 默认参数（无 multiplier）下 gate 行为与改前完全一致（向后兼容）。

**回归验证**
- 新增/更新单测全绿，相关套件 `122 passed`：
  - gate multiplier 数学：生产 `30/120/480/900` 档期、`>1` 边界双侧、默认 2× 向后兼容、自定义倍数更快封顶。
  - `config→tracker→gate` 接线钉死 `4.0/900`（防悄悄回退 2×/600）。
  - A 抑制谓词行为：断连 / 静默 / `websocket=None` 必抑制，仅「在线且非静默」不抑制。
- 多维对抗式 review（退避数学 / 抑制逻辑 / 接线回归 / 测试充分性）+ 逐条证伪：无 blocker/major，3 条 nit（docstring/注释措辞、测试 accept-side 边界）已修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 活动猜测的重试退避支持可配置倍数（默认 2 倍），并在校验倍数参数后按倍数增长；退避封顶提升至 900s。
* **Bug 修复**
  * 活动叙述抑制逻辑扩展：在“猫娘静默”或“当前无已连接 WebSocket”时都会抑制，减少断连后不必要的触发与计算。
* **测试**
  * 新增并补强退避调度与叙述抑制的单元测试与生产配置回归校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->