### PR TITLE
fix(cloudsave): enable packaged RemoteStorage bundle sync

### DIFF
--- a/docs/deployment/manual.md
+++ b/docs/deployment/manual.md
@@ -71,7 +71,7 @@ uv run python app/agent_server.py
 
 Notes:
 
-- To validate the production Steam Auto-Cloud path, launch through Steam or the desktop launcher. Desktop source runs on Windows, macOS, and Linux can now use the RemoteStorage bundle helper when Steam is running and logged in, but that helper is still a development-side compatibility path rather than the packaged app's main sync path.
+- To validate the production Steam cloud path, launch through Steam or the desktop launcher. Packaged builds and desktop source runs on Windows, macOS, and Linux use the RemoteStorage bundle helper when Steam is running and logged in, while Steam Auto-Cloud still syncs the raw `cloudsave/` directory when the App Admin rules match the platform anchor path.
 - In manual three-server mode, `main_server` will still perform a fallback snapshot import when needed and will try to notify `memory_server` to reload afterward.
 - Shutdown no longer stages runtime changes into `cloudsave/` automatically. If you want Steam to upload new character data, prepare or overwrite the staged snapshot for that character from Cloud Save Manager before you exit.
 - On macOS source runs, if Apple reports that `SteamworksPy.dylib` cannot be verified, Gatekeeper is usually blocking the local unnotarized Steamworks libraries. First make sure you are launching from the project root. If it is still blocked, run the following from the repo root:

--- a/docs/design/cloud-save-sync-optimization-plan.md
+++ b/docs/design/cloud-save-sync-optimization-plan.md
@@ -192,9 +192,9 @@
 
 ## 6. source/frozen 与 bundle helper 边界
 
-- `download_cloudsave_bundle_from_steam()` / `upload_cloudsave_bundle_to_steam()` 在非 source launch 下直接返回 `reason = "not_source_launch"`。
-- source launch 且平台支持时，才走 RemoteStorage bundle helper。
-- 打包运行主路径仍然是 Steam Auto-Cloud 同步 `cloudsave/`。
+- `download_cloudsave_bundle_from_steam()` / `upload_cloudsave_bundle_to_steam()` 在 source launch 或 frozen/packaged launch 下都可走 RemoteStorage bundle helper。
+- 非 source 且非 packaged 的普通 Python 进程仍直接返回 `reason = "not_source_launch"`，避免测试、脚本和非发行态误初始化 Steam。
+- 打包运行保留 Steam Auto-Cloud 同步 `cloudsave/`，同时使用 RemoteStorage bundle 作为跨设备兜底；当 Auto-Cloud 路径配置失配或用户存储位置与 anchor 分叉时，bundle 仍能把同一份快照同步到另一台设备。
 
 ---
 
@@ -208,7 +208,7 @@
 
 `cloudsave/` 目录：
 
-- 三平台统一为运行时根目录下 `cloudsave/`。
+- 三平台统一为固定 anchor root 下 `cloudsave/`。默认情况下 anchor root 等于平台标准应用数据目录；当用户把运行时数据迁移到其他位置时，`cloudsave/` 仍留在 anchor root，避免 Steam 云目录随用户自选路径漂移。
 
 Steam Auto-Cloud 推荐规则：
 

--- a/docs/ja/deployment/manual.md
+++ b/docs/ja/deployment/manual.md
@@ -68,7 +68,7 @@ uv run python app/agent_server.py
 
 補足:
 
-- 本番の Steam Auto-Cloud 主経路を検証したい場合は、引き続き Steam またはデスクトップランチャー経由で起動してください。現在は Windows / macOS / Linux のソース実行でも、Steam が起動中かつログイン済みであれば RemoteStorage bundle helper を使ったクロスデバイス検証が可能ですが、この経路はあくまで開発用の互換パスであり、パッケージ版の主同期経路ではありません。
+- 本番の Steam クラウド経路を検証する場合は、Steam またはデスクトップランチャー経由で起動してください。Windows / macOS / Linux のパッケージ版とソース実行は、Steam が起動中かつログイン済みであれば RemoteStorage bundle helper を使用します。同時に、Steam 側の Auto-Cloud ルールがプラットフォームの anchor パスと一致している場合は、従来どおり生の `cloudsave/` ディレクトリも同期されます。
 - 手動の 3 サーバーモードでは、必要に応じて `main_server` がフォールバックのスナップショット import を実行し、その後 `memory_server` に reload を通知しようとします。
 - shutdown では実行中データを `cloudsave/` に自動で書き戻しません。Steam に新しいキャラクターデータをアップロードしたい場合は、終了前に Cloud Save Manager から対象キャラクターの staged snapshot を手動で生成または上書きしてください。
 - macOS でソース実行したときに「Apple は `SteamworksPy.dylib` を検証できません」と表示される場合、通常は Gatekeeper がローカルの未公証 Steamworks ライブラリをブロックしています。まずプロジェクトのルートディレクトリから起動していることを確認してください。まだブロックされる場合は、リポジトリルートで次を実行します:

