### PR TITLE
深话题投递改权重计数 + 投递前前端预告气泡

### DIFF
--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -114,7 +114,10 @@ type CompactHistoryBubbleTone = {
 };
 
 export function isCompactExportMessageSelectable(message: ChatMessage) {
-  return !!message.id && message.status !== 'sending';
+  // Frontend-only topic-hint teasers are hidden from the history view and never
+  // exported, so they must not count toward selectable/selected totals either —
+  // otherwise the header count diverges from what's visible/selectable.
+  return !!message.id && message.status !== 'sending' && !isTopicHintMessage(message);
 }
 
 function isSelectionIgnoredTarget(target: EventTarget | null, currentTarget: EventTarget) {

--- a/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
+++ b/frontend/react-neko-chat/src/CompactExportHistoryPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { i18n } from './i18n';
 import MessageBlockView from './MessageBlockView';
 import ThinkingDots from './ThinkingDots';
+import { isTopicHintMessage } from './TopicHintBubble';
 import { type ChatMessage, type MessageAction } from './message-schema';
 
 export const COMPACT_EXPORT_SELECTION_LIMIT = 100;
@@ -214,7 +215,7 @@ function getCompactHistoryBubbleTone(
 }
 
 export default function CompactExportHistoryPanel({
-  messages,
+  messages: allMessages,
   selectedIds,
   selectedCount,
   selectableCount,
@@ -243,6 +244,13 @@ export default function CompactExportHistoryPanel({
   onHistoryResizePointerUp,
   onHistoryResizePointerCancel,
 }: CompactExportHistoryPanelProps) {
+  // Frontend-only topic-hint teasers live in the host message list so they can
+  // render, but they carry no real history — exclude them from the history view,
+  // selection, and export so they can't show up as blank rows / empty entries.
+  const messages = useMemo(
+    () => allMessages.filter((message) => !isTopicHintMessage(message)),
+    [allMessages],
+  );
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const autoScrollToBottomRef = useRef(autoScrollToBottom);
   autoScrollToBottomRef.current = autoScrollToBottom;

--- a/frontend/react-neko-chat/src/MessageBubble.tsx
+++ b/frontend/react-neko-chat/src/MessageBubble.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { i18n } from './i18n';
 import MessageBlockView, { isGuideMessage } from './MessageBlockView';
+import TopicHintBubble, { isTopicHintMessage } from './TopicHintBubble';
 import {
   type ChatMessage,
   type MessageAction,
@@ -54,6 +55,10 @@ export default function MessageBubble({
   const showAvatar = message.role !== 'system' && !isGroupedWithPrevious;
   const showMeta = message.role !== 'system' && !isGroupedWithPrevious;
   const showFailed = message.role !== 'system' && message.status === 'failed';
+
+  if (isTopicHintMessage(message)) {
+    return <TopicHintBubble message={message} />;
+  }
 
   if (message.role === 'system') {
     return (

--- a/frontend/react-neko-chat/src/TopicHintBubble.test.tsx
+++ b/frontend/react-neko-chat/src/TopicHintBubble.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import TopicHintBubble, { isTopicHintMessage } from './TopicHintBubble';
 import MessageBubble from './MessageBubble';
+import { isCompactExportMessageSelectable } from './CompactExportHistoryPanel';
 import { parseChatMessage, type ChatMessage } from './message-schema';
 
 function topicHintMessage(author = '桃奈'): ChatMessage {
@@ -78,6 +79,19 @@ describe('TopicHintBubble', () => {
     const text = container.querySelector('.topic-hint-chip')?.textContent ?? '';
     expect(text).toContain('桃奈');
     expect(text).not.toContain('chat.topicHint');
+  });
+
+  it('excludes topic-hint teasers from compact-export selection accounting', () => {
+    expect(isCompactExportMessageSelectable(topicHintMessage())).toBe(false);
+    expect(
+      isCompactExportMessageSelectable({
+        id: 'a-1',
+        role: 'assistant',
+        author: 'Neko',
+        time: '10:00',
+        blocks: [{ type: 'text', text: 'hi' }],
+      }),
+    ).toBe(true);
   });
 
   it('rejects a whitespace-only author at the schema boundary', () => {

--- a/frontend/react-neko-chat/src/TopicHintBubble.test.tsx
+++ b/frontend/react-neko-chat/src/TopicHintBubble.test.tsx
@@ -69,4 +69,26 @@ describe('TopicHintBubble', () => {
     // Must NOT fall back to the generic system-chip.
     expect(container.querySelector('.system-chip')).toBeNull();
   });
+
+  it('falls back to the default copy when safeT echoes the key back', () => {
+    // A non-i18next safeT returning the key (missing translation) must not leak
+    // the raw key into the bubble.
+    (window as unknown as Record<string, unknown>).safeT = (key: string) => key;
+    const { container } = render(<TopicHintBubble message={topicHintMessage('桃奈')} />);
+    const text = container.querySelector('.topic-hint-chip')?.textContent ?? '';
+    expect(text).toContain('桃奈');
+    expect(text).not.toContain('chat.topicHint');
+  });
+
+  it('rejects a whitespace-only author at the schema boundary', () => {
+    expect(() =>
+      parseChatMessage({
+        id: 'topic-hint-x',
+        role: 'system',
+        author: 'x',
+        time: '10:00',
+        blocks: [{ type: 'topic-hint', author: '   ' }],
+      }),
+    ).toThrow();
+  });
 });

--- a/frontend/react-neko-chat/src/TopicHintBubble.test.tsx
+++ b/frontend/react-neko-chat/src/TopicHintBubble.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import TopicHintBubble, { isTopicHintMessage } from './TopicHintBubble';
+import MessageBubble from './MessageBubble';
+import { parseChatMessage, type ChatMessage } from './message-schema';
+
+function topicHintMessage(author = '桃奈'): ChatMessage {
+  return {
+    id: 'topic-hint-1',
+    role: 'system',
+    author,
+    time: '10:00',
+    blocks: [{ type: 'topic-hint', author }],
+  };
+}
+
+afterEach(() => {
+  delete (window as unknown as Record<string, unknown>).safeT;
+  delete (window as unknown as Record<string, unknown>).t;
+});
+
+describe('TopicHintBubble', () => {
+  it('accepts a topic-hint block on the message schema', () => {
+    const parsed = parseChatMessage(topicHintMessage());
+    expect(parsed.blocks[0]?.type).toBe('topic-hint');
+  });
+
+  it('detects topic-hint system messages and ignores ordinary ones', () => {
+    expect(isTopicHintMessage(topicHintMessage())).toBe(true);
+    expect(
+      isTopicHintMessage({
+        id: 's-1',
+        role: 'system',
+        author: 'x',
+        time: '10:00',
+        blocks: [{ type: 'status', text: 'hi' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('interpolates the character name when the backend returns a raw template', () => {
+    // Mirrors the crash-proof window.t stub: returns defaultValue verbatim.
+    (window as unknown as Record<string, unknown>).safeT = (_k: string, arg: unknown) =>
+      typeof arg === 'string' ? arg : (arg as { defaultValue: string }).defaultValue;
+    const { container } = render(<TopicHintBubble message={topicHintMessage('YUI')} />);
+    const chip = container.querySelector('.topic-hint-chip');
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain('YUI');
+    expect(chip?.textContent).not.toContain('{author}');
+    expect(chip?.textContent).not.toContain('{{author}}');
+  });
+
+  it('uses the already-interpolated string when real i18next resolves the var', () => {
+    // Mirrors real i18next: given { author }, it interpolates and returns the
+    // finished string; the local re-apply must be a no-op (no double work).
+    (window as unknown as Record<string, unknown>).safeT = (key: string, arg: unknown) => {
+      const author = (arg as { author?: string })?.author ?? '';
+      return key === 'chat.topicHint' ? `${author} has something to say` : '';
+    };
+    const { container } = render(<TopicHintBubble message={topicHintMessage('Neko')} />);
+    expect(container.querySelector('.topic-hint-chip')?.textContent).toBe('Neko has something to say');
+  });
+
+  it('routes topic-hint messages through MessageBubble to the dedicated chip', () => {
+    (window as unknown as Record<string, unknown>).safeT = (_k: string, arg: unknown) =>
+      typeof arg === 'string' ? arg : (arg as { defaultValue: string }).defaultValue;
+    const { container } = render(<MessageBubble message={topicHintMessage()} />);
+    expect(container.querySelector('.topic-hint-chip')).not.toBeNull();
+    // Must NOT fall back to the generic system-chip.
+    expect(container.querySelector('.system-chip')).toBeNull();
+  });
+});

--- a/frontend/react-neko-chat/src/TopicHintBubble.tsx
+++ b/frontend/react-neko-chat/src/TopicHintBubble.tsx
@@ -1,0 +1,46 @@
+import { i18n } from './i18n';
+import { type ChatMessage, type TopicHintBlock } from './message-schema';
+
+/**
+ * A topic-hint message is a frontend-only teaser ("she has a topic she'd like
+ * to bring up") shown right before a proactive deep-topic opener. It never
+ * enters the chat-LLM context — the backend sends it on a dedicated
+ * ``topic_hint`` WS frame that skips the sync queue, and it carries a single
+ * ``topic-hint`` block instead of normal text.
+ */
+export function isTopicHintMessage(message: ChatMessage): boolean {
+  return (
+    message.role === 'system' &&
+    message.blocks.length > 0 &&
+    message.blocks.every((block) => block.type === 'topic-hint')
+  );
+}
+
+type TopicHintBubbleProps = {
+  message: ChatMessage;
+};
+
+export default function TopicHintBubble({ message }: TopicHintBubbleProps) {
+  const block = message.blocks.find(
+    (b): b is TopicHintBlock => b.type === 'topic-hint',
+  );
+  const author = (block?.author || message.author || '').trim();
+  // Pass author through to i18next interpolation; i18n() also re-applies it
+  // locally so the crash-proof window.t stub (which returns the raw template)
+  // still renders the name.
+  const text = i18n('chat.topicHint', '{{author}}好像有点想找你聊的话题…', { author });
+
+  return (
+    <article
+      className="message-row message-row-system"
+      data-message-id={message.id}
+      data-message-role="system"
+      data-topic-hint="true"
+      data-message-sort-key={message.sortKey ?? ''}
+    >
+      <div className="topic-hint-chip">
+        <span className="topic-hint-chip-text">{text}</span>
+      </div>
+    </article>
+  );
+}

--- a/frontend/react-neko-chat/src/i18n.ts
+++ b/frontend/react-neko-chat/src/i18n.ts
@@ -17,7 +17,9 @@ export function i18n(key: string, fallback: string, vars?: Record<string, string
   };
   if (typeof w.safeT === 'function') {
     const v = (w.safeT as (k: string, f: unknown) => unknown)(key, arg);
-    if (typeof v === 'string') return apply(v);
+    // Guard against a safeT that echoes the key back on a missing translation
+    // (mirrors the window.t branch) so we fall through to the fallback instead.
+    if (typeof v === 'string' && v !== key) return apply(v);
   }
   if (typeof w.t === 'function') {
     try {

--- a/frontend/react-neko-chat/src/i18n.ts
+++ b/frontend/react-neko-chat/src/i18n.ts
@@ -1,12 +1,29 @@
 /** 使用 Xiao8 i18n 系统（window.t / window.safeT），英文作为最终 fallback */
-export function i18n(key: string, fallback: string): string {
+export function i18n(key: string, fallback: string, vars?: Record<string, string>): string {
   const w = window as unknown as Record<string, unknown>;
-  if (typeof w.safeT === 'function') return (w.safeT as (k: string, f: string) => string)(key, fallback);
+  // When interpolation vars are supplied, hand them to i18next (so the real
+  // window.t resolves {{var}} itself) AND re-apply them locally: the crash-proof
+  // window.t stub returns the raw template untouched, and i18next would strip an
+  // un-passed {{var}} to empty, so local re-application is the belt-and-braces
+  // that makes the result correct under both backends.
+  const arg: unknown = vars ? { ...vars, defaultValue: fallback } : fallback;
+  const apply = (s: string): string => {
+    if (!vars) return s;
+    let out = s;
+    for (const [name, value] of Object.entries(vars)) {
+      out = out.split(`{{${name}}}`).join(value).split(`{${name}}`).join(value);
+    }
+    return out;
+  };
+  if (typeof w.safeT === 'function') {
+    const v = (w.safeT as (k: string, f: unknown) => unknown)(key, arg);
+    if (typeof v === 'string') return apply(v);
+  }
   if (typeof w.t === 'function') {
     try {
-      const v = (w.t as (k: string, f: string) => string)(key, fallback);
-      if (v && v !== key) return v;
+      const v = (w.t as (k: string, f: unknown) => unknown)(key, arg);
+      if (typeof v === 'string' && v && v !== key) return apply(v);
     } catch {}
   }
-  return fallback;
+  return apply(fallback);
 }

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -37,6 +37,14 @@ const statusBlockSchema = z.object({
   text: z.string(),
 });
 
+// Frontend-only "she has a topic she'd like to bring up" teaser, shown just
+// before a proactive deep-topic opener. Backend sends only the character name
+// (no LLM-context text); the dedicated TopicHintBubble renders localized copy.
+const topicHintBlockSchema = z.object({
+  type: z.literal('topic-hint'),
+  author: z.string().min(1),
+});
+
 const buttonGroupBlockSchema = z.object({
   type: z.literal('buttons'),
   buttons: z.array(messageActionSchema),
@@ -202,6 +210,7 @@ export const messageBlockSchema = z.discriminatedUnion('type', [
   linkBlockSchema,
   statusBlockSchema,
   buttonGroupBlockSchema,
+  topicHintBlockSchema,
 ]);
 
 const turnIdSchema = z.preprocess((value) => {
@@ -360,6 +369,7 @@ export type ImageBlock = z.infer<typeof imageBlockSchema>;
 export type LinkBlock = z.infer<typeof linkBlockSchema>;
 export type StatusBlock = z.infer<typeof statusBlockSchema>;
 export type ButtonGroupBlock = z.infer<typeof buttonGroupBlockSchema>;
+export type TopicHintBlock = z.infer<typeof topicHintBlockSchema>;
 export type ComposerAttachment = z.infer<typeof composerAttachmentSchema>;
 export type ChatSurfaceMode = z.infer<typeof chatSurfaceModeSchema>;
 export type CompactChatState = z.infer<typeof compactChatStateSchema>;

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -42,7 +42,9 @@ const statusBlockSchema = z.object({
 // (no LLM-context text); the dedicated TopicHintBubble renders localized copy.
 const topicHintBlockSchema = z.object({
   type: z.literal('topic-hint'),
-  author: z.string().min(1),
+  // Trim before length check so a whitespace-only author is rejected, matching
+  // the trim the bubble does at render time.
+  author: z.string().trim().min(1),
 });
 
 const buttonGroupBlockSchema = z.object({

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1273,6 +1273,27 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
   white-space: normal;
 }
 
+/* 深话题预告气泡：她"有想聊的话题"的前端专属提示，斜体 + 特殊强调色，
+   与普通 system-chip 区分。纯前端展示，不进 LLM 上下文。 */
+.topic-hint-chip {
+  max-width: min(82%, 640px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-style: italic;
+  color: #7d5fc4;
+  background: rgba(130, 105, 205, 0.12);
+  border: 1px solid rgba(130, 105, 205, 0.22);
+}
+
+.topic-hint-chip-text {
+  white-space: normal;
+}
+
 .composer-panel {
   display: grid;
   /* 显式 1 列、min 边为 0：阻断 grid item 默认 min-width: auto 把内部
@@ -5559,6 +5580,12 @@ body.electron-chat-window.subtitle-web-host .compact-export-history-anchor {
 
 [data-theme="dark"] .system-chip-time {
   color: #7a8494;
+}
+
+[data-theme="dark"] .topic-hint-chip {
+  color: #c2acf2;
+  background: rgba(124, 104, 184, 0.24);
+  border-color: rgba(150, 128, 214, 0.36);
 }
 
 /* --- 输入区域 --- */

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1292,6 +1292,8 @@ body.neko-electron-runtime .app-shell:not(.chat-surface-mode-compact)[data-focus
 
 .topic-hint-chip-text {
   white-space: normal;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .composer-panel {

--- a/frontend/react-neko-chat/vite.config.js
+++ b/frontend/react-neko-chat/vite.config.js
@@ -6,6 +6,11 @@ export default defineConfig({
         environment: 'jsdom',
         globals: true,
         setupFiles: './src/test/setup.ts',
+        // App.test.tsx 用 `import ... from './styles.css?raw'` 读取样式原文做断言。Vitest 默认把所有 CSS
+        // 导入打桩成空串（提速），会让 `?raw` 也拿到空串；这里仅放行 styles.css 走真实处理，其余 CSS 仍打桩。
+        css: {
+            include: [/styles\.css/],
+        },
     },
     build: {
         lib: {

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -7964,6 +7964,17 @@ class LLMSessionManager:
                 for cb in active_callbacks:
                     resolve_callback_delivery_ack(cb, delivered)
 
+            # Deep-topic teaser: now committed to opening (passed both re-gates
+            # and the preempt check), surface the frontend-only "she has a topic
+            # she'd like to bring up" bubble just before the opener streams. One
+            # bubble per batch even if several topic hooks coalesced. Failure to
+            # send is non-fatal — the opener still goes out.
+            if any(
+                isinstance(cb, dict) and cb.get("channel") == "topic_hook"
+                for cb in active_callbacks
+            ):
+                await self.send_topic_hint(turn_id=proactive_sid)
+
             _sid_token = _proactive_expected_sid.set(proactive_sid)
             # Text-mode playback boundary for the pacing manager: no frontend
             # audio signal arrives for text delivery, so bracket prompt_ephemeral
@@ -10152,6 +10163,34 @@ class LLMSessionManager:
         except Exception as e:
             logger.error(f"💥 WS Send Status Error: {e}")
     
+    async def send_topic_hint(self, *, turn_id: Optional[str] = None) -> bool:
+        """Show a frontend-only teaser bubble right before she opens a deep-topic hook.
+
+        Deliberately does NOT touch ``sync_message_queue`` / chat memory — the
+        teaser is pure frontend display (rendered by react-neko-chat's dedicated
+        topic-hint component) and must never enter the chat-LLM context, the
+        same isolation as :meth:`passthrough_to_chat_bubble`. The frontend
+        renders the localized copy itself; we only hand it the character name.
+        """
+        if not (
+            self.websocket
+            and hasattr(self.websocket, 'client_state')
+            and self.websocket.client_state == self.websocket.client_state.CONNECTED
+        ):
+            return False
+        try:
+            await self.websocket.send_json({
+                "type": "topic_hint",
+                "author": self.lanlan_name,
+                "turn_id": str(turn_id or ''),
+            })
+            return True
+        except WebSocketDisconnect:
+            return False
+        except Exception as e:
+            logger.warning("[%s] send_topic_hint failed: %s", self.lanlan_name, e)
+            return False
+
     async def send_session_preparing(self, input_mode: str): # 通知前端session正在准备（静默期）
         try:
             if self.websocket and hasattr(self.websocket, 'client_state') and self.websocket.client_state == self.websocket.client_state.CONNECTED:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -7977,6 +7977,25 @@ class LLMSessionManager:
                 for cb in active_callbacks
             ):
                 topic_hint_sent = await self.send_topic_hint(turn_id=proactive_sid)
+                # send_topic_hint awaits a WS write — a NEW yield point past the
+                # last preempt check. If the user grabbed the turn during that
+                # await, abort before prompt_ephemeral (whose output would be
+                # SID-dropped yet could still ack as committed and leave the
+                # teaser/history as if the opener landed): retract the teaser and
+                # requeue, mirroring the preempt handling above.
+                async with self.lock:
+                    preempted_after_hint = (
+                        self.state.is_proactive_preempted()
+                        or self.current_speech_id != proactive_sid
+                    )
+                if preempted_after_hint:
+                    logger.info("[%s] trigger_agent_callbacks: preempted during topic hint send, aborting before prompt", self.lanlan_name)
+                    if topic_hint_sent:
+                        await self.send_cancel_topic_hint(turn_id=proactive_sid)
+                    self.pending_agent_callbacks.extend(active_callbacks)
+                    callbacks_snapshot[:] = []
+                    self.proactive_manager.release_inflight_noop()
+                    return False
 
             _sid_token = _proactive_expected_sid.set(proactive_sid)
             # Text-mode playback boundary for the pacing manager: no frontend

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -7968,12 +7968,15 @@ class LLMSessionManager:
             # and the preempt check), surface the frontend-only "she has a topic
             # she'd like to bring up" bubble just before the opener streams. One
             # bubble per batch even if several topic hooks coalesced. Failure to
-            # send is non-fatal — the opener still goes out.
+            # send is non-fatal — the opener still goes out. If the opener then
+            # fails before any committed output (API error / no-output), the
+            # teaser is retracted below so it can't dangle as an orphan.
+            topic_hint_sent = False
             if any(
                 isinstance(cb, dict) and cb.get("channel") == "topic_hook"
                 for cb in active_callbacks
             ):
-                await self.send_topic_hint(turn_id=proactive_sid)
+                topic_hint_sent = await self.send_topic_hint(turn_id=proactive_sid)
 
             _sid_token = _proactive_expected_sid.set(proactive_sid)
             # Text-mode playback boundary for the pacing manager: no frontend
@@ -8003,6 +8006,10 @@ class LLMSessionManager:
                         )
                         delivered = True
                     else:
+                        # Opener errored before any committed output — retract the
+                        # teaser so the frontend doesn't keep an orphan bubble.
+                        if topic_hint_sent:
+                            await self.send_cancel_topic_hint(turn_id=proactive_sid)
                         raise
             finally:
                 _proactive_expected_sid.reset(_sid_token)
@@ -8028,6 +8035,11 @@ class LLMSessionManager:
                 return True
             else:
                 _resolve_text_delivery_ack(False)
+                # No committed output — retract the teaser so it can't dangle
+                # while the callback is requeued for a later retry (which will
+                # send its own fresh teaser).
+                if topic_hint_sent:
+                    await self.send_cancel_topic_hint(turn_id=proactive_sid)
                 self.pending_agent_callbacks.extend(active_callbacks)
                 return False
 
@@ -10189,6 +10201,31 @@ class LLMSessionManager:
             return False
         except Exception as e:
             logger.warning("[%s] send_topic_hint failed: %s", self.lanlan_name, e)
+            return False
+
+    async def send_cancel_topic_hint(self, *, turn_id: Optional[str] = None) -> bool:
+        """Retract a previously sent topic-hint teaser (matched by ``turn_id``).
+
+        Used when the opener fails before any committed output, so the frontend
+        removes the dangling teaser instead of leaving an orphan bubble. Like
+        :meth:`send_topic_hint`, this stays off ``sync_message_queue`` entirely.
+        """
+        if not (
+            self.websocket
+            and hasattr(self.websocket, 'client_state')
+            and self.websocket.client_state == self.websocket.client_state.CONNECTED
+        ):
+            return False
+        try:
+            await self.websocket.send_json({
+                "type": "cancel_topic_hint",
+                "turn_id": str(turn_id or ''),
+            })
+            return True
+        except WebSocketDisconnect:
+            return False
+        except Exception as e:
+            logger.warning("[%s] send_cancel_topic_hint failed: %s", self.lanlan_name, e)
             return False
 
     async def send_session_preparing(self, input_mode: str): # 通知前端session正在准备（静默期）

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -57,10 +57,6 @@ _UNANSWERED_TOPIC_WEIGHT = 1.0 / 3.0
 _TOPIC_RESPONSE_WINDOW_SECONDS = 10 * 60
 # Tolerance for the daily weight-sum quota comparison (weight units).
 _QUOTA_WEIGHT_EPSILON = 1e-6
-# Separate tolerance for matching a used record by its used_at timestamp
-# (seconds). Kept distinct from the weight epsilon so tuning one never silently
-# widens the other — they share a value today but mean different things.
-_USED_AT_MATCH_EPSILON = 1e-6
 
 
 def _clean_text(value: Any, *, token_limit: int = _MAX_TEXT_TOKENS) -> str:
@@ -960,13 +956,18 @@ class TopicHookPool:
 
         The record is persisted at the unanswered weight by ``_mark_topic_used``;
         a user turn inside the window upgrades it to full via
-        ``_maybe_upgrade_topic_response``. Keyed by ``used_at`` so the upgrade
-        targets exactly this delivery's record.
+        ``_maybe_upgrade_topic_response``. We hold a direct reference to the
+        just-appended record rather than keying on ``used_at`` — coarse clock
+        resolution (e.g. ~15 ms on Windows) can give two close deliveries the
+        same timestamp, and a value match would then upgrade the wrong record.
         """
         used_at = float(material.get("used_at") or time.time())
+        with self._used_topics_lock:
+            records = self._used_topics.get(name) or []
+            record = records[-1] if records else None
         self._awaiting_response[name] = {
-            "used_at": used_at,
             "deadline": used_at + _TOPIC_RESPONSE_WINDOW_SECONDS,
+            "record": record,
         }
 
     def _maybe_upgrade_topic_response(self, name: str, *, now: float | None = None) -> None:
@@ -979,22 +980,16 @@ class TopicHookPool:
         self._awaiting_response.pop(name, None)
         if current > float(pending.get("deadline") or 0.0):
             return
-        if self._upgrade_used_weight(
-            name,
-            used_at=float(pending.get("used_at") or 0.0),
-            weight=1.0,
-        ):
-            logger.info("[%s] topic response within window: quota weight upgraded to full", name)
-            self._request_used_topics_persist()
-
-    def _upgrade_used_weight(self, name: str, *, used_at: float, weight: float) -> bool:
-        clamped = max(0.0, min(1.0, float(weight)))
+        record = pending.get("record")
+        if record is None:
+            return
         with self._used_topics_lock:
-            for record in self._used_topics.get(name, []):
-                if abs(float(record.get("used_at") or 0.0) - used_at) <= _USED_AT_MATCH_EPSILON:
-                    record["weight"] = clamped
-                    return True
-        return False
+            # Guard against the record having been pruned out of the live list.
+            if record not in self._used_topics.get(name, ()):
+                return
+            record["weight"] = 1.0
+        logger.info("[%s] topic response within window: quota weight upgraded to full", name)
+        self._request_used_topics_persist()
 
     def _mark_topic_used(
         self,

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import threading
 import time
 from collections import defaultdict
@@ -54,7 +55,12 @@ _USED_TOPIC_RECENT_SECONDS = 48 * 60 * 60
 _UNANSWERED_TOPIC_WEIGHT = 1.0 / 3.0
 # A user turn arriving within this window after a delivery counts as a response.
 _TOPIC_RESPONSE_WINDOW_SECONDS = 10 * 60
+# Tolerance for the daily weight-sum quota comparison (weight units).
 _QUOTA_WEIGHT_EPSILON = 1e-6
+# Separate tolerance for matching a used record by its used_at timestamp
+# (seconds). Kept distinct from the weight epsilon so tuning one never silently
+# widens the other — they share a value today but mean different things.
+_USED_AT_MATCH_EPSILON = 1e-6
 
 
 def _clean_text(value: Any, *, token_limit: int = _MAX_TEXT_TOKENS) -> str:
@@ -80,7 +86,7 @@ def _record_weight(record: Mapping[str, Any]) -> float:
         weight = float(record.get("weight", 1.0))
     except (TypeError, ValueError):
         return 1.0
-    if weight != weight:  # NaN
+    if math.isnan(weight):
         return 1.0
     return max(0.0, min(1.0, weight))
 
@@ -985,7 +991,7 @@ class TopicHookPool:
         clamped = max(0.0, min(1.0, float(weight)))
         with self._used_topics_lock:
             for record in self._used_topics.get(name, []):
-                if abs(float(record.get("used_at") or 0.0) - used_at) <= _QUOTA_WEIGHT_EPSILON:
+                if abs(float(record.get("used_at") or 0.0) - used_at) <= _USED_AT_MATCH_EPSILON:
                     record["weight"] = clamped
                     return True
         return False

--- a/main_logic/topic/pipeline.py
+++ b/main_logic/topic/pipeline.py
@@ -46,6 +46,15 @@ _CANDIDATE_MATURE_SECONDS = 60.0
 _MIN_TOPIC_TRIGGER_GAP_SECONDS = 4 * 60 * 60
 _MAX_DAILY_TOPIC_TRIGGERS = 2
 _USED_TOPIC_RECENT_SECONDS = 48 * 60 * 60
+# Quota is weight-based, not count-based: a delivery the user never engages with
+# costs only a fraction of the daily budget, so we keep trying until topics
+# actually land. A delivered-but-unanswered hook starts at this weight and is
+# upgraded to a full 1.0 once the user replies within the response window —
+# roughly three ignored deliveries equal one full success.
+_UNANSWERED_TOPIC_WEIGHT = 1.0 / 3.0
+# A user turn arriving within this window after a delivery counts as a response.
+_TOPIC_RESPONSE_WINDOW_SECONDS = 10 * 60
+_QUOTA_WEIGHT_EPSILON = 1e-6
 
 
 def _clean_text(value: Any, *, token_limit: int = _MAX_TEXT_TOKENS) -> str:
@@ -58,6 +67,22 @@ def _clean_timestamp(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return time.time()
+
+
+def _record_weight(record: Mapping[str, Any]) -> float:
+    """Quota weight of a used-topic record.
+
+    Records persisted before the weight field existed (or with a malformed
+    value) count as a full 1.0 — they were full successes under the old
+    count-based quota, so treating them as such is the conservative default.
+    """
+    try:
+        weight = float(record.get("weight", 1.0))
+    except (TypeError, ValueError):
+        return 1.0
+    if weight != weight:  # NaN
+        return 1.0
+    return max(0.0, min(1.0, weight))
 
 
 def _local_day(value: float) -> date:
@@ -268,6 +293,11 @@ class TopicHookPool:
         self._used_topics: dict[str, list[dict[str, Any]]] = defaultdict(list)
         self._used_topics_lock = threading.RLock()
         self._used_topics_write_lock = threading.Lock()
+        # Per-character "a topic was just delivered, awaiting a user reply"
+        # marker: {used_at, deadline}. In-memory only — a delivery whose
+        # response window straddles a restart simply stays at the unanswered
+        # weight (conservative). See note_user_message / _arm_topic_response_window.
+        self._awaiting_response: dict[str, dict[str, float]] = {}
         self._load_used_topics()
         # Restored persisted signals are dirty once after startup: they should
         # be eligible for the next heartbeat, then stop unless a new turn
@@ -282,6 +312,7 @@ class TopicHookPool:
         self._signal_store.clear(name)
         self._materials.pop(name, None)
         self._dirty.discard(name)
+        self._awaiting_response.pop(name, None)
         with self._used_topics_lock:
             self._used_topics.pop(name, None)
         self._persist_used_topics()
@@ -389,6 +420,10 @@ class TopicHookPool:
         if not cleaned:
             return
         name = str(lanlan_name or "default")
+        # A real user turn after a delivery is the response signal: upgrade the
+        # delivered hook from the unanswered weight to a full success. The AI's
+        # own opener arrives via note_ai_message, so it can never self-upgrade.
+        self._maybe_upgrade_topic_response(name)
         self._seq[name] += 1
         self._signal_store.note_turn(name, actor="user", text=cleaned)
         self._langs[name] = lang or self._langs.get(name, "zh")
@@ -704,6 +739,7 @@ class TopicHookPool:
             current_material["status"] = "used"
             current_material["used_at"] = time.time()
             self._mark_topic_used(name, current_material, persist=False)
+            self._arm_topic_response_window(name, current_material)
             await asyncio.to_thread(self._persist_used_topics)
             self._materials[name] = []
             await self._discard_delivered_signals_async(name, current_material)
@@ -836,7 +872,9 @@ class TopicHookPool:
     def _daily_quota_reached(self, name: str, *, now: float | None = None) -> bool:
         if self._daily_topic_limit <= 0:
             return True
-        return len(self._prune_used_topics(name, now=now)) >= self._daily_topic_limit
+        today = self._prune_used_topics(name, now=now)
+        total_weight = sum(_record_weight(record) for record in today)
+        return total_weight >= self._daily_topic_limit - _QUOTA_WEIGHT_EPSILON
 
     def _seconds_until_next_topic_trigger(self, name: str, *, now: float | None = None) -> float:
         if self._min_trigger_gap_seconds <= 0:
@@ -911,6 +949,47 @@ class TopicHookPool:
             available.append(dict(material))
         return available
 
+    def _arm_topic_response_window(self, name: str, material: Mapping[str, Any]) -> None:
+        """Mark a just-delivered topic as awaiting a user reply.
+
+        The record is persisted at the unanswered weight by ``_mark_topic_used``;
+        a user turn inside the window upgrades it to full via
+        ``_maybe_upgrade_topic_response``. Keyed by ``used_at`` so the upgrade
+        targets exactly this delivery's record.
+        """
+        used_at = float(material.get("used_at") or time.time())
+        self._awaiting_response[name] = {
+            "used_at": used_at,
+            "deadline": used_at + _TOPIC_RESPONSE_WINDOW_SECONDS,
+        }
+
+    def _maybe_upgrade_topic_response(self, name: str, *, now: float | None = None) -> None:
+        pending = self._awaiting_response.get(name)
+        if not pending:
+            return
+        current = float(now if now is not None else time.time())
+        # One-shot: clear the marker whether or not it is still in-window, so a
+        # later turn can't upgrade a stale delivery.
+        self._awaiting_response.pop(name, None)
+        if current > float(pending.get("deadline") or 0.0):
+            return
+        if self._upgrade_used_weight(
+            name,
+            used_at=float(pending.get("used_at") or 0.0),
+            weight=1.0,
+        ):
+            logger.info("[%s] topic response within window: quota weight upgraded to full", name)
+            self._request_used_topics_persist()
+
+    def _upgrade_used_weight(self, name: str, *, used_at: float, weight: float) -> bool:
+        clamped = max(0.0, min(1.0, float(weight)))
+        with self._used_topics_lock:
+            for record in self._used_topics.get(name, []):
+                if abs(float(record.get("used_at") or 0.0) - used_at) <= _QUOTA_WEIGHT_EPSILON:
+                    record["weight"] = clamped
+                    return True
+        return False
+
     def _mark_topic_used(
         self,
         name: str,
@@ -923,6 +1002,7 @@ class TopicHookPool:
             self._used_topics[name].append(
                 {
                     "used_at": float(material.get("used_at") or time.time()),
+                    "weight": _UNANSWERED_TOPIC_WEIGHT,
                     "hook_id": str(material.get("hook_id") or "").strip(),
                     "hook_id_hash": _topic_fingerprint(material.get("hook_id")),
                     "interest": _clean_text(material.get("interest"), token_limit=90),
@@ -972,6 +1052,7 @@ class TopicHookPool:
                 loaded.append(
                     {
                         "used_at": used_at,
+                        "weight": _record_weight(entry),
                         "hook_id_hash": _stored_topic_fingerprint(
                             entry.get("hook_id_hash") or entry.get("hook_id")
                         ),
@@ -1015,6 +1096,7 @@ class TopicHookPool:
                     name: [
                         {
                             "used_at": float(record.get("used_at") or 0.0),
+                            "weight": _record_weight(record),
                             "hook_id_hash": _stored_topic_fingerprint(
                                 record.get("hook_id_hash") or record.get("hook_id")
                             ),

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -898,6 +898,29 @@
         });
     }
 
+    // ======================== appendReactTopicHint（深话题预告气泡） ========================
+
+    // Frontend-only teaser shown right before a proactive deep-topic opener.
+    // Backend sends a `topic_hint` WS frame that never touches the sync queue /
+    // chat memory, so this bubble is display-only and never re-enters LLM
+    // context. Rendered by react-neko-chat's dedicated TopicHintBubble.
+    function appendReactTopicHint(author) {
+        var host = getHost();
+        if (!host || typeof host.appendMessage !== 'function') return null;
+
+        var name = String(author || getCurrentAssistantName() || '').trim();
+        if (!name) return null;
+
+        return host.appendMessage({
+            id: nextReactMessageId('topic-hint'),
+            role: 'system',
+            author: name,
+            time: getCurrentTimeString(),
+            createdAt: Date.now(),
+            blocks: [{ type: 'topic-hint', author: name }]
+        });
+    }
+
     // ======================== refreshReactAssistantAvatars ========================
 
     function refreshReactAssistantAvatars() {
@@ -925,6 +948,7 @@
     window._tryFlushPendingHostMessages = _tryFlushPendingHostMessages;
     window._clearPendingHostMessagesByIds = _clearPendingHostMessagesByIds;
     window._resetReactChatSwitchState = _resetReactChatSwitchState;
+    window.appendReactTopicHint = appendReactTopicHint;
 
     // 覆盖 appChat 上的方法
     if (window.appChat) {
@@ -932,6 +956,7 @@
         window.appChat.createGeminiBubble = createGeminiBubble;
         window.appChat.processRealisticQueue = processRealisticQueue;
         window.appChat.appendReactUserMessage = appendReactUserMessage;
+        window.appChat.appendReactTopicHint = appendReactTopicHint;
         window.appChat.setReactMessageStatus = setReactMessageStatus;
     }
 

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -904,21 +904,42 @@
     // Backend sends a `topic_hint` WS frame that never touches the sync queue /
     // chat memory, so this bubble is display-only and never re-enters LLM
     // context. Rendered by react-neko-chat's dedicated TopicHintBubble.
-    function appendReactTopicHint(author) {
+    function topicHintMessageId(turnId) {
+        // Deterministic id keyed on the turn so a later cancel_topic_hint frame
+        // can remove exactly this teaser. Falls back to an auto id when no turn
+        // is supplied (then it just can't be cancelled, which is fine).
+        var tid = String(turnId || '').trim();
+        return tid ? 'topic-hint-' + tid : nextReactMessageId('topic-hint');
+    }
+
+    function appendReactTopicHint(author, turnId) {
         var host = getHost();
         if (!host || typeof host.appendMessage !== 'function') return null;
 
-        var name = String(author || getCurrentAssistantName() || '').trim();
+        // Trim BEFORE falling back: a whitespace-only author must yield the
+        // assistant name, not an empty bubble.
+        var name = String(author || '').trim() || String(getCurrentAssistantName() || '').trim();
         if (!name) return null;
 
         return host.appendMessage({
-            id: nextReactMessageId('topic-hint'),
+            id: topicHintMessageId(turnId),
             role: 'system',
             author: name,
             time: getCurrentTimeString(),
             createdAt: Date.now(),
+            turnId: String(turnId || '').trim() || undefined,
             blocks: [{ type: 'topic-hint', author: name }]
         });
+    }
+
+    // Retract a previously shown teaser when its opener failed before producing
+    // any output (backend send_cancel_topic_hint). No-op if it was never shown.
+    function removeReactTopicHint(turnId) {
+        var host = getHost();
+        if (!host || typeof host.removeMessage !== 'function') return;
+        var tid = String(turnId || '').trim();
+        if (!tid) return;
+        host.removeMessage('topic-hint-' + tid);
     }
 
     // ======================== refreshReactAssistantAvatars ========================
@@ -949,6 +970,7 @@
     window._clearPendingHostMessagesByIds = _clearPendingHostMessagesByIds;
     window._resetReactChatSwitchState = _resetReactChatSwitchState;
     window.appendReactTopicHint = appendReactTopicHint;
+    window.removeReactTopicHint = removeReactTopicHint;
 
     // 覆盖 appChat 上的方法
     if (window.appChat) {
@@ -957,6 +979,7 @@
         window.appChat.processRealisticQueue = processRealisticQueue;
         window.appChat.appendReactUserMessage = appendReactUserMessage;
         window.appChat.appendReactTopicHint = appendReactTopicHint;
+        window.appChat.removeReactTopicHint = removeReactTopicHint;
         window.appChat.setReactMessageStatus = setReactMessageStatus;
     }
 

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -334,7 +334,8 @@
                 if (!message || !message.id || !Array.isArray(message.blocks)) return false;
                 // Drop frontend-only topic-hint teasers: they carry no exportable
                 // text and would otherwise become blank entries in the export.
-                if (message.blocks.length > 0 && message.blocks.every(function (b) {
+                // Mirror isTopicHintMessage (role==='system' + all topic-hint blocks).
+                if (message.role === 'system' && message.blocks.length > 0 && message.blocks.every(function (b) {
                     return b && b.type === 'topic-hint';
                 })) return false;
                 return true;

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -331,7 +331,13 @@
             var snapshot = host.getState();
             var list = (snapshot && Array.isArray(snapshot.messages)) ? snapshot.messages : [];
             return list.filter(function (message) {
-                return message && message.id && Array.isArray(message.blocks);
+                if (!message || !message.id || !Array.isArray(message.blocks)) return false;
+                // Drop frontend-only topic-hint teasers: they carry no exportable
+                // text and would otherwise become blank entries in the export.
+                if (message.blocks.length > 0 && message.blocks.every(function (b) {
+                    return b && b.type === 'topic-hint';
+                })) return false;
+                return true;
             });
         } catch (error) {
             logExportError('getReactMessages', error);

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1943,6 +1943,16 @@
                         detail: { active: !!response.active },
                     }));
 
+                // -------- topic_hint（深话题预告气泡，仅前端展示，不入上下文）--------
+                } else if (response.type === 'topic_hint') {
+                    if (typeof window.appendReactTopicHint === 'function') {
+                        try {
+                            window.appendReactTopicHint(response.author);
+                        } catch (topicHintErr) {
+                            console.warn('[topic_hint] append failed', topicHintErr);
+                        }
+                    }
+
                 // -------- status --------
                 } else if (response.type === 'status') {
                     var statusCode = null;

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1947,9 +1947,19 @@
                 } else if (response.type === 'topic_hint') {
                     if (typeof window.appendReactTopicHint === 'function') {
                         try {
-                            window.appendReactTopicHint(response.author);
+                            window.appendReactTopicHint(response.author, response.turn_id);
                         } catch (topicHintErr) {
                             console.warn('[topic_hint] append failed', topicHintErr);
+                        }
+                    }
+
+                // -------- cancel_topic_hint（开场白生成失败时撤回孤儿预告气泡）--------
+                } else if (response.type === 'cancel_topic_hint') {
+                    if (typeof window.removeReactTopicHint === 'function') {
+                        try {
+                            window.removeReactTopicHint(response.turn_id);
+                        } catch (cancelHintErr) {
+                            console.warn('[cancel_topic_hint] remove failed', cancelHintErr);
                         }
                     }
 

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -30,7 +30,7 @@
 
     // locale 资源版本（用于 cache-busting，避免客户端长期缓存旧语言包导致新增 key 不生效）
     // 更新语言包内容时可以递增此值
-    const LOCALE_VERSION = '2026-06-22-vllm-omni-clone';
+    const LOCALE_VERSION = '2026-06-29-topic-hint';
 
     function initDecorativeImageDragGuard() {
         const markImage = (img) => {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "Chat",
+        "topicHint": "{{author}} seems to have something they'd like to chat about…",
         "viewerTitle": "Chat (Viewer Mode)",
         "tooltip": "Chat Area",
         "textInputPlaceholder": "Press Enter to send, Shift+Enter for new line",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "Charlar",
+        "topicHint": "{{author}} parece tener algo de lo que quiere hablar…",
         "viewerTitle": "Chat (modo espectador)",
         "tooltip": "Área de chat",
         "textInputPlaceholder": "Presione Enter para enviar, Shift+Enter para una nueva línea",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "チャット",
+        "topicHint": "{{author}}は何か話したいことがあるみたい…",
         "viewerTitle": "チャット（ビューアーモード）",
         "tooltip": "チャットエリア",
         "textInputPlaceholder": "Enterで送信、Shift+Enterで改行",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "채팅",
+        "topicHint": "{{author}}이(가) 하고 싶은 이야기가 있나 봐요…",
         "viewerTitle": "채팅(뷰어 모드)",
         "tooltip": "채팅 영역",
         "textInputPlaceholder": "보내려면 Enter를 누르고, 줄을 바꾸려면 Shift+Enter를 누르세요.",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "Bater papo",
+        "topicHint": "{{author}} parece ter algo sobre o que quer conversar…",
         "viewerTitle": "Bate-papo (modo visualizador)",
         "tooltip": "Área de bate-papo",
         "textInputPlaceholder": "Pressione Enter para enviar, Shift+Enter para nova linha",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "Чат",
+        "topicHint": "Кажется, {{author}} хочет о чём-то поговорить…",
         "viewerTitle": "Чат (Режим просмотра)",
         "tooltip": "Область чата",
         "textInputPlaceholder": "Нажмите Enter для отправки, Shift+Enter для новой строки",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "对话",
+        "topicHint": "{{author}}好像有点想找你聊的话题…",
         "viewerTitle": "对话 (观看模式)",
         "tooltip": "对话区",
         "textInputPlaceholder": "回车发送，Shift+回车换行",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -674,6 +674,7 @@
     },
     "chat": {
         "title": "對話",
+        "topicHint": "{{author}}好像有點想找你聊的話題…",
         "viewerTitle": "對話 (觀看模式)",
         "tooltip": "對話區",
         "textInputPlaceholder": "回車發送，Shift+回車換行",

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -1947,6 +1947,10 @@ def test_legacy_used_topic_without_weight_loads_as_full(tmp_path):
     # count-based quota), never silently demoted to the unanswered 1/3.
     signal_path = tmp_path / "topic_signals.json"
     used_path = signal_path.with_name(f"{signal_path.stem}.used_topics.json")
+    # Pin a single timestamp for both records and the quota checks so the test
+    # can't straddle a calendar-day boundary (which would drop the legacy record
+    # from "today" and flake the assertions).
+    now = time.time()
     used_path.write_text(
         json.dumps(
             {
@@ -1954,7 +1958,7 @@ def test_legacy_used_topic_without_weight_loads_as_full(tmp_path):
                 "characters": {
                     "妮可": [
                         {
-                            "used_at": time.time(),
+                            "used_at": now,
                             "hook_id_hash": "",
                             "interest_hash": "",
                             "keyword_hashes": [],
@@ -1979,13 +1983,13 @@ def test_legacy_used_topic_without_weight_loads_as_full(tmp_path):
     # The legacy record reads as a full success, not the unanswered 1/3.
     assert _record_weight(records[0]) == pytest.approx(1.0)
     # One full legacy unit is under the limit of 2; a second full delivery fills it.
-    assert pool._daily_quota_reached("妮可") is False
+    assert pool._daily_quota_reached("妮可", now=now) is False
     pool._mark_topic_used(
         "妮可",
-        {"used_at": time.time(), "interest": "新", "keywords": ["新"]},
+        {"used_at": now, "interest": "新", "keywords": ["新"]},
     )
     pool._used_topics["妮可"][-1]["weight"] = 1.0
-    assert pool._daily_quota_reached("妮可") is True
+    assert pool._daily_quota_reached("妮可", now=now) is True
 
 
 def test_topic_pool_daily_topic_limit_resets_on_calendar_day():

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -1789,12 +1789,27 @@ async def test_topic_pool_limits_daily_topic_triggers_to_two():
     )
 
     for idx in range(3):
+        prev_delivered = len(delivered)
         pool.note_user_message("妮可", f"第{idx}轮认真聊一个新方向，信息量足够做深话题", lang="zh-CN")
         await pool.process_now("妮可")
-        for _ in range(20):
-            if len(delivered) >= min(idx + 1, 2):
-                break
-            await asyncio.sleep(0.01)
+        if idx < 2:
+            # Wait until this round's delivery is fully booked: the record is
+            # marked AND the response window is armed. Only then will the NEXT
+            # round's user turn deterministically upgrade it to full weight —
+            # without this the weight-based quota check races the async booking
+            # (fake_trigger appends to `delivered` BEFORE _arm runs).
+            for _ in range(200):
+                if len(delivered) > prev_delivered and pool._awaiting_response.get("妮可"):
+                    break
+                await asyncio.sleep(0.01)
+        else:
+            # Round 2 must stay blocked by the daily quota (two full-weight
+            # successes). Give the would-be trigger a chance to run and confirm
+            # it does not deliver a third time.
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if len(delivered) > prev_delivered:
+                    break
 
     assert delivered == ["凯迪拉克预算压力", "周末海边旅行计划"]
     ready = pool.get_ready_materials("妮可")
@@ -1913,7 +1928,7 @@ def test_used_topic_weight_survives_persist_load_roundtrip(tmp_path):
     used_at = time.time()
     material = {"used_at": used_at, "interest": "持久化话题", "keywords": ["持久化"]}
     pool._mark_topic_used("妮可", material)
-    pool._upgrade_used_weight("妮可", used_at=used_at, weight=1.0)
+    pool._used_topics["妮可"][0]["weight"] = 1.0
     pool._persist_used_topics()
 
     reloaded = TopicHookPool(
@@ -1924,6 +1939,53 @@ def test_used_topic_weight_survives_persist_load_roundtrip(tmp_path):
         signal_store_path=signal_path,
     )
     assert _record_weight(reloaded._used_topics["妮可"][0]) == pytest.approx(1.0)
+
+
+def test_legacy_used_topic_without_weight_loads_as_full(tmp_path):
+    # Backward-compat guarantee: records persisted before the weight field
+    # existed must load as a full 1.0 (they were full successes under the old
+    # count-based quota), never silently demoted to the unanswered 1/3.
+    signal_path = tmp_path / "topic_signals.json"
+    used_path = signal_path.with_name(f"{signal_path.stem}.used_topics.json")
+    used_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "characters": {
+                    "妮可": [
+                        {
+                            "used_at": time.time(),
+                            "hook_id_hash": "",
+                            "interest_hash": "",
+                            "keyword_hashes": [],
+                            "bigram_hashes": [],
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    pool = TopicHookPool(
+        auto_schedule=False,
+        enable_online_enrichment=False,
+        daily_topic_limit=2,
+        min_user_turns_for_topic=1,
+        signal_store_path=signal_path,
+    )
+    records = pool._used_topics["妮可"]
+    assert len(records) == 1
+    # The legacy record reads as a full success, not the unanswered 1/3.
+    assert _record_weight(records[0]) == pytest.approx(1.0)
+    # One full legacy unit is under the limit of 2; a second full delivery fills it.
+    assert pool._daily_quota_reached("妮可") is False
+    pool._mark_topic_used(
+        "妮可",
+        {"used_at": time.time(), "interest": "新", "keywords": ["新"]},
+    )
+    pool._used_topics["妮可"][-1]["weight"] = 1.0
+    assert pool._daily_quota_reached("妮可") is True
 
 
 def test_topic_pool_daily_topic_limit_resets_on_calendar_day():

--- a/tests/unit/test_topic_pipeline.py
+++ b/tests/unit/test_topic_pipeline.py
@@ -7,7 +7,12 @@ from datetime import datetime
 
 import pytest
 
-from main_logic.topic.pipeline import TopicHookPool, _clean_material
+from main_logic.topic.pipeline import (
+    TopicHookPool,
+    _clean_material,
+    _UNANSWERED_TOPIC_WEIGHT,
+    _record_weight,
+)
 from main_logic.topic.signals import TopicSignalStore
 
 
@@ -1814,20 +1819,111 @@ async def test_topic_pool_candidate_ignores_daily_quota():
         daily_topic_limit=1,
         min_user_turns_for_topic=1,
     )
-    pool._mark_topic_used(
-        "妮可",
-        {
-            "used_at": time.time(),
-            "interest": "今天已经投递过的话题",
-            "keywords": ["已投递"],
-        },
-    )
+    # Weight-based quota: an unanswered delivery only costs 1/3, so it takes
+    # roughly three ignored deliveries to fill daily_topic_limit=1.
+    for idx in range(3):
+        pool._mark_topic_used(
+            "妮可",
+            {
+                "used_at": time.time(),
+                "interest": f"今天已经投递过的话题{idx}",
+                "keywords": [f"已投递{idx}"],
+            },
+        )
     assert pool._daily_quota_reached("妮可")
 
     pool.note_user_message("妮可", "今天 quota 满了，但 candidate 仍然应该能抽取新话题", lang="zh-CN")
     await pool.process_now("妮可")
 
     assert pool.get_ready_materials("妮可")[0]["interest"] == "新抽取的话题仍可入池"
+
+
+def test_unanswered_delivery_costs_fractional_quota():
+    pool = TopicHookPool(
+        auto_schedule=False,
+        enable_online_enrichment=False,
+        daily_topic_limit=2,
+        min_user_turns_for_topic=1,
+    )
+    # New deliveries land at the unanswered weight (1/3 each).
+    for idx in range(5):
+        pool._mark_topic_used(
+            "妮可",
+            {"used_at": time.time(), "interest": f"话题{idx}", "keywords": [f"k{idx}"]},
+        )
+        records = pool._used_topics["妮可"]
+        assert _record_weight(records[-1]) == pytest.approx(_UNANSWERED_TOPIC_WEIGHT)
+
+    # 5 ignored deliveries = ~1.67 < 2.0 → still under budget; the 6th tips it over.
+    assert not pool._daily_quota_reached("妮可")
+    pool._mark_topic_used(
+        "妮可",
+        {"used_at": time.time(), "interest": "话题5", "keywords": ["k5"]},
+    )
+    assert pool._daily_quota_reached("妮可")
+
+
+def test_user_reply_within_window_upgrades_quota_weight():
+    pool = TopicHookPool(
+        auto_schedule=False,
+        enable_online_enrichment=False,
+        daily_topic_limit=2,
+        min_user_turns_for_topic=1,
+    )
+    used_at = time.time()
+    material = {"used_at": used_at, "interest": "投出的话题", "keywords": ["投出"]}
+    pool._mark_topic_used("妮可", material)
+    pool._arm_topic_response_window("妮可", material)
+
+    # A real user turn inside the window upgrades the delivery to a full success.
+    pool.note_user_message("妮可", "诶我刚好也在想这个，你说说看", lang="zh-CN")
+    assert _record_weight(pool._used_topics["妮可"][0]) == pytest.approx(1.0)
+    # One-shot: the marker is consumed, a later turn does not re-upgrade anything.
+    assert "妮可" not in pool._awaiting_response
+
+
+def test_user_reply_after_window_keeps_unanswered_weight():
+    pool = TopicHookPool(
+        auto_schedule=False,
+        enable_online_enrichment=False,
+        daily_topic_limit=2,
+        min_user_turns_for_topic=1,
+    )
+    used_at = time.time()
+    material = {"used_at": used_at, "interest": "投出的话题", "keywords": ["投出"]}
+    pool._mark_topic_used("妮可", material)
+    pool._arm_topic_response_window("妮可", material)
+    # Force the window to have already elapsed.
+    pool._awaiting_response["妮可"]["deadline"] = used_at - 1.0
+
+    pool.note_user_message("妮可", "现在才回，已经超出回应窗口了", lang="zh-CN")
+    assert _record_weight(pool._used_topics["妮可"][0]) == pytest.approx(_UNANSWERED_TOPIC_WEIGHT)
+    assert "妮可" not in pool._awaiting_response
+
+
+def test_used_topic_weight_survives_persist_load_roundtrip(tmp_path):
+    signal_path = tmp_path / "topic_signals.json"
+    pool = TopicHookPool(
+        auto_schedule=False,
+        enable_online_enrichment=False,
+        daily_topic_limit=2,
+        min_user_turns_for_topic=1,
+        signal_store_path=signal_path,
+    )
+    used_at = time.time()
+    material = {"used_at": used_at, "interest": "持久化话题", "keywords": ["持久化"]}
+    pool._mark_topic_used("妮可", material)
+    pool._upgrade_used_weight("妮可", used_at=used_at, weight=1.0)
+    pool._persist_used_topics()
+
+    reloaded = TopicHookPool(
+        auto_schedule=False,
+        enable_online_enrichment=False,
+        daily_topic_limit=2,
+        min_user_turns_for_topic=1,
+        signal_store_path=signal_path,
+    )
+    assert _record_weight(reloaded._used_topics["妮可"][0]) == pytest.approx(1.0)
 
 
 def test_topic_pool_daily_topic_limit_resets_on_calendar_day():


### PR DESCRIPTION
## 背景

主动深话题投递（deep topic hooks）：后台从对话证据抽取用户在意的话题、联网备料，空闲窗口让角色像随口想起一样开口。本 PR 做两件事。

## 需求 1：投递配额改为权重累加制

**原本**：投递一旦确认投出就记 1 条 used、直接吃掉当天 1/2 配额（`daily_topic_limit=2`），不管用户理不理。

**现在**：
- 投出先记 **0.33**（`_UNANSWERED_TOPIC_WEIGHT`）；用户在 **10 分钟回应窗口**（`_TOPIC_RESPONSE_WINDOW_SECONDS`）内发真实消息 → 升到满权重 **1.0**。约 3 次无人理会折合 1 次完整成功，封顶仍是 2，故最多约 6 次无效投递/天。
- `_daily_quota_reached` 改为「今日权重之和 ≥ 阈值」。权重随 used-topics 持久化落盘，旧记录缺字段默认 1.0。
- 升级挂在 `note_user_message`（角色自己的开场白走 `note_ai_message`，不会自我误升级），一次性消费 marker。
- **冷却间隔不变**：`_MIN_TOPIC_TRIGGER_GAP_SECONDS = 4h` 仍由每次投递盖的 `used_at` 驱动，未被理会的 0.33 投递照样触发 4h 冷却，不会立刻重投。

## 需求 2：投递前的前端专用预告气泡

她真要开口讲这个话题之前，对话框插一条斜体紫色特殊气泡「{角色名}好像有点想找你聊的话题…」，**纯前端展示、不进 LLM 上下文**。

- 后端 `send_topic_hint` 走独立 WS 帧 `topic_hint`，完全不进 `sync_message_queue`，与 `passthrough_to_chat_bubble` 同款隔离；emit 点卡在过完所有撤回 + 抢占检查、开场白生成之前那一刻（保证不会“预告了却没说成”）。
- 前端专用组件 `TopicHintBubble`（斜体 + 紫色特殊气泡，浅/深色），新增 `topic-hint` block 类型 + WS 分发 + 适配器 append；文案用角色名，八语 i18n（`chat.topicHint`）。
- 共享 `i18n()` 加插值参数，兼容真实 i18next 与兜底 stub 两种后端。

## 回归报告

**改动**
- `main_logic/topic/pipeline.py`：投递配额从计数改为权重累加；新增回应窗口升级、权重 persist/load。
- `main_logic/core.py`：新增 `send_topic_hint`（不进 sync 队列）+ 文本投递点 emit。
- 前端：`TopicHintBubble.tsx`（新）、`message-schema.ts`（topic-hint block）、`MessageBubble.tsx`（路由）、`i18n.ts`（插值参数）、`styles.css`、`static/app-chat-adapter.js`、`static/app-websocket.js`、八语 locale。

**理由**
- 投了用户不理的不该把当天额度一次烧光，应一直试到话题真正落地；回应才是“成功”的信号。
- 投递前给一条轻量预告，降低“她突然开口”的突兀感；该提示是 UI 线索，不应污染对话历史/记忆。

**前后**
- 前：1 次投出 = 吃满 1 次配额（无视也算满）；无任何投递前提示。
- 后：投出先 0.33、回应升 1.0；配额按权重和；4h 冷却不变；投递前多一条不进上下文的预告气泡。

**回归**
- 后端：`test_topic_pipeline.py`（新增权重计数 / 回应窗口升级 / 超窗保持 / 持久化往返 4 例，改 1 旧例）、`test_topic_delivery.py`、`test_proactive_delivery.py`、`test_passthrough_to_chat_bubble.py` 全过；`py_compile` OK。
- 前端：`TopicHintBubble.test.tsx`（6 例，覆盖 schema 解析、MessageBubble 路由、raw-template / 已插值两种 i18n 后端）；全量 vitest、tsc typecheck、vite build 全过。
- 未触及 4h 冷却闸与去重逻辑；权重对旧持久化记录向后兼容（默认 1.0）。
- 构建产物 `static/react/neko-chat/*` 为 gitignored，CI/部署时生成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 聊天界面新增“话题提示”气泡：根据作者生成专用样式，并可在合适时机自动撤回；历史与导出时自动过滤该类提示。
* **改进**
  * 多语言文案变量插值更稳健（支持 `{name}`/`{{name}}`），翻译缺失或异常时不再泄露占位符/键文本。
  * 话题触发配额改为按权重累积，并兼容旧数据，支持在用户回复窗口内升级计费。
* **测试/构建**
  * 新增话题提示与配额相关单元测试；调整前端测试对样式导入的处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->