### PR TITLE
优化新手引导重置后的提示弹窗样式，替换原生提示为页面内弹窗，并适配成功/失败状态、暗色模式与图标居中

### DIFF
--- a/static/css/memory_browser.css
+++ b/static/css/memory_browser.css
@@ -605,6 +605,10 @@ body .container-header {
     background: linear-gradient(to right, #4BD4FD, #17A7FF);
 }
 
+.tutorial-reset-notice-card[data-variant="error"] .tutorial-reset-notice-header {
+    background: linear-gradient(to right, #ff8a70, #ff4d67);
+}
+
 .tutorial-reset-notice-mark {
     position: relative;
     flex: 0 0 auto;
@@ -716,6 +720,10 @@ body .container-header {
     background: linear-gradient(to right, #1880aa, #0a3585);
 }
 
+[data-theme="dark"] .tutorial-reset-notice-card[data-variant="error"] .tutorial-reset-notice-header {
+    background: linear-gradient(to right, #c04b42, #8f1d3a);
+}
+
 [data-theme="dark"] .tutorial-reset-notice-mark {
     background: #252525;
     box-shadow: inset 0 -3px 7px rgba(74, 163, 223, 0.18), 0 4px 12px rgba(0, 0, 0, 0.28);
@@ -758,6 +766,19 @@ body .container-header {
     to {
         opacity: 0;
         transform: translateY(8px) scale(0.98);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tutorial-reset-notice-backdrop,
+    .tutorial-reset-notice-backdrop.is-closing,
+    .tutorial-reset-notice-card,
+    .tutorial-reset-notice-backdrop.is-closing .tutorial-reset-notice-card {
+        animation: none;
+    }
+
+    .tutorial-reset-notice-ok {
+        transition: none;
     }
 }
 

--- a/static/css/memory_browser.css
+++ b/static/css/memory_browser.css
@@ -564,6 +564,203 @@ body .container-header {
     box-shadow: none;
 }
 
+.tutorial-reset-notice-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(23, 87, 122, 0.36);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    animation: tutorial-reset-notice-fade 0.18s ease-out;
+}
+
+.tutorial-reset-notice-backdrop.is-closing {
+    animation: tutorial-reset-notice-fade-out 0.16s ease-in forwards;
+}
+
+.tutorial-reset-notice-card {
+    width: min(440px, 100%);
+    overflow: hidden;
+    border: 2px solid rgba(179, 229, 252, 0.92);
+    border-radius: 20px;
+    background: #ffffff;
+    box-shadow: 0 18px 46px rgba(64, 197, 241, 0.24), 0 8px 20px rgba(23, 167, 255, 0.16);
+    font-family: 'Comic Neue', 'Source Han Sans CN', 'Noto Sans SC', sans-serif;
+    animation: tutorial-reset-notice-pop 0.22s ease-out;
+}
+
+.tutorial-reset-notice-backdrop.is-closing .tutorial-reset-notice-card {
+    animation: tutorial-reset-notice-pop-out 0.16s ease-in forwards;
+}
+
+.tutorial-reset-notice-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 18px 22px;
+    background: linear-gradient(to right, #4BD4FD, #17A7FF);
+}
+
+.tutorial-reset-notice-mark {
+    position: relative;
+    flex: 0 0 auto;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: inset 0 -3px 7px rgba(64, 197, 241, 0.18), 0 4px 12px rgba(23, 167, 255, 0.25);
+}
+
+.tutorial-reset-notice-mark::before {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 10px;
+    height: 16px;
+    border: solid #22b3ff;
+    border-width: 0 3px 3px 0;
+    transform: translate(-50%, -58%) rotate(45deg);
+}
+
+.tutorial-reset-notice-card[data-variant="error"] .tutorial-reset-notice-mark::before {
+    content: "!";
+    left: 0;
+    top: 2px;
+    width: 100%;
+    height: auto;
+    border: 0;
+    color: #ff5252;
+    font-size: 25px;
+    font-weight: 900;
+    line-height: 34px;
+    text-align: center;
+    transform: none;
+}
+
+.tutorial-reset-notice-title {
+    min-width: 0;
+    margin: 0;
+    color: #ffffff;
+    font-size: 1.18rem;
+    font-weight: 800;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+    text-shadow: 0 2px 0 rgba(34, 179, 255, 0.48);
+}
+
+.tutorial-reset-notice-body {
+    padding: 22px 24px 10px;
+}
+
+.tutorial-reset-notice-message {
+    margin: 0;
+    color: #268fb8;
+    font-size: 0.98rem;
+    font-weight: 600;
+    line-height: 1.7;
+    overflow-wrap: anywhere;
+}
+
+.tutorial-reset-notice-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 14px 24px 24px;
+}
+
+.tutorial-reset-notice-ok {
+    min-width: 112px;
+    min-height: 42px;
+    padding: 10px 22px;
+    border: 0;
+    border-radius: 50px;
+    background: linear-gradient(135deg, #40C5F1 0%, #22b3ff 100%);
+    color: #ffffff;
+    font-size: 0.95rem;
+    font-weight: 800;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    box-shadow: 0 6px 16px rgba(64, 197, 241, 0.28);
+}
+
+.tutorial-reset-notice-ok:hover {
+    opacity: 0.95;
+    transform: translateY(-1px);
+    box-shadow: 0 8px 20px rgba(64, 197, 241, 0.34);
+}
+
+.tutorial-reset-notice-ok:active {
+    transform: translateY(1px) scale(0.98);
+}
+
+.tutorial-reset-notice-ok:focus-visible {
+    outline: 3px solid rgba(64, 197, 241, 0.32);
+    outline-offset: 3px;
+}
+
+[data-theme="dark"] .tutorial-reset-notice-backdrop {
+    background: rgba(0, 0, 0, 0.58);
+}
+
+[data-theme="dark"] .tutorial-reset-notice-card {
+    border-color: rgba(74, 163, 223, 0.45);
+    background: #2d2d2d;
+    box-shadow: 0 22px 54px rgba(0, 0, 0, 0.48), 0 8px 22px rgba(58, 159, 216, 0.16);
+}
+
+[data-theme="dark"] .tutorial-reset-notice-header {
+    background: linear-gradient(to right, #1880aa, #0a3585);
+}
+
+[data-theme="dark"] .tutorial-reset-notice-mark {
+    background: #252525;
+    box-shadow: inset 0 -3px 7px rgba(74, 163, 223, 0.18), 0 4px 12px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .tutorial-reset-notice-message {
+    color: #e0e0e0;
+}
+
+[data-theme="dark"] .tutorial-reset-notice-ok {
+    color: #ffffff;
+}
+
+@keyframes tutorial-reset-notice-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes tutorial-reset-notice-fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
+@keyframes tutorial-reset-notice-pop {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.97);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes tutorial-reset-notice-pop-out {
+    from {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(8px) scale(0.98);
+    }
+}
+
 @media (max-width: 760px) {
     .tutorial-cascader-popup {
         width: 100%;
@@ -571,6 +768,22 @@ body .container-header {
 
     .tutorial-cascader-column {
         width: 50%;
+    }
+
+    .tutorial-reset-notice-backdrop {
+        padding: 18px;
+    }
+
+    .tutorial-reset-notice-header {
+        padding: 16px 18px;
+    }
+
+    .tutorial-reset-notice-body {
+        padding: 18px 18px 8px;
+    }
+
+    .tutorial-reset-notice-actions {
+        padding: 12px 18px 20px;
     }
 }
 

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -75,6 +75,107 @@
         }
     }
 
+    function getTutorialResetNoticeTitle() {
+        const titleEl = document.querySelector('.tutorial-section .file-list-title');
+        const domTitle = titleEl ? String(titleEl.textContent || '').trim() : '';
+        return translate('memory.tutorialReset', domTitle || 'Tutorial');
+    }
+
+    function showTutorialResetNotice(message, options) {
+        const config = options && typeof options === 'object' ? options : {};
+        const title = config.title || getTutorialResetNoticeTitle();
+        const okText = config.okText || translate('common.ok', 'OK');
+        const variant = config.variant === 'error' ? 'error' : 'success';
+        const existing = document.querySelector('.tutorial-reset-notice-backdrop');
+        if (existing && existing.parentNode) {
+            existing.parentNode.removeChild(existing);
+        }
+
+        return new Promise(function (resolve) {
+            const backdrop = document.createElement('div');
+            backdrop.className = 'tutorial-reset-notice-backdrop';
+
+            const card = document.createElement('div');
+            card.className = 'tutorial-reset-notice-card';
+            card.setAttribute('role', 'dialog');
+            card.setAttribute('aria-modal', 'true');
+            card.setAttribute('aria-labelledby', 'tutorial-reset-notice-title');
+            card.setAttribute('aria-describedby', 'tutorial-reset-notice-message');
+            card.dataset.variant = variant;
+
+            const header = document.createElement('div');
+            header.className = 'tutorial-reset-notice-header';
+
+            const mark = document.createElement('span');
+            mark.className = 'tutorial-reset-notice-mark';
+            mark.setAttribute('aria-hidden', 'true');
+
+            const titleEl = document.createElement('h3');
+            titleEl.className = 'tutorial-reset-notice-title';
+            titleEl.id = 'tutorial-reset-notice-title';
+            titleEl.textContent = title;
+
+            header.appendChild(mark);
+            header.appendChild(titleEl);
+
+            const body = document.createElement('div');
+            body.className = 'tutorial-reset-notice-body';
+
+            const messageEl = document.createElement('p');
+            messageEl.className = 'tutorial-reset-notice-message';
+            messageEl.id = 'tutorial-reset-notice-message';
+            messageEl.textContent = String(message || '');
+            body.appendChild(messageEl);
+
+            const actions = document.createElement('div');
+            actions.className = 'tutorial-reset-notice-actions';
+
+            const okButton = document.createElement('button');
+            okButton.type = 'button';
+            okButton.className = 'tutorial-reset-notice-ok';
+            okButton.textContent = okText;
+            actions.appendChild(okButton);
+
+            card.appendChild(header);
+            card.appendChild(body);
+            card.appendChild(actions);
+            backdrop.appendChild(card);
+
+            let closed = false;
+            function close() {
+                if (closed) return;
+                closed = true;
+                document.removeEventListener('keydown', onKeydown);
+                backdrop.classList.add('is-closing');
+                window.setTimeout(function () {
+                    if (backdrop.parentNode) {
+                        backdrop.parentNode.removeChild(backdrop);
+                    }
+                    resolve(true);
+                }, 160);
+            }
+
+            function onKeydown(event) {
+                if (event.key === 'Escape' || event.key === 'Enter') {
+                    event.preventDefault();
+                    close();
+                }
+            }
+
+            okButton.addEventListener('click', close);
+            backdrop.addEventListener('click', function (event) {
+                if (event.target === backdrop) {
+                    close();
+                }
+            });
+            document.addEventListener('keydown', onKeydown);
+            document.body.appendChild(backdrop);
+            window.setTimeout(function () {
+                okButton.focus();
+            }, 0);
+        });
+    }
+
     function syncMemoryChatPanelHeight() {
         const main = document.querySelector('.main');
         const sidebar = document.querySelector('.left-column');
@@ -535,7 +636,7 @@
                 });
             }
             await resetHomeTutorialPromptState('memory_browser_home_all_reset');
-            alert(getTutorialHomeAllResetSuccessMessage());
+            await showTutorialResetNotice(getTutorialHomeAllResetSuccessMessage());
             return;
         }
         if (selection.type === 'page' && typeof window.resetTutorialForPage === 'function') {
@@ -2059,5 +2160,6 @@
     }
 
     window.resetSelectedTutorial = resetSelectedTutorial;
+    window.showTutorialResetNotice = showTutorialResetNotice;
 
 })();

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -81,14 +81,15 @@
         return translate('memory.tutorialReset', domTitle || 'Tutorial');
     }
 
+    let activeTutorialResetNotice = null;
+
     function showTutorialResetNotice(message, options) {
         const config = options && typeof options === 'object' ? options : {};
         const title = config.title || getTutorialResetNoticeTitle();
         const okText = config.okText || translate('common.ok', 'OK');
         const variant = config.variant === 'error' ? 'error' : 'success';
-        const existing = document.querySelector('.tutorial-reset-notice-backdrop');
-        if (existing && existing.parentNode) {
-            existing.parentNode.removeChild(existing);
+        if (activeTutorialResetNotice) {
+            activeTutorialResetNotice.dispose(false);
         }
 
         return new Promise(function (resolve) {
@@ -142,17 +143,42 @@
             backdrop.appendChild(card);
 
             let closed = false;
+            let cleaned = false;
+            let settled = false;
+
+            function cleanup() {
+                if (cleaned) return;
+                cleaned = true;
+                document.removeEventListener('keydown', onKeydown);
+                if (backdrop.parentNode) {
+                    backdrop.parentNode.removeChild(backdrop);
+                }
+                if (activeTutorialResetNotice && activeTutorialResetNotice.backdrop === backdrop) {
+                    activeTutorialResetNotice = null;
+                }
+            }
+
+            function settle(result) {
+                if (settled) return;
+                settled = true;
+                resolve(result);
+            }
+
             function close() {
                 if (closed) return;
                 closed = true;
-                document.removeEventListener('keydown', onKeydown);
                 backdrop.classList.add('is-closing');
                 window.setTimeout(function () {
-                    if (backdrop.parentNode) {
-                        backdrop.parentNode.removeChild(backdrop);
-                    }
-                    resolve(true);
+                    cleanup();
+                    settle(true);
                 }, 160);
+            }
+
+            function dispose(result) {
+                if (cleaned) return;
+                closed = true;
+                cleanup();
+                settle(result);
             }
 
             function onKeydown(event) {
@@ -170,6 +196,7 @@
             });
             document.addEventListener('keydown', onKeydown);
             document.body.appendChild(backdrop);
+            activeTutorialResetNotice = { backdrop, dispose };
             window.setTimeout(function () {
                 okButton.focus();
             }, 0);

--- a/static/tutorial/avatar/floating-guide-reset.js
+++ b/static/tutorial/avatar/floating-guide-reset.js
@@ -310,6 +310,10 @@
             '已重置第 {{day}} 天新手教程，请刷新 Neko 后启动。',
             { day }
         );
+        if (typeof window.showTutorialResetNotice === 'function') {
+            void window.showTutorialResetNotice(message);
+            return;
+        }
         if (typeof window.showStatusToast === 'function') {
             window.showStatusToast(message, 2500, { priority: 1 });
             return;
@@ -335,13 +339,16 @@
                     });
                 } catch (error) {
                     console.error('[AvatarFloatingGuideReset] 重置失败:', error);
-                    if (typeof window.showStatusToast === 'function') {
+                    const message = translateResetMessage(
+                        'tutorial.reset.dayFailed',
+                        '新手教程重置失败，请稍后再试。',
+                        { day }
+                    );
+                    if (typeof window.showTutorialResetNotice === 'function') {
+                        void window.showTutorialResetNotice(message, { variant: 'error' });
+                    } else if (typeof window.showStatusToast === 'function') {
                         window.showStatusToast(
-                            translateResetMessage(
-                                'tutorial.reset.dayFailed',
-                                '新手教程重置失败，请稍后再试。',
-                                { day }
-                            ),
+                            message,
                             3000,
                             { priority: 2 }
                         );

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -3793,6 +3793,31 @@ async function initUniversalTutorialManager() {
  * 全局函数：重置所有引导
  * 供 HTML 按钮调用
  */
+async function showTutorialResetMessage(message, options = {}) {
+    const title = options.title || (window.t ? window.t('memory.tutorialReset', 'Tutorial') : 'Tutorial');
+    if (typeof window.showTutorialResetNotice === 'function') {
+        try {
+            await window.showTutorialResetNotice(message, Object.assign({}, options, { title }));
+            return;
+        } catch (error) {
+            console.warn('[TutorialReset] custom notice failed:', error);
+        }
+    }
+    if (typeof window.showAlert === 'function') {
+        try {
+            await window.showAlert(message, title);
+            return;
+        } catch (error) {
+            console.warn('[TutorialReset] common alert failed:', error);
+        }
+    }
+    if (typeof window.alert === 'function') {
+        window.alert(message);
+        return;
+    }
+    console.log('[TutorialReset]', message);
+}
+
 async function resetAllTutorials() {
     if (window.universalTutorialManager) {
         await window.universalTutorialManager.resetAllTutorials();
@@ -3805,7 +3830,10 @@ async function resetAllTutorials() {
         localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
         dispatchHomeTutorialResetEvent('all', 'manual_all_tutorial_reset');
     }
-    alert(window.t ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。') : '已重置所有引导，下次进入各页面时将重新显示引导。');
+    const resetMessage = window.t
+        ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。')
+        : '已重置所有引导，下次进入各页面时将重新显示引导。';
+    await showTutorialResetMessage(resetMessage);
 }
 
 /**
@@ -3834,19 +3862,19 @@ async function resetTutorialForPage(pageKey) {
                 const fallbackError = window.t
                     ? window.t('memory.currentPersonalityResetFailed', '触发当前角色性格重选失败，请稍后再试。')
                     : '触发当前角色性格重选失败，请稍后再试。';
-                alert(payload && payload.error ? payload.error : fallbackError);
+                void showTutorialResetMessage(payload && payload.error ? payload.error : fallbackError, { variant: 'error' });
                 return;
             }
 
             const successMessage = window.t
                 ? window.t('memory.currentPersonalityResetSuccess', '已记录当前角色的性格重选请求，请回到主页刷新后继续。')
                 : '已记录当前角色的性格重选请求，请回到主页刷新后继续。';
-            alert(successMessage);
+            void showTutorialResetMessage(successMessage);
         }).catch(() => {
             const fallbackError = window.t
                 ? window.t('memory.currentPersonalityResetFailed', '触发当前角色性格重选失败，请稍后再试。')
                 : '触发当前角色性格重选失败，请稍后再试。';
-            alert(fallbackError);
+            void showTutorialResetMessage(fallbackError, { variant: 'error' });
         });
         return;
     }
@@ -3873,7 +3901,7 @@ async function resetTutorialForPage(pageKey) {
     const message = window.t
         ? window.t('memory.tutorialPageResetSuccessWithName', { pageName: pageName, defaultValue: `已重置「${pageName}」的引导，下次进入该页面时将重新显示引导。` })
         : `已重置「${pageName}」的引导，下次进入该页面时将重新显示引导。`;
-    alert(message);
+    await showTutorialResetMessage(message);
 }
 
 /**

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -236,6 +236,52 @@ def test_memory_browser_current_personality_reset_requests_home_reselect(
 
 
 @pytest.mark.frontend
+def test_memory_browser_reset_notice_replaces_open_notice_without_pending_promise(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file,
+):
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file)
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_function("typeof window.showTutorialResetNotice === 'function'")
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const first = window.showTutorialResetNotice('First message');
+            const second = window.showTutorialResetNotice('Second message');
+            const firstResult = await Promise.race([
+                first,
+                new Promise((resolve) => window.setTimeout(() => resolve('timeout'), 250)),
+            ]);
+            const visibleNotices = document.querySelectorAll('.tutorial-reset-notice-backdrop').length;
+            const message = document.querySelector('.tutorial-reset-notice-message')?.textContent || '';
+            document.querySelector('.tutorial-reset-notice-ok')?.click();
+            const secondResult = await Promise.race([
+                second,
+                new Promise((resolve) => window.setTimeout(() => resolve('timeout'), 500)),
+            ]);
+            return {
+                firstResult,
+                secondResult,
+                visibleNotices,
+                message,
+                remainingNotices: document.querySelectorAll('.tutorial-reset-notice-backdrop').length,
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "firstResult": False,
+        "secondResult": True,
+        "visibleNotices": 1,
+        "message": "Second message",
+        "remainingNotices": 0,
+    }
+
+
+@pytest.mark.frontend
 def test_memory_browser_all_tutorial_reset_includes_avatar_guide_state(
     mock_page: Page,
     running_server: str,

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -11,6 +11,14 @@ def _request_json(route):
     return post_data_json() if callable(post_data_json) else post_data_json
 
 
+def _assert_tutorial_reset_notice(page: Page, message: str) -> None:
+    notice = page.locator(".tutorial-reset-notice-backdrop")
+    expect(notice).to_be_visible()
+    expect(page.locator(".tutorial-reset-notice-message")).to_have_text(message)
+    page.locator(".tutorial-reset-notice-ok").click()
+    expect(notice).to_have_count(0)
+
+
 @pytest.fixture
 def seed_memory_file(clean_user_data_dir, running_server):
     """Create a seed memory file in the test memory directory."""
@@ -218,18 +226,13 @@ def test_memory_browser_current_personality_reset_requests_home_reselect(
         and r.request.method == "POST"
         and r.status == 200
     ):
-        with mock_page.expect_event("dialog") as dialog_info:
-            mock_page.locator("#tutorial-reset-btn").click()
-
-    dialog = dialog_info.value
-    dialog_messages = [dialog.message]
-    dialog.accept()
+        mock_page.locator("#tutorial-reset-btn").click()
 
     assert request_log == [{
         "url": f"{running_server}/api/characters/persona-reselect-current",
         "method": "POST",
     }]
-    assert dialog_messages == ["已记录当前角色的性格重选请求，请回到主页刷新后继续。"]
+    _assert_tutorial_reset_notice(mock_page, "已记录当前角色的性格重选请求，请回到主页刷新后继续。")
 
 
 @pytest.mark.frontend
@@ -307,8 +310,6 @@ def test_memory_browser_home_all_reset_restarts_avatar_guide_from_day_one(
     expect(mock_page.locator(".tutorial-cascader-popup")).to_be_hidden()
     expect(mock_page.locator("#tutorial-reset-btn")).to_be_enabled()
 
-    dialog_messages = []
-    mock_page.once("dialog", lambda dialog: (dialog_messages.append(dialog.message), dialog.accept()))
     mock_page.locator("#tutorial-reset-btn").click()
     mock_page.wait_for_function("window.__tutorialResetCalls.length === 2")
 
@@ -316,7 +317,7 @@ def test_memory_browser_home_all_reset_restarts_avatar_guide_from_day_one(
         {"type": "avatar", "options": {"source": "memory_browser_reset_home_all"}},
         {"type": "prompt", "reason": "memory_browser_home_all_reset"},
     ]
-    assert dialog_messages == ["已重置主页 7 天新手教程，请重新加载 Neko 后从第 1 天开始。"]
+    _assert_tutorial_reset_notice(mock_page, "已重置主页 7 天新手教程，请重新加载 Neko 后从第 1 天开始。")
 
 
 @pytest.mark.frontend
@@ -401,17 +402,15 @@ def test_memory_browser_home_all_reset_falls_back_to_prompt_reset_api_without_ma
     mock_page.locator(".tutorial-cascader-option[data-tutorial-home-all='true']").click()
 
     with mock_page.expect_response("**/api/tutorial-prompt/reset"):
-        with mock_page.expect_event("dialog") as dialog_info:
-            mock_page.locator("#tutorial-reset-btn").click()
+        mock_page.locator("#tutorial-reset-btn").click()
 
-    dialog = dialog_info.value
-    dialog.accept()
     mock_page.wait_for_function("window.__tutorialResetCalls.length === 1")
 
     assert mock_page.evaluate("window.__tutorialResetCalls") == [
         {"type": "avatar", "options": {"source": "memory_browser_reset_home_all"}},
     ]
     assert prompt_reset_payloads == [{"reason": "memory_browser_home_all_reset"}]
+    _assert_tutorial_reset_notice(mock_page, "已重置主页 7 天新手教程，请重新加载 Neko 后从第 1 天开始。")
 
 
 @pytest.mark.frontend


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

优化新手引导重置后的提示弹窗样式，替换原生提示为页面内弹窗，并适配成功/失败状态、暗色模式与图标居中
顺便修复重置时卡死的问题

## 测试 / Testing

手动测试重置


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“新手引导重置提示”弹窗：全屏遮罩、卡片入场/退场动效、错误态配色、标题渐变与状态标记；支持深色主题与 `prefers-reduced-motion` 降动；支持遮罩/OK 按钮/键盘（Esc/Enter）关闭与聚焦到 OK。
* **改进**
  * 将部分重置流程中的阻塞式提示替换为统一的重置通知（优先接管展示，必要时回退到原提示方式），并统一 i18n 标题与文案生成。
* **测试**
  * 更新前端校验方式，新增连续调用时的时序不留悬挂遮罩用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->