### PR TITLE
fix(tutorial): 防止每日教程刷新复播

### DIFF
--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -640,8 +640,8 @@ class UniversalTutorialManager {
         if (state.completedRounds.includes(round) || state.skippedRounds.includes(round)) {
             return false;
         }
-        if (state.pendingRound || state.manualResetRound) {
-            return state.pendingRound === round || state.manualResetRound === round;
+        if (state.manualResetRound) {
+            return state.manualResetRound === round;
         }
         return this.getNextAvatarFloatingGuideAutoRound() === round;
     }
@@ -743,9 +743,7 @@ class UniversalTutorialManager {
                 return;
             }
             this.startAvatarFloatingGuideRound(round, { source: 'auto' }).then((result) => {
-                if (result !== false) {
-                    this.markAvatarFloatingGuideRoundAutoShown(round);
-                } else {
+                if (result === false) {
                     this.dispatchStartupGreetingRelease('avatar-floating-round-start-skipped', { day: round });
                 }
             }).catch((error) => {

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -661,7 +661,7 @@ class UniversalTutorialManager {
     getNextAvatarFloatingGuideAutoRound() {
         const state = loadAvatarFloatingGuideState();
         const today = getTodayLocalDateForAvatarFloatingGuide();
-        const pendingManualRound = state.pendingRound || state.manualResetRound;
+        const pendingManualRound = state.manualResetRound;
         if (pendingManualRound) {
             return pendingManualRound;
         }
@@ -2998,6 +2998,10 @@ class UniversalTutorialManager {
             yuiGuideSceneId: 'avatar_floating_day' + round,
         }];
         this.activeAvatarFloatingGuideRound = round;
+        if (source === 'auto') {
+            // Reserve the daily auto start before long narration so refreshes cannot replay it.
+            this.markAvatarFloatingGuideRoundAutoShown(round);
+        }
         this.setAvatarFloatingGuideCurrentRound(round);
         this.snapshotAvatarFloatingModelInteractionState('avatar-floating-guide-start');
         this.isTutorialRunning = true;

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2275,6 +2275,36 @@ test('avatar floating auto-start rechecks current due round before delayed launc
     assert.doesNotMatch(pendingCheckBlock, /state\.lastAutoShownDate === today/);
 });
 
+test('avatar floating auto-start reserves the round before long playback can be refreshed', () => {
+    const managerSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/core/universal-manager.js'), 'utf8');
+    const startRoundBlock = managerSource.split('    async startAvatarFloatingGuideRound(day, options = {}) {')[1].split(
+        '    async waitForTutorialTeardownSettled(reason = ',
+        1
+    )[0];
+    const autoReservationIndex = startRoundBlock.indexOf("if (source === 'auto')");
+    const setCurrentIndex = startRoundBlock.indexOf('this.setAvatarFloatingGuideCurrentRound(round);');
+
+    assert.notEqual(autoReservationIndex, -1, 'auto round starts should reserve same-day playback before long narration');
+    assert.notEqual(setCurrentIndex, -1, 'round starts should still persist current round state');
+    assert.ok(autoReservationIndex < setCurrentIndex, 'auto reservation should be written before pending/current round state');
+    assert.match(startRoundBlock, /if \(source === 'auto'\) \{[\s\S]*?this\.markAvatarFloatingGuideRoundAutoShown\(round\);[\s\S]*?\}/);
+});
+
+test('avatar floating auto due calculation ignores runtime pending round after refresh', () => {
+    const managerSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/core/universal-manager.js'), 'utf8');
+    const nextAutoBlock = managerSource.split('    getNextAvatarFloatingGuideAutoRound() {')[1].split(
+        '    getHomeAvatarFloatingGuideStartRound(options = {}) {',
+        1
+    )[0];
+
+    assert.match(nextAutoBlock, /const pendingManualRound = state\.manualResetRound;/);
+    assert.doesNotMatch(nextAutoBlock, /state\.pendingRound\s*\|\|\s*state\.manualResetRound/);
+    assert.ok(
+        nextAutoBlock.indexOf('if (pendingManualRound)') < nextAutoBlock.indexOf('if (state.lastAutoShownDate === today)'),
+        'manual resets should still override same-day auto reservation'
+    );
+});
+
 test('tutorial destroy requests share the PC global overlay cleanup path', () => {
     const managerSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/core/universal-manager.js'), 'utf8');
     const clearOverlayBlock = managerSource.split('    clearPcTutorialGlobalOverlay(reason = ')[1].split(

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2268,9 +2268,12 @@ test('avatar floating auto-start rechecks current due round before delayed launc
 
     assert.match(maybeAutoBlock, /if \(!this\.isAvatarFloatingGuideRoundPendingAutoStart\(round\)\) \{[\s\S]*?return;\s*\}/);
     assert.match(pendingCheckBlock, /const state = loadAvatarFloatingGuideState\(\);/);
+    assert.match(pendingCheckBlock, /if \(state\.manualResetRound\) \{[\s\S]*?return state\.manualResetRound === round;[\s\S]*?\}/);
     assert.match(pendingCheckBlock, /return this\.getNextAvatarFloatingGuideAutoRound\(\) === round;/);
     assert.match(pendingCheckBlock, /state\.completedRounds\.includes\(round\)/);
     assert.match(pendingCheckBlock, /state\.skippedRounds\.includes\(round\)/);
+    assert.doesNotMatch(pendingCheckBlock, /state\.pendingRound\s*\|\|/);
+    assert.doesNotMatch(pendingCheckBlock, /state\.pendingRound === round/);
     assert.doesNotMatch(pendingCheckBlock, /state\.lastAutoShownRound === round/);
     assert.doesNotMatch(pendingCheckBlock, /state\.lastAutoShownDate === today/);
 });
@@ -2303,6 +2306,18 @@ test('avatar floating auto due calculation ignores runtime pending round after r
         nextAutoBlock.indexOf('if (pendingManualRound)') < nextAutoBlock.indexOf('if (state.lastAutoShownDate === today)'),
         'manual resets should still override same-day auto reservation'
     );
+});
+
+test('avatar floating auto start does not mark auto-shown again after playback settles', () => {
+    const managerSource = fs.readFileSync(path.join(repoRoot, 'static', 'tutorial/core/universal-manager.js'), 'utf8');
+    const maybeAutoBlock = managerSource.split('    async maybeStartAvatarFloatingGuideAutoRound(delayMs = 1200) {')[1].split(
+        '    ensureTutorialSkipController() {',
+        1
+    )[0];
+
+    assert.match(maybeAutoBlock, /this\.startAvatarFloatingGuideRound\(round, \{ source: 'auto' \}\)\.then\(\(result\) => \{/);
+    assert.match(maybeAutoBlock, /if \(result === false\) \{[\s\S]*?avatar-floating-round-start-skipped/);
+    assert.doesNotMatch(maybeAutoBlock, /markAvatarFloatingGuideRoundAutoShown\(round\)/);
 });
 
 test('tutorial destroy requests share the PC global overlay cleanup path', () => {


### PR DESCRIPTION
﻿## 改动概览

修复每日悬浮新手教程在自动启动后刷新页面会重复播放当天轮次的问题，同时保留 Day1 跳过后后续 Day2-Day7 到期自动续播的行为。

## 为什么改

#2071 将延迟启动前的二次检查改为重新计算当前应播放轮次，解决了 Day2-Day7 被 `lastAutoShownDate` 误挡的问题。但自动展示标记仍在整段教程 Promise 结束后才写入，而启动流程会先把 `pendingRound` 持久化。用户在教程播放中刷新时，新的页面会把这个运行中残留的 `pendingRound` 当作待启动轮次，从而复播当天教程。

## 怎么改

自动启动路径在进入每日教程长演出前先写入当天 `lastAutoShownRound/lastAutoShownDate`，把“今天已经自动展示过”作为启动预占位，而不是等教程完成后才记录。同时，自动续播计算只让 `manualResetRound` 具备手动优先级，不再让普通 `pendingRound` 绕过同日去重；手动重置仍然可以明确要求重播对应轮次。

相关静态契约补充了两条约束：自动启动必须在写入当前轮次 pending 前完成预占位；自动 due round 计算必须忽略刷新残留的运行中 pending。

## 风险与边界

本次只影响首页每日悬浮新手教程的自动启动判定与对应静态契约，不改具体教程内容、Day1 首页引导文本、角色卡、聊天或语音主流程。风险集中在本地教程状态异常时的续播判断；已保留完成/跳过轮次优先拦截、手动重置优先启动和下一天继续播放后续轮次的边界。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 调整首页每日“头像悬浮窗教程”的自动起播轮次判定逻辑：更严格区分待自动起播与手动重置来源，避免临时轮次状态造成误触发。
  * 优化“已展示”标记写入时机：自动启动时按来源更一致地记录，减少同日长播前后重复或异常展示。
* **Tests**
  * 补充并更新自动起播与“已展示”标记顺序的测试覆盖，防止重复标记与刷新后判定偏差。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->