### PR TITLE
[codex] fix mic popup speaker volume without devices

### DIFF
--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1513,15 +1513,7 @@
             if (!isPopupAvailable()) return false;
             micPopup.innerHTML = '';
 
-            if (audioInputs.length === 0) {
-                var noMicItem = document.createElement('div');
-                noMicItem.textContent = window.t ? window.t('microphone.noDevices') : '没有检测到麦克风设备';
-                noMicItem.style.padding = '8px 12px';
-                noMicItem.style.color = 'var(--neko-popup-text-sub)';
-                noMicItem.style.fontSize = '13px';
-                micPopup.appendChild(noMicItem);
-                return true;
-            }
+            var hasMicrophoneDevices = audioInputs.length > 0;
 
             // ===== 双栏布局 =====
             var leftColumn = document.createElement('div');
@@ -1753,6 +1745,12 @@
             gainSlider.step = '1';
             gainSlider.value = String(S.microphoneGainDb);
             Object.assign(gainSlider.style, { width: '100%', height: '6px', borderRadius: '3px', cursor: 'pointer', accentColor: '#4f8cff' });
+            if (!hasMicrophoneDevices) {
+                gainSlider.disabled = true;
+                gainSlider.style.cursor = 'not-allowed';
+                gainSlider.style.opacity = '0.55';
+                gainValueEl.style.color = 'var(--neko-popup-text-sub)';
+            }
 
             gainSlider.addEventListener('input', function (e) {
                 var newGainDb = parseFloat(e.target.value);
@@ -1828,33 +1826,40 @@
             rightColumn.appendChild(deviceTitle);
 
             // 默认麦克风选项
-            var defaultOption = document.createElement('button');
-            defaultOption.className = 'mic-option';
-            defaultOption.textContent = window.t ? window.t('microphone.defaultDevice') : '系统默认麦克风';
-            if (S.selectedMicrophoneId === null) defaultOption.classList.add('selected');
-            Object.assign(defaultOption.style, { padding: '8px 12px', cursor: 'pointer', border: 'none', background: S.selectedMicrophoneId === null ? 'var(--neko-popup-selected-bg)' : 'transparent', borderRadius: '6px', transition: 'background 0.2s ease', fontSize: '13px', width: '100%', textAlign: 'left', color: S.selectedMicrophoneId === null ? '#4f8cff' : 'var(--neko-popup-text)', fontWeight: S.selectedMicrophoneId === null ? '500' : '400' });
-            defaultOption.addEventListener('mouseenter', function () { if (S.selectedMicrophoneId !== null) defaultOption.style.background = 'var(--neko-popup-hover)'; });
-            defaultOption.addEventListener('mouseleave', function () { if (S.selectedMicrophoneId !== null) defaultOption.style.background = 'transparent'; });
-            defaultOption.addEventListener('click', async function () { await selectMicrophone(null); updateMicListSelection(); });
-            rightColumn.appendChild(defaultOption);
+            if (hasMicrophoneDevices) {
+                var defaultOption = document.createElement('button');
+                defaultOption.className = 'mic-option';
+                defaultOption.textContent = window.t ? window.t('microphone.defaultDevice') : '系统默认麦克风';
+                if (S.selectedMicrophoneId === null) defaultOption.classList.add('selected');
+                Object.assign(defaultOption.style, { padding: '8px 12px', cursor: 'pointer', border: 'none', background: S.selectedMicrophoneId === null ? 'var(--neko-popup-selected-bg)' : 'transparent', borderRadius: '6px', transition: 'background 0.2s ease', fontSize: '13px', width: '100%', textAlign: 'left', color: S.selectedMicrophoneId === null ? '#4f8cff' : 'var(--neko-popup-text)', fontWeight: S.selectedMicrophoneId === null ? '500' : '400' });
+                defaultOption.addEventListener('mouseenter', function () { if (S.selectedMicrophoneId !== null) defaultOption.style.background = 'var(--neko-popup-hover)'; });
+                defaultOption.addEventListener('mouseleave', function () { if (S.selectedMicrophoneId !== null) defaultOption.style.background = 'transparent'; });
+                defaultOption.addEventListener('click', async function () { await selectMicrophone(null); updateMicListSelection(); });
+                rightColumn.appendChild(defaultOption);
 
-            var sep3 = document.createElement('div');
-            Object.assign(sep3.style, { height: '1px', backgroundColor: 'var(--neko-popup-separator)', margin: '5px 0' });
-            rightColumn.appendChild(sep3);
+                var sep3 = document.createElement('div');
+                Object.assign(sep3.style, { height: '1px', backgroundColor: 'var(--neko-popup-separator)', margin: '5px 0' });
+                rightColumn.appendChild(sep3);
 
-            // 各个设备选项
-            audioInputs.forEach(function (device, idx) {
-                var option = document.createElement('button');
-                option.className = 'mic-option';
-                option.dataset.deviceId = device.deviceId;
-                option.textContent = device.label || (window.t ? window.t('microphone.deviceLabel', { index: idx + 1 }) : '麦克风 ' + (idx + 1));
-                if (S.selectedMicrophoneId === device.deviceId) option.classList.add('selected');
-                Object.assign(option.style, { padding: '8px 12px', cursor: 'pointer', border: 'none', background: S.selectedMicrophoneId === device.deviceId ? 'var(--neko-popup-selected-bg)' : 'transparent', borderRadius: '6px', transition: 'background 0.2s ease', fontSize: '13px', width: '100%', textAlign: 'left', color: S.selectedMicrophoneId === device.deviceId ? '#4f8cff' : 'var(--neko-popup-text)', fontWeight: S.selectedMicrophoneId === device.deviceId ? '500' : '400' });
-                option.addEventListener('mouseenter', function () { if (S.selectedMicrophoneId !== device.deviceId) option.style.background = 'var(--neko-popup-hover)'; });
-                option.addEventListener('mouseleave', function () { if (S.selectedMicrophoneId !== device.deviceId) option.style.background = 'transparent'; });
-                option.addEventListener('click', async function () { await selectMicrophone(device.deviceId); updateMicListSelection(); });
-                rightColumn.appendChild(option);
-            });
+                // 各个设备选项
+                audioInputs.forEach(function (device, idx) {
+                    var option = document.createElement('button');
+                    option.className = 'mic-option';
+                    option.dataset.deviceId = device.deviceId;
+                    option.textContent = device.label || (window.t ? window.t('microphone.deviceLabel', { index: idx + 1 }) : '麦克风 ' + (idx + 1));
+                    if (S.selectedMicrophoneId === device.deviceId) option.classList.add('selected');
+                    Object.assign(option.style, { padding: '8px 12px', cursor: 'pointer', border: 'none', background: S.selectedMicrophoneId === device.deviceId ? 'var(--neko-popup-selected-bg)' : 'transparent', borderRadius: '6px', transition: 'background 0.2s ease', fontSize: '13px', width: '100%', textAlign: 'left', color: S.selectedMicrophoneId === device.deviceId ? '#4f8cff' : 'var(--neko-popup-text)', fontWeight: S.selectedMicrophoneId === device.deviceId ? '500' : '400' });
+                    option.addEventListener('mouseenter', function () { if (S.selectedMicrophoneId !== device.deviceId) option.style.background = 'var(--neko-popup-hover)'; });
+                    option.addEventListener('mouseleave', function () { if (S.selectedMicrophoneId !== device.deviceId) option.style.background = 'transparent'; });
+                    option.addEventListener('click', async function () { await selectMicrophone(device.deviceId); updateMicListSelection(); });
+                    rightColumn.appendChild(option);
+                });
+            } else {
+                var noMicItem = document.createElement('div');
+                noMicItem.textContent = window.t ? window.t('microphone.noDevices') : '没有检测到麦克风设备';
+                Object.assign(noMicItem.style, { padding: '8px 12px', color: 'var(--neko-popup-text-sub)', fontSize: '13px' });
+                rightColumn.appendChild(noMicItem);
+            }
 
             // 组装
             micPopup.appendChild(leftColumn);

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1749,6 +1749,7 @@
                 gainSlider.disabled = true;
                 gainSlider.style.cursor = 'not-allowed';
                 gainSlider.style.opacity = '0.55';
+                gainLabel.style.color = 'var(--neko-popup-text-sub)';
                 gainValueEl.style.color = 'var(--neko-popup-text-sub)';
             }
 

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -292,7 +292,7 @@ def test_mic_capture_failure_restores_composer_without_outer_voice_start_lifecyc
 def test_floating_mic_popup_keeps_speaker_volume_without_microphone_devices():
     source = _read(APP_AUDIO_CAPTURE_PATH)
     render_start = source.index("window.renderFloatingMicList = async function")
-    render_end = source.index("/** 轻量级更新：仅更新选中状态 */", render_start)
+    render_end = source.index("function updateMicListSelection()", render_start)
     render = source[render_start:render_end]
 
     assert "var hasMicrophoneDevices = audioInputs.length > 0;" in render

--- a/tests/unit/test_voice_start_failure_static.py
+++ b/tests/unit/test_voice_start_failure_static.py
@@ -289,6 +289,25 @@ def test_mic_capture_failure_restores_composer_without_outer_voice_start_lifecyc
     assert failure.index("stopGameVoiceSttGate({ restoreOrdinaryMic: false });") < throw_index
 
 
+def test_floating_mic_popup_keeps_speaker_volume_without_microphone_devices():
+    source = _read(APP_AUDIO_CAPTURE_PATH)
+    render_start = source.index("window.renderFloatingMicList = async function")
+    render_end = source.index("/** 轻量级更新：仅更新选中状态 */", render_start)
+    render = source[render_start:render_end]
+
+    assert "var hasMicrophoneDevices = audioInputs.length > 0;" in render
+    assert "micPopup.appendChild(noMicItem);\n                return true;" not in render
+
+    layout_index = render.index("// ===== 双栏布局 =====")
+    speaker_index = render.index("speakerContainer.className = 'speaker-volume-container';")
+    devices_guard_index = render.index("if (hasMicrophoneDevices) {")
+    no_devices_index = render.index("noMicItem.textContent = window.t ? window.t('microphone.noDevices')")
+
+    assert layout_index < speaker_index < devices_guard_index < no_devices_index
+    assert "gainSlider.disabled = true;" in render
+    assert "rightColumn.appendChild(noMicItem);" in render
+
+
 def test_outer_voice_start_failure_clears_pending_flags_before_composer_restore():
     source = _read(APP_BUTTONS_PATH)
     start_flow = _mic_button_start_flow(source)


### PR DESCRIPTION
## Summary
- Keep the floating microphone popup rendering the speaker volume controls when no microphone device is detected.
- Show the no-microphone message only in the device list column.
- Disable the microphone gain slider in the no-device state.

## Root Cause
The no-device branch returned before the popup created the shared audio controls, so the speaker volume slider disappeared together with microphone-only controls.

## Validation
- node --check static/app-audio-capture.js
- uv run pytest tests/unit/test_voice_start_failure_static.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化麦克风设备弹窗在未检测到麦克风时的渲染流程，避免因过早分支返回导致界面状态异常。
  * 无可用麦克风时：禁用“麦克风增益”滑块，并在右侧设备列表显示“没有检测到麦克风设备”提示，同时保持扬声器音量相关区域正常显示。
  * 检测到麦克风设备时：保持原有“系统默认麦克风 + 各设备选项”的展示与交互不变。
* **Tests**
  * 新增静态渲染用例，覆盖无麦克风设备场景下的 UI 分支、滑块禁用与右侧提示展示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->