--- a/docs/zh-CN/deployment/manual.md
+++ b/docs/zh-CN/deployment/manual.md
@@ -68,7 +68,7 @@ uv run python app/agent_server.py
 
 补充说明：
 
-- 想验证生产态的 Steam Auto-Cloud 主路径，仍应优先通过 Steam 或桌面启动器启动。现在 Windows / macOS / Linux 的源码模式在 Steam 运行且已登录时，也可以走 RemoteStorage bundle helper 做跨设备联调；但这条链路仍是开发态兼容路径，不是打包版主同步路径。
+- 想验证生产态的 Steam 云路径，应通过 Steam 或桌面启动器启动。Windows / macOS / Linux 的打包版与源码模式，在 Steam 运行且已登录时都会使用 RemoteStorage bundle helper；同时，当 Steam 后台 Auto-Cloud 规则与平台 anchor 路径匹配时，仍会同步原始 `cloudsave/` 目录。
 - 手动三服务模式更适合开发调试；当前 `main_server` 会在需要时兜底导入快照，并尝试通知 `memory_server` reload。
 - shutdown 不会再自动把运行时变化写回 `cloudsave/`。如果希望 Steam 上传新的角色数据，需要在退出前先到云存档管理页手动为对应角色生成或覆盖 staged snapshot。
 - macOS 源码模式如果提示“Apple 无法验证 `SteamworksPy.dylib`”，通常是 Gatekeeper 在拦截未公证的本地动态库。先确认从项目根目录启动；如果仍被拦截，可在项目根目录执行：

