### PR TITLE
Fix plugin registry failure isolation

### DIFF
--- a/frontend/plugin-manager/src/components/plugin/PluginActions.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginActions.vue
@@ -106,6 +106,17 @@ const uiActionLabel = computed(() =>
   resolveLocalizedText(uiAction.value?.label, locale.value, t('plugins.ui.open')),
 )
 
+function showActionError(error: any, fallbackMessage: string) {
+  const status = error?.response?.status
+  if (error?.request && !error?.response) {
+    return
+  }
+  if (typeof status === 'number' && ![401, 403, 404].includes(status)) {
+    return
+  }
+  ElMessage.error(error?.message || fallbackMessage)
+}
+
 async function handleOpenUi() {
   if (!uiAction.value || uiDisabled.value) {
     return
@@ -179,7 +190,7 @@ async function handleStart() {
     await pluginStore.start(props.pluginId)
     ElMessage.success(t('messages.pluginStarted'))
   } catch (error: any) {
-    ElMessage.error(error.message || t('messages.startFailed'))
+    showActionError(error, t('messages.startFailed'))
   } finally {
     loading.value = false
   }
@@ -195,7 +206,7 @@ async function handleStop() {
     ElMessage.success(t('messages.pluginStopped'))
   } catch (error: any) {
     if (error !== 'cancel') {
-      ElMessage.error(error.message || t('messages.stopFailed'))
+      showActionError(error, t('messages.stopFailed'))
     }
   } finally {
     loading.value = false
@@ -212,7 +223,7 @@ async function handleReload() {
     ElMessage.success(t('messages.pluginReloaded'))
   } catch (error: any) {
     if (error !== 'cancel') {
-      ElMessage.error(error.message || t('messages.reloadFailed'))
+      showActionError(error, t('messages.reloadFailed'))
     }
   } finally {
     loading.value = false
@@ -229,7 +240,7 @@ async function handleDisableExt() {
     ElMessage.success(t('messages.extensionDisabled'))
   } catch (error: any) {
     if (error !== 'cancel') {
-      ElMessage.error(error.message || t('messages.disableExtFailed'))
+      showActionError(error, t('messages.disableExtFailed'))
     }
   } finally {
     loading.value = false
@@ -242,7 +253,7 @@ async function handleEnableExt() {
     await pluginStore.enableExt(props.pluginId)
     ElMessage.success(t('messages.extensionEnabled'))
   } catch (error: any) {
-    ElMessage.error(error.message || t('messages.enableExtFailed'))
+    showActionError(error, t('messages.enableExtFailed'))
   } finally {
     loading.value = false
   }

--- a/frontend/plugin-manager/src/components/plugin/PluginActions.vue
+++ b/frontend/plugin-manager/src/components/plugin/PluginActions.vue
@@ -72,6 +72,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { usePluginStore } from '@/stores/plugin'
 import { resolveLocalizedText } from '@/utils/i18nLabel'
 import { openExternalUrl } from '@/utils/openExternal'
+import { formatHttpError } from '@/utils/request'
 
 interface Props {
   pluginId: string
@@ -114,7 +115,7 @@ function showActionError(error: any, fallbackMessage: string) {
   if (typeof status === 'number' && ![401, 403, 404].includes(status)) {
     return
   }
-  ElMessage.error(error?.message || fallbackMessage)
+  ElMessage.error(formatHttpError(error) || fallbackMessage)
 }
 
 async function handleOpenUi() {

--- a/plugin/core/entry_points.py
+++ b/plugin/core/entry_points.py
@@ -43,3 +43,33 @@ def normalize_plugin_entry_point(
     if not suffix:
         return entry_point
     return f"plugins.{suffix}:{class_name}"
+
+
+def describe_plugin_entry_directory_mismatch(entry_point: str, *, config_path: Path) -> str | None:
+    """Return an error message when a ``plugins.<name>`` entry targets another directory.
+
+    User plugins are loaded from ``<plugin-root>/<directory>/plugin.toml``.  If
+    an entry points at ``plugins.some_id`` but the package directory is not
+    ``some_id``, the normal namespace import cannot resolve the plugin package.
+    Treat that as a packaging/config error instead of silently loading a
+    different directory.
+    """
+
+    if ":" not in entry_point:
+        return None
+
+    module_path, _class_name = entry_point.split(":", 1)
+    parts = module_path.split(".")
+    if len(parts) < 2 or parts[0] != "plugins":
+        return None
+
+    entry_package = parts[1]
+    plugin_dir_name = config_path.parent.name
+    if entry_package == plugin_dir_name:
+        return None
+
+    return (
+        f"Plugin entry '{entry_point}' targets package 'plugins.{entry_package}', "
+        f"but plugin.toml is located in directory '{plugin_dir_name}'. "
+        f"Rename the directory to '{entry_package}' or update [plugin].entry to match the directory."
+    )

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -30,7 +30,10 @@ from plugin.core.registry import (
     _resolve_plugin_id_conflict,
     scan_static_metadata,
 )
-from plugin.core.entry_points import normalize_plugin_entry_point
+from plugin.core.entry_points import (
+    describe_plugin_entry_directory_mismatch,
+    normalize_plugin_entry_point,
+)
 from plugin.core.state import state
 from plugin.logging_config import get_logger
 from plugin.server.domain import IO_RUNTIME_ERRORS, RUNTIME_ERRORS
@@ -341,6 +344,32 @@ def _resolve_registered_config_path_sync(plugin_meta: dict[str, object] | None) 
         return Path(config_path_obj)
 
 
+def _registered_load_failure_error(plugin_id: str, plugin_meta: dict[str, object] | None) -> ServerDomainError | None:
+    if not isinstance(plugin_meta, dict) or plugin_meta.get("runtime_load_state") != "failed":
+        return None
+
+    error_type_obj = plugin_meta.get("runtime_load_error_type")
+    error_message_obj = plugin_meta.get("runtime_load_error_message")
+    error_phase_obj = plugin_meta.get("runtime_load_error_phase")
+    error_type = str(error_type_obj or "PluginLoadFailed")
+    if error_type not in {"PluginEntryDirectoryMismatch", "SyntaxError"}:
+        return None
+
+    error_message = str(error_message_obj or "Plugin failed to load during registry refresh")
+    error_phase = str(error_phase_obj or "unknown")
+    code = "PLUGIN_ENTRY_DIRECTORY_MISMATCH" if error_type == "PluginEntryDirectoryMismatch" else "PLUGIN_LOAD_FAILED"
+    return _to_domain_error(
+        code=code,
+        message=(
+            f"Plugin '{plugin_id}' cannot be started because its entry failed during "
+            f"registry phase '{error_phase}': {error_type}: {error_message}"
+        ),
+        status_code=400,
+        plugin_id=plugin_id,
+        error_type=error_type,
+    )
+
+
 async def _cleanup_started_host(plugin_id: str, host: PluginHostContract) -> None:
     removed = await asyncio.to_thread(_pop_plugin_host_sync, plugin_id)
     target_host = host
@@ -607,6 +636,9 @@ class PluginLifecycleService:
                 plugin_id=current_plugin_id,
                 error_type="ConfigNotFound",
             )
+        registered_load_error = _registered_load_failure_error(current_plugin_id, registered_meta)
+        if registered_load_error is not None:
+            raise registered_load_error
 
         host_obj: PluginHostContract | None = None
         registered_plugin_id: str | None = None
@@ -742,6 +774,15 @@ class PluginLifecycleService:
                 config_path=config_path,
                 builtin_plugin_root=BUILTIN_PLUGIN_CONFIG_ROOT,
             )
+            entry_mismatch = describe_plugin_entry_directory_mismatch(entry, config_path=config_path)
+            if entry_mismatch:
+                raise _to_domain_error(
+                    code="PLUGIN_ENTRY_DIRECTORY_MISMATCH",
+                    message=entry_mismatch,
+                    status_code=400,
+                    plugin_id=current_plugin_id,
+                    error_type="PluginEntryDirectoryMismatch",
+                )
 
             resolved_id = _resolve_plugin_id_conflict(
                 current_plugin_id,

--- a/plugin/server/application/plugins/registry_service.py
+++ b/plugin/server/application/plugins/registry_service.py
@@ -403,16 +403,14 @@ def _build_discovery_payload(
         )
     else:
         entries_preview: list[dict[str, object]]
-        dependency_errors: list[str] = []
-        for dep in ctx.dependencies:
-            satisfied, dep_error = _check_plugin_dependency(dep, logger, plugin_id)
-            if not satisfied:
-                dependency_errors.append(str(dep_error or "dependency check failed"))
-                break
-        if dependency_errors:
-            error_type = "DependencyCheckFailed"
-            error_message = dependency_errors[0]
-            error_phase = "dependency_check"
+        entry_mismatch = describe_plugin_entry_directory_mismatch(
+            ctx.entry,
+            config_path=ctx.toml_path,
+        )
+        if entry_mismatch:
+            error_type = "PluginEntryDirectoryMismatch"
+            error_message = entry_mismatch
+            error_phase = "entry_validation"
             entries_preview = _extract_entries_preview(
                 plugin_id,
                 cls=type("FailedPluginStub", (), {}),
@@ -420,14 +418,16 @@ def _build_discovery_payload(
                 pdata=ctx.pdata,
             )
         else:
-            missing_requirements = _find_missing_python_requirements(
-                ctx.python_requirements,
-                search_paths=ctx.python_requirement_paths,
-            )
-            if missing_requirements:
-                error_type = "MissingPythonDependencies"
-                error_message = f"Unsatisfied Python dependencies: {missing_requirements}"
-                error_phase = "python_requirements"
+            dependency_errors: list[str] = []
+            for dep in ctx.dependencies:
+                satisfied, dep_error = _check_plugin_dependency(dep, logger, plugin_id)
+                if not satisfied:
+                    dependency_errors.append(str(dep_error or "dependency check failed"))
+                    break
+            if dependency_errors:
+                error_type = "DependencyCheckFailed"
+                error_message = dependency_errors[0]
+                error_phase = "dependency_check"
                 entries_preview = _extract_entries_preview(
                     plugin_id,
                     cls=type("FailedPluginStub", (), {}),
@@ -435,24 +435,14 @@ def _build_discovery_payload(
                     pdata=ctx.pdata,
                 )
             else:
-                # The startup loader installs vendor paths on sys.path before
-                # importing each plugin's entry module; do the same here so a
-                # plugin whose [project].dependencies live only under its own
-                # vendor/ directory does not get falsely recorded as
-                # ImportError/ModuleNotFoundError during a registry refresh.
-                _ensure_python_requirement_paths(
-                    ctx.python_requirement_paths,
-                    logger,
-                    plugin_id,
+                missing_requirements = _find_missing_python_requirements(
+                    ctx.python_requirements,
+                    search_paths=ctx.python_requirement_paths,
                 )
-                entry_mismatch = describe_plugin_entry_directory_mismatch(
-                    ctx.entry,
-                    config_path=ctx.toml_path,
-                )
-                if entry_mismatch:
-                    error_type = "PluginEntryDirectoryMismatch"
-                    error_message = entry_mismatch
-                    error_phase = "entry_validation"
+                if missing_requirements:
+                    error_type = "MissingPythonDependencies"
+                    error_message = f"Unsatisfied Python dependencies: {missing_requirements}"
+                    error_phase = "python_requirements"
                     entries_preview = _extract_entries_preview(
                         plugin_id,
                         cls=type("FailedPluginStub", (), {}),
@@ -460,6 +450,16 @@ def _build_discovery_payload(
                         pdata=ctx.pdata,
                     )
                 else:
+                    # The startup loader installs vendor paths on sys.path before
+                    # importing each plugin's entry module; do the same here so a
+                    # plugin whose [project].dependencies live only under its own
+                    # vendor/ directory does not get falsely recorded as
+                    # ImportError/ModuleNotFoundError during a registry refresh.
+                    _ensure_python_requirement_paths(
+                        ctx.python_requirement_paths,
+                        logger,
+                        plugin_id,
+                    )
                     try:
                         module_path, class_name = ctx.entry.split(":", 1)
                         module_obj = _import_plugin_module(module_path, ctx.toml_path, logger)

--- a/plugin/server/application/plugins/registry_service.py
+++ b/plugin/server/application/plugins/registry_service.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from plugin.core.dependency import _topological_sort_plugins
+from plugin.core.entry_points import describe_plugin_entry_directory_mismatch
 from plugin.core.host import _import_plugin_module
 from plugin.core.registry import (
     PluginContext,
@@ -352,7 +353,22 @@ def _discover_registry_snapshot_sync(roots: tuple[Path, ...]) -> PluginDiscovery
                 )
                 continue
 
-            records.append(_build_discovery_record_from_context(ctx))
+            try:
+                records.append(_build_discovery_record_from_context(ctx))
+            except Exception as exc:
+                logger.warning(
+                    "plugin discovery payload failed for {}: err_type={}, err={}",
+                    config_path,
+                    type(exc).__name__,
+                    str(exc),
+                )
+                failures.append(
+                    PluginDiscoveryFailure(
+                        plugin_id=ctx.pid or config_path.parent.name or None,
+                        config_path=config_path,
+                        error=str(exc),
+                    )
+                )
 
     return PluginDiscoverySnapshot(
         records=records,
@@ -429,31 +445,46 @@ def _build_discovery_payload(
                     logger,
                     plugin_id,
                 )
-                try:
-                    module_path, class_name = ctx.entry.split(":", 1)
-                    module_obj = _import_plugin_module(module_path, ctx.toml_path, logger)
-                    cls_obj = getattr(module_obj, class_name)
-                    entries_preview = _extract_entries_preview(plugin_id, cls_obj, ctx.conf, ctx.pdata)
-                except (ImportError, ModuleNotFoundError) as exc:
-                    error_type = type(exc).__name__
-                    error_message = str(exc)
-                    error_phase = "import_module"
+                entry_mismatch = describe_plugin_entry_directory_mismatch(
+                    ctx.entry,
+                    config_path=ctx.toml_path,
+                )
+                if entry_mismatch:
+                    error_type = "PluginEntryDirectoryMismatch"
+                    error_message = entry_mismatch
+                    error_phase = "entry_validation"
                     entries_preview = _extract_entries_preview(
                         plugin_id,
                         cls=type("FailedPluginStub", (), {}),
                         conf=ctx.conf,
                         pdata=ctx.pdata,
                     )
-                except AttributeError as exc:
-                    error_type = "AttributeError"
-                    error_message = f"Class not found for entry '{ctx.entry}': {exc}"
-                    error_phase = "import_class"
-                    entries_preview = _extract_entries_preview(
-                        plugin_id,
-                        cls=type("FailedPluginStub", (), {}),
-                        conf=ctx.conf,
-                        pdata=ctx.pdata,
-                    )
+                else:
+                    try:
+                        module_path, class_name = ctx.entry.split(":", 1)
+                        module_obj = _import_plugin_module(module_path, ctx.toml_path, logger)
+                        cls_obj = getattr(module_obj, class_name)
+                        entries_preview = _extract_entries_preview(plugin_id, cls_obj, ctx.conf, ctx.pdata)
+                    except (ImportError, ModuleNotFoundError, SyntaxError) as exc:
+                        error_type = type(exc).__name__
+                        error_message = str(exc)
+                        error_phase = "import_module"
+                        entries_preview = _extract_entries_preview(
+                            plugin_id,
+                            cls=type("FailedPluginStub", (), {}),
+                            conf=ctx.conf,
+                            pdata=ctx.pdata,
+                        )
+                    except AttributeError as exc:
+                        error_type = "AttributeError"
+                        error_message = f"Class not found for entry '{ctx.entry}': {exc}"
+                        error_phase = "import_class"
+                        entries_preview = _extract_entries_preview(
+                            plugin_id,
+                            cls=type("FailedPluginStub", (), {}),
+                            conf=ctx.conf,
+                            pdata=ctx.pdata,
+                        )
 
     plugin_meta = _build_plugin_meta(
         plugin_id,

--- a/plugin/tests/unit/server/test_plugin_registry_service.py
+++ b/plugin/tests/unit/server/test_plugin_registry_service.py
@@ -407,6 +407,57 @@ async def test_refresh_registry_marks_entry_directory_mismatch_failed(
 
 
 @pytest.mark.asyncio
+async def test_refresh_registry_prioritizes_entry_directory_mismatch_before_requirements(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "plugins"
+    config_path = _write_package_plugin_fixture(
+        root,
+        "repo_file_manager",
+        plugin_id="file_manager",
+        entry_package="file_manager",
+    )
+    (config_path.parent / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["definitely-missing-lib>=1"]\n',
+        encoding="utf-8",
+    )
+    requirements_checked = False
+
+    def _fake_find_missing(requirements, *, search_paths=None):
+        nonlocal requirements_checked
+        requirements_checked = True
+        return ["definitely-missing-lib>=1"]
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+
+        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (root,))
+        monkeypatch.setattr(module, "_find_missing_python_requirements", _fake_find_missing)
+
+        result = await module.PluginRegistryService().refresh_registry()
+
+        assert result["success"] is True
+        assert requirements_checked is False
+        with module.state.acquire_plugins_read_lock():
+            plugin_meta = dict(module.state.plugins["file_manager"])
+
+        assert plugin_meta["runtime_load_state"] == "failed"
+        assert plugin_meta["runtime_load_error_type"] == "PluginEntryDirectoryMismatch"
+        assert plugin_meta["runtime_load_error_phase"] == "entry_validation"
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.asyncio
 async def test_list_autostart_plugin_ids_uses_dependency_order(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/plugin/tests/unit/server/test_plugin_registry_service.py
+++ b/plugin/tests/unit/server/test_plugin_registry_service.py
@@ -86,6 +86,50 @@ def _write_ordered_plugin_fixture(
     return plugin_dir / "plugin.toml"
 
 
+def _write_package_plugin_fixture(
+    root: Path,
+    directory_name: str,
+    *,
+    plugin_id: str | None = None,
+    entry_package: str | None = None,
+    source: str | None = None,
+) -> Path:
+    resolved_plugin_id = plugin_id or directory_name
+    resolved_entry_package = entry_package or directory_name
+    plugin_dir = root / directory_name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "__init__.py").write_text(
+        source
+        or "\n".join(
+            [
+                "class DemoPlugin:",
+                "    pass",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.toml").write_text(
+        "\n".join(
+            [
+                "[plugin]",
+                f"id = '{resolved_plugin_id}'",
+                f"name = '{resolved_plugin_id}'",
+                "type = 'plugin'",
+                f"entry = 'plugins.{resolved_entry_package}:DemoPlugin'",
+                "version = '0.1.0'",
+                "",
+                "[plugin_runtime]",
+                "enabled = true",
+                "auto_start = false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return plugin_dir / "plugin.toml"
+
+
 @pytest.mark.asyncio
 async def test_refresh_registry_syncs_metadata_and_marks_missing_running_plugin(
     monkeypatch: pytest.MonkeyPatch,
@@ -274,6 +318,86 @@ async def test_refresh_registry_keeps_existing_metadata_when_config_parse_fails(
             preserved = dict(module.state.plugins["broken_plugin"])
         assert preserved["name"] == "Broken Plugin"
         assert "runtime_source_missing" not in preserved
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.asyncio
+async def test_refresh_registry_marks_syntax_error_plugin_failed_without_aborting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "plugins"
+    _write_package_plugin_fixture(root, "healthy_plugin")
+    _write_package_plugin_fixture(
+        root,
+        "broken_plugin",
+        source="def broken(:\n    pass\n",
+    )
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+
+        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (root,))
+
+        result = await module.PluginRegistryService().refresh_registry()
+
+        assert result["success"] is True
+        with module.state.acquire_plugins_read_lock():
+            healthy = dict(module.state.plugins["healthy_plugin"])
+            broken = dict(module.state.plugins["broken_plugin"])
+
+        assert healthy.get("runtime_load_state") != "failed"
+        assert broken["runtime_load_state"] == "failed"
+        assert broken["runtime_load_error_type"] == "SyntaxError"
+        assert broken["runtime_load_error_phase"] == "import_module"
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.asyncio
+async def test_refresh_registry_marks_entry_directory_mismatch_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "plugins"
+    _write_package_plugin_fixture(
+        root,
+        "repo_file_manager",
+        plugin_id="file_manager",
+        entry_package="file_manager",
+    )
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+
+        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (root,))
+
+        result = await module.PluginRegistryService().refresh_registry()
+
+        assert result["success"] is True
+        with module.state.acquire_plugins_read_lock():
+            plugin_meta = dict(module.state.plugins["file_manager"])
+
+        assert plugin_meta["runtime_load_state"] == "failed"
+        assert plugin_meta["runtime_load_error_type"] == "PluginEntryDirectoryMismatch"
+        assert "repo_file_manager" in plugin_meta["runtime_load_error_message"]
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -386,6 +386,81 @@ async def test_start_plugin_checks_python_requirements_against_vendor_paths(
 
 @pytest.mark.plugin_unit
 @pytest.mark.asyncio
+async def test_start_plugin_rejects_entry_directory_mismatch_before_creating_host(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "repo_file_manager" / "plugin.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "\n".join(
+            [
+                "[plugin]",
+                "id = 'file_manager'",
+                "name = 'File Manager'",
+                "type = 'plugin'",
+                "entry = 'plugins.file_manager:FileManagerPlugin'",
+                "",
+                "[plugin_runtime]",
+                "enabled = true",
+                "auto_start = false",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    host_created = False
+
+    class _UnexpectedHost(_FakeProcessHost):
+        def __init__(self, *args, **kwargs) -> None:
+            nonlocal host_created
+            host_created = True
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        module,
+        "resolve_plugin_config_from_path",
+        lambda *args, **kwargs: {
+            "effective_config": kwargs["base_config"],
+            "warnings": [],
+        },
+    )
+    monkeypatch.setattr(module, "PluginProcessHost", _UnexpectedHost)
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+    try:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins["file_manager"] = {
+                "id": "file_manager",
+                "config_path": str(config_path),
+                "runtime_enabled": True,
+                "runtime_auto_start": False,
+            }
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+
+        with pytest.raises(ServerDomainError) as exc_info:
+            await module.PluginLifecycleService().start_plugin("file_manager", refresh_registry=False)
+
+        assert exc_info.value.code == "PLUGIN_ENTRY_DIRECTORY_MISMATCH"
+        assert exc_info.value.status_code == 400
+        assert "repo_file_manager" in exc_info.value.message
+        assert host_created is False
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
 async def test_start_plugin_uses_default_startup_timeout_when_runtime_timeout_omitted(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## 改动概述 / Summary

修复插件系统中坏插件会影响整体插件列表/启动体验的问题：

- registry 刷新时将 `SyntaxError` 隔离为单插件 `load_failed`，不再中断整次刷新。
- 对 `plugins.<name>` entry 与实际插件目录不一致的情况，明确标记为 `PluginEntryDirectoryMismatch`，不再表现为模糊的 500。
- 启动插件前阻断明确不可恢复的 `PluginEntryDirectoryMismatch` / `SyntaxError`，但保留其他 `load_failed` 插件的重试能力。
- 前端插件操作按钮避免对同一个 Axios 错误重复弹 toast。

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `.venv\Scripts\python.exe -m pytest plugin\tests\unit\server\test_plugin_registry_service.py plugin\tests\unit\server\test_plugins_lifecycle_service.py -q`
  - `50 passed`
- `npm run type-check`
- `.venv\Scripts\python.exe -m py_compile plugin\core\entry_points.py plugin\server\application\plugins\registry_service.py plugin\server\application\plugins\lifecycle_service.py plugin\tests\unit\server\test_plugin_registry_service.py plugin\tests\unit\server\test_plugins_lifecycle_service.py`
- `git diff --check`
- 额外做了真实 registry 刷新探针：内置插件未被误伤，仅目录/entry 明确不一致的用户插件被标记为 `load_failed`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了插件启停/重载/启用停用等操作的错误提示逻辑，更加精准展示相关错误信息，减少不必要提示。
  * 插件扫描与启动将更早校验插件入口目录与配置的匹配关系，发现不一致将以明确失败原因中断启动（HTTP 400）。
  * 即使个别插件加载/解析失败，插件刷新仍可继续完成，并为失败插件记录更具体的失败阶段与错误类型（如入口目录不匹配、语法错误）。

* **Tests**
  * 补充插件注册与启动相关单元测试，覆盖失败状态、入口目录不匹配、以及与依赖缺失同时发生时的处理结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->