### PR TITLE
fix(chat): A/B 曝光改用 counter 上报，event 通道只落本地不进遥测

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -694,7 +694,7 @@ describe('App', () => {
     window.localStorage.removeItem(COMPACT_EXPORT_HISTORY_OPEN_STORAGE_KEY);
     window.localStorage.setItem(COMPACT_HISTORY_DEFAULT_EXPERIMENT_KEY, 'closed');
     const telemetry = vi.fn(() => true);
-    (window as unknown as { appTelemetry?: { event: (n: string, f?: Record<string, unknown>) => boolean } }).appTelemetry = { event: telemetry };
+    (window as unknown as { appTelemetry?: { counter: (n: string, v?: number, d?: Record<string, unknown>) => boolean } }).appTelemetry = { counter: telemetry };
     // 只让 sessionStorage.getItem 抛（隐私浏览器/webview），localStorage 仍可读 cohort——
     // 二者共享 Storage.prototype，按 this 区分。
     const realGetItem = Storage.prototype.getItem;
@@ -712,7 +712,7 @@ describe('App', () => {
         window.dispatchEvent(new Event('neko:tutorial-completed'));
       });
       // sessionStorage 去重读失败不能吞掉曝光：有 variant 的用户仍要发出 experiment_exposure。
-      expect(telemetry).toHaveBeenCalledWith('experiment_exposure', expect.objectContaining({
+      expect(telemetry).toHaveBeenCalledWith('experiment_exposure', 1, expect.objectContaining({
         experiment: 'compact_history_default',
         variant: 'closed',
       }));

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -631,8 +631,11 @@ function reportCompactHistoryExperimentExposure(): boolean {
   if (readCompactHistoryExposureReportedThisSession()) return true;
   let sent = false;
   try {
-    sent = (window as unknown as { appTelemetry?: { event?: (n: string, f?: Record<string, unknown>) => boolean } })
-      .appTelemetry?.event?.('experiment_exposure', { experiment: 'compact_history_default', variant }) === true;
+    // 必须走 counter 不是 event：event 只落本地 events.jsonl、不进 instrument.snapshot()，
+    // 永远到不了 TokenTracker 的远程上报通道（见 utils/instrument.py、utils/event_logger.py）。
+    // A/B 曝光要进远程指标必须用 counter，与 session_start / session_end 同范式。
+    sent = (window as unknown as { appTelemetry?: { counter?: (n: string, v?: number, d?: Record<string, unknown>) => boolean } })
+      .appTelemetry?.counter?.('experiment_exposure', 1, { experiment: 'compact_history_default', variant }) === true;
   } catch {
     // 投递本身抛错：留给调用方挂 socket open 重试。
     return false;


### PR DESCRIPTION
## 问题

`compact_history_default` A/B 实验的曝光埋点 `experiment_exposure` 用了 `appTelemetry.event(...)` 投递（`App.tsx:635`）。但在这套 telemetry SDK 里，`event` 通道（`instrument.event` → `event_logger.emit`）**只把数据写进本机 `config_dir/telemetry_events/events-YYYYMMDD.jsonl`（7 天滚动删除、无任何上传）**；而 `instrument.snapshot()`（TokenTracker 60s HTTP 上报唯一的数据源）只吐 `counters` + `histograms`，event 永远不在内。

结果：该实验自上线起，遥测服务器收到的曝光数据始终为 0，A/B 实际无法分析。

## 根因

- `event` 是「本地稀疏事件流」通道（crash / 调试用），**没有远程上报路径**
- 只有 `counter` / `histogram` 进 `snapshot()` → `POST {_TELEMETRY_SERVER_URL}/api/v1/telemetry`
- codebase 既有范式是 **event + counter 成对**（`session_start` / `session_end` / `crash` 都如此：counter 上报、event 留本地带 context）；本曝光点漏了 counter 这一半，是全仓**唯一没配对 counter 的 event**

## 修复

`App.tsx` 把曝光改用 `counter`（与 `session_*` 同范式）：

```diff
- .appTelemetry?.event?.('experiment_exposure', { experiment: 'compact_history_default', variant })
+ .appTelemetry?.counter?.('experiment_exposure', 1, { experiment: 'compact_history_default', variant })
```

- `counter` 的 dims 是**第 3 个**参数，同步改内联类型注解（否则 dims 落到 `value` 位、被后端当非数字回退成 `+1`、维度全丢）
- `experiment` / `variant` 是低基数维度（1 × 2 = 2 个 counter key），`_make_key` 完整保留、`_sanitize_dims` 不截断，服务端可按组切分
- 去重（sessionStorage）+ WS 未就绪轮询补报逻辑不依赖投递 API、只消费 boolean 返回值（`counter` 与 `event` 同返回 `_send` 的 boolean），无需改动
- 同步更新 `App.test.tsx` 的 mock（改挂 `counter`）与断言（3 参形态），否则旧测试因 `counter` 未 mock 而失败

## 验证

- `vitest run`：5 文件 **254 tests 全过**（含 3 条曝光用例）
- `tsc -b`（桌面构建用的类型检查，`tsconfig.app.json` 已 include `.test.tsx`）：**exit 0**

## 影响 / 范围

- 仅前端 `.tsx`，不触及 watched 的 Python 模块，无需回归报告段
- 修复只让曝光**从此开始**上报；修复前的曝光（服务端 0、本地 jsonl 已滚删）无法事后归因。存量用户的分组（localStorage cohort）仍稳定，下次启动会补报
- 衡量「历史默认开 vs 关」效果的**转化指标**由维护者从 telemetry 后续数据侧评估，不在本 PR

## 旁注（不在本 PR）

`tsc -b` 暴露出 `frontend/react-neko-chat/vite.config.js`（checked-in 的 tsc emit 产物）与源 `vite.config.ts` 不同步（`.js` 少了一段为 `styles.css?raw` 断言加的 `css.include`）。已还原、未纳入本 PR，另行处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整了聊天历史首启默认曝光的上报方式，提升遥测数据的记录一致性。
  * 保持重复曝光去重与失败重试逻辑不变，避免重复统计。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->