--- a/tests/unit/test_steam_cloud_bundle_i18n_names.py
+++ b/tests/unit/test_steam_cloud_bundle_i18n_names.py
@@ -366,6 +366,72 @@ def test_download_cloudsave_bundle_preserves_newer_local_autocloud_snapshot(tmp_
 
 
 @pytest.mark.unit
+def test_download_cloudsave_bundle_repairs_damaged_newer_local_autocloud_snapshot(tmp_path):
+    remote_cm = _make_config_manager(tmp_path / "remote")
+    local_cm = _make_config_manager(tmp_path / "local")
+    bootstrap_local_cloudsave_environment(remote_cm)
+    bootstrap_local_cloudsave_environment(local_cm)
+
+    _write_runtime_state(remote_cm, character_name="远端健康角色", recent_message="healthy remote")
+    remote_export = export_local_cloudsave_snapshot(remote_cm)
+    _write_runtime_state(local_cm, character_name="本地损坏角色", recent_message="damaged local")
+    local_export = export_local_cloudsave_snapshot(local_cm)
+
+    remote_manifest_path = remote_cm.cloudsave_dir / "manifest.json"
+    remote_manifest = json.loads(remote_manifest_path.read_text(encoding="utf-8"))
+    remote_manifest["exported_at_utc"] = "2026-01-01T00:00:00Z"
+    remote_manifest_path.write_text(json.dumps(remote_manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    local_manifest_path = local_cm.cloudsave_dir / "manifest.json"
+    local_manifest = json.loads(local_manifest_path.read_text(encoding="utf-8"))
+    local_manifest["exported_at_utc"] = "2026-01-02T00:00:00Z"
+    local_manifest_path.write_text(json.dumps(local_manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    damaged_relative_path = next(iter(local_export["manifest"]["files"].keys()))
+    (local_cm.cloudsave_dir / damaged_relative_path).write_text("damaged payload", encoding="utf-8")
+
+    bundle_path = tmp_path / "healthy_remote_bundle.zip"
+    _write_remote_bundle(bundle_path, remote_cm)
+    bundle_bytes = bundle_path.read_bytes()
+    remote_meta = {
+        "schema_version": 1,
+        "bundle_format": "zip",
+        "manifest_fingerprint": remote_export["manifest"]["fingerprint"],
+        "sequence_number": remote_export["manifest"]["sequence_number"],
+        "exported_at_utc": "2026-01-01T00:00:00Z",
+        "file_count": len(remote_export["manifest"]["files"]),
+    }
+
+    class _DummyBridge:
+        def cloud_enabled(self):
+            return True
+
+        def file_exists(self, filename):
+            return filename in {REMOTE_META_FILENAME, REMOTE_BUNDLE_FILENAME}
+
+        def read_file(self, filename):
+            if filename == REMOTE_META_FILENAME:
+                return json.dumps(remote_meta, ensure_ascii=False).encode("utf-8")
+            if filename == REMOTE_BUNDLE_FILENAME:
+                return bundle_bytes
+            raise FileNotFoundError(filename)
+
+    @contextlib.contextmanager
+    def _fake_bridge(*, steamworks=None):
+        yield _DummyBridge()
+
+    with patch("utils.steam_cloud_bundle.is_source_launch", return_value=True), patch(
+        "utils.steam_cloud_bundle.sys.platform", "win32"
+    ), patch("utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge):
+        result = download_cloudsave_bundle_from_steam(local_cm)
+
+    assert result["success"] is True
+    assert result["action"] == "downloaded"
+    assert json.loads((local_cm.cloudsave_dir / "manifest.json").read_text(encoding="utf-8"))[
+        "fingerprint"
+    ] == remote_export["manifest"]["fingerprint"]
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("platform_name", ["darwin", "linux"])
 def test_upload_cloudsave_bundle_uses_bridge_on_desktop_source_launch(platform_name: str, tmp_path):
     cm = _make_config_manager(tmp_path / platform_name)

--- a/tests/unit/test_steam_cloud_bundle_i18n_names.py
+++ b/tests/unit/test_steam_cloud_bundle_i18n_names.py
@@ -386,7 +386,11 @@ def test_download_cloudsave_bundle_repairs_damaged_newer_local_autocloud_snapsho
     local_manifest = json.loads(local_manifest_path.read_text(encoding="utf-8"))
     local_manifest["exported_at_utc"] = "2026-01-02T00:00:00Z"
     local_manifest_path.write_text(json.dumps(local_manifest, ensure_ascii=False, indent=2), encoding="utf-8")
-    damaged_relative_path = next(iter(local_export["manifest"]["files"].keys()))
+    damaged_relative_path = next(
+        relative_path
+        for relative_path in local_export["manifest"]["files"].keys()
+        if relative_path in remote_export["manifest"]["files"]
+    )
     (local_cm.cloudsave_dir / damaged_relative_path).write_text("damaged payload", encoding="utf-8")
 
     bundle_path = tmp_path / "healthy_remote_bundle.zip"
@@ -429,6 +433,9 @@ def test_download_cloudsave_bundle_repairs_damaged_newer_local_autocloud_snapsho
     assert json.loads((local_cm.cloudsave_dir / "manifest.json").read_text(encoding="utf-8"))[
         "fingerprint"
     ] == remote_export["manifest"]["fingerprint"]
+    assert (local_cm.cloudsave_dir / damaged_relative_path).read_bytes() == (
+        remote_cm.cloudsave_dir / damaged_relative_path
+    ).read_bytes()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_steam_cloud_bundle_i18n_names.py
+++ b/tests/unit/test_steam_cloud_bundle_i18n_names.py
@@ -29,6 +29,7 @@ from utils.steam_cloud_bundle import (
     download_cloudsave_bundle_from_steam,
     upload_cloudsave_bundle_to_steam,
 )
+import utils.steam_cloud_bundle as steam_cloud_bundle
 
 
 VALID_I18N_CASES = [
@@ -195,6 +196,42 @@ def test_download_cloudsave_bundle_uses_bridge_on_windows_packaged_launch(tmp_pa
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "nuitka_marker",
+    ["module_compiled", "main_binary_dir"],
+)
+def test_download_cloudsave_bundle_uses_bridge_on_nuitka_packaged_launch(nuitka_marker: str, tmp_path):
+    cm = _make_config_manager(tmp_path / "target")
+    bootstrap_local_cloudsave_environment(cm)
+    observed = {"entered": False}
+
+    class _DummyBridge:
+        def cloud_enabled(self):
+            observed["entered"] = True
+            return False
+
+    @contextlib.contextmanager
+    def _fake_bridge(*, steamworks=None):
+        yield _DummyBridge()
+
+    marker_patches = [
+        patch.dict(steam_cloud_bundle.__dict__, {"__compiled__": True})
+        if nuitka_marker == "module_compiled"
+        else patch.object(sys.modules["__main__"], "__nuitka_binary_dir", str(tmp_path), create=True)
+    ]
+
+    with marker_patches[0], patch("utils.steam_cloud_bundle.is_source_launch", return_value=False), patch(
+        "utils.steam_cloud_bundle.sys.platform", "win32"
+    ), patch("utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge):
+        result = download_cloudsave_bundle_from_steam(cm)
+
+    assert observed["entered"] is True
+    assert result["success"] is True
+    assert result["action"] == "skipped"
+    assert result["reason"] == "cloud_disabled"
+
+
+@pytest.mark.unit
 def test_download_cloudsave_bundle_uses_bridge_on_windows_source_launch(tmp_path):
     cm = _make_config_manager(tmp_path / "target")
     bootstrap_local_cloudsave_environment(cm)
@@ -261,6 +298,71 @@ def test_download_cloudsave_bundle_continues_when_remote_meta_is_not_json_object
     assert result.get("meta") is None
     imported_manifest = json.loads((target_cm.cloudsave_dir / "manifest.json").read_text(encoding="utf-8"))
     assert imported_manifest["fingerprint"] == export_result["manifest"]["fingerprint"]
+
+
+@pytest.mark.unit
+def test_download_cloudsave_bundle_preserves_newer_local_autocloud_snapshot(tmp_path):
+    remote_cm = _make_config_manager(tmp_path / "remote")
+    local_cm = _make_config_manager(tmp_path / "local")
+    bootstrap_local_cloudsave_environment(remote_cm)
+    bootstrap_local_cloudsave_environment(local_cm)
+
+    _write_runtime_state(remote_cm, character_name="远端旧角色", recent_message="old remote")
+    remote_export = export_local_cloudsave_snapshot(remote_cm)
+    _write_runtime_state(local_cm, character_name="本地新角色", recent_message="new local")
+    local_export = export_local_cloudsave_snapshot(local_cm)
+
+    remote_manifest_path = remote_cm.cloudsave_dir / "manifest.json"
+    remote_manifest = json.loads(remote_manifest_path.read_text(encoding="utf-8"))
+    remote_manifest["exported_at_utc"] = "2026-01-01T00:00:00Z"
+    remote_manifest_path.write_text(json.dumps(remote_manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    local_manifest_path = local_cm.cloudsave_dir / "manifest.json"
+    local_manifest = json.loads(local_manifest_path.read_text(encoding="utf-8"))
+    local_manifest["exported_at_utc"] = "2026-01-02T00:00:00Z"
+    local_manifest_path.write_text(json.dumps(local_manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    bundle_path = tmp_path / "older_remote_bundle.zip"
+    _write_remote_bundle(bundle_path, remote_cm)
+    bundle_bytes = bundle_path.read_bytes()
+    remote_meta = {
+        "schema_version": 1,
+        "bundle_format": "zip",
+        "manifest_fingerprint": remote_export["manifest"]["fingerprint"],
+        "sequence_number": remote_export["manifest"]["sequence_number"],
+        "exported_at_utc": "2026-01-01T00:00:00Z",
+        "file_count": len(remote_export["manifest"]["files"]),
+    }
+
+    class _DummyBridge:
+        def cloud_enabled(self):
+            return True
+
+        def file_exists(self, filename):
+            return filename in {REMOTE_META_FILENAME, REMOTE_BUNDLE_FILENAME}
+
+        def read_file(self, filename):
+            if filename == REMOTE_META_FILENAME:
+                return json.dumps(remote_meta, ensure_ascii=False).encode("utf-8")
+            if filename == REMOTE_BUNDLE_FILENAME:
+                return bundle_bytes
+            raise FileNotFoundError(filename)
+
+    @contextlib.contextmanager
+    def _fake_bridge(*, steamworks=None):
+        yield _DummyBridge()
+
+    with patch("utils.steam_cloud_bundle.is_source_launch", return_value=True), patch(
+        "utils.steam_cloud_bundle.sys.platform", "win32"
+    ), patch("utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge):
+        result = download_cloudsave_bundle_from_steam(local_cm)
+
+    assert result["success"] is True
+    assert result["action"] == "skipped"
+    assert result["reason"] == "local_snapshot_newer_or_equal"
+    assert json.loads((local_cm.cloudsave_dir / "manifest.json").read_text(encoding="utf-8"))[
+        "fingerprint"
+    ] == local_export["manifest"]["fingerprint"]
 
 
 @pytest.mark.unit
@@ -370,6 +472,44 @@ def test_upload_cloudsave_bundle_uses_bridge_on_windows_packaged_launch(tmp_path
     ), patch.object(sys, "frozen", True, create=True), patch(
         "utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge
     ):
+        result = upload_cloudsave_bundle_to_steam(cm)
+
+    assert observed["entered"] is True
+    assert result["success"] is True
+    assert result["action"] == "skipped"
+    assert result["reason"] == "cloud_disabled"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "nuitka_marker",
+    ["module_compiled", "main_binary_dir"],
+)
+def test_upload_cloudsave_bundle_uses_bridge_on_nuitka_packaged_launch(nuitka_marker: str, tmp_path):
+    cm = _make_config_manager(tmp_path / "target")
+    bootstrap_local_cloudsave_environment(cm)
+    _write_runtime_state(cm, character_name="Nuitka上传角色", recent_message="hello")
+    export_local_cloudsave_snapshot(cm)
+    observed = {"entered": False}
+
+    class _DummyBridge:
+        def cloud_enabled(self):
+            observed["entered"] = True
+            return False
+
+    @contextlib.contextmanager
+    def _fake_bridge(*, steamworks=None):
+        yield _DummyBridge()
+
+    marker_patches = [
+        patch.dict(steam_cloud_bundle.__dict__, {"__compiled__": True})
+        if nuitka_marker == "module_compiled"
+        else patch.object(sys.modules["__main__"], "__nuitka_binary_dir", str(tmp_path), create=True)
+    ]
+
+    with marker_patches[0], patch("utils.steam_cloud_bundle.is_source_launch", return_value=False), patch(
+        "utils.steam_cloud_bundle.sys.platform", "win32"
+    ), patch("utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge):
         result = upload_cloudsave_bundle_to_steam(cm)
 
     assert observed["entered"] is True

--- a/tests/unit/test_steam_cloud_bundle_i18n_names.py
+++ b/tests/unit/test_steam_cloud_bundle_i18n_names.py
@@ -2,6 +2,7 @@ import io
 import json
 import shutil
 import contextlib
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -166,15 +167,31 @@ def test_download_cloudsave_bundle_uses_bridge_on_desktop_source_launch(platform
 
 
 @pytest.mark.unit
-def test_download_cloudsave_bundle_skips_on_windows_frozen_launch():
+def test_download_cloudsave_bundle_uses_bridge_on_windows_packaged_launch(tmp_path):
+    cm = _make_config_manager(tmp_path / "target")
+    bootstrap_local_cloudsave_environment(cm)
+    observed = {"entered": False}
+
+    class _DummyBridge:
+        def cloud_enabled(self):
+            observed["entered"] = True
+            return False
+
+    @contextlib.contextmanager
+    def _fake_bridge(*, steamworks=None):
+        yield _DummyBridge()
+
     with patch("utils.steam_cloud_bundle.is_source_launch", return_value=False), patch(
         "utils.steam_cloud_bundle.sys.platform", "win32"
+    ), patch.object(sys, "frozen", True, create=True), patch(
+        "utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge
     ):
-        result = download_cloudsave_bundle_from_steam(object())
+        result = download_cloudsave_bundle_from_steam(cm)
 
+    assert observed["entered"] is True
     assert result["success"] is True
     assert result["action"] == "skipped"
-    assert result["reason"] == "not_source_launch"
+    assert result["reason"] == "cloud_disabled"
 
 
 @pytest.mark.unit
@@ -276,20 +293,89 @@ def test_upload_cloudsave_bundle_uses_bridge_on_desktop_source_launch(platform_n
 
 
 @pytest.mark.unit
-def test_upload_cloudsave_bundle_skips_on_windows_frozen_launch(tmp_path):
+def test_upload_cloudsave_bundle_wraps_bundle_and_meta_writes_in_batch(tmp_path):
+    cm = _make_config_manager(tmp_path / "target")
+    bootstrap_local_cloudsave_environment(cm)
+    _write_runtime_state(cm, character_name="批量上传角色", recent_message="batch")
+    export_local_cloudsave_snapshot(cm)
+
+    class _BatchBridge:
+        def __init__(self):
+            self.storage = {}
+            self.events = []
+
+        def cloud_enabled(self):
+            return True
+
+        def begin_file_write_batch(self):
+            self.events.append("begin")
+            return True
+
+        def end_file_write_batch(self):
+            self.events.append("end")
+            return True
+
+        def file_exists(self, remote_name):
+            return remote_name in self.storage
+
+        def read_file(self, remote_name):
+            return self.storage[remote_name]
+
+        def write_file(self, remote_name, payload):
+            self.events.append(f"write:{remote_name}")
+            self.storage[remote_name] = payload
+
+        def delete_file(self, remote_name):
+            self.events.append(f"delete:{remote_name}")
+            self.storage.pop(remote_name, None)
+            return True
+
+    bridge = _BatchBridge()
+
+    @contextlib.contextmanager
+    def _fake_bridge(*, steamworks=None):
+        yield bridge
+
+    with patch("utils.steam_cloud_bundle.is_source_launch", return_value=True), patch(
+        "utils.steam_cloud_bundle.sys.platform", "win32"
+    ), patch("utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge):
+        result = upload_cloudsave_bundle_to_steam(cm)
+
+    assert result["action"] == "uploaded"
+    assert bridge.events[0] == "begin"
+    assert bridge.events[-1] == "end"
+    assert f"write:{REMOTE_BUNDLE_FILENAME}" in bridge.events
+    assert f"write:{REMOTE_META_FILENAME}" in bridge.events
+
+
+@pytest.mark.unit
+def test_upload_cloudsave_bundle_uses_bridge_on_windows_packaged_launch(tmp_path):
     cm = _make_config_manager(tmp_path / "target")
     bootstrap_local_cloudsave_environment(cm)
     _write_runtime_state(cm, character_name="冻结上传角色", recent_message="hello")
     export_local_cloudsave_snapshot(cm)
+    observed = {"entered": False}
+
+    class _DummyBridge:
+        def cloud_enabled(self):
+            observed["entered"] = True
+            return False
+
+    @contextlib.contextmanager
+    def _fake_bridge(*, steamworks=None):
+        yield _DummyBridge()
 
     with patch("utils.steam_cloud_bundle.is_source_launch", return_value=False), patch(
         "utils.steam_cloud_bundle.sys.platform", "win32"
+    ), patch.object(sys, "frozen", True, create=True), patch(
+        "utils.steam_cloud_bundle.steam_cloud_bundle_bridge", _fake_bridge
     ):
         result = upload_cloudsave_bundle_to_steam(cm)
 
+    assert observed["entered"] is True
     assert result["success"] is True
     assert result["action"] == "skipped"
-    assert result["reason"] == "not_source_launch"
+    assert result["reason"] == "cloud_disabled"
 
 
 @pytest.mark.unit

--- a/utils/steam_cloud_bundle.py
+++ b/utils/steam_cloud_bundle.py
@@ -155,6 +155,8 @@ def _local_cloudsave_snapshot_is_newer_or_equal(config_manager, remote_manifest_
     )
     if local_fingerprint and remote_fingerprint and local_fingerprint == remote_fingerprint:
         return _cloudsave_manifest_matches_local_files(config_manager, remote_fingerprint)
+    if not local_fingerprint or not _cloudsave_manifest_matches_local_files(config_manager, local_fingerprint):
+        return False
 
     local_exported_at = _parse_manifest_export_time(local_manifest.get("exported_at_utc"))
     remote_exported_at = _parse_manifest_export_time(remote_manifest_like.get("exported_at_utc"))

--- a/utils/steam_cloud_bundle.py
+++ b/utils/steam_cloud_bundle.py
@@ -26,6 +26,7 @@ import zipfile
 import ctypes
 from contextlib import contextmanager
 from ctypes import POINTER, c_bool, c_char_p, c_int32, c_void_p, create_string_buffer
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
 from uuid import uuid4
@@ -129,6 +130,39 @@ def _cloudsave_manifest_matches_local_files(config_manager, manifest_fingerprint
     return config_manager.cloudsave_manifest_path.is_file()
 
 
+def _parse_manifest_export_time(value: object) -> datetime | None:
+    raw_value = str(value or "").strip()
+    if not raw_value:
+        return None
+    if raw_value.endswith("Z"):
+        raw_value = f"{raw_value[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw_value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _local_cloudsave_snapshot_is_newer_or_equal(config_manager, remote_manifest_like: dict[str, Any]) -> bool:
+    local_manifest = _load_json_if_exists(config_manager.cloudsave_manifest_path)
+    if not isinstance(local_manifest, dict) or not isinstance(remote_manifest_like, dict):
+        return False
+    local_fingerprint = str(local_manifest.get("fingerprint") or "")
+    remote_fingerprint = str(
+        remote_manifest_like.get("manifest_fingerprint") or remote_manifest_like.get("fingerprint") or ""
+    )
+    if local_fingerprint and remote_fingerprint and local_fingerprint == remote_fingerprint:
+        return _cloudsave_manifest_matches_local_files(config_manager, remote_fingerprint)
+
+    local_exported_at = _parse_manifest_export_time(local_manifest.get("exported_at_utc"))
+    remote_exported_at = _parse_manifest_export_time(remote_manifest_like.get("exported_at_utc"))
+    if local_exported_at is None or remote_exported_at is None:
+        return False
+    return local_exported_at >= remote_exported_at
+
+
 def _write_remote_bundle(
     stage_bundle_path: Path,
     config_manager,
@@ -230,6 +264,7 @@ def _apply_bundle_to_local_cloudsave(
     meta_payload: dict[str, Any] | None,
     *,
     deadline_monotonic: float | None = None,
+    preserve_newer_local: bool = False,
 ) -> dict[str, Any]:
     _assert_deadline_not_exceeded(
         deadline_monotonic,
@@ -267,6 +302,14 @@ def _apply_bundle_to_local_cloudsave(
         staged_file = stage_cloudsave_root / relative_path
         if not staged_file.is_file():
             raise FileNotFoundError(f"remote cloudsave bundle is missing {relative_path}")
+
+    if preserve_newer_local and _local_cloudsave_snapshot_is_newer_or_equal(config_manager, stage_manifest):
+        return {
+            "manifest_fingerprint": remote_fingerprint,
+            "downloaded_file_count": 0,
+            "skipped": True,
+            "reason": "local_snapshot_newer_or_equal",
+        }
 
     stage_replacement_root = stage_root / "cloudsave-replacement"
     stage_replacement_root.mkdir(parents=True, exist_ok=True)
@@ -544,6 +587,13 @@ def download_cloudsave_bundle_from_steam(
                 "reason": "already_synced",
                 "meta": meta_payload,
             }
+        if isinstance(meta_payload, dict) and _local_cloudsave_snapshot_is_newer_or_equal(config_manager, meta_payload):
+            return {
+                "success": True,
+                "action": "skipped",
+                "reason": "local_snapshot_newer_or_equal",
+                "meta": meta_payload,
+            }
 
         _assert_deadline_not_exceeded(
             deadline_monotonic,
@@ -556,7 +606,16 @@ def download_cloudsave_bundle_from_steam(
             bundle_bytes,
             meta_payload,
             deadline_monotonic=deadline_monotonic,
+            preserve_newer_local=True,
         )
+        if apply_result.get("skipped"):
+            return {
+                "success": True,
+                "action": "skipped",
+                "reason": str(apply_result.get("reason") or "local_snapshot_newer_or_equal"),
+                "meta": meta_payload,
+                "result": apply_result,
+            }
         return {
             "success": True,
             "action": "downloaded",
@@ -664,6 +723,8 @@ def upload_cloudsave_bundle_to_steam(
             finally:
                 if batch_started and callable(end_batch):
                     try:
+                        # Steam's batch must be closed once opened, even if the
+                        # first write failed or rollback writes happened inside it.
                         end_batch()
                     except Exception as exc:
                         logger.warning("steam_cloud_bundle: failed to end remote write batch: %s", exc)

--- a/utils/steam_cloud_bundle.py
+++ b/utils/steam_cloud_bundle.py
@@ -58,6 +58,22 @@ def is_source_launch() -> bool:
     return not getattr(sys, "frozen", False) and Path(sys.argv[0]).suffix.lower() in _SOURCE_SCRIPT_SUFFIXES
 
 
+def _is_packaged_launch() -> bool:
+    if getattr(sys, "frozen", False):
+        return True
+    if "__compiled__" in globals() or "__nuitka_binary_dir" in globals():
+        return True
+    main_mod = sys.modules.get("__main__")
+    return bool(
+        main_mod is not None
+        and (hasattr(main_mod, "__compiled__") or hasattr(main_mod, "__nuitka_binary_dir"))
+    )
+
+
+def _steam_remote_bundle_launch_allowed() -> bool:
+    return bool(is_source_launch() or _is_packaged_launch())
+
+
 def _managed_cloudsave_relative_paths(config_manager) -> list[str]:
     manifest = load_cloudsave_manifest(config_manager)
     manifest_files = manifest.get("files") if isinstance(manifest.get("files"), dict) else {}
@@ -380,6 +396,15 @@ class SteamCloudBundleBridge:
         self._api.SteamAPI_ISteamRemoteStorage_FileDelete.restype = c_bool
         self._api.SteamAPI_ISteamRemoteStorage_FileWrite.argtypes = [c_void_p, c_char_p, c_void_p, c_int32]
         self._api.SteamAPI_ISteamRemoteStorage_FileWrite.restype = c_bool
+        self._batch_api_available = False
+        try:
+            self._api.SteamAPI_ISteamRemoteStorage_BeginFileWriteBatch.argtypes = [c_void_p]
+            self._api.SteamAPI_ISteamRemoteStorage_BeginFileWriteBatch.restype = c_bool
+            self._api.SteamAPI_ISteamRemoteStorage_EndFileWriteBatch.argtypes = [c_void_p]
+            self._api.SteamAPI_ISteamRemoteStorage_EndFileWriteBatch.restype = c_bool
+            self._batch_api_available = True
+        except AttributeError:
+            self._batch_api_available = False
         self._api.SteamAPI_ISteamRemoteStorage_FileRead.argtypes = [c_void_p, c_char_p, c_void_p, c_int32]
         self._api.SteamAPI_ISteamRemoteStorage_FileRead.restype = c_int32
         self._api.SteamAPI_ISteamRemoteStorage_GetFileSize.argtypes = [c_void_p, c_char_p]
@@ -435,6 +460,16 @@ class SteamCloudBundleBridge:
         if not success:
             raise RuntimeError(f"failed to write remote storage file: {remote_name}")
 
+    def begin_file_write_batch(self) -> bool:
+        if not self._batch_api_available:
+            return False
+        return bool(self._api.SteamAPI_ISteamRemoteStorage_BeginFileWriteBatch(self._remote))
+
+    def end_file_write_batch(self) -> bool:
+        if not self._batch_api_available:
+            return False
+        return bool(self._api.SteamAPI_ISteamRemoteStorage_EndFileWriteBatch(self._remote))
+
     def delete_file(self, remote_name: str) -> bool:
         return bool(self._api.SteamAPI_ISteamRemoteStorage_FileDelete(self._remote, remote_name.encode("ascii")))
 
@@ -454,7 +489,7 @@ def download_cloudsave_bundle_from_steam(
     steamworks=None,
     deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
-    if not is_source_launch():
+    if not _steam_remote_bundle_launch_allowed():
         return {
             "success": True,
             "action": "skipped",
@@ -536,7 +571,7 @@ def upload_cloudsave_bundle_to_steam(
     steamworks=None,
     deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
-    if not is_source_launch():
+    if not _steam_remote_bundle_launch_allowed():
         return {
             "success": True,
             "action": "skipped",
@@ -592,31 +627,46 @@ def upload_cloudsave_bundle_to_steam(
             if bridge.file_exists(REMOTE_META_FILENAME):
                 previous_meta_bytes = bridge.read_file(REMOTE_META_FILENAME)
 
-            bridge.write_file(REMOTE_BUNDLE_FILENAME, bundle_bytes)
+            batch_started = False
+            begin_batch = getattr(bridge, "begin_file_write_batch", None)
+            end_batch = getattr(bridge, "end_file_write_batch", None)
+            if callable(begin_batch) and callable(end_batch):
+                try:
+                    batch_started = bool(begin_batch())
+                except Exception as exc:
+                    logger.warning("steam_cloud_bundle: failed to begin remote write batch; continuing: %s", exc)
             try:
-                bridge.write_file(REMOTE_META_FILENAME, meta_bytes)
-            except Exception as exc:
-                rollback_errors: list[str] = []
+                bridge.write_file(REMOTE_BUNDLE_FILENAME, bundle_bytes)
                 try:
-                    if previous_bundle_bytes is None:
-                        bridge.delete_file(REMOTE_BUNDLE_FILENAME)
-                    else:
-                        bridge.write_file(REMOTE_BUNDLE_FILENAME, previous_bundle_bytes)
-                except Exception as restore_bundle_error:
-                    rollback_errors.append(f"restore bundle failed: {restore_bundle_error}")
-                try:
-                    if previous_meta_bytes is None:
-                        bridge.delete_file(REMOTE_META_FILENAME)
-                    else:
-                        bridge.write_file(REMOTE_META_FILENAME, previous_meta_bytes)
-                except Exception as restore_meta_error:
-                    rollback_errors.append(f"restore meta failed: {restore_meta_error}")
-                if rollback_errors:
-                    raise RuntimeError(
-                        "failed to write remote cloudsave meta and rollback previous remote bundle state: "
-                        + "; ".join(rollback_errors)
-                    ) from exc
-                raise
+                    bridge.write_file(REMOTE_META_FILENAME, meta_bytes)
+                except Exception as exc:
+                    rollback_errors: list[str] = []
+                    try:
+                        if previous_bundle_bytes is None:
+                            bridge.delete_file(REMOTE_BUNDLE_FILENAME)
+                        else:
+                            bridge.write_file(REMOTE_BUNDLE_FILENAME, previous_bundle_bytes)
+                    except Exception as restore_bundle_error:
+                        rollback_errors.append(f"restore bundle failed: {restore_bundle_error}")
+                    try:
+                        if previous_meta_bytes is None:
+                            bridge.delete_file(REMOTE_META_FILENAME)
+                        else:
+                            bridge.write_file(REMOTE_META_FILENAME, previous_meta_bytes)
+                    except Exception as restore_meta_error:
+                        rollback_errors.append(f"restore meta failed: {restore_meta_error}")
+                    if rollback_errors:
+                        raise RuntimeError(
+                            "failed to write remote cloudsave meta and rollback previous remote bundle state: "
+                            + "; ".join(rollback_errors)
+                        ) from exc
+                    raise
+            finally:
+                if batch_started and callable(end_batch):
+                    try:
+                        end_batch()
+                    except Exception as exc:
+                        logger.warning("steam_cloud_bundle: failed to end remote write batch: %s", exc)
             return {
                 "success": True,
                 "action": "uploaded",


### PR DESCRIPTION
## 改动概述 / Summary

修复正式打包版 Steam 云存档跨设备同步不稳定的问题。

根因是：应用生成的 `cloudsave/` 快照固定写入平台 anchor root，但 Steam Auto-Cloud 后台规则一旦没有正确监控该目录，正式包就没有第二条同步链路，导致用户在设备 A 生成快照后，设备 B 看不到云端数据。

本 PR 做了：

- 让 packaged/frozen 发行版也启用已有的 Steam RemoteStorage bundle 上传/下载兜底。
- 兼容 PyInstaller 与 Nuitka 打包识别。
- 上传 `__neko_cloudsave_bundle__.zip` 与 `__neko_cloudsave_bundle_meta__.json` 时使用 Steam RemoteStorage file write batch，保证 bundle 与 meta 作为一组状态更新。
- 保留原 Steam Auto-Cloud `cloudsave/` 原始目录同步能力，后台配置正确时仍继续生效。
- 更新云存档设计文档与部署文档，明确正式包现在使用 RemoteStorage bundle 作为跨设备兜底链路。

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

已验证：

```bash
uv run pytest -q tests/unit/test_steam_cloud_bundle_i18n_names.py tests/unit/test_cloudsave_autocloud.py tests/unit/test_cloudsave_lifecycle_flow.py tests/unit/test_cloudsave_autocloud_router.py tests/unit/test_storage_layout.py tests/unit/test_storage_policy.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 当 Steam 运行且已登录时，打包/编译后运行与源码启动均支持云存档同步；在可用时启用更稳定的批量写入。
* **改进**
  * 强化本地/远端快照对比：本地更新或相等则避免覆盖；本地损坏会在需要时修复并以远端为准更新。
  * 统一跨平台 `cloudsave/` 落在固定的 anchor 目录下，减少路径迁移导致的不同步；同时更清晰说明 Auto-Cloud 规则匹配时的同步范围。
* **文档**
  * 更新部署手册（中/日）与同步边界说明，明确验证生产 Steam 云路径的方式。
* **测试**
  * 扩展并调整打包与批量写入相关的云存档桥接、跳过与快照比较用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->