### PR TITLE
fix(config): keep free assist model ids fixed

### DIFF
--- a/tests/unit/test_config_manager_follow_urls.py
+++ b/tests/unit/test_config_manager_follow_urls.py
@@ -88,6 +88,37 @@ def test_follow_assist_uses_saved_model_id_for_text_tiers():
         shutil.rmtree(config_dir, ignore_errors=True)
 
 
+def test_free_follow_assist_ignores_stale_saved_model_id_for_text_tiers():
+    """Free assist has fixed model names and must not reuse stale paid provider IDs."""
+    config_dir = _make_workspace_temp_dir()
+    try:
+        cm = _manager_with_core_config(config_dir, {
+            "coreApiKey": "free-access",
+            "coreApi": "free",
+            "assistApi": "free",
+            "assistApiKey": "free-access",
+            "enableCustomApi": True,
+            "conversationModelProvider": "follow_assist",
+            "conversationModelUrl": "https://www.lanlan.tech/text/v1",
+            "conversationModelId": "deepseek-v4-pro",
+            "conversationModelApiKey": "free-access",
+            "emotionModelProvider": "follow_assist",
+            "emotionModelUrl": "https://www.lanlan.tech/text/v1",
+            "emotionModelId": "deepseek-v4-pro",
+            "emotionModelApiKey": "free-access",
+            "agentModelProvider": "follow_assist",
+            "agentModelUrl": "https://www.lanlan.tech/text/v1",
+            "agentModelId": "deepseek-v4-pro",
+            "agentModelApiKey": "free-access",
+        })
+
+        assert cm.get_model_api_config("conversation")["model"] == "free-model"
+        assert cm.get_model_api_config("emotion")["model"] == "free-mini-model"
+        assert cm.get_model_api_config("agent")["model"] == "free-agent-model"
+    finally:
+        shutil.rmtree(config_dir, ignore_errors=True)
+
+
 def test_follow_core_uses_saved_model_id_for_text_tiers():
     """follow_core keeps saved text model IDs while following URL and key."""
     config_dir = _make_workspace_temp_dir()

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -4272,7 +4272,10 @@ class ConfigManager:
                 elif provider == 'follow_summary':
                     config[model_key] = config.get('SUMMARY_MODEL', '')
                 elif provider in ('follow_core', 'follow_assist'):
+                    uses_fixed_free_assist_model = provider == 'follow_assist' and assist_api_value == 'free'
                     if (
+                        not uses_fixed_free_assist_model
+                        and
                         prefix not in ('gameMain', 'gameSummary', 'omni', 'tts')
                         and isinstance(cfg_model, str)
                         and cfg_model.strip()


### PR DESCRIPTION
## 改动概述 / Summary
- 修复 `assistApi=free` 且模型槽位为 `follow_assist` 时，配置解析错误复用历史保存的付费模型 ID（例如 `deepseek-v4-pro`）的问题。
- 免费辅助 API 使用固定模型名：`conversation=free-model`、`emotion=free-mini-model`、`agent=free-agent-model`。
- 保留 #2052 的原有意图：DeepSeek / Qwen 等非 free provider 的 `follow_assist` / `follow_core` 仍会保留用户保存的模型 ID。

## 回归报告 / Regression Report
不适用。本 PR 未修改 `app/`、`main_logic/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split
不适用。变更只包含一个配置解析边界修复和对应单测。

## 测试 / Testing
- `uv run pytest tests/unit/test_config_manager_follow_urls.py -q`
- `python3 -m py_compile utils/config_manager.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了在启用跟随助手配置且使用免费模式时，旧的模型标识可能被误保留的问题。
  * 现在相关文本模型会正确回退到当前可用的免费模型，避免沿用过期配置。

* **Tests**
  * 新增回归测试，覆盖免费模式下跟随助手配置的模型回退行为，确保不会再次出现旧模型 ID 被错误复用的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->