### PR TITLE
[codex] 修复新手教程光标定位与首启模型同步

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -4220,8 +4220,6 @@
         };
         if (patch && Object.prototype.hasOwnProperty.call(patch, 'cursor')) {
             payload.cursor = patch.cursor || null;
-        } else {
-            payload.cursor = yuiGuidePcOverlayCursor;
         }
         var runId = resolveYuiGuidePcOverlayRunIdForSend(
             sendOptions.tutorialRunId,

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -4220,6 +4220,8 @@
         };
         if (patch && Object.prototype.hasOwnProperty.call(patch, 'cursor')) {
             payload.cursor = patch.cursor || null;
+        } else if (yuiGuidePcOverlayCursor) {
+            payload.cursor = yuiGuidePcOverlayCursor;
         }
         var runId = resolveYuiGuidePcOverlayRunIdForSend(
             sendOptions.tutorialRunId,

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -56,7 +56,8 @@
     };
     const setStatus = (msg) => {
         const { status } = el();
-        status.forEach(s => { if (s) s.textContent = msg || ''; });
+        const text = window.isInTutorial === true ? 'NekoClaw server ready' : (msg || '');
+        status.forEach(s => { if (s) s.textContent = text; });
     };
     const currentLanlanName = () => {
         const fromConfig = window.lanlan_config && typeof window.lanlan_config.lanlan_name === 'string'

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -54,9 +54,31 @@
         };
         return map[key] || key;
     };
-    const setStatus = (msg) => {
+    const isTutorialAgentStatusLocked = () => {
+        if (window.isInTutorial !== true) return false;
+        if (window.isNekoHomeTutorialPending === true) return true;
+        if (window.universalTutorialManager && window.universalTutorialManager.isTutorialRunning === true) return true;
+        if (typeof window.isNekoHomeTutorialInteractionLocked === 'function') {
+            try {
+                if (window.isNekoHomeTutorialInteractionLocked() === true) return true;
+            } catch (_) {}
+        }
+        if (
+            window.NekoHomeTutorialFeatureController
+            && typeof window.NekoHomeTutorialFeatureController.isActive === 'function'
+        ) {
+            try {
+                if (window.NekoHomeTutorialFeatureController.isActive() === true) return true;
+            } catch (_) {}
+        }
+        return false;
+    };
+    const setStatus = (msg, options) => {
         const { status } = el();
-        const text = window.isInTutorial === true ? 'NekoClaw server ready' : (msg || '');
+        const shouldStabilizeTutorialText = options
+            && options.stabilizeTutorialText === true
+            && isTutorialAgentStatusLocked();
+        const text = shouldStabilizeTutorialText ? 'NekoClaw server ready' : (msg || '');
         status.forEach(s => { if (s) s.textContent = text; });
     };
     const currentLanlanName = () => {
@@ -322,7 +344,9 @@
                 });
                 sync(list);
             });
-            setStatus(window.t ? window.t('agent.status.connecting') : 'Agent状态同步中...');
+            setStatus(window.t ? window.t('agent.status.connecting') : 'Agent状态同步中...', {
+                stabilizeTutorialText: true
+            });
             return;
         }
 
@@ -431,13 +455,21 @@
             c => c && typeof c.reason === 'string' && c.reason.includes('PENDING')
         );
         if (state.globalBusy) {
-            setStatus(window.t ? window.t('settings.toggles.checking') : '已接受操作，切换中...');
+            setStatus(window.t ? window.t('settings.toggles.checking') : '已接受操作，切换中...', {
+                stabilizeTutorialText: true
+            });
         } else if (anyPending) {
-            setStatus(window.t ? window.t('agent.status.connectivityCheck') : 'Agent LLM 连接检查中...');
+            setStatus(window.t ? window.t('agent.status.connectivityCheck') : 'Agent LLM 连接检查中...', {
+                stabilizeTutorialText: true
+            });
         } else if (!analyzerEnabled) {
-            setStatus(window.t ? window.t('agent.status.ready') : 'Agent服务器就绪');
+            setStatus(window.t ? window.t('agent.status.ready') : 'Agent服务器就绪', {
+                stabilizeTutorialText: true
+            });
         } else {
-            setStatus(window.t ? window.t('agent.status.enabled') : 'Agent模式已开启');
+            setStatus(window.t ? window.t('agent.status.enabled') : 'Agent模式已开启', {
+                stabilizeTutorialText: true
+            });
         }
         state.suppressChange = false;
 

--- a/static/tutorial/core/round-prelude-controller.js
+++ b/static/tutorial/core/round-prelude-controller.js
@@ -30,6 +30,7 @@
             this.beginAvatarOverride = normalizedOptions.beginAvatarOverride || noop;
             this.revealPrepared = normalizedOptions.revealPrepared || noop;
             this.ensureVisible = normalizedOptions.ensureVisible || noop;
+            this.waitForAvatarReady = normalizedOptions.waitForAvatarReady || noop;
             this.sleep = normalizedOptions.sleep || noop;
             this.beginTakingOver = normalizedOptions.beginTakingOver || noop;
             this.setLifecycleActive = normalizedOptions.setLifecycleActive || noop;
@@ -69,6 +70,11 @@
                 return toPromise(() => this.revealPrepared()).then(() => {
                     throw error;
                 });
