### PR TITLE
修复 PNGTuber 说话时右侧栏跳动

### DIFF
--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -688,9 +688,6 @@
             if (this.lastOverlayPositionUpdateAt && timestamp - this.lastOverlayPositionUpdateAt < minIntervalMs) return;
             this.lastOverlayPositionUpdateAt = timestamp;
             this.updateLockIconPosition();
-            if (typeof this.updateFloatingButtonsPosition === 'function') {
-                this.updateFloatingButtonsPosition();
-            }
         }
 
         applyAnimationTransform(timestamp = performance.now()) {

--- a/tests/unit/test_pngtuber_static_contracts.py
+++ b/tests/unit/test_pngtuber_static_contracts.py
@@ -465,7 +465,7 @@ def test_pngtuber_animation_loops_throttle_overlay_position_updates():
     assert "const minIntervalMs = 120;" in helper_block
     assert "timestamp - this.lastOverlayPositionUpdateAt < minIntervalMs" in helper_block
     assert "this.updateLockIconPosition();" in helper_block
-    assert "this.updateFloatingButtonsPosition();" in helper_block
+    assert "this.updateFloatingButtonsPosition();" not in helper_block
     assert "applyAnimationTransform(timestamp = performance.now())" in helper_block
     assert "if (this.lastAnimationTransformAt === timestamp) return;" in helper_block
     assert "this.lastAnimationTransformAt = timestamp;" in helper_block


### PR DESCRIPTION
﻿## 改动概述

PNGTuber 分层形象在说话时会通过 `talkingHop` 修改头像图像的视觉 transform。此前动画帧同时触发浮动按钮重新定位，而定位逻辑读取的是已经包含 transform 的 `getBoundingClientRect()`，导致按钮和挂在按钮上的右侧栏把视觉跳动误当成布局变化一起抖动。

本次调整把说话/呼吸这类纯视觉动画和浮动 UI 布局更新拆开：动画帧仍然保留锁图标的节流刷新，但不再重新计算 floating buttons 的位置。浮动按钮和右侧栏继续只跟随拖拽、缩放、加载、窗口尺寸变化等真实布局变化。

## 风险与边界

本次不改变 PNGTuber 的说话跳动幅度、口型同步、分层渲染和按钮本身的常规布局算法，只收窄动画帧期间的 overlay 更新范围。主要回归风险在于动画过程中锁图标仍需保持遮挡判断和位置刷新；浮动按钮位置会在动画期间保持稳定，真实位置变化仍由现有拖拽、缩放和 resize 路径处理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了动画更新时的覆盖层位置同步逻辑，避免在特定动画循环中额外刷新悬浮按钮位置，从而减少不必要的界面抖动或位置变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->