### PR TITLE
修复每日悬浮新手引导自动续播

### DIFF
--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -643,11 +643,7 @@ class UniversalTutorialManager {
         if (state.pendingRound || state.manualResetRound) {
             return state.pendingRound === round || state.manualResetRound === round;
         }
-        if (state.pendingRound !== round && state.manualResetRound !== round) {
-            const today = getTodayLocalDateForAvatarFloatingGuide();
-            return state.lastAutoShownRound === round && state.lastAutoShownDate === today;
-        }
-        return true;
+        return this.getNextAvatarFloatingGuideAutoRound() === round;
     }
 
     isAvatarFloatingGuideRoundRegistered(day) {

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2252,23 +2252,27 @@ test('return petal transition cancels immediately when tutorial is skipped', () 
     assert.doesNotMatch(executeBlock, /await finishTransition\(transition\);/);
 });
 
-test('avatar floating auto-start rechecks pending state before delayed launch', () => {
+test('avatar floating auto-start rechecks current due round before delayed launch', () => {
     const managerSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/core/universal-manager.js'), 'utf8');
     const maybeAutoBlock = managerSource.split('    async maybeStartAvatarFloatingGuideAutoRound(delayMs = 1200) {')[1].split(
         '    ensureTutorialSkipController() {',
         1
     )[0];
-    const pendingCheckMatch = managerSource.match(
-        /    isAvatarFloatingGuideRoundPendingAutoStart\(day\) \{([\s\S]*?)\n    \}\n\n    async maybeStartAvatarFloatingGuideAutoRound/
-    );
-    assert.ok(pendingCheckMatch, 'expected manager to expose stale auto-start pending guard');
-    const pendingCheckBlock = pendingCheckMatch[1];
+    const pendingCheckBlock = managerSource.split(
+        '    isAvatarFloatingGuideRoundPendingAutoStart(day) {'
+    )[1].split(
+        '    isAvatarFloatingGuideRoundRegistered(day) {',
+        1
+    )[0];
+    assert.ok(pendingCheckBlock, 'expected manager to expose stale auto-start pending guard');
 
-    assert.match(maybeAutoBlock, /if \(!this\.isAvatarFloatingGuideRoundPendingAutoStart\(round\)\) \{\s*return;\s*\}/);
+    assert.match(maybeAutoBlock, /if \(!this\.isAvatarFloatingGuideRoundPendingAutoStart\(round\)\) \{[\s\S]*?return;\s*\}/);
     assert.match(pendingCheckBlock, /const state = loadAvatarFloatingGuideState\(\);/);
-    assert.match(pendingCheckBlock, /state\.pendingRound !== round && state\.manualResetRound !== round/);
+    assert.match(pendingCheckBlock, /return this\.getNextAvatarFloatingGuideAutoRound\(\) === round;/);
     assert.match(pendingCheckBlock, /state\.completedRounds\.includes\(round\)/);
     assert.match(pendingCheckBlock, /state\.skippedRounds\.includes\(round\)/);
+    assert.doesNotMatch(pendingCheckBlock, /state\.lastAutoShownRound === round/);
+    assert.doesNotMatch(pendingCheckBlock, /state\.lastAutoShownDate === today/);
 });
 
 test('tutorial destroy requests share the PC global overlay cleanup path', () => {


### PR DESCRIPTION
## 改动概览

修复 7 天悬浮新手引导在 Day1 跳过或完成后，后续 Day2-Day7 到期却不自动弹出的阻断问题。

## 为什么改

原逻辑在延迟启动前做二次检查时，把“今天是否已经自动展示过”作为待启动判断的一部分。正常 Day2 到期时，调度阶段已经能算出 Day2，但延迟后的待启动检查会因为 `lastAutoShownDate` 不是今天而返回 false，导致引导被误判为不应启动。

## 怎么改

保留已完成、已跳过、手动 pending/reset 的优先级；普通自动续播场景下，二次检查改为重新计算当前应自动展示的轮次，并要求它与原定轮次一致。这样既能挡住状态变化后的过期启动，也不会把真正到期的 Day2-Day7 拦掉。

## 风险与边界

本次只调整悬浮新手引导的自动续播判定和对应静态断言，不改 Day1 首页引导、不改具体每日引导内容，也不改角色卡、模型切换或聊天窗口逻辑。风险主要集中在本地引导状态异常时的续播判断；已保留 completed/skipped/manual pending 的原有保护边界。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了头像浮层引导的自动启动判断，改为按下一次应启动的轮次进行判定，减少误判和重复触发。
* **Tests**
  * 更新了相关测试，覆盖新的自动启动判定逻辑，并同步调整了“已展示过”的判断条件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->