+            });
+            await toPromise(() => this.waitForAvatarReady(sceneId, {
+                deferRevealPrepared
+            })).catch((error) => {
+                this.warn('[Tutorial] 等待 YUI 模型视觉就绪失败，继续启动教程:', error);
             });
 
             await toPromise(() => this.sleep(delayMs));

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -800,7 +800,7 @@ class UniversalTutorialManager {
                 beginAvatarOverride: (overrideOptions) => this.beginTutorialAvatarOverride(overrideOptions),
                 revealPrepared: () => this.revealTutorialLive2dPrepared(),
                 ensureVisible: (sceneId, ensureOptions) => this.ensureTutorialYuiLive2dVisible(sceneId, ensureOptions),
-                waitForAvatarReady: (sceneId) => this.waitForTutorialYuiLive2dVisualReady(sceneId, 12000),
+                waitForAvatarReady: (sceneId, _options) => this.waitForTutorialYuiLive2dVisualReady(sceneId, 12000),
                 sleep: (delayMs) => this.sleep(delayMs),
                 beginTakingOver: (detail) => {
                     const director = detail && detail.director;

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -800,6 +800,7 @@ class UniversalTutorialManager {
                 beginAvatarOverride: (overrideOptions) => this.beginTutorialAvatarOverride(overrideOptions),
                 revealPrepared: () => this.revealTutorialLive2dPrepared(),
                 ensureVisible: (sceneId, ensureOptions) => this.ensureTutorialYuiLive2dVisible(sceneId, ensureOptions),
+                waitForAvatarReady: (sceneId) => this.waitForTutorialYuiLive2dVisualReady(sceneId, 12000),
                 sleep: (delayMs) => this.sleep(delayMs),
                 beginTakingOver: (detail) => {
                     const director = detail && detail.director;
@@ -1899,6 +1900,60 @@ class UniversalTutorialManager {
             return true;
         }
         return ['preparing', 'applying', 'settling'].includes(String(manager._modelLoadState || ''));
+    }
+
+    isTutorialYuiLive2dVisualReady() {
+        const manager = window.live2dManager || null;
+        if (!this.isTutorialYuiLive2dActive() || !this.hasTutorialYuiLive2dRenderableModel(manager)) {
+            return false;
+        }
+        if (manager._isLoadingModel === true) {
+            return false;
+        }
+        const state = String(manager._modelLoadState || '');
+        if (state !== 'ready') {
+            return false;
+        }
+        if (manager._isModelReadyForInteraction !== true) {
+            return false;
+        }
+        return true;
+    }
+
+    waitForTutorialYuiLive2dVisualReady(reason = '', maxWaitTime = 12000) {
+        if (this.isTutorialYuiLive2dVisualReady()) {
+            return Promise.resolve(true);
+        }
+
+        return new Promise((resolve) => {
+            let resolved = false;
+            const timeoutMs = Math.max(0, Math.floor(Number(maxWaitTime) || 0));
+            const done = (result) => {
+                if (resolved) {
+                    return;
+                }
+                resolved = true;
+                clearTimeout(timer);
+                clearInterval(poller);
+                window.removeEventListener('neko-live2d-model-ready', onReady);
+                window.removeEventListener('live2d-model-ready', onReady);
+                if (!result) {
+                    console.warn('[Tutorial] 等待 YUI Live2D 视觉就绪超时，继续启动教程:', reason || 'unknown');
+                }
+                resolve(result);
+            };
+            const checkReady = () => {
+                if (this.isTutorialYuiLive2dVisualReady()) {
+                    done(true);
+                }
+            };
+            const onReady = () => checkReady();
+            const poller = setInterval(checkReady, 100);
+            const timer = setTimeout(() => done(false), timeoutMs);
+            window.addEventListener('neko-live2d-model-ready', onReady);
+            window.addEventListener('live2d-model-ready', onReady);
+            checkReady();
+        });
     }
 
     waitForLive2dModelLoadIdle(maxWaitTime = 30000) {

--- a/static/tutorial/yui-guide/days/day6-agent-guide.js
+++ b/static/tutorial/yui-guide/days/day6-agent-guide.js
@@ -80,7 +80,8 @@
                     voiceKey: 'avatar_floating_day6_plugin_side_panel',
                     text: '除了之前介绍的功能，这里还有超多好玩的插件呢。',
                     emotion: 'happy',
-                    operation: 'day6-plugin-open-management-panel-flow'
+                    operation: 'day6-plugin-open-management-panel-flow',
+                    afterSceneDelayMs: 0
                 },
                 {
                     id: 'day6_plugin_dashboard',

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -7191,6 +7191,28 @@
         async runDay6PluginOpenManagementPanelFlow(scene) {
             const sceneId = scene && scene.id ? scene.id : 'day6_plugin_side_panel';
             const guardFailed = () => this.isStopping();
+            const refreshUserPluginHighlight = (target) => {
+                if (!target || guardFailed()) {
+                    return false;
+                }
+                this.applyGuideHighlights({
+                    key: sceneId + '-user-plugin',
+                    primary: target
+                });
+                return true;
+            };
+            const refreshManagementHighlight = (button) => {
+                if (!button || guardFailed()) {
+                    return null;
+                }
+                this.clearVirtualSpotlight('plugin-management-entry');
+                const spotlightTarget = this.createPluginManagementEntrySpotlight(button) || button;
+                this.applyGuideHighlights({
+                    key: sceneId + '-management-panel',
+                    primary: spotlightTarget
+                });
+                return spotlightTarget;
+            };
             const userPluginToggle = await this.waitForElement(() => {
                 const toggle = this.getAgentToggleElement('agent-user-plugin');
                 return this.getElementRect(toggle) ? toggle : null;
@@ -7198,14 +7220,41 @@
             if (!userPluginToggle || guardFailed()) {
                 return false;
             }
-            this.applyGuideHighlights({
-                key: sceneId + '-user-plugin',
-                primary: userPluginToggle
-            });
-            if (!(await this.moveCursorToElement(userPluginToggle, DAY6_PLUGIN_SIDE_PANEL_CURSOR_MOVE_MS, {
-                exactDuration: true
-            })) || guardFailed()) {
+            if (!(await this.waitForStableElementRect(userPluginToggle, 760)) || guardFailed()) {
                 return false;
+            }
+            if (!refreshUserPluginHighlight(userPluginToggle)) {
+                return false;
+            }
+            if (!(await this.moveCursorToTrackedElement(
+                userPluginToggle,
+                DAY6_PLUGIN_SIDE_PANEL_CURSOR_MOVE_MS,
+                {
+                    exactDuration: true,
+                    recheckDelayMs: 120,
+                    settleDelayMs: 40
+                }
+            )) || guardFailed()) {
+                return false;
+            }
+            if (!refreshUserPluginHighlight(userPluginToggle)) {
+                return false;
+            }
+            if (!this.isCursorAlignedWithElement(userPluginToggle, 5)) {
+                if (!(await this.moveCursorToTrackedElement(
+                    userPluginToggle,
+                    220,
+                    {
+                        exactDuration: true,
+                        recheckDelayMs: 60,
+                        settleDelayMs: 20
+                    }
+                )) || guardFailed()) {
+                    return false;
+                }
+                if (!refreshUserPluginHighlight(userPluginToggle)) {
+                    return false;
+                }
             }
             const sidePanelShown = await this.runActionWithCursorClickExact(
                 DAY6_PLUGIN_SIDE_PANEL_CLICK_VISIBLE_MS,
@@ -7223,15 +7272,40 @@
             if (!managementButton || guardFailed()) {
                 return false;
             }
-            const managementSpotlightTarget = this.createPluginManagementEntrySpotlight(managementButton) || managementButton;
-            this.applyGuideHighlights({
-                key: sceneId + '-management-panel',
-                primary: managementSpotlightTarget
-            });
-            if (!(await this.moveCursorToElement(managementButton, DAY6_PLUGIN_SIDE_PANEL_CURSOR_MOVE_MS, {
-                exactDuration: true
-            })) || guardFailed()) {
+            if (!(await this.waitForStableElementRect(managementButton, 760)) || guardFailed()) {
                 return false;
+            }
+            let managementSpotlightTarget = refreshManagementHighlight(managementButton);
+            if (!managementSpotlightTarget || guardFailed()) {
+                return false;
+            }
+            if (!(await this.moveCursorToTrackedElement(
+                managementButton,
+                DAY6_PLUGIN_SIDE_PANEL_CURSOR_MOVE_MS,
+                {
+                    exactDuration: true,
+                    recheckDelayMs: 120,
+                    settleDelayMs: 40
+                }
+            )) || guardFailed()) {
+                return false;
+            }
+            managementSpotlightTarget = refreshManagementHighlight(managementButton);
+            if (!managementSpotlightTarget || guardFailed()) {
+                return false;
+            }
+            if (!this.isCursorAlignedWithElement(managementButton, 5)) {
+                if (!(await this.realignCursorToAgentSidePanelAction(
+                    'agent-user-plugin',
+                    'management-panel',
+                    220
+                )) || guardFailed()) {
+                    return false;
+                }
+                managementSpotlightTarget = refreshManagementHighlight(managementButton);
+                if (!managementSpotlightTarget || guardFailed()) {
+                    return false;
+                }
             }
             const managementOpenResult = await this.runActionWithCursorClickExact(
                 DAY6_PLUGIN_SIDE_PANEL_CLICK_VISIBLE_MS,
@@ -7664,6 +7738,14 @@
             }
 
             if (sceneId === 'day1_takeover_return_control') {
+                const keyboardToggle = this.getAgentToggleElement('agent-keyboard');
+                const keyboardRect = this.getElementRect(keyboardToggle);
+                if (keyboardRect) {
+                    return {
+                        x: keyboardRect.left + keyboardRect.width / 2,
+                        y: keyboardRect.top + keyboardRect.height / 2
+                    };
+                }
                 const keyboardControlAnchor = this.getAvatarFloatingSceneCursorAnchor('day1_takeover_capture_cursor');
                 if (keyboardControlAnchor) {
                     return keyboardControlAnchor;
@@ -9200,8 +9282,13 @@
             const normalizedOptions = options || {};
             this.setHomePcCursorOutputSuppressedForExternalizedChat(false);
             const totalDurationMs = Number.isFinite(durationMs) ? durationMs : DEFAULT_CURSOR_DURATION_MS;
-            const firstLegMs = Math.max(180, Math.round(totalDurationMs * 0.7));
-            const secondLegMs = Math.max(140, totalDurationMs - firstLegMs);
+            const exactDuration = normalizedOptions.exactDuration === true;
+            const firstLegMs = exactDuration
+                ? Math.max(0, Math.round(totalDurationMs * 0.7))
+                : Math.max(180, Math.round(totalDurationMs * 0.7));
+            const secondLegMs = exactDuration
+                ? Math.max(0, totalDurationMs - firstLegMs)
+                : Math.max(140, totalDurationMs - firstLegMs);
             const recheckDelayMs = Number.isFinite(normalizedOptions.recheckDelayMs)
                 ? normalizedOptions.recheckDelayMs
                 : 320;
@@ -9216,6 +9303,7 @@
             while (!this.isStopping()) {
                 const movedToInitialPoint = await this.cursor.moveToPoint(initialPoint.x, initialPoint.y, {
                     durationMs: firstLegMs,
+                    exactDuration: exactDuration,
                     pauseCheck: () => this.scenePausedForResistance,
                     cancelCheck: () => this.isStopping()
                 });
@@ -9257,6 +9345,7 @@
             while (!this.isStopping()) {
                 const movedToFinalPoint = await this.cursor.moveToPoint(finalPoint.x, finalPoint.y, {
                     durationMs: secondLegMs,
+                    exactDuration: exactDuration,
                     pauseCheck: () => this.scenePausedForResistance,
                     cancelCheck: () => this.isStopping()
                 });
@@ -9634,23 +9723,91 @@
             if (!keyboardToggle || guardFailed()) {
                 return false;
             }
-            const keyboardToggleSpotlight = createToggleSpotlightTarget('takeover-keyboard-toggle', keyboardToggle);
-            this.addRetainedExtraSpotlight(keyboardToggleSpotlight);
+            let keyboardToggleSpotlight = null;
+            const isKeyboardToggleSpotlight = (candidate) => {
+                return !!(
+                    candidate === keyboardToggleSpotlight
+                    || (
+                        candidate
+                        && typeof candidate.getAttribute === 'function'
+                        && candidate.getAttribute('data-yui-guide-virtual-spotlight') === 'takeover-keyboard-toggle'
+                    )
+                );
+            };
+            const refreshKeyboardToggleSpotlight = (options) => {
+                const normalizedOptions = options || {};
+                const refreshedSpotlight = createToggleSpotlightTarget('takeover-keyboard-toggle', keyboardToggle);
+                if (!refreshedSpotlight || guardFailed()) {
+                    return null;
+                }
+                this.replaceRetainedExtraSpotlight(isKeyboardToggleSpotlight, refreshedSpotlight);
+                if (normalizedOptions.activate === true) {
+                    this.overlay.activateSpotlight(refreshedSpotlight);
+                }
+                keyboardToggleSpotlight = refreshedSpotlight;
+                return refreshedSpotlight;
+            };
+            await this.waitForStableElementRect(keyboardToggle, scaleSceneMs(320, 160, 760));
+            keyboardToggleSpotlight = refreshKeyboardToggleSpotlight({ activate: true });
+            if (!keyboardToggleSpotlight || guardFailed()) {
+                return false;
+            }
             this.removeRetainedExtraSpotlight(agentMasterSpotlight);
 
-            const enabledKeyboardControl = await this.performHighlightedApiClick({
-                target: keyboardToggleSpotlight,
-                durationMs: scaleSceneMs(520, 320, 950),
-                runId: runId,
-                action: async () => {
+            this.applyGuideHighlights({
+                primary: keyboardToggleSpotlight
+            });
+            const movedToKeyboardToggle = await this.moveCursorToTrackedElement(
+                keyboardToggle,
+                scaleSceneMs(520, 320, 950),
+                {
+                    recheckDelayMs: scaleSceneMs(180, 80, 420),
+                    settleDelayMs: scaleSceneMs(80, 40, 180)
+                }
+            );
+            if (!movedToKeyboardToggle || guardFailed()) {
+                return false;
+            }
+
+            keyboardToggleSpotlight = refreshKeyboardToggleSpotlight();
+            if (!keyboardToggleSpotlight || guardFailed()) {
+                return false;
+            }
+            if (!this.isCursorAlignedWithElement(keyboardToggle, 5)) {
+                const realignedToKeyboardToggle = await this.moveCursorToTrackedElement(
+                    keyboardToggle,
+                    scaleSceneMs(220, 120, 420),
+                    {
+                        recheckDelayMs: scaleSceneMs(80, 40, 180),
+                        settleDelayMs: scaleSceneMs(40, 20, 120)
+                    }
+                );
+                if (!realignedToKeyboardToggle || guardFailed()) {
+                    return false;
+                }
+                keyboardToggleSpotlight = refreshKeyboardToggleSpotlight();
+                if (!keyboardToggleSpotlight || guardFailed()) {
+                    return false;
+                }
+            }
+
+            const enabledKeyboardControl = await this.runActionWithCursorClick(
+                DEFAULT_CURSOR_CLICK_VISIBLE_MS,
+                async () => {
                     const enabled = await this.setAgentFlagEnabled('computer_use_enabled', true);
                     if (!enabled) {
                         return false;
                     }
                     return !!(await this.waitForAgentToggleState('agent-keyboard', true, 1800));
                 }
-            });
+            );
             if (!enabledKeyboardControl || guardFailed()) {
+                return false;
+            }
+
+            await this.waitForStableElementRect(keyboardToggle, scaleSceneMs(320, 160, 760));
+            keyboardToggleSpotlight = refreshKeyboardToggleSpotlight();
+            if (!keyboardToggleSpotlight || guardFailed()) {
                 return false;
             }
             this.rememberAvatarFloatingSceneCursorAnchor('day1_takeover_capture_cursor', keyboardToggleSpotlight);

--- a/static/yui-guide-audio-files.test.cjs
+++ b/static/yui-guide-audio-files.test.cjs
@@ -359,6 +359,7 @@ test('day6 plugin side panel opens management preview through timeline operation
     assert.equal(operationCommand.at, 1);
     assert.equal(operationCommand.operation, 'day6-plugin-open-management-panel-flow');
     assert.equal(operationCommand.blocking, true);
+    assert.equal(scene.afterSceneDelayMs, 0);
 });
 
 test('day6 plugin dashboard handoff runs through timeline operation after narration starts', () => {

--- a/static/yui-guide-day1-round-structure.test.cjs
+++ b/static/yui-guide-day1-round-structure.test.cjs
@@ -23,6 +23,24 @@ function getSceneBlock(source, sceneId) {
   return source.slice(start, end + '\n                }'.length);
 }
 
+function getBalancedBlockFrom(source, startIndex) {
+  const openBraceIndex = source.indexOf('{', startIndex);
+  assert.notStrictEqual(openBraceIndex, -1, 'expected block opening brace');
+  let depth = 0;
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    const character = source[index];
+    if (character === '{') {
+      depth += 1;
+    } else if (character === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(startIndex, index + 1);
+      }
+    }
+  }
+  assert.fail('expected balanced block closing brace');
+}
+
 test('Day1 activation stays timeline-owned while greeting uses the generic scene path', () => {
   const operationRegistryBlock = operationRegistrySource.match(/registerBuiltInOperations\(\)\s*\{([\s\S]*?)\n\s*\}\n\s*\n\s*resolveTargetEntry/);
   assert.ok(operationRegistryBlock, 'expected to find built-in operation registrations');
@@ -172,7 +190,7 @@ test('Day1 return control cursor start prefers the current keyboard toggle geome
   const resolverBody = resolverMatch[1];
   const returnControlIndex = resolverBody.indexOf("if (sceneId === 'day1_takeover_return_control') {");
   assert.notStrictEqual(returnControlIndex, -1, 'expected day1_takeover_return_control cursor start branch');
-  const returnControlBlock = resolverBody.slice(returnControlIndex, resolverBody.indexOf("if (sceneId === 'day1_open_chat')", returnControlIndex));
+  const returnControlBlock = getBalancedBlockFrom(resolverBody, returnControlIndex);
   assert.match(returnControlBlock, /const keyboardToggle = this\.getAgentToggleElement\('agent-keyboard'\);/);
   assert.match(returnControlBlock, /const keyboardRect = this\.getElementRect\(keyboardToggle\);/);
   assert.ok(

--- a/static/yui-guide-day1-round-structure.test.cjs
+++ b/static/yui-guide-day1-round-structure.test.cjs
@@ -149,12 +149,36 @@ test('Day1 takeover capture click is owned by the embedded takeover sequence', (
   assert.doesNotMatch(sceneBlock, /cursorAction:\s*'click'/);
 });
 
-test('Day1 takeover capture leaves the next cursor start on the keyboard control toggle', () => {
+test('Day1 takeover capture resamples the keyboard control target before click and anchor persistence', () => {
   const sequenceMatch = directorSource.match(/async runTakeoverKeyboardControlSequence\(step, performance, runId\)\s*\{([\s\S]*?)\n\s*\}\n\s*async runPluginDashboardLaunchSequence/);
   assert.ok(sequenceMatch, 'expected to find runTakeoverKeyboardControlSequence');
   const sequenceBody = sequenceMatch[1];
-  assert.match(sequenceBody, /const keyboardToggleSpotlight = createToggleSpotlightTarget\('takeover-keyboard-toggle', keyboardToggle\);/);
+  assert.match(sequenceBody, /const refreshKeyboardToggleSpotlight = \(options\) => \{/);
+  assert.match(sequenceBody, /createToggleSpotlightTarget\('takeover-keyboard-toggle', keyboardToggle\)/);
+  assert.match(sequenceBody, /this\.replaceRetainedExtraSpotlight\(isKeyboardToggleSpotlight, refreshedSpotlight\);/);
+  assert.match(sequenceBody, /if \(normalizedOptions\.activate === true\) \{\s*this\.overlay\.activateSpotlight\(refreshedSpotlight\);/);
+  assert.match(sequenceBody, /keyboardToggleSpotlight = refreshKeyboardToggleSpotlight\(\{ activate: true \}\);/);
+  assert.match(sequenceBody, /await this\.waitForStableElementRect\(keyboardToggle,/);
+  assert.match(sequenceBody, /this\.moveCursorToTrackedElement\(\s*keyboardToggle,/);
+  assert.match(sequenceBody, /if \(!this\.isCursorAlignedWithElement\(keyboardToggle, 5\)\) \{/);
+  assert.match(sequenceBody, /keyboardToggleSpotlight = refreshKeyboardToggleSpotlight\(\);[\s\S]*const enabledKeyboardControl = await this\.runActionWithCursorClick/);
+  assert.match(sequenceBody, /this\.runActionWithCursorClick\([\s\S]*this\.setAgentFlagEnabled\('computer_use_enabled', true\)/);
   assert.match(sequenceBody, /this\.rememberAvatarFloatingSceneCursorAnchor\('day1_takeover_capture_cursor', keyboardToggleSpotlight\);/);
+});
+
+test('Day1 return control cursor start prefers the current keyboard toggle geometry', () => {
+  const resolverMatch = directorSource.match(/resolveAvatarFloatingCursorStartPoint\(scene, targets, previousSceneId\)\s*\{([\s\S]*?)\n\s*\}\n\s*async moveAvatarFloatingCursor/);
+  assert.ok(resolverMatch, 'expected to find resolveAvatarFloatingCursorStartPoint');
+  const resolverBody = resolverMatch[1];
+  const returnControlIndex = resolverBody.indexOf("if (sceneId === 'day1_takeover_return_control') {");
+  assert.notStrictEqual(returnControlIndex, -1, 'expected day1_takeover_return_control cursor start branch');
+  const returnControlBlock = resolverBody.slice(returnControlIndex, resolverBody.indexOf("if (sceneId === 'day1_open_chat')", returnControlIndex));
+  assert.match(returnControlBlock, /const keyboardToggle = this\.getAgentToggleElement\('agent-keyboard'\);/);
+  assert.match(returnControlBlock, /const keyboardRect = this\.getElementRect\(keyboardToggle\);/);
+  assert.ok(
+    returnControlBlock.indexOf('keyboardRect') < returnControlBlock.indexOf("getAvatarFloatingSceneCursorAnchor('day1_takeover_capture_cursor')"),
+    'expected current keyboard toggle geometry to be sampled before falling back to the saved anchor'
+  );
 });
 
 test('Day1 return control highlights the capsule input and keeps the petal cue', () => {

--- a/static/yui-guide-round-prelude.test.cjs
+++ b/static/yui-guide-round-prelude.test.cjs
@@ -30,6 +30,10 @@ test('round prelude runs avatar override, visibility, delay, lifecycle and start
             calls.push(['visible', sceneId]);
             return Promise.resolve();
         },
+        waitForAvatarReady(sceneId) {
+            calls.push(['ready', sceneId]);
+            return Promise.resolve();
+        },
         sleep(delayMs) {
             calls.push(['sleep', delayMs]);
             return Promise.resolve();
@@ -54,6 +58,7 @@ test('round prelude runs avatar override, visibility, delay, lifecycle and start
         'begin',
         'reveal',
         ['visible', 'avatar_floating_day4'],
+        ['ready', 'avatar_floating_day4'],
         ['sleep', 1500],
         ['takeover', 4, 'manual'],
         ['lifecycle', true],
@@ -75,6 +80,10 @@ test('round prelude starts takeover for day one before audio activation', async 
         },
         ensureVisible() {
             calls.push('visible');
+            return Promise.resolve();
+        },
+        waitForAvatarReady() {
+            calls.push('ready');
             return Promise.resolve();
         },
         sleep() {
@@ -101,6 +110,7 @@ test('round prelude starts takeover for day one before audio activation', async 
         'begin',
         'reveal',
         'visible',
+        'ready',
         'sleep',
         'takeover',
         'lifecycle',
@@ -205,6 +215,62 @@ test('round prelude stops after visibility failure', async () => {
         'reveal'
     ]);
     assert.equal(warnings.length, 1);
+});
+
+test('round prelude continues after avatar ready wait failure', async () => {
+    const { TutorialRoundPreludeController } = require('./tutorial/core/round-prelude-controller.js');
+    const calls = [];
+    const warnings = [];
+    const controller = new TutorialRoundPreludeController({
+        beginAvatarOverride() {
+            calls.push('begin');
+        },
+        revealPrepared() {
+            calls.push('reveal');
+        },
+        ensureVisible() {
+            calls.push('visible');
+        },
+        waitForAvatarReady() {
+            calls.push('ready');
+            return Promise.reject(new Error('ready timeout'));
+        },
+        sleep(delayMs) {
+            calls.push(['sleep', delayMs]);
+            return Promise.resolve();
+        },
+        beginTakingOver(detail) {
+            calls.push(['takeover', detail.day, detail.source]);
+        },
+        setLifecycleActive(active) {
+            calls.push(['lifecycle', active]);
+        },
+        showSkipButton() {
+            calls.push('skip');
+        },
+        dispatchStarted(detail) {
+            calls.push(['started', detail.day, detail.source]);
+        },
+        warn(message) {
+            warnings.push(message);
+        }
+    });
+
+    await controller.play(1, { source: 'auto', delayMs: 20 });
+
+    assert.deepEqual(calls, [
+        'begin',
+        'reveal',
+        'visible',
+        'ready',
+        ['sleep', 20],
+        ['takeover', 1, 'auto'],
+        ['lifecycle', true],
+        'skip',
+        ['started', 1, 'auto']
+    ]);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /等待 YUI 模型视觉就绪失败/);
 });
 
 test('manager delegates avatar floating prelude to TutorialRoundPreludeController', () => {

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -3344,10 +3344,31 @@ def test_day6_status_and_plugin_lines_run_split_plugin_dashboard_flow(mock_page:
                 });
                 return true;
             };
+            director.moveCursorToTrackedElement = async (element, durationMs, options) => {
+                calls.push({
+                    type: 'trackedMove',
+                    id: element && element.id,
+                    durationMs,
+                    exactDuration: !!(options && options.exactDuration),
+                    recheckDelayMs: options && options.recheckDelayMs,
+                    settleDelayMs: options && options.settleDelayMs,
+                });
+                return true;
+            };
+            director.waitForStableElementRect = async (element, timeoutMs) => {
+                calls.push({
+                    type: 'stableRect',
+                    id: element && element.id,
+                    timeoutMs,
+                });
+                return element;
+            };
+            director.isCursorAlignedWithElement = () => true;
             director.cursor = {
                 hasPosition: () => true,
                 showAt: () => {},
                 moveToRect: async () => true,
+                moveToPoint: async () => true,
                 click: (visibleMs) => calls.push({ type: 'click', visibleMs }),
                 wobble: () => calls.push({ type: 'wobble' }),
                 cancel: () => {},
@@ -3452,13 +3473,27 @@ def test_day6_status_and_plugin_lines_run_split_plugin_dashboard_flow(mock_page:
         {"type": "move", "id": "live2d-btn-agent", "durationMs": 760, "exactDuration": False},
         {"type": "click", "visibleMs": 420},
         {"type": "api:openAgentPanel"},
+        {"type": "stableRect", "id": "live2d-toggle-agent-user-plugin", "timeoutMs": 760},
         {
             "type": "highlight",
             "key": "day6_plugin_side_panel-user-plugin",
             "primaryId": "live2d-toggle-agent-user-plugin",
             "persistentId": None,
         },
-        {"type": "move", "id": "live2d-toggle-agent-user-plugin", "durationMs": 420, "exactDuration": True},
+        {
+            "type": "trackedMove",
+            "id": "live2d-toggle-agent-user-plugin",
+            "durationMs": 420,
+            "exactDuration": True,
+            "recheckDelayMs": 120,
+            "settleDelayMs": 40,
+        },
+        {
+            "type": "highlight",
+            "key": "day6_plugin_side_panel-user-plugin",
+            "primaryId": "live2d-toggle-agent-user-plugin",
+            "persistentId": None,
+        },
         {"type": "click", "visibleMs": 320},
         {"type": "api:ensureAgentSidePanel", "toggleId": "user-plugin"},
         {
@@ -3466,6 +3501,12 @@ def test_day6_status_and_plugin_lines_run_split_plugin_dashboard_flow(mock_page:
             "toggleId": "agent-user-plugin",
             "actionId": "management-panel",
         },
+        {
+            "type": "stableRect",
+            "id": "neko-sidepanel-action-agent-user-plugin-management-panel",
+            "timeoutMs": 760,
+        },
+        {"type": "ui:clearVirtualSpotlight", "key": "plugin-management-entry"},
         {"type": "virtualSpotlight", "key": "plugin-management-entry", "padding": "0", "width": 216, "height": 64},
         {
             "type": "highlight",
@@ -3474,10 +3515,20 @@ def test_day6_status_and_plugin_lines_run_split_plugin_dashboard_flow(mock_page:
             "persistentId": None,
         },
         {
-            "type": "move",
+            "type": "trackedMove",
             "id": "neko-sidepanel-action-agent-user-plugin-management-panel",
             "durationMs": 420,
             "exactDuration": True,
+            "recheckDelayMs": 120,
+            "settleDelayMs": 40,
+        },
+        {"type": "ui:clearVirtualSpotlight", "key": "plugin-management-entry"},
+        {"type": "virtualSpotlight", "key": "plugin-management-entry", "padding": "0", "width": 216, "height": 64},
+        {
+            "type": "highlight",
+            "key": "day6_plugin_side_panel-management-panel",
+            "primaryId": "",
+            "persistentId": None,
         },
         {"type": "click", "visibleMs": 320},
         {"type": "api:waitForOpenedWindow", "windowName": "plugin_dashboard", "timeoutMs": 120},

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -3185,12 +3185,14 @@ def test_agent_ui_v2_free_warning_accepts_command_gate_shape():
 
 def test_agent_ui_v2_keeps_agent_status_short_during_tutorial():
     source = Path("static/js/agent_ui_v2.js").read_text(encoding="utf-8")
-    status_block = source.split("const setStatus = (msg) => {", 1)[1].split(
+    status_block = source.split("const setStatus = (msg, options) => {", 1)[1].split(
         "const currentLanlanName",
         1,
     )[0]
 
-    assert "window.isInTutorial === true ? 'NekoClaw server ready' : (msg || '')" in status_block
+    assert "options.stabilizeTutorialText === true" in status_block
+    assert "isTutorialAgentStatusLocked()" in status_block
+    assert "shouldStabilizeTutorialText ? 'NekoClaw server ready' : (msg || '')" in status_block
     assert "s.textContent = text;" in status_block
 
 

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -3183,6 +3183,17 @@ def test_agent_ui_v2_free_warning_accepts_command_gate_shape():
     assert "window.showAlert(msg, title)" in source
 
 
+def test_agent_ui_v2_keeps_agent_status_short_during_tutorial():
+    source = Path("static/js/agent_ui_v2.js").read_text(encoding="utf-8")
+    status_block = source.split("const setStatus = (msg) => {", 1)[1].split(
+        "const currentLanlanName",
+        1,
+    )[0]
+
+    assert "window.isInTutorial === true ? 'NekoClaw server ready' : (msg || '')" in status_block
+    assert "s.textContent = text;" in status_block
+
+
 def test_get_model_api_config_agent_uses_agent_fields_without_custom_switch():
     manager = object.__new__(ConfigManager)
     manager.get_core_config = lambda: {

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -301,6 +301,7 @@ def test_day6_round_wrap_returns_to_capsule_input_like_day2_wrap():
     assert_scene_order(round_block, EXPECTED_DAY6_SCENES)
     assert "除了之前介绍的功能，这里还有超多好玩的插件呢。" in plugin_side_panel_block
     assert "除了之前介绍的功能，这里还有超多好玩的插件呢'," not in plugin_side_panel_block
+    assert "afterSceneDelayMs: 0" in plugin_side_panel_block
     assert "target: '#agent-task-hud'" in task_hud_block
     assert "cursorAction: 'move'" in task_hud_block
     assert "cursorAction: 'tour'" not in task_hud_block
@@ -605,7 +606,7 @@ def test_pc_overlay_cursor_effect_is_one_shot_not_persisted_on_external_chat_bri
     assert "function withoutTransientYuiGuideCursorEffect(cursor)" in source
     assert "yuiGuidePcOverlayCursor = withoutTransientYuiGuideCursorEffect(patch.cursor);" in bridge_block
     assert "payload.cursor = patch.cursor || null;" in bridge_block
-    assert "payload.cursor = yuiGuidePcOverlayCursor;" in bridge_block
+    assert "payload.cursor = yuiGuidePcOverlayCursor;" not in bridge_block
 
 
 def test_day1_round_start_uses_avatar_floating_round_lifecycle():

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -606,7 +606,7 @@ def test_pc_overlay_cursor_effect_is_one_shot_not_persisted_on_external_chat_bri
     assert "function withoutTransientYuiGuideCursorEffect(cursor)" in source
     assert "yuiGuidePcOverlayCursor = withoutTransientYuiGuideCursorEffect(patch.cursor);" in bridge_block
     assert "payload.cursor = patch.cursor || null;" in bridge_block
-    assert "payload.cursor = yuiGuidePcOverlayCursor;" not in bridge_block
+    assert "payload.cursor = yuiGuidePcOverlayCursor;" in bridge_block
 
 
 def test_day1_round_start_uses_avatar_floating_round_lifecycle():

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -4,10 +4,17 @@ from pathlib import Path
 UNIVERSAL_TUTORIAL_MANAGER_PATH = (
     Path(__file__).resolve().parents[2] / "static" / "tutorial/core/universal-manager.js"
 )
+ROUND_PRELUDE_CONTROLLER_PATH = (
+    Path(__file__).resolve().parents[2] / "static" / "tutorial/core/round-prelude-controller.js"
+)
 
 
 def _read_manager() -> str:
     return UNIVERSAL_TUTORIAL_MANAGER_PATH.read_text(encoding="utf-8")
+
+
+def _read_round_prelude() -> str:
+    return ROUND_PRELUDE_CONTROLLER_PATH.read_text(encoding="utf-8")
 
 
 def test_universal_tutorial_manager_excludes_legacy_driver_tutorial_system():
@@ -154,6 +161,19 @@ def test_tutorial_yui_visibility_does_not_trust_stale_live2d_path_without_model(
     assert "YUI 临时模型需要重新加载以恢复视觉对象" in visible_block
     assert "&& this.hasTutorialYuiLive2dRenderableModel()" in visible_block
     assert "&& placementReady === true;" in visible_block
+    assert "isTutorialYuiLive2dVisualReady()" in source
+    visual_ready_block = source.split(
+        "    isTutorialYuiLive2dVisualReady() {",
+        1,
+    )[1].split(
+        "    waitForTutorialYuiLive2dVisualReady(reason = '', maxWaitTime = 12000) {",
+        1,
+    )[0]
+    assert "this.isTutorialYuiLive2dActive()" in visual_ready_block
+    assert "this.hasTutorialYuiLive2dRenderableModel(manager)" in visual_ready_block
+    assert "manager._isLoadingModel === true" in visual_ready_block
+    assert "state !== 'ready'" in visual_ready_block
+    assert "manager._isModelReadyForInteraction !== true" in visual_ready_block
 
     restore_block = source.split(
         "    restoreTutorialLive2dDisplayState(reason = '', options = {}) {",
@@ -170,6 +190,24 @@ def test_tutorial_yui_visibility_does_not_trust_stale_live2d_path_without_model(
     assert "live2dContainer.style.setProperty('opacity', '1', 'important');" in restore_block
     assert "live2dCanvas.style.removeProperty('opacity');" in restore_block
     assert "live2dCanvas.style.setProperty('opacity', '1', 'important');" in restore_block
+
+
+def test_round_prelude_waits_for_yui_visual_ready_before_taking_over():
+    source = _read_round_prelude()
+    play_block = source.split("        async play(day, options) {", 1)[1].split(
+        "    return {",
+        1,
+    )[0]
+
+    assert "this.waitForAvatarReady = normalizedOptions.waitForAvatarReady || noop;" in source
+    assert "await toPromise(() => this.ensureVisible(sceneId, {" in play_block
+    assert "await toPromise(() => this.waitForAvatarReady(sceneId, {" in play_block
+    assert play_block.index("await toPromise(() => this.ensureVisible(sceneId, {") < play_block.index(
+        "await toPromise(() => this.waitForAvatarReady(sceneId, {"
+    )
+    assert play_block.index("await toPromise(() => this.waitForAvatarReady(sceneId, {") < play_block.index(
+        "this.beginTakingOver({"
+    )
 
 
 def test_tutorial_yui_teardown_clears_non_live2d_runtime_residue_before_replay():
@@ -236,6 +274,7 @@ def test_tutorial_yui_teardown_clears_non_live2d_runtime_residue_before_replay()
     assert "hideTutorialLive2dRuntimeSurfaceAfterResidueClear()" in source
     assert "await this.waitForTutorialTeardownSettled('avatar-floating-guide-start');" in start_round_block
     assert "async waitForTutorialTeardownSettled(reason = '')" in source
+    assert "waitForAvatarReady: (sceneId) => this.waitForTutorialYuiLive2dVisualReady(sceneId, 12000)" in source
     assert "if (!this.hasTutorialYuiLive2dRenderableModel(manager)) {" in placement_block
     assert "deferRevealPrepared: true" in prelude_block
     assert "const deferRevealPrepared = options && options.deferRevealPrepared === true;" in ensure_visible_block

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -274,7 +274,7 @@ def test_tutorial_yui_teardown_clears_non_live2d_runtime_residue_before_replay()
     assert "hideTutorialLive2dRuntimeSurfaceAfterResidueClear()" in source
     assert "await this.waitForTutorialTeardownSettled('avatar-floating-guide-start');" in start_round_block
     assert "async waitForTutorialTeardownSettled(reason = '')" in source
-    assert "waitForAvatarReady: (sceneId) => this.waitForTutorialYuiLive2dVisualReady(sceneId, 12000)" in source
+    assert "waitForAvatarReady: (sceneId, _options) => this.waitForTutorialYuiLive2dVisualReady(sceneId, 12000)" in source
     assert "if (!this.hasTutorialYuiLive2dRenderableModel(manager)) {" in placement_block
     assert "deferRevealPrepared: true" in prelude_block
     assert "const deferRevealPrepared = options && options.deferRevealPrepared === true;" in ensure_visible_block


### PR DESCRIPTION
﻿## 改动概述 / Summary

本 PR 包含两个新手教程修复提交：

- 修复 Day1 / Day6 新手教程中 Ghost Cursor 与高亮定位在目标布局变化时的抖动和错位问题。
- 在悬浮窗教程 prelude 中，等待 YUI Live2D 临时模型进入视觉与交互 ready 后再正式进入教程，缓解首次使用经过存储位置选择后的冷启动动画延迟。

根因：部分教程目标会在预检文案、侧栏状态或 overlay patch 中发生布局/状态变化；首启路径则会在存储位置选择后才启动主应用和 Live2D 加载，浮动按钮出现早于模型完全 ready，导致台词先播而模型动作晚半拍。

## 回归报告 / Regression Report

不适用。本 PR 未修改 app/、main_logic/、memory/ 下的 Python 业务模块。

## 不拆分理由 / Why Not Split

不适用。本 PR 改动文件数未超过拆分阈值。

## 测试 / Testing

- `node --check static/tutorial/core/universal-manager.js`
- `node --check static/tutorial/core/round-prelude-controller.js`
- `node --check static/yui-guide-round-prelude.test.cjs`
- `.venv\Scripts\python.exe -m pytest tests/unit/test_universal_tutorial_manager_static.py`
- `node static/yui-guide-round-prelude.test.cjs`
- `node static/tutorial-timeline-engine.test.cjs`

补充说明：额外执行过 `node static/yui-guide-day1-round-structure.test.cjs`，其中 2 个既有契约失败与本 PR 改动无关，分别涉及当前 Day1 greeting timeline 配置与 app-interpage 正则契约不一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 教程进入前等待“YUI Live2D 视觉就绪”，超时后不中断流程继续进行。
* **Bug Fixes**
  * 教程锁定期间状态文案更稳定，避免被其他消息覆盖（固定为“server ready”）。
  * 教程光标追踪与高亮刷新流程更可靠，管理面板/键盘开关步骤衔接更顺畅。
  * 修正覆盖层在未携带光标时的兜底语义，避免意外写入 `cursor=null`。
  * 明确 day6 管理面板预览后的场景切换延迟为 0ms。
* **Tests**
  * 更新并新增等待、稳定矩形/追踪移动、状态文案稳定等相关单测与回归断言。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->