### PR TITLE
[codex] 补齐多学科知识图谱 seed 与跨学科桥

### DIFF
--- a/plugin/plugins/study_companion/entry_knowledge_entries.py
+++ b/plugin/plugins/study_companion/entry_knowledge_entries.py
@@ -121,6 +121,11 @@ class _KnowledgeEntriesMixin:
                 name = str(payload.get("name") or payload.get("topic") or topic_id).strip()
                 if not topic_id or not name:
                     raise ValueError("topic candidate requires id/topic_id and name/topic")
+                existing_topic = self._store.get_topic(topic_id)
+                if existing_topic and existing_topic.get("source") == "seed":
+                    raise ValueError(
+                        "candidate topic_id conflicts with canonical seed topic"
+                    )
                 self._store.upsert_topic(
                     {
                         "id": topic_id,
@@ -157,7 +162,7 @@ class _KnowledgeEntriesMixin:
                         "aliases": payload.get("aliases")
                         if isinstance(payload.get("aliases"), list)
                         else [],
-                        "source": "seed",
+                        "source": "runtime",
                     }
                 )
                 invalidate_guidance_cache = getattr(
@@ -286,7 +291,7 @@ class _KnowledgeEntriesMixin:
             "properties": {
                 "topic_id": {"type": "string", "default": ""},
                 "query": {"type": "string", "default": ""},
-                "limit": {"type": "integer", "default": 500},
+                "limit": {"type": "integer", "default": 1000},
                 "stage": {"type": "string", "default": ""},
                 "course_family": {"type": "string", "default": ""},
                 "max_depth": {"type": "integer", "default": 3},
@@ -307,14 +312,14 @@ class _KnowledgeEntriesMixin:
         self,
         topic_id: str = "",
         query: str = "",
-        limit: int = 500,
+        limit: int = 1000,
         stage: str = "",
         course_family: str = "",
         max_depth: int = 3,
         **_,
     ):
         try:
-            safe_limit = max(1, min(5000, int(limit or 500)))
+            safe_limit = max(1, min(5000, int(limit or 1000)))
             stage_key = str(stage or "").strip()
             course_family_key = str(course_family or "").strip()
             topics = await asyncio.to_thread(

--- a/plugin/plugins/study_companion/knowledge_graph_guidance.py
+++ b/plugin/plugins/study_companion/knowledge_graph_guidance.py
@@ -45,6 +45,16 @@ GENERIC_QUERY_TERMS = {
     "\u4e0d\u4e00\u5b9a",
 }
 SUBJECT_QUERY_HINTS = {
+    "math": {
+        "\u6570\u5b66",
+        "\u51fd\u6570",
+        "\u65b9\u7a0b",
+        "\u51e0\u4f55",
+        "\u6982\u7387",
+        "\u4ee3\u6570",
+        "math",
+        "mathematics",
+    },
     "physics": {
         "\u725b\u987f",
         "\u53d7\u529b",
@@ -86,6 +96,54 @@ SUBJECT_QUERY_HINTS = {
         "bfs",
         "dfs",
         "\u904d\u5386",
+    },
+    "politics": {
+        "\u653f\u6cbb",
+        "\u6cd5\u6cbb",
+        "\u516c\u6c11",
+        "\u6c11\u4e3b",
+        "\u54f2\u5b66",
+        "politics",
+        "civics",
+        "government",
+    },
+    "chinese": {
+        "\u8bed\u6587",
+        "\u4e2d\u6587",
+        "\u9605\u8bfb",
+        "\u4f5c\u6587",
+        "\u6587\u8a00\u6587",
+        "\u8bd7\u6b4c",
+        "chinese",
+        "literature",
+    },
+    "history": {
+        "\u5386\u53f2",
+        "\u671d\u4ee3",
+        "\u9769\u547d",
+        "\u6218\u4e89",
+        "\u6587\u660e",
+        "history",
+        "historical",
+    },
+    "geography": {
+        "\u5730\u7406",
+        "\u6c14\u5019",
+        "\u5730\u5f62",
+        "\u7ecf\u7eac\u5ea6",
+        "\u533a\u57df",
+        "geography",
+        "climate",
+    },
+    "economics": {
+        "\u7ecf\u6d4e",
+        "\u4f9b\u7ed9",
+        "\u9700\u6c42",
+        "\u5e02\u573a",
+        "\u901a\u8d27\u81a8\u80c0",
+        "economics",
+        "economy",
+        "market",
     },
 }
 RELATION_GROUP_TITLES = {
@@ -234,13 +292,26 @@ def build_topic_edges(topics: list[dict[str, Any]]) -> list[dict[str, Any]]:
             related_id = _ref_id(ref)
             if not related_id:
                 continue
+            relation = _edge_relation("related", ref)
+            if relation == "prerequisite":
+                edges.append(
+                    _edge_payload(
+                        source=by_id.get(related_id),
+                        target=topic,
+                        source_id=related_id,
+                        target_id=target_id,
+                        relation=relation,
+                        ref=ref,
+                    )
+                )
+                continue
             edges.append(
                 _edge_payload(
                     source=topic,
                     target=by_id.get(related_id),
                     source_id=target_id,
                     target_id=related_id,
-                    relation=_edge_relation("related", ref),
+                    relation=relation,
                     ref=ref,
                 )
             )
@@ -377,8 +448,6 @@ def match_topics(
                 score += 18
             elif subject:
                 score -= 10
-        if score and subject == "math":
-            score += 2
         if score:
             scored.append(
                 {
@@ -563,6 +632,10 @@ def _build_diagnosis_questions(
                 )
             )
             continue
+        if len(
+            [item for item in questions if item["kind"] == "prerequisite_probe"]
+        ) >= 3:
+            continue
         add(
             _question_payload(
                 kind="prerequisite_probe",
@@ -575,8 +648,6 @@ def _build_diagnosis_questions(
                 edge=edge,
             )
         )
-        if len([item for item in questions if item["kind"] == "prerequisite_probe"]) >= 3:
-            break
 
     for edge in confusions:
         topic_id, topic_label = _other_topic_for_edge(edge, selected_id)
@@ -689,6 +760,7 @@ def build_knowledge_guidance_payload(
     subgraph_budget = SubgraphBudget(
         focus_topics=max(1, min(3, int(match_limit or 3))),
         max_depth=max(1, min(2, int(max_depth or 2))),
+        max_nodes=24,
     )
     relevant_subgraph = build_relevant_subgraph(
         graph_index,

--- a/plugin/plugins/study_companion/knowledge_retrieval_eval.py
+++ b/plugin/plugins/study_companion/knowledge_retrieval_eval.py
@@ -188,6 +188,8 @@ def evaluate_knowledge_retrieval_queries(
     topic_subjects, topic_labels = _topic_maps(topics)
     summary = {
         "case_count": 0,
+        "passed_count": 0,
+        "failed_count": 0,
         "focus_hit_count": 0,
         "cross_subject_case_count": 0,
         "cross_subject_edge_count": 0,
@@ -238,8 +240,17 @@ def evaluate_knowledge_retrieval_queries(
         has_raw_seed = _has_raw_seed(model_context)
         focus_hit = not expected_topic_ids or focus_topic_id in expected_topic_ids
         bad_hub_absorbed = bool(expected_topic_ids) and not focus_hit
+        cross_subject_ok = not expect_cross_subject or has_cross_edge
+        case_passed = focus_hit and cross_subject_ok
+        failure_reasons: list[str] = []
+        if not focus_hit:
+            failure_reasons.append("expected focus topic was not selected")
+        if not cross_subject_ok:
+            failure_reasons.append("expected cross-subject edge was not returned")
 
         summary["case_count"] += 1
+        summary["passed_count"] += int(case_passed)
+        summary["failed_count"] += int(not case_passed)
         summary["focus_hit_count"] += int(focus_hit)
         summary["cross_subject_case_count"] += int(expect_cross_subject)
         summary["cross_subject_edge_count"] += int(expect_cross_subject and has_cross_edge)
@@ -260,6 +271,8 @@ def evaluate_knowledge_retrieval_queries(
                 "expect_cross_subject": expect_cross_subject,
                 "focus_topic_id": focus_topic_id,
                 "focus_hit": focus_hit,
+                "passed": case_passed,
+                "failure_reasons": failure_reasons,
                 "bad_hub_absorbed": bad_hub_absorbed,
                 "top_matches": _compact_matches(payload.get("matches")),
                 "subgraph_node_ids": [
@@ -331,7 +344,7 @@ def main(argv: list[str] | None = None) -> int:
         min_active_core_groups=max(1, int(args.min_active_core_groups)),
     )
     print(json.dumps(report, ensure_ascii=False, indent=2))
-    return 0
+    return 0 if int(report["summary"].get("failed_count") or 0) == 0 else 1
 
 
 if __name__ == "__main__":

--- a/plugin/plugins/study_companion/knowledge_seed_validator.py
+++ b/plugin/plugins/study_companion/knowledge_seed_validator.py
@@ -199,51 +199,100 @@ def _iter_seed_files(
     manifest_path: Path,
     payload: dict[str, Any],
     issues: list[KnowledgeSeedIssue],
+    seen_paths: set[Path] | None = None,
+    manifest_stack: set[Path] | None = None,
 ) -> Iterable[Path]:
-    files = payload.get("files")
-    if not isinstance(files, list):
-        yield manifest_path
+    resolved_manifest = manifest_path.resolve()
+    shared_seen = seen_paths if seen_paths is not None else set()
+    active_manifests = manifest_stack if manifest_stack is not None else set()
+    if resolved_manifest in active_manifests:
+        issues.append(
+            KnowledgeSeedIssue(
+                "circular_manifest_reference",
+                f"manifest reference cycle includes: {resolved_manifest}",
+                str(manifest_path),
+            )
+        )
         return
-    seen_paths: set[Path] = set()
-    for item in files:
-        if isinstance(item, dict):
-            raw_path = item.get("path") or item.get("file")
-        else:
-            raw_path = item
-        child_name = str(raw_path or "").strip()
-        if not child_name:
-            issues.append(
-                KnowledgeSeedIssue(
-                    "invalid_manifest_file",
-                    "manifest file entry must include path",
-                    str(manifest_path),
-                )
+    if resolved_manifest in shared_seen:
+        issues.append(
+            KnowledgeSeedIssue(
+                "duplicate_manifest_file",
+                f"manifest references duplicate seed file: {resolved_manifest}",
+                str(manifest_path),
             )
-            continue
-        child_path = Path(child_name)
-        if not child_path.is_absolute():
-            child_path = manifest_path.parent / child_path
-        child_path = child_path.resolve()
-        if child_path in seen_paths:
-            issues.append(
-                KnowledgeSeedIssue(
-                    "duplicate_manifest_file",
-                    f"manifest references duplicate seed file: {child_name}",
-                    str(manifest_path),
+        )
+        return
+
+    shared_seen.add(resolved_manifest)
+    active_manifests.add(resolved_manifest)
+    try:
+        files = payload.get("files")
+        if not isinstance(files, list):
+            yield resolved_manifest
+            return
+        for item in files:
+            if isinstance(item, dict):
+                raw_path = item.get("path") or item.get("file")
+            else:
+                raw_path = item
+            child_name = str(raw_path or "").strip()
+            if not child_name:
+                issues.append(
+                    KnowledgeSeedIssue(
+                        "invalid_manifest_file",
+                        "manifest file entry must include path",
+                        str(manifest_path),
+                    )
                 )
-            )
-            continue
-        seen_paths.add(child_path)
-        if not child_path.is_file():
-            issues.append(
-                KnowledgeSeedIssue(
-                    "missing_manifest_file",
-                    f"manifest seed file does not exist: {child_name}",
-                    str(manifest_path),
+                continue
+            child_path = Path(child_name)
+            if not child_path.is_absolute():
+                child_path = manifest_path.parent / child_path
+            child_path = child_path.resolve()
+            if child_path in active_manifests:
+                issues.append(
+                    KnowledgeSeedIssue(
+                        "circular_manifest_reference",
+                        f"manifest reference cycle includes: {child_name}",
+                        str(manifest_path),
+                    )
                 )
-            )
-            continue
-        yield child_path
+                continue
+            if child_path in shared_seen:
+                issues.append(
+                    KnowledgeSeedIssue(
+                        "duplicate_manifest_file",
+                        f"manifest references duplicate seed file: {child_name}",
+                        str(manifest_path),
+                    )
+                )
+                continue
+            if not child_path.is_file():
+                issues.append(
+                    KnowledgeSeedIssue(
+                        "missing_manifest_file",
+                        f"manifest seed file does not exist: {child_name}",
+                        str(manifest_path),
+                    )
+                )
+                continue
+            child_payload = _read_json(child_path, issues)
+            if child_payload is None:
+                continue
+            if isinstance(child_payload.get("files"), list):
+                yield from _iter_seed_files(
+                    child_path,
+                    child_payload,
+                    issues,
+                    shared_seen,
+                    active_manifests,
+                )
+                continue
+            shared_seen.add(child_path)
+            yield child_path
+    finally:
+        active_manifests.discard(resolved_manifest)
 
 
 def _normalize_topic(
@@ -749,7 +798,7 @@ def _build_quality_report(topics: tuple[KnowledgeSeedTopic, ...]) -> dict[str, A
                     outbound[topic_id] = outbound.get(topic_id, 0) + 1
                 if target_id in inbound:
                     inbound[target_id] = inbound.get(target_id, 0) + 1
-                if field == "prerequisites" and topic_id:
+                if relation == "prerequisite" and topic_id:
                     prerequisite_edges.setdefault(topic_id, set()).add(target_id)
                 target_subject = topic_subject_by_id.get(target_id)
                 if target_subject and target_subject != subject:

--- a/plugin/plugins/study_companion/knowledge_seed_validator.py
+++ b/plugin/plugins/study_companion/knowledge_seed_validator.py
@@ -201,10 +201,17 @@ def _iter_seed_files(
     issues: list[KnowledgeSeedIssue],
     seen_paths: set[Path] | None = None,
     manifest_stack: set[Path] | None = None,
+    manifest_seed_paths: dict[Path, set[Path]] | None = None,
 ) -> Iterable[Path]:
     resolved_manifest = manifest_path.resolve()
     shared_seen = seen_paths if seen_paths is not None else set()
     active_manifests = manifest_stack if manifest_stack is not None else set()
+    shared_manifest_seed_paths = (
+        manifest_seed_paths if manifest_seed_paths is not None else {}
+    )
+    descendant_seed_paths = shared_manifest_seed_paths.setdefault(
+        resolved_manifest, set()
+    )
     if resolved_manifest in active_manifests:
         issues.append(
             KnowledgeSeedIssue(
@@ -229,6 +236,7 @@ def _iter_seed_files(
     try:
         files = payload.get("files")
         if not isinstance(files, list):
+            descendant_seed_paths.add(resolved_manifest)
             yield resolved_manifest
             return
         for item in files:
@@ -287,9 +295,14 @@ def _iter_seed_files(
                     issues,
                     shared_seen,
                     active_manifests,
+                    shared_manifest_seed_paths,
+                )
+                descendant_seed_paths.update(
+                    shared_manifest_seed_paths.get(child_path, set())
                 )
                 continue
             shared_seen.add(child_path)
+            descendant_seed_paths.add(child_path)
             yield child_path
     finally:
         active_manifests.discard(resolved_manifest)
@@ -1041,7 +1054,13 @@ def validate_knowledge_seed_manifest(path: Path | str) -> KnowledgeSeedValidatio
     taxonomy = _load_taxonomy(manifest_path, issues)
 
     topics: list[KnowledgeSeedTopic] = []
-    for seed_path in _iter_seed_files(manifest_path, manifest_payload, issues):
+    manifest_seed_paths: dict[Path, set[Path]] = {}
+    for seed_path in _iter_seed_files(
+        manifest_path,
+        manifest_payload,
+        issues,
+        manifest_seed_paths=manifest_seed_paths,
+    ):
         payload = _read_json(seed_path, issues)
         if payload is None:
             continue
@@ -1099,7 +1118,11 @@ def validate_knowledge_seed_manifest(path: Path | str) -> KnowledgeSeedValidatio
             if not seed_path.is_absolute():
                 seed_path = manifest_path.parent / seed_path
             expected = item.get("topic_count")
-            actual = sum(1 for topic in topics if topic.path.resolve() == seed_path.resolve())
+            resolved_seed_path = seed_path.resolve()
+            counted_paths = manifest_seed_paths.get(
+                resolved_seed_path, {resolved_seed_path}
+            )
+            actual = sum(1 for topic in topics if topic.path.resolve() in counted_paths)
             if expected != actual:
                 issues.append(
                     KnowledgeSeedIssue(

--- a/plugin/plugins/study_companion/static/knowledge_eval_cases.json
+++ b/plugin/plugins/study_companion/static/knowledge_eval_cases.json
@@ -1,0 +1,1081 @@
+{
+  "type": "study_companion_knowledge_retrieval_eval_cases",
+  "version": 1,
+  "cases": [
+    {
+      "query": "极限和函数值有什么区别？",
+      "expected_topic_ids": [
+        "college_limit_concept",
+        "college_function_value"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "连续为什么不一定可导？",
+      "expected_topic_ids": [
+        "college_continuity",
+        "college_derivative_existence"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "导数怎么用来求极值？",
+      "expected_topic_ids": [
+        "senior_derivative_extrema",
+        "college_monotonic_extrema",
+        "college_stationary_points",
+        "college_extreme_value_points"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "极值和最值有什么区别？",
+      "expected_topic_ids": [
+        "college_extreme_value_points",
+        "college_absolute_extrema"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "定积分面积题怎么做？",
+      "expected_topic_ids": [
+        "college_integral_area_problem",
+        "college_definite_integral",
+        "college_integral_application"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "特征值怎么求？",
+      "expected_topic_ids": [
+        "college_eigenvalue",
+        "college_characteristic_matrix",
+        "college_characteristic_polynomial"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "排列和组合怎么区分？",
+      "expected_topic_ids": [
+        "senior_probability_counting",
+        "college_permutation",
+        "college_combination"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "二项分布和正态分布有什么关系？",
+      "expected_topic_ids": [
+        "college_binomial_distribution",
+        "college_normal_distribution"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "置信区间和假设检验有什么关系？",
+      "expected_topic_ids": [
+        "college_confidence_interval",
+        "college_hypothesis_testing"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "图的最短路怎么学？",
+      "expected_topic_ids": [
+        "college_graph_shortest_path",
+        "college_graph_theory_intro"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "受力分析怎么做？",
+      "expected_topic_ids": [
+        "college_force_analysis"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "BFS和DFS有什么区别？",
+      "expected_topic_ids": [
+        "college_graph_traversal"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "最短路算法怎么学？",
+      "expected_topic_ids": [
+        "college_ds_shortest_path",
+        "college_graph_shortest_path"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "速度和加速度有什么区别？",
+      "expected_topic_ids": [
+        "physics_senior_experiment_acceleration",
+        "college_physics_kinematics_calculus"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "牛顿第二定律题怎么做？",
+      "expected_topic_ids": [
+        "physics_senior_newton_laws"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "氧化还原反应怎么配平？",
+      "expected_topic_ids": [
+        "chem_senior_redox",
+        "chem_senior_redox_balance"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "化学平衡移动怎么判断？",
+      "expected_topic_ids": [
+        "chem_senior_equilibrium",
+        "chem_senior_equilibrium_constant"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "基因型和表现型有什么区别？",
+      "expected_topic_ids": [
+        "bio_senior_genetics_law",
+        "bio_junior_inheritance_intro"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "减数分裂和有丝分裂有什么区别？",
+      "expected_topic_ids": [
+        "bio_senior_meiosis",
+        "bio_senior_mitosis_image"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "阅读理解主旨题怎么做？",
+      "expected_topic_ids": [
+        "english_senior_reading_main_idea"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "数组和链表有什么区别？",
+      "expected_topic_ids": [
+        "college_ds_linear_list",
+        "college_ds_linked_list",
+        "college_ds_dynamic_array"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "递归和迭代有什么区别？",
+      "expected_topic_ids": [
+        "college_ds_recursion_iteration",
+        "college_c_recursion_basic"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "地图比例尺怎么看？",
+      "expected_topic_ids": [
+        "geo_junior_map_skills"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "工业区位因素怎么分析？",
+      "expected_topic_ids": [
+        "geo_senior_industrial_location",
+        "geo_junior_agriculture_industry"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "史料题怎么分析？",
+      "expected_topic_ids": [
+        "history_senior_material_analysis"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "依法治国材料题怎么答？",
+      "expected_topic_ids": [
+        "pol_senior_rule_of_law"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "文言虚词怎么判断？",
+      "expected_topic_ids": [
+        "chinese_junior_classical_function_words",
+        "chinese_senior_classical_function_words"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "需求和供给曲线怎么看？",
+      "expected_topic_ids": [
+        "college_micro_demand_supply"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "财政政策和货币政策有什么区别？",
+      "expected_topic_ids": [
+        "college_macro_fiscal_policy",
+        "college_macro_monetary_policy"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "驻点和极值点怎么区分？",
+      "expected_topic_ids": [
+        "college_stationary_points",
+        "college_critical_points"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "导数和速度加速度有什么关系？",
+      "expected_topic_ids": [
+        "physics_senior_experiment_acceleration",
+        "college_physics_kinematics_calculus",
+        "college_derivative_calculation"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "边际成本为什么用导数？",
+      "expected_topic_ids": [
+        "college_derivative_definition",
+        "college_micro_cost_short_run"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "矩阵和图算法有什么关系？",
+      "expected_topic_ids": [
+        "college_rank",
+        "college_matrix_operations",
+        "college_ds_graph_representation"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "函数图像怎么看物理运动？",
+      "expected_topic_ids": [
+        "function_graph_reading",
+        "physics_senior_motion_graph_synthesis"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "需求供给曲线和函数图像有什么关系？",
+      "expected_topic_ids": [
+        "college_micro_demand_supply",
+        "linear_function_graph"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "弹性分析和斜率有什么关系？",
+      "expected_topic_ids": [
+        "college_micro_elasticity",
+        "linear_function_kb"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "极值怎么用来分析利润最大化？",
+      "expected_topic_ids": [
+        "college_micro_firm_profit",
+        "college_extreme_value_points",
+        "college_absolute_extrema"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "积分和物理做功有什么关系？",
+      "expected_topic_ids": [
+        "physics_junior_work_power",
+        "college_integral_physics_application"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "三角函数和简谐运动有什么关系？",
+      "expected_topic_ids": [
+        "trig_area",
+        "physics_senior_simple_harmonic",
+        "college_physics_simple_harmonic_oscillation",
+        "senior_trig_graph"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "向量和力的分解有什么关系？",
+      "expected_topic_ids": [
+        "physics_senior_force_decomposition",
+        "senior_plane_vector_concept"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "递归为什么和证明思路有关？",
+      "expected_topic_ids": [
+        "geometric_proof_strategy",
+        "college_c_recursion_basic",
+        "proof_writing"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "复杂度和函数增长有什么关系？",
+      "expected_topic_ids": [
+        "quadratic_monotonicity",
+        "college_ds_algorithm_complexity",
+        "function_thinking",
+        "senior_exponential_function"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "图论和图遍历算法怎么连起来？",
+      "expected_topic_ids": [
+        "college_ds_algorithm_complexity",
+        "college_graph_theory_intro",
+        "college_ds_graph_traversal"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "二维数组和矩阵运算有什么关系？",
+      "expected_topic_ids": [
+        "college_matrix_operations",
+        "college_c_2d_array_matrix"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "动态规划和矩阵思维有什么关系？",
+      "expected_topic_ids": [
+        "college_ds_greedy_dp_intro",
+        "college_matrix_operations"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "边际收益和导数有什么关系？",
+      "expected_topic_ids": [
+        "college_derivative_definition",
+        "college_micro_firm_profit"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "供需均衡为什么要看交点？",
+      "expected_topic_ids": [
+        "linear_function_intersection",
+        "college_micro_demand_supply"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "比率变化和经济弹性怎么连接？",
+      "expected_topic_ids": [
+        "college_micro_elasticity",
+        "function_concept"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "位移时间图像和一次函数有什么关系？",
+      "expected_topic_ids": [
+        "linear_function_graph",
+        "physics_senior_motion_graph_synthesis"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "加速度为什么可以用导数理解？",
+      "expected_topic_ids": [
+        "physics_senior_experiment_acceleration",
+        "college_derivative_calculation"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "变力做功为什么要用积分？",
+      "expected_topic_ids": [
+        "college_integral_physics_application",
+        "physics_senior_work_energy_path"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "斜面力分解和三角函数有什么关系？",
+      "expected_topic_ids": [
+        "trig_area",
+        "physics_senior_force_decomposition",
+        "senior_trig_definitions"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "矢量空间和物理矢量有什么关系？",
+      "expected_topic_ids": [
+        "college_physics_vector_calculus",
+        "college_vector_space",
+        "senior_vector_linear_operation"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "功和动能定理为什么要用被积函数和数量积？",
+      "expected_topic_ids": [
+        "college_integral_application_integrand",
+        "college_physics_work_energy_theorem",
+        "senior_vector_dot_product"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "简谐运动为什么可以用三角函数描述？",
+      "expected_topic_ids": [
+        "college_physics_simple_harmonic_oscillation",
+        "physics_senior_simple_harmonic",
+        "senior_trig_graph",
+        "trig_area"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "阻尼振动和指数函数增长衰减有什么关系？",
+      "expected_topic_ids": [
+        "college_physics_damped_forced_oscillation",
+        "senior_exponential_function"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "经济增长和指数函数有什么关系？",
+      "expected_topic_ids": [
+        "college_econ_growth_productivity",
+        "senior_exponential_function"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "经济数据图表为什么要懂期望方差和正态分布？",
+      "expected_topic_ids": [
+        "college_econ_data_graph",
+        "college_expectation_variance",
+        "college_normal_distribution"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "短期成本曲线为什么要用导数和单调极值？",
+      "expected_topic_ids": [
+        "college_derivative_calculation",
+        "college_micro_cost_short_run",
+        "college_monotonic_extrema"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "利润最大化为什么既看二次函数最值又看导数？",
+      "expected_topic_ids": [
+        "college_derivative_calculation",
+        "college_extreme_value_points",
+        "college_micro_firm_profit",
+        "quadratic_max_min"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "图的存储结构和邻接矩阵怎么联系？",
+      "expected_topic_ids": [
+        "college_c_2d_array_matrix",
+        "college_ds_graph_representation",
+        "college_matrix_operations"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "递归程序和数列递推有什么关系？",
+      "expected_topic_ids": [
+        "college_ds_recursion_iteration",
+        "college_c_recursion_basic",
+        "senior_sequence_recursion"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "图论里的遍历和算法里的BFS DFS有什么关系？",
+      "expected_topic_ids": [
+        "college_graph_traversal",
+        "college_ds_graph_traversal"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "地图三要素和比例尺有什么关系？",
+      "expected_topic_ids": [
+        "geo_junior_map_skills",
+        "primary_ratio_scale"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "世界气候类型和函数图像信息读取有什么关系？",
+      "expected_topic_ids": [
+        "geo_junior_climate_types",
+        "function_graph_reading"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "农业工业区位和需求供给模型有什么关系？",
+      "expected_topic_ids": [
+        "geo_junior_agriculture_industry",
+        "college_micro_demand_supply"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "区域可持续发展和政策权衡分析有什么关系？",
+      "expected_topic_ids": [
+        "geo_senior_regional_sustainability",
+        "pol_senior_economy_market"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "秦统一与中央集权和全面依法治国有什么关系？",
+      "expected_topic_ids": [
+        "history_junior_qin_unification",
+        "pol_senior_rule_of_law"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "工业革命和产业区位与区域发展有什么关系？",
+      "expected_topic_ids": [
+        "history_junior_industrial_revolution",
+        "geo_senior_industrial_location"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "史料实证方法和实用类文本信息筛选有什么关系？",
+      "expected_topic_ids": [
+        "history_senior_material_analysis",
+        "chinese_senior_practical_filter"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "权利与义务和阅读题规范分点有什么关系？",
+      "expected_topic_ids": [
+        "pol_junior_rights_obligations",
+        "chinese_senior_text_answer_template"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "市场机制与宏观调控和财政政策有什么关系？",
+      "expected_topic_ids": [
+        "pol_senior_economy_market",
+        "college_macro_fiscal_policy"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "唯物辩证法和议论文论证层次有什么关系？",
+      "expected_topic_ids": [
+        "pol_senior_philosophy_dialectics",
+        "chinese_senior_composition_argument_layer"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "阅读细节定位题和实用类文本信息筛选有什么关系？",
+      "expected_topic_ids": [
+        "english_senior_reading_detail_location",
+        "chinese_senior_practical_filter"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "作者态度与观点题和逻辑与思维方法有什么关系？",
+      "expected_topic_ids": [
+        "english_senior_reading_author_attitude",
+        "pol_senior_logical_thinking"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "概要写作和压缩语段与概括有什么关系？",
+      "expected_topic_ids": [
+        "english_senior_summary_writing",
+        "chinese_senior_language_compression"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "化学方程式配平和一元一次方程有什么关系？",
+      "expected_topic_ids": [
+        "chem_junior_chemical_equation",
+        "linear_equation"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "弱电解质电离与 pH 和对数函数有什么关系？",
+      "expected_topic_ids": [
+        "chem_senior_ph_ionization",
+        "senior_logarithmic_function"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "化学反应速率影响因素和函数单调性有什么关系？",
+      "expected_topic_ids": [
+        "chem_senior_rate_factors",
+        "senior_function_monotonicity"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "酸碱中和滴定和一次函数交点有什么关系？",
+      "expected_topic_ids": [
+        "chem_senior_acid_base_titration",
+        "linear_function_intersection"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "孟德尔遗传定律和二项分布有什么关系？",
+      "expected_topic_ids": [
+        "bio_senior_genetics_law",
+        "senior_binomial_distribution"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "酶活性曲线分析和导数与极值最值有什么关系？",
+      "expected_topic_ids": [
+        "bio_senior_enzyme_curve",
+        "senior_derivative_extrema"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "实验误差与结论评价和方差有什么关系？",
+      "expected_topic_ids": [
+        "bio_senior_experiment_error_analysis",
+        "variance"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "电势图像和函数图像分析有什么关系？",
+      "expected_topic_ids": [
+        "physics_senior_electric_potential_graph",
+        "college_function_graph_analysis"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "实验数据处理和方差有什么关系？",
+      "expected_topic_ids": [
+        "physics_senior_experiment_data",
+        "variance"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "几何光学和相似三角形有什么关系？",
+      "expected_topic_ids": [
+        "college_physics_geometric_optics",
+        "similar_triangles"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "有机同分异构和排列组合有什么关系？",
+      "expected_topic_ids": [
+        "chem_senior_organic_isomer",
+        "college_combination"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "PCR和电泳与指数增长有什么关系？",
+      "expected_topic_ids": [
+        "bio_senior_pcr_electrophoresis",
+        "senior_exponential_function"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "群落演替和地理可持续发展有什么关系？",
+      "expected_topic_ids": [
+        "bio_senior_community_succession",
+        "geo_senior_regional_sustainability"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "逻辑思维和议论文论证有什么关系？",
+      "expected_topic_ids": [
+        "pol_senior_logical_thinking",
+        "chinese_senior_composition_argument_layer"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "三角函数图像怎么解释简谐运动？",
+      "expected_topic_ids": [
+        "senior_trig_transform",
+        "senior_trig_graph",
+        "physics_senior_simple_harmonic",
+        "special_angles"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "波动干涉为什么要用和差角公式？",
+      "expected_topic_ids": [
+        "senior_double_angle",
+        "senior_sum_difference_formula",
+        "physics_senior_wave_interference",
+        "senior_trig_graph"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "角平分线和几何证明思路怎么连起来？",
+      "expected_topic_ids": [
+        "angle_bisector",
+        "geometric_proof_strategy",
+        "congruence_criteria"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "垂直平分线为什么能帮助判断圆上距离？",
+      "expected_topic_ids": [
+        "perpendicular_bisector",
+        "circle_concept",
+        "circle_position_relation"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "重要极限和算法复杂度渐近分析有什么关系？",
+      "expected_topic_ids": [
+        "college_important_limits",
+        "college_limit_concept",
+        "college_ds_algorithm_complexity"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "定积分性质怎么用来解释物理中的功？",
+      "expected_topic_ids": [
+        "college_definite_integral_properties",
+        "college_integral_physics_application",
+        "college_physics_work_energy_theorem"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "泰勒公式为什么能做物理小量近似？",
+      "expected_topic_ids": [
+        "college_taylor_formula",
+        "college_differential",
+        "college_physics_simple_harmonic_oscillation"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "坐标系中的面积和运动图像位移有什么关系？",
+      "expected_topic_ids": [
+        "coordinate_area",
+        "physics_senior_motion_graph_synthesis"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "含参方程怎么和物理建模连接？",
+      "expected_topic_ids": [
+        "equation_parameter",
+        "physics_senior_motion_graph_synthesis",
+        "mathematical_modeling"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "方差怎么支持实验误差与结论评价？",
+      "expected_topic_ids": [
+        "variance",
+        "college_standard_deviation",
+        "bio_senior_experiment_error_analysis"
+      ],
+      "expect_cross_subject": true
+    },
+    {
+      "query": "ε-δ极限定义怎么证明？",
+      "expected_topic_ids": [
+        "college_epsilon_delta_limit",
+        "college_limit_concept"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "极限证明里ε和δ怎么选？",
+      "expected_topic_ids": [
+        "college_limit_concept",
+        "college_epsilon_delta_limit"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "一致连续和普通连续有什么区别？",
+      "expected_topic_ids": [
+        "college_uniform_continuity_intro",
+        "college_continuity",
+        "college_epsilon_delta_limit"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "黎曼积分定义和定积分计算有什么关系？",
+      "expected_topic_ids": [
+        "college_riemann_integral_definition",
+        "college_definite_integral"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "黎曼和为什么能表示面积？",
+      "expected_topic_ids": [
+        "college_riemann_integral_definition",
+        "college_integral_area_problem"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "变上限积分为什么可以求导？",
+      "expected_topic_ids": [
+        "college_variable_upper_limit_integral",
+        "college_newton_leibniz"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "反常积分为什么要看极限？",
+      "expected_topic_ids": [
+        "college_improper_integral",
+        "college_limit_concept"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "一阶微分方程怎么分类？",
+      "expected_topic_ids": [
+        "college_ode_first_order",
+        "college_first_order_linear_ode",
+        "college_separable_ode"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "可分离变量方程怎么解？",
+      "expected_topic_ids": [
+        "college_separable_ode",
+        "college_indefinite_integral"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "一阶线性微分方程积分因子怎么用？",
+      "expected_topic_ids": [
+        "college_first_order_linear_ode",
+        "college_ode_first_order"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "一阶方程和二阶方程有什么区别？",
+      "expected_topic_ids": [
+        "college_ode_first_order",
+        "college_ode_second_order"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "矩阵初等变换和线性方程组有什么关系？",
+      "expected_topic_ids": [
+        "college_matrix_elementary_transform",
+        "college_linear_systems"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "矩阵秩怎么判断方程组解的个数？",
+      "expected_topic_ids": [
+        "linear_system",
+        "college_rank",
+        "college_linear_systems"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "可对角化和特征向量个数有什么关系？",
+      "expected_topic_ids": [
+        "college_eigen_diagonalizable_check",
+        "college_eigenvector_solution",
+        "college_eigenvalue"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "实对称矩阵为什么能正交对角化？",
+      "expected_topic_ids": [
+        "college_symmetric_matrix",
+        "college_eigen_diagonalizable_check"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "二次型和特征值有什么关系？",
+      "expected_topic_ids": [
+        "college_quadratic_form",
+        "college_eigenvalue",
+        "college_symmetric_matrix"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "协方差和相关系数有什么区别？",
+      "expected_topic_ids": [
+        "college_covariance_correlation",
+        "college_expectation_variance"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "期望方差和常见分布怎么连接？",
+      "expected_topic_ids": [
+        "college_expectation_variance",
+        "college_common_distributions"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "参数估计和假设检验怎么衔接？",
+      "expected_topic_ids": [
+        "college_parameter_estimation",
+        "college_hypothesis_testing"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "原假设和备择假设怎么区分？",
+      "expected_topic_ids": [
+        "college_alternative_hypothesis",
+        "college_null_hypothesis",
+        "college_hypothesis_testing"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "卡方检验什么时候用？",
+      "expected_topic_ids": [
+        "college_chi_square_test",
+        "college_hypothesis_testing"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "梯度和方向导数有什么关系？",
+      "expected_topic_ids": [
+        "college_gradient_directional_derivative",
+        "college_partial_derivative"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "二重积分区域怎么画？",
+      "expected_topic_ids": [
+        "college_double_integral_region",
+        "college_multiple_integral"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "定积分单位和正负号怎么检查？",
+      "expected_topic_ids": [
+        "college_integral_unit_sign_check",
+        "college_integral_physics_application"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "优化建模题为什么要先列目标函数？",
+      "expected_topic_ids": [
+        "college_optimization_problem",
+        "college_monotonic_extrema"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "一致连续为什么比逐点连续要求更强？",
+      "expected_topic_ids": [
+        "college_uniform_continuity_intro",
+        "college_continuity"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "定积分应用题结果的单位和正负号怎么一起检查？",
+      "expected_topic_ids": [
+        "college_integral_unit_sign_check",
+        "college_integral_application"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "优化建模中约束条件和目标函数怎么配合求最值？",
+      "expected_topic_ids": [
+        "college_optimization_problem",
+        "college_absolute_extrema"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "卡方检验里的列联表独立性检验怎么判断适用条件？",
+      "expected_topic_ids": [
+        "college_chi_square_test",
+        "college_hypothesis_testing"
+      ],
+      "expect_cross_subject": false
+    },
+    {
+      "query": "二阶线性微分方程为什么要先看特征方程？",
+      "expected_topic_ids": [
+        "college_ode_second_order",
+        "college_ode_first_order"
+      ],
+      "expect_cross_subject": false
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_graph_seed.json
+++ b/plugin/plugins/study_companion/static/knowledge_graph_seed.json
@@ -7,7 +7,57 @@
       "path": "knowledge_seeds/math.json",
       "subject": "math",
       "topic_count": 457
+    },
+    {
+      "path": "knowledge_seeds/english.json",
+      "subject": "english",
+      "topic_count": 45
+    },
+    {
+      "path": "knowledge_seeds/chinese.json",
+      "subject": "chinese",
+      "topic_count": 45
+    },
+    {
+      "path": "knowledge_seeds/physics.json",
+      "subject": "physics",
+      "topic_count": 74
+    },
+    {
+      "path": "knowledge_seeds/chemistry.json",
+      "subject": "chemistry",
+      "topic_count": 44
+    },
+    {
+      "path": "knowledge_seeds/biology.json",
+      "subject": "biology",
+      "topic_count": 44
+    },
+    {
+      "path": "knowledge_seeds/history.json",
+      "subject": "history",
+      "topic_count": 14
+    },
+    {
+      "path": "knowledge_seeds/geography.json",
+      "subject": "geography",
+      "topic_count": 14
+    },
+    {
+      "path": "knowledge_seeds/politics.json",
+      "subject": "politics",
+      "topic_count": 13
+    },
+    {
+      "path": "knowledge_seeds/computer_science.json",
+      "subject": "computer_science",
+      "topic_count": 40
+    },
+    {
+      "path": "knowledge_seeds/economics.json",
+      "subject": "economics",
+      "topic_count": 30
     }
   ],
-  "total_topics": 457
+  "total_topics": 820
 }

--- a/plugin/plugins/study_companion/static/knowledge_seeds/biology.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/biology.json
@@ -727,12 +727,14 @@
         {
           "id": "senior_binomial_distribution",
           "relation": "application",
-          "priority": "useful",
+          "priority": "core",
           "context": "practice",
-          "confidence": 0.83,
+          "confidence": 0.94,
           "reason": "Independent offspring outcomes can be modeled as repeated Bernoulli trials in family-size questions.",
           "use_cases": [
+            "diagnosis",
             "learning_path",
+            "hint_generation",
             "practice_planning",
             "review"
           ],

--- a/plugin/plugins/study_companion/static/knowledge_seeds/biology.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/biology.json
@@ -1,0 +1,7150 @@
+{
+  "version": "1.0",
+  "subject": "biology",
+  "topics": [
+    {
+      "id": "bio_junior_cell_structure",
+      "name": "细胞结构",
+      "subject": "biology",
+      "stage": "junior_high",
+      "chapter": "生命系统",
+      "depth": 1,
+      "difficulty": 0.36,
+      "prerequisites": [
+        {
+          "id": "bio_junior_microscope",
+          "relation": "prerequisite",
+          "reason": "Microscope use supports reliable observation before cell structure identification.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_cell_structure"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_junior_photosynthesis_respiration",
+          "relation": "extends",
+          "reason": "Continue from bio_junior_cell_structure to bio_junior_photosynthesis_respiration in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_cell_structure"
+          }
+        },
+        {
+          "id": "bio_junior_microscope",
+          "relation": "procedure_step",
+          "reason": "Observation questions first adjust the microscope and then identify visible cell parts.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_cell_structure"
+          }
+        },
+        {
+          "id": "bio_senior_cell_structure_function",
+          "relation": "confusable",
+          "reason": "Junior structure naming is often confused with senior structure function explanation.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_cell_structure"
+          }
+        },
+        {
+          "id": "bio_junior_photosynthesis_respiration",
+          "relation": "application",
+          "reason": "Cell structures such as chloroplasts and mitochondria are applied in metabolism questions.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_cell_structure"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "细胞与人体",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "概念辨析",
+        "图像识别"
+      ],
+      "examples": [
+        {
+          "prompt": "识别植物细胞和动物细胞结构差异，并说明细胞壁和叶绿体作用。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "bio_junior_photosynthesis_respiration",
+      "name": "光合作用与呼吸作用",
+      "subject": "biology",
+      "stage": "junior_high",
+      "chapter": "生命系统",
+      "depth": 2,
+      "difficulty": 0.52,
+      "prerequisites": [
+        {
+          "id": "bio_junior_cell_structure",
+          "relation": "prerequisite",
+          "reason": "Chloroplast and mitochondrion recognition supports photosynthesis and respiration comparison.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_photosynthesis_respiration"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_junior_human_body_systems",
+          "relation": "extends",
+          "reason": "Continue from bio_junior_photosynthesis_respiration to bio_junior_human_body_systems in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_photosynthesis_respiration"
+          }
+        },
+        {
+          "id": "bio_senior_photosynthesis_curve",
+          "relation": "procedure_step",
+          "reason": "Comparison tasks list site material product and energy change before reading rate curves.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_photosynthesis_respiration"
+          }
+        },
+        {
+          "id": "bio_senior_cell_respiration",
+          "relation": "confusable",
+          "reason": "Photosynthesis and respiration are often reversed in raw material product and energy direction.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_photosynthesis_respiration"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "application",
+          "reason": "Photosynthesis and respiration explain energy input and loss in ecosystem questions.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_photosynthesis_respiration"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "细胞与人体",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "过程分析",
+        "实验探究"
+      ],
+      "examples": [
+        {
+          "prompt": "比较光合作用和呼吸作用的场所、原料、产物和能量变化。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "bio_junior_human_body_systems",
+      "name": "人体系统协调",
+      "subject": "biology",
+      "stage": "junior_high",
+      "chapter": "生命系统",
+      "depth": 2,
+      "difficulty": 0.5,
+      "prerequisites": [
+        {
+          "id": "bio_junior_cell_structure",
+          "relation": "prerequisite",
+          "reason": "Cells and tissues are the foundation for understanding organs and body systems.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_human_body_systems"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_junior_ecology_food_chain",
+          "relation": "extends",
+          "reason": "Continue from bio_junior_human_body_systems to bio_junior_ecology_food_chain in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_human_body_systems"
+          }
+        },
+        {
+          "id": "bio_senior_neural_regulation",
+          "relation": "procedure_step",
+          "reason": "System coordination questions trace stimulus receptor center effector and response.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_human_body_systems"
+          }
+        },
+        {
+          "id": "bio_senior_homeostasis",
+          "relation": "confusable",
+          "reason": "Body system coordination is often confused with senior homeostasis feedback models.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_human_body_systems"
+          }
+        },
+        {
+          "id": "bio_senior_hormone_regulation",
+          "relation": "application",
+          "reason": "Human body system knowledge is applied in regulation and feedback scenarios.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_human_body_systems"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "细胞与人体",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "概念网络",
+        "实际应用"
+      ],
+      "examples": [
+        {
+          "prompt": "说明消化、呼吸、循环系统如何共同为运动供能。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "bio_junior_ecology_food_chain",
+      "name": "食物链与生态系统",
+      "subject": "biology",
+      "stage": "junior_high",
+      "chapter": "生命系统",
+      "depth": 2,
+      "difficulty": 0.48,
+      "prerequisites": [
+        {
+          "id": "bio_junior_photosynthesis_respiration",
+          "relation": "prerequisite",
+          "reason": "Producer energy input must be understood before tracing food chain transfer.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_ecology_food_chain"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_junior_microscope",
+          "relation": "extends",
+          "reason": "Continue from bio_junior_ecology_food_chain to bio_junior_microscope in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_ecology_food_chain"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "procedure_step",
+          "reason": "Trace producer consumer and decomposer links before explaining energy flow direction.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_ecology_food_chain"
+          }
+        },
+        {
+          "id": "bio_senior_ecosystem_material_cycle",
+          "relation": "confusable",
+          "reason": "Food chain energy direction is often confused with cyclic material movement.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_ecology_food_chain"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_calculation",
+          "relation": "application",
+          "reason": "Food chain reasoning is applied when estimating transfer efficiency and biomass change.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_ecology_food_chain"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "细胞与人体",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "生态分析",
+        "图表题"
+      ],
+      "examples": [
+        {
+          "prompt": "根据食物网判断某种生物减少后其他种群可能变化。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "bio_senior_genetics_law",
+      "name": "孟德尔遗传定律",
+      "aliases": [
+        "孟德尔遗传",
+        "遗传概率",
+        "基因型",
+        "表现型",
+        "基因型和表现型",
+        "分离定律"
+      ],
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_junior_inheritance_intro",
+          "required_mastery": 0.6,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "孟德尔遗传计算需要先分清性状、基因型、表现型和显隐性关系。",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_meiosis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "遗传定律的配子类型和比例依赖减数分裂中等位基因的分离。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "bio_senior_gene_frequency",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "种群基因频率是遗传概率思想在群体层面的延伸应用。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "bio_senior_dna_expression",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "基因型、表现型讨论遗传结果，基因表达讨论 DNA 信息如何转录翻译为功能产物。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "senior_probability_counting",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Genotype and gamete-count problems apply counting rules before probability ratios are computed.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "genetic_cross_to_counting"
+          }
+        },
+        {
+          "id": "college_conditional_probability",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Genetic risk after known phenotype or family history uses conditional probability reasoning.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "genetic_risk_conditioning"
+          }
+        },
+        {
+          "id": "senior_binomial_distribution",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Independent offspring outcomes can be modeled as repeated Bernoulli trials in family-size questions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "offspring_trials_binomial"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "遗传稳态生态",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "遗传计算",
+        "概率推理"
+      ],
+      "examples": [
+        {
+          "prompt": "根据亲本基因型推断后代表现型比例。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_dna_expression",
+      "name": "DNA复制与基因表达",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [
+        {
+          "id": "bio_senior_genetics_law",
+          "relation": "prerequisite",
+          "reason": "Inheritance law vocabulary supports later DNA expression and phenotype reasoning.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_dna_expression"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_homeostasis",
+          "relation": "extends",
+          "reason": "Continue from bio_senior_dna_expression to bio_senior_homeostasis in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_dna_expression"
+          }
+        },
+        {
+          "id": "bio_senior_gene_expression_regulation",
+          "relation": "procedure_step",
+          "reason": "Expression tasks trace DNA transcription translation and regulation before judging phenotype.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_dna_expression"
+          }
+        },
+        {
+          "id": "bio_senior_dna_replication_experiment",
+          "relation": "confusable",
+          "reason": "Replication template copying is often confused with expression from gene to protein.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_dna_expression"
+          }
+        },
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "application",
+          "reason": "DNA expression knowledge is applied when explaining target gene expression in engineering.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_dna_expression"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "遗传稳态生态",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "过程分析",
+        "概念辨析"
+      ],
+      "examples": [
+        {
+          "prompt": "比较 DNA 复制、转录、翻译的模板、原料和场所。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_homeostasis",
+      "name": "稳态与调节",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "bio_senior_neural_regulation",
+          "relation": "prerequisite",
+          "reason": "Neural regulation provides core pathways before integrated homeostasis analysis.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_homeostasis"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "extends",
+          "reason": "Continue from bio_senior_homeostasis to bio_senior_ecology_energy_flow in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_homeostasis"
+          }
+        },
+        {
+          "id": "bio_senior_hormone_regulation",
+          "relation": "procedure_step",
+          "reason": "Homeostasis questions trace signal pathway feedback target organ and response.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_homeostasis"
+          }
+        },
+        {
+          "id": "bio_senior_immunity_process",
+          "relation": "confusable",
+          "reason": "Immune regulation is often mixed with nervous and endocrine homeostasis feedback.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_homeostasis"
+          }
+        },
+        {
+          "id": "bio_senior_exam_integrated_context",
+          "relation": "application",
+          "reason": "Homeostasis reasoning is applied in integrated disease exercise and environment scenarios.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_homeostasis"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "遗传稳态生态",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "调节过程",
+        "图表分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析血糖调节过程中胰岛素和胰高血糖素的作用。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_ecology_energy_flow",
+      "name": "生态系统能量流动",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物",
+      "depth": 2,
+      "difficulty": 0.64,
+      "prerequisites": [
+        {
+          "id": "bio_junior_ecology_food_chain",
+          "relation": "prerequisite",
+          "reason": "Food chain direction is the foundation for energy flow and trophic level analysis.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecology_energy_flow"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_experiment_design",
+          "relation": "extends",
+          "reason": "Continue from bio_senior_ecology_energy_flow to bio_senior_experiment_design in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecology_energy_flow"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_calculation",
+          "relation": "procedure_step",
+          "reason": "Energy flow questions identify trophic levels before calculating transfer efficiency.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecology_energy_flow"
+          }
+        },
+        {
+          "id": "bio_senior_ecosystem_material_cycle",
+          "relation": "confusable",
+          "reason": "One way energy flow is often confused with recyclable material cycling.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecology_energy_flow"
+          }
+        },
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "application",
+          "reason": "Energy flow limits help explain population size and ecosystem carrying patterns.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecology_energy_flow"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "遗传稳态生态",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "生态分析",
+        "计算题"
+      ],
+      "examples": [
+        {
+          "prompt": "根据能量金字塔计算相邻营养级能量传递效率。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_experiment_design",
+      "name": "生物实验设计",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物",
+      "depth": 3,
+      "difficulty": 0.72,
+      "prerequisites": [
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "prerequisite",
+          "reason": "Control design must be mastered before full biological experiment design tasks.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_design"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_meiosis",
+          "relation": "extends",
+          "reason": "Continue from bio_senior_experiment_design to bio_senior_meiosis in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_design"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "procedure_step",
+          "reason": "Experiment design tasks define variables and then extract evidence from tables or curves.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_design"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "confusable",
+          "reason": "Designing an experiment is often confused with evaluating errors after data are collected.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_design"
+          }
+        },
+        {
+          "id": "bio_senior_exam_integrated_context",
+          "relation": "application",
+          "reason": "Experiment design is applied in integrated biology scenarios with unfamiliar materials.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_design"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把相近概念机械背诵，缺少过程联系",
+        "实验题不区分自变量、因变量和无关变量",
+        "遗传题没有写清基因型、表现型和概率路径"
+      ],
+      "unit": "遗传稳态生态",
+      "skills": [
+        "建立结构、功能、过程和调节之间的联系",
+        "从图表或实验中提取变量和结论",
+        "用生命系统层次解释现象"
+      ],
+      "question_types": [
+        "实验探究",
+        "变量控制"
+      ],
+      "examples": [
+        {
+          "prompt": "设计实验验证某环境因素对酶活性的影响，写出自变量和对照组。",
+          "answer_outline": [
+            "识别考查层次：分子、细胞、个体、种群或生态系统。",
+            "圈出结构、过程、变量或遗传关系。",
+            "按因果链、调节链或概率链推理。",
+            "检查结论是否符合生物学术语和实验设计。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_junior_microscope",
+      "name": "显微镜使用",
+      "subject": "biology",
+      "stage": "junior_high",
+      "chapter": "生命系统",
+      "depth": 1,
+      "difficulty": 0.36,
+      "prerequisites": [
+        {
+          "id": "data_collection",
+          "relation": "prerequisite",
+          "reason": "Basic data collection habits are needed before recording microscope observations.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "chapter_focus": "junior_microscope"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_junior_inheritance_intro",
+          "relation": "extends",
+          "reason": "Continue from bio_junior_microscope to bio_junior_inheritance_intro in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_microscope"
+          }
+        },
+        {
+          "id": "bio_junior_cell_structure",
+          "relation": "procedure_step",
+          "reason": "Microscope tasks adjust magnification focus the image and then identify cell structures.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_microscope"
+          }
+        },
+        {
+          "id": "bio_senior_mitosis_image",
+          "relation": "confusable",
+          "reason": "Students often confuse microscope operation steps with image based cell phase judgment.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_microscope"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "application",
+          "reason": "Microscope observation is applied when designing controls and recording visible evidence.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.81,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_microscope"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "概念背诵和过程理解脱节",
+        "实验变量与对照组不清",
+        "遗传概率路径写不完整"
+      ],
+      "unit": "实验技能",
+      "skills": [
+        "识别生命系统层次、结构和过程",
+        "用图表、遗传图解或实验变量推理",
+        "用规范术语表达因果链和结论"
+      ],
+      "question_types": [
+        "实验操作",
+        "图像识别"
+      ],
+      "examples": [
+        {
+          "prompt": "说明从低倍镜换高倍镜观察细胞时视野亮度和调焦变化。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "bio_junior_inheritance_intro",
+      "name": "性状遗传初步",
+      "aliases": [
+        "性状遗传",
+        "遗传概率题",
+        "基因型",
+        "表现型",
+        "显性隐性",
+        "遗传推理"
+      ],
+      "subject": "biology",
+      "stage": "junior_high",
+      "chapter": "遗传与进化",
+      "depth": 2,
+      "difficulty": 0.54,
+      "prerequisites": [
+        {
+          "id": "bio_junior_cell_structure",
+          "relation": "prerequisite",
+          "reason": "Trait inheritance questions assume students can connect cells, chromosomes, and inherited material.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_inheritance_intro"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_genetics_law",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "遗传概率题要从亲本基因型写到配子，再组合出子代表现型比例。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "bio_senior_dna_expression",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "基因型和表现型属于遗传推理，不能直接等同于基因表达过程。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "tree_diagram",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Basic inheritance crosses use tree diagrams to enumerate gamete combinations and phenotype outcomes.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "inheritance_cross_tree_diagram"
+          }
+        },
+        {
+          "id": "bio_senior_pedigree_analysis",
+          "relation": "application",
+          "reason": "Basic genotype and phenotype inference is reused when pedigree tasks infer inheritance mode.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "junior_inheritance_intro"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "概念背诵和过程理解脱节",
+        "实验变量与对照组不清",
+        "遗传概率路径写不完整"
+      ],
+      "unit": "遗传基础",
+      "skills": [
+        "识别生命系统层次、结构和过程",
+        "用图表、遗传图解或实验变量推理",
+        "用规范术语表达因果链和结论"
+      ],
+      "question_types": [
+        "遗传推理",
+        "概率计算"
+      ],
+      "examples": [
+        {
+          "prompt": "根据亲代和子代表现推断显隐性关系。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "bio_senior_meiosis",
+      "name": "减数分裂",
+      "aliases": [
+        "减数分裂",
+        "有丝分裂和减数分裂",
+        "减数分裂和有丝分裂",
+        "配子形成",
+        "同源染色体分离"
+      ],
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "遗传与进化",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_mitosis_image",
+          "relation": "prerequisite",
+          "reason": "Mitosis image reading gives the chromosome-count baseline needed before meiosis comparison.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_meiosis"
+          },
+          "required_mastery": 0.6
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_mitosis_image",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "减数分裂和有丝分裂最容易在染色体行为、子细胞数和遗传物质变化上混淆。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "bio_senior_genetics_law",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "减数分裂解释等位基因分离和配子类型，是遗传概率题的细胞学基础。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "bio_senior_gene_frequency",
+          "relation": "extends",
+          "reason": "Practice 种群基因频率 after 减数分裂; it is the next topic in the senior_high biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "bio_senior_meiosis_abnormal",
+          "relation": "procedure_step",
+          "reason": "Students first trace normal homolog separation and then diagnose nondisjunction patterns.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_meiosis"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "概念背诵和过程理解脱节",
+        "实验变量与对照组不清",
+        "遗传概率路径写不完整"
+      ],
+      "unit": "细胞分裂",
+      "skills": [
+        "识别生命系统层次、结构和过程",
+        "用图表、遗传图解或实验变量推理",
+        "用规范术语表达因果链和结论"
+      ],
+      "question_types": [
+        "过程分析",
+        "图像识别"
+      ],
+      "examples": [
+        {
+          "prompt": "根据细胞分裂图判断时期、染色体数和 DNA 数变化。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_gene_frequency",
+      "name": "种群基因频率",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "遗传与进化",
+      "depth": 3,
+      "difficulty": 0.72,
+      "prerequisites": [
+        {
+          "id": "bio_senior_evolution_selection",
+          "relation": "prerequisite",
+          "reason": "Natural selection and population concepts prepare students for allele frequency change.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_frequency"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_biotech_engineering",
+          "relation": "extends",
+          "reason": "Continue from bio_senior_gene_frequency to bio_senior_biotech_engineering in the biology learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_frequency"
+          }
+        },
+        {
+          "id": "senior_classical_probability",
+          "relation": "procedure_step",
+          "reason": "Gene frequency problems compute genotype or allele proportions before interpreting evolution.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "chapter_focus": "senior_gene_frequency"
+          }
+        },
+        {
+          "id": "bio_senior_mendel_ratio_variant",
+          "relation": "confusable",
+          "reason": "Population allele frequency is often confused with family cross genotype ratios.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_frequency"
+          }
+        },
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "application",
+          "reason": "Gene frequency reasoning is applied when population size selection and migration change traits.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_frequency"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "概念背诵和过程理解脱节",
+        "实验变量与对照组不清",
+        "遗传概率路径写不完整"
+      ],
+      "unit": "进化",
+      "skills": [
+        "识别生命系统层次、结构和过程",
+        "用图表、遗传图解或实验变量推理",
+        "用规范术语表达因果链和结论"
+      ],
+      "question_types": [
+        "计算题",
+        "概念辨析"
+      ],
+      "examples": [
+        {
+          "prompt": "计算某种群中显性和隐性基因频率，并判断是否发生进化。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_biotech_engineering",
+      "name": "现代生物技术工程",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "生物技术",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "prerequisite",
+          "reason": "Gene engineering flow is required before biotech engineering application tasks.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "biotech_engineering"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_pcr_electrophoresis",
+          "relation": "procedure_step",
+          "reason": "PCR and electrophoresis provide a verification step for engineered DNA products.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "biotech_engineering"
+          }
+        },
+        {
+          "id": "bio_senior_cell_engineering",
+          "relation": "confusable",
+          "reason": "Students often mix gene engineering and cell engineering when selecting tools for a task.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "biotech_engineering"
+          }
+        },
+        {
+          "id": "bio_senior_exam_integrated_context",
+          "relation": "application",
+          "reason": "Biotech engineering is applied in integrated scenarios about medicine agriculture and environment.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "biotech_engineering"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "概念背诵和过程理解脱节",
+        "实验变量与对照组不清",
+        "遗传概率路径写不完整"
+      ],
+      "unit": "工程应用",
+      "skills": [
+        "识别生命系统层次、结构和过程",
+        "用图表、遗传图解或实验变量推理",
+        "用规范术语表达因果链和结论"
+      ],
+      "question_types": [
+        "流程分析",
+        "实际应用"
+      ],
+      "examples": [
+        {
+          "prompt": "概括基因工程从目的基因获取到表达检测的基本步骤。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只写教材关键词，没有补出结构和功能之间的因果。",
+            "遗传、稳态、生态或实验层次混用。",
+            "实验题漏写自变量、因变量、对照或无关变量控制。"
+          ],
+          "grading_points": [
+            "核心概念表述准确，并能扣住题干情境。",
+            "因果链条、图表信息或实验变量分析完整。",
+            "答案使用规范生物术语并说明结论边界。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_biology",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_cell_structure_function",
+      "name": "细胞结构与功能对应",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物细胞与代谢",
+      "unit": "细胞结构",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_genetics_law",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 孟德尔遗传定律 before 细胞结构与功能对应; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_genetics_law",
+          "relation": "co_occurs",
+          "reason": "Review 细胞结构与功能对应 together with 孟德尔遗传定律 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_membrane_transport",
+          "relation": "co_occurs",
+          "reason": "Review 细胞结构与功能对应 together with 物质跨膜运输 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_membrane_transport",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Cell structure-function matching is used to explain selective transport and secretion scenarios.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_junior_cell_structure",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Students often mix organelle recognition with senior-level structure-function reasoning.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据细胞器结构解释分泌、能量转换或物质运输。",
+          "answer_outline": [
+            "先判断题目属于细胞结构与功能对应的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_membrane_transport",
+      "name": "物质跨膜运输",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物细胞与代谢",
+      "unit": "细胞结构",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_cell_structure_function",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 细胞结构与功能对应 before 物质跨膜运输; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_cell_structure_function",
+          "relation": "co_occurs",
+          "reason": "Review 物质跨膜运输 together with 细胞结构与功能对应 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_enzyme_curve",
+          "relation": "co_occurs",
+          "reason": "Review 物质跨膜运输 together with 酶活性曲线分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Transport mechanisms are commonly tested through osmosis, concentration gradients, and controlled variable experiments.",
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "bio_senior_cell_structure_function",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "reason": "Learners may confuse membrane component functions with the transport mode chosen from a scenario.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "判断自由扩散、协助扩散、主动运输和胞吞胞吐。",
+          "answer_outline": [
+            "先判断题目属于物质跨膜运输的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_enzyme_curve",
+      "name": "酶活性曲线分析",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物细胞与代谢",
+      "unit": "酶与 ATP",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_membrane_transport",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 物质跨膜运输 before 酶活性曲线分析; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_membrane_transport",
+          "relation": "co_occurs",
+          "reason": "Review 酶活性曲线分析 together with 物质跨膜运输 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_cell_respiration",
+          "relation": "co_occurs",
+          "reason": "Review 酶活性曲线分析 together with 细胞呼吸过程与计算 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_cell_respiration",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Enzyme activity curves help explain reaction-rate limits in respiration and metabolism questions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "Students often treat curve-reading skills as the biological enzyme conclusion without separating data pattern from mechanism.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Enzyme activity curves require reading peaks, intervals, and trend changes from function graphs.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "enzyme_curve_graph_reading"
+          }
+        },
+        {
+          "id": "senior_function_monotonicity",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Before explaining optimum enzyme conditions, students identify increasing and decreasing intervals.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "enzyme_curve_monotonicity"
+          }
+        },
+        {
+          "id": "senior_derivative_extrema",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Optimal temperature or pH points connect enzyme-rate maxima with derivative extrema reasoning, so curve peaks should be read as biological optimum points and mathematical maxima.",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "enzyme_optimum_extrema",
+            "cross_subject": true,
+            "added_for": "fixed_retrieval_eval_cross_subject_cases"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据温度、pH 或底物浓度曲线解释酶活性变化。",
+          "answer_outline": [
+            "先判断题目属于酶活性曲线分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_cell_respiration",
+      "name": "细胞呼吸过程与计算",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物细胞与代谢",
+      "unit": "细胞呼吸",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_enzyme_curve",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 酶活性曲线分析 before 细胞呼吸过程与计算; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_enzyme_curve",
+          "relation": "co_occurs",
+          "reason": "Review 细胞呼吸过程与计算 together with 酶活性曲线分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_photosynthesis_curve",
+          "relation": "co_occurs",
+          "reason": "Review 细胞呼吸过程与计算 together with 光合作用曲线分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_ecosystem_material_cycle",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Respiration calculations connect cellular carbon release to carbon-cycle and material-flow contexts.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "bio_senior_photosynthesis_curve",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "reason": "Respiration and photosynthesis questions often share gas-exchange graphs but reverse matter and energy directions.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "比较有氧呼吸、无氧呼吸阶段和物质能量变化。",
+          "answer_outline": [
+            "先判断题目属于细胞呼吸过程与计算的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_photosynthesis_curve",
+      "name": "光合作用曲线分析",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物细胞与代谢",
+      "unit": "光合作用",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_cell_respiration",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 细胞呼吸过程与计算 before 光合作用曲线分析; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_cell_respiration",
+          "relation": "co_occurs",
+          "reason": "Review 光合作用曲线分析 together with 细胞呼吸过程与计算 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_mitosis_image",
+          "relation": "co_occurs",
+          "reason": "Review 光合作用曲线分析 together with 有丝分裂图像判断 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Photosynthetic rate analysis supports ecosystem productivity and energy-input questions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "bio_senior_cell_respiration",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "reason": "Net photosynthesis, total photosynthesis, and respiration are easy to confuse in light-intensity graphs.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Light-response and CO2-response curves require extracting intercepts, plateaus, and limiting intervals.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "photosynthesis_curve_graph_reading"
+          }
+        },
+        {
+          "id": "senior_function_monotonicity",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Photosynthesis-rate questions apply monotonicity to separate limiting-factor regions from saturation regions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "photosynthesis_limiting_regions"
+          }
+        },
+        {
+          "id": "senior_derivative_extrema",
+          "relation": "application",
+          "priority": "optional",
+          "context": "explanation",
+          "confidence": 0.77,
+          "reason": "Compensation and saturation analysis can be extended to maximum-rate reasoning on smooth curves.",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "photosynthesis_curve_extrema"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析光照、CO2、温度对净光合速率的影响。",
+          "answer_outline": [
+            "先判断题目属于光合作用曲线分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_mitosis_image",
+      "name": "有丝分裂图像判断",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "细胞分裂",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_photosynthesis_curve",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 光合作用曲线分析 before 有丝分裂图像判断; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_photosynthesis_curve",
+          "relation": "co_occurs",
+          "reason": "Review 有丝分裂图像判断 together with 光合作用曲线分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_meiosis_abnormal",
+          "relation": "co_occurs",
+          "reason": "Review 有丝分裂图像判断 together with 减数分裂异常与配子 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_meiosis_abnormal",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Chromosome image identification is used before analyzing abnormal segregation and gamete outcomes.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_meiosis",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "Mitosis and meiosis images are often confused when homologous chromosome pairing and separation are not checked.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据染色体形态和数量判断分裂时期。",
+          "answer_outline": [
+            "先判断题目属于有丝分裂图像判断的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_meiosis_abnormal",
+      "name": "减数分裂异常与配子",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "细胞分裂",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_mitosis_image",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 有丝分裂图像判断 before 减数分裂异常与配子; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_mitosis_image",
+          "relation": "co_occurs",
+          "reason": "Review 减数分裂异常与配子 together with 有丝分裂图像判断 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_mendel_ratio_variant",
+          "relation": "co_occurs",
+          "reason": "Review 减数分裂异常与配子 together with 孟德尔比例变式 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_mendel_ratio_variant",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Abnormal meiosis can explain unexpected gamete types and nonstandard inheritance ratios.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_mitosis_image",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Students may attribute nondisjunction in gamete formation to ordinary mitotic image changes.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析同源染色体或姐妹染色单体异常分离的结果。",
+          "answer_outline": [
+            "先判断题目属于减数分裂异常与配子的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_mendel_ratio_variant",
+      "name": "孟德尔比例变式",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "遗传规律",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_meiosis_abnormal",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 减数分裂异常与配子 before 孟德尔比例变式; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_meiosis_abnormal",
+          "relation": "co_occurs",
+          "reason": "Review 孟德尔比例变式 together with 减数分裂异常与配子 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_linkage_exchange",
+          "relation": "co_occurs",
+          "reason": "Review 孟德尔比例变式 together with 连锁互换与遗传图谱 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_pedigree_analysis",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Variant Mendelian ratios support genotype inference in pedigree and probability questions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_genetics_law",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "Standard Mendelian ratios and variant ratios are confused when lethal genes or interaction effects are ignored.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "senior_classical_probability",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Variant Mendelian ratios convert genotype outcome spaces into classical probability calculations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "mendelian_ratio_sample_space"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据子代表型比例判断显隐性、基因型和致死因素。",
+          "answer_outline": [
+            "先判断题目属于孟德尔比例变式的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_linkage_exchange",
+      "name": "连锁互换与遗传图谱",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "遗传规律",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_mendel_ratio_variant",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 孟德尔比例变式 before 连锁互换与遗传图谱; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_mendel_ratio_variant",
+          "relation": "co_occurs",
+          "reason": "Review 连锁互换与遗传图谱 together with 孟德尔比例变式 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_pedigree_analysis",
+          "relation": "co_occurs",
+          "reason": "Review 连锁互换与遗传图谱 together with 遗传系谱图分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_meiosis",
+          "relation": "procedure_step",
+          "reason": "Linkage-map tasks first locate crossing-over in meiosis before using recombination data.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_linkage_exchange"
+          }
+        },
+        {
+          "id": "bio_senior_mendel_ratio_variant",
+          "relation": "confusable",
+          "reason": "Independent assortment ratios and linked-gene ratios look similar until recombination evidence is checked.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_linkage_exchange"
+          }
+        },
+        {
+          "id": "bio_senior_pedigree_analysis",
+          "relation": "application",
+          "reason": "Linkage and recombination reasoning can support inheritance-risk inference in pedigree contexts.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_linkage_exchange"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "由重组率判断连锁关系和基因距离。",
+          "answer_outline": [
+            "先判断题目属于连锁互换与遗传图谱的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_pedigree_analysis",
+      "name": "遗传系谱图分析",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "遗传规律",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_linkage_exchange",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 连锁互换与遗传图谱 before 遗传系谱图分析; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_linkage_exchange",
+          "relation": "co_occurs",
+          "reason": "Review 遗传系谱图分析 together with 连锁互换与遗传图谱 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_dna_replication_experiment",
+          "relation": "co_occurs",
+          "reason": "Review 遗传系谱图分析 together with DNA 半保留复制实验 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_genetics_law",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Pedigree analysis applies Mendelian genotype and phenotype rules to family-line probability inference.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_linkage_exchange",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.81,
+          "reason": "Pedigree probability and linkage-map reasoning both use inheritance evidence but differ in the target conclusion.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_conditional_probability",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Pedigree inference updates genotype probabilities after each observed family phenotype.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "pedigree_conditional_update"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据系谱图判断遗传方式和个体基因型概率。",
+          "answer_outline": [
+            "先判断题目属于遗传系谱图分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_dna_replication_experiment",
+      "name": "DNA 半保留复制实验",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "分子遗传",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_pedigree_analysis",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 遗传系谱图分析 before DNA 半保留复制实验; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_pedigree_analysis",
+          "relation": "co_occurs",
+          "reason": "Review DNA 半保留复制实验 together with 遗传系谱图分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_gene_expression_regulation",
+          "relation": "co_occurs",
+          "reason": "Review DNA 半保留复制实验 together with 基因表达与调控 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_gene_expression_regulation",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "DNA replication experiment evidence prepares learners to reason about molecular information flow and regulation.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "bio_senior_dna_expression",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "reason": "Replication evidence is often mixed up with transcription and translation when templates and products are not separated.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析同位素标记和密度梯度结果。",
+          "answer_outline": [
+            "先判断题目属于DNA 半保留复制实验的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_gene_expression_regulation",
+      "name": "基因表达与调控",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "分子遗传",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_dna_replication_experiment",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master DNA 半保留复制实验 before 基因表达与调控; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_dna_replication_experiment",
+          "relation": "co_occurs",
+          "reason": "Review 基因表达与调控 together with DNA 半保留复制实验 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_mutation_variation",
+          "relation": "co_occurs",
+          "reason": "Review 基因表达与调控 together with 变异类型与育种应用 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_dna_expression",
+          "relation": "procedure_step",
+          "reason": "Expression-regulation explanations first trace transcription and translation before adding control points.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_expression_regulation"
+          }
+        },
+        {
+          "id": "bio_senior_dna_replication_experiment",
+          "relation": "confusable",
+          "reason": "Replication copies DNA, while expression regulation changes RNA or protein output without copying the genome.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_expression_regulation"
+          }
+        },
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "application",
+          "reason": "Gene engineering uses promoters, vectors, and expression control to obtain target protein products.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_expression_regulation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "解释转录、翻译和基因选择性表达。",
+          "answer_outline": [
+            "先判断题目属于基因表达与调控的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_mutation_variation",
+      "name": "变异类型与育种应用",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "变异育种",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_gene_expression_regulation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 基因表达与调控 before 变异类型与育种应用; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_gene_expression_regulation",
+          "relation": "co_occurs",
+          "reason": "Review 变异类型与育种应用 together with 基因表达与调控 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_evolution_selection",
+          "relation": "co_occurs",
+          "reason": "Review 变异类型与育种应用 together with 自然选择与进化证据 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_meiosis_abnormal",
+          "relation": "procedure_step",
+          "reason": "Variation classification checks gene mutation, recombination, and chromosome abnormality as separate paths.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_mutation_variation"
+          }
+        },
+        {
+          "id": "bio_senior_gene_expression_regulation",
+          "relation": "confusable",
+          "reason": "Heritable sequence or chromosome variation is different from temporary expression-level regulation.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_mutation_variation"
+          }
+        },
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "application",
+          "reason": "Breeding and gene-engineering tasks apply variation sources to select or construct useful traits.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_mutation_variation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "区分基因突变、基因重组和染色体变异。",
+          "answer_outline": [
+            "先判断题目属于变异类型与育种应用的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_evolution_selection",
+      "name": "自然选择与进化证据",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物遗传与进化",
+      "unit": "生物进化",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_mutation_variation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 变异类型与育种应用 before 自然选择与进化证据; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_mutation_variation",
+          "relation": "co_occurs",
+          "reason": "Review 自然选择与进化证据 together with 变异类型与育种应用 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_neural_regulation",
+          "relation": "co_occurs",
+          "reason": "Review 自然选择与进化证据 together with 神经调节与反射弧 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_gene_frequency",
+          "relation": "procedure_step",
+          "reason": "Evolution-selection items often quantify allele-frequency change before explaining adaptation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_evolution_selection"
+          }
+        },
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "confusable",
+          "reason": "Population size change is not the same claim as allele-frequency change under selection.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_evolution_selection"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_calculation",
+          "relation": "application",
+          "reason": "Selection explanations are applied when ecological data are used to infer fitness and adaptation.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_evolution_selection"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "用种群基因频率和适应性解释进化过程。",
+          "answer_outline": [
+            "先判断题目属于自然选择与进化证据的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_neural_regulation",
+      "name": "神经调节与反射弧",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物稳态与调节",
+      "unit": "神经体液调节",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_evolution_selection",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 自然选择与进化证据 before 神经调节与反射弧; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_evolution_selection",
+          "relation": "co_occurs",
+          "reason": "Review 神经调节与反射弧 together with 自然选择与进化证据 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_hormone_regulation",
+          "relation": "co_occurs",
+          "reason": "Review 神经调节与反射弧 together with 激素调节与反馈 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_homeostasis",
+          "relation": "procedure_step",
+          "reason": "Neural-regulation answers trace receptor, afferent pathway, center, efferent pathway, and effector.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_neural_regulation"
+          }
+        },
+        {
+          "id": "bio_senior_hormone_regulation",
+          "relation": "confusable",
+          "reason": "Neural signals are fast and pathway-specific, while hormone signals are blood-borne and slower.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_neural_regulation"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "application",
+          "reason": "Reaction-time and synaptic-transmission data require reading biological curves and tables.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_neural_regulation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析兴奋传导、突触传递和反射弧完整性。",
+          "answer_outline": [
+            "先判断题目属于神经调节与反射弧的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_hormone_regulation",
+      "name": "激素调节与反馈",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物稳态与调节",
+      "unit": "神经体液调节",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_neural_regulation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 神经调节与反射弧 before 激素调节与反馈; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_neural_regulation",
+          "relation": "co_occurs",
+          "reason": "Review 激素调节与反馈 together with 神经调节与反射弧 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_immunity_process",
+          "relation": "co_occurs",
+          "reason": "Review 激素调节与反馈 together with 免疫调节过程 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_homeostasis",
+          "relation": "procedure_step",
+          "reason": "Hormone-regulation questions usually trace stimulus, endocrine response, target organ, and feedback.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_hormone_regulation"
+          }
+        },
+        {
+          "id": "bio_senior_neural_regulation",
+          "relation": "confusable",
+          "reason": "Hormone feedback is easily mixed with reflex-arc signaling but uses different routes and timing.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_hormone_regulation"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "application",
+          "reason": "Blood-glucose and thyroid-hormone feedback items often require curve and table interpretation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_hormone_regulation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "解释甲状腺激素、血糖调节和反馈机制。",
+          "answer_outline": [
+            "先判断题目属于激素调节与反馈的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_immunity_process",
+      "name": "免疫调节过程",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物稳态与调节",
+      "unit": "免疫调节",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_hormone_regulation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 激素调节与反馈 before 免疫调节过程; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_hormone_regulation",
+          "relation": "co_occurs",
+          "reason": "Review 免疫调节过程 together with 激素调节与反馈 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_plant_hormone",
+          "relation": "co_occurs",
+          "reason": "Review 免疫调节过程 together with 植物激素调节 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_homeostasis",
+          "relation": "procedure_step",
+          "reason": "Immunity-process answers order antigen recognition, lymphocyte activation, effector action, and memory.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_immunity_process"
+          }
+        },
+        {
+          "id": "bio_senior_hormone_regulation",
+          "relation": "confusable",
+          "reason": "Immune regulation uses antigen-specific responses, not endocrine feedback loops.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_immunity_process"
+          }
+        },
+        {
+          "id": "bio_senior_biotech_engineering",
+          "relation": "application",
+          "reason": "Vaccination, antibody use, and immune detection connect immunity concepts to biotechnology tasks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_immunity_process"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "区分非特异性免疫、体液免疫和细胞免疫。",
+          "answer_outline": [
+            "先判断题目属于免疫调节过程的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_plant_hormone",
+      "name": "植物激素调节",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物稳态与调节",
+      "unit": "植物生命活动",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_immunity_process",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 免疫调节过程 before 植物激素调节; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_immunity_process",
+          "relation": "co_occurs",
+          "reason": "Review 植物激素调节 together with 免疫调节过程 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "co_occurs",
+          "reason": "Review 植物激素调节 together with 种群数量变化曲线 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "procedure_step",
+          "reason": "Plant-hormone experiments first control hormone concentration, light, material, and time variables.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_plant_hormone"
+          }
+        },
+        {
+          "id": "bio_senior_hormone_regulation",
+          "relation": "confusable",
+          "reason": "Plant hormones coordinate growth responses, while animal hormones act through endocrine target organs.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_plant_hormone"
+          }
+        },
+        {
+          "id": "bio_senior_cell_engineering",
+          "relation": "application",
+          "reason": "Plant tissue culture applies auxin and cytokinin ratios to control callus and organ differentiation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_plant_hormone"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析生长素运输、浓度效应和实验现象。",
+          "answer_outline": [
+            "先判断题目属于植物激素调节的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_population_growth",
+      "name": "种群数量变化曲线",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物生态",
+      "unit": "种群群落",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_plant_hormone",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 植物激素调节 before 种群数量变化曲线; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_population_growth"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_plant_hormone",
+          "relation": "co_occurs",
+          "reason": "Review 种群数量变化曲线 together with 植物激素调节 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_community_succession",
+          "relation": "co_occurs",
+          "reason": "Review 种群数量变化曲线 together with 群落结构与演替 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Population growth curves require reading slope, plateau, and inflection information from graphs.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "population_curve_graph_reading"
+          }
+        },
+        {
+          "id": "senior_function_modeling",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Ecological population questions translate time and population size into function-model language.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "population_growth_function_model"
+          }
+        },
+        {
+          "id": "bio_senior_gene_frequency",
+          "relation": "confusable",
+          "reason": "Population size change is often confused with allele frequency change; one tracks individuals while the other tracks gene pool composition.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_population_growth"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_calculation",
+          "relation": "procedure_step",
+          "reason": "Population questions first identify growth rate and carrying capacity before applying energy or biomass calculations.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_population_growth"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "判断 J 型、S 型增长和环境容纳量变化。",
+          "answer_outline": [
+            "先判断题目属于种群数量变化曲线的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_community_succession",
+      "name": "群落结构与演替",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物生态",
+      "unit": "种群群落",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_population_growth",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 种群数量变化曲线 before 群落结构与演替; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_community_succession"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "co_occurs",
+          "reason": "Review 群落结构与演替 together with 种群数量变化曲线 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_ecosystem_material_cycle",
+          "relation": "co_occurs",
+          "reason": "Review 群落结构与演替 together with 生态系统物质循环 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_ecosystem_material_cycle",
+          "relation": "application",
+          "reason": "Succession changes community composition and is applied when explaining nutrient cycling after disturbance.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_community_succession"
+          }
+        },
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "confusable",
+          "reason": "Succession describes community replacement over time, while population growth describes one species count change.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_community_succession"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "procedure_step",
+          "reason": "Succession analysis first identifies dominant species and trophic structure before explaining energy flow changes.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_community_succession"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据物种组成和环境变化判断演替方向。",
+          "answer_outline": [
+            "先判断题目属于群落结构与演替的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_ecosystem_material_cycle",
+      "name": "生态系统物质循环",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物生态",
+      "unit": "生态系统",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_community_succession",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 群落结构与演替 before 生态系统物质循环; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecosystem_material_cycle"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_community_succession",
+          "relation": "co_occurs",
+          "reason": "Review 生态系统物质循环 together with 群落结构与演替 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_ecology_calculation",
+          "relation": "co_occurs",
+          "reason": "Review 生态系统物质循环 together with 生态能量流动计算 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_ecology_calculation",
+          "relation": "application",
+          "reason": "Material-cycle reasoning is applied when separating cyclic matter movement from one-way energy transfer in calculation items.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecosystem_material_cycle"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "confusable",
+          "reason": "Matter cycles through ecosystems, while energy flows one way and is lost as heat.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecosystem_material_cycle"
+          }
+        },
+        {
+          "id": "bio_junior_ecology_food_chain",
+          "relation": "procedure_step",
+          "reason": "Material-cycle answers first locate producers consumers and decomposers in the food web.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecosystem_material_cycle"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析碳循环、能量流动和生态系统稳定性。",
+          "answer_outline": [
+            "先判断题目属于生态系统物质循环的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_ecology_calculation",
+      "name": "生态能量流动计算",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物生态",
+      "unit": "生态系统",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_ecosystem_material_cycle",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 生态系统物质循环 before 生态能量流动计算; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecology_calculation"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_ecosystem_material_cycle",
+          "relation": "co_occurs",
+          "reason": "Review 生态能量流动计算 together with 生态系统物质循环 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "co_occurs",
+          "reason": "Review 生态能量流动计算 together with 生物实验对照设计 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "direct_proportion",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Energy-transfer calculations apply proportional reasoning between trophic levels and transfer efficiency.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "energy_flow_proportion"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "confusable",
+          "reason": "Qualitative energy-flow direction is often confused with quantitative transfer-efficiency calculation.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_ecology_calculation"
+          }
+        },
+        {
+          "id": "direct_proportion",
+          "relation": "procedure_step",
+          "reason": "Energy-transfer items set up trophic-level ratios before solving for biomass or energy values.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "chapter_focus": "senior_ecology_calculation",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "energy_transfer_ratio_steps"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据营养级能量关系计算传递效率和同化量。",
+          "answer_outline": [
+            "先判断题目属于生态能量流动计算的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_experiment_control",
+      "name": "生物实验对照设计",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物实验",
+      "unit": "实验设计",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_ecology_calculation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 生态能量流动计算 before 生物实验对照设计; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_control"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_ecology_calculation",
+          "relation": "co_occurs",
+          "reason": "Review 生物实验对照设计 together with 生态能量流动计算 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "co_occurs",
+          "reason": "Review 生物实验对照设计 together with 实验图表信息提取 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "application",
+          "reason": "Control design is applied when judging whether an experimental conclusion is supported by the evidence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_control"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "confusable",
+          "reason": "Control design asks what changes and what stays fixed, while curve-table work asks how to read the resulting data.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_control"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "procedure_step",
+          "reason": "Experimental analysis first identifies independent variable dependent variable and control group before reading trends.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_control"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "设计空白对照、条件对照或自身对照并控制变量。",
+          "answer_outline": [
+            "先判断题目属于生物实验对照设计的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_experiment_curve_table",
+      "name": "实验图表信息提取",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物实验",
+      "unit": "实验设计",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_experiment_control",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 生物实验对照设计 before 实验图表信息提取; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_curve_table"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "co_occurs",
+          "reason": "Review 实验图表信息提取 together with 生物实验对照设计 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "co_occurs",
+          "reason": "Review 实验图表信息提取 together with 实验误差与结论评价 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "mean_median_mode",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Biology experiment summaries often apply mean values to compare treatment and control groups.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "experiment_mean_comparison"
+          }
+        },
+        {
+          "id": "statistical_charts",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Experimental tables and biological charts apply statistical-chart reading to compare trends and groups.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "bio_experiment_chart_reading"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "confusable",
+          "reason": "Reading a trend from a graph is often confused with evaluating whether the conclusion exceeds the data.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_curve_table"
+          }
+        },
+        {
+          "id": "statistical_charts",
+          "relation": "procedure_step",
+          "reason": "Graph-table questions first identify axes units groups and trend before making biological conclusions.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "chapter_focus": "senior_experiment_curve_table",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "bio_chart_reading_steps"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "从曲线或表格提取趋势并写出实验结论。",
+          "answer_outline": [
+            "先判断题目属于实验图表信息提取的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_experiment_error_analysis",
+      "name": "实验误差与结论评价",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物实验",
+      "unit": "实验评价",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 实验图表信息提取 before 实验误差与结论评价; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_error_analysis"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "co_occurs",
+          "reason": "Review 实验误差与结论评价 together with 实验图表信息提取 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_pcr_electrophoresis",
+          "relation": "co_occurs",
+          "reason": "Review 实验误差与结论评价 together with PCR 与电泳结果分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "variance",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.97,
+          "reason": "实验误差与结论评价 uses 方差 to judge repeated-measurement dispersion before deciding whether the conclusion is reliable.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "experiment_variance_error"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "confusable",
+          "reason": "Error analysis judges reliability after data collection, while control design plans fair comparison before data collection.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_experiment_error_analysis"
+          }
+        },
+        {
+          "id": "variance",
+          "relation": "procedure_step",
+          "reason": "实验误差与结论评价 first compares repeated measurements, then uses 方差 to quantify dispersion before judging conclusion reliability.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.96,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "math",
+            "chapter_focus": "senior_experiment_error_analysis",
+            "bridge_direction": "biology_to_math",
+            "bridge_focus": "bio_error_dispersion_steps"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "判断实验操作导致的误差方向和结论可靠性。",
+          "answer_outline": [
+            "先判断题目属于实验误差与结论评价的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_pcr_electrophoresis",
+      "name": "PCR 与电泳结果分析",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物技术",
+      "unit": "现代生物技术",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 实验误差与结论评价 before PCR 与电泳结果分析; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_pcr_electrophoresis"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "co_occurs",
+          "reason": "Review PCR 与电泳结果分析 together with 实验误差与结论评价 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "co_occurs",
+          "reason": "Review PCR 与电泳结果分析 together with 基因工程流程 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "application",
+          "reason": "PCR amplification and electrophoresis are applied to screen and verify target DNA in gene engineering workflows.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_pcr_electrophoresis"
+          }
+        },
+        {
+          "id": "bio_senior_dna_replication_experiment",
+          "relation": "confusable",
+          "reason": "PCR copies DNA in vitro with primers and polymerase, while DNA replication experiments trace replication in living cells.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_pcr_electrophoresis"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "procedure_step",
+          "reason": "Electrophoresis analysis first compares band position and brightness before inferring fragment size or genotype.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_pcr_electrophoresis"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "解释 PCR 扩增、凝胶电泳条带和结果判断。",
+          "answer_outline": [
+            "先判断题目属于PCR 与电泳结果分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_gene_engineering",
+      "name": "基因工程流程",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物技术",
+      "unit": "现代生物技术",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_pcr_electrophoresis",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master PCR 与电泳结果分析 before 基因工程流程; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_engineering"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_pcr_electrophoresis",
+          "relation": "co_occurs",
+          "reason": "Review 基因工程流程 together with PCR 与电泳结果分析 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_cell_engineering",
+          "relation": "co_occurs",
+          "reason": "Review 基因工程流程 together with 植物组织培养与细胞工程 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_biotech_engineering",
+          "relation": "application",
+          "reason": "Gene engineering is applied in broader biotechnology tasks such as transgenic production and molecular screening.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_engineering"
+          }
+        },
+        {
+          "id": "bio_senior_gene_expression_regulation",
+          "relation": "confusable",
+          "reason": "Gene engineering changes or transfers DNA, while expression regulation explains when and how an existing gene is expressed.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_engineering"
+          }
+        },
+        {
+          "id": "bio_senior_pcr_electrophoresis",
+          "relation": "procedure_step",
+          "reason": "Gene engineering workflows verify target fragments by PCR or electrophoresis before screening transformants.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_gene_engineering"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "梳理目的基因、载体、受体细胞和筛选鉴定流程。",
+          "answer_outline": [
+            "先判断题目属于基因工程流程的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_cell_engineering",
+      "name": "植物组织培养与细胞工程",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物技术",
+      "unit": "现代生物技术",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_gene_engineering",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 基因工程流程 before 植物组织培养与细胞工程; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_cell_engineering"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "co_occurs",
+          "reason": "Review 植物组织培养与细胞工程 together with 基因工程流程 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_exam_integrated_context",
+          "relation": "co_occurs",
+          "reason": "Review 植物组织培养与细胞工程 together with 生物综合情境题 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_biotech_engineering",
+          "relation": "application",
+          "reason": "Cell engineering applies tissue culture and cell fusion to cloning breeding and biotechnology production scenarios.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_cell_engineering"
+          }
+        },
+        {
+          "id": "bio_senior_gene_engineering",
+          "relation": "confusable",
+          "reason": "Cell engineering manipulates cells or tissues, while gene engineering manipulates DNA constructs and transfer.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_cell_engineering"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_control",
+          "relation": "procedure_step",
+          "reason": "Tissue culture tasks control asepsis hormones explant source and medium before evaluating differentiation results.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_cell_engineering"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析脱分化、再分化、细胞融合和应用场景。",
+          "answer_outline": [
+            "先判断题目属于植物组织培养与细胞工程的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_exam_integrated_context",
+      "name": "生物综合情境题",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物综合",
+      "unit": "综合应用",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_cell_engineering",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 植物组织培养与细胞工程 before 生物综合情境题; it supplies the foundation for this biology learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_exam_integrated_context"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_cell_engineering",
+          "relation": "co_occurs",
+          "reason": "Review 生物综合情境题 together with 植物组织培养与细胞工程 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_answer_standardization",
+          "relation": "co_occurs",
+          "reason": "Review 生物综合情境题 together with 生物规范表述 when diagnosing adjacent biology skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_answer_standardization",
+          "relation": "application",
+          "reason": "Integrated scenarios require applying standard biological wording to connect evidence conditions and conclusion.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_exam_integrated_context"
+          }
+        },
+        {
+          "id": "bio_senior_answer_standardization",
+          "relation": "confusable",
+          "reason": "Finding the integrated scenario clue is often confused with writing a complete standardized answer.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_exam_integrated_context"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "procedure_step",
+          "reason": "Integrated biology items first classify the scenario as genetics regulation ecology engineering or experiment before combining evidence.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_exam_integrated_context"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "把遗传、稳态、生态或实验信息整合成因果解释。",
+          "answer_outline": [
+            "先判断题目属于生物综合情境题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "bio_senior_answer_standardization",
+      "name": "生物规范表述",
+      "subject": "biology",
+      "stage": "senior_high",
+      "chapter": "高中生物综合",
+      "unit": "答题规范",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "bio_senior_exam_integrated_context",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "bio_senior_exam_integrated_context supports prerequisite checks before bio_senior_answer_standardization.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_answer_standardization"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "bio_senior_exam_integrated_context",
+          "relation": "co_occurs",
+          "reason": "Review bio_senior_answer_standardization with bio_senior_exam_integrated_context for adjacent biology diagnosis.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_answer_standardization"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "procedure_step",
+          "reason": "Standard answers first extract variables data trend and conclusion from the prompt.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_answer_standardization"
+          }
+        },
+        {
+          "id": "bio_senior_exam_integrated_context",
+          "relation": "confusable",
+          "reason": "Students often confuse finding the scenario clue with writing a complete biological statement.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_answer_standardization"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "application",
+          "reason": "Standardized expression is applied when evaluating conclusions limitations and evidence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "learning_path"
+          ],
+          "metadata": {
+            "source_subject": "biology",
+            "target_subject": "biology",
+            "chapter_focus": "senior_answer_standardization"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记关键词但没有说明因果链条",
+        "把细胞层次、个体层次和生态层次混用",
+        "实验题漏写自变量、因变量或无关变量控制"
+      ],
+      "skills": [
+        "把概念放入结构、功能和调节链条中解释",
+        "识别实验变量、对照组和结论边界",
+        "用图表信息和教材概念共同支持判断"
+      ],
+      "question_types": [
+        "概念辨析",
+        "实验分析"
+      ],
+      "examples": [
+        {
+          "prompt": "用教材术语、因果连接和限定条件组织答案。",
+          "answer_outline": [
+            "先判断题目属于生物规范表述的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用生物核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "biology",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_biology"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/chemistry.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/chemistry.json
@@ -1,0 +1,6726 @@
+{
+  "version": "1.0",
+  "subject": "chemistry",
+  "topics": [
+    {
+      "id": "chem_junior_substance_classification",
+      "name": "物质分类",
+      "subject": "chemistry",
+      "stage": "junior_high",
+      "chapter": "物质与变化",
+      "depth": 1,
+      "difficulty": 0.34,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_junior_chemical_equation",
+          "relation": "extends",
+          "reason": "Practice 化学方程式配平 after 物质分类; it is the next topic in the junior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_junior_chemical_equation",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Classifying substances and reaction types is the first check before writing and balancing a chemical equation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_junior_solution_solubility",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Students often confuse pure substances, mixtures, and solutions when interpreting classification questions.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "基础概念",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "概念辨析",
+        "分类题"
+      ],
+      "examples": [
+        {
+          "prompt": "判断空气、氧气、盐水、铁粉分别属于混合物还是纯净物。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chem_junior_chemical_equation",
+      "name": "化学方程式配平",
+      "subject": "chemistry",
+      "stage": "junior_high",
+      "chapter": "物质与变化",
+      "depth": 2,
+      "difficulty": 0.48,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_junior_solution_solubility",
+          "relation": "extends",
+          "reason": "Practice 溶液与溶解度 after 化学方程式配平; it is the next topic in the junior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Balanced equations provide mole ratios before limiting-reagent or yield calculations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "Full chemical equations and net ionic equations are commonly mixed up in equation-writing tasks.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "primary_ratio_meaning",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Balancing equations applies ratio meaning because coefficients compare particle and mole counts.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "equation_coefficients_as_ratios"
+          }
+        },
+        {
+          "id": "linear_equation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Unknown coefficients in a chemical equation can be solved by setting atom-count balance equations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "atom_balance_linear_equations"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "基础概念",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "基础计算",
+        "方程式书写"
+      ],
+      "examples": [
+        {
+          "prompt": "配平铁在氧气中燃烧的方程式，并说明质量守恒。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chem_junior_solution_solubility",
+      "name": "溶液与溶解度",
+      "subject": "chemistry",
+      "stage": "junior_high",
+      "chapter": "物质与变化",
+      "depth": 2,
+      "difficulty": 0.54,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_junior_acid_base_salt",
+          "relation": "extends",
+          "reason": "Practice 酸碱盐基础 after 溶液与溶解度; it is the next topic in the junior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Solubility and solution state checks often come before concentration or dilution calculations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_precipitation_equilibrium",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Solubility curve questions can be confused with precipitation-equilibrium and solubility-product reasoning.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "基础概念",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "图像分析",
+        "计算题"
+      ],
+      "examples": [
+        {
+          "prompt": "根据溶解度曲线判断降温后是否有晶体析出。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chem_junior_acid_base_salt",
+      "name": "酸碱盐基础",
+      "subject": "chemistry",
+      "stage": "junior_high",
+      "chapter": "物质与变化",
+      "depth": 2,
+      "difficulty": 0.6,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_junior_gas_preparation",
+          "relation": "extends",
+          "reason": "Practice 气体制取与检验 after 酸碱盐基础; it is the next topic in the junior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_ionic_reaction",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Identifying acids, bases, and salts prepares students to write ions and judge ionic reactions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_ph_ionization",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "reason": "Acid-base classification, pH, and ionization strength are frequently conflated in diagnosis questions.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "基础概念",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "物质推断",
+        "实验现象"
+      ],
+      "examples": [
+        {
+          "prompt": "根据酸碱盐反应现象判断生成物并写方程式。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chem_senior_ionic_reaction",
+      "name": "离子反应与离子方程式",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学反应原理",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_equilibrium",
+          "relation": "extends",
+          "reason": "Practice 化学平衡移动 after 离子反应与离子方程式; it is the next topic in the senior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.93,
+          "reason": "Ionic reaction recognition is followed by splitting soluble strong electrolytes and writing the net ionic equation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Students often confuse whether ions can coexist with whether an ionic reaction equation should be written.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "平衡与电化学",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "离子方程式",
+        "反应判断"
+      ],
+      "examples": [
+        {
+          "prompt": "写出氢氧化钡和硫酸反应的离子方程式并说明删去旁观离子。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_redox",
+      "name": "氧化还原反应",
+      "aliases": [
+        "氧化剂",
+        "还原剂",
+        "氧化还原反应",
+        "氧化剂和还原剂",
+        "氧化还原配平"
+      ],
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学反应原理",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_ionic_reaction",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "氧化还原反应常和离子反应、离子方程式条件一起判断。",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_redox_balance",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.94,
+          "reason": "氧化还原配平需要先标化合价，再用电子守恒配平。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_redox_titration",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "氧化还原滴定是氧化剂、还原剂和电子守恒的典型应用。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "学生容易把氧化还原配平和离子方程式拆写条件混在一起。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "平衡与电化学",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "电子守恒",
+        "方程式配平"
+      ],
+      "examples": [
+        {
+          "prompt": "用化合价升降法配平一个氧化还原反应。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_equilibrium",
+      "name": "化学平衡移动",
+      "aliases": [
+        "化学平衡移动",
+        "平衡移动",
+        "勒夏特列原理",
+        "平衡移动判断"
+      ],
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学反应原理",
+      "depth": 3,
+      "difficulty": 0.72,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_equilibrium_constant",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "判断平衡移动时需要结合浓度、温度、压强变化和 Q 与 K 的关系。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_equilibrium_graph",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "平衡图像综合题会把移动方向、速率变化和转化率放在同一题中考查。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "速率变大不等于平衡一定正向移动，二者需要分开判断。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chem_senior_electrochemistry",
+          "relation": "extends",
+          "reason": "Practice 原电池与电解池 after 化学平衡移动; it is the next topic in the senior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "平衡与电化学",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "平衡分析",
+        "图像题"
+      ],
+      "examples": [
+        {
+          "prompt": "改变温度、压强、浓度后判断平衡移动方向和转化率变化。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_electrochemistry",
+      "name": "原电池与电解池",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学反应原理",
+      "depth": 3,
+      "difficulty": 0.76,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_organic_functional_group",
+          "relation": "extends",
+          "reason": "Practice 有机官能团 after 原电池与电解池; it is the next topic in the senior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_primary_battery",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Electrochemistry concepts lead into identifying electrodes, ion movement, and reactions in primary cells.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_electrolysis_product",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "Galvanic-cell reasoning and electrolysis-product judgment are easy to reverse because electrode roles differ.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "平衡与电化学",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "电化学",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "判断原电池正负极、电极反应和电子流向。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_organic_functional_group",
+      "name": "有机官能团",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学反应原理",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_mole_calculation",
+          "relation": "extends",
+          "reason": "Practice 物质的量计算 after 有机官能团; it is the next topic in the senior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_organic_reaction_route",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Recognizing functional groups is the first step before predicting transformations in an organic synthesis route.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_organic_isomer",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "Functional-group identification is often confused with isomer enumeration when structures have the same formula.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背方程式，不判断反应条件和现象",
+        "离子方程式漏写沉淀、气体或弱电解质",
+        "实验题忽略安全、除杂顺序和变量控制"
+      ],
+      "unit": "平衡与电化学",
+      "skills": [
+        "识别物质类别、反应类型和实验目的",
+        "配平方程式并追踪元素、离子或电子守恒",
+        "用现象、条件和计算验证化学结论"
+      ],
+      "question_types": [
+        "有机推断",
+        "结构识别"
+      ],
+      "examples": [
+        {
+          "prompt": "根据分子式和反应现象判断醇、醛、羧酸或酯。",
+          "answer_outline": [
+            "判断物质类别、反应类型和实验目标。",
+            "写出方程式、离子方程式或守恒关系。",
+            "结合现象、条件、装置或数据作推理。",
+            "检查配平、单位、过量少量和实验可行性。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_junior_gas_preparation",
+      "name": "气体制取与检验",
+      "subject": "chemistry",
+      "stage": "junior_high",
+      "chapter": "化学实验",
+      "depth": 2,
+      "difficulty": 0.58,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_junior_metal_activity",
+          "relation": "extends",
+          "reason": "Practice 金属活动性顺序 after 气体制取与检验; it is the next topic in the junior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_gas",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Basic gas preparation supports later choices of collection, purification, drying, and testing steps.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_separation",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.81,
+          "reason": "Gas collection and purification operations can be confused with general separation and purification methods.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "方程式与实验条件混淆",
+        "忽略守恒关系或离子共存限制",
+        "实验结论没有对应现象和对照"
+      ],
+      "unit": "气体实验",
+      "skills": [
+        "判断反应条件、现象和守恒关系",
+        "用方程式、离子方程式或结构式解释问题",
+        "检查实验变量、过量少量和数据单位"
+      ],
+      "question_types": [
+        "实验探究",
+        "现象判断"
+      ],
+      "examples": [
+        {
+          "prompt": "实验室制取氧气并检验，写出装置选择、操作步骤和验满方法。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chem_junior_metal_activity",
+      "name": "金属活动性顺序",
+      "subject": "chemistry",
+      "stage": "junior_high",
+      "chapter": "金属与材料",
+      "depth": 2,
+      "difficulty": 0.6,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_redox",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Metal activity comparisons lead into electron-transfer reasoning for oxidation and reduction reactions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_primary_battery",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Metal activity order is often confused with electrode potential and anode-cathode judgment in cells.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "方程式与实验条件混淆",
+        "忽略守恒关系或离子共存限制",
+        "实验结论没有对应现象和对照"
+      ],
+      "unit": "金属活动性",
+      "skills": [
+        "判断反应条件、现象和守恒关系",
+        "用方程式、离子方程式或结构式解释问题",
+        "检查实验变量、过量少量和数据单位"
+      ],
+      "question_types": [
+        "物质推断",
+        "实验探究"
+      ],
+      "examples": [
+        {
+          "prompt": "根据金属与盐溶液反应现象判断三种金属活动性强弱。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chem_senior_mole_calculation",
+      "name": "物质的量计算",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学计量",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_thermochemistry",
+          "relation": "extends",
+          "reason": "Practice 反应热与盖斯定律 after 物质的量计算; it is the next topic in the senior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "Mole conversion is the setup step before applying equation ratios and identifying limiting reagents.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "Amount of substance, molar mass, and solution concentration are commonly substituted for one another incorrectly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "方程式与实验条件混淆",
+        "忽略守恒关系或离子共存限制",
+        "实验结论没有对应现象和对照"
+      ],
+      "unit": "物质的量",
+      "skills": [
+        "判断反应条件、现象和守恒关系",
+        "用方程式、离子方程式或结构式解释问题",
+        "检查实验变量、过量少量和数据单位"
+      ],
+      "question_types": [
+        "计算题",
+        "守恒关系"
+      ],
+      "examples": [
+        {
+          "prompt": "由气体体积和溶液浓度计算反应生成物的物质的量。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_thermochemistry",
+      "name": "反应热与盖斯定律",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学反应原理",
+      "depth": 3,
+      "difficulty": 0.7,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_experiment_design",
+          "relation": "extends",
+          "reason": "Practice 化学实验方案评价 after 反应热与盖斯定律; it is the next topic in the senior_high chemistry learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_reaction_heat_diagram",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Thermochemistry concepts are applied by reading energy diagrams and mapping reactants, products, and enthalpy change.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Energy change and reaction rate are often confused when catalyst or temperature information appears together.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "方程式与实验条件混淆",
+        "忽略守恒关系或离子共存限制",
+        "实验结论没有对应现象和对照"
+      ],
+      "unit": "反应热",
+      "skills": [
+        "判断反应条件、现象和守恒关系",
+        "用方程式、离子方程式或结构式解释问题",
+        "检查实验变量、过量少量和数据单位"
+      ],
+      "question_types": [
+        "计算题",
+        "反应原理"
+      ],
+      "examples": [
+        {
+          "prompt": "利用两个热化学方程式求目标反应的焓变。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_experiment_design",
+      "name": "化学实验方案评价",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "化学实验",
+      "depth": 3,
+      "difficulty": 0.76,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chem_senior_experiment_variable_control",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Experiment design proceeds by identifying variables, controls, observations, and evaluation criteria.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_separation",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Designing a controlled experiment is often confused with choosing a separation or purification operation.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "方程式与实验条件混淆",
+        "忽略守恒关系或离子共存限制",
+        "实验结论没有对应现象和对照"
+      ],
+      "unit": "方案评价",
+      "skills": [
+        "判断反应条件、现象和守恒关系",
+        "用方程式、离子方程式或结构式解释问题",
+        "检查实验变量、过量少量和数据单位"
+      ],
+      "question_types": [
+        "实验探究",
+        "方案评价"
+      ],
+      "examples": [
+        {
+          "prompt": "评价除去 CO2 中少量 HCl 的实验方案，说明试剂选择和顺序。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只背反应结论，没有检查元素、电荷和电子守恒。",
+            "忽略反应条件、过量关系、离子共存或实验目的。",
+            "把现象、操作和结论之间的对应关系写反。"
+          ],
+          "grading_points": [
+            "能把题干信息转化为反应、守恒或实验流程。",
+            "关键方程式、条件和计算关系正确。",
+            "结论能用现象、数据或微粒变化支撑。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_chemistry",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_atomic_structure_periodic",
+      "name": "原子结构与元素周期律",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学物质结构",
+      "unit": "元素周期律",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_redox",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 氧化还原反应 before 原子结构与元素周期律; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_redox",
+          "relation": "co_occurs",
+          "reason": "Review 原子结构与元素周期律 together with 氧化还原反应 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_chemical_bonding",
+          "relation": "co_occurs",
+          "reason": "Review 原子结构与元素周期律 together with 化学键与晶体类型 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_chemical_bonding",
+          "relation": "procedure_step",
+          "reason": "Periodic position and valence electrons are checked before predicting bond type and crystal structure.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "structure",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_chemical_bonding",
+          "relation": "confusable",
+          "reason": "Periodic trends describe element behavior, while bonding and crystal type describe how particles are connected.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "structure",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据核外电子排布比较半径、金属性和非金属性。",
+          "answer_outline": [
+            "先判断题目属于原子结构与元素周期律的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_chemical_bonding",
+      "name": "化学键与晶体类型",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学物质结构",
+      "unit": "结构与性质",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_atomic_structure_periodic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 原子结构与元素周期律 before 化学键与晶体类型; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_atomic_structure_periodic",
+          "relation": "co_occurs",
+          "reason": "Review 化学键与晶体类型 together with 原子结构与元素周期律 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_material_structure_inference",
+          "relation": "co_occurs",
+          "reason": "Review 化学键与晶体类型 together with 结构性质信息推断 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_material_structure_inference",
+          "relation": "procedure_step",
+          "reason": "Bond type and crystal category are used before inferring melting point, conductivity, and solubility patterns.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "structure",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_atomic_structure_periodic",
+          "relation": "confusable",
+          "reason": "Atomic periodicity and chemical bonding are adjacent structure topics but answer different evidence questions.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "structure",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "判断离子键、共价键、分子间作用力和晶体性质。",
+          "answer_outline": [
+            "先判断题目属于化学键与晶体类型的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_material_structure_inference",
+      "name": "结构性质信息推断",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学物质结构",
+      "unit": "结构与性质",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_chemical_bonding",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 化学键与晶体类型 before 结构性质信息推断; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_chemical_bonding",
+          "relation": "co_occurs",
+          "reason": "Review 结构性质信息推断 together with 化学键与晶体类型 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "co_occurs",
+          "reason": "Review 结构性质信息推断 together with 过量与不足量计算 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "relation": "procedure_step",
+          "reason": "Structure-property inference narrows candidate substances before a broader unknown-substance conclusion is selected.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "structure",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_chemical_bonding",
+          "relation": "confusable",
+          "reason": "Bonding classification is source evidence, while structure-property inference uses that evidence to explain observations.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "structure",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "从新材料信息中提取结构单元并解释性质差异。",
+          "answer_outline": [
+            "先判断题目属于结构性质信息推断的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_stoichiometry_limiting",
+      "name": "过量与不足量计算",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学计量",
+      "unit": "物质的量",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_material_structure_inference",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_material_structure_inference before chem_senior_stoichiometry_limiting because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_material_structure_inference",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_material_structure_inference with chem_senior_stoichiometry_limiting because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        },
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_solution_concentration with chem_senior_stoichiometry_limiting because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        },
+        {
+          "id": "direct_proportion",
+          "relation": "application",
+          "reason": "Apply chem_senior_stoichiometry_limiting when solving direct_proportion tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "stoichiometry and solution",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "stoichiometric_ratio_scaling"
+          }
+        },
+        {
+          "id": "linear_equation_application",
+          "relation": "application",
+          "reason": "Apply chem_senior_stoichiometry_limiting when solving linear_equation_application tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "stoichiometry and solution",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "stoichiometry_linear_equation_application"
+          }
+        },
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "procedure_step",
+          "reason": "Find the limiting reagent before converting remaining amount into solution concentration.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        },
+        {
+          "id": "chem_senior_mole_calculation",
+          "relation": "confusable",
+          "reason": "Mole calculation converts quantities, while limiting-reagent questions compare competing reactants.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据反应方程式判断限制试剂并计算产物或剩余量。",
+          "answer_outline": [
+            "先判断题目属于过量与不足量计算的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_solution_concentration",
+      "name": "溶液浓度与稀释",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学计量",
+      "unit": "溶液",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_stoichiometry_limiting before chem_senior_solution_concentration because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_stoichiometry_limiting with chem_senior_solution_concentration because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        },
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_ion_coexistence with chem_senior_solution_concentration because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        },
+        {
+          "id": "primary_unit_conversion",
+          "relation": "application",
+          "reason": "Apply chem_senior_solution_concentration when solving primary_unit_conversion tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "stoichiometry and solution",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "solution_units_conversion"
+          }
+        },
+        {
+          "id": "primary_proportion_application",
+          "relation": "application",
+          "reason": "Apply chem_senior_solution_concentration when solving primary_proportion_application tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "stoichiometry and solution",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "dilution_proportion"
+          }
+        },
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "procedure_step",
+          "reason": "Convert concentration and amount data before judging whether ions can coexist.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        },
+        {
+          "id": "chem_senior_acid_base_titration",
+          "relation": "confusable",
+          "reason": "Concentration calculation is a tool, while titration adds endpoint and stoichiometric reaction judgment.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "stoichiometry and solution"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "进行物质的量浓度、质量分数和稀释混合计算。",
+          "answer_outline": [
+            "先判断题目属于溶液浓度与稀释的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_ion_coexistence",
+      "name": "离子共存判断",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "离子反应",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_solution_concentration before chem_senior_ion_coexistence because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_solution_concentration with chem_senior_ion_coexistence because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_ionic_equation_writing with chem_senior_ion_coexistence because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "procedure_step",
+          "reason": "Screen incompatible ions before writing a net ionic equation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_precipitation_equilibrium",
+          "relation": "confusable",
+          "reason": "Coexistence elimination uses strong reaction rules, while precipitation equilibrium compares ion product with Ksp.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "relation": "application",
+          "reason": "Ion coexistence checks narrow possible ions in unknown-substance inference.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "结合沉淀、气体、弱电解质和氧化还原判断共存。",
+          "answer_outline": [
+            "先判断题目属于离子共存判断的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_ionic_equation_writing",
+      "name": "离子方程式书写正误",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "离子反应",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_ion_coexistence before chem_senior_ionic_equation_writing because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_ion_coexistence with chem_senior_ionic_equation_writing because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_redox_balance",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_redox_balance with chem_senior_ionic_equation_writing because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_redox_balance",
+          "relation": "procedure_step",
+          "reason": "Write valid ionic species first, then balance charge and atoms in redox equations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "confusable",
+          "reason": "Coexistence asks whether ions can remain together, while ionic-equation writing records the actual reaction.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        },
+        {
+          "id": "chem_senior_redox_balance",
+          "relation": "application",
+          "reason": "Net ionic equations are used when balancing many aqueous redox reactions.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "ion reaction"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "从拆写、守恒和条件三个角度判断离子方程式。",
+          "answer_outline": [
+            "先判断题目属于离子方程式书写正误的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_redox_balance",
+      "name": "氧化还原配平",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "氧化还原",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_ionic_equation_writing before chem_senior_redox_balance because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "redox reaction"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_ionic_equation_writing with chem_senior_redox_balance because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "redox reaction"
+          }
+        },
+        {
+          "id": "chem_senior_redox_titration",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_redox_titration with chem_senior_redox_balance because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "redox reaction"
+          }
+        },
+        {
+          "id": "chem_senior_redox_titration",
+          "relation": "procedure_step",
+          "reason": "Balance electron transfer before using the equation in redox titration calculation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "redox reaction"
+          }
+        },
+        {
+          "id": "chem_senior_ionic_equation_writing",
+          "relation": "confusable",
+          "reason": "Ionic equations require species writing, while redox balance focuses on electron conservation.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "redox reaction"
+          }
+        },
+        {
+          "id": "chem_senior_redox_titration",
+          "relation": "application",
+          "reason": "Balanced redox equations provide stoichiometric ratios for titration endpoints.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "redox reaction"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用化合价升降和电子守恒配平反应。",
+          "answer_outline": [
+            "先判断题目属于氧化还原配平的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_redox_titration",
+      "name": "氧化还原滴定",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学实验",
+      "unit": "定量实验",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_redox_balance",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_redox_balance before chem_senior_redox_titration because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "quantitative experiment"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_redox_balance",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_redox_balance with chem_senior_redox_titration because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "quantitative experiment"
+          }
+        },
+        {
+          "id": "chem_senior_reaction_heat_diagram",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_reaction_heat_diagram with chem_senior_redox_titration because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "quantitative experiment"
+          }
+        },
+        {
+          "id": "chem_senior_redox_balance",
+          "relation": "procedure_step",
+          "reason": "Balance the redox equation before calculating titrant volume or sample purity.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "quantitative experiment"
+          }
+        },
+        {
+          "id": "chem_senior_acid_base_titration",
+          "relation": "confusable",
+          "reason": "Both use equivalence points, but redox titration tracks electron transfer instead of proton transfer.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "quantitative experiment"
+          }
+        },
+        {
+          "id": "chem_senior_experiment_variable_control",
+          "relation": "application",
+          "reason": "Redox titration data are used to evaluate experimental control, standardization, and endpoint error.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "quantitative experiment"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由滴定数据计算浓度并分析终点误差。",
+          "answer_outline": [
+            "先判断题目属于氧化还原滴定的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_reaction_heat_diagram",
+      "name": "反应热图像与盖斯定律",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "反应热",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_redox_titration",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_redox_titration before chem_senior_reaction_heat_diagram because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "thermochemistry"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_redox_titration",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_redox_titration with chem_senior_reaction_heat_diagram because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "thermochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_rate_factors with chem_senior_reaction_heat_diagram because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "thermochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "procedure_step",
+          "reason": "Read activation energy and enthalpy change before judging catalyst and rate effects.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "thermochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_redox_titration",
+          "relation": "confusable",
+          "reason": "Thermochemical diagrams track energy changes, while redox titration tracks electron-equivalent amounts.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "thermochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "application",
+          "reason": "Reaction heat diagrams help explain activation energy changes in rate-factor questions.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "thermochemistry"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "从能量图或热化学方程式求目标反应热。",
+          "answer_outline": [
+            "先判断题目属于反应热图像与盖斯定律的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_rate_factors",
+      "name": "化学反应速率影响因素",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "速率与平衡",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_reaction_heat_diagram",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_reaction_heat_diagram before chem_senior_rate_factors because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_reaction_heat_diagram",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_reaction_heat_diagram with chem_senior_rate_factors because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_equilibrium_constant",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_equilibrium_constant with chem_senior_rate_factors because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "reason": "Apply chem_senior_rate_factors when solving function_graph_reading tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "rate and equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "reaction_rate_graph_slope"
+          }
+        },
+        {
+          "id": "senior_function_monotonicity",
+          "relation": "application",
+          "reason": "Apply chem_senior_rate_factors when solving senior_function_monotonicity tasks that require this chemistry reasoning pattern.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "rate and equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "rate_factor_function_change"
+          }
+        },
+        {
+          "id": "chem_senior_equilibrium_constant",
+          "relation": "procedure_step",
+          "reason": "Analyze rate factors before judging whether equilibrium position or only reaching speed changes.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_reaction_heat_diagram",
+          "relation": "confusable",
+          "reason": "Catalysts change rate and pathway activation energy, not the reaction enthalpy difference.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "判断浓度、温度、压强和催化剂对速率的影响。",
+          "answer_outline": [
+            "先判断题目属于化学反应速率影响因素的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_equilibrium_constant",
+      "name": "平衡常数与转化率",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "速率与平衡",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_rate_factors before chem_senior_equilibrium_constant because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_rate_factors with chem_senior_equilibrium_constant because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_equilibrium_graph",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_equilibrium_graph with chem_senior_equilibrium_constant because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "senior_function_modeling",
+          "relation": "application",
+          "reason": "Apply chem_senior_equilibrium_constant when solving senior_function_modeling tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "rate and equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "equilibrium_constant_function_model"
+          }
+        },
+        {
+          "id": "inverse_function_graph",
+          "relation": "application",
+          "reason": "Apply chem_senior_equilibrium_constant when solving inverse_function_graph tasks that require this chemistry reasoning pattern.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "rate and equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "equilibrium_ratio_inverse_variation"
+          }
+        },
+        {
+          "id": "chem_senior_equilibrium_graph",
+          "relation": "procedure_step",
+          "reason": "Calculate K or Q first, then use graph changes to judge shift direction and final state.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "confusable",
+          "reason": "Rate factors explain how fast equilibrium is reached, while K describes composition at equilibrium.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "列三段式计算平衡常数、转化率和浓度。",
+          "answer_outline": [
+            "先判断题目属于平衡常数与转化率的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_equilibrium_graph",
+      "name": "平衡图像综合",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "速率与平衡",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_equilibrium_constant",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_equilibrium_constant before chem_senior_equilibrium_graph because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_equilibrium_constant",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_equilibrium_constant with chem_senior_equilibrium_graph because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_acid_base_titration",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_acid_base_titration with chem_senior_equilibrium_graph because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "reason": "Apply chem_senior_equilibrium_graph when solving function_graph_reading tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "rate and equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "equilibrium_graph_interpretation"
+          }
+        },
+        {
+          "id": "senior_function_zero",
+          "relation": "application",
+          "reason": "Apply chem_senior_equilibrium_graph when solving senior_function_zero tasks that require this chemistry reasoning pattern.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "rate and equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "equilibrium_net_change_zero"
+          }
+        },
+        {
+          "id": "chem_senior_equilibrium_constant",
+          "relation": "procedure_step",
+          "reason": "Read concentration changes from the graph, then connect them to Q and K.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "confusable",
+          "reason": "Graph slope and time-to-equilibrium reflect rate, while plateau ratios reflect equilibrium composition.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "rate and equilibrium"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由速率或浓度图像判断平衡移动和条件变化。",
+          "answer_outline": [
+            "先判断题目属于平衡图像综合的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_acid_base_titration",
+      "name": "酸碱中和滴定",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "水溶液",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_equilibrium_graph",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_equilibrium_graph before chem_senior_acid_base_titration because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_equilibrium_graph",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_equilibrium_graph with chem_senior_acid_base_titration because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_ph_ionization",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_ph_ionization with chem_senior_acid_base_titration because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "reason": "Apply chem_senior_acid_base_titration when solving function_graph_reading tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "aqueous equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "titration_curve_graph_reading"
+          }
+        },
+        {
+          "id": "linear_function_intersection",
+          "relation": "application",
+          "reason": "Apply chem_senior_acid_base_titration when solving linear_function_intersection tasks that require this chemistry reasoning pattern.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "aqueous equilibrium",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "titration_endpoint_intersection"
+          }
+        },
+        {
+          "id": "chem_senior_ph_ionization",
+          "relation": "procedure_step",
+          "reason": "Use ionization and pH judgment before interpreting the titration curve and endpoint.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_precipitation_equilibrium",
+          "relation": "confusable",
+          "reason": "Both use solution equilibria, but titration tracks neutralization stoichiometry and endpoint selection.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "选择指示剂、读取滴定数据并分析误差方向。",
+          "answer_outline": [
+            "先判断题目属于酸碱中和滴定的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_ph_ionization",
+      "name": "弱电解质电离与 pH",
+      "aliases": [
+        "pH计算",
+        "pH",
+        "pH怎么计算",
+        "弱电解质电离",
+        "电离平衡"
+      ],
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "水溶液",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_acid_base_titration",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 酸碱中和滴定 before 弱电解质电离与 pH; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_acid_base_titration",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "pH 计算通常要先判断酸碱强弱、过量关系和电荷守恒，再代入浓度关系。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chem_senior_mole_calculation",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "pH 计算会用到物质的量，但核心判断是电离、水解和氢离子浓度。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chem_senior_precipitation_equilibrium",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "沉淀溶解平衡题常和溶液 pH、离子浓度变化一起出现。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chem_senior_acid_base_titration",
+          "relation": "co_occurs",
+          "reason": "Review 弱电解质电离与 pH together with 酸碱中和滴定 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_precipitation_equilibrium",
+          "relation": "co_occurs",
+          "reason": "Review 弱电解质电离与 pH together with 沉淀溶解平衡 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "senior_logarithm_operation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.92,
+          "reason": "pH calculations apply logarithm operations because pH is the negative base-ten log of hydrogen-ion concentration.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "ph_logarithm_operation"
+          }
+        },
+        {
+          "id": "senior_logarithmic_function",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Ionization-equilibrium graphs apply logarithmic-function intuition when concentration changes shift pH nonlinearly.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "ph_logarithmic_function_graph"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "比较弱酸弱碱电离、盐类水解和 pH 变化。",
+          "answer_outline": [
+            "先判断题目属于弱电解质电离与 pH的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_precipitation_equilibrium",
+      "name": "沉淀溶解平衡",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "水溶液",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_ph_ionization",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_ph_ionization before chem_senior_precipitation_equilibrium because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_ph_ionization",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_ph_ionization with chem_senior_precipitation_equilibrium because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_primary_battery",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_primary_battery with chem_senior_precipitation_equilibrium because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "procedure_step",
+          "reason": "Check common precipitating ion pairs before deciding whether an equilibrium calculation is needed.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_ion_coexistence",
+          "relation": "confusable",
+          "reason": "Ion coexistence often treats precipitation as complete, while Ksp questions require equilibrium judgment.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        },
+        {
+          "id": "chem_senior_acid_base_titration",
+          "relation": "application",
+          "reason": "Precipitation equilibrium supports endpoint interference and ion-removal analysis in titration contexts.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "aqueous equilibrium"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "利用 Ksp 判断沉淀生成、转化和溶解。",
+          "answer_outline": [
+            "先判断题目属于沉淀溶解平衡的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_primary_battery",
+      "name": "原电池原理与电极判断",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "电化学",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_precipitation_equilibrium",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_precipitation_equilibrium before chem_senior_primary_battery because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_precipitation_equilibrium",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_precipitation_equilibrium with chem_senior_primary_battery because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_electrolysis_product",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_electrolysis_product with chem_senior_primary_battery because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_electrolysis_product",
+          "relation": "procedure_step",
+          "reason": "Distinguish anode and cathode rules in primary cells before comparing them with electrolysis products.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_electrolysis_product",
+          "relation": "confusable",
+          "reason": "Primary batteries are spontaneous galvanic cells, while electrolysis is driven by external current.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_electrochem_calculation",
+          "relation": "application",
+          "reason": "Primary battery electrode reactions provide electron counts for electrochemical calculation.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "判断正负极、电极反应和电子/离子移动方向。",
+          "answer_outline": [
+            "先判断题目属于原电池原理与电极判断的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_electrolysis_product",
+      "name": "电解产物判断",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "电化学",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_primary_battery",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_primary_battery before chem_senior_electrolysis_product because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_primary_battery",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_primary_battery with chem_senior_electrolysis_product because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_electrochem_calculation",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_electrochem_calculation with chem_senior_electrolysis_product because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_electrochem_calculation",
+          "relation": "procedure_step",
+          "reason": "Determine products before using electron transfer amounts in electrochemical calculation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_primary_battery",
+          "relation": "confusable",
+          "reason": "Students often mix galvanic-cell spontaneous electrodes with electrolytic forced electrodes.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_electrochem_calculation",
+          "relation": "application",
+          "reason": "Electrolysis product rules support charge, gas volume, and deposited mass calculations.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据放电顺序和电极材料判断电解产物。",
+          "answer_outline": [
+            "先判断题目属于电解产物判断的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_electrochem_calculation",
+      "name": "电化学定量计算",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学反应原理",
+      "unit": "电化学",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_electrolysis_product",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_electrolysis_product before chem_senior_electrochem_calculation because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_electrolysis_product",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_electrolysis_product with chem_senior_electrochem_calculation because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_organic_isomer",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_organic_isomer with chem_senior_electrochem_calculation because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "linear_function_concept",
+          "relation": "application",
+          "reason": "Apply chem_senior_electrochem_calculation when solving linear_function_concept tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "electrochemistry",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "electrochemistry_linear_charge_relation"
+          }
+        },
+        {
+          "id": "primary_unit_conversion",
+          "relation": "application",
+          "reason": "Apply chem_senior_electrochem_calculation when solving primary_unit_conversion tasks that require this chemistry reasoning pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "math",
+            "chapter_focus": "electrochemistry",
+            "bridge_direction": "chemistry_to_math",
+            "bridge_focus": "electrochemistry_unit_conversion"
+          }
+        },
+        {
+          "id": "chem_senior_electrolysis_product",
+          "relation": "procedure_step",
+          "reason": "Identify electrode products before converting electrons to gas volume or deposited mass.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "confusable",
+          "reason": "Both use mole ratios, but electrochemical calculation routes through electron amount and charge.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "electrochemistry"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用电子守恒和法拉第关系计算质量、气体或电量。",
+          "answer_outline": [
+            "先判断题目属于电化学定量计算的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_organic_isomer",
+      "name": "有机同分异构体",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学有机化学",
+      "unit": "结构与性质",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_electrochem_calculation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 电化学定量计算 before 有机同分异构体; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_electrochem_calculation",
+          "relation": "co_occurs",
+          "reason": "Review 有机同分异构体 together with 电化学定量计算 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_organic_reaction_route",
+          "relation": "co_occurs",
+          "reason": "Review 有机同分异构体 together with 有机合成路线推断 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_organic_reaction_route",
+          "relation": "procedure_step",
+          "reason": "Enumerating valid isomers is a step before selecting intermediates in an organic synthesis route.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "organic",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_organic_functional_group",
+          "relation": "confusable",
+          "reason": "Functional-group recognition identifies reactive sites, while isomer counting also tracks carbon skeleton and position.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "organic",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据官能团、碳链和位置关系枚举同分异构体。",
+          "answer_outline": [
+            "先判断题目属于有机同分异构体的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_organic_reaction_route",
+      "name": "有机合成路线推断",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学有机化学",
+      "unit": "合成推断",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_organic_isomer",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 有机同分异构体 before 有机合成路线推断; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_organic_isomer",
+          "relation": "co_occurs",
+          "reason": "Review 有机合成路线推断 together with 有机同分异构体 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_organic_polymer",
+          "relation": "co_occurs",
+          "reason": "Review 有机合成路线推断 together with 高分子与聚合反应 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_organic_polymer",
+          "relation": "procedure_step",
+          "reason": "Functional-group conversion reasoning supports identifying monomers and repeat units in polymer problems.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "organic",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_organic_isomer",
+          "relation": "confusable",
+          "reason": "Route inference asks for reaction order and conditions, not only all structures with the same formula.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "organic",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由官能团转化关系补全反应条件和中间体。",
+          "answer_outline": [
+            "先判断题目属于有机合成路线推断的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_organic_polymer",
+      "name": "高分子与聚合反应",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学有机化学",
+      "unit": "材料与高分子",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_organic_reaction_route",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 有机合成路线推断 before 高分子与聚合反应; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_organic_reaction_route",
+          "relation": "co_occurs",
+          "reason": "Review 高分子与聚合反应 together with 有机合成路线推断 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_separation",
+          "relation": "co_occurs",
+          "reason": "Review 高分子与聚合反应 together with 物质分离提纯实验 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_organic_reaction_route",
+          "relation": "procedure_step",
+          "reason": "Tracing a repeat unit back to monomers is a step in many organic route inference tasks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "organic",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_organic_reaction_route",
+          "relation": "confusable",
+          "reason": "Polymer questions focus on addition or condensation patterns, while route questions may include many small-molecule conversions.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "organic",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "识别加聚、缩聚单体和结构单元。",
+          "answer_outline": [
+            "先判断题目属于高分子与聚合反应的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_experiment_separation",
+      "name": "物质分离提纯实验",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学实验",
+      "unit": "实验操作",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_organic_polymer",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 高分子与聚合反应 before 物质分离提纯实验; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_organic_polymer",
+          "relation": "co_occurs",
+          "reason": "Review 物质分离提纯实验 together with 高分子与聚合反应 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_gas",
+          "relation": "co_occurs",
+          "reason": "Review 物质分离提纯实验 together with 气体制备与检验 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_gas",
+          "relation": "procedure_step",
+          "reason": "Separation and purification choices come before deciding gas drying, collection, and impurity-removal steps.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "experiment",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_experiment_gas",
+          "relation": "confusable",
+          "reason": "Separation operations isolate mixtures, while gas preparation problems center on generation, purification, collection, and testing.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "experiment",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "选择过滤、蒸馏、萃取、结晶等操作并说明依据。",
+          "answer_outline": [
+            "先判断题目属于物质分离提纯实验的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_experiment_gas",
+      "name": "气体制备与检验",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学实验",
+      "unit": "实验操作",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_experiment_separation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 物质分离提纯实验 before 气体制备与检验; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_experiment_separation",
+          "relation": "co_occurs",
+          "reason": "Review 气体制备与检验 together with 物质分离提纯实验 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_variable_control",
+          "relation": "co_occurs",
+          "reason": "Review 气体制备与检验 together with 实验变量控制与评价 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_variable_control",
+          "relation": "procedure_step",
+          "reason": "Gas preparation plans must control reagent amount, gas flow, drying, and tail-gas handling before evaluation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "experiment",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_junior_gas_preparation",
+          "relation": "confusable",
+          "reason": "Senior gas experiment items extend junior gas preparation with impurity removal, safety, and device evaluation.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "experiment",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "设计气体发生、净化、收集和尾气处理流程。",
+          "answer_outline": [
+            "先判断题目属于气体制备与检验的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_experiment_variable_control",
+      "name": "实验变量控制与评价",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学实验",
+      "unit": "方案评价",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_experiment_gas",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 气体制备与检验 before 实验变量控制与评价; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_experiment_gas",
+          "relation": "co_occurs",
+          "reason": "Review 实验变量控制与评价 together with 气体制备与检验 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_industrial_process_flow",
+          "relation": "co_occurs",
+          "reason": "Review 实验变量控制与评价 together with 工业流程信息题 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_experiment_design",
+          "relation": "procedure_step",
+          "reason": "Identifying independent, dependent, and controlled variables is a core step in judging an experiment design.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "experiment",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_experiment_gas",
+          "relation": "confusable",
+          "reason": "A gas apparatus detail may be evidence, but variable-control questions ask what is changed, measured, or held constant.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "experiment",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "识别对照、变量和干扰因素并评价方案可行性。",
+          "answer_outline": [
+            "先判断题目属于实验变量控制与评价的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_industrial_process_flow",
+      "name": "工业流程信息题",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学综合",
+      "unit": "工业流程",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_experiment_variable_control",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 实验变量控制与评价 before 工业流程信息题; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_experiment_variable_control",
+          "relation": "co_occurs",
+          "reason": "Review 工业流程信息题 together with 实验变量控制与评价 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "relation": "co_occurs",
+          "reason": "Review 工业流程信息题 together with 无机物推断综合 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "relation": "procedure_step",
+          "reason": "Reading each transformation in a process flow is a step before inferring substances from reactions and products.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_experiment_variable_control",
+          "relation": "confusable",
+          "reason": "Process-flow questions track recycle, conversion, and separation logic, not only one controlled laboratory variable.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "从流程图中提取除杂、转化、循环和产品分离逻辑。",
+          "answer_outline": [
+            "先判断题目属于工业流程信息题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_unknown_substance_inference",
+      "name": "无机物推断综合",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学综合",
+      "unit": "推断综合",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_industrial_process_flow",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 工业流程信息题 before 无机物推断综合; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_industrial_process_flow",
+          "relation": "co_occurs",
+          "reason": "Review 无机物推断综合 together with 工业流程信息题 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_data_table_reasoning",
+          "relation": "co_occurs",
+          "reason": "Review 无机物推断综合 together with 化学数据表格推理 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_data_table_reasoning",
+          "relation": "procedure_step",
+          "reason": "Substance inference often converts color, precipitate, and gas clues into a table of possible identities.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_industrial_process_flow",
+          "relation": "confusable",
+          "reason": "Unknown-substance inference follows evidence clues, while process-flow tasks emphasize staged production and separation decisions.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据颜色、沉淀、气体和转化关系推断物质。",
+          "answer_outline": [
+            "先判断题目属于无机物推断综合的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_data_table_reasoning",
+      "name": "化学数据表格推理",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学综合",
+      "unit": "信息题",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 无机物推断综合 before 化学数据表格推理; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "relation": "co_occurs",
+          "reason": "Review 化学数据表格推理 together with 无机物推断综合 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_green_chemistry_context",
+          "relation": "co_occurs",
+          "reason": "Review 化学数据表格推理 together with 绿色化学与情境应用 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_green_chemistry_context",
+          "relation": "procedure_step",
+          "reason": "Data-table comparison supports evaluating yield, atom economy, emissions, and energy use in real contexts.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "relation": "confusable",
+          "reason": "Data-table reasoning compares trends and constraints, while unknown-substance inference identifies species from diagnostic evidence.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用表格数据比较趋势并建立定量或定性结论。",
+          "answer_outline": [
+            "先判断题目属于化学数据表格推理的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_green_chemistry_context",
+      "name": "绿色化学与情境应用",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学综合",
+      "unit": "真实情境",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_data_table_reasoning",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 化学数据表格推理 before 绿色化学与情境应用; it supplies the foundation for this chemistry learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_data_table_reasoning",
+          "relation": "co_occurs",
+          "reason": "Review 绿色化学与情境应用 together with 化学数据表格推理 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_exam_synthesis_strategy",
+          "relation": "co_occurs",
+          "reason": "Review 绿色化学与情境应用 together with 化学压轴综合策略 when diagnosing adjacent chemistry skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chem_senior_exam_synthesis_strategy",
+          "relation": "procedure_step",
+          "reason": "Green-chemistry checks are a final step when evaluating real-context synthesis and industrial-process answers.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        },
+        {
+          "id": "chem_senior_data_table_reasoning",
+          "relation": "confusable",
+          "reason": "Green-chemistry context asks for environmental and resource evaluation, not just extracting a numerical table trend.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "synthesis",
+            "batch": "chemistry_ready_gap_2026_06"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "结合原子利用率、污染控制和能源利用评价方案。",
+          "answer_outline": [
+            "先判断题目属于绿色化学与情境应用的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chem_senior_exam_synthesis_strategy",
+      "name": "化学压轴综合策略",
+      "subject": "chemistry",
+      "stage": "senior_high",
+      "chapter": "高中化学综合",
+      "unit": "压轴策略",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chem_senior_green_chemistry_context",
+          "relation": "prerequisite",
+          "reason": "Master chem_senior_green_chemistry_context before chem_senior_exam_synthesis_strategy because it supplies the core concepts and checks used in this topic.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "exam synthesis"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "chem_senior_green_chemistry_context",
+          "relation": "co_occurs",
+          "reason": "Practice chem_senior_green_chemistry_context with chem_senior_exam_synthesis_strategy because exam items often combine these ideas in one reasoning chain.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "exam synthesis"
+          }
+        },
+        {
+          "id": "chem_senior_industrial_process_flow",
+          "relation": "procedure_step",
+          "reason": "Use a synthesis plan: read the context, mark key reactions, track quantities, then validate feasibility.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "exam synthesis"
+          }
+        },
+        {
+          "id": "chem_senior_data_table_reasoning",
+          "relation": "confusable",
+          "reason": "Both use dense information, but synthesis strategy plans the whole path while table reasoning extracts local constraints.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "exam synthesis"
+          }
+        },
+        {
+          "id": "chem_senior_unknown_substance_inference",
+          "relation": "application",
+          "reason": "Exam synthesis strategy is applied to multi-step unknown-substance inference questions.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chemistry",
+            "target_subject": "chemistry",
+            "chapter_focus": "exam synthesis"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论但没有守恒、电荷和条件校验",
+        "忽略反应条件、过量关系或离子共存限制",
+        "把实验现象、操作目的和结论对应错位"
+      ],
+      "skills": [
+        "从微粒、守恒和能量变化三个角度分析反应",
+        "把题干条件转成方程、图像或实验流程",
+        "用电荷守恒、元素守恒和现象一致性校验答案"
+      ],
+      "question_types": [
+        "信息推断",
+        "综合应用"
+      ],
+      "examples": [
+        {
+          "prompt": "把平衡、电化学、实验或流程题拆成守恒和条件链条。",
+          "answer_outline": [
+            "先判断题目属于化学压轴综合策略的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用化学核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chemistry",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_chemistry"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
@@ -150,17 +150,7 @@
       "chapter": "语文基础",
       "depth": 1,
       "difficulty": 0.34,
-      "prerequisites": [],
-      "related": [
-        {
-          "id": "chinese_primary_paragraph_main_idea",
-          "relation": "next",
-          "reason": "Practice 段落主要内容 after 扩句缩句; it is the next topic in the primary chinese learning sequence.",
-          "use_cases": [
-            "learning_path",
-            "practice_planning"
-          ]
-        },
+      "prerequisites": [
         {
           "id": "chinese_primary_pinyin_character",
           "relation": "prerequisite",
@@ -178,6 +168,17 @@
             "target_subject": "chinese",
             "validation_batch": "chinese_ready_core_relations_2026_06_26"
           }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_primary_paragraph_main_idea",
+          "relation": "next",
+          "reason": "Practice 段落主要内容 after 扩句缩句; it is the next topic in the primary chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
         },
         {
           "id": "chinese_primary_paragraph_main_idea",

--- a/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
@@ -362,7 +362,7 @@
         },
         {
           "id": "chinese_junior_narrative_reading",
-          "relation": "prerequisite",
+          "relation": "extends",
           "reason": "Finding a paragraph main idea prepares students to track events, character changes, and emotion in junior narrative reading.",
           "priority": "core",
           "context": "explanation",

--- a/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
@@ -1,0 +1,7699 @@
+{
+  "version": "1.0",
+  "subject": "chinese",
+  "topics": [
+    {
+      "id": "chinese_primary_pinyin_character",
+      "name": "拼音与识字",
+      "subject": "chinese",
+      "stage": "primary",
+      "chapter": "语文基础",
+      "depth": 1,
+      "difficulty": 0.22,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_primary_sentence_expansion",
+          "relation": "next",
+          "reason": "Practice 扩句缩句 after 拼音与识字; it is the next topic in the primary chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_primary_sentence_expansion",
+          "relation": "prerequisite",
+          "reason": "Pinyin and character recognition supply the decoding base for sentence expansion and short text work.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_primary_sentence_expansion",
+          "relation": "procedure_step",
+          "reason": "Read the sound, confirm the character meaning, then use the word accurately in an expanded sentence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "english_primary_phonics",
+          "relation": "confusable",
+          "reason": "Both train sound-symbol mapping, but pinyin supports Chinese character reading while phonics supports alphabetic decoding.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "english_primary_phonics",
+          "relation": "application",
+          "reason": "Initial-final and tone awareness can help students compare sound-symbol rules when learning English phonics.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "字词句段",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "基础积累",
+        "字音字形"
+      ],
+      "examples": [
+        {
+          "prompt": "给一组多音字注音并根据语境组词。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "chinese_primary_sentence_expansion",
+      "name": "扩句缩句",
+      "subject": "chinese",
+      "stage": "primary",
+      "chapter": "语文基础",
+      "depth": 1,
+      "difficulty": 0.34,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_primary_paragraph_main_idea",
+          "relation": "next",
+          "reason": "Practice 段落主要内容 after 扩句缩句; it is the next topic in the primary chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_primary_pinyin_character",
+          "relation": "prerequisite",
+          "reason": "Accurate character reading and word meaning are needed before adding modifiers to a sentence.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_primary_paragraph_main_idea",
+          "relation": "procedure_step",
+          "reason": "Expand a basic sentence with who, when, where, and how details before judging paragraph focus.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_primary_paragraph_main_idea",
+          "relation": "confusable",
+          "reason": "Sentence expansion adds concrete details, while paragraph main idea removes details to keep the central point.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_primary_observation_writing",
+          "relation": "application",
+          "reason": "Expanded sentences become usable detail sentences in observation writing.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "relation": "extends",
+          "reason": "Sentence expansion and contraction are early forms of sentence control before senior rewrite and imitation tasks.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_internal_bridge_2026_06_28",
+            "bridge_focus": "primary_sentence_control_to_senior_rewrite"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "字词句段",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "句子训练",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "把“花开了”扩写成包含时间、地点、颜色和感受的句子。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "chinese_primary_paragraph_main_idea",
+      "name": "段落主要内容",
+      "subject": "chinese",
+      "stage": "primary",
+      "chapter": "语文基础",
+      "depth": 1,
+      "difficulty": 0.38,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_primary_sentence_expansion",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Paragraph main idea tasks are often confused with sentence expansion tasks because both ask students to process wording, but one summarizes while the other elaborates.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_primary_observation_writing",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Summarizing a paragraph helps students select key details before turning observations into a short composition.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_primary_observation_writing",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After identifying the main idea, students can organize selected details into a coherent observation-writing paragraph.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_primary_observation_writing",
+          "relation": "next",
+          "reason": "Practice 观察作文 after 段落主要内容; it is the next topic in the primary chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_junior_narrative_reading",
+          "relation": "prerequisite",
+          "reason": "Finding a paragraph main idea prepares students to track events, character changes, and emotion in junior narrative reading.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_internal_bridge_2026_06_28",
+            "bridge_focus": "primary_main_idea_to_junior_narrative_reading"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_material_review",
+          "relation": "application",
+          "reason": "Observation writing trains selecting concrete details, which later supports reviewing and organizing composition materials.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_internal_bridge_2026_06_28",
+            "bridge_focus": "primary_observation_to_senior_composition_material"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "字词句段",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "现代文阅读",
+        "概括题"
+      ],
+      "examples": [
+        {
+          "prompt": "读一段写景文字，用一句话概括主要内容。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "chinese_primary_observation_writing",
+      "name": "观察作文",
+      "subject": "chinese",
+      "stage": "primary",
+      "chapter": "语文基础",
+      "depth": 2,
+      "difficulty": 0.44,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_primary_sentence_expansion",
+          "relation": "prerequisite",
+          "reason": "Observation writing needs sentence expansion so details can be written clearly instead of listed loosely.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_primary_sentence_expansion",
+          "relation": "procedure_step",
+          "reason": "Turn observed objects, order, and feelings into expanded sentences before forming a paragraph.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_primary_paragraph_main_idea",
+          "relation": "confusable",
+          "reason": "Observation writing develops selected details, while paragraph main idea summarizes a text in one focused statement.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "english_primary_picture_writing",
+          "relation": "application",
+          "reason": "The observe-select-order-write routine transfers to English picture writing tasks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.81,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "字词句段",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "习作",
+        "观察表达"
+      ],
+      "examples": [
+        {
+          "prompt": "写一段观察植物变化的短文，包含顺序、细节和感受。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "chinese_junior_narrative_reading",
+      "name": "记叙文阅读",
+      "subject": "chinese",
+      "stage": "junior_high",
+      "chapter": "现代文阅读",
+      "depth": 2,
+      "difficulty": 0.54,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_junior_expository_reading",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Narrative reading asks about events, characters, and emotion, while expository reading asks about object features and explanation methods.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_image",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Narrative reading skills transfer to character-image analysis because both rely on actions, language, psychology, and context evidence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Narrative reading answers should move from locating plot evidence to naming character or emotion, then formatting the response by points.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_junior_expository_reading",
+          "relation": "next",
+          "reason": "Practice 说明文阅读 after 记叙文阅读; it is the next topic in the junior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "阅读方法",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "现代文阅读",
+        "人物形象"
+      ],
+      "examples": [
+        {
+          "prompt": "分析人物一次选择背后的性格特点，并找出两处文本依据。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chinese_junior_expository_reading",
+      "name": "说明文阅读",
+      "subject": "chinese",
+      "stage": "junior_high",
+      "chapter": "现代文阅读",
+      "depth": 2,
+      "difficulty": 0.52,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_junior_argumentative_reading",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Expository reading explains objects and methods, while argumentative reading tracks claims, reasons, and evidence.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Expository reading prepares students to filter factual information and match textual details to task requirements.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After extracting explanation targets and key features, students can compress the passage into a concise summary.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_junior_argumentative_reading",
+          "relation": "next",
+          "reason": "Practice 议论文阅读 after 说明文阅读; it is the next topic in the junior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "阅读方法",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "说明文阅读",
+        "说明方法"
+      ],
+      "examples": [
+        {
+          "prompt": "判断文中使用的说明方法，并说明它如何帮助读者理解对象。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chinese_junior_argumentative_reading",
+      "name": "议论文阅读",
+      "subject": "chinese",
+      "stage": "junior_high",
+      "chapter": "现代文阅读",
+      "depth": 2,
+      "difficulty": 0.58,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_junior_expository_reading",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Argumentative reading focuses on claims and proof, which students often confuse with expository object-feature explanation.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_argument",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Understanding argument structure supports later argumentative writing and helps students build claims with evidence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After identifying the central claim, students should map supporting points and the order of reasoning.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_junior_classical_function_words",
+          "relation": "next",
+          "reason": "Practice 文言虚词 after 议论文阅读; it is the next topic in the junior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Argumentative reading trains claim-evidence-reasoning checks that transfer to political logic questions and structured material answers.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "politics",
+            "bridge_direction": "chinese_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "阅读方法",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "议论文阅读",
+        "论证思路"
+      ],
+      "examples": [
+        {
+          "prompt": "找出中心论点、分论点和论证方法，概括论证思路。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chinese_junior_classical_function_words",
+      "name": "文言虚词",
+      "subject": "chinese",
+      "stage": "junior_high",
+      "chapter": "现代文阅读",
+      "depth": 2,
+      "difficulty": 0.6,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_classical_function_words",
+          "relation": "prerequisite",
+          "reason": "Junior function-word usage prepares students for denser senior classical function-word analysis.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "procedure_step",
+          "reason": "Mark each function word by sentence role before translating the clause.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_content_words",
+          "relation": "confusable",
+          "reason": "Function words show grammar relations, while content words carry lexical meaning and historical sense shifts.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "application",
+          "reason": "Reading classical function words helps students use short classical source excerpts in cultural exchange analysis.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "阅读方法",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "文言文阅读",
+        "词义辨析"
+      ],
+      "examples": [
+        {
+          "prompt": "解释“之、其、而、以”在不同句子中的用法。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "chinese_senior_literary_text",
+      "name": "文学类文本阅读",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "procedure_step",
+          "reason": "Question review should lead to evidence location, then structured answer points for literary-text reading.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_image",
+          "relation": "application",
+          "reason": "Literary-text reading applies to character image analysis because plot, action, and narration provide evidence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_practical_text",
+          "relation": "confusable",
+          "reason": "Literary text asks about theme, image, emotion, and technique, while practical text asks for factual information and task matching.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "高考阅读写作",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "文学类阅读",
+        "作用题"
+      ],
+      "examples": [
+        {
+          "prompt": "分析小说中环境描写对人物心理和主题表达的作用。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ],
+          "common_traps": [
+            "只摘原文词句，没有归纳分析角度。",
+            "忽略文本语境、表达手法和题干限定。",
+            "作文观点泛化，材料扣合、论据分析和结构层次不足。"
+          ],
+          "grading_points": [
+            "答题角度明确，能回到文本或材料依据。",
+            "概括、分析和作用说明层次清楚。",
+            "语言规范，分点完整，扣合题干任务。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_chinese",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_practical_text",
+      "name": "实用类文本阅读",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_poetry_appreciation",
+          "relation": "next",
+          "reason": "Practice 古诗词鉴赏 after 实用类文本阅读; it is the next topic in the senior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "procedure_step",
+          "reason": "Question review should lead to locating task-relevant facts, then grouping information into concise answer points.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_new_gaokao_mixed_text",
+          "relation": "application",
+          "reason": "Practical-text reading supports mixed-text tasks because students must compare sources and integrate task-matched information.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_text",
+          "relation": "confusable",
+          "reason": "Practical text focuses on information filtering, which students often confuse with literary theme and emotion analysis.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "高考阅读写作",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "信息类阅读",
+        "材料整合"
+      ],
+      "examples": [
+        {
+          "prompt": "整合两则材料，概括某项政策的背景、措施和效果。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ],
+          "common_traps": [
+            "只摘原文词句，没有归纳分析角度。",
+            "忽略文本语境、表达手法和题干限定。",
+            "作文观点泛化，材料扣合、论据分析和结构层次不足。"
+          ],
+          "grading_points": [
+            "答题角度明确，能回到文本或材料依据。",
+            "概括、分析和作用说明层次清楚。",
+            "语言规范，分点完整，扣合题干任务。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_chinese",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_poetry_appreciation",
+      "name": "古诗词鉴赏",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_composition_argument",
+          "relation": "next",
+          "reason": "Practice 议论文写作 after 古诗词鉴赏; it is the next topic in the senior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_image_emotion",
+          "relation": "procedure_step",
+          "reason": "Question review should locate images and wording, connect them to emotion, then form structured appreciation points.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "application",
+          "reason": "Poetry appreciation uses image and emotion analysis before explaining expression techniques and their effects.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "confusable",
+          "reason": "Students often name a technique when the prompt asks for emotion, or state emotion without explaining the technique effect.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "高考阅读写作",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "诗歌鉴赏",
+        "情感手法"
+      ],
+      "examples": [
+        {
+          "prompt": "分析诗句中的意象、炼字和情感转折。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ],
+          "common_traps": [
+            "只摘原文词句，没有归纳分析角度。",
+            "忽略文本语境、表达手法和题干限定。",
+            "作文观点泛化，材料扣合、论据分析和结构层次不足。"
+          ],
+          "grading_points": [
+            "答题角度明确，能回到文本或材料依据。",
+            "概括、分析和作用说明层次清楚。",
+            "语言规范，分点完整，扣合题干任务。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_chinese",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_composition_argument",
+      "name": "议论文写作",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文",
+      "depth": 3,
+      "difficulty": 0.72,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_language_use",
+          "relation": "next",
+          "reason": "Practice 语言文字运用 after 议论文写作; it is the next topic in the senior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_material_review",
+          "relation": "procedure_step",
+          "reason": "Argument writing should begin with prompt review, constraint extraction, and a focused arguable claim.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "relation": "application",
+          "reason": "A clear argument becomes stronger when students choose evidence and analyze how it proves the claim.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_task_driven_writing",
+          "relation": "confusable",
+          "reason": "General argument writing can be confused with task-driven writing that requires role, audience, and situation constraints.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "高考阅读写作",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "作文",
+        "论证结构"
+      ],
+      "examples": [
+        {
+          "prompt": "围绕“技术与人的成长”写议论文提纲，包含论点、分论点和材料。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ],
+          "common_traps": [
+            "只摘原文词句，没有归纳分析角度。",
+            "忽略文本语境、表达手法和题干限定。",
+            "作文观点泛化，材料扣合、论据分析和结构层次不足。"
+          ],
+          "grading_points": [
+            "答题角度明确，能回到文本或材料依据。",
+            "概括、分析和作用说明层次清楚。",
+            "语言规范，分点完整，扣合题干任务。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_chinese",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_language_use",
+      "name": "语言文字运用",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文",
+      "depth": 2,
+      "difficulty": 0.6,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "next",
+          "reason": "Practice 文言翻译 after 语言文字运用; it is the next topic in the senior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "procedure_step",
+          "reason": "Question review should identify the requested form, locate key language material, then organize the answer by rule.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "application",
+          "reason": "Language-use tasks improve structured answer habits because wording, order, and constraints must all be checked.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_error_correction",
+          "relation": "confusable",
+          "reason": "Language-use prompts may ask for expression, cohesion, compression, or correction, so the task type must be separated first.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈主题",
+        "文言词义只记现代义，忽略语境",
+        "作文有观点但缺少材料展开和结构层次"
+      ],
+      "unit": "高考阅读写作",
+      "skills": [
+        "提取文本内容、结构和表达手法",
+        "结合语境解释字词、句意或材料观点",
+        "按题型组织阅读、文言或写作答案"
+      ],
+      "question_types": [
+        "语用题",
+        "表达得体"
+      ],
+      "examples": [
+        {
+          "prompt": "修改一段病句和语体不当的邀请函。",
+          "answer_outline": [
+            "判断题型：基础积累、阅读理解、文言诗词或写作。",
+            "回到文本圈画关键词句、结构层次和表达手法。",
+            "用“内容+作用+情感/观点”的方式组织答案。",
+            "检查是否答到题干限定和分值要点。"
+          ],
+          "common_traps": [
+            "只摘原文词句，没有归纳分析角度。",
+            "忽略文本语境、表达手法和题干限定。",
+            "作文观点泛化，材料扣合、论据分析和结构层次不足。"
+          ],
+          "grading_points": [
+            "答题角度明确，能回到文本或材料依据。",
+            "概括、分析和作用说明层次清楚。",
+            "语言规范，分点完整，扣合题干任务。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_chinese",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_classical_translation",
+      "name": "文言翻译",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_task_driven_writing",
+          "relation": "next",
+          "reason": "Practice 任务驱动作文 after 文言翻译; it is the next topic in the senior_high chinese learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_content_words",
+          "relation": "procedure_step",
+          "reason": "Translation should first locate content-word meanings, then align sentence structure and produce fluent modern wording.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_sentence_patterns",
+          "relation": "application",
+          "reason": "Special sentence patterns help students turn literal parsing into accurate classical Chinese translation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_summary",
+          "relation": "confusable",
+          "reason": "Translation asks for word and sentence accuracy, while summary asks for event meaning and viewpoint.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Classical translation helps decode institutions, titles, rituals, and cultural terms that appear in historical cultural-exchange materials.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "bridge_direction": "chinese_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈",
+        "答题角度不全",
+        "表达缺少层次"
+      ],
+      "unit": "文言文阅读",
+      "skills": [
+        "回到文本提取内容结构和手法",
+        "结合语境解释词句和观点",
+        "按题型组织规范答案"
+      ],
+      "question_types": [
+        "文言文阅读",
+        "翻译题"
+      ],
+      "examples": [
+        {
+          "prompt": "翻译含省略、倒装和词类活用的文言句子，并补出省略成分。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只摘原文词句，没有归纳分析角度。",
+            "忽略文本语境、表达手法和题干限定。",
+            "作文观点泛化，材料扣合、论据分析和结构层次不足。"
+          ],
+          "grading_points": [
+            "答题角度明确，能回到文本或材料依据。",
+            "概括、分析和作用说明层次清楚。",
+            "语言规范，分点完整，扣合题干任务。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_chinese",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_task_driven_writing",
+      "name": "任务驱动作文",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文",
+      "depth": 3,
+      "difficulty": 0.74,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "chinese_senior_composition_task_context",
+          "relation": "procedure_step",
+          "reason": "Task-driven writing should review identity, audience, purpose, and constraints before forming the central idea.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "application",
+          "reason": "After reviewing the task and forming an idea, students need layered argument organization to develop the response.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_argument",
+          "relation": "confusable",
+          "reason": "Task-driven writing is often mistaken for ordinary argument writing when situational requirements are ignored.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离文本空谈",
+        "答题角度不全",
+        "表达缺少层次"
+      ],
+      "unit": "作文",
+      "skills": [
+        "回到文本提取内容结构和手法",
+        "结合语境解释词句和观点",
+        "按题型组织规范答案"
+      ],
+      "question_types": [
+        "作文",
+        "材料写作"
+      ],
+      "examples": [
+        {
+          "prompt": "围绕青年责任的多材料任务写作，明确对象意识和文体要求。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "只摘原文词句，没有归纳分析角度。",
+            "忽略文本语境、表达手法和题干限定。",
+            "作文观点泛化，材料扣合、论据分析和结构层次不足。"
+          ],
+          "grading_points": [
+            "答题角度明确，能回到文本或材料依据。",
+            "概括、分析和作用说明层次清楚。",
+            "语言规范，分点完整，扣合题干任务。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_chinese",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_modern_argument_structure",
+      "name": "论述类文本论证结构",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文现代文阅读",
+      "unit": "论述类文本",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_literary_text",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "literary text builds the foundation needed before studying modern argument structure.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读 -> 高中语文"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_literary_text",
+          "relation": "co_occurs",
+          "reason": "modern argument structure and literary text commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读 -> 高中语文"
+          }
+        },
+        {
+          "id": "chinese_senior_modern_info_comparison",
+          "relation": "co_occurs",
+          "reason": "modern argument structure and modern info comparison commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "procedure_step",
+          "reason": "Argument-structure answers should review the prompt, locate claim and evidence, then describe the reasoning order.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "application",
+          "reason": "Reading argument structure supports writing because students can reuse claim, evidence, and reasoning layers.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_modern_info_comparison",
+          "relation": "confusable",
+          "reason": "Argument-structure questions track reasoning, while information-comparison questions match and integrate factual points.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "梳理论点、论据和论证方法并判断选项正误。",
+          "answer_outline": [
+            "先判断题目属于论述类文本论证结构的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_modern_info_comparison",
+      "name": "信息类文本比较整合",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文现代文阅读",
+      "unit": "信息类文本",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_modern_argument_structure",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "modern argument structure builds the foundation needed before studying modern info comparison.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_modern_argument_structure",
+          "relation": "co_occurs",
+          "reason": "modern info comparison and modern argument structure commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_literary_image",
+          "relation": "co_occurs",
+          "reason": "modern info comparison and literary image commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "procedure_step",
+          "reason": "Comparison tasks should review dimensions, locate matched information, then organize similarities and differences.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_new_gaokao_mixed_text",
+          "relation": "application",
+          "reason": "Information comparison directly supports mixed-text reading because both require cross-source integration.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_modern_argument_structure",
+          "relation": "confusable",
+          "reason": "Information comparison is often confused with argument-structure analysis when students summarize claims instead of comparing details.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Cross-text comparison in Chinese builds the same evidence matching and viewpoint comparison needed in historical material analysis.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "bridge_direction": "chinese_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "比较多则材料的对象、角度和结论差异。",
+          "answer_outline": [
+            "先判断题目属于信息类文本比较整合的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_literary_image",
+      "name": "小说人物形象分析",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文现代文阅读",
+      "unit": "文学类文本",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_modern_info_comparison",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "modern info comparison builds the foundation needed before studying literary image.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_prose_language_appreciation",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Character-image questions focus on people and evidence, while prose language appreciation focuses on expression and style.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_environment",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Environment description often supports character mood, identity, and theme interpretation.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_plot_effect",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Character analysis should use plot actions, dialogue, and conflict as evidence.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_modern_info_comparison",
+          "relation": "co_occurs",
+          "reason": "literary image and modern info comparison commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_literary_plot_effect",
+          "relation": "co_occurs",
+          "reason": "literary image and literary plot effect commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "从情节、描写、环境和主题分析人物形象。",
+          "answer_outline": [
+            "先判断题目属于小说人物形象分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ],
+      "aliases": [
+        "小说人物形象",
+        "人物形象分析",
+        "文学类文本人物",
+        "小说人物怎么分析"
+      ]
+    },
+    {
+      "id": "chinese_senior_literary_plot_effect",
+      "name": "小说情节作用题",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文现代文阅读",
+      "unit": "文学类文本",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_literary_image",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "literary image builds the foundation needed before studying literary plot effect.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_literary_environment",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.81,
+          "reason": "Plot-effect questions ask how events advance conflict and theme, while environment-effect questions ask how setting shapes mood and character.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Plot-effect answers need a stable point-by-point template covering content, structure, character, and theme.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_image",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "After locating a plot segment, students should connect it to character behavior and conflict before explaining its effect.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_image",
+          "relation": "co_occurs",
+          "reason": "literary plot effect and literary image commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_literary_environment",
+          "relation": "co_occurs",
+          "reason": "literary plot effect and literary environment commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "说明情节对人物、主题、结构和读者效果的作用。",
+          "answer_outline": [
+            "先判断题目属于小说情节作用题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_literary_environment",
+      "name": "环境描写作用",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文现代文阅读",
+      "unit": "文学类文本",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_literary_plot_effect",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "literary plot effect builds the foundation needed before studying literary environment.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_literary_plot_effect",
+          "relation": "co_occurs",
+          "reason": "literary environment and literary plot effect commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_prose_language_appreciation",
+          "relation": "co_occurs",
+          "reason": "literary environment and prose language appreciation commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_literary_plot_effect",
+          "relation": "procedure_step",
+          "reason": "Environment-effect answers should locate the scene, connect it to plot and character, then state the thematic effect.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_literary_image",
+          "relation": "application",
+          "reason": "Environment description often reveals character mood and image through setting, atmosphere, and contrast.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_prose_language_appreciation",
+          "relation": "confusable",
+          "reason": "Environment-effect questions ask what the setting does, while language-appreciation questions ask how wording creates effect.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "分析自然/社会环境对氛围、人物和主题的作用。",
+          "answer_outline": [
+            "先判断题目属于环境描写作用的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_prose_language_appreciation",
+      "name": "散文语言赏析",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文现代文阅读",
+      "unit": "文学类文本",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_literary_environment",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "literary environment builds the foundation needed before studying prose language appreciation.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_literary_environment",
+          "relation": "co_occurs",
+          "reason": "prose language appreciation and literary environment commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "co_occurs",
+          "reason": "prose language appreciation and practical filter commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "procedure_step",
+          "reason": "Language-appreciation answers should review the angle, locate key wording, analyze effect, and write by points.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_language_style",
+          "relation": "application",
+          "reason": "Prose wording appreciation transfers to poetry language style because both connect diction and rhythm to expression.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "confusable",
+          "reason": "Language style focuses on wording and tone, while expression technique focuses on method and effect.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "从修辞、句式、词语和情感角度赏析语言。",
+          "answer_outline": [
+            "先判断题目属于散文语言赏析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_practical_filter",
+      "name": "实用类文本信息筛选",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文现代文阅读",
+      "unit": "实用类文本",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_prose_language_appreciation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "prose language appreciation builds the foundation needed before studying practical filter.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_modern_info_comparison",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Information filtering selects accurate details from one text, while comparison tasks integrate similarities and differences across texts.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_practical_text",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Filtering information is a core operation in practical-text reading questions about reports, interviews, and nonliterary materials.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After filtering valid information, students often need to compress it into a brief answer that satisfies the question limit.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_prose_language_appreciation",
+          "relation": "co_occurs",
+          "reason": "practical filter and prose language appreciation commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_content_words",
+          "relation": "co_occurs",
+          "reason": "practical filter and classical content words commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文现代文阅读 -> 高中语文文言文"
+          }
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Practical-text filtering transfers to historical source questions because both require selecting reliable evidence before answering the prompt.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "bridge_direction": "chinese_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "从材料中筛选事实、观点、数据和条件限制。",
+          "answer_outline": [
+            "先判断题目属于实用类文本信息筛选的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_classical_content_words",
+      "name": "文言实词语境义",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文文言文",
+      "unit": "文言基础",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_practical_filter",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "practical filter builds the foundation needed before studying classical content words.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文 -> 高中语文现代文阅读"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "co_occurs",
+          "reason": "classical content words and practical filter commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文 -> 高中语文现代文阅读"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_function_words",
+          "relation": "co_occurs",
+          "reason": "classical content words and classical function words commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "procedure_step",
+          "reason": "Content-word meaning should be located in context before students translate the full sentence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_summary",
+          "relation": "application",
+          "reason": "Accurate content-word interpretation supports classical passage summary because event relations depend on key meanings.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_function_words",
+          "relation": "confusable",
+          "reason": "Content words carry concrete meaning, while function words mark grammar, tone, or logical relations.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "结合语境、词类活用和古今异义判断实词含义。",
+          "answer_outline": [
+            "先判断题目属于文言实词语境义的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_classical_function_words",
+      "name": "文言虚词用法",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文文言文",
+      "unit": "文言基础",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_classical_content_words",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "classical content words builds the foundation needed before studying classical function words.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_junior_classical_function_words",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Junior and senior function-word tasks share terms but differ in depth, sentence complexity, and evidence requirements.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Function-word judgement is directly used when translating classical Chinese sentences accurately.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_sentence_patterns",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "After identifying a function word, the next step is to verify its role inside the sentence pattern and translation structure.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_content_words",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Classical function-word analysis depends on reading the local context and separating content-word meaning from grammatical function.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_content_words",
+          "relation": "co_occurs",
+          "reason": "classical function words and classical content words commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_sentence_patterns",
+          "relation": "co_occurs",
+          "reason": "classical function words and classical sentence patterns commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "比较之、其、以、而等虚词的语法作用。",
+          "answer_outline": [
+            "先判断题目属于文言虚词用法的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ],
+      "aliases": [
+        "文言虚词",
+        "虚词用法",
+        "而之其以用法",
+        "文言虚词判断"
+      ]
+    },
+    {
+      "id": "chinese_senior_classical_sentence_patterns",
+      "name": "文言特殊句式",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文文言文",
+      "unit": "文言翻译",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_classical_function_words",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "classical function words builds the foundation needed before studying classical sentence patterns.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_classical_function_words",
+          "relation": "co_occurs",
+          "reason": "classical sentence patterns and classical function words commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_summary",
+          "relation": "co_occurs",
+          "reason": "classical sentence patterns and classical summary commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "procedure_step",
+          "reason": "Sentence-pattern recognition should precede translation so omitted, inverted, and passive elements are restored.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_summary",
+          "relation": "application",
+          "reason": "Recognizing sentence patterns helps students identify who did what before summarizing classical text content.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_content_words",
+          "relation": "confusable",
+          "reason": "Sentence-pattern questions focus on structure, while content-word questions focus on contextual meaning.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "识别判断句、被动句、省略句、倒装句并落实翻译。",
+          "answer_outline": [
+            "先判断题目属于文言特殊句式的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_classical_summary",
+      "name": "文言内容概括",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文文言文",
+      "unit": "文言阅读",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_classical_sentence_patterns",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "classical sentence patterns builds the foundation needed before studying classical summary.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_classical_sentence_patterns",
+          "relation": "co_occurs",
+          "reason": "classical summary and classical sentence patterns commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_image_emotion",
+          "relation": "co_occurs",
+          "reason": "classical summary and poetry image emotion commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文 -> 高中语文古诗词"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_sentence_patterns",
+          "relation": "prerequisite",
+          "reason": "Sentence-pattern recognition is needed before summarizing who did what and why in classical passages.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "procedure_step",
+          "reason": "Translate key clauses first, then compress events, causes, and attitudes into a summary.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "confusable",
+          "reason": "Translation keeps sentence-level meaning, while summary condenses the passage into main events and viewpoints.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "application",
+          "reason": "Classical summary skills support concise extraction of actors, events, and claims from historical materials.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "梳理人物、事件和评价，判断选项曲解。",
+          "answer_outline": [
+            "先判断题目属于文言内容概括的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_poetry_image_emotion",
+      "name": "诗歌意象与情感",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文古诗词",
+      "unit": "诗歌鉴赏",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_classical_summary",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "classical summary builds the foundation needed before studying poetry image emotion.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词 -> 高中语文文言文"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_poetry_compare",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Single-poem image-emotion questions differ from comparison questions that require similarities and differences across texts.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_language_style",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Imagery and emotion are often supported by diction, tone, and language style evidence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Poetry image analysis should connect imagery to expression technique before naming the emotion.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_classical_summary",
+          "relation": "co_occurs",
+          "reason": "poetry image emotion and classical summary commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词 -> 高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "co_occurs",
+          "reason": "poetry image emotion and poetry expression technique commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        },
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Poetic imagery about routes, objects, and customs can support historical interpretation of cultural exchange and regional interaction.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "bridge_direction": "chinese_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "由意象、关键词和背景判断诗歌情感。",
+          "answer_outline": [
+            "先判断题目属于诗歌意象与情感的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ],
+      "aliases": [
+        "诗歌意象",
+        "诗歌情感",
+        "意象与情感",
+        "诗歌意象情感分析"
+      ]
+    },
+    {
+      "id": "chinese_senior_poetry_expression_technique",
+      "name": "诗歌表达技巧",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文古诗词",
+      "unit": "诗歌鉴赏",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_poetry_image_emotion",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "poetry image emotion builds the foundation needed before studying poetry expression technique.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_poetry_image_emotion",
+          "relation": "co_occurs",
+          "reason": "poetry expression technique and poetry image emotion commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_language_style",
+          "relation": "co_occurs",
+          "reason": "poetry expression technique and poetry language style commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_image_emotion",
+          "relation": "procedure_step",
+          "reason": "Technique answers should locate image and wording evidence before naming the method and explaining emotion.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_compare",
+          "relation": "application",
+          "reason": "Technique analysis supports poetry comparison because students can compare methods, effects, and emotions across poems.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_language_style",
+          "relation": "confusable",
+          "reason": "Expression technique explains method, while language style explains diction, tone, and rhythm.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "识别借景抒情、虚实结合、对比和用典等手法。",
+          "answer_outline": [
+            "先判断题目属于诗歌表达技巧的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_poetry_language_style",
+      "name": "诗歌炼字与语言风格",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文古诗词",
+      "unit": "诗歌鉴赏",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "poetry expression technique builds the foundation needed before studying poetry language style.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "co_occurs",
+          "reason": "poetry language style and poetry expression technique commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_compare",
+          "relation": "co_occurs",
+          "reason": "poetry language style and poetry compare commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "procedure_step",
+          "reason": "Language-style answers should locate representative words, infer tone, then connect wording to expression effect.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_poetry_compare",
+          "relation": "application",
+          "reason": "Language-style analysis helps compare poems by diction, rhythm, tone, and emotional expression.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_prose_language_appreciation",
+          "relation": "confusable",
+          "reason": "Poetry language style shares wording analysis with prose appreciation but must account for poetic compression and rhythm.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "分析关键词的画面、情感和结构作用。",
+          "answer_outline": [
+            "先判断题目属于诗歌炼字与语言风格的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_poetry_compare",
+      "name": "诗歌比较鉴赏",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文古诗词",
+      "unit": "诗歌鉴赏",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_poetry_language_style",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "poetry language style builds the foundation needed before studying poetry compare.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_poetry_language_style",
+          "relation": "co_occurs",
+          "reason": "poetry compare and poetry language style commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词"
+          }
+        },
+        {
+          "id": "chinese_senior_language_cohesion",
+          "relation": "co_occurs",
+          "reason": "poetry compare and language cohesion commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文古诗词 -> 高中语文语言运用"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_language_style",
+          "relation": "prerequisite",
+          "reason": "Language-style judgment gives the vocabulary needed to compare two poems accurately.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_expression_technique",
+          "relation": "procedure_step",
+          "reason": "Compare images and emotion first, then compare expression techniques and language style.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_poetry_image_emotion",
+          "relation": "confusable",
+          "reason": "Image-emotion analysis studies one poem deeply, while poetry comparison must align similarities and differences across texts.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "application",
+          "reason": "Comparing poems strengthens period-context comparison used in cultural exchange history questions.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "比较两首诗的题材、手法、情感和语言差异。",
+          "answer_outline": [
+            "先判断题目属于诗歌比较鉴赏的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_language_cohesion",
+      "name": "语句衔接排序",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文语言运用",
+      "unit": "语言文字运用",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_poetry_compare",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "poetry compare builds the foundation needed before studying language cohesion.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用 -> 高中语文古诗词"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_poetry_compare",
+          "relation": "co_occurs",
+          "reason": "language cohesion and poetry compare commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用 -> 高中语文古诗词"
+          }
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "co_occurs",
+          "reason": "language cohesion and language compression commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Chinese sentence-ordering work strengthens cohesion awareness that transfers to English paragraph links, transitions, and logical flow.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "bridge_direction": "chinese_to_english"
+          }
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "procedure_step",
+          "reason": "Sentence-ordering questions first identify topic sentence, connector words, pronoun references, and logical sequence before compressing the ordered meaning into a concise answer.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        },
+        {
+          "id": "english_senior_seven_choice_coherence",
+          "relation": "confusable",
+          "reason": "Chinese sentence-ordering and English seven-choice coherence both use discourse links, but Chinese items usually reorder given sentences while English items select missing sentences from options.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "bridge_direction": "chinese_to_english"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "根据话题、指代、逻辑和句式完成排序或补写。",
+          "answer_outline": [
+            "先判断题目属于语句衔接排序的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_language_compression",
+      "name": "压缩语段与概括",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文语言运用",
+      "unit": "语言文字运用",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_language_cohesion",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "language cohesion builds the foundation needed before studying language compression.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_language_cohesion",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Compression tasks require condensing key information, while cohesion tasks require ordering sentences by logic and connectors.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "A concise compressed answer depends on first filtering out invalid, repeated, or secondary information.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "After selecting key information, students often rewrite sentence patterns to meet word-count and expression requirements.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_cohesion",
+          "relation": "co_occurs",
+          "reason": "language compression and language cohesion commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "relation": "co_occurs",
+          "reason": "language compression and language sentence rewrite commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "english_senior_summary_writing",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Chinese compression and gist extraction transfer to English summary writing through selecting main ideas and deleting minor details.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "bridge_direction": "chinese_to_english"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "提取对象、事件、原因和结果并压缩成规范表达。",
+          "answer_outline": [
+            "先判断题目属于压缩语段与概括的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_language_sentence_rewrite",
+      "name": "句式变换与仿写",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文语言运用",
+      "unit": "语言文字运用",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_language_compression",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "language compression builds the foundation needed before studying language sentence rewrite.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "co_occurs",
+          "reason": "language sentence rewrite and language compression commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "chinese_senior_language_error_correction",
+          "relation": "co_occurs",
+          "reason": "language sentence rewrite and language error correction commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "english_senior_summary_paraphrase",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Chinese sentence rewriting builds paraphrase control that helps English summaries avoid copying while preserving the original meaning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "bridge_direction": "chinese_to_english"
+          }
+        },
+        {
+          "id": "chinese_senior_language_error_correction",
+          "relation": "procedure_step",
+          "reason": "Sentence rewriting requires preserving the original meaning, selecting the target sentence pattern, adjusting word order, and then checking for grammar or logic errors.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "confusable",
+          "reason": "Sentence rewriting changes form while keeping meaning complete, whereas language compression deletes secondary information to produce a shorter summary.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "保持语义和修辞一致完成句式变换或仿写。",
+          "answer_outline": [
+            "先判断题目属于句式变换与仿写的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_language_error_correction",
+      "name": "病句辨析修改",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文语言运用",
+      "unit": "语言文字运用",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "language sentence rewrite builds the foundation needed before studying language error correction.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "relation": "co_occurs",
+          "reason": "language error correction and language sentence rewrite commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "chinese_senior_language_graphic",
+          "relation": "co_occurs",
+          "reason": "language error correction and language graphic commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "relation": "procedure_step",
+          "reason": "For 病句辨析修改, locate the fault type, explain the grammar or logic problem, then rewrite the sentence so the correction is explicit and testable.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        },
+        {
+          "id": "english_senior_error_correction",
+          "relation": "confusable",
+          "reason": "Chinese 病句修改 focuses on Chinese syntax, collocation, logic, and punctuation, while English error correction checks tense, agreement, articles, and clause grammar.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "bridge_direction": "chinese_to_english"
+          }
+        },
+        {
+          "id": "english_senior_error_correction",
+          "relation": "application",
+          "reason": "The habit of identifying an error category, locating evidence in context, and rewriting the sentence transfers directly to English short-passage error-correction items.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.83,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "bridge_direction": "chinese_to_english"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "从成分残缺、搭配不当、语序和逻辑角度修改病句。",
+          "answer_outline": [
+            "先判断题目属于病句辨析修改的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_language_graphic",
+      "name": "图文转换",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文语言运用",
+      "unit": "图文转换",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_language_error_correction",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "language error correction builds the foundation needed before studying language graphic.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_language_error_correction",
+          "relation": "co_occurs",
+          "reason": "language graphic and language error correction commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_material_review",
+          "relation": "co_occurs",
+          "reason": "language graphic and composition material review commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文语言运用 -> 高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "procedure_step",
+          "reason": "Graph-to-text answers read the title, legend, axes, figures, and trend first, then compress the visual information into a clear sentence or recommendation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_material_review",
+          "relation": "confusable",
+          "reason": "图文转换 asks students to describe data or visual meaning accurately, while composition material review turns a material into an essay claim and argument direction.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        },
+        {
+          "id": "pol_senior_economy_market",
+          "relation": "application",
+          "reason": "Chart description and trend extraction support politics economy material questions that ask students to read market data, policy effects, and macro-control signals.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "politics",
+            "bridge_direction": "chinese_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "描述图表信息并提炼趋势、寓意或建议。",
+          "answer_outline": [
+            "先判断题目属于图文转换的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_composition_material_review",
+      "name": "材料作文审题立意",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文写作",
+      "unit": "作文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_language_graphic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "language graphic builds the foundation needed before studying composition material review.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作 -> 高中语文语言运用"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_composition_task_context",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "General material essays and task-driven essays both require prompt reading, but task-driven writing adds audience, role, and situation constraints.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "A valid thesis needs matching evidence and analysis rather than disconnected examples.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "After reviewing the prompt, students need to turn the central claim into layered argument structure.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_graphic",
+          "relation": "co_occurs",
+          "reason": "composition material review and language graphic commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作 -> 高中语文语言运用"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "co_occurs",
+          "reason": "composition material review and composition argument layer commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "pol_senior_philosophy_dialectics",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Essay prompt review trains students to identify contradictions, relations, and value angles before applying dialectical analysis to political materials.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "politics",
+            "bridge_direction": "chinese_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "提炼材料核心关系，确定立意边界和写作任务。",
+          "answer_outline": [
+            "先判断题目属于材料作文审题立意的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ],
+      "aliases": [
+        "材料作文",
+        "审题立意",
+        "材料作文审题立意",
+        "作文立意"
+      ]
+    },
+    {
+      "id": "chinese_senior_composition_argument_layer",
+      "name": "议论文论证层次",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文写作",
+      "unit": "作文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_composition_material_review",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "composition material review builds the foundation needed before studying composition argument layer.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Argument layers organize reasoning, while example argument work selects evidence and explains how it proves the claim.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_opening_ending",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "A clear argument layer guides how the opening introduces the claim and how the ending returns to the central point.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After setting the argument layers, students should choose evidence for each layer and explain the proof connection.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_material_review",
+          "relation": "co_occurs",
+          "reason": "composition argument layer and composition material review commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "relation": "co_occurs",
+          "reason": "composition argument layer and composition example argument commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Layered argumentative writing maps well to law-rule material answers, where claims, legal basis, analysis, and conclusion must be ordered.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "politics",
+            "bridge_direction": "chinese_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "用提出问题、分析问题、解决问题组织论证。",
+          "answer_outline": [
+            "先判断题目属于议论文论证层次的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_composition_example_argument",
+      "name": "论据选择与分析",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文写作",
+      "unit": "作文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "composition argument layer builds the foundation needed before studying composition example argument.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "co_occurs",
+          "reason": "composition example argument and composition argument layer commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_task_context",
+          "relation": "co_occurs",
+          "reason": "composition example argument and composition task context commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "prerequisite",
+          "reason": "Layered argument structure is needed before examples can be placed as evidence rather than decoration.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_material_review",
+          "relation": "procedure_step",
+          "reason": "Review the material claim, choose a matching example, then explain how the example proves the claim.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "confusable",
+          "reason": "Examples provide evidence, while argument layers explain the logical progress of the essay.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "application",
+          "reason": "Example selection trains claim-evidence-reasoning checks used in political logic answers.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "politics",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "选择典型论据并完成因果、对比或假设分析。",
+          "answer_outline": [
+            "先判断题目属于论据选择与分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_composition_task_context",
+      "name": "任务驱动作文情境",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文写作",
+      "unit": "作文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "composition example argument builds the foundation needed before studying composition task context.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "relation": "co_occurs",
+          "reason": "composition task context and composition example argument commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_opening_ending",
+          "relation": "co_occurs",
+          "reason": "composition task context and composition opening ending commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_example_argument",
+          "relation": "prerequisite",
+          "reason": "Knowing how examples support claims helps students adapt evidence to a specific writing task context.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_material_review",
+          "relation": "procedure_step",
+          "reason": "Identify the role, audience, and task limit before selecting the central claim and evidence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_argument",
+          "relation": "confusable",
+          "reason": "General argumentative writing can state a broad claim, while task-context writing must answer the assigned role and situation.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "application",
+          "reason": "Task-context awareness helps structure political material answers around role, condition, and requested angle.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "politics",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "扣住身份、对象、场合和文体完成表达任务。",
+          "answer_outline": [
+            "先判断题目属于任务驱动作文情境的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_composition_opening_ending",
+      "name": "作文开头结尾设计",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文写作",
+      "unit": "作文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_composition_task_context",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "composition task context builds the foundation needed before studying composition opening ending.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_composition_task_context",
+          "relation": "co_occurs",
+          "reason": "composition opening ending and composition task context commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_language_polish",
+          "relation": "co_occurs",
+          "reason": "composition opening ending and composition language polish commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_task_context",
+          "relation": "prerequisite",
+          "reason": "Openings and endings should first match the task context, audience, and claim direction.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_language_polish",
+          "relation": "procedure_step",
+          "reason": "Draft a clear opening and ending, then polish wording for rhythm, precision, and cohesion.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_task_context",
+          "relation": "confusable",
+          "reason": "Opening and ending design shapes expression, while task context determines what the essay must answer.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "english_senior_application_speech",
+          "relation": "application",
+          "reason": "Clear opening and closing moves transfer to English speech writing tasks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.79,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "用材料切入、观点亮明和回扣升华提升结构。",
+          "answer_outline": [
+            "先判断题目属于作文开头结尾设计的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_composition_language_polish",
+      "name": "作文语言打磨",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文写作",
+      "unit": "作文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_composition_opening_ending",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "composition opening ending builds the foundation needed before studying composition language polish.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_composition_opening_ending",
+          "relation": "co_occurs",
+          "reason": "composition language polish and composition opening ending commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_culture",
+          "relation": "co_occurs",
+          "reason": "composition language polish and classical culture commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文写作 -> 高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_opening_ending",
+          "relation": "prerequisite",
+          "reason": "A complete essay frame is needed before language polish can improve emphasis and flow.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "procedure_step",
+          "reason": "After ideas are organized, revise wording for precision, cohesion, and sentence variety.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_language_error_correction",
+          "relation": "confusable",
+          "reason": "Language polish improves style and force, while error correction fixes grammar, wording, and punctuation faults.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "english_senior_writing_rubric_revision",
+          "relation": "application",
+          "reason": "Polishing for clarity, cohesion, and audience fit transfers to English rubric-based writing revision.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "通过句式节奏、关键词复现和修辞提升表达。",
+          "answer_outline": [
+            "先判断题目属于作文语言打磨的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_classical_culture",
+      "name": "古代文化常识",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文文言文",
+      "unit": "文言基础",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_composition_language_polish",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "composition language polish builds the foundation needed before studying classical culture.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文 -> 高中语文写作"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_composition_language_polish",
+          "relation": "co_occurs",
+          "reason": "classical culture and composition language polish commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文 -> 高中语文写作"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "co_occurs",
+          "reason": "classical culture and text answer template commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文文言文 -> 高中语文综合"
+          }
+        },
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Classical cultural knowledge gives historical background for rituals, institutions, calendars, and exchange symbols in cultural history questions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "bridge_direction": "chinese_to_history"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_translation",
+          "relation": "procedure_step",
+          "reason": "Classical-culture questions first identify dynasties, official titles, rites, calendars, geography, or institutions, then use that context to translate and explain the sentence accurately.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        },
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "confusable",
+          "reason": "古代文化常识 tests fixed cultural terms and institutional background in classical texts, while history cultural-exchange questions analyze causes, routes, influence, and period context.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "bridge_direction": "chinese_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "识别官职、礼俗、科举、纪年等文化常识。",
+          "answer_outline": [
+            "先判断题目属于古代文化常识的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_text_answer_template",
+      "name": "阅读题规范分点",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文综合",
+      "unit": "答题规范",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_classical_culture",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "classical culture builds the foundation needed before studying text answer template.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合 -> 高中语文文言文"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_classical_culture",
+          "relation": "co_occurs",
+          "reason": "text answer template and classical culture commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合 -> 高中语文文言文"
+          }
+        },
+        {
+          "id": "chinese_senior_new_gaokao_mixed_text",
+          "relation": "co_occurs",
+          "reason": "text answer template and new gaokao mixed text commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合"
+          }
+        },
+        {
+          "id": "chinese_senior_classical_culture",
+          "relation": "prerequisite",
+          "reason": "Background knowledge and genre awareness help choose the right answer template for mixed Chinese text tasks.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.83,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_new_gaokao_mixed_text",
+          "relation": "procedure_step",
+          "reason": "Use the template to state point, evidence, analysis, and conclusion for mixed-text answers.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_exam_revision_strategy",
+          "relation": "confusable",
+          "reason": "An answer template formats a response, while revision strategy tracks errors and plans later practice.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "application",
+          "reason": "Point-evidence-analysis templates support structured answers for history material-analysis questions.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "按角度、依据、效果组织现代文和古诗文答案。",
+          "answer_outline": [
+            "先判断题目属于阅读题规范分点的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_new_gaokao_mixed_text",
+      "name": "新高考多文本阅读",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文综合",
+      "unit": "新高考题型",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_text_answer_template",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "text answer template builds the foundation needed before studying new gaokao mixed text.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "co_occurs",
+          "reason": "new gaokao mixed text and text answer template commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合"
+          }
+        },
+        {
+          "id": "chinese_senior_exam_revision_strategy",
+          "relation": "co_occurs",
+          "reason": "new gaokao mixed text and exam revision strategy commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合"
+          }
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Mixed-text reading strengthens source grouping, viewpoint extraction, and evidence synthesis for historical document-based questions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "history",
+            "bridge_direction": "chinese_to_history"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "procedure_step",
+          "reason": "New-gaokao mixed-text reading classifies source type, extracts each text's claim and evidence, compares relationships, then writes the answer with a point-evidence-analysis template.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "bridge_direction": "chinese_internal"
+          }
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "confusable",
+          "reason": "Mixed-text reading synthesizes viewpoints from several sources, while politics logical-thinking tasks judge premise, conclusion, contradiction, and reasoning validity.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "politics",
+            "bridge_direction": "chinese_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "整合论述类、信息类或文学类多材料完成比较分析。",
+          "answer_outline": [
+            "先判断题目属于新高考多文本阅读的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "chinese_senior_exam_revision_strategy",
+      "name": "语文考试复盘策略",
+      "subject": "chinese",
+      "stage": "senior_high",
+      "chapter": "高中语文综合",
+      "unit": "考试策略",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "chinese_senior_new_gaokao_mixed_text",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "new gaokao mixed text builds the foundation needed before studying exam revision strategy.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_prerequisite_dict",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_senior_new_gaokao_mixed_text",
+          "relation": "co_occurs",
+          "reason": "exam revision strategy and new gaokao mixed text commonly appear together in senior Chinese review planning.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.74,
+          "use_cases": [
+            "practice_planning",
+            "review",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "migrated_from": "legacy_nearby_relation",
+            "migrated_for": "chinese_edge_migration_2026_06_26",
+            "chapter_focus": "高中语文综合"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "prerequisite",
+          "reason": "Reusable answer templates give revision records a stable structure for error diagnosis.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "procedure_step",
+          "reason": "Classify the missed question, map it to an answer template, then rewrite the response with evidence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "confusable",
+          "reason": "Revision strategy studies why a mistake happened, while an answer template only organizes the final response.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "chinese",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        },
+        {
+          "id": "english_senior_exam_time_strategy",
+          "relation": "application",
+          "reason": "Error-log timing and question-type review can transfer to English exam time strategy.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.79,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "chinese",
+            "target_subject": "english",
+            "validation_batch": "chinese_ready_core_relations_2026_06_26"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只摘抄原文但没有概括分析角度",
+        "文言、诗歌题忽略语境和手法作用",
+        "作文观点泛化，材料扣合和论证层次不足"
+      ],
+      "skills": [
+        "抓住文本对象、结构和表达手法",
+        "把材料信息转成观点、依据和作用分析",
+        "按题型组织分点作答并扣合语境"
+      ],
+      "question_types": [
+        "文本分析",
+        "规范表达"
+      ],
+      "examples": [
+        {
+          "prompt": "按题型归因错因并沉淀可复用答题步骤。",
+          "answer_outline": [
+            "先判断题目属于语文考试复盘策略的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用语文核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "chinese",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_chinese"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/chinese.json
@@ -23,7 +23,7 @@
         },
         {
           "id": "chinese_primary_sentence_expansion",
-          "relation": "prerequisite",
+          "relation": "extends",
           "reason": "Pinyin and character recognition supply the decoding base for sentence expansion and short text work.",
           "priority": "core",
           "context": "explanation",

--- a/plugin/plugins/study_companion/static/knowledge_seeds/computer_science.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/computer_science.json
@@ -1,0 +1,6845 @@
+{
+  "version": "1.0",
+  "subject": "computer_science",
+  "topics": [
+    {
+      "id": "college_c_basic_program_structure",
+      "name": "C 程序结构",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "程序基础",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_discrete_logic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_discrete_logic",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_variables_types",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_variables_types",
+          "relation": "procedure_step",
+          "reason": "Identify translation units and main, then trace declarations before statement execution.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_cs_modular_design",
+          "relation": "application",
+          "reason": "Program structure is used to organize small C programs into readable modules.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_variables_types",
+          "relation": "confusable",
+          "reason": "Learners often mix the program skeleton with declarations that live inside it.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "阅读一个含 main 函数的 C 程序，指出头文件、语句和返回值作用。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_variables_types",
+      "name": "变量与基本数据类型",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "数据类型",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_basic_program_structure",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_basic_program_structure",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_expression_precedence",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_expression_precedence",
+          "relation": "procedure_step",
+          "reason": "After choosing types, evaluate expressions using conversion and operator rules.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_cs_memory_model_intro",
+          "relation": "application",
+          "reason": "Type choices affect storage size, value range, and memory interpretation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_expression_precedence",
+          "relation": "confusable",
+          "reason": "A declared type is often confused with the result type of an expression.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "判断 int、double、char 运算中的类型转换和结果。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_expression_precedence",
+      "name": "表达式与运算符优先级",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "表达式",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_variables_types",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_variables_types",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_branch_control",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_branch_control",
+          "relation": "procedure_step",
+          "reason": "Expression results become conditions for if, switch, and guarded execution.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_debug_boundary",
+          "relation": "application",
+          "reason": "Precedence checks explain many wrong branch and arithmetic results.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_branch_control",
+          "relation": "confusable",
+          "reason": "Operator grouping is often confused with the control-flow order of statements.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "根据优先级和结合性求复合表达式的值。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_branch_control",
+      "name": "条件分支结构",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "控制结构",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_expression_precedence",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_expression_precedence",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_loop_invariant",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_loop_invariant",
+          "relation": "procedure_step",
+          "reason": "Branch predicates lead into loop guards and invariant checks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_debug_boundary",
+          "relation": "application",
+          "reason": "Branch control is used to test boundary cases and unreachable paths.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_loop_invariant",
+          "relation": "confusable",
+          "reason": "A one-time branch condition is often confused with a loop invariant.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "用 if-else 或 switch 处理分段函数。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_loop_invariant",
+      "name": "循环与循环不变量",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "控制结构",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_branch_control",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_branch_control",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_array_traversal",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_array_traversal",
+          "relation": "procedure_step",
+          "reason": "Loop invariants guide index updates during array traversal.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "application",
+          "reason": "Loop reasoning supports time complexity counts for iterative algorithms.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_branch_control",
+          "relation": "confusable",
+          "reason": "A loop invariant must hold across iterations, unlike a single branch test.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "分析 for/while 循环每轮变量变化并判断输出。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_array_traversal",
+      "name": "一维数组遍历",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "数组",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_loop_invariant",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_loop_invariant",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_2d_array_matrix",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "senior_sequence_concept",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "This edge points to a common use case where the topic is applied in code or analysis.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "array_traversal_to_sequences",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_matrix_dimension",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge separates concepts that learners commonly mix up during diagnosis.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "array_length_vs_matrix_dimension",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_2d_array_matrix",
+          "relation": "procedure_step",
+          "reason": "One-dimensional traversal generalizes to nested loops for matrix data.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "编写遍历数组求最大值、均值或计数的程序。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_2d_array_matrix",
+      "name": "二维数组与矩阵操作",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "数组",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_array_traversal",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_matrix_operations",
+          "required_mastery": 0.54,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.88,
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "matrix_math_to_2d_arrays",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_array_traversal",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_string_char_array",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_matrix_operations",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.96,
+          "reason": "Two-dimensional arrays model row-column data, so matrix operations are the direct math bridge for array indexing, traversal, and table computation.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "two_dimensional_arrays_to_matrix_operations",
+            "cross_subject": true,
+            "added_for": "acceptance_query_cross_subject_stability",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_matrix_dimension",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "reason": "This edge separates concepts that learners commonly mix up during diagnosis.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "array_shape_vs_matrix_dimension",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_linear_transformation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "This edge points to a common use case where the topic is applied in code or analysis.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "matrix_to_linear_algebra_algorithms",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_matrix_elementary_transform",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "This edge points to a common use case where the topic is applied in code or analysis.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "2d_arrays_to_elementary_matrix_transforms",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_linear_systems",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "This edge points to a common use case where the topic is applied in code or analysis.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "2d_arrays_to_linear_system_tables",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_rank",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.8,
+          "reason": "This edge points to a common use case where the topic is applied in code or analysis.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "2d_array_row_reduction_to_rank",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_string_char_array",
+          "relation": "procedure_step",
+          "reason": "Matrix indexing prepares learners for row-major character array access.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "用二维数组完成矩阵转置或行列求和。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_string_char_array",
+      "name": "字符串与字符数组",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "字符串",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_2d_array_matrix",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_2d_array_matrix",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_function_parameter",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_function_parameter",
+          "relation": "procedure_step",
+          "reason": "String arrays are commonly passed to functions as array parameters.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_file_io",
+          "relation": "application",
+          "reason": "Character arrays buffer text read from files and standard input.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_pointer_array",
+          "relation": "confusable",
+          "reason": "A character array is often confused with a pointer to character storage.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "处理以 \\0 结尾的字符串长度、复制或查找。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_function_parameter",
+      "name": "函数与参数传递",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "函数",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_string_char_array",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_string_char_array",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_recursion_basic",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_pointer_address",
+          "relation": "procedure_step",
+          "reason": "Parameter passing motivates when a function needs an address argument.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_cs_modular_design",
+          "relation": "application",
+          "reason": "Function parameters define module boundaries and reusable interfaces.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_pointer_address",
+          "relation": "confusable",
+          "reason": "Pass-by-value is often confused with changing an object through a pointer.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "区分值传递和数组参数，并跟踪函数调用结果。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_recursion_basic",
+      "name": "递归函数基础",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "函数",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_function_parameter",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 函数与参数传递 before 递归函数基础; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "proof_writing",
+          "required_mastery": 0.52,
+          "relation": "prerequisite",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.82,
+          "reason": "Recursive correctness arguments need a clear base case and induction-style step; proof-writing structure helps students justify the recursion, not just run it.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "recursion_to_induction",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_function_parameter",
+          "relation": "co_occurs",
+          "reason": "递归函数基础 and 函数与参数传递 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_c_pointer_address",
+          "relation": "extends",
+          "reason": "Practice 指针与地址 after 递归函数基础; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_sequence_recursion",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.88,
+          "reason": "Recursive functions implement recurrence-style definitions, so sequence recursion gives a mathematical model for base cases and recursive steps.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "recursion_to_recurrence",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_sequence_concept",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "Recursive functions often generate ordered terms, so sequence concepts help students name each call result as a term indexed by depth.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "recursion_depth_to_sequence_terms",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_geometric_sequence",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Divide-and-branch recursion can create term counts that grow like a geometric sequence across recursion levels.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "recursion_tree_to_geometric_sequence",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "proof_writing",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.85,
+          "reason": "After writing a recursive base case and recursive step, students can justify correctness with an induction-style proof structure.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "recursive_correctness_to_induction_proof",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "写出阶乘、斐波那契或递归求和的终止条件和递推式。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_pointer_address",
+      "name": "指针与地址",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "指针",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_recursion_basic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_recursion_basic",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_pointer_array",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_pointer_array",
+          "relation": "procedure_step",
+          "reason": "Address and dereference rules prepare pointer arithmetic over arrays.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_cs_memory_model_intro",
+          "relation": "application",
+          "reason": "Pointer addresses connect source code variables to concrete memory locations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_pointer_array",
+          "relation": "confusable",
+          "reason": "A single object address is often confused with an array base address.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "根据指针变量和取地址/解引用操作判断内存值变化。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_pointer_array",
+      "name": "指针与数组关系",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "指针",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_pointer_address",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_pointer_address",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_struct_record",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_struct_record",
+          "relation": "procedure_step",
+          "reason": "Pointer and array access patterns prepare traversal of record collections.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_ds_dynamic_array",
+          "relation": "application",
+          "reason": "Pointer-array reasoning is used in resizable storage and contiguous buffers.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_array_traversal",
+          "relation": "confusable",
+          "reason": "Pointer arithmetic is often confused with index-based traversal.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "解释数组名、指针偏移和下标访问之间的关系。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_struct_record",
+      "name": "结构体与记录建模",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "结构体",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_pointer_array",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_pointer_array",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_file_io",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_file_io",
+          "relation": "procedure_step",
+          "reason": "Record fields are often serialized to and restored from files.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_ds_linked_list",
+          "relation": "application",
+          "reason": "Struct records are used as nodes in linked lists and other data structures.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_pointer_address",
+          "relation": "confusable",
+          "reason": "A struct value is often confused with a pointer to that struct.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "用结构体表示学生成绩并完成排序或统计。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_file_io",
+      "name": "文件读写基础",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "文件",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_struct_record",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_struct_record",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_debug_boundary",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_debug_boundary",
+          "relation": "procedure_step",
+          "reason": "File I/O code should be followed by checks for EOF, errors, and short reads.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_struct_record",
+          "relation": "application",
+          "reason": "File I/O stores and reloads arrays of records in practical C programs.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_c_string_char_array",
+          "relation": "confusable",
+          "reason": "Text buffers are often confused with the file stream that fills them.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "使用 fopen/fscanf/fprintf 读取数据并输出统计结果。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_c_debug_boundary",
+      "name": "C 程序边界调试",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "C 语言程序设计",
+      "unit": "调试",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_file_io",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_c_file_io",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "procedure_step",
+          "reason": "After correctness debugging, analyze how the code scales with input size.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_cs_test_cases",
+          "relation": "application",
+          "reason": "Boundary debugging uses focused tests for empty, singleton, and maximum inputs.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        },
+        {
+          "id": "college_cs_test_cases",
+          "relation": "confusable",
+          "reason": "Finding a bug at a boundary is often confused with designing full test coverage.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "C 语言程序设计"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "给定代码找出数组越界、未初始化或死循环风险。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_ds_algorithm_complexity",
+      "name": "算法复杂度分析",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "算法分析",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_c_debug_boundary",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master C 程序边界调试 before 算法复杂度分析; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        },
+        {
+          "id": "function_thinking",
+          "required_mastery": 0.55,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "Asymptotic complexity compares algorithms as functions of input size, so function thinking is needed before interpreting growth rates.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "complexity_to_function_growth",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_sorting_basic",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Sorting practice uses time-complexity analysis to compare algorithms as input size changes.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_linear_list",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Complexity analysis first counts primitive operations, then applies the result to linear-list access, insertion, and deletion costs.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_c_debug_boundary",
+          "relation": "co_occurs",
+          "reason": "算法复杂度分析 and C 程序边界调试 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_linear_list",
+          "relation": "extends",
+          "reason": "Practice 线性表顺序存储 after 算法复杂度分析; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_exponential_function",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.88,
+          "reason": "Exponential growth such as 2^n must be distinguished from polynomial or logarithmic complexity when ranking algorithms.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "complexity_growth_classes",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_logarithmic_function",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Logarithmic functions explain why halving-search patterns such as binary search have much slower growth than linear scans.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "complexity_to_log_growth",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_power_function",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "Polynomial complexity classes such as n, n^2, and n^3 are easier to compare when students read them as power functions.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "complexity_to_power_functions",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_logarithm_operation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Repeated halving in algorithms maps directly to logarithm operations when solving for the number of steps.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "halving_steps_to_logarithms",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_function_modeling",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.82,
+          "reason": "Runtime analysis builds a function model T(n) from input size to operation count before comparing algorithms.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "runtime_to_function_modeling",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_limit_concept",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.8,
+          "reason": "Asymptotic notation compares long-run growth, so the limit concept supports explanations of dominant terms and negligible constants.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "asymptotic_growth_to_limits",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "判断循环、递归或嵌套结构的时间复杂度。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_linear_list",
+      "name": "线性表顺序存储",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "线性表",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_algorithm_complexity",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 算法复杂度分析 before 线性表顺序存储; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_dynamic_array",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Dynamic arrays extend sequential lists with capacity management and amortized-cost reasoning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_c_array_traversal",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Sequential-list analysis starts from array index access and continuous traversal of stored elements.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "co_occurs",
+          "reason": "线性表顺序存储 and 算法复杂度分析 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_linked_list",
+          "relation": "extends",
+          "reason": "Practice 单链表操作 after 线性表顺序存储; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "分析顺序表插入、删除和查找的移动次数。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_linked_list",
+      "name": "单链表操作",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "线性表",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_linear_list",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 线性表顺序存储 before 单链表操作; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_dynamic_array",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_c_pointer_address",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_linear_list",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_linear_list",
+          "relation": "co_occurs",
+          "reason": "单链表操作 and 线性表顺序存储 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_stack",
+          "relation": "extends",
+          "reason": "Practice 栈与表达式求值 after 单链表操作; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "画出单链表插入、删除和反转中的指针变化。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures",
+      "aliases": [
+        "linked list",
+        "数组和链表",
+        "链表",
+        "单链表",
+        "单链表怎么插入删除节点",
+        "链表和数组有什么区别"
+      ]
+    },
+    {
+      "id": "college_ds_stack",
+      "name": "栈与表达式求值",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "栈和队列",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_linked_list",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 单链表操作 before 栈与表达式求值; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_graph_traversal",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_c_array_traversal",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_queue_circular",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_linked_list",
+          "relation": "co_occurs",
+          "reason": "栈与表达式求值 and 单链表操作 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_queue_circular",
+          "relation": "extends",
+          "reason": "Practice 循环队列 after 栈与表达式求值; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "用栈完成括号匹配或后缀表达式求值。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures",
+      "aliases": [
+        "栈和队列",
+        "栈",
+        "后进先出",
+        "stack",
+        "栈怎么处理括号匹配",
+        "表达式求值为什么要用栈"
+      ]
+    },
+    {
+      "id": "college_ds_queue_circular",
+      "name": "循环队列",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "栈和队列",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_stack",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 栈与表达式求值 before 循环队列; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_graph_traversal",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "BFS uses a queue to keep pending vertices by layer, making it a direct queue application.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_linear_list",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Circular-queue implementation first chooses sequential storage, then maintains front, rear, and modular movement.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_stack",
+          "relation": "co_occurs",
+          "reason": "循环队列 and 栈与表达式求值 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_tree_traversal",
+          "relation": "extends",
+          "reason": "Practice 二叉树遍历 after 循环队列; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "根据 front/rear 判断队空、队满和入队出队结果。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_tree_traversal",
+      "name": "二叉树遍历",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "树",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_queue_circular",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 循环队列 before 二叉树遍历; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_binary_search_tree",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "BST search, insertion, and deletion all use traversal order to locate nodes and subtrees.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_recursion_iteration",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Binary-tree traversal usually fixes recursive visit order before converting it to an iterative stack process.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_queue_circular",
+          "relation": "co_occurs",
+          "reason": "二叉树遍历 and 循环队列 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_binary_search_tree",
+          "relation": "extends",
+          "reason": "Practice 二叉搜索树 after 二叉树遍历; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "根据先序、中序、后序遍历序列还原二叉树。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_binary_search_tree",
+      "name": "二叉搜索树",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "树",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_tree_traversal",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 二叉树遍历 before 二叉搜索树; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_search_binary",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "A BST extends ordered-search thinking to dynamic sets and is useful to compare with binary search.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_tree_traversal",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "BST operations first traverse the tree while preserving the ordered left-child and right-child constraint.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_tree_traversal",
+          "relation": "co_occurs",
+          "reason": "二叉搜索树 and 二叉树遍历 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_heap_priority_queue",
+          "relation": "extends",
+          "reason": "Practice 堆与优先队列 after 二叉搜索树; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "完成二叉搜索树插入、查找和删除的过程分析。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_heap_priority_queue",
+      "name": "堆与优先队列",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "树",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_binary_search_tree",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 二叉搜索树 before 堆与优先队列; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_shortest_path",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Dijkstra-style shortest-path algorithms commonly use a priority queue to pick the smallest tentative distance.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_tree_traversal",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Heap sift-up and sift-down operations depend on complete-binary-tree parent and child positions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_binary_search_tree",
+          "relation": "co_occurs",
+          "reason": "堆与优先队列 and 二叉搜索树 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_graph_representation",
+          "relation": "extends",
+          "reason": "Practice 图的存储结构 after 堆与优先队列; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "由数组表示的堆执行上滤、下滤和删除堆顶。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_graph_representation",
+      "name": "图的存储结构",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "图",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_heap_priority_queue",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 堆与优先队列 before 图的存储结构; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        },
+        {
+          "id": "college_graph_theory_intro",
+          "required_mastery": 0.55,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "Adjacency lists and adjacency matrices encode vertices, edges, direction, and weights from graph theory.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "graph_theory_to_representation",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_graph_traversal",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "BFS and DFS depend on the graph representation to enumerate neighbors accurately.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_linear_list",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Graph storage turns vertex and edge sets into linear structures that can enumerate adjacent vertices.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_heap_priority_queue",
+          "relation": "co_occurs",
+          "reason": "图的存储结构 and 堆与优先队列 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_graph_traversal",
+          "relation": "extends",
+          "reason": "Practice 图的 BFS 与 DFS after 图的存储结构; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_matrix_operations",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "An adjacency matrix is a matrix representation of a graph; matrix operations can express reachability and weighted-edge calculations.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "matrix_to_graph_representation",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_matrix_dimension",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "An adjacency matrix for n vertices has n by n dimensions, which connects graph storage choices to matrix shape.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "adjacency_matrix_to_matrix_dimension",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_graph_shortest_path",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Weighted graph representations store the edge weights that shortest-path models use as path lengths.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "weighted_representation_to_shortest_path_model",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "比较邻接矩阵和邻接表的空间复杂度和适用场景。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_graph_traversal",
+      "name": "图的 BFS 与 DFS",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "图",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_graph_representation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 图的存储结构 before 图的 BFS 与 DFS; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        },
+        {
+          "id": "college_graph_traversal",
+          "required_mastery": 0.55,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "BFS and DFS are algorithmic procedures for the mathematical idea of graph traversal.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "graph_theory_to_traversal",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_topological_sort",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Topological sort applies graph traversal ideas to directed acyclic graphs with in-degree updates.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_queue_circular",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Graph traversal first chooses BFS or DFS, then uses a queue or stack to manage pending vertices.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_graph_representation",
+          "relation": "co_occurs",
+          "reason": "图的 BFS 与 DFS and 图的存储结构 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_shortest_path",
+          "relation": "extends",
+          "reason": "Practice 最短路径算法 after 图的 BFS 与 DFS; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_graph_connectivity",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Traversal is commonly used to test connected components and prove reachability in graph models.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "traversal_to_connectivity",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_graph_shortest_path",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "BFS traversal gives shortest paths in an unweighted graph because it visits vertices by increasing edge distance.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "bfs_to_unweighted_shortest_path",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_spanning_tree",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.82,
+          "reason": "DFS and BFS can record parent links that form traversal trees, which connect directly to spanning-tree ideas.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "graph_traversal_to_spanning_tree",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_graph_traversal",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "When solving graph traversal problems, the code step of marking visited vertices mirrors the mathematical traversal process.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "visited_marks_to_graph_traversal_process",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "按给定邻接表写出 BFS/DFS 访问序列。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_shortest_path",
+      "name": "最短路径算法",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "图",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_graph_traversal",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 图的 BFS 与 DFS before 最短路径算法; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_graph_representation",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Shortest-path algorithms read edge weights from adjacency matrices or adjacency lists before updating distances.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_heap_priority_queue",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Weighted shortest-path solving maintains tentative distances and then selects the next vertex with a priority queue.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_graph_traversal",
+          "relation": "co_occurs",
+          "reason": "最短路径算法 and 图的 BFS 与 DFS are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_minimum_spanning_tree",
+          "relation": "extends",
+          "reason": "Practice 最小生成树 after 最短路径算法; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_graph_shortest_path",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Dijkstra, Bellman-Ford, and Floyd-style code are implementations of the mathematical shortest-path model.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "shortest_path_code_to_math_model",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_matrix_operations",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "All-pairs shortest-path algorithms can update a distance matrix, making matrix operations useful for tracing intermediate states.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "distance_matrix_to_matrix_operations",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "college_graph_connectivity",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.81,
+          "reason": "Before interpreting a shortest-path result, students must check whether vertices are connected or unreachable.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "reachability_check_before_shortest_path",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "用 Dijkstra 或 Floyd 算法求图中最短路径。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_minimum_spanning_tree",
+      "name": "最小生成树",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "图",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_shortest_path",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_shortest_path",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_sorting_basic",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_spanning_tree",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge points to a common use case where the topic is applied in code or analysis.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "mst_algorithm_to_spanning_tree",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_graph_connectivity",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "connectivity_before_minimum_spanning_tree",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_shortest_path",
+          "relation": "procedure_step",
+          "reason": "After identifying weighted graph structure, compare MST goals with path goals.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_shortest_path",
+          "relation": "confusable",
+          "reason": "MST minimizes total connection cost, while shortest path minimizes one route.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "比较 Prim 和 Kruskal 算法构造过程。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_sorting_basic",
+      "name": "基础排序算法",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "排序",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_minimum_spanning_tree",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 最小生成树 before 基础排序算法; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_search_binary",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Binary search requires an ordered sequence, so basic sorting directly prepares searchable data.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Sorting practice executes comparison and swap steps, then uses complexity analysis to evaluate efficiency.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_minimum_spanning_tree",
+          "relation": "co_occurs",
+          "reason": "基础排序算法 and 最小生成树 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_quick_merge_sort",
+          "relation": "extends",
+          "reason": "Practice 快速排序与归并排序 after 基础排序算法; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "分析冒泡、选择、插入排序每趟结果和复杂度。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_quick_merge_sort",
+      "name": "快速排序与归并排序",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "排序",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_sorting_basic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 基础排序算法 before 快速排序与归并排序; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_search_binary",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_ds_sorting_basic",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "This topic should be understood first and is used for diagnosis and learning-path guidance.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_ds_sorting_basic",
+          "relation": "co_occurs",
+          "reason": "快速排序与归并排序 and 基础排序算法 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_hash_table",
+          "relation": "extends",
+          "reason": "Practice 散列表与冲突处理 after 快速排序与归并排序; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_sequence_recursion",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "Quick sort and merge sort lead to recurrence-style formulas for subproblem sizes and total work.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "divide_and_conquer_sorting_to_recurrence",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_logarithmic_function",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "The height of balanced divide-and-conquer sorting is logarithmic in the input size.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "balanced_sort_recursion_to_log_depth",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "写出一次划分或合并过程并分析复杂度。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures",
+      "aliases": [
+        "快速排序",
+        "归并排序",
+        "快排归并",
+        "quick sort merge sort",
+        "快速排序和归并排序怎么比较",
+        "快排一趟划分怎么做"
+      ]
+    },
+    {
+      "id": "college_ds_hash_table",
+      "name": "散列表与冲突处理",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "查找",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_quick_merge_sort",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_search_binary",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge separates concepts that learners commonly mix up during diagnosis.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_linked_list",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge marks the next step in a practical solving or implementation workflow.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_quick_merge_sort",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_search_binary",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_search_binary",
+          "relation": "application",
+          "reason": "Hash tables support fast lookup when ordered binary search is not required.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "用开放定址或链地址法处理哈希冲突。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures",
+      "aliases": [
+        "哈希表",
+        "散列表",
+        "哈希冲突",
+        "hash collision",
+        "哈希冲突怎么处理",
+        "散列表查找为什么快"
+      ]
+    },
+    {
+      "id": "college_ds_search_binary",
+      "name": "折半查找",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "查找",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_hash_table",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_hash_table",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_cs_memory_model_intro",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "senior_logarithmic_function",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge points to a common use case where the topic is applied in code or analysis.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "binary_search_to_logarithmic_growth",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "procedure_step",
+          "reason": "Binary search analysis counts halving steps before proving logarithmic time.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        },
+        {
+          "id": "college_ds_hash_table",
+          "relation": "confusable",
+          "reason": "Binary search needs sorted order, while hash lookup depends on hashing and collisions.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "数据结构"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "在有序表中跟踪 low/mid/high 并判断查找次数。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_cs_memory_model_intro",
+      "name": "程序内存模型初步",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "计算机基础",
+      "unit": "程序运行",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_search_binary",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "This prerequisite supplies the model needed before this topic can be practiced reliably.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "计算机基础"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_search_binary",
+          "relation": "co_occurs",
+          "reason": "This review companion helps compare nearby concepts in the same learning path.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "计算机基础"
+          }
+        },
+        {
+          "id": "college_cs_bit_binary",
+          "relation": "extends",
+          "reason": "This follow-up topic extends the current idea into a later course step.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "计算机基础"
+          }
+        },
+        {
+          "id": "college_c_pointer_address",
+          "relation": "procedure_step",
+          "reason": "Memory model study proceeds to address, dereference, and object lifetime rules.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "计算机基础"
+          }
+        },
+        {
+          "id": "college_c_debug_boundary",
+          "relation": "application",
+          "reason": "Memory model reasoning explains out-of-bounds access and lifetime bugs.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "计算机基础"
+          }
+        },
+        {
+          "id": "college_c_variables_types",
+          "relation": "confusable",
+          "reason": "A variable name is often confused with the storage object and bytes behind it.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "computer_science",
+            "chapter_focus": "计算机基础"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "解释栈、堆、静态区和局部变量生命周期。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming",
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "computer_science_foundations"
+    },
+    {
+      "id": "college_cs_bit_binary",
+      "name": "二进制与位运算",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "计算机基础",
+      "unit": "数据表示",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_cs_memory_model_intro",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 程序内存模型初步 before 二进制与位运算; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_cs_memory_model_intro",
+          "relation": "co_occurs",
+          "reason": "二进制与位运算 and 程序内存模型初步 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_cs_modular_design",
+          "relation": "extends",
+          "reason": "Practice 模块化程序设计 after 二进制与位运算; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_discrete_logic",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Bitwise AND, OR, XOR, and NOT are solved by mapping each bit position to a Boolean proposition before combining the binary values.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "bit_operations_to_boolean_logic",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        },
+        {
+          "id": "senior_set_operations",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Binary masks can represent set membership, so bitwise operations apply set union, intersection, and difference ideas to compact flags.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "bitmask_to_set_operations",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "完成二进制、十六进制转换和按位与或异或运算。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_cs_modular_design",
+      "name": "模块化程序设计",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "计算机基础",
+      "unit": "程序设计方法",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_cs_bit_binary",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 二进制与位运算 before 模块化程序设计; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_cs_bit_binary",
+          "relation": "co_occurs",
+          "reason": "模块化程序设计 and 二进制与位运算 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_cs_test_cases",
+          "relation": "extends",
+          "reason": "Practice 测试用例设计 after 模块化程序设计; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_function_domain_range",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Module design first fixes each module's input domain, output range, and side effects before choosing the implementation details.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "module_contract_to_function_domain_range",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        },
+        {
+          "id": "college_set_relation",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.82,
+          "reason": "A module interface defines allowed relations between caller inputs and returned values, which helps check coupling between modules.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "module_interface_to_set_relation",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "把一个统计任务拆成输入、计算、输出三个函数。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_cs_test_cases",
+      "name": "测试用例设计",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "计算机基础",
+      "unit": "程序质量",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_cs_modular_design",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 模块化程序设计 before 测试用例设计; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_cs_modular_design",
+          "relation": "co_occurs",
+          "reason": "测试用例设计 and 模块化程序设计 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_recursion_iteration",
+          "relation": "extends",
+          "reason": "Practice 递归与迭代转换 after 测试用例设计; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_set_relation",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Test-case design starts by partitioning the input set into equivalence classes and boundary subsets before selecting concrete cases.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "test_partition_to_set_relation",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        },
+        {
+          "id": "function_domain_junior",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Boundary and invalid tests apply domain analysis by checking values inside, outside, and at the edge of the accepted input domain.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "test_boundaries_to_function_domain",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "为数组处理函数设计正常、边界和异常用例。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_c_programming"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "c_programming"
+    },
+    {
+      "id": "college_ds_recursion_iteration",
+      "name": "递归与迭代转换",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "算法设计",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_cs_test_cases",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 测试用例设计 before 递归与迭代转换; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_tree_traversal",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_c_loop_invariant",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_c_recursion_basic",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "This topic should be understood first and is used for diagnosis and learning-path guidance.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_cs_test_cases",
+          "relation": "co_occurs",
+          "reason": "递归与迭代转换 and 测试用例设计 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_dynamic_array",
+          "relation": "extends",
+          "reason": "Practice 动态数组扩容 after 递归与迭代转换; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_sequence_recursion",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "Recursion in programs and recurrence relations share self-reference, but one describes execution while the other defines mathematical terms.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "recursion_vs_recurrence",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_sequence_sum",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "reason": "Converting recursion to iteration often turns repeated recursive contributions into an accumulated sequence sum.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "recursion_iteration_to_sequence_sum",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "proof_writing",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.82,
+          "reason": "Equivalence between a recursive version and an iterative version can be argued with an induction-style invariant proof.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "recursive_iterative_equivalence_to_induction",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "把递归求和或树遍历改写成迭代过程。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures",
+      "aliases": [
+        "递归和迭代",
+        "递归",
+        "迭代",
+        "recursion iteration",
+        "递归怎么改成循环",
+        "递归和迭代什么时候选"
+      ]
+    },
+    {
+      "id": "college_ds_dynamic_array",
+      "name": "动态数组扩容",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "线性表",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_recursion_iteration",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 递归与迭代转换 before 动态数组扩容; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_recursion_iteration",
+          "relation": "co_occurs",
+          "reason": "动态数组扩容 and 递归与迭代转换 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_union_find",
+          "relation": "extends",
+          "reason": "Practice 并查集 after 动态数组扩容; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_sequence_recursion",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Capacity expansion is traced as a recurrence such as cap(k+1)=2*cap(k) before summing copied elements over append operations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "dynamic_array_growth_to_recurrence",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        },
+        {
+          "id": "growth_rate_problem",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.85,
+          "reason": "Amortized append analysis uses geometric growth to compare total copy work with the number of insertions.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "amortized_array_resize_to_growth_rate",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "分析动态数组扩容策略和摊还复杂度。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_union_find",
+      "name": "并查集",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "集合结构",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_dynamic_array",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 动态数组扩容 before 并查集; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_dynamic_array",
+          "relation": "co_occurs",
+          "reason": "并查集 and 动态数组扩容 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_topological_sort",
+          "relation": "extends",
+          "reason": "Practice 拓扑排序 after 并查集; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_set_relation",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Union-find operations maintain a partition of elements by repeatedly finding representatives and merging equivalence classes.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "union_find_to_equivalence_relation",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        },
+        {
+          "id": "college_graph_connectivity",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Union-find answers graph connectivity queries by merging endpoints of edges and comparing component representatives.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "union_find_to_graph_connectivity",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "用路径压缩和按秩合并处理连通性问题。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_topological_sort",
+      "name": "拓扑排序",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "图",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_union_find",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 并查集 before 拓扑排序; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_union_find",
+          "relation": "co_occurs",
+          "reason": "拓扑排序 and 并查集 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_ds_greedy_dp_intro",
+          "relation": "extends",
+          "reason": "Practice 贪心与动态规划初步 after 拓扑排序; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_graph_theory_intro",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Topological sorting first models prerequisites as a directed acyclic graph, then repeatedly removes vertices with zero in-degree.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "topological_sort_to_dag_model",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        },
+        {
+          "id": "college_set_relation",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "A valid topological order applies a partial-order relation by arranging every prerequisite before the dependent task.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "topological_order_to_partial_order_relation",
+            "cross_subject": true,
+            "added_for": "computer_science_ready_gap_cleanup"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "根据依赖关系图判断是否存在拓扑序列。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    },
+    {
+      "id": "college_ds_greedy_dp_intro",
+      "name": "贪心与动态规划初步",
+      "subject": "computer_science",
+      "stage": "college",
+      "chapter": "数据结构",
+      "unit": "算法设计",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_ds_topological_sort",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 拓扑排序 before 贪心与动态规划初步; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_matrix_operations",
+          "required_mastery": 0.5,
+          "relation": "prerequisite",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Two-dimensional dynamic-programming tables use matrix-like indexing, transitions, and boundary rows or columns.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "matrix_to_dynamic_programming",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_ds_topological_sort",
+          "relation": "co_occurs",
+          "reason": "贪心与动态规划初步 and 拓扑排序 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_matrix_dimension",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.81,
+          "reason": "Dynamic-programming table design first fixes state dimensions and boundary rows or columns before filling recurrence values.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_concept": "matrix_dimension_to_dp_table_design",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_sequence_recursion",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Dynamic programming stores recurrence values after turning a recursive sequence relation into reusable states.",
+          "use_cases": [
+            "diagnosis",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "dynamic_programming_to_recurrence_values",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "senior_sequence_sum",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.8,
+          "reason": "Many dynamic-programming transitions combine earlier terms, so sequence sums help explain accumulated optimal values.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "dp_transition_to_sequence_sum",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        },
+        {
+          "id": "proof_writing",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.81,
+          "reason": "After defining DP states and transitions, a proof-writing step explains why the recurrence covers all valid choices.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "computer_science",
+            "target_subject": "math",
+            "bridge_direction": "computer_science_to_math",
+            "bridge_concept": "dp_correctness_to_proof_structure",
+            "cross_subject": true,
+            "added_for": "cs_math_cross_seed_links"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背语法但不追踪变量和内存状态",
+        "忽略边界条件、空输入或重复元素",
+        "把能运行的程序误当成复杂度和鲁棒性都正确"
+      ],
+      "skills": [
+        "把问题拆成输入、状态、操作和输出",
+        "用代码、图示或复杂度分析表达算法过程",
+        "通过边界用例和不变量检查实现正确性"
+      ],
+      "question_types": [
+        "程序阅读",
+        "算法设计"
+      ],
+      "examples": [
+        {
+          "prompt": "比较局部最优选择和状态转移方程的适用条件。",
+          "answer_outline": [
+            "先识别题目考查的计算机基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "只背语法但不追踪变量和内存状态",
+            "忽略边界条件、空输入或重复元素"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "computer_science",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "college_data_structures"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "data_structures"
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/economics.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/economics.json
@@ -1692,25 +1692,6 @@
           }
         },
         {
-          "id": "quadratic_max_min",
-          "relation": "confusable",
-          "priority": "useful",
-          "context": "diagnosis",
-          "confidence": 0.8,
-          "reason": "Quadratic maximum templates can find a profit peak, but economic profit maximization still requires MR, MC, and feasibility checks.",
-          "use_cases": [
-            "diagnosis",
-            "hint_generation",
-            "review"
-          ],
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "economics",
-            "bridge": "math_to_economics",
-            "focus": "quadratic_maximum_vs_profit_rule"
-          }
-        },
-        {
           "id": "college_optimization_applications",
           "relation": "application",
           "priority": "core",

--- a/plugin/plugins/study_companion/static/knowledge_seeds/economics.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/economics.json
@@ -1,0 +1,5401 @@
+{
+  "version": "1.0",
+  "subject": "economics",
+  "topics": [
+    {
+      "id": "college_econ_scarcity_opportunity_cost",
+      "name": "稀缺性与机会成本",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "经济学导论",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "mathematical_modeling",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 数学建模与应用题审题 before 稀缺性与机会成本; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_index_real_nominal",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "Opportunity cost is about the next best forgone alternative, not about nominal versus real measurement.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Opportunity cost is a core input when comparing costs and benefits of choices.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_ppf",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "The production possibilities frontier visualizes scarcity, trade-offs, and opportunity cost.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "mathematical_modeling",
+          "relation": "co_occurs",
+          "reason": "稀缺性与机会成本 and 数学建模与应用题审题 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_ppf",
+          "relation": "extends",
+          "reason": "Practice 生产可能性边界 after 稀缺性与机会成本; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用机会成本解释一个学习或消费选择。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics",
+      "aliases": [
+        "机会成本",
+        "稀缺性",
+        "稀缺性与机会成本",
+        "opportunity cost"
+      ]
+    },
+    {
+      "id": "college_econ_ppf",
+      "name": "生产可能性边界",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "经济学导论",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_scarcity_opportunity_cost",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 稀缺性与机会成本 before 生产可能性边界; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_scarcity_opportunity_cost",
+          "relation": "co_occurs",
+          "reason": "生产可能性边界 and 稀缺性与机会成本 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "extends",
+          "reason": "Practice 需求供给模型 after 生产可能性边界; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After using the PPF to identify scarcity and trade-offs, learners can analyze how markets allocate goods through demand and supply.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_scarcity_opportunity_cost",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.9,
+          "reason": "PPF questions apply scarcity and opportunity cost by showing feasible choices and the cost of moving along the frontier.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_growth_productivity",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Students often confuse movement along a fixed PPF with outward shifts caused by growth or productivity improvements.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "由 PPF 图判断效率、机会成本和经济增长。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_demand_supply",
+      "name": "需求供给模型",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "市场均衡",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_ppf",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 生产可能性边界 before 需求供给模型; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "function_concept",
+          "required_mastery": 0.6,
+          "relation": "prerequisite",
+          "reason": "Function concepts are a math prerequisite for reading demand and supply curves as mappings between price and quantity.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "function_to_supply_demand_curve"
+          }
+        },
+        {
+          "id": "function_graph_reading",
+          "required_mastery": 0.6,
+          "relation": "prerequisite",
+          "reason": "Demand-supply analysis needs graph-reading skill before learners interpret curve shifts, slopes, and intersections on price-quantity axes.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "supply_demand_curve_to_function_graph_reading"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_aggregate_demand_supply",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "Micro demand-supply curves differ from macro aggregate demand and aggregate supply models in scope and interpretation.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_consumer_choice",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Demand curves connect individual choice to market demand and equilibrium outcomes.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_elasticity",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "After drawing demand and supply curves, elasticity helps explain response size and incidence.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Linear function graph skills transfer directly to drawing demand and supply schedules as curves on price-quantity axes.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "function_graph_to_supply_demand_curve"
+          }
+        },
+        {
+          "id": "linear_function_application",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Set up price as an input and quantity as an output before solving shifts, intersections, and equilibrium changes.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "function_modeling_to_market_equilibrium"
+          }
+        },
+        {
+          "id": "linear_function_kb",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Slope and intercept describe a line, while economic interpretation asks whether the curve is demand or supply and what changed.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "slope_intercept_vs_economic_interpretation"
+          }
+        },
+        {
+          "id": "senior_function_modeling",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Supply and demand curves apply function modeling by translating economic assumptions into price-quantity relationships.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "supply_demand_curve_to_function_modeling"
+          }
+        },
+        {
+          "id": "linear_function_intersection",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Finding market equilibrium follows the same procedural step as locating the intersection of two linear functions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "market_equilibrium_to_function_intersection"
+          }
+        },
+        {
+          "id": "senior_function_monotonicity",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "A curve's mathematical monotonicity is not the same as the economic cause of a demand or supply shift.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "curve_direction_vs_economic_shift"
+          }
+        },
+        {
+          "id": "function_concept",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Supply and demand analysis applies the function concept by treating price and quantity as linked variables.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "supply_demand_to_function_concept"
+          }
+        },
+        {
+          "id": "linear_function_expression",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Linear demand and supply schedules apply linear function expressions when learners write equations for market curves.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "market_curves_to_linear_function_expression"
+          }
+        },
+        {
+          "id": "linear_system_application",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Market equilibrium applies linear system solving when demand and supply equations are set equal.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "equilibrium_to_linear_system_application"
+          }
+        },
+        {
+          "id": "coordinate_system",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Drawing supply and demand curves proceeds through coordinate-system setup with quantity and price axes.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "market_graph_to_coordinate_system"
+          }
+        },
+        {
+          "id": "college_econ_ppf",
+          "relation": "co_occurs",
+          "reason": "需求供给模型 and 生产可能性边界 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_elasticity",
+          "relation": "extends",
+          "reason": "Practice 弹性分析 after 需求供给模型; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "分析需求或供给变动对均衡价格和数量的影响。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics",
+      "aliases": [
+        "需求供给",
+        "需求和供给曲线",
+        "供需模型",
+        "demand supply"
+      ]
+    },
+    {
+      "id": "college_micro_elasticity",
+      "name": "弹性分析",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "市场均衡",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_demand_supply",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 需求供给模型 before 弹性分析; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "linear_function_kb",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Slope and intercept ideas prepare learners to compare absolute curve changes with percentage ratio changes in elasticity.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "ratio_change_elasticity"
+          }
+        },
+        {
+          "id": "primary_ratio_meaning",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Elasticity compares percentage changes as a ratio, so learners need ratio meaning before interpreting elastic and inelastic responses.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "elasticity_to_ratio_change"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "co_occurs",
+          "reason": "弹性分析 and 需求供给模型 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_consumer_choice",
+          "relation": "extends",
+          "reason": "Practice 消费者选择 after 弹性分析; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Elasticity analysis starts by identifying the relevant demand or supply curve and the direction of price or quantity change.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.81,
+          "reason": "Elasticity supports cost-benefit reasoning by estimating how consumers or firms respond to price and policy changes.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_derivative_calculation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Point elasticity applies derivative calculation by multiplying the local rate of quantity change by the price-quantity ratio.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "derivative_to_point_elasticity"
+          }
+        },
+        {
+          "id": "function_concept",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Elasticity work first identifies the function linking price and quantity, then compares percentage changes along that relation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "function_to_ratio_change"
+          }
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "The slope of a demand curve is an absolute rate, while elasticity is a percentage ratio change and varies with the point.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "slope_vs_elasticity"
+          }
+        },
+        {
+          "id": "growth_rate_problem",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Elasticity applies percentage-change reasoning from growth-rate problems to price and quantity responses.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "elasticity_to_percentage_change"
+          }
+        },
+        {
+          "id": "college_derivative_definition",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Point elasticity proceeds from average percentage changes to local rate-of-change reasoning expressed by the derivative definition.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "point_elasticity_to_derivative_definition"
+          }
+        },
+        {
+          "id": "direct_proportion",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.79,
+          "reason": "Elasticity is a ratio of percentage changes, not a claim that price and quantity are directly proportional.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "elasticity_ratio_vs_direct_proportion"
+          }
+        },
+        {
+          "id": "senior_derivative_concept",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Point elasticity applies derivative concepts to describe local responsiveness of quantity to price.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "point_elasticity_to_derivative_concept"
+          }
+        },
+        {
+          "id": "primary_percent_meaning",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Elasticity applies percent meaning because it compares percentage changes in price and quantity.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "elasticity_to_percent_meaning"
+          }
+        },
+        {
+          "id": "senior_derivative_tangent",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "Point elasticity applies tangent-slope reasoning when interpreting the local slope of a demand curve.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "point_elasticity_to_tangent_slope"
+          }
+        },
+        {
+          "id": "college_chain_rule",
+          "relation": "procedure_step",
+          "priority": "optional",
+          "context": "review",
+          "confidence": 0.78,
+          "reason": "Advanced elasticity work can proceed to chain-rule reasoning when variables affect demand through intermediate functions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "elasticity_to_chain_rule_extension"
+          }
+        },
+        {
+          "id": "college_macro_cpi_inflation",
+          "relation": "confusable",
+          "priority": "optional",
+          "context": "diagnosis",
+          "confidence": 0.74,
+          "reason": "Elasticity measures responsiveness, while inflation measures changes in the overall price level; both use percentages but answer different questions.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "计算需求价格弹性并判断总收益变化。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_consumer_choice",
+      "name": "消费者选择",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "消费者理论",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_elasticity",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 弹性分析 before 消费者选择; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_elasticity",
+          "relation": "co_occurs",
+          "reason": "消费者选择 and 弹性分析 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_utility_marginal",
+          "relation": "extends",
+          "reason": "Practice 边际效用递减 after 消费者选择; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_utility_marginal",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Consumer choice problems proceed from preferences and budget constraints to marginal utility comparisons at the chosen bundle.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Consumer choice explains where individual demand curves come from before they are aggregated into market demand.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_scarcity_opportunity_cost",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "A budget constraint is a specific income-price limit, while opportunity cost is the broader value of the next best forgone option.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用预算线和无差异曲线解释最优消费组合。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_utility_marginal",
+      "name": "边际效用递减",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "消费者理论",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_consumer_choice",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 消费者选择 before 边际效用递减; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_consumer_choice",
+          "relation": "co_occurs",
+          "reason": "边际效用递减 and 消费者选择 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_cost_short_run",
+          "relation": "extends",
+          "reason": "Practice 短期成本曲线 after 边际效用递减; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_consumer_choice",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Marginal utility calculations feed into consumer choice by comparing marginal utility per unit of price across goods.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.8,
+          "reason": "Diminishing marginal utility helps explain why demand curves usually slope downward.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_elasticity",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.76,
+          "reason": "Marginal utility describes added satisfaction from consumption, while elasticity describes responsiveness to price or income changes.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "根据边际效用表判断消费决策。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_cost_short_run",
+      "name": "短期成本曲线",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "生产与成本",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_utility_marginal",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 边际效用递减 before 短期成本曲线; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_derivative_calculation",
+          "required_mastery": 0.6,
+          "relation": "prerequisite",
+          "reason": "Derivative calculation is a math prerequisite for interpreting marginal cost as the rate of change of total cost.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "derivative_to_marginal_cost"
+          }
+        },
+        {
+          "id": "college_derivative_definition",
+          "required_mastery": 0.6,
+          "relation": "prerequisite",
+          "reason": "Marginal cost depends on understanding a derivative as the instantaneous change in total cost with respect to output.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "marginal_cost_to_derivative_definition"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_utility_marginal",
+          "relation": "co_occurs",
+          "reason": "短期成本曲线 and 边际效用递减 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_firm_profit",
+          "relation": "extends",
+          "reason": "Practice 厂商利润最大化 after 短期成本曲线; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_firm_profit",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Short-run cost curves are used next to compare marginal revenue with marginal cost and determine profit-maximizing output.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_perfect_competition",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Perfect competition problems apply short-run cost curves to shutdown, supply, and profit calculations.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_monotonic_extrema",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Monotonicity and extrema analysis helps explain turning points and marginal-average relationships on cost curves.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "extrema_to_cost_curve_shape"
+          }
+        },
+        {
+          "id": "college_derivative_calculation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Short-run cost curves apply derivative calculation when deriving marginal cost from a total cost function.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "marginal_cost_to_derivative_calculation"
+          }
+        },
+        {
+          "id": "college_function_graph_analysis",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Average and marginal cost curves apply function graph analysis to compare shape, turning points, and intersections.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "cost_curves_to_function_graph_analysis"
+          }
+        },
+        {
+          "id": "college_second_derivative_test",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.83,
+          "reason": "Explaining cost-curve curvature can proceed to second-derivative tests for convexity and minimum-cost points.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "cost_curve_curvature_to_second_derivative"
+          }
+        },
+        {
+          "id": "college_derivative_definition",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.87,
+          "reason": "Marginal cost applies the derivative definition as the limiting change in total cost per extra unit of output.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "marginal_cost_to_derivative_definition"
+          }
+        },
+        {
+          "id": "college_tangent_line_equation",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Marginal cost applies tangent-line reasoning when a cost curve is approximated near a chosen output level.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "marginal_cost_to_tangent_line"
+          }
+        },
+        {
+          "id": "college_convavity_inflection",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.82,
+          "reason": "Cost-curve shape applies concavity and inflection reasoning when interpreting increasing or decreasing marginal cost.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "cost_curve_shape_to_concavity"
+          }
+        },
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.79,
+          "reason": "Short-run production cost concepts are narrower than general cost-benefit analysis and depend on fixed versus variable inputs.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "区分固定成本、可变成本、平均成本和边际成本。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_firm_profit",
+      "name": "厂商利润最大化",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "生产与成本",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_cost_short_run",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 短期成本曲线 before 厂商利润最大化; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_absolute_extrema",
+          "required_mastery": 0.62,
+          "relation": "prerequisite",
+          "reason": "Absolute extrema reasoning is a math prerequisite for checking whether a candidate output maximizes profit over the feasible range.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "extrema_to_profit_maximization"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_cost_short_run",
+          "relation": "co_occurs",
+          "reason": "厂商利润最大化 and 短期成本曲线 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_perfect_competition",
+          "relation": "extends",
+          "reason": "Practice 完全竞争市场 after 厂商利润最大化; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_cost_short_run",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Profit maximization requires identifying revenue, total cost, marginal cost, and marginal revenue before choosing output.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_derivative_calculation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Profit maximization applies derivatives because marginal revenue and marginal cost are rates of change of revenue and cost.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "derivative_to_marginal_revenue_cost"
+          }
+        },
+        {
+          "id": "college_extreme_value_points",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After setting marginal revenue equal to marginal cost, learners test candidate extreme points against boundaries and assumptions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "critical_point_to_profit_choice"
+          }
+        },
+        {
+          "id": "quadratic_max_min",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Quadratic maximum templates can find a profit peak, but economic profit maximization still requires MR, MC, and feasibility checks.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge": "math_to_economics",
+            "focus": "quadratic_maximum_vs_profit_rule"
+          }
+        },
+        {
+          "id": "college_optimization_applications",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Firm profit maximization is an economics application of optimization: choose output to maximize profit under feasibility constraints.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "profit_maximization_to_optimization"
+          }
+        },
+        {
+          "id": "college_monotonic_extrema",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Profit maximization applies monotonicity and extrema reasoning when comparing marginal revenue, marginal cost, and boundary outputs.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "profit_maximization_to_extrema"
+          }
+        },
+        {
+          "id": "college_second_derivative_test",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "After MR equals MC, the second-derivative test helps check whether the candidate output is a profit maximum.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "profit_maximum_to_second_derivative_test"
+          }
+        },
+        {
+          "id": "college_critical_points",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Profit maximization applies critical-point analysis when MR equals MC or a boundary output must be checked.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "profit_maximization_to_critical_points"
+          }
+        },
+        {
+          "id": "college_absolute_extrema",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Profit maximization applies absolute-extrema reasoning because the best output must be chosen over the feasible range.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "profit_maximization_to_absolute_extrema"
+          }
+        },
+        {
+          "id": "senior_derivative_extrema",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Firm output choice applies derivative-extrema methods to locate and verify profit peaks.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "firm_output_choice_to_derivative_extrema"
+          }
+        },
+        {
+          "id": "college_lagrange_multiplier",
+          "relation": "application",
+          "priority": "optional",
+          "context": "review",
+          "confidence": 0.78,
+          "reason": "Constrained profit problems apply Lagrange multiplier ideas when firms optimize under resource or technology constraints.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "constrained_profit_to_lagrange_multiplier"
+          }
+        },
+        {
+          "id": "college_micro_perfect_competition",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Firm profit rules are applied directly when analyzing output and entry decisions in competitive markets.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Economic profit includes opportunity cost, while simple accounting comparisons may omit implicit costs.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用 MR=MC 判断产量选择和利润。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_perfect_competition",
+      "name": "完全竞争市场",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "市场结构",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_firm_profit",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 厂商利润最大化 before 完全竞争市场; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_firm_profit",
+          "relation": "co_occurs",
+          "reason": "完全竞争市场 and 厂商利润最大化 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_monopoly",
+          "relation": "extends",
+          "reason": "Practice 垄断市场 after 完全竞争市场; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_firm_profit",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Competitive-market analysis proceeds by applying the firm profit rule under the price-taking assumption.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.85,
+          "reason": "Perfect competition applies demand and supply logic to markets with many buyers and sellers and no individual price control.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_monopoly",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "Perfect competition and monopoly use different assumptions about price-taking, market power, and marginal revenue.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "分析完全竞争厂商短期供给和停产条件。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_monopoly",
+      "name": "垄断市场",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "市场结构",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_perfect_competition",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 完全竞争市场 before 垄断市场; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_perfect_competition",
+          "relation": "co_occurs",
+          "reason": "垄断市场 and 完全竞争市场 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_externality",
+          "relation": "extends",
+          "reason": "Practice 外部性与矫正政策 after 垄断市场; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_firm_profit",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Monopoly problems use the profit-maximization workflow but require a separate marginal revenue curve below demand.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_externality",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.77,
+          "reason": "Monopoly is a market power case that can be compared with other sources of market failure such as externalities.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_perfect_competition",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "Students often apply competitive price-taking rules to monopoly even though monopoly faces the market demand curve.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "比较垄断定价、产量和社会福利损失。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_externality",
+      "name": "外部性与矫正政策",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "市场失灵",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_monopoly",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 垄断市场 before 外部性与矫正政策; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_monopoly",
+          "relation": "co_occurs",
+          "reason": "外部性与矫正政策 and 垄断市场 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_public_goods",
+          "relation": "extends",
+          "reason": "Practice 公共物品与搭便车 after 外部性与矫正政策; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Externality analysis starts from market demand and supply, then adds private and social cost or benefit curves.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "Externality cases are common applications for evaluating taxes, subsidies, regulation, and efficiency-equity trade-offs.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_micro_public_goods",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "Externalities and public goods are both market failures, but public goods are defined by non-rivalry and non-excludability.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用图像解释污染税或补贴如何改变社会最优。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_micro_public_goods",
+      "name": "公共物品与搭便车",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "微观经济学",
+      "unit": "市场失灵",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_externality",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 外部性与矫正政策 before 公共物品与搭便车; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_externality",
+          "relation": "co_occurs",
+          "reason": "公共物品与搭便车 and 外部性与矫正政策 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_gdp_accounting",
+          "relation": "extends",
+          "reason": "Practice GDP 核算 after 公共物品与搭便车; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "procedure_step",
+          "reason": "After identifying public-good features, learners compare provision, financing, and equity trade-offs.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "public_goods_to_policy_tradeoff"
+          }
+        },
+        {
+          "id": "college_micro_externality",
+          "relation": "confusable",
+          "reason": "Public goods create market failure, but the key test is non-excludability and non-rivalry rather than any external cost or benefit.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "public_goods_vs_externality"
+          }
+        },
+        {
+          "id": "pol_senior_economy_market",
+          "relation": "application",
+          "reason": "Public-good cases apply market-government boundary reasoning when judging whether collective provision is needed.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "public_goods_to_market_government_boundary"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "判断非竞争性、非排他性和公共供给理由。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_macro_gdp_accounting",
+      "name": "GDP 核算",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "国民收入核算",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_micro_public_goods",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 公共物品与搭便车 before GDP 核算; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_micro_public_goods",
+          "relation": "co_occurs",
+          "reason": "GDP 核算 and 公共物品与搭便车 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_cpi_inflation",
+          "relation": "extends",
+          "reason": "Practice CPI 与通货膨胀 after GDP 核算; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "GDP accounting problems proceed by reading economic data, identifying components, and applying the expenditure or income approach.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_index_real_nominal",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "GDP data often require converting between nominal and real values before comparing output across time.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_cpi_inflation",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "GDP deflator and CPI both measure price changes, but GDP accounting covers domestic production while CPI tracks a consumer basket.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用支出法计算 GDP 并识别不计入项目。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_macro_cpi_inflation",
+      "name": "CPI 与通货膨胀",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "价格水平",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_gdp_accounting",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master GDP 核算 before CPI 与通货膨胀; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_gdp_accounting",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "CPI measures consumer price changes, while GDP accounting measures output and income flows.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_monetary_policy",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Inflation indicators are central evidence for monetary policy decisions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_index_real_nominal",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Inflation analysis requires converting nominal values to real values and reading price indexes correctly.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "primary_percent_application",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "CPI and inflation calculations apply percent-change methods to compare price levels across periods.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "cpi_inflation_to_percent_application"
+          }
+        },
+        {
+          "id": "weighted_mean",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "CPI applies weighted-mean reasoning because category prices contribute according to basket weights.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "cpi_basket_to_weighted_mean"
+          }
+        },
+        {
+          "id": "primary_line_chart_trend",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Inflation time-series work applies line-chart trend reading to describe changes in the price level.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "inflation_series_to_line_chart_trend"
+          }
+        },
+        {
+          "id": "growth_rate_problem",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Inflation-rate questions apply growth-rate problem solving when comparing CPI values between periods.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "inflation_rate_to_growth_rate_problem"
+          }
+        },
+        {
+          "id": "college_macro_gdp_accounting",
+          "relation": "co_occurs",
+          "reason": "CPI 与通货膨胀 and GDP 核算 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_unemployment",
+          "relation": "extends",
+          "reason": "Practice 失业类型 after CPI 与通货膨胀; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "根据价格篮子计算 CPI 和通胀率。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics",
+      "aliases": [
+        "通货膨胀",
+        "CPI",
+        "居民消费价格指数",
+        "通货膨胀和CPI"
+      ]
+    },
+    {
+      "id": "college_macro_unemployment",
+      "name": "失业类型",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "就业与失业",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_cpi_inflation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master CPI 与通货膨胀 before 失业类型; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_cpi_inflation",
+          "relation": "co_occurs",
+          "reason": "失业类型 and CPI 与通货膨胀 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_aggregate_demand_supply",
+          "relation": "extends",
+          "reason": "Practice 总需求总供给模型 after 失业类型; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_macro_aggregate_demand_supply",
+          "relation": "procedure_step",
+          "reason": "After measuring unemployment, learners use AD-AS to explain demand shocks, output gaps, and labor-market pressure.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "unemployment_to_ad_as"
+          }
+        },
+        {
+          "id": "college_macro_cpi_inflation",
+          "relation": "confusable",
+          "reason": "Unemployment measures unused labor, while inflation measures price-level change; Phillips-curve links do not make them the same variable.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "unemployment_vs_inflation"
+          }
+        },
+        {
+          "id": "primary_line_chart_trend",
+          "relation": "application",
+          "reason": "Unemployment-rate series apply line-chart trend reading when learners compare peaks, troughs, and recoveries.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "unemployment_series_to_line_chart"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "区分摩擦性、结构性、周期性失业。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_macro_aggregate_demand_supply",
+      "name": "总需求总供给模型",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "宏观波动",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_unemployment",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 失业类型 before 总需求总供给模型; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_unemployment",
+          "relation": "co_occurs",
+          "reason": "总需求总供给模型 and 失业类型 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_multiplier",
+          "relation": "extends",
+          "reason": "Practice 乘数效应 after 总需求总供给模型; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Aggregate demand and aggregate supply analysis applies function graph reading to interpret shifts, intersections, and output-price changes.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "aggregate_supply_demand_to_function_graph_reading"
+          }
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "AD-AS diagrams apply linear function graph skills when learners compare slopes, shifts, and intercept-style readings.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "ad_as_to_linear_function_graph"
+          }
+        },
+        {
+          "id": "linear_function_intersection",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Short-run macro equilibrium applies intersection reasoning where aggregate demand and aggregate supply meet.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "ad_as_equilibrium_to_function_intersection"
+          }
+        },
+        {
+          "id": "senior_function_modeling",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Aggregate demand and supply apply function modeling by translating macro assumptions into output-price relationships.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "ad_as_to_function_modeling"
+          }
+        },
+        {
+          "id": "college_macro_multiplier",
+          "relation": "procedure_step",
+          "reason": "After finding AD-AS equilibrium, learners can trace how spending changes are amplified through aggregate demand.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "ad_as_to_multiplier"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "confusable",
+          "reason": "Micro demand-supply explains one market, while AD-AS explains economy-wide output and the price level.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "micro_supply_demand_vs_ad_as"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "分析 AD 或 AS 移动对产出和价格水平的影响。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_macro_multiplier",
+      "name": "乘数效应",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "宏观政策",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_aggregate_demand_supply",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 总需求总供给模型 before 乘数效应; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_aggregate_demand_supply",
+          "relation": "co_occurs",
+          "reason": "乘数效应 and 总需求总供给模型 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_fiscal_policy",
+          "relation": "extends",
+          "reason": "Practice 财政政策 after 乘数效应; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_macro_fiscal_policy",
+          "relation": "procedure_step",
+          "reason": "After computing multiplier effects, learners judge how tax or spending changes shift aggregate demand.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "multiplier_to_fiscal_policy"
+          }
+        },
+        {
+          "id": "college_macro_aggregate_demand_supply",
+          "relation": "confusable",
+          "reason": "The multiplier is a change-amplification mechanism, while AD-AS is the diagram used to place the resulting output and price effects.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "multiplier_vs_ad_as"
+          }
+        },
+        {
+          "id": "linear_function_application",
+          "relation": "application",
+          "reason": "Multiplier exercises apply linear-function reasoning when estimating total income change from an initial spending change.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "multiplier_to_linear_function_application"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "由边际消费倾向计算政府支出乘数。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_macro_fiscal_policy",
+      "name": "财政政策",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "宏观政策",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_multiplier",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 乘数效应 before 财政政策; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Fiscal-policy questions often require weighing inflation, unemployment, debt, and growth trade-offs.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_monetary_policy",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "Fiscal policy changes government spending or taxes, while monetary policy changes money and interest-rate conditions.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_multiplier",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Fiscal policy analysis should connect spending or tax changes to multiplier effects and aggregate demand.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_macro_multiplier",
+          "relation": "co_occurs",
+          "reason": "财政政策 and 乘数效应 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_money_banking",
+          "relation": "extends",
+          "reason": "Practice 货币与银行体系 after 财政政策; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "解释扩张性财政政策对总需求和债务的影响。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics",
+      "aliases": [
+        "财政政策",
+        "财政政策和货币政策",
+        "扩张性财政政策",
+        "fiscal policy"
+      ]
+    },
+    {
+      "id": "college_macro_money_banking",
+      "name": "货币与银行体系",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "货币金融",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_fiscal_policy",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 财政政策 before 货币与银行体系; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_fiscal_policy",
+          "relation": "co_occurs",
+          "reason": "货币与银行体系 and 财政政策 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_monetary_policy",
+          "relation": "extends",
+          "reason": "Practice 货币政策 after 货币与银行体系; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_macro_monetary_policy",
+          "relation": "procedure_step",
+          "reason": "After learning deposits, reserves, and money creation, learners analyze how central-bank tools affect money and credit.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "money_banking_to_monetary_policy"
+          }
+        },
+        {
+          "id": "college_macro_fiscal_policy",
+          "relation": "confusable",
+          "reason": "Banking and money creation operate through financial institutions, while fiscal policy changes government spending or taxes.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "money_banking_vs_fiscal_policy"
+          }
+        },
+        {
+          "id": "pol_senior_economy_market",
+          "relation": "application",
+          "reason": "Banking regulation applies market-order reasoning because credit creation links private finance with public stability goals.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "banking_to_market_order_policy"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "计算存款创造过程中的货币乘数。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_macro_monetary_policy",
+      "name": "货币政策",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "货币金融",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_money_banking",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 货币与银行体系 before 货币政策; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_money_banking",
+          "relation": "co_occurs",
+          "reason": "货币政策 and 货币与银行体系 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_macro_exchange_rate",
+          "relation": "extends",
+          "reason": "Practice 汇率与国际收支 after 货币政策; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_macro_exchange_rate",
+          "relation": "procedure_step",
+          "reason": "After analyzing interest-rate and money-supply tools, learners trace effects on capital flows and exchange rates.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "monetary_policy_to_exchange_rate"
+          }
+        },
+        {
+          "id": "college_macro_fiscal_policy",
+          "relation": "confusable",
+          "reason": "Monetary policy uses central-bank money and interest-rate tools, while fiscal policy uses government budgets.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "monetary_vs_fiscal_policy"
+          }
+        },
+        {
+          "id": "primary_line_chart_trend",
+          "relation": "application",
+          "reason": "Monetary-policy analysis applies line-chart trend reading to interest-rate, inflation, and money-supply series.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "monetary_policy_to_line_chart"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "分析降准、降息或公开市场操作对经济的影响。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_macro_exchange_rate",
+      "name": "汇率与国际收支",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "开放经济",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_monetary_policy",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 货币政策 before 汇率与国际收支; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_monetary_policy",
+          "relation": "co_occurs",
+          "reason": "汇率与国际收支 and 货币政策 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_growth_productivity",
+          "relation": "extends",
+          "reason": "Practice 经济增长与生产率 after 汇率与国际收支; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_growth_productivity",
+          "relation": "procedure_step",
+          "reason": "After exchange-rate analysis, learners can connect currency changes to trade competitiveness and long-run productivity.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "exchange_rate_to_growth_productivity"
+          }
+        },
+        {
+          "id": "college_econ_index_real_nominal",
+          "relation": "confusable",
+          "reason": "Nominal exchange-rate changes are not the same as real purchasing-power changes after inflation adjustment.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "nominal_fx_vs_real_values"
+          }
+        },
+        {
+          "id": "geo_junior_transport_trade",
+          "relation": "application",
+          "reason": "Exchange-rate cases apply to trade geography when learners explain exports, imports, and transport-linked market access.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "exchange_rate_to_trade_geography"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "判断汇率变动对出口、进口和资本流动的影响。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_growth_productivity",
+      "name": "经济增长与生产率",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "宏观经济学",
+      "unit": "长期增长",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_macro_exchange_rate",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 汇率与国际收支 before 经济增长与生产率; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_macro_exchange_rate",
+          "relation": "co_occurs",
+          "reason": "经济增长与生产率 and 汇率与国际收支 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_game_prisoner",
+          "relation": "extends",
+          "reason": "Practice 博弈论囚徒困境 after 经济增长与生产率; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "procedure_step",
+          "reason": "After defining growth and productivity, learners read data series to compare trends and sources of change.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "growth_productivity_to_data_graph"
+          }
+        },
+        {
+          "id": "college_macro_exchange_rate",
+          "relation": "confusable",
+          "reason": "Exchange-rate appreciation can change trade prices, but productivity growth means more output per input.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "exchange_rate_vs_productivity_growth"
+          }
+        },
+        {
+          "id": "growth_rate_problem",
+          "relation": "application",
+          "reason": "Growth and productivity questions apply percentage-growth calculations when comparing output per worker over time.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "growth_productivity_to_growth_rate_problem"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用资本、劳动、技术解释长期增长来源。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_game_prisoner",
+      "name": "博弈论囚徒困境",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "策略互动",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_growth_productivity",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 经济增长与生产率 before 博弈论囚徒困境; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_growth_productivity",
+          "relation": "co_occurs",
+          "reason": "博弈论囚徒困境 and 经济增长与生产率 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_information_asymmetry",
+          "relation": "extends",
+          "reason": "Practice 信息不对称 after 博弈论囚徒困境; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_information_asymmetry",
+          "relation": "procedure_step",
+          "reason": "After modeling strategic incentives, learners can study how hidden information changes cooperation and bargaining.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "game_theory_to_information_asymmetry"
+          }
+        },
+        {
+          "id": "college_micro_perfect_competition",
+          "relation": "confusable",
+          "reason": "Perfect competition assumes many price takers, while prisoner-dilemma models emphasize strategic interdependence.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "perfect_competition_vs_prisoner_dilemma"
+          }
+        },
+        {
+          "id": "pol_senior_international_relations",
+          "relation": "application",
+          "reason": "Prisoner-dilemma reasoning applies to international cooperation problems where each side weighs unilateral incentives.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "prisoner_dilemma_to_international_relations"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用支付矩阵判断占优策略和纳什均衡。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_information_asymmetry",
+      "name": "信息不对称",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "市场失灵",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_game_prisoner",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 博弈论囚徒困境 before 信息不对称; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_game_prisoner",
+          "relation": "co_occurs",
+          "reason": "信息不对称 and 博弈论囚徒困境 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "extends",
+          "reason": "Practice 成本收益分析 after 信息不对称; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "procedure_step",
+          "reason": "After diagnosing hidden information, learners compare screening, signaling, and regulation by expected costs and benefits.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "information_asymmetry_to_cost_benefit"
+          }
+        },
+        {
+          "id": "college_micro_monopoly",
+          "relation": "confusable",
+          "reason": "Monopoly is market power from a single seller, while information asymmetry is unequal knowledge between parties.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "monopoly_vs_information_asymmetry"
+          }
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "application",
+          "reason": "Information-asymmetry cases apply rule-of-law reasoning when disclosure duties and consumer protection reduce hidden risk.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "information_asymmetry_to_rule_of_law"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "解释逆向选择或道德风险的机制。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_cost_benefit",
+      "name": "成本收益分析",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "决策分析",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_information_asymmetry",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 信息不对称 before 成本收益分析; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_information_asymmetry",
+          "relation": "co_occurs",
+          "reason": "成本收益分析 and 信息不对称 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "extends",
+          "reason": "Practice 经济数据图表解读 after 成本收益分析; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "primary_ratio_meaning",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Cost-benefit analysis applies ratio reasoning when comparing benefit-cost ratios and relative returns.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "cost_benefit_to_ratio_reasoning"
+          }
+        },
+        {
+          "id": "primary_optimization_strategy",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "Cost-benefit analysis applies optimization strategy when choosing the option with the greatest net benefit under constraints.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "cost_benefit_to_optimization_strategy"
+          }
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "procedure_step",
+          "reason": "After defining costs and benefits, learners gather or read evidence before making a justified comparison.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "cost_benefit_to_data_graph"
+          }
+        },
+        {
+          "id": "college_micro_cost_short_run",
+          "relation": "confusable",
+          "reason": "Short-run cost curves describe firm production costs, while cost-benefit analysis compares total gains and losses from a decision.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "short_run_cost_vs_cost_benefit"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "比较一个项目的显性成本、隐性成本和收益。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_data_graph",
+      "name": "经济数据图表解读",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "数据分析",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_cost_benefit",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 成本收益分析 before 经济数据图表解读; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "co_occurs",
+          "reason": "经济数据图表解读 and 成本收益分析 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "statistical_charts",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Economic data interpretation applies statistical chart skills when learners read bars, lines, and comparative displays.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "economic_data_to_statistical_charts"
+          }
+        },
+        {
+          "id": "senior_statistics_regression",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Economic scatterplots apply regression intuition when learners describe association without overclaiming causation.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "economic_scatterplot_to_regression_intuition"
+          }
+        },
+        {
+          "id": "senior_linear_regression_equation",
+          "relation": "application",
+          "priority": "optional",
+          "context": "review",
+          "confidence": 0.8,
+          "reason": "Economic trend questions apply linear regression equations when estimating simple relationships from observed data.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "economics",
+            "target_subject": "math",
+            "bridge_direction": "economics_to_math",
+            "bridge_focus": "economic_trend_to_linear_regression_equation"
+          }
+        },
+        {
+          "id": "college_econ_index_real_nominal",
+          "relation": "extends",
+          "reason": "Practice 名义量与实际量 after 经济数据图表解读; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_index_real_nominal",
+          "relation": "procedure_step",
+          "reason": "After reading an economic graph, learners often adjust nominal data into real or indexed values.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "data_graph_to_real_nominal_index"
+          }
+        },
+        {
+          "id": "statistical_charts",
+          "relation": "confusable",
+          "reason": "Statistical chart reading is the tool, while economic data interpretation also requires economic units, timing, and model context.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "statistical_chart_vs_economic_interpretation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "根据折线图或柱状图描述经济指标趋势。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_index_real_nominal",
+      "name": "名义量与实际量",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "数据分析",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_data_graph",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 经济数据图表解读 before 名义量与实际量; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_data_graph",
+          "relation": "co_occurs",
+          "reason": "名义量与实际量 and 经济数据图表解读 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "extends",
+          "reason": "Practice 政策权衡分析 after 名义量与实际量; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "procedure_step",
+          "reason": "After converting nominal values into real terms, learners can judge policy trade-offs using comparable evidence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "real_nominal_to_policy_tradeoff"
+          }
+        },
+        {
+          "id": "college_macro_cpi_inflation",
+          "relation": "confusable",
+          "reason": "CPI inflation measures price-level change, while real-nominal conversion uses that change to adjust economic values.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "cpi_inflation_vs_real_nominal"
+          }
+        },
+        {
+          "id": "history_senior_economic_history",
+          "relation": "application",
+          "reason": "Real-nominal adjustment applies to economic-history comparisons when prices differ across periods.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "real_nominal_to_economic_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "用价格指数把名义收入调整为实际收入。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_policy_tradeoff",
+      "name": "政策权衡分析",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "政策分析",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_index_real_nominal",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 名义量与实际量 before 政策权衡分析; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_index_real_nominal",
+          "relation": "co_occurs",
+          "reason": "政策权衡分析 and 名义量与实际量 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_market_failure_synthesis",
+          "relation": "extends",
+          "reason": "Practice 市场失灵综合 after 政策权衡分析; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_market_failure_synthesis",
+          "relation": "procedure_step",
+          "reason": "After weighing policy trade-offs, learners synthesize market failures and choose a targeted intervention.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "policy_tradeoff_to_market_failure_synthesis"
+          }
+        },
+        {
+          "id": "college_macro_monetary_policy",
+          "relation": "confusable",
+          "reason": "A policy trade-off is the evaluation problem, while monetary policy is one instrument that may be evaluated.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "policy_tradeoff_vs_monetary_tool"
+          }
+        },
+        {
+          "id": "pol_senior_economy_market",
+          "relation": "application",
+          "reason": "Policy trade-off questions apply market-and-government reasoning when balancing efficiency, equity, stability, and growth.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "policy_tradeoff_to_economy_market"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "比较效率、公平和稳定目标之间的取舍。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_market_failure_synthesis",
+      "name": "市场失灵综合",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "综合应用",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_policy_tradeoff",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 政策权衡分析 before 市场失灵综合; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "co_occurs",
+          "reason": "市场失灵综合 and 政策权衡分析 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_exam_model_answer",
+          "relation": "extends",
+          "reason": "Practice 经济学规范作答 after 市场失灵综合; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_exam_model_answer",
+          "relation": "procedure_step",
+          "reason": "After synthesizing a market-failure case, learners organize assumptions, evidence, policy choice, and evaluation in an exam answer.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "market_failure_synthesis_to_model_answer"
+          }
+        },
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "confusable",
+          "reason": "Market-failure synthesis diagnoses the cause and intervention, while policy trade-off analysis compares consequences across goals.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "market_failure_synthesis_vs_policy_tradeoff"
+          }
+        },
+        {
+          "id": "geo_senior_regional_sustainability",
+          "relation": "application",
+          "reason": "Market-failure synthesis applies to regional sustainability when environmental costs, public goods, and incentives interact.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "market_failure_to_regional_sustainability"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "判断外部性、公共物品、垄断和信息不对称的政策应对。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    },
+    {
+      "id": "college_econ_exam_model_answer",
+      "name": "经济学规范作答",
+      "subject": "economics",
+      "stage": "college",
+      "chapter": "经济学基础",
+      "unit": "答题规范",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_econ_market_failure_synthesis",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 市场失灵综合 before 经济学规范作答; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_econ_market_failure_synthesis",
+          "relation": "co_occurs",
+          "reason": "经济学规范作答 and 市场失灵综合 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "procedure_step",
+          "reason": "A strong economics answer first extracts evidence from data or diagrams before explaining mechanism and evaluation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "model_answer_evidence_step"
+          }
+        },
+        {
+          "id": "college_econ_market_failure_synthesis",
+          "relation": "confusable",
+          "reason": "Market-failure synthesis is a content task, while a model answer is the structured communication of that reasoning.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "content_synthesis_vs_answer_structure"
+          }
+        },
+        {
+          "id": "college_macro_fiscal_policy",
+          "relation": "application",
+          "reason": "Model-answer structure applies to fiscal-policy questions that require mechanism, diagram evidence, and balanced evaluation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source": "economics_ready_batch_20260626",
+            "focus": "model_answer_to_fiscal_policy"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离模型假设直接套结论",
+        "把相关关系当成因果关系",
+        "忽略机会成本、边际变化或外部性"
+      ],
+      "skills": [
+        "识别模型假设、变量和约束条件",
+        "用图像、公式或边际分析解释经济机制",
+        "区分短期长期、个体整体和相关因果"
+      ],
+      "question_types": [
+        "模型分析",
+        "情境解释"
+      ],
+      "examples": [
+        {
+          "prompt": "按概念、图形、机制、结论组织经济学简答题。",
+          "answer_outline": [
+            "先识别题目考查的经济学基础模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "脱离模型假设直接套结论",
+            "把相关关系当成因果关系"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "economics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_economics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "economics"
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/english.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/english.json
@@ -1,0 +1,6119 @@
+{
+  "version": "1.0",
+  "subject": "english",
+  "topics": [
+    {
+      "id": "english_primary_phonics",
+      "name": "自然拼读",
+      "subject": "english",
+      "stage": "primary",
+      "chapter": "英语启蒙与基础",
+      "depth": 1,
+      "difficulty": 0.26,
+      "prerequisites": [
+        {
+          "id": "chinese_primary_pinyin_character",
+          "relation": "prerequisite",
+          "reason": "Pinyin letter-sound awareness gives young learners a familiar bridge for hearing English phoneme changes.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.78,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "chapter_focus": "primary_phonics"
+          },
+          "required_mastery": 0.5
+        }
+      ],
+      "related": [
+        {
+          "id": "english_primary_sight_words",
+          "relation": "extends",
+          "reason": "Phonics practice prepares students to read common sight words with more stable sound and spelling links.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_phonics"
+          }
+        },
+        {
+          "id": "english_primary_sight_words",
+          "relation": "procedure_step",
+          "reason": "After decoding letter groups, students consolidate high-frequency words through quick recognition and oral reading.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_phonics"
+          }
+        },
+        {
+          "id": "english_primary_sight_words",
+          "relation": "confusable",
+          "reason": "Phonics asks students to decode sound patterns, while sight-word practice asks them to recognize frequent words instantly.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_phonics"
+          }
+        },
+        {
+          "id": "english_primary_daily_dialogue",
+          "relation": "application",
+          "reason": "Accurate decoding supports short greetings and classroom replies because students can pronounce familiar words aloud.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_phonics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只凭中文直觉选词，忽略搭配和语境",
+        "阅读题只看单句，不回到段落逻辑",
+        "写作表达有结论但缺少支撑句和连接词"
+      ],
+      "unit": "自然拼读与词汇",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "拼读规则",
+        "听说基础"
+      ],
+      "examples": [
+        {
+          "prompt": "根据字母组合 sh/ch/th 的发音，读出 ship、chair、three 并归类。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "english_primary_sight_words",
+      "name": "小学高频词",
+      "subject": "english",
+      "stage": "primary",
+      "chapter": "英语启蒙与基础",
+      "depth": 1,
+      "difficulty": 0.24,
+      "prerequisites": [
+        {
+          "id": "english_primary_phonics",
+          "relation": "prerequisite",
+          "reason": "Basic phonics helps students attach sound patterns to frequent words instead of memorizing word shapes only.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_sight_words"
+          },
+          "required_mastery": 0.52
+        }
+      ],
+      "related": [
+        {
+          "id": "english_primary_daily_dialogue",
+          "relation": "extends",
+          "reason": "Sight words become useful when students place them into simple classroom and daily dialogue patterns.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_sight_words"
+          }
+        },
+        {
+          "id": "english_primary_daily_dialogue",
+          "relation": "procedure_step",
+          "reason": "After recognizing frequent words, students combine them with greetings, requests, and simple responses.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_sight_words"
+          }
+        },
+        {
+          "id": "english_primary_phonics",
+          "relation": "confusable",
+          "reason": "Sight-word fluency is instant recognition, while phonics is decoding unfamiliar spelling patterns.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_sight_words"
+          }
+        },
+        {
+          "id": "english_primary_picture_writing",
+          "relation": "application",
+          "reason": "High-frequency words supply the sentence starters and verbs needed for simple picture-based sentences.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_sight_words"
+          }
+        },
+        {
+          "id": "english_junior_reading_detail",
+          "relation": "prerequisite",
+          "reason": "Fast recognition of high-frequency words reduces decoding load before students locate details in junior reading passages.",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "validation_batch": "english_internal_bridge_2026_06_28",
+            "bridge_focus": "primary_sight_words_to_junior_reading_detail"
+          }
+        },
+        {
+          "id": "english_senior_application_email",
+          "relation": "application",
+          "reason": "Daily dialogue routines for greeting, asking, thanking, and replying become the communicative moves used in senior application emails.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "validation_batch": "english_internal_bridge_2026_06_28",
+            "bridge_focus": "primary_dialogue_to_senior_application_email"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只凭中文直觉选词，忽略搭配和语境",
+        "阅读题只看单句，不回到段落逻辑",
+        "写作表达有结论但缺少支撑句和连接词"
+      ],
+      "unit": "自然拼读与词汇",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "词汇记忆",
+        "语境填空"
+      ],
+      "examples": [
+        {
+          "prompt": "用 I, you, he, she, like, have 完成 5 个简单句。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "english_primary_daily_dialogue",
+      "name": "日常交际用语",
+      "subject": "english",
+      "stage": "primary",
+      "chapter": "英语启蒙与基础",
+      "depth": 1,
+      "difficulty": 0.3,
+      "prerequisites": [
+        {
+          "id": "english_primary_sight_words",
+          "relation": "prerequisite",
+          "reason": "Common words give students the vocabulary base for greetings, thanks, requests, and short replies.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_dialogue"
+          },
+          "required_mastery": 0.52
+        }
+      ],
+      "related": [
+        {
+          "id": "english_primary_picture_writing",
+          "relation": "extends",
+          "reason": "Dialogue patterns can be reused as short written sentences when students describe people, actions, and feelings in pictures.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_dialogue"
+          }
+        },
+        {
+          "id": "english_primary_picture_writing",
+          "relation": "procedure_step",
+          "reason": "After oral exchanges, students write one clear sentence that names the speaker, action, or response.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_dialogue"
+          }
+        },
+        {
+          "id": "english_primary_picture_writing",
+          "relation": "confusable",
+          "reason": "Dialogue practice values appropriate response choice, while picture writing values sentence completeness and visual detail.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_dialogue"
+          }
+        },
+        {
+          "id": "english_primary_picture_writing",
+          "relation": "application",
+          "reason": "Daily dialogue frames give students ready sentence patterns for captions and simple picture descriptions.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_dialogue"
+          }
+        },
+        {
+          "id": "english_senior_continuation_writing",
+          "relation": "extends",
+          "reason": "Picture writing builds the habit of turning visual cues into complete sentences before senior continuation writing adds plot and emotion arcs.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "validation_batch": "english_internal_bridge_2026_06_28",
+            "bridge_focus": "primary_picture_writing_to_senior_continuation_writing"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只凭中文直觉选词，忽略搭配和语境",
+        "阅读题只看单句，不回到段落逻辑",
+        "写作表达有结论但缺少支撑句和连接词"
+      ],
+      "unit": "自然拼读与词汇",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "口语表达",
+        "情景交际"
+      ],
+      "examples": [
+        {
+          "prompt": "根据“问候、感谢、道歉、请求帮助”四个场景各写一句英文回应。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "english_primary_picture_writing",
+      "name": "看图写句",
+      "subject": "english",
+      "stage": "primary",
+      "chapter": "英语启蒙与基础",
+      "depth": 1,
+      "difficulty": 0.36,
+      "prerequisites": [
+        {
+          "id": "english_primary_daily_dialogue",
+          "relation": "prerequisite",
+          "reason": "Short dialogue patterns help students form basic subject-verb-object sentences before writing from a picture.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_picture_writing"
+          },
+          "required_mastery": 0.52
+        }
+      ],
+      "related": [
+        {
+          "id": "chinese_primary_sentence_expansion",
+          "relation": "procedure_step",
+          "reason": "Picture writing improves when students first expand who, what, where, and feeling details into a complete sentence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "chapter_focus": "primary_picture_writing"
+          }
+        },
+        {
+          "id": "english_primary_daily_dialogue",
+          "relation": "confusable",
+          "reason": "Picture writing requires a complete written sentence, while daily dialogue may be a short situational response.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "primary_picture_writing"
+          }
+        },
+        {
+          "id": "chinese_primary_observation_writing",
+          "relation": "application",
+          "reason": "The same visual observation routine supports English captions and Chinese picture observation writing.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.79,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "chapter_focus": "primary_picture_writing"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只凭中文直觉选词，忽略搭配和语境",
+        "阅读题只看单句，不回到段落逻辑",
+        "写作表达有结论但缺少支撑句和连接词"
+      ],
+      "unit": "自然拼读与词汇",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "写作入门",
+        "图文表达"
+      ],
+      "examples": [
+        {
+          "prompt": "看图写 4 句英文，至少包含人物、动作、地点和感受。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "primary",
+        "curriculum_context",
+        "primary_local_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_primary",
+        "renjiao_primary",
+        "beishi_primary",
+        "sujiao_primary"
+      ],
+      "exam_region": [
+        "primary_local_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "primary_term_exam"
+      ]
+    },
+    {
+      "id": "english_junior_tense_system",
+      "name": "初中时态体系",
+      "subject": "english",
+      "stage": "junior_high",
+      "chapter": "英语语法",
+      "depth": 2,
+      "difficulty": 0.48,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_junior_clause_intro",
+          "relation": "procedure_step",
+          "reason": "After identifying time markers and verb forms, students check clause boundaries and conjunctions before analyzing the full sentence.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9
+        }
+      ],
+      "typical_misconceptions": [
+        "Choosing tense only from Chinese translation instead of time markers.",
+        "Ignoring subject person and number when changing verb forms.",
+        "Mixing present perfect with simple past when the time boundary is clear."
+      ],
+      "unit": "时态与句法",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "tense identification",
+        "verb form choice",
+        "sentence transformation"
+      ],
+      "examples": [
+        {
+          "prompt": "用一般现在、一般过去、现在进行、现在完成分别描述同一学习计划。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "english_junior_clause_intro",
+      "name": "宾语从句与状语从句",
+      "subject": "english",
+      "stage": "junior_high",
+      "chapter": "英语语法",
+      "depth": 2,
+      "difficulty": 0.58,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_junior_reading_detail",
+          "relation": "procedure_step",
+          "reason": "After parsing clauses, students use the clause structure to locate who did what, when, where, and why in reading details.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9
+        }
+      ],
+      "typical_misconceptions": [
+        "Keeping question word order inside an object clause.",
+        "Choosing conjunctions by translation while ignoring logical relation.",
+        "Forgetting tense consistency between the main clause and subordinate clause."
+      ],
+      "unit": "时态与句法",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "object clause choice",
+        "adverbial clause connection",
+        "sentence combination"
+      ],
+      "examples": [
+        {
+          "prompt": "把两个简单句合并成含 because/if/when/that 的复合句。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "english_junior_reading_detail",
+      "name": "阅读细节定位",
+      "subject": "english",
+      "stage": "junior_high",
+      "chapter": "英语语法",
+      "depth": 2,
+      "difficulty": 0.46,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_junior_cloze_context",
+          "relation": "procedure_step",
+          "reason": "After locating explicit information, students extend the same evidence habit to infer missing words from nearby context in cloze tasks.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9
+        }
+      ],
+      "typical_misconceptions": [
+        "Answering from memory of keywords instead of returning to the exact sentence.",
+        "Treating a distractor with similar wording as direct evidence.",
+        "Missing negation, time, number, or speaker limits in the stem."
+      ],
+      "unit": "时态与句法",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "detail location",
+        "information matching",
+        "evidence-based reading"
+      ],
+      "examples": [
+        {
+          "prompt": "阅读一段校园活动通知，找出时间、地点、报名方式和注意事项。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "english_junior_cloze_context",
+      "name": "完形填空语境推断",
+      "aliases": [
+        "完形填空",
+        "完形填空怎么做",
+        "语境推断",
+        "上下文选词",
+        "完形语境"
+      ],
+      "subject": "english",
+      "stage": "junior_high",
+      "chapter": "英语语法",
+      "depth": 2,
+      "difficulty": 0.56,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_cloze_logic",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "完形填空要先根据上下文逻辑线索判断转折、因果、递进或复现关系。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_cloze_collocation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "完形选项常同时考查语境意义、固定搭配和语义场。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "完形填空重在语篇语义选择，语法填空更重在形式和语法约束。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只凭中文直觉选词，忽略搭配和语境",
+        "阅读题只看单句，不回到段落逻辑",
+        "写作表达有结论但缺少支撑句和连接词"
+      ],
+      "unit": "时态与句法",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "完形填空",
+        "词义辨析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据上下文情绪变化选择合适动词和连词，并说明线索。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "english_senior_long_reading_structure",
+      "name": "长篇阅读篇章结构",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "英语阅读写作",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_reading_main_idea",
+          "relation": "procedure_step",
+          "reason": "After mapping paragraph functions, students summarize the central claim before handling detailed inference questions.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_grammar_filling",
+          "relation": "extends",
+          "reason": "Practice 语法填空 after 长篇阅读篇章结构; it is the next topic in the senior_high english learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8
+        }
+      ],
+      "typical_misconceptions": [
+        "Reading paragraph by paragraph without tracking the whole passage structure.",
+        "Mistaking examples or data for the author's central claim.",
+        "Ignoring contrast, concession, and cause-effect signals between paragraphs."
+      ],
+      "unit": "高中阅读与写作",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "discourse structure analysis",
+        "main idea inference",
+        "paragraph function"
+      ],
+      "examples": [
+        {
+          "prompt": "分析一篇说明文每段主旨，判断哪一句适合放回文中空缺处。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ],
+          "common_traps": [
+            "脱离原文定位，按中文经验猜选项或表达。",
+            "忽略上下文逻辑、指代关系和语篇目的。",
+            "写作只完成句子堆叠，缺少任务要点和衔接。"
+          ],
+          "grading_points": [
+            "信息定位、语法判断或写作任务回应准确。",
+            "能说明上下文依据、语篇逻辑或表达选择理由。",
+            "语言自然，结构完整，符合题型评分要求。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_english",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_reading_inference",
+      "name": "推理判断题",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "英语阅读写作",
+      "depth": 2,
+      "difficulty": 0.64,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_reading_detail_location",
+          "relation": "procedure_step",
+          "reason": "Inference questions start by reading the stem, locating evidence, and eliminating options that overstate, reverse, or import outside information.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_reading_author_attitude",
+          "relation": "confusable",
+          "reason": "Inference asks what can be concluded from evidence; attitude asks the author's stance or emotional coloring, so the evidence focus is different.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "english_senior_exam_time_strategy",
+          "relation": "application",
+          "reason": "The same stem-first and evidence-check routine helps students allocate time before choosing between close inference options.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_junior_narrative_reading",
+          "relation": "application",
+          "reason": "English inference from textual clues transfers to Chinese narrative reading when students infer motivation, plot cause, and implied emotion from evidence.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "application",
+          "reason": "English inference practice builds the evidence-bound reasoning needed to infer standpoint, cause, and context from history source materials.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "history",
+            "bridge_direction": "english_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只凭中文直觉选词，忽略搭配和语境",
+        "阅读题只看单句，不回到段落逻辑",
+        "写作表达有结论但缺少支撑句和连接词"
+      ],
+      "unit": "高中阅读与写作",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "阅读理解",
+        "推理判断"
+      ],
+      "examples": [
+        {
+          "prompt": "根据作者用词和例证判断作者对 AI tutoring 的态度。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ],
+          "common_traps": [
+            "脱离原文定位，按中文经验猜选项或表达。",
+            "忽略上下文逻辑、指代关系和语篇目的。",
+            "写作只完成句子堆叠，缺少任务要点和衔接。"
+          ],
+          "grading_points": [
+            "信息定位、语法判断或写作任务回应准确。",
+            "能说明上下文依据、语篇逻辑或表达选择理由。",
+            "语言自然，结构完整，符合题型评分要求。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_english",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_grammar_filling",
+      "name": "语法填空",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "英语阅读写作",
+      "depth": 2,
+      "difficulty": 0.6,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_tense_voice_context",
+          "relation": "procedure_step",
+          "reason": "Grammar cloze first requires judging sentence role and context, then selecting tense and voice for verb blanks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_application_letter",
+          "relation": "extends",
+          "reason": "Practice 应用文写作 after 语法填空; it is the next topic in the senior_high english learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8
+        }
+      ],
+      "typical_misconceptions": [
+        "Filling a blank from a fixed phrase without checking sentence function.",
+        "Ignoring whether the blank needs a finite verb, non-finite verb, or derived word.",
+        "Missing agreement, tense, voice, or article constraints from nearby words."
+      ],
+      "unit": "高中阅读与写作",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "grammar cloze",
+        "verb form completion",
+        "word formation in context"
+      ],
+      "examples": [
+        {
+          "prompt": "在一篇短文中填入动词形式、冠词、介词和连词，并解释依据。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ],
+          "common_traps": [
+            "脱离原文定位，按中文经验猜选项或表达。",
+            "忽略上下文逻辑、指代关系和语篇目的。",
+            "写作只完成句子堆叠，缺少任务要点和衔接。"
+          ],
+          "grading_points": [
+            "信息定位、语法判断或写作任务回应准确。",
+            "能说明上下文依据、语篇逻辑或表达选择理由。",
+            "语言自然，结构完整，符合题型评分要求。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_english",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_application_letter",
+      "name": "应用文写作",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "英语阅读写作",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_application_email",
+          "relation": "procedure_step",
+          "reason": "After identifying purpose, audience, and required points, students draft the email body with appropriate tone and paragraph order.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_continuation_writing",
+          "relation": "extends",
+          "reason": "Practice 读后续写 after 应用文写作; it is the next topic in the senior_high english learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8
+        }
+      ],
+      "typical_misconceptions": [
+        "Writing fluent sentences that do not cover all required task points.",
+        "Using an informal tone for a formal letter or notice.",
+        "Listing information without paragraph logic or closing request."
+      ],
+      "unit": "高中阅读与写作",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "application writing outline",
+        "letter purpose and audience",
+        "formal expression revision"
+      ],
+      "examples": [
+        {
+          "prompt": "给交换生写一封邀请信，包含活动时间、内容、意义和期待回复。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ],
+          "common_traps": [
+            "脱离原文定位，按中文经验猜选项或表达。",
+            "忽略上下文逻辑、指代关系和语篇目的。",
+            "写作只完成句子堆叠，缺少任务要点和衔接。"
+          ],
+          "grading_points": [
+            "信息定位、语法判断或写作任务回应准确。",
+            "能说明上下文依据、语篇逻辑或表达选择理由。",
+            "语言自然，结构完整，符合题型评分要求。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_english",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_continuation_writing",
+      "name": "读后续写",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "英语阅读写作",
+      "depth": 3,
+      "difficulty": 0.76,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_continuation_plot_logic",
+          "relation": "procedure_step",
+          "reason": "Continuation writing begins by extracting conflict, character goals, and paragraph openings, then planning a coherent plot step.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_summary_writing",
+          "relation": "extends",
+          "reason": "Practice 概要写作 after 读后续写; it is the next topic in the senior_high english learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8
+        },
+        {
+          "id": "chinese_senior_literary_plot_effect",
+          "relation": "application",
+          "reason": "English continuation writing helps Chinese literary text analysis by tracking conflict, plot turn, character motive, and effect on theme.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "Adding dramatic events that break the original story logic.",
+        "Forgetting to resolve the conflict implied by the two given opening sentences.",
+        "Imitating vocabulary only while losing character motivation and emotional progression."
+      ],
+      "unit": "高中阅读与写作",
+      "skills": [
+        "定位语篇线索并判断题目考查的语言点",
+        "在语境中选择词汇、语法或篇章策略",
+        "用原文证据或表达规则解释答案"
+      ],
+      "question_types": [
+        "continuation plot design",
+        "emotion arc completion",
+        "language imitation"
+      ],
+      "examples": [
+        {
+          "prompt": "根据故事开头续写两段，保持人物动机、冲突和情感转折一致。",
+          "answer_outline": [
+            "识别题型：词汇、语法、阅读或写作任务。",
+            "圈出关键词、连接词、时态、人称或段落主旨。",
+            "依据语境、结构或题干要求作答。",
+            "检查语法一致性、表达自然度和证据是否充分。"
+          ],
+          "common_traps": [
+            "脱离原文定位，按中文经验猜选项或表达。",
+            "忽略上下文逻辑、指代关系和语篇目的。",
+            "写作只完成句子堆叠，缺少任务要点和衔接。"
+          ],
+          "grading_points": [
+            "信息定位、语法判断或写作任务回应准确。",
+            "能说明上下文依据、语篇逻辑或表达选择理由。",
+            "语言自然，结构完整，符合题型评分要求。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_english",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_summary_writing",
+      "name": "概要写作",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "英语阅读写作",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_listening_note",
+          "relation": "extends",
+          "reason": "Practice 听力速记策略 after 概要写作; it is the next topic in the senior_high english learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_summary_paraphrase",
+          "relation": "procedure_step",
+          "reason": "Summary writing moves from reading the task and locating main points to paraphrasing them without copying long source phrases.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "application",
+          "reason": "After compressing source information, cohesion checks make the summary read as one logical paragraph instead of separated notes.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_compression",
+          "relation": "application",
+          "reason": "English summary writing transfers to Chinese language compression by preserving core information while deleting examples, repetition, and secondary modifiers.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离语境选词",
+        "阅读答案没有证据",
+        "写作缺少结构和连接"
+      ],
+      "unit": "高中写作",
+      "skills": [
+        "用语境判断词汇语法和篇章关系",
+        "定位原文证据或写作任务要求",
+        "检查表达准确性和连贯性"
+      ],
+      "question_types": [
+        "概要写作",
+        "信息整合"
+      ],
+      "examples": [
+        {
+          "prompt": "把一篇介绍环保行动的短文压缩成 60 词概要，保留主旨和关键支撑。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "脱离原文定位，按中文经验猜选项或表达。",
+            "忽略上下文逻辑、指代关系和语篇目的。",
+            "写作只完成句子堆叠，缺少任务要点和衔接。"
+          ],
+          "grading_points": [
+            "信息定位、语法判断或写作任务回应准确。",
+            "能说明上下文依据、语篇逻辑或表达选择理由。",
+            "语言自然，结构完整，符合题型评分要求。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_english",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_listening_note",
+      "name": "听力速记策略",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "英语听力口语",
+      "depth": 2,
+      "difficulty": 0.58,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "english_senior_listening_inference",
+          "relation": "procedure_step",
+          "reason": "Listening notes first capture names, numbers, time, place, and contrast markers, then support inference about intention or attitude.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_exam_time_strategy",
+          "relation": "application",
+          "reason": "Fast note symbols reduce replay dependence and help reserve enough time for reading and writing sections.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "脱离语境选词",
+        "阅读答案没有证据",
+        "写作缺少结构和连接"
+      ],
+      "unit": "听力策略",
+      "skills": [
+        "用语境判断词汇语法和篇章关系",
+        "定位原文证据或写作任务要求",
+        "检查表达准确性和连贯性"
+      ],
+      "question_types": [
+        "听力理解",
+        "信息记录"
+      ],
+      "examples": [
+        {
+          "prompt": "听一段活动安排，记录时间、地点、人物、数字和转折信息。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "脱离原文定位，按中文经验猜选项或表达。",
+            "忽略上下文逻辑、指代关系和语篇目的。",
+            "写作只完成句子堆叠，缺少任务要点和衔接。"
+          ],
+          "grading_points": [
+            "信息定位、语法判断或写作任务回应准确。",
+            "能说明上下文依据、语篇逻辑或表达选择理由。",
+            "语言自然，结构完整，符合题型评分要求。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "new_gaokao_english",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_tense_voice_context",
+      "name": "时态语态语境判断",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "动词系统",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_reading_inference",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 推理判断题 before 时态语态语境判断; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_reading_inference",
+          "relation": "co_occurs",
+          "reason": "Review 时态语态语境判断 together with 推理判断题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82
+        },
+        {
+          "id": "english_senior_nonfinite_verbs",
+          "relation": "procedure_step",
+          "reason": "After confirming the finite predicate, remaining verb forms are checked as non-finite structures or modifiers.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9
+        }
+      ],
+      "typical_misconceptions": [
+        "Selecting passive voice only because the Chinese translation sounds passive.",
+        "Ignoring whether the sentence already has a finite predicate.",
+        "Using a tense marker mechanically without checking discourse time."
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "tense and voice choice",
+        "predicate verb analysis",
+        "contextual grammar cloze"
+      ],
+      "examples": [
+        {
+          "prompt": "根据时间线、语境和主被动关系选择谓语形式。",
+          "answer_outline": [
+            "先判断题目属于时态语态语境判断的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_nonfinite_verbs",
+      "name": "非谓语动词",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "动词系统",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_tense_voice_context",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 时态语态语境判断 before 非谓语动词; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_tense_voice_context",
+          "relation": "co_occurs",
+          "reason": "Review 非谓语动词 together with 时态语态语境判断 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82
+        },
+        {
+          "id": "english_senior_clause_connection",
+          "relation": "procedure_step",
+          "reason": "When a verb cannot be reduced to a non-finite phrase, students next check whether a finite clause and connector are required.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9
+        }
+      ],
+      "typical_misconceptions": [
+        "Treating every verb blank as a predicate verb.",
+        "Choosing -ing, -ed, or to-do by memorized translation instead of active-passive and time relation.",
+        "Missing the logical subject of the non-finite phrase."
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "non-finite verb form",
+        "modifier structure analysis",
+        "grammar cloze verb blank"
+      ],
+      "examples": [
+        {
+          "prompt": "判断 to do、doing、done 在句中的逻辑主语和功能。",
+          "answer_outline": [
+            "先判断题目属于非谓语动词的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_clause_connection",
+      "name": "从句连接词选择",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "复合句",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_nonfinite_verbs",
+          "relation": "prerequisite",
+          "reason": "Students need to distinguish predicate and non-finite verb roles before choosing a finite clause connector.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_clause_connection"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_nonfinite_verbs",
+          "relation": "co_occurs",
+          "reason": "Connector choice is often checked beside non-finite verb reduction because both depend on clause structure.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_clause_connection"
+          }
+        },
+        {
+          "id": "english_senior_relative_clause",
+          "relation": "procedure_step",
+          "reason": "After identifying clause function and connector meaning, students handle relative clauses by matching antecedent, role, and comma pattern.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_clause_connection"
+          }
+        },
+        {
+          "id": "english_senior_relative_clause",
+          "relation": "confusable",
+          "reason": "General clause connector questions test clause type and logic, while relative clauses test antecedent role and modification.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_clause_connection"
+          }
+        },
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "relation": "application",
+          "reason": "Clause connector analysis is applied in grammar cloze when blanks require that, which, whether, because, or other linking words.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_clause_connection"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "区分名词性从句、定语从句和状语从句连接词。",
+          "answer_outline": [
+            "先判断题目属于从句连接词选择的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_relative_clause",
+      "name": "定语从句限定与非限定",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "复合句",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_clause_connection",
+          "relation": "prerequisite",
+          "reason": "Relative clause decisions build on recognizing clause boundaries, connector function, and the missing sentence role.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_relative_clause"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_clause_connection",
+          "relation": "co_occurs",
+          "reason": "Relative clause review should stay connected to broader clause connector diagnosis.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_relative_clause"
+          }
+        },
+        {
+          "id": "english_senior_subject_verb_agreement",
+          "relation": "procedure_step",
+          "reason": "After choosing the relative marker, students check whether the clause verb agrees with the antecedent or internal subject.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_relative_clause"
+          }
+        },
+        {
+          "id": "english_senior_clause_connection",
+          "relation": "confusable",
+          "reason": "Relative clauses modify nouns, while noun and adverbial clauses fill subject, object, predicative, or logical relation slots.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_relative_clause"
+          }
+        },
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "application",
+          "reason": "Accurate relative clauses let students combine short ideas and upgrade sentence cohesion in writing.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_relative_clause"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据先行词、成分缺失和逗号判断关系词。",
+          "answer_outline": [
+            "先判断题目属于定语从句限定与非限定的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_subject_verb_agreement",
+      "name": "主谓一致",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "句法一致",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_relative_clause",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 定语从句限定与非限定 before 主谓一致; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_special_sentence_patterns",
+          "relation": "procedure_step",
+          "reason": "After students identify the real subject and verb form, they can handle inversion, emphasis, and ellipsis without losing sentence control.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_subject_verb_agreement"
+          }
+        },
+        {
+          "id": "english_senior_relative_clause",
+          "relation": "co_occurs",
+          "reason": "Review 主谓一致 together with 定语从句限定与非限定 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_special_sentence_patterns",
+          "relation": "co_occurs",
+          "reason": "Review 主谓一致 together with 倒装强调省略 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据真正主语、就近原则和意义一致确定谓语。",
+          "answer_outline": [
+            "先判断题目属于主谓一致的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_special_sentence_patterns",
+      "name": "倒装强调省略",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "特殊句式",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_subject_verb_agreement",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 主谓一致 before 倒装强调省略; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_word_formation",
+          "relation": "procedure_step",
+          "reason": "After special sentence patterns are recognized, students use part of speech and derivation clues to complete more precise forms.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_special_sentence_patterns"
+          }
+        },
+        {
+          "id": "english_senior_subject_verb_agreement",
+          "relation": "co_occurs",
+          "reason": "Review 倒装强调省略 together with 主谓一致 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_word_formation",
+          "relation": "co_occurs",
+          "reason": "Review 倒装强调省略 together with 词性转换与派生 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "识别倒装、强调句和省略结构的触发条件。",
+          "answer_outline": [
+            "先判断题目属于倒装强调省略的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_word_formation",
+      "name": "词性转换与派生",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "词汇运用",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_special_sentence_patterns",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 倒装强调省略 before 词性转换与派生; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_cloze_logic",
+          "relation": "procedure_step",
+          "reason": "Once students can form the required word class, they apply those lexical clues inside cloze passages and test each option against discourse logic.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_word_formation"
+          }
+        },
+        {
+          "id": "english_senior_special_sentence_patterns",
+          "relation": "co_occurs",
+          "reason": "Review 词性转换与派生 together with 倒装强调省略 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_cloze_logic",
+          "relation": "co_occurs",
+          "reason": "Review 词性转换与派生 together with 完形填空逻辑线索 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据句法位置和语义关系完成词性转换。",
+          "answer_outline": [
+            "先判断题目属于词性转换与派生的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_cloze_logic",
+      "name": "完形填空逻辑线索",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "完形填空",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_word_formation",
+          "relation": "prerequisite",
+          "reason": "Word formation knowledge helps students separate lexical form clues from discourse logic in cloze options.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_logic"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_word_formation",
+          "relation": "co_occurs",
+          "reason": "Cloze diagnosis often checks whether an error comes from word form, collocation, or discourse logic.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_logic"
+          }
+        },
+        {
+          "id": "english_senior_cloze_collocation",
+          "relation": "procedure_step",
+          "reason": "After identifying contrast, cause, repetition, or progression, students test whether the option fits local collocation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_logic"
+          }
+        },
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "relation": "confusable",
+          "reason": "Cloze logic selects meaning across options, while grammar cloze selects a constrained form for one blank.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_logic"
+          }
+        },
+        {
+          "id": "english_senior_cloze_collocation",
+          "relation": "application",
+          "reason": "Logical relation mapping narrows collocation choices by showing whether the sentence continues, contrasts, or explains the previous idea.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_logic"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据转折、因果、复现和情感色彩选择词汇。",
+          "answer_outline": [
+            "先判断题目属于完形填空逻辑线索的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_cloze_collocation",
+      "name": "完形搭配与语义场",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "完形填空",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_cloze_logic",
+          "relation": "prerequisite",
+          "reason": "Students should establish passage logic before deciding which collocation best fits the semantic field.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_collocation"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_cloze_logic",
+          "relation": "co_occurs",
+          "reason": "Collocation review belongs with cloze logic because both decide whether an option fits the same passage context.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.81,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_collocation"
+          }
+        },
+        {
+          "id": "english_senior_reading_main_idea",
+          "relation": "procedure_step",
+          "reason": "After local collocation checks, students reread the paragraph main idea to confirm tone and semantic field.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_collocation"
+          }
+        },
+        {
+          "id": "english_senior_vocabulary_context_review",
+          "relation": "confusable",
+          "reason": "Collocation questions test fixed word partners, while vocabulary context review tests meaning inferred from surrounding clues.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_collocation"
+          }
+        },
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "relation": "application",
+          "reason": "Collocation awareness supports grammar cloze when prepositions, verb patterns, or fixed phrases constrain the blank.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_cloze_collocation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "识别固定搭配、近义词差异和上下文语义场。",
+          "answer_outline": [
+            "先判断题目属于完形搭配与语义场的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_reading_main_idea",
+      "name": "阅读主旨大意题",
+      "aliases": [
+        "阅读理解主旨题",
+        "主旨大意题",
+        "文章主旨",
+        "标题题",
+        "main idea"
+      ],
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "阅读理解",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_cloze_collocation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 完形搭配与语义场 before 阅读主旨大意题; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_long_reading_structure",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "主旨题要先识别篇章结构和主题句，再排除只覆盖局部细节的选项。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_reading_detail_location",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "主旨题问全文或段落中心，细节题问具体信息定位，选项范围不同。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "english_senior_reading_author_attitude",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "作者态度题需要在把握主旨和论证方向后判断观点色彩。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "english_senior_cloze_collocation",
+          "relation": "co_occurs",
+          "reason": "Review 阅读主旨大意题 together with 完形搭配与语义场 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_reading_detail_location",
+          "relation": "co_occurs",
+          "reason": "Review 阅读主旨大意题 together with 阅读细节定位题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chinese_primary_paragraph_main_idea",
+          "relation": "application",
+          "reason": "English main idea questions train students to separate central claims from examples, which transfers to Chinese paragraph main idea reading.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "概括段落和全文中心，排除局部细节干扰。",
+          "answer_outline": [
+            "先判断题目属于阅读主旨大意题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_reading_detail_location",
+      "name": "阅读细节定位题",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "阅读理解",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_reading_main_idea",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 阅读主旨大意题 before 阅读细节定位题; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_reading_main_idea",
+          "relation": "co_occurs",
+          "reason": "Review 阅读细节定位题 together with 阅读主旨大意题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82
+        },
+        {
+          "id": "english_senior_reading_word_guess",
+          "relation": "procedure_step",
+          "reason": "After locating the evidence sentence, students use local definition, contrast, cause-effect, or example clues to infer unfamiliar words.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9
+        },
+        {
+          "id": "english_senior_reading_main_idea",
+          "relation": "confusable",
+          "reason": "Detail questions ask for located facts, while main idea questions ask for the whole passage or paragraph point; keyword overlap can hide the scope shift.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "application",
+          "reason": "English detail-location habits transfer to Chinese practical text filtering by requiring exact evidence, scope words, and condition checks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        },
+        {
+          "id": "chinese_senior_practical_text",
+          "relation": "application",
+          "reason": "English information matching supports Chinese practical text analysis because both depend on locating purpose, audience, limits, and explicit details.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "Choosing an option because it repeats a keyword but changes the condition.",
+        "Missing scope words such as most, only, first, never, or according to.",
+        "Using outside knowledge instead of evidence from the located sentence."
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "detail evidence location",
+        "option-text matching",
+        "fact inference from evidence"
+      ],
+      "examples": [
+        {
+          "prompt": "用题干关键词定位原文并完成同义替换。",
+          "answer_outline": [
+            "先判断题目属于阅读细节定位题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_reading_word_guess",
+      "name": "词义猜测题",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "阅读理解",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_reading_detail_location",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 阅读细节定位题 before 词义猜测题; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_reading_detail_location",
+          "relation": "co_occurs",
+          "reason": "Review 词义猜测题 together with 阅读细节定位题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_reading_author_attitude",
+          "relation": "co_occurs",
+          "reason": "Review 词义猜测题 together with 作者态度与观点题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_reading_author_attitude",
+          "relation": "procedure_step",
+          "reason": "After using local clues to infer word meaning, students check evaluative words and contrast markers to judge author attitude.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_reading_detail_location",
+          "relation": "confusable",
+          "reason": "Word-guess items need local semantic clues, while detail items need factual matching; both may reuse the same sentence but ask different operations.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据定义、转折、例证和上下文推断词义。",
+          "answer_outline": [
+            "先判断题目属于词义猜测题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_reading_author_attitude",
+      "name": "作者态度与观点题",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "阅读理解",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_reading_word_guess",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 词义猜测题 before 作者态度与观点题; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_reading_word_guess",
+          "relation": "co_occurs",
+          "reason": "Review 作者态度与观点题 together with 词义猜测题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_seven_choice_coherence",
+          "relation": "co_occurs",
+          "reason": "Review 作者态度与观点题 together with 七选五衔接题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_seven_choice_coherence",
+          "relation": "procedure_step",
+          "reason": "After judging author attitude, students use tone and paragraph function to choose coherent sentences in gap-filling reading tasks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_reading_inference",
+          "relation": "confusable",
+          "reason": "Attitude questions ask for stance words such as supportive or skeptical; inference questions ask for a conclusion supported by textual evidence.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "chinese_junior_argumentative_reading",
+          "relation": "application",
+          "reason": "English author attitude questions transfer to Chinese argumentative reading by tracking stance words, evidence tone, and evaluation direction.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "application",
+          "reason": "Author attitude analysis supports politics material reasoning because both require identifying the claim, value stance, and support relation before judging options.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "politics",
+            "bridge_direction": "english_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "从评价词、让步转折和结论句判断态度。",
+          "answer_outline": [
+            "先判断题目属于作者态度与观点题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_seven_choice_coherence",
+      "name": "七选五衔接题",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "七选五",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_reading_author_attitude",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 作者态度与观点题 before 七选五衔接题; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_reading_author_attitude",
+          "relation": "co_occurs",
+          "reason": "Review 七选五衔接题 together with 作者态度与观点题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "relation": "co_occurs",
+          "reason": "Review 七选五衔接题 together with 语法填空上下文约束 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "relation": "procedure_step",
+          "reason": "Seven-choice coherence trains reference and logic tracking, then grammar cloze applies the same context check to form and function blanks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "application",
+          "reason": "Coherence clues from gap-filling reading transfer to paragraph linking and sentence order choices in writing revision.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据指代、逻辑关系和段落功能选择句子。",
+          "answer_outline": [
+            "先判断题目属于七选五衔接题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_grammar_cloze_context",
+      "name": "语法填空上下文约束",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "语法填空",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_seven_choice_coherence",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 七选五衔接题 before 语法填空上下文约束; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_seven_choice_coherence",
+          "relation": "co_occurs",
+          "reason": "Review 语法填空上下文约束 together with 七选五衔接题 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_error_correction",
+          "relation": "co_occurs",
+          "reason": "Review 语法填空上下文约束 together with 短文改错/语法纠错 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_error_correction",
+          "relation": "procedure_step",
+          "reason": "After filling blanks by context and grammar, students use the same checks to scan a passage for tense, agreement, article, and connector errors.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_cloze_logic",
+          "relation": "confusable",
+          "reason": "Grammar cloze is constrained by form and sentence function, while cloze logic chooses the best meaning from discourse relations.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "综合句法成分、词性和上下文确定答案。",
+          "answer_outline": [
+            "先判断题目属于语法填空上下文约束的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_error_correction",
+      "name": "短文改错/语法纠错",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语语法",
+      "unit": "综合纠错",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 语法填空上下文约束 before 短文改错/语法纠错; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_grammar_cloze_context",
+          "relation": "co_occurs",
+          "reason": "Review 短文改错/语法纠错 together with 语法填空上下文约束 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_listening_inference",
+          "relation": "co_occurs",
+          "reason": "Review 短文改错/语法纠错 together with 听力推断与态度 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_listening_inference",
+          "relation": "procedure_step",
+          "reason": "Error correction sharpens marker awareness, then listening inference uses stress, contrast, and modal verbs to infer intention or attitude.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "从动词、名词、代词、连词和冠词角度排查错误。",
+          "answer_outline": [
+            "先判断题目属于短文改错/语法纠错的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_listening_inference",
+      "name": "听力推断与态度",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语听力",
+      "unit": "听力理解",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_error_correction",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 短文改错/语法纠错 before 听力推断与态度; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_error_correction",
+          "relation": "co_occurs",
+          "reason": "Review 听力推断与态度 together with 短文改错/语法纠错 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_application_email",
+          "relation": "co_occurs",
+          "reason": "Review 听力推断与态度 together with 应用文邮件写作 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_application_email",
+          "relation": "procedure_step",
+          "reason": "After inferring speaker purpose and attitude, students convert the communicative intent into audience-aware email content.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "english_senior_reading_author_attitude",
+          "relation": "confusable",
+          "reason": "Listening attitude relies on spoken cues such as stress and hesitation, while reading attitude relies on wording and argument direction.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据重音、转折和场景信息推断说话人意图。",
+          "answer_outline": [
+            "先判断题目属于听力推断与态度的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_application_email",
+      "name": "应用文邮件写作",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "应用文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_listening_inference",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 听力推断与态度 before 应用文邮件写作; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_listening_inference",
+          "relation": "co_occurs",
+          "reason": "Review 应用文邮件写作 together with 听力推断与态度 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_application_notice",
+          "relation": "co_occurs",
+          "reason": "Review 应用文邮件写作 together with 通知与倡议书写作 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_application_notice",
+          "relation": "procedure_step",
+          "reason": "Email writing organizes purpose, audience, and required points, then notice writing applies the same task-reading routine to public information.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "按目的、对象和礼貌程度组织邮件结构。",
+          "answer_outline": [
+            "先判断题目属于应用文邮件写作的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_application_notice",
+      "name": "通知与倡议书写作",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "应用文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_application_email",
+          "relation": "prerequisite",
+          "reason": "Email writing establishes audience, purpose, and required-point coverage before students write notices or proposals.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_application_notice"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_application_email",
+          "relation": "co_occurs",
+          "reason": "Email and notice writing should be compared through audience, tone, opening, closing, and task-point coverage.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_application_notice"
+          }
+        },
+        {
+          "id": "english_senior_application_speech",
+          "relation": "procedure_step",
+          "reason": "After notice writing, students extend the same public-purpose structure into a short speech with audience engagement.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_application_notice"
+          }
+        },
+        {
+          "id": "english_senior_application_email",
+          "relation": "confusable",
+          "reason": "Notices use concise public information and calls to action, while emails use personal address, greeting, and closing conventions.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_application_notice"
+          }
+        },
+        {
+          "id": "english_senior_writing_rubric_revision",
+          "relation": "application",
+          "reason": "Notice drafts can be checked against rubric items for task response, point completeness, tone, and language accuracy.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_application_notice"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "写清活动信息、对象、行动要求和呼吁。",
+          "answer_outline": [
+            "先判断题目属于通知与倡议书写作的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_application_speech",
+      "name": "演讲稿写作",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "应用文",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_application_notice",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 通知与倡议书写作 before 演讲稿写作; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_writing_rubric_revision",
+          "relation": "procedure_step",
+          "reason": "After drafting a speech for audience, purpose, and call to action, students use rubric revision to check task coverage, tone, and language accuracy.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_application_speech"
+          }
+        },
+        {
+          "id": "english_senior_application_notice",
+          "relation": "co_occurs",
+          "reason": "Review 演讲稿写作 together with 通知与倡议书写作 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_continuation_plot_logic",
+          "relation": "co_occurs",
+          "reason": "Review 演讲稿写作 together with 读后续写情节推进 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "用开场、观点、理由和号召完成演讲稿。",
+          "answer_outline": [
+            "先判断题目属于演讲稿写作的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_continuation_plot_logic",
+      "name": "读后续写情节推进",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "读后续写",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_application_speech",
+          "relation": "prerequisite",
+          "reason": "Speech writing helps students control audience, purpose, and sequence before planning a coherent continuation plot.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.78,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_continuation_plot"
+          },
+          "required_mastery": 0.56
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_application_speech",
+          "relation": "co_occurs",
+          "reason": "Both speech and continuation writing need clear purpose, sequence, and reader-facing coherence.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.76,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_continuation_plot"
+          }
+        },
+        {
+          "id": "english_senior_continuation_emotion_arc",
+          "relation": "procedure_step",
+          "reason": "After plot events are ordered, students map the emotion arc so each action changes the character state naturally.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_continuation_plot"
+          }
+        },
+        {
+          "id": "english_senior_summary_writing",
+          "relation": "confusable",
+          "reason": "Continuation writing creates plausible new events, while summary writing compresses source information without adding plot.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_continuation_plot"
+          }
+        },
+        {
+          "id": "chinese_senior_literary_plot_effect",
+          "relation": "application",
+          "reason": "English continuation planning transfers to literary analysis by tracking conflict, turning point, motive, and theme effect.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "chapter_focus": "senior_continuation_plot"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据原文冲突、人物动机和伏笔设计后续情节。",
+          "answer_outline": [
+            "先判断题目属于读后续写情节推进的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_continuation_emotion_arc",
+      "name": "读后续写情绪弧线",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "读后续写",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_continuation_plot_logic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 读后续写情节推进 before 读后续写情绪弧线; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_continuation_language_imitation",
+          "relation": "procedure_step",
+          "reason": "After mapping the character emotion arc, students imitate tense, point of view, tone, and detail density so the continuation sounds consistent.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_continuation_emotion_arc"
+          }
+        },
+        {
+          "id": "english_senior_continuation_plot_logic",
+          "relation": "co_occurs",
+          "reason": "Review 读后续写情绪弧线 together with 读后续写情节推进 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_continuation_language_imitation",
+          "relation": "co_occurs",
+          "reason": "Review 读后续写情绪弧线 together with 读后续写语言协同 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "用动作、心理和环境描写推动人物情绪变化。",
+          "answer_outline": [
+            "先判断题目属于读后续写情绪弧线的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_continuation_language_imitation",
+      "name": "读后续写语言协同",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "读后续写",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_continuation_emotion_arc",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 读后续写情绪弧线 before 读后续写语言协同; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "procedure_step",
+          "reason": "After matching the source style in continuation writing, students revise links between sentences so the new ending remains fluent and coherent.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_continuation_language_imitation"
+          }
+        },
+        {
+          "id": "english_senior_continuation_emotion_arc",
+          "relation": "co_occurs",
+          "reason": "Review 读后续写语言协同 together with 读后续写情绪弧线 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_summary_paraphrase",
+          "relation": "co_occurs",
+          "reason": "Review 读后续写语言协同 together with 概要写作转述压缩 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "模仿原文时态、人称、语气和细节密度。",
+          "answer_outline": [
+            "先判断题目属于读后续写语言协同的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_summary_paraphrase",
+      "name": "概要写作转述压缩",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "概要写作",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_continuation_language_imitation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 读后续写语言协同 before 概要写作转述压缩; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_continuation_language_imitation",
+          "relation": "co_occurs",
+          "reason": "Review 概要写作转述压缩 together with 读后续写语言协同 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "co_occurs",
+          "reason": "Review 概要写作转述压缩 together with 写作衔接与句式升级 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "procedure_step",
+          "reason": "Paraphrase and compression are followed by cohesion checks so the shortened text preserves logic, reference, and paragraph flow.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "relation": "application",
+          "reason": "English paraphrase practice transfers to Chinese sentence rewriting because both keep meaning stable while changing structure and wording.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "抓主干信息并用同义改写压缩细节。",
+          "answer_outline": [
+            "先判断题目属于概要写作转述压缩的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_writing_cohesion",
+      "name": "写作衔接与句式升级",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "表达提升",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_summary_paraphrase",
+          "relation": "prerequisite",
+          "reason": "Paraphrase and compression practice gives students the sentence control needed before revising cohesion and style.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_cohesion"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_summary_paraphrase",
+          "relation": "co_occurs",
+          "reason": "Cohesion revision should be checked with paraphrase quality because both affect clarity and flow.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_cohesion"
+          }
+        },
+        {
+          "id": "english_senior_exam_time_strategy",
+          "relation": "co_occurs",
+          "reason": "Time strategy matters for leaving a final pass to check connectors, reference, and sentence variety.",
+          "priority": "optional",
+          "context": "review",
+          "confidence": 0.76,
+          "use_cases": [
+            "learning_path",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_cohesion"
+          }
+        },
+        {
+          "id": "english_senior_writing_rubric_revision",
+          "relation": "procedure_step",
+          "reason": "After improving cohesion and sentence variety, students use the writing rubric to verify task coverage and language accuracy.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_cohesion"
+          }
+        },
+        {
+          "id": "english_senior_summary_paraphrase",
+          "relation": "confusable",
+          "reason": "Cohesion revision links ideas across sentences, while paraphrase revision preserves meaning with different wording.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_cohesion"
+          }
+        },
+        {
+          "id": "chinese_senior_language_cohesion",
+          "relation": "application",
+          "reason": "English cohesion revision transfers to Chinese cohesion tasks through reference, connectors, sentence order, and paragraph flow.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "chapter_focus": "senior_writing_cohesion"
+          }
+        },
+        {
+          "id": "chinese_senior_modern_argument_structure",
+          "relation": "application",
+          "reason": "English paragraph cohesion supports argumentative writing by linking claim, reason, evidence, and conclusion in order.",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.83,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "chapter_focus": "senior_writing_cohesion"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "用连接词、非谓语和从句提升段落连贯性。",
+          "answer_outline": [
+            "先判断题目属于写作衔接与句式升级的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_exam_time_strategy",
+      "name": "英语考试时间分配",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语综合",
+      "unit": "考试策略",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_writing_cohesion",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 写作衔接与句式升级 before 英语考试时间分配; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "co_occurs",
+          "reason": "Review 英语考试时间分配 together with 写作衔接与句式升级 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_vocabulary_context_review",
+          "relation": "co_occurs",
+          "reason": "Review 英语考试时间分配 together with 语境词汇复习 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_vocabulary_context_review",
+          "relation": "procedure_step",
+          "reason": "A timed exam review first assigns minutes by section, then uses remaining review time to strengthen high-frequency contextual vocabulary.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "按题型难度和分值安排阅读、完形和写作时间。",
+          "answer_outline": [
+            "先判断题目属于英语考试时间分配的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_vocabulary_context_review",
+      "name": "语境词汇复习",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语综合",
+      "unit": "词汇策略",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_exam_time_strategy",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 英语考试时间分配 before 语境词汇复习; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_translation_chinese_interference",
+          "relation": "procedure_step",
+          "reason": "After reviewing vocabulary in context, students correct Chinese-influenced wording by checking collocation, word order, and natural expression.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_vocabulary_context_review"
+          }
+        },
+        {
+          "id": "english_senior_exam_time_strategy",
+          "relation": "co_occurs",
+          "reason": "Review 语境词汇复习 together with 英语考试时间分配 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_translation_chinese_interference",
+          "relation": "co_occurs",
+          "reason": "Review 语境词汇复习 together with 中式表达纠偏 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "按主题语境、搭配和派生词建立词汇网络。",
+          "answer_outline": [
+            "先判断题目属于语境词汇复习的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_translation_chinese_interference",
+      "name": "中式表达纠偏",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语综合",
+      "unit": "表达提升",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_vocabulary_context_review",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 语境词汇复习 before 中式表达纠偏; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_writing_rubric_revision",
+          "relation": "procedure_step",
+          "reason": "After removing Chinese-influenced wording, students use rubric revision to verify accuracy, cohesion, task response, and expression quality.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_translation_chinese_interference"
+          }
+        },
+        {
+          "id": "english_senior_vocabulary_context_review",
+          "relation": "co_occurs",
+          "reason": "Review 中式表达纠偏 together with 语境词汇复习 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_reading_new_gaokao_information",
+          "relation": "co_occurs",
+          "reason": "Review 中式表达纠偏 together with 新高考信息类阅读 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "chinese_senior_language_error_correction",
+          "relation": "confusable",
+          "reason": "Chinese interference in English translation is a useful mirror for Chinese error correction because both expose word order, collocation, and logical expression problems.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        },
+        {
+          "id": "chinese_senior_language_sentence_rewrite",
+          "relation": "application",
+          "reason": "Correcting Chinese-influenced English trains students to separate intended meaning from surface wording, which helps Chinese expression rewriting.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.81,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "chinese",
+            "bridge_direction": "english_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "识别中文直译造成的搭配、语序和逻辑问题。",
+          "answer_outline": [
+            "先判断题目属于中式表达纠偏的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_reading_new_gaokao_information",
+      "name": "新高考信息类阅读",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语阅读",
+      "unit": "阅读理解",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_translation_chinese_interference",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 中式表达纠偏 before 新高考信息类阅读; it supplies the foundation for this english learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_writing_rubric_revision",
+          "relation": "procedure_step",
+          "reason": "After extracting purpose, data, and constraints from informational reading, students apply the same checklist to revise writing for complete task response.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_reading_new_gaokao_information"
+          }
+        },
+        {
+          "id": "english_senior_translation_chinese_interference",
+          "relation": "co_occurs",
+          "reason": "Review 新高考信息类阅读 together with 中式表达纠偏 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "english_senior_writing_rubric_revision",
+          "relation": "co_occurs",
+          "reason": "Review 新高考信息类阅读 together with 写作评分标准自查 when diagnosing adjacent english skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "application",
+          "reason": "English informational reading strategies transfer to history material analysis through source purpose, data selection, qualification, and evidence comparison.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "history",
+            "bridge_direction": "english_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "处理说明文、科普文和应用文中的信息结构。",
+          "answer_outline": [
+            "先判断题目属于新高考信息类阅读的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "english_senior_writing_rubric_revision",
+      "name": "写作评分标准自查",
+      "subject": "english",
+      "stage": "senior_high",
+      "chapter": "高中英语写作",
+      "unit": "表达提升",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "english_senior_reading_new_gaokao_information",
+          "relation": "prerequisite",
+          "reason": "Information reading trains task extraction and evidence selection before students revise writing against rubric points.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.82,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_rubric"
+          },
+          "required_mastery": 0.58
+        }
+      ],
+      "related": [
+        {
+          "id": "english_senior_reading_new_gaokao_information",
+          "relation": "co_occurs",
+          "reason": "Rubric revision and information reading both require checking task purpose, relevant evidence, and omitted details.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_rubric"
+          }
+        },
+        {
+          "id": "english_senior_exam_time_strategy",
+          "relation": "procedure_step",
+          "reason": "After learning rubric checks, students reserve final exam time for task coverage, grammar, cohesion, and handwriting review.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_rubric"
+          }
+        },
+        {
+          "id": "english_senior_writing_cohesion",
+          "relation": "confusable",
+          "reason": "Rubric revision checks scoring dimensions overall, while cohesion revision focuses on links between sentences and paragraphs.",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "english",
+            "chapter_focus": "senior_writing_rubric"
+          }
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "application",
+          "reason": "Writing rubric self-check supports argument tasks by testing claim clarity, evidence relevance, and logical order.",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "english",
+            "target_subject": "politics",
+            "chapter_focus": "senior_writing_rubric"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只按中文直译导致语法和搭配不自然",
+        "阅读题脱离原文定位凭感觉推断",
+        "写作缺少语篇衔接和情节/任务约束"
+      ],
+      "skills": [
+        "定位原文信息并识别语篇逻辑",
+        "根据语法、搭配和上下文约束选择表达",
+        "组织符合题型要求的段落和衔接句"
+      ],
+      "question_types": [
+        "语篇理解",
+        "表达运用"
+      ],
+      "examples": [
+        {
+          "prompt": "从内容、结构、语言和书写四项修订作文。",
+          "answer_outline": [
+            "先判断题目属于写作评分标准自查的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用英语核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "english",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "required_subject_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "new_gaokao_english"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/geography.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/geography.json
@@ -1,0 +1,1986 @@
+{
+  "version": "1.0",
+  "subject": "geography",
+  "topics": [
+    {
+      "id": "geo_junior_map_skills",
+      "name": "地图三要素",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "自然地理",
+      "depth": 1,
+      "difficulty": 0.34,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_junior_transport_trade",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_china_regions",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "primary_ratio_scale",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "primary_ratio_scale",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Map scale questions apply ratio reasoning to convert map distance into real distance.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math"
+          }
+        },
+        {
+          "id": "coordinate_system",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Latitude and longitude reading transfers naturally to coordinate-plane location and ordered-pair thinking.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math"
+          }
+        },
+        {
+          "id": "geo_junior_climate_types",
+          "relation": "extends",
+          "reason": "Practice 世界气候类型 after 地图三要素; it is the next topic in the junior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "地图与地球",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "读图题",
+        "基础技能"
+      ],
+      "examples": [
+        {
+          "prompt": "根据比例尺、方向和图例判断两地距离和方位。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "地图比例尺",
+        "比例尺",
+        "地图三要素",
+        "地图上怎么判断方向",
+        "比例尺怎么换算实际距离"
+      ]
+    },
+    {
+      "id": "geo_junior_climate_types",
+      "name": "世界气候类型",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "自然地理",
+      "depth": 2,
+      "difficulty": 0.5,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_senior_water_cycle",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_agriculture_industry",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_senior_atmospheric_circulation",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_river_landform",
+          "relation": "extends",
+          "reason": "Practice 河流与地形 after 世界气候类型; it is the next topic in the junior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Climate graphs require reading curve trends, intervals, maxima, minima, and variable relationships from function-like graphs.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math"
+          }
+        },
+        {
+          "id": "statistical_charts",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Temperature and precipitation charts use the same evidence extraction skills as statistical chart interpretation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math"
+          }
+        },
+        {
+          "id": "linear_function_application",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "confidence": 0.85,
+          "reason": "Transport cost, distance, and time questions can be modeled with linear-function applications.",
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "地图与地球",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "图表判读",
+        "区域分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据气温曲线和降水柱状图判断气候类型。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "季风气候",
+        "气候类型",
+        "气候判断",
+        "怎么根据气温降水判断气候类型",
+        "世界气候类型有什么分布规律"
+      ]
+    },
+    {
+      "id": "geo_junior_river_landform",
+      "name": "河流与地形",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "自然地理",
+      "depth": 2,
+      "difficulty": 0.52,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_senior_water_cycle",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_natural_disaster",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_senior_geomorphology",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_population_city",
+          "relation": "extends",
+          "reason": "Practice 人口与城市 after 河流与地形; it is the next topic in the junior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "bio_junior_ecology_food_chain",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.84,
+          "reason": "River landform and watershed questions often explain habitats that support food-chain and ecosystem analysis.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "biology",
+            "bridge_direction": "geography_to_biology"
+          }
+        },
+        {
+          "id": "bio_senior_ecology_energy_flow",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "River corridors and floodplains provide geographic contexts for tracing ecosystem energy flow and carrying capacity.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "biology",
+            "bridge_direction": "geography_to_biology"
+          }
+        },
+        {
+          "id": "weighted_mean",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "confidence": 0.84,
+          "reason": "Agriculture and industry location comparisons often combine multiple weighted factors before choosing a region.",
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "confidence": 0.86,
+          "reason": "Runoff, precipitation, and evaporation process lines require function-graph reading before geographic interpretation.",
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "地图与地球",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "过程分析",
+        "区域分析"
+      ],
+      "examples": [
+        {
+          "prompt": "解释河流上中下游地貌差异及成因。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "河流地貌",
+        "河流地貌形成",
+        "流水地貌",
+        "河流为什么会形成冲积平原",
+        "河流侵蚀和堆积怎么区分"
+      ]
+    },
+    {
+      "id": "geo_junior_population_city",
+      "name": "人口与城市",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "人文地理",
+      "depth": 2,
+      "difficulty": 0.48,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_junior_agriculture_industry",
+          "relation": "extends",
+          "reason": "Practice 农业工业区位 after 人口与城市; it is the next topic in the junior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78
+        },
+        {
+          "id": "geo_junior_agriculture_industry",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Population and city analysis should next connect people, labor, market, and land use to agricultural and industrial location factors.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_transport_trade",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Urban hierarchy and population concentration are commonly applied to explain transport networks, commuting, tourism, and regional flows.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_china_regions",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Students often mix population or city distribution questions with broader regional-difference comparisons, so hints should separate the evidence used for each.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Population and urbanization charts train the same data-reading habits used in economic data graph interpretation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "economics",
+            "bridge_direction": "geography_to_economics"
+          }
+        },
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Human population maps connect to biological population-growth curves through density, growth rate, and carrying-capacity reasoning.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "biology",
+            "bridge_direction": "geography_to_biology"
+          }
+        },
+        {
+          "id": "statistical_charts",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "confidence": 0.86,
+          "reason": "Population structure, migration, and urbanization questions require reading statistical charts and trend graphs.",
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "区域发展",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "图表分析",
+        "原因影响"
+      ],
+      "examples": [
+        {
+          "prompt": "根据人口统计图分析城市化带来的问题和措施。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "geo_junior_agriculture_industry",
+      "name": "农业工业区位",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "人文地理",
+      "depth": 2,
+      "difficulty": 0.56,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_junior_population_city",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_transport_trade",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_senior_industrial_location",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_china_regions",
+          "relation": "extends",
+          "reason": "Practice 中国区域差异 after 农业工业区位; it is the next topic in the junior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Agricultural and industrial location choices respond to market size, resource availability, cost, and supply-demand conditions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "economics",
+            "bridge_direction": "geography_to_economics"
+          }
+        },
+        {
+          "id": "college_econ_scarcity_opportunity_cost",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Land, water, labor, and transport constraints make location decisions a practical opportunity-cost comparison.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "economics",
+            "bridge_direction": "geography_to_economics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "区域发展",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "区位分析",
+        "综合题"
+      ],
+      "examples": [
+        {
+          "prompt": "分析某地发展水稻种植或电子工业的区位条件。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "工业区位",
+        "区位因素",
+        "产业区位",
+        "农业区位因素怎么分析",
+        "工业布局要考虑哪些因素"
+      ]
+    },
+    {
+      "id": "geo_junior_china_regions",
+      "name": "中国区域差异",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "人文地理",
+      "depth": 2,
+      "difficulty": 0.54,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_junior_natural_disaster",
+          "relation": "extends",
+          "reason": "Practice 自然灾害与防灾减灾 after 中国区域差异; it is the next topic in the junior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78
+        },
+        {
+          "id": "geo_junior_map_skills",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Regional comparison should start by locating boundaries, relative position, scale, and map symbols before explaining differences.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_agriculture_industry",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "China regional differences are commonly applied to compare farming systems, industrial layout, and development conditions across regions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_population_city",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Regional natural-human differences can be confused with population and urbanization patterns; diagnosis should ask which variable the question targets.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "区域发展",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "区域认知",
+        "比较题"
+      ],
+      "examples": [
+        {
+          "prompt": "比较南方地区和北方地区自然、人文差异。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "geo_senior_atmospheric_circulation",
+      "name": "大气环流与天气系统",
+      "subject": "geography",
+      "stage": "senior_high",
+      "chapter": "高中地理",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_senior_water_cycle",
+          "relation": "extends",
+          "reason": "Practice 水循环与水资源 after 大气环流与天气系统; it is the next topic in the senior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78
+        },
+        {
+          "id": "geo_junior_map_skills",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Weather-system problems first require reading isobars, wind direction, fronts, and spatial position from maps before explaining circulation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_natural_disaster",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Atmospheric circulation and weather systems are applied to explain rainstorms, typhoons, cold waves, drought, and disaster prevention scenarios.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_climate_types",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "reason": "Students often confuse short-term weather-system judgment with long-term climate-type classification, so feedback should contrast time scale and evidence.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "综合思维",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "过程分析",
+        "图像题"
+      ],
+      "examples": [
+        {
+          "prompt": "根据等压线图判断风向、天气和气压系统。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "geo_senior_water_cycle",
+      "name": "水循环与水资源",
+      "subject": "geography",
+      "stage": "senior_high",
+      "chapter": "高中地理",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_senior_industrial_location",
+          "relation": "extends",
+          "reason": "Practice 产业区位与区域发展 after 水循环与水资源; it is the next topic in the senior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78
+        },
+        {
+          "id": "geo_senior_geomorphology",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After identifying precipitation, runoff, infiltration, and human intervention, learners can trace how water movement shapes erosion and deposition landforms.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_natural_disaster",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Water-cycle reasoning is commonly applied to flood, drought, urban waterlogging, and water-resource management questions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_river_landform",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "reason": "Water-cycle processes are often mixed with river-landform formation; diagnosis should separate circulation links from erosion and deposition results.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "综合思维",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "过程分析",
+        "措施题"
+      ],
+      "examples": [
+        {
+          "prompt": "分析城市内涝成因并提出海绵城市措施。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "geo_senior_industrial_location",
+      "name": "产业区位与区域发展",
+      "subject": "geography",
+      "stage": "senior_high",
+      "chapter": "高中地理",
+      "depth": 3,
+      "difficulty": 0.7,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_senior_earth_movement",
+          "relation": "extends",
+          "reason": "Practice 地球运动 after 产业区位与区域发展; it is the next topic in the senior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78
+        },
+        {
+          "id": "geo_junior_agriculture_industry",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Industrial-location evaluation should first list location factors such as resources, labor, market, transport, technology, policy, and environment.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_senior_regional_sustainability",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Industrial location and industrial transfer are applied to evaluate regional transformation, carrying capacity, and sustainable development paths.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_transport_trade",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Transport conditions are one location factor, but students often treat transport influence as the whole industrial-location analysis.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_econ_cost_benefit",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Industrial transfer and site selection require comparing transport, labor, land, policy, and environmental costs against expected benefits.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "economics",
+            "bridge_direction": "geography_to_economics"
+          }
+        },
+        {
+          "id": "history_junior_industrial_revolution",
+          "relation": "supports",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.82,
+          "reason": "Modern industrial-location patterns are easier to explain when linked to the historical rise of factories, transport networks, and urban labor markets.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "history",
+            "bridge_direction": "geography_to_history"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "读图不看图例、比例尺和方向",
+        "只列自然因素，忽略人类活动或区域差异",
+        "原因题和措施题混写，缺少针对性"
+      ],
+      "unit": "综合思维",
+      "skills": [
+        "读图提取位置、要素和空间关系",
+        "从自然和人文两类因素解释地理现象",
+        "用区域尺度和综合思维组织答案"
+      ],
+      "question_types": [
+        "区位分析",
+        "材料题"
+      ],
+      "examples": [
+        {
+          "prompt": "评价某地区承接产业转移的优势和风险。",
+          "answer_outline": [
+            "先读图名、图例、坐标、比例尺和区域位置。",
+            "分自然因素与人文因素提取信息。",
+            "按因果链解释分布、变化或区域差异。",
+            "措施题要对应问题、条件和可持续性。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "geo_junior_natural_disaster",
+      "name": "自然灾害与防灾减灾",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "自然地理",
+      "depth": 2,
+      "difficulty": 0.52,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_junior_transport_trade",
+          "relation": "extends",
+          "reason": "Practice 交通运输与区域联系 after 自然灾害与防灾减灾; it is the next topic in the junior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78
+        },
+        {
+          "id": "geo_senior_water_cycle",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Flood and drought questions should trace precipitation, runoff, infiltration, storage, and human activity before proposing mitigation measures.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_senior_regional_sustainability",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Disaster analysis is applied to land-use planning, ecological restoration, resilient infrastructure, and regional sustainable development.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_river_landform",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "River landform formation can be confused with flood-disaster causation; feedback should distinguish normal geomorphic process from hazard exposure and vulnerability.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "statistical_charts",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "confidence": 0.84,
+          "reason": "Regional sustainability comparisons depend on reading indicator tables, radar charts, and trend charts together.",
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "忽略图例比例尺方向",
+        "原因和措施混写",
+        "只列因素不建因果链"
+      ],
+      "unit": "灾害地理",
+      "skills": [
+        "读图提取位置、图例和空间关系",
+        "分自然与人文因素解释区域现象",
+        "给出针对区域问题的措施"
+      ],
+      "question_types": [
+        "区域分析",
+        "措施题"
+      ],
+      "examples": [
+        {
+          "prompt": "分析某地洪涝灾害成因并提出防灾减灾措施。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "geo_junior_transport_trade",
+      "name": "交通运输与区域联系",
+      "subject": "geography",
+      "stage": "junior_high",
+      "chapter": "人文地理",
+      "depth": 2,
+      "difficulty": 0.5,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_junior_map_skills",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Transport and trade questions should first read route direction, node location, distance, and regional connections from the map.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_senior_industrial_location",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Transport accessibility and trade links are commonly applied to explain industrial layout, logistics cost, and regional economic ties.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_junior_agriculture_industry",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Students often confuse transport effects with the full set of agricultural and industrial location factors, so review should separate factor type and conclusion.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "忽略图例比例尺方向",
+        "原因和措施混写",
+        "只列因素不建因果链"
+      ],
+      "unit": "交通与贸易",
+      "skills": [
+        "读图提取位置、图例和空间关系",
+        "分自然与人文因素解释区域现象",
+        "给出针对区域问题的措施"
+      ],
+      "question_types": [
+        "区位分析",
+        "实际应用"
+      ],
+      "examples": [
+        {
+          "prompt": "说明高铁开通对沿线城市旅游和产业联系的影响。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "geo_senior_earth_movement",
+      "name": "地球运动",
+      "subject": "geography",
+      "stage": "senior_high",
+      "chapter": "自然地理过程",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_senior_geomorphology",
+          "relation": "extends",
+          "reason": "Practice 外力作用与地貌 after 地球运动; it is the next topic in the senior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78
+        },
+        {
+          "id": "geo_junior_map_skills",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Earth-movement calculations should first read latitude, date, direction, and diagram labels before judging solar altitude and day length.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_climate_types",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.81,
+          "reason": "Seasonal solar-radiation differences help explain temperature belts, seasonal change, and some climate-distribution patterns.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "geo_senior_atmospheric_circulation",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Students may attribute seasonal day-length or solar-altitude changes to weather systems instead of Earth movement, so diagnosis should contrast mechanism and time scale.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "senior_trig_angle_system",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Solar altitude, latitude, longitude, and time-zone calculations rely on angle measurement and angular distance.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math"
+          }
+        },
+        {
+          "id": "senior_function_periodicity",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Day-night alternation and seasonal change provide concrete contexts for periodic-function reasoning.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "math",
+            "bridge_direction": "geography_to_math"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "忽略图例比例尺方向",
+        "原因和措施混写",
+        "只列因素不建因果链"
+      ],
+      "unit": "地球运动",
+      "skills": [
+        "读图提取位置、图例和空间关系",
+        "分自然与人文因素解释区域现象",
+        "给出针对区域问题的措施"
+      ],
+      "question_types": [
+        "图像题",
+        "计算题"
+      ],
+      "examples": [
+        {
+          "prompt": "根据太阳直射点移动判断昼夜长短和正午太阳高度变化。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "geo_senior_geomorphology",
+      "name": "外力作用与地貌",
+      "subject": "geography",
+      "stage": "senior_high",
+      "chapter": "自然地理过程",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_senior_regional_sustainability",
+          "relation": "extends",
+          "reason": "Practice 区域可持续发展 after 外力作用与地貌; it is the next topic in the senior_high geography learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_river_landform",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Geomorphology problems can be confused with named river-landform recall unless students explain process, material, and time scale.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "geography",
+            "bridge_direction": "geography_internal"
+          }
+        },
+        {
+          "id": "geo_senior_regional_sustainability",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After explaining landform processes, students can evaluate land use, hazard exposure, and restoration choices in a region.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "geography",
+            "bridge_direction": "geography_internal"
+          }
+        },
+        {
+          "id": "geo_junior_natural_disaster",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Slope, river, and coastal landform analysis supports disaster-risk questions about erosion, landslides, floods, and mitigation.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "geography",
+            "bridge_direction": "geography_internal"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "忽略图例比例尺方向",
+        "原因和措施混写",
+        "只列因素不建因果链"
+      ],
+      "unit": "地貌过程",
+      "skills": [
+        "读图提取位置、图例和空间关系",
+        "分自然与人文因素解释区域现象",
+        "给出针对区域问题的措施"
+      ],
+      "question_types": [
+        "过程分析",
+        "图像题"
+      ],
+      "examples": [
+        {
+          "prompt": "根据河流阶地或冲积扇示意图解释形成过程。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "geo_senior_regional_sustainability",
+      "name": "区域可持续发展",
+      "subject": "geography",
+      "stage": "senior_high",
+      "chapter": "区域发展",
+      "depth": 3,
+      "difficulty": 0.72,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "bio_senior_community_succession",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Regional sustainability problems often require explaining ecological restoration through community succession and habitat recovery.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "biology",
+            "bridge_direction": "geography_to_biology"
+          }
+        },
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Sustainable regional planning should compare ecological protection, growth, jobs, cost, and equity as explicit policy tradeoffs.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "economics",
+            "bridge_direction": "geography_to_economics"
+          }
+        },
+        {
+          "id": "geo_senior_industrial_location",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.81,
+          "reason": "Regional sustainability is often confused with industrial location analysis unless ecological capacity and long-run governance are included.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "geography",
+            "target_subject": "geography",
+            "bridge_direction": "geography_internal"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "忽略图例比例尺方向",
+        "原因和措施混写",
+        "只列因素不建因果链"
+      ],
+      "unit": "可持续发展",
+      "skills": [
+        "读图提取位置、图例和空间关系",
+        "分自然与人文因素解释区域现象",
+        "给出针对区域问题的措施"
+      ],
+      "question_types": [
+        "区域分析",
+        "措施题"
+      ],
+      "examples": [
+        {
+          "prompt": "评价资源型城市转型的优势、问题和可持续路径。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "geography",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/geography.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/geography.json
@@ -1274,7 +1274,7 @@
         },
         {
           "id": "history_junior_industrial_revolution",
-          "relation": "supports",
+          "relation": "co_occurs",
           "priority": "useful",
           "context": "explanation",
           "confidence": 0.82,

--- a/plugin/plugins/study_companion/static/knowledge_seeds/history.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/history.json
@@ -1,0 +1,1927 @@
+{
+  "version": "1.0",
+  "subject": "history",
+  "topics": [
+    {
+      "id": "history_junior_qin_unification",
+      "name": "秦统一与中央集权",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "中国古代史",
+      "depth": 2,
+      "difficulty": 0.46,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_tang_song_change",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_junior_mingqing_transition",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_institution_change",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_junior_tang_song_change",
+          "relation": "extends",
+          "reason": "Practice 唐宋社会变化 after 秦统一与中央集权; it is the next topic in the junior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.9,
+          "reason": "Qin centralization helps students compare rule-by-law administration with modern rule of law institutions.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics"
+          }
+        },
+        {
+          "id": "pol_senior_political_participation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Centralized imperial governance is useful contrast evidence for modern state institutions and participation mechanisms.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "制度与统一",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "史实理解",
+        "影响分析"
+      ],
+      "examples": [
+        {
+          "prompt": "概括秦统一措施，并评价中央集权制度的历史影响。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "秦朝中央集权",
+        "秦统一",
+        "中央集权",
+        "郡县制",
+        "秦朝为什么能统一六国",
+        "秦统一后怎么加强中央集权"
+      ]
+    },
+    {
+      "id": "history_junior_tang_song_change",
+      "name": "唐宋社会变化",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "中国古代史",
+      "depth": 2,
+      "difficulty": 0.52,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_qin_unification",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "Learners often mix social-economic change with centralized political control, so contrast the historical evidence and scope.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_economic_history",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Tang-Song urban, commercial, and cultural shifts are common evidence for economic-history practice.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After identifying the period changes, students should extract material evidence and connect it to learned facts.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_junior_mingqing_transition",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "Practice 明清强化君主专制 after 唐宋社会变化; it is the next topic in the junior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "Ming-Qing monarchy cases help students contrast rule by personal authority with modern rule-of-law governance.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "制度与统一",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "阶段特征",
+        "材料分析"
+      ],
+      "examples": [
+        {
+          "prompt": "从经济、城市、文化角度说明唐宋时期社会变化。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "history_junior_mingqing_transition",
+      "name": "明清强化君主专制",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "中国古代史",
+      "depth": 2,
+      "difficulty": 0.54,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_qin_unification",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Both topics involve central power, but the evidence differs between unification institutions and later monarchy strengthening.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_institution_change",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.85,
+          "reason": "Ming-Qing political change is a concrete case for reviewing institutional change and state governance.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Students should move from listing autocratic measures to using source material to explain causes and effects.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_junior_opium_war",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "Practice 鸦片战争与近代开端 after 明清强化君主专制; it is the next topic in the junior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_economy_market",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Economic-history cases ground political analysis of market mechanisms, state regulation, and macro governance.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "制度与统一",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "史实理解",
+        "原因影响"
+      ],
+      "examples": [
+        {
+          "prompt": "分析明清君主专制强化的表现和影响。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "history_junior_opium_war",
+      "name": "鸦片战争与近代开端",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "中国近现代史",
+      "depth": 2,
+      "difficulty": 0.5,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_senior_modernization_comparison",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_junior_reform_revolution",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_junior_reform_revolution",
+          "relation": "extends",
+          "reason": "Practice 戊戌变法与辛亥革命 after 鸦片战争与近代开端; it is the next topic in the junior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "geo_junior_transport_trade",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Treaty-port history connects naturally to transport routes, coastal access, and regional trade links.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "geography",
+            "bridge_direction": "history_to_geography"
+          }
+        },
+        {
+          "id": "geo_senior_industrial_location",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "Modern opening questions can use location factors to explain ports, resources, markets, and foreign pressure.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "geography",
+            "bridge_direction": "history_to_geography"
+          }
+        },
+        {
+          "id": "pol_senior_international_relations",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.89,
+          "reason": "The Opium War is a concrete case for sovereignty, unequal relations, diplomacy, and changes in world order.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "近代转型",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "材料题",
+        "原因影响"
+      ],
+      "examples": [
+        {
+          "prompt": "结合条约内容说明中国社会性质变化。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "鸦片战争",
+        "近代开端",
+        "中国近代史开端",
+        "为什么说鸦片战争是中国近代史开端",
+        "鸦片战争对中国社会有什么影响"
+      ]
+    },
+    {
+      "id": "history_junior_reform_revolution",
+      "name": "戊戌变法与辛亥革命",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "中国近现代史",
+      "depth": 2,
+      "difficulty": 0.58,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_opium_war",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "Learners can confuse the foreign-pressure background with the domestic reform and revolution responses.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_modernization_comparison",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Reform and revolution cases support practice comparing paths of modernization.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Comparison questions should proceed by locating claims in material, then matching goals, methods, and effects.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_junior_new_china",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "Practice 新中国建设道路 after 戊戌变法与辛亥革命; it is the next topic in the junior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_political_participation",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Reform and revolution cases give historical evidence for discussing political participation and institutional change.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "近代转型",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "比较题",
+        "历史评价"
+      ],
+      "examples": [
+        {
+          "prompt": "比较戊戌变法和辛亥革命的目标、方式和影响。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "history_junior_new_china",
+      "name": "新中国建设道路",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "中国近现代史",
+      "depth": 2,
+      "difficulty": 0.56,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_reform_revolution",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.77,
+          "reason": "Students may blur late-Qing reform and revolution with the later state-building path after national founding.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_institution_change",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "New China construction provides cases for applying institutional-change and governance analysis.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Timeline questions should move from chronology to source evidence and then to a cause-effect explanation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_junior_world_ancient",
+          "relation": "extends",
+          "priority": "optional",
+          "context": "review",
+          "confidence": 0.76,
+          "reason": "Practice 世界古代文明 after 新中国建设道路; it is the next topic in the junior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_socialism_market",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.86,
+          "reason": "New China construction provides the historical path for understanding socialist market-economy formation and reform.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics",
+            "validation_batch": "cross_subject_bridge_2026_06_28"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "近代转型",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "时间线",
+        "史论结合"
+      ],
+      "examples": [
+        {
+          "prompt": "按时间线整理新中国成立后制度建设和经济探索。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "history_senior_material_analysis",
+      "name": "史料实证方法",
+      "subject": "history",
+      "stage": "senior_high",
+      "chapter": "高中历史",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_senior_economic_history",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_modernization_comparison",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_institution_change",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_senior_globalization",
+          "relation": "extends",
+          "reason": "Practice 世界市场与全球化 after 史料实证方法; it is the next topic in the senior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_practical_filter",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Source analysis and practical text reading both require filtering claims, facts, dates, actors, and evidence from materials.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "chinese",
+            "bridge_direction": "history_to_chinese"
+          }
+        },
+        {
+          "id": "chinese_senior_modern_argument_structure",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "reason": "Historical source explanations strengthen argument reading by linking evidence, reasoning, and conclusion structure.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "chinese",
+            "bridge_direction": "history_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "史料实证与综合",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "材料解析",
+        "史料实证"
+      ],
+      "examples": [
+        {
+          "prompt": "判断一则史料的作者立场、时代背景和史料价值。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ],
+      "aliases": [
+        "史料题",
+        "史料分析",
+        "史料实证",
+        "材料题",
+        "历史材料题怎么分析",
+        "史料实证题怎么答"
+      ]
+    },
+    {
+      "id": "history_senior_globalization",
+      "name": "世界市场与全球化",
+      "subject": "history",
+      "stage": "senior_high",
+      "chapter": "高中历史",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_industrial_revolution",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.79,
+          "reason": "Industrialization and globalization are connected but should be separated by cause, stage, and scale.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_economic_history",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "World market and globalization evidence is central to economic-history practice.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Globalization questions should proceed by periodizing evidence, identifying links, and checking the conclusion against the prompt.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_senior_modernization_comparison",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "Practice 中西现代化比较 after 世界市场与全球化; it is the next topic in the senior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "史料实证与综合",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "阶段特征",
+        "比较题"
+      ],
+      "examples": [
+        {
+          "prompt": "从新航路开辟、工业革命和信息技术说明世界联系加强。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "history_senior_modernization_comparison",
+      "name": "中西现代化比较",
+      "subject": "history",
+      "stage": "senior_high",
+      "chapter": "高中历史",
+      "depth": 3,
+      "difficulty": 0.74,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_senior_globalization",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "Students may treat global connectedness as the same thing as modernization path comparison.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_economic_history",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Modernization comparison often applies economic-history evidence to explain different development paths.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Comparison tasks should extract criteria from the material before organizing similarities and differences.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_senior_institution_change",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "Practice 制度变迁与国家治理 after 中西现代化比较; it is the next topic in the senior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只记结论，不说明时代背景和因果链",
+        "材料题照抄原文，不结合所学知识",
+        "评价题只站单一角度，缺少辩证表达"
+      ],
+      "unit": "史料实证与综合",
+      "skills": [
+        "按时间、空间和主体整理史实",
+        "分析历史事件的原因、过程、影响和评价",
+        "从材料中提取观点并结合所学论证"
+      ],
+      "question_types": [
+        "综合探究",
+        "比较题"
+      ],
+      "examples": [
+        {
+          "prompt": "比较中国近代化探索和西方工业化道路的差异。",
+          "answer_outline": [
+            "定位时代、地区、主体和材料出处。",
+            "整理背景、措施、过程、结果和影响。",
+            "结合材料关键词与所学史实作答。",
+            "用多角度评价并注意史论结合。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "history_junior_world_ancient",
+      "name": "世界古代文明",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "世界史",
+      "depth": 2,
+      "difficulty": 0.44,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_industrial_revolution",
+          "relation": "extends",
+          "reason": "Practice 工业革命 after 世界古代文明; it is the next topic in the junior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_junior_qin_unification",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Students often mix ancient world civilizations with ancient China timelines, state forms, and evidence types.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        },
+        {
+          "id": "history_junior_industrial_revolution",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After comparing ancient civilizations, students can trace how later production changes reshaped world history.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        },
+        {
+          "id": "geo_junior_river_landform",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "River-valley civilization materials can be explained with floodplains, irrigation, transport, and settlement location.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "geography",
+            "bridge_direction": "history_to_geography"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论不讲背景",
+        "材料信息和所学知识割裂",
+        "评价缺少多角度"
+      ],
+      "unit": "古代文明",
+      "skills": [
+        "定位时代背景、历史主体和材料出处",
+        "用史实解释原因、过程、影响和评价",
+        "组织史论结合的分层答案"
+      ],
+      "question_types": [
+        "史实理解",
+        "比较题"
+      ],
+      "examples": [
+        {
+          "prompt": "比较古埃及、古巴比伦、古印度和古希腊文明特点。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "history_junior_industrial_revolution",
+      "name": "工业革命",
+      "subject": "history",
+      "stage": "junior_high",
+      "chapter": "世界近现代史",
+      "depth": 2,
+      "difficulty": 0.54,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_junior_world_ancient",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_globalization",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "history_senior_economic_history",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_growth_productivity",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "Industrial Revolution evidence illustrates productivity growth through technology, capital deepening, and labor reorganization.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "economics",
+            "bridge_direction": "history_to_economics"
+          }
+        },
+        {
+          "id": "geo_junior_population_city",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.87,
+          "reason": "Industrialization provides historical evidence for urbanization, labor migration, and changing population distribution.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "geography",
+            "bridge_direction": "history_to_geography"
+          }
+        },
+        {
+          "id": "geo_senior_industrial_location",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "After identifying industrialization stages, students can explain factory location using resources, transport, labor, and markets.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "geography",
+            "bridge_direction": "history_to_geography"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论不讲背景",
+        "材料信息和所学知识割裂",
+        "评价缺少多角度"
+      ],
+      "unit": "工业化",
+      "skills": [
+        "定位时代背景、历史主体和材料出处",
+        "用史实解释原因、过程、影响和评价",
+        "组织史论结合的分层答案"
+      ],
+      "question_types": [
+        "原因影响",
+        "材料题"
+      ],
+      "examples": [
+        {
+          "prompt": "分析工业革命对生产方式、城市和世界市场的影响。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "工业革命",
+        "工业革命影响",
+        "蒸汽时代",
+        "工业革命为什么首先发生在英国",
+        "工业革命带来了哪些影响"
+      ]
+    },
+    {
+      "id": "history_senior_institution_change",
+      "name": "制度变迁与国家治理",
+      "subject": "history",
+      "stage": "senior_high",
+      "chapter": "国家制度与社会治理",
+      "depth": 3,
+      "difficulty": 0.7,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_senior_economic_history",
+          "relation": "extends",
+          "reason": "Practice 经济史专题 after 制度变迁与国家治理; it is the next topic in the senior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_junior_rule_law",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "reason": "Institutional change cases help students connect historical governance with rules, authority, and civic legal awareness.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "politics",
+            "bridge_direction": "history_to_politics"
+          }
+        },
+        {
+          "id": "history_senior_modernization_comparison",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.81,
+          "reason": "Institutional-change prompts are easily confused with broad modernization comparison unless the answer centers rules and governance.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        },
+        {
+          "id": "history_senior_economic_history",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "After identifying institutional change, students should explain how rules affected taxation, markets, labor, and growth.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论不讲背景",
+        "材料信息和所学知识割裂",
+        "评价缺少多角度"
+      ],
+      "unit": "制度史",
+      "skills": [
+        "定位时代背景、历史主体和材料出处",
+        "用史实解释原因、过程、影响和评价",
+        "组织史论结合的分层答案"
+      ],
+      "question_types": [
+        "综合探究",
+        "史论结合"
+      ],
+      "examples": [
+        {
+          "prompt": "比较古代中国中央集权与近代西方代议制的治理逻辑。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "history_senior_economic_history",
+      "name": "经济史专题",
+      "subject": "history",
+      "stage": "senior_high",
+      "chapter": "经济与社会生活",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "extends",
+          "reason": "Practice 中外文化交流 after 经济史专题; it is the next topic in the senior_high history learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_macro_gdp_accounting",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Economic history cases give concrete background for interpreting output, sector change, and long-run growth indicators.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "economics",
+            "bridge_direction": "history_to_economics"
+          }
+        },
+        {
+          "id": "history_senior_globalization",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "Economic-history answers can drift into globalization summaries unless they track production, exchange, finance, and living standards.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        },
+        {
+          "id": "history_senior_cultural_exchange",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "After explaining economic links, students can analyze how trade routes and markets carried ideas, technology, and culture.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论不讲背景",
+        "材料信息和所学知识割裂",
+        "评价缺少多角度"
+      ],
+      "unit": "经济史",
+      "skills": [
+        "定位时代背景、历史主体和材料出处",
+        "用史实解释原因、过程、影响和评价",
+        "组织史论结合的分层答案"
+      ],
+      "question_types": [
+        "阶段特征",
+        "材料题"
+      ],
+      "examples": [
+        {
+          "prompt": "说明明清商品经济、近代工业化和现代市场化之间的变化线索。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "history_senior_cultural_exchange",
+      "name": "中外文化交流",
+      "subject": "history",
+      "stage": "senior_high",
+      "chapter": "文化交流传播",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "geo_junior_china_regions",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "Cultural exchange topics can be anchored by regional differences, routes, and spatial interaction patterns.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "geography",
+            "bridge_direction": "history_to_geography"
+          }
+        },
+        {
+          "id": "chinese_senior_modern_info_comparison",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Cultural exchange materials support cross-text comparison of viewpoints, evidence, and cultural context.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "chinese",
+            "bridge_direction": "history_to_chinese"
+          }
+        },
+        {
+          "id": "history_senior_globalization",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Cultural-exchange prompts overlap with globalization but should foreground mutual borrowing, translation, adaptation, and identity.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        },
+        {
+          "id": "history_senior_material_analysis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Cultural-exchange questions usually require source attribution, evidence extraction, and source-based explanation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "history",
+            "target_subject": "history",
+            "bridge_direction": "history_internal"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背结论不讲背景",
+        "材料信息和所学知识割裂",
+        "评价缺少多角度"
+      ],
+      "unit": "文化史",
+      "skills": [
+        "定位时代背景、历史主体和材料出处",
+        "用史实解释原因、过程、影响和评价",
+        "组织史论结合的分层答案"
+      ],
+      "question_types": [
+        "材料分析",
+        "影响评价"
+      ],
+      "examples": [
+        {
+          "prompt": "从丝绸之路到全球化分析文化交流的双向影响。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "history",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/math.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/math.json
@@ -6577,27 +6577,6 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
-        },
-        {
-          "id": "college_ds_algorithm_complexity",
-          "relation": "application",
-          "reason": "二次函数开口方向 is applied through 算法复杂度分析, linking the math method to a concrete cross-topic or cross-subject problem type.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "practice",
-          "confidence": 0.89,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "computer_science",
-            "added_for": "math_core_pack_second_batch_20260626",
-            "cross_subject": true,
-            "bridge_direction": "math_to_computer_science"
-          }
         }
       ],
       "typical_misconceptions": [
@@ -7189,6 +7168,28 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "college_micro_firm_profit",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.92,
+          "reason": "Quadratic maxima model profit peaks when revenue and cost reduce to a quadratic objective; economic interpretation still checks marginal conditions and feasibility.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge_direction": "math_to_economics",
+            "bridge_focus": "quadratic_extrema_to_profit_maximization",
+            "cross_subject": true
+          }
         }
       ],
       "typical_misconceptions": [
@@ -7581,44 +7582,6 @@
             "learning_path",
             "hint_generation"
           ]
-        },
-        {
-          "id": "college_micro_demand_supply",
-          "relation": "confusable",
-          "reason": "Contrast 二次函数利润应用 with 需求供给模型; learners often mix their conditions, notation, or use cases.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "diagnosis",
-          "confidence": 0.87,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "economics",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
-        },
-        {
-          "id": "college_micro_demand_supply",
-          "relation": "procedure_step",
-          "reason": "After 二次函数利润应用, use 需求供给模型 as the next procedural step in problem solving.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "practice",
-          "confidence": 0.9,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "economics",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
         },
         {
           "id": "college_micro_elasticity",
@@ -17968,44 +17931,6 @@
         }
       ],
       "related": [
-        {
-          "id": "bio_senior_experiment_error_analysis",
-          "relation": "confusable",
-          "reason": "Contrast 复合事件概率 with 实验误差与结论评价; learners often mix their conditions, notation, or use cases.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "diagnosis",
-          "confidence": 0.87,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "biology",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
-        },
-        {
-          "id": "bio_senior_experiment_error_analysis",
-          "relation": "procedure_step",
-          "reason": "After 复合事件概率, use 实验误差与结论评价 as the next procedural step in problem solving.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "practice",
-          "confidence": 0.9,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "biology",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
-        },
         {
           "id": "function_graph_reading",
           "relation": "application",
@@ -29727,32 +29652,7 @@
       "chapter": "数与运算",
       "depth": 1,
       "difficulty": 0.18,
-      "prerequisites": [
-        {
-          "id": "chinese_primary_paragraph_main_idea",
-          "relation": "prerequisite",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning",
-            "review"
-          ],
-          "priority": "core",
-          "context": "diagnosis",
-          "confidence": 0.87,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "chinese",
-            "added_for": "math_core_pack_third_batch_20260626",
-            "cycle_fix": "avoid_primary_math_prerequisite_cycle",
-            "cross_subject": true,
-            "bridge_direction": "math_to_chinese"
-          },
-          "reason": "Basic paragraph main-idea reading supports number-sense tasks by helping learners extract quantities, place-value words, and comparison conditions from short problem statements without creating a math prerequisite cycle.",
-          "required_mastery": 0.55
-        }
-      ],
+      "prerequisites": [],
       "related": [
         {
           "id": "real_number_concept",
@@ -42029,44 +41929,6 @@
       ],
       "related": [
         {
-          "id": "bio_senior_experiment_error_analysis",
-          "relation": "confusable",
-          "reason": "Contrast 古典概型 with 实验误差与结论评价; learners often mix their conditions, notation, or use cases.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "diagnosis",
-          "confidence": 0.87,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "biology",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
-        },
-        {
-          "id": "bio_senior_experiment_error_analysis",
-          "relation": "procedure_step",
-          "reason": "After 古典概型, use 实验误差与结论评价 as the next procedural step in problem solving.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "practice",
-          "confidence": 0.9,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "biology",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
-        },
-        {
           "id": "function_graph_reading",
           "relation": "application",
           "reason": "古典概型 is applied through 函数图像信息读取, linking the math method to a concrete cross-topic or cross-subject problem type.",
@@ -42159,44 +42021,6 @@
         }
       ],
       "related": [
-        {
-          "id": "college_micro_elasticity",
-          "relation": "confusable",
-          "reason": "Contrast 随机变量及分布列 with 弹性分析; learners often mix their conditions, notation, or use cases.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "diagnosis",
-          "confidence": 0.87,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "economics",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
-        },
-        {
-          "id": "college_micro_elasticity",
-          "relation": "procedure_step",
-          "reason": "After 随机变量及分布列, use 弹性分析 as the next procedural step in problem solving.",
-          "use_cases": [
-            "diagnosis",
-            "learning_path",
-            "hint_generation",
-            "practice_planning"
-          ],
-          "priority": "core",
-          "context": "practice",
-          "confidence": 0.9,
-          "metadata": {
-            "source_subject": "math",
-            "target_subject": "economics",
-            "added_for": "math_core_pack_second_batch_20260626"
-          }
-        },
         {
           "id": "function_graph_reading",
           "relation": "application",
@@ -43220,7 +43044,7 @@
         },
         {
           "id": "college_derivative_definition",
-          "relation": "prerequisite",
+          "relation": "extends",
           "reason": "Master 极限概念 before 导数定义; it supplies the foundation used by later steps.",
           "use_cases": [
             "diagnosis",

--- a/plugin/plugins/study_companion/static/knowledge_seeds/math.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/math.json
@@ -73,6 +73,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "college_cs_bit_binary",
+          "relation": "application",
+          "reason": "Real-number magnitude and approximation connect to computer numeric representation, binary scale, and rounding limits.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -340,6 +357,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "application",
+          "reason": "Motion graph interpretation uses absolute distance and signed displacement to distinguish position change from path length.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -466,6 +500,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "application",
+          "reason": "Chemical stoichiometry uses scientific notation for particle counts, molar quantities, and very small or large masses.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -586,6 +637,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "college_cs_bit_binary",
+          "relation": "application",
+          "reason": "Binary representation and bit shifts rely on powers of two as the numeric scale for computer storage.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -717,6 +785,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "application",
+          "reason": "Algebraic expressions model unknown coefficients and proportional quantities in chemical stoichiometry calculations.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -837,6 +922,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "application",
+          "reason": "Polynomial expressions describe position, velocity, and time relationships in motion models.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -1253,6 +1355,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "application",
+          "reason": "Fractional expressions model mole ratios, concentration ratios, and limiting-reagent comparisons.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -1363,6 +1482,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "Projectile and energy formulas can lead to square-root expressions when solving for speed, time, or height.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -1479,6 +1615,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Market equilibrium sets demand equal to supply, making equation modeling a core tool for economic analysis.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -1610,6 +1763,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "application",
+          "reason": "Uniform-motion equations use linear relationships among position, velocity, and time.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -1731,6 +1901,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Linear price, quantity, revenue, and cost assumptions are modeled with one-variable equations in market problems.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -1998,6 +2185,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Supply-demand equilibrium often solves a system linking price and quantity.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -2119,6 +2323,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "Projectile height-time models lead to quadratic equations for landing time and maximum-height conditions.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -2261,6 +2482,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "Factoring can solve projectile height equations when the time roots are simple.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -2398,6 +2636,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "The quadratic formula solves motion equations when projectile time or height roots do not factor neatly.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -2519,6 +2774,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Quadratic supply-demand or profit models use discriminants to judge whether feasible equilibrium or break-even roots exist.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -2649,6 +2921,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Economic quadratic models use Vieta relations to reason about paired break-even quantities without solving every root directly.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -2769,6 +3058,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Economic constraints such as budget, capacity, and minimum profit are naturally expressed as inequalities.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -2910,6 +3216,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Supply-demand and pricing models use linear inequalities for feasible price or quantity ranges.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -3036,6 +3359,23 @@
             "batch": "math_second_fill",
             "scope": "real_algebra_equations_inequalities"
           }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Market feasibility problems combine supply, demand, budget, and capacity constraints as inequality systems.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -3147,6 +3487,23 @@
             "learning_path",
             "practice_planning",
             "hint_generation"
+          ],
+          "metadata": {
+            "batch": "math_second_fill",
+            "scope": "real_algebra_equations_inequalities"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Economic decision problems use inequalities to compare supply, demand, cost, revenue, and capacity constraints.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "practice_planning",
+            "hint_generation",
+            "review"
           ],
           "metadata": {
             "batch": "math_second_fill",
@@ -3270,6 +3627,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "application",
+          "reason": "平面直角坐标系 is applied through 运动图像综合, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
           }
         }
       ],
@@ -3399,6 +3777,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "geo_senior_earth_movement",
+          "relation": "application",
+          "reason": "点的坐标 is applied through 地球运动, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "geography",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_geography"
           }
         }
       ],
@@ -3677,6 +4076,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "reason": "坐标对称 is applied through 简谐运动图像, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -3806,6 +4226,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "college_physics_momentum_center_mass",
+          "relation": "application",
+          "reason": "中点坐标公式 is applied through 动量与质心运动, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
           }
         }
       ],
@@ -3937,6 +4378,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "两点距离公式 is applied through 平抛与斜抛运动, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
           }
         }
       ],
@@ -4194,6 +4656,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "application",
+          "reason": "正比例函数 is applied through 溶液浓度与稀释, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "chemistry",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_chemistry"
           }
         }
       ],
@@ -4934,6 +5417,28 @@
             "hint_generation",
             "practice_planning"
           ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "Market equilibrium in demand-supply models applies the same intersection idea: set the demand and supply functions equal, then interpret the crossing point as equilibrium price and quantity.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.93,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "bridge_direction": "math_to_economics",
+            "bridge_focus": "function_intersection_to_market_equilibrium",
+            "cross_subject": true,
+            "added_for": "fixed_retrieval_eval_cross_subject_cases"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -5190,6 +5695,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "reason": "分段一次函数 is applied through 需求供给模型, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_economics"
           }
         }
       ],
@@ -5452,6 +5978,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "二次函数一般式 is applied through 平抛与斜抛运动, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
           }
         }
       ],
@@ -5730,6 +6277,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "reason": "二次函数对称轴 is applied through 简谐运动图像, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -5859,6 +6427,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "二次函数顶点坐标 is applied through 平抛与斜抛运动, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -5987,6 +6576,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "application",
+          "reason": "二次函数开口方向 is applied through 算法复杂度分析, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "computer_science",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_computer_science"
           }
         }
       ],
@@ -6428,6 +7038,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "reason": "二次函数与方程根 is applied through 平抛与斜抛运动, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -6698,6 +7329,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "application",
+          "reason": "由点求二次函数解析式 is applied through 高中物理实验数据处理, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -6827,6 +7479,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "physics_junior_work_power",
+          "relation": "application",
+          "reason": "二次函数面积应用 is applied through 功和功率, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -6908,6 +7581,65 @@
             "learning_path",
             "hint_generation"
           ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "confusable",
+          "reason": "Contrast 二次函数利润应用 with 需求供给模型; learners often mix their conditions, notation, or use cases.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "procedure_step",
+          "reason": "After 二次函数利润应用, use 需求供给模型 as the next procedural step in problem solving.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "college_micro_elasticity",
+          "relation": "application",
+          "reason": "二次函数利润应用 is applied through 弹性分析, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_economics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -7975,6 +8707,27 @@
           },
           "reason": "After identifying 三角形内角和, move to 三角形三边关系 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "三角形内角和 applies to 平抛与斜抛运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -8104,6 +8857,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 三角形三边关系, move to 勾股定理 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_junior_force_balance",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "三角形三边关系 applies to 二力平衡, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -8366,6 +9140,27 @@
           },
           "reason": "After identifying 三角形全等判定, move to 三角形相似判定 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_experiment_vernier",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "三角形全等判定 applies to 游标卡尺与螺旋测微器读数, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -8494,6 +9289,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 等腰三角形, move to 三角形全等判定 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_junior_force_balance",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "等腰三角形 applies to 二力平衡, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -9428,6 +10244,27 @@
           },
           "reason": "After identifying 四边形概念, move to 平行线性质 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "geo_senior_earth_movement",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "geography",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_geography"
+          },
+          "reason": "四边形概念 applies to 地球运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -9557,6 +10394,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 平行线性质, move to 平行四边形 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_electric_magnetic_field",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "平行线性质 applies to 电场磁场综合, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -9995,6 +10853,27 @@
           },
           "reason": "After identifying 矩形, move to 正方形 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_junior_work_power",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "矩形 applies to 功和功率, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -10124,6 +11003,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 菱形, move to 正方形 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_electric_potential_graph",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "菱形 applies to 电势与场强图像, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -10266,6 +11166,27 @@
           },
           "reason": "After identifying 正方形, move to 菱形 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_junior_pressure_buoyancy",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "正方形 applies to 压强与浮力, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -10407,6 +11328,27 @@
           },
           "reason": "After identifying 梯形, move to 三角形中位线 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_junior_work_power",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "梯形 applies to 功和功率, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -10536,6 +11478,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 三角形中位线, move to 梯形 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "三角形中位线 applies to 平抛与斜抛运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -10829,6 +11792,27 @@
           },
           "reason": "After identifying 圆的基本概念, move to 圆心角与弧 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "圆的基本概念 applies to 圆周运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -10959,6 +11943,27 @@
           },
           "reason": "After identifying 圆心角与弧, move to 圆周角定理 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "圆心角与弧 applies to 圆周运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -11088,6 +12093,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 圆周角定理, move to 圆内接四边形 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "圆周角定理 applies to 圆周运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -11230,6 +12256,27 @@
           },
           "reason": "After identifying 圆内接四边形, move to 圆综合题 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_gravitation_orbit",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "圆内接四边形 applies to 万有引力与天体运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -11371,6 +12418,27 @@
           },
           "reason": "After identifying 切线概念, move to 切线性质与判定 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_electric_magnetic_field",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "切线概念 applies to 电场磁场综合, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -11499,6 +12567,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 切线性质与判定, move to 弦与垂径定理 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_critical",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "切线性质与判定 applies to 圆周运动临界条件, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -11640,6 +12729,27 @@
           },
           "reason": "After identifying 弦与垂径定理, move to 圆周角定理 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "弦与垂径定理 applies to 简谐运动图像, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -11770,6 +12880,27 @@
           },
           "reason": "After identifying 弧长公式, move to 扇形面积 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "弧长公式 applies to 圆周运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -11898,6 +13029,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 扇形面积, move to 圆综合题 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "扇形面积 applies to 圆周运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -12040,6 +13192,27 @@
           },
           "reason": "After identifying 圆综合题, move to 特殊四边形判定与证明 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_critical",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "圆综合题 applies to 圆周运动临界条件, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -12168,6 +13341,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_design",
+          "relation": "application",
+          "reason": "数据收集与整理 is applied through 生物实验设计, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_biology"
           }
         }
       ],
@@ -12298,6 +13492,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "application",
+          "reason": "平均数中位数众数 is applied through 实验图表信息提取, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_biology"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -12427,6 +13642,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "application",
+          "reason": "加权平均数 is applied through 经济数据图表解读, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_economics"
           }
         }
       ],
@@ -12701,6 +13937,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "application",
+          "reason": "频数分布直方图 is applied through 高中物理实验数据处理, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -12829,6 +14086,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "application",
+          "reason": "概率概念 is applied through 实验误差与结论评价, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_biology"
           }
         }
       ],
@@ -13099,6 +14377,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "bio_senior_experiment_design",
+          "relation": "application",
+          "reason": "列表法与树状图 is applied through 生物实验设计, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_biology"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -13348,6 +14647,27 @@
           },
           "reason": "After identifying 轴对称, move to 旋转 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "轴对称 applies to 简谐运动图像, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -13478,6 +14798,27 @@
           },
           "reason": "After identifying 旋转, move to 坐标旋转与中心对称 as the next proof, construction, or calculation step.",
           "context": "practice"
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "旋转 applies to 圆周运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
+          "context": "practice"
         }
       ],
       "typical_misconceptions": [
@@ -13606,6 +14947,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 中心对称, move to 坐标对称 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "中心对称 applies to 简谐运动图像, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -13736,6 +15098,27 @@
             "added_for": "math_geometry_core_pack_20260626"
           },
           "reason": "After identifying 位似, move to 比例尺 as the next proof, construction, or calculation step.",
+          "context": "practice"
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_geometry_core_pack_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "位似 applies to 平抛与斜抛运动, connecting geometry structure with a concrete cross-topic or cross-subject model.",
           "context": "practice"
         }
       ],
@@ -14263,6 +15646,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 特殊角三角函数值, use sin cos tan 定义 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Special-angle values anchor sine and cosine readings in simple harmonic motion graphs at standard phase positions."
         }
       ],
       "typical_misconceptions": [
@@ -14395,6 +15800,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 三角函数表与计算, use 测高测距应用 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Using trigonometric values supports projectile-motion component calculations when launch angles are not special angles."
         }
       ],
       "typical_misconceptions": [
@@ -14538,6 +15965,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 测高测距应用, use 锐角三角函数综合题 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Height-and-distance trigonometry transfers directly to projectile and line-of-sight physical modeling."
         }
       ],
       "typical_misconceptions": [
@@ -14671,6 +16120,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 锐角三角函数综合题, use 三角函数图像与性质 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_wave_interference",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Comprehensive trigonometry supports wave-graph reading where phase, amplitude, and period are represented by sine or cosine models."
         }
       ],
       "typical_misconceptions": [
@@ -14783,6 +16254,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 完全平方公式, use 公式法因式分解 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "chem_senior_stoichiometry_limiting",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "chemistry",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_chemistry"
+          },
+          "reason": "Perfect-square identities support algebraic simplification before stoichiometry equations are solved for limiting or excess quantities."
         }
       ],
       "typical_misconceptions": [
@@ -14895,6 +16388,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 平方差公式, use 公式法因式分解 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "chem_senior_mole_calculation",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "chemistry",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_chemistry"
+          },
+          "reason": "Difference-of-squares transformations simplify expressions before chemical amount relations are rearranged and solved."
         }
       ],
       "typical_misconceptions": [
@@ -15018,6 +16533,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 分式方程, use 方程解的检验 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "chemistry",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_chemistry"
+          },
+          "reason": "Fractional equations model concentration and dilution problems where the unknown is embedded in a ratio or reciprocal relation."
         }
       ],
       "typical_misconceptions": [
@@ -15141,6 +16678,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 含参方程, use 二次函数参数范围 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Parameter equations connect to motion graphs when changing initial speed, acceleration, or time shifts the solution set of a physical model."
         }
       ],
       "typical_misconceptions": [
@@ -15264,6 +16823,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 坐标系中的面积, use 坐标法证明几何关系 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Coordinate-area reasoning connects to displacement from velocity-time graphs and to area interpretation in data-rich physical models."
         }
       ],
       "typical_misconceptions": [
@@ -15507,6 +17088,28 @@
           "priority": "core",
           "context": "practice",
           "confidence": 0.9
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "application",
+          "reason": "Algorithm complexity analysis compares how runtime functions grow with input size; monotonicity and growth-rate reading help distinguish linear, polynomial, logarithmic, and exponential behavior.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.94,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "computer_science",
+            "bridge_direction": "math_to_computer_science",
+            "bridge_focus": "function_growth_to_algorithm_complexity",
+            "cross_subject": true,
+            "added_for": "fixed_retrieval_eval_cross_subject_cases"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -16125,6 +17728,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 多边形内角和, use 特殊四边形判定与证明 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Polygon angle-sum reasoning supports circular and rotational geometry diagrams used in physical path and angle constraints."
         }
       ],
       "typical_misconceptions": [
@@ -16248,6 +17873,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 点线圆位置关系, use 切线性质与判定 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Point-line-circle position relations transfer to circular-motion diagrams where radius, tangent direction, and contact conditions matter."
         }
       ],
       "typical_misconceptions": [
@@ -16321,6 +17968,44 @@
         }
       ],
       "related": [
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "confusable",
+          "reason": "Contrast 复合事件概率 with 实验误差与结论评价; learners often mix their conditions, notation, or use cases.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "procedure_step",
+          "reason": "After 复合事件概率, use 实验误差与结论评价 as the next procedural step in problem solving.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
         {
           "id": "function_graph_reading",
           "relation": "application",
@@ -16462,6 +18147,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 图形变换综合题, use 坐标旋转与中心对称 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Transformation reasoning supports symmetry and periodicity arguments in oscillation graphs and physical motion models."
         }
       ],
       "typical_misconceptions": [
@@ -16585,6 +18292,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 三角函数与面积, use 向量数量积 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Trigonometric area and projection reasoning support force decomposition and vector component calculations."
         }
       ],
       "typical_misconceptions": [
@@ -16707,6 +18436,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 有理数混合运算, use 分式概念与运算 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "chem_senior_solution_concentration",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "chemistry",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_chemistry"
+          },
+          "reason": "Rational-number operations are used when concentration, dilution, and ratio data must be converted into consistent chemical calculations."
         }
       ],
       "typical_misconceptions": [
@@ -16828,6 +18579,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 平方根与立方根, use 二次根式 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Square-root reasoning appears when projectile-motion formulas are solved backward for time, speed, or height from quadratic relations."
         }
       ],
       "typical_misconceptions": [
@@ -16949,6 +18722,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 无理数估算, use 数轴与相反数 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Irrational-number estimation helps judge whether measured physical data and rounded experimental results are reasonable."
         }
       ],
       "typical_misconceptions": [
@@ -22718,6 +24513,52 @@
           ]
         },
         {
+          "id": "college_c_recursion_basic",
+          "relation": "application",
+          "reason": "Geometric proof organization and recursive programming both depend on a base case, a repeatable step, and a justification that the step preserves correctness.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "computer_science",
+            "bridge_direction": "math_to_computer_science",
+            "bridge_focus": "proof_structure_to_recursion_correctness",
+            "cross_subject": true,
+            "added_for": "fixed_retrieval_eval_cross_subject_cases"
+          }
+        },
+        {
+          "id": "college_ds_recursion_iteration",
+          "relation": "application",
+          "reason": "Geometric proof organization and recursion-to-iteration conversion both require a base case, a repeatable step, and a correctness argument for each transition.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "computer_science",
+            "bridge_direction": "math_to_computer_science",
+            "bridge_focus": "proof_structure_to_recursion_iteration",
+            "cross_subject": true,
+            "added_for": "fixed_retrieval_eval_cross_subject_cases"
+          }
+        },
+        {
           "id": "auxiliary_line_strategy",
           "relation": "procedure_step",
           "priority": "core",
@@ -24741,6 +26582,27 @@
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
           }
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "application",
+          "reason": "抽样调查 is applied through 经济数据图表解读, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_economics"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -24870,6 +26732,27 @@
             "source_subject": "math",
             "target_subject": "math",
             "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_curve_table",
+          "relation": "application",
+          "reason": "统计图表综合 is applied through 实验图表信息提取, linking the math method to a concrete cross-topic or cross-subject problem type.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_biology"
           }
         }
       ],
@@ -27844,7 +29727,32 @@
       "chapter": "数与运算",
       "depth": 1,
       "difficulty": 0.18,
-      "prerequisites": [],
+      "prerequisites": [
+        {
+          "id": "chinese_primary_paragraph_main_idea",
+          "relation": "prerequisite",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "chinese",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cycle_fix": "avoid_primary_math_prerequisite_cycle",
+            "cross_subject": true,
+            "bridge_direction": "math_to_chinese"
+          },
+          "reason": "Basic paragraph main-idea reading supports number-sense tasks by helping learners extract quantities, place-value words, and comparison conditions from short problem statements without creating a math prerequisite cycle.",
+          "required_mastery": 0.55
+        }
+      ],
       "related": [
         {
           "id": "real_number_concept",
@@ -27910,6 +29818,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 数感与数位, use 有理数混合运算 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "chem_senior_mole_calculation",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "chemistry",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_chemistry"
+          },
+          "reason": "Number sense supports mole and quantity calculations by keeping units, place value, and magnitude estimates coherent before formula substitution."
         }
       ],
       "typical_misconceptions": [
@@ -34568,6 +36498,36 @@
       ],
       "related": [
         {
+          "id": "chem_senior_ph_ionization",
+          "relation": "application",
+          "reason": "Application: exponential and logarithmic models support pH and ionization calculations.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_physics_damped_forced_oscillation",
+          "relation": "application",
+          "reason": "Application: exponential decay and growth intuition supports damping models.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_econ_growth_productivity",
+          "relation": "application",
+          "reason": "Application: exponential growth models support productivity and economic growth analysis.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
           "id": "senior_power_function",
           "relation": "confusable",
           "reason": "Exponential functions have the variable in the exponent, while power functions have the variable in the base; their graph growth and domains differ.",
@@ -34592,6 +36552,37 @@
           "priority": "core",
           "context": "practice",
           "confidence": 0.9
+        },
+        {
+          "id": "bio_senior_pcr_electrophoresis",
+          "relation": "application",
+          "reason": "PCR amplification follows repeated doubling intuition, so exponential-function growth helps explain why DNA copies increase rapidly before electrophoresis verification.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "practice_planning",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "bio_senior_pcr_electrophoresis",
+          "relation": "procedure_step",
+          "reason": "Procedure step: model PCR amplification as repeated doubling with an exponential function before interpreting electrophoresis verification results.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.95,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "batch": "math_relation_gap_fill",
+            "scope": "cross_subject_retrieval_stability",
+            "cross_subject": true
+          }
         }
       ],
       "typical_misconceptions": [
@@ -34780,6 +36771,16 @@
         }
       ],
       "related": [
+        {
+          "id": "chem_senior_ph_ionization",
+          "relation": "application",
+          "reason": "Application: logarithmic functions are used in pH scale reasoning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
         {
           "id": "senior_exponential_function",
           "relation": "confusable",
@@ -35849,6 +37850,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 两角和差公式, use 三角函数图像与性质 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_wave_interference",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Sum-difference formulas explain phase shifts and superposition patterns in wave interference problems."
         }
       ],
       "typical_misconceptions": [
@@ -35963,6 +37986,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "After 二倍角公式, use 三角函数图像与性质 as the next procedural step in solving or proving the problem."
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Double-angle formulas help transform oscillation expressions and interpret frequency-doubling patterns in harmonic models."
         }
       ],
       "typical_misconceptions": [
@@ -36690,6 +38735,19 @@
             "diagnosis",
             "hint_generation",
             "review"
+          ]
+        },
+        {
+          "id": "college_ds_recursion_iteration",
+          "relation": "application",
+          "reason": "Recursive sequence thinking transfers to computer-science recursion and iteration, where later states depend on previous states.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
           ]
         }
       ],
@@ -39514,6 +41572,28 @@
             "learning_path",
             "hint_generation"
           ]
+        },
+        {
+          "id": "bio_senior_enzyme_curve",
+          "relation": "application",
+          "reason": "Enzyme activity curves use extrema reasoning when identifying optimal temperature or pH; derivative-based maximum and minimum thinking explains why curve peaks matter.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "bridge_direction": "math_to_biology",
+            "bridge_focus": "derivative_extrema_to_enzyme_activity_curve",
+            "cross_subject": true,
+            "added_for": "fixed_retrieval_eval_cross_subject_cases"
+          }
         }
       ],
       "typical_misconceptions": [
@@ -39949,6 +42029,44 @@
       ],
       "related": [
         {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "confusable",
+          "reason": "Contrast 古典概型 with 实验误差与结论评价; learners often mix their conditions, notation, or use cases.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "bio_senior_experiment_error_analysis",
+          "relation": "procedure_step",
+          "reason": "After 古典概型, use 实验误差与结论评价 as the next procedural step in problem solving.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "biology",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
           "id": "function_graph_reading",
           "relation": "application",
           "reason": "古典概型 is applied through 函数图像信息读取, linking the math method to a concrete cross-topic or cross-subject problem type.",
@@ -40041,6 +42159,44 @@
         }
       ],
       "related": [
+        {
+          "id": "college_micro_elasticity",
+          "relation": "confusable",
+          "reason": "Contrast 随机变量及分布列 with 弹性分析; learners often mix their conditions, notation, or use cases.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.87,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
+        {
+          "id": "college_micro_elasticity",
+          "relation": "procedure_step",
+          "reason": "After 随机变量及分布列, use 弹性分析 as the next procedural step in problem solving.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "economics",
+            "added_for": "math_core_pack_second_batch_20260626"
+          }
+        },
         {
           "id": "function_graph_reading",
           "relation": "application",
@@ -41515,6 +43671,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "Contrast 两个重要极限 with 极限运算法则; learners often mix their conditions, formulas, or use cases."
+        },
+        {
+          "id": "college_ds_algorithm_complexity",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "computer_science",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_computer_science"
+          },
+          "reason": "Important limits support asymptotic comparison when algorithm complexity focuses on dominant growth behavior."
         }
       ],
       "typical_misconceptions": [
@@ -43248,6 +45426,16 @@
           ]
         },
         {
+          "id": "college_physics_kinematics_calculus",
+          "relation": "application",
+          "reason": "Application: derivatives model velocity and acceleration in college kinematics.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
           "id": "college_mean_value_theorem",
           "relation": "application",
           "reason": "Application: apply college_derivative_calculation when solving or modeling tasks involving college_mean_value_theorem in the calculus cluster.",
@@ -43797,6 +45985,28 @@
             "added_for": "math_core_pack_third_batch_20260626"
           },
           "reason": "Contrast 微分 with 函数图像信息读取; learners often mix their conditions, formulas, or use cases."
+        },
+        {
+          "id": "college_physics_kinematics_calculus",
+          "relation": "application",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "math",
+            "target_subject": "physics",
+            "added_for": "math_core_pack_third_batch_20260626",
+            "cross_subject": true,
+            "bridge_direction": "math_to_physics"
+          },
+          "reason": "Differentials connect local change in calculus with instantaneous velocity and small-displacement physical approximations."
         }
       ],
       "typical_misconceptions": [
@@ -48284,6 +50494,16 @@
             "learning_path",
             "hint_generation"
           ]
+        },
+        {
+          "id": "college_physics_work_energy_theorem",
+          "relation": "application",
+          "reason": "Application: definite integrals model accumulated work and energy transfer.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
         }
       ],
       "typical_misconceptions": [
@@ -49442,6 +51662,16 @@
           "id": "college_force_analysis",
           "relation": "procedure_step",
           "reason": "Procedure step: after 定积分物理应用, move to 受力分析. Keep the workflow explicit so guidance can ask for the next missing step.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_physics_momentum_center_mass",
+          "relation": "application",
+          "reason": "Application: integral accumulation connects force over time with momentum and impulse.",
           "use_cases": [
             "diagnosis",
             "learning_path",
@@ -50999,6 +53229,19 @@
           "confidence": 0.88
         },
         {
+          "id": "college_c_2d_array_matrix",
+          "relation": "application",
+          "reason": "Application: college_matrix_operations is used when solving or modeling tasks involving college_c_2d_array_matrix.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88
+        },
+        {
           "id": "college_matrix_dimension",
           "relation": "confusable",
           "reason": "Contrast college_matrix_operations with college_matrix_dimension; students often mix their conditions, notation, or conclusions.",
@@ -51238,6 +53481,19 @@
           "id": "college_matrix_dimension",
           "relation": "application",
           "reason": "Application: college_linear_transformation is used when solving or modeling tasks involving college_matrix_dimension.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88
+        },
+        {
+          "id": "college_c_2d_array_matrix",
+          "relation": "application",
+          "reason": "Application: college_linear_transformation is used when solving or modeling tasks involving college_c_2d_array_matrix.",
           "use_cases": [
             "diagnosis",
             "learning_path",
@@ -55481,6 +57737,32 @@
           "confidence": 0.88
         },
         {
+          "id": "bio_senior_genetics_law",
+          "relation": "application",
+          "reason": "Application: college_expectation_variance is used when solving or modeling tasks involving bio_senior_genetics_law.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "application",
+          "reason": "Application: college_expectation_variance is used when solving or modeling tasks involving college_econ_data_graph.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88
+        },
+        {
           "id": "college_standard_deviation",
           "relation": "procedure_step",
           "reason": "Procedure step: use college_standard_deviation while working through college_expectation_variance so the solving workflow stays explicit.",
@@ -56303,6 +58585,19 @@
             "hint_generation",
             "review"
           ]
+        },
+        {
+          "id": "bio_senior_population_growth",
+          "relation": "application",
+          "reason": "First-order differential equations model change-rate processes such as idealized population growth or decay before more complex systems are introduced.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
         }
       ],
       "typical_misconceptions": [
@@ -57110,6 +59405,36 @@
           ]
         },
         {
+          "id": "college_ds_shortest_path",
+          "relation": "application",
+          "reason": "Application: graph theory provides the model behind shortest-path algorithms.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_ds_graph_traversal",
+          "relation": "application",
+          "reason": "Application: graph theory underlies BFS and DFS traversal.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_ds_graph_representation",
+          "relation": "application",
+          "reason": "Application: graph theory concepts map to adjacency-list and adjacency-matrix storage.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
           "id": "college_spanning_tree",
           "relation": "application",
           "reason": "Application: apply college_graph_theory_intro when solving or modeling tasks involving college_spanning_tree in the discrete_logic cluster.",
@@ -57695,6 +60020,19 @@
             "hint_generation",
             "review"
           ]
+        },
+        {
+          "id": "college_ds_hash_table",
+          "relation": "application",
+          "reason": "Number-theory ideas about remainders support modular hashing and table indexing in data-structure applications.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
         }
       ],
       "typical_misconceptions": [
@@ -58056,6 +60394,19 @@
             "diagnosis",
             "hint_generation",
             "review"
+          ]
+        },
+        {
+          "id": "college_micro_consumer_choice",
+          "relation": "application",
+          "reason": "Unit-rate and unit-price comparison are early forms of cost-benefit reasoning used later in consumer-choice examples.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
           ]
         }
       ],
@@ -61338,6 +63689,19 @@
             "hint_generation",
             "review"
           ]
+        },
+        {
+          "id": "chinese_senior_exam_revision_strategy",
+          "relation": "application",
+          "reason": "Multi-choice review benefits from exam-revision habits such as classifying errors, revisiting evidence, and tracking option traps.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
         }
       ],
       "typical_misconceptions": [
@@ -64111,6 +66475,16 @@
             "learning_path",
             "hint_generation"
           ]
+        },
+        {
+          "id": "bio_senior_genetics_law",
+          "relation": "application",
+          "reason": "Application: binomial models support Mendelian genetics count and probability questions.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
         }
       ],
       "skills": [
@@ -64210,6 +66584,16 @@
           "id": "college_hypothesis_testing",
           "relation": "application",
           "reason": "Application: use 正态分布 to handle 假设检验. normal approximation supports many classical tests.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "college_econ_data_graph",
+          "relation": "application",
+          "reason": "Application: normal models support economic data summaries and interval interpretation.",
           "use_cases": [
             "diagnosis",
             "learning_path",
@@ -64627,6 +67011,19 @@
             "hint_generation",
             "review"
           ]
+        },
+        {
+          "id": "college_physics_damped_forced_oscillation",
+          "relation": "application",
+          "reason": "Linear first-order solution habits prepare students for forced-response thinking before they meet higher-order linear vibration models.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
         }
       ],
       "typical_misconceptions": [
@@ -64721,6 +67118,19 @@
             "diagnosis",
             "hint_generation",
             "review"
+          ]
+        },
+        {
+          "id": "chem_senior_rate_factors",
+          "relation": "application",
+          "reason": "Separable equations give the mathematical pattern behind simple rate-law growth or decay models used when discussing reaction-rate change.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
           ]
         }
       ],
@@ -64920,6 +67330,19 @@
             "diagnosis",
             "hint_generation",
             "review"
+          ]
+        },
+        {
+          "id": "college_ds_hash_table",
+          "relation": "application",
+          "reason": "Modulo operations are used to map keys into hash-table buckets and to reason about cyclic indexing.",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
           ]
         }
       ],
@@ -67809,7 +70232,19 @@
       "chapter": "微积分",
       "depth": 3,
       "difficulty": 0.7,
-      "prerequisites": [],
+      "prerequisites": [
+        {
+          "id": "physics_junior_force_balance",
+          "relation": "prerequisite",
+          "reason": "Master physics_junior_force_balance before 受力分析; it supplies the foundation for this college math concept.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "required_mastery": 0.55
+        }
+      ],
       "related": [
         {
           "id": "college_energy_conservation",

--- a/plugin/plugins/study_companion/static/knowledge_seeds/physics.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/physics.json
@@ -1,0 +1,11807 @@
+{
+  "version": "1.0",
+  "subject": "physics",
+  "topics": [
+    {
+      "id": "physics_junior_speed",
+      "name": "速度与运动图像",
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "力学",
+      "depth": 2,
+      "difficulty": 0.42,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "physics_junior_force_balance",
+          "relation": "extends",
+          "reason": "Practice 二力平衡 after 速度与运动图像; it is the next topic in the junior_high physics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "读 s-t、v-t 图像前，需要先会从函数图像读取斜率、截距、增减和区间信息。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "函数图像->运动图像",
+            "physics_use": "从运动图像判断速度、路程和运动状态"
+          }
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Motion graph tasks use linear-function graphs to compare uniform motion segments and read slope as speed.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "motion_graph_linear_function"
+          }
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After reading a basic s-t or v-t graph, the next procedure is to mark intervals, slopes, and areas before comparing multi-stage motion graphs.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "function_graph_reading_to_motion_graph_steps",
+            "physics_use": "turns graph-reading into a repeatable slope-area workflow for motion problems"
+          }
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "Students often confuse graph height with graph slope; comparing basic speed graphs with synthesis problems exposes that error early.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "graph_height_vs_slope_confusion",
+            "physics_use": "separates position, velocity, slope, and area meanings on motion graphs"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "运动与力",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "计算题",
+        "图像分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据 s-t 图像判断物体各段运动状态并计算平均速度。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_junior_force_balance",
+      "name": "二力平衡",
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "力学",
+      "depth": 2,
+      "difficulty": 0.48,
+      "prerequisites": [
+        {
+          "id": "physics_junior_speed",
+          "relation": "prerequisite",
+          "reason": "Force-balance problems require motion-state vocabulary before deciding whether acceleration is zero.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_junior_pressure_buoyancy",
+          "relation": "extends",
+          "reason": "physics_junior_force_balance uses physics_junior_pressure_buoyancy as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "senior_vector_linear_operation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Force balance diagrams apply vector addition because the net force is represented by a zero resultant.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "force_balance_vector_addition",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "senior_vector_coordinate",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Before checking equilibrium, students can project each force onto coordinate axes and compare component sums.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "equilibrium_component_setup",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "confusable",
+          "reason": "Balanced resultant force is often confused with decomposing a single force into components.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "运动与力",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "概念辨析",
+        "受力分析"
+      ],
+      "examples": [
+        {
+          "prompt": "判断静止物体受力是否平衡，并画出力的示意图。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_junior_pressure_buoyancy",
+      "name": "压强与浮力",
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "力学",
+      "depth": 2,
+      "difficulty": 0.58,
+      "prerequisites": [
+        {
+          "id": "physics_junior_force_balance",
+          "relation": "prerequisite",
+          "reason": "Pressure and buoyancy analysis starts from identifying forces such as weight, support, and buoyant force.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_junior_work_power",
+          "relation": "extends",
+          "reason": "physics_junior_pressure_buoyancy uses physics_junior_work_power as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "physics_junior_work_power",
+          "relation": "procedure_step",
+          "reason": "After pressure or buoyancy forces are known, later tasks may connect the force to displacement, work, or power.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "physics_junior_force_balance",
+          "relation": "confusable",
+          "reason": "Students often confuse pressure as a force instead of force per unit area.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "application",
+          "reason": "Buoyancy and pressure directions prepare students for component reasoning in more complex force models.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "运动与力",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "计算题",
+        "实验探究"
+      ],
+      "examples": [
+        {
+          "prompt": "分析物体浸入液体前后弹簧测力计示数变化，求浮力。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_junior_work_power",
+      "name": "功和功率",
+      "aliases": [
+        "功和能量",
+        "做功",
+        "功率",
+        "机械功",
+        "功和动能"
+      ],
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "力学",
+      "depth": 2,
+      "difficulty": 0.54,
+      "prerequisites": [
+        {
+          "id": "physics_junior_force_balance",
+          "relation": "prerequisite",
+          "reason": "Work and power tasks require identifying the acting force before multiplying by displacement or time rate.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_work_energy_path",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "physics_junior_work_power uses physics_senior_work_energy_path as a procedure step link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "physics_senior_energy_momentum",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "physics_junior_work_power uses physics_senior_energy_momentum as a application link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "college_physics_work_energy_theorem",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "physics_junior_work_power uses college_physics_work_energy_theorem as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "physics_junior_circuit_recognition",
+          "relation": "extends",
+          "reason": "physics_junior_work_power uses physics_junior_circuit_recognition as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "senior_vector_dot_product",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Work problems apply dot-product thinking by using only the force component along displacement.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "work_effective_component",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "college_integral_physics_application",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "Variable-force work questions give a concrete physics case for integral accumulation over displacement.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "work_integral_application",
+            "chapter_focus": "力学"
+          }
+        },
+        {
+          "id": "physics_senior_work_energy_path",
+          "relation": "confusable",
+          "reason": "Basic work-power formulas are often confused with path-based work-energy reasoning.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "力学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "运动与力",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "计算题",
+        "实际应用"
+      ],
+      "examples": [
+        {
+          "prompt": "计算搬运物体做功和功率，并说明哪些力没有做功。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_junior_circuit_recognition",
+      "name": "串并联电路识别",
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "电学",
+      "depth": 2,
+      "difficulty": 0.46,
+      "prerequisites": [
+        {
+          "id": "linear_equation",
+          "relation": "prerequisite",
+          "reason": "Circuit recognition practice often labels unknown current or voltage with simple linear equations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_junior_ohm_law",
+          "relation": "extends",
+          "reason": "physics_junior_circuit_recognition uses physics_junior_ohm_law as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_junior_ohm_law",
+          "relation": "procedure_step",
+          "reason": "Once the topology is recognized, Ohm law can be applied to the relevant branch or component.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_junior_experiment_resistance",
+          "relation": "confusable",
+          "reason": "Ammeter and voltmeter placement in circuit recognition is often confused with resistance-measurement setup.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_junior_electric_power",
+          "relation": "application",
+          "reason": "Correct series and parallel recognition is needed before choosing an electric-power formula.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "电路与欧姆定律",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "电路分析",
+        "概念辨析"
+      ],
+      "examples": [
+        {
+          "prompt": "判断一个含开关和电表的电路中哪些用电器串联或并联。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_junior_ohm_law",
+      "name": "欧姆定律",
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "电学",
+      "depth": 2,
+      "difficulty": 0.56,
+      "prerequisites": [
+        {
+          "id": "physics_junior_circuit_recognition",
+          "relation": "prerequisite",
+          "reason": "Ohm law calculation depends on recognizing which voltage and current belong to the same resistor.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_junior_electric_power",
+          "relation": "extends",
+          "reason": "physics_junior_ohm_law uses physics_junior_electric_power as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Use linear I-U graphs to identify proportional voltage-current behavior and resistor characteristics.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "ohm_law_linear_graph",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "linear_function_kb",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Read slope and intercept meanings before interpreting experimental current-voltage data.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "slope_interpretation_for_circuits",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_junior_electric_power",
+          "relation": "confusable",
+          "reason": "Students often mix resistance formulas with electric-power formulas when variables overlap.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "电路与欧姆定律",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "计算题",
+        "电路分析"
+      ],
+      "examples": [
+        {
+          "prompt": "已知电压和电阻求电流，再讨论滑动变阻器变化对电表示数的影响。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_junior_electric_power",
+      "name": "电功率",
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "电学",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [
+        {
+          "id": "physics_junior_ohm_law",
+          "relation": "prerequisite",
+          "reason": "Electric-power formulas require Ohm law relationships among voltage, current, and resistance.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_junior_experiment_resistance",
+          "relation": "extends",
+          "reason": "physics_junior_electric_power uses physics_junior_experiment_resistance as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "quadratic_function_concept",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Electric power formulas such as P=U^2/R and P=I^2R are quadratic relationships under fixed resistance.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "electric_power_quadratic_model",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_junior_experiment_resistance",
+          "relation": "procedure_step",
+          "reason": "Measured resistance can be used in later power checks and appliance-rating problems.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_junior_ohm_law",
+          "relation": "confusable",
+          "reason": "Power P, voltage U, current I, and resistance R are often interchanged without checking formula conditions.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "电路与欧姆定律",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "计算题",
+        "实际应用"
+      ],
+      "examples": [
+        {
+          "prompt": "比较两个灯泡在额定电压和实际电压下的亮度。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_junior_experiment_resistance",
+      "name": "测电阻实验",
+      "subject": "physics",
+      "stage": "junior_high",
+      "chapter": "电学",
+      "depth": 2,
+      "difficulty": 0.64,
+      "prerequisites": [
+        {
+          "id": "physics_junior_circuit_recognition",
+          "relation": "prerequisite",
+          "reason": "Resistance experiments require recognizing series placement of the ammeter and parallel placement of the voltmeter.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_junior_ohm_law",
+          "relation": "procedure_step",
+          "reason": "The experiment procedure ends by calculating resistance from matched voltage-current readings.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_senior_experiment_resistance",
+          "relation": "confusable",
+          "reason": "Junior resistance measurement is often confused with senior method selection and internal-resistance corrections.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        },
+        {
+          "id": "physics_junior_electric_power",
+          "relation": "application",
+          "reason": "Measured resistance supports appliance power estimates and safety checks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "电路与欧姆定律",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "实验探究",
+        "误差分析"
+      ],
+      "examples": [
+        {
+          "prompt": "设计伏安法测电阻实验，说明电路连接、表格和误差来源。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "physics_senior_newton_laws",
+      "name": "牛顿运动定律综合",
+      "aliases": [
+        "牛顿第二定律",
+        "牛顿运动定律",
+        "F=ma",
+        "动力学建模",
+        "牛二题",
+        "牛顿第二定律题"
+      ],
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中力学",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_junior_force_balance",
+          "required_mastery": 0.62,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.9,
+          "reason": "牛顿第二定律题需要先会确定研究对象并完成受力分析。",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.92,
+          "reason": "动力学建模通常按选对象、画受力图、正交分解、列 F=ma 的步骤推进。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_acceleration",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "探究加速度与力质量关系是牛顿第二定律的实验化应用。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_energy_momentum",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "力学综合题常在牛顿定律之后切换到动量或能量路径。",
+          "use_cases": [
+            "learning_path",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_thermo_second_law_entropy",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "学生提到“第二定律”时需要区分牛顿第二定律和热力学第二定律。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "牛顿运动与能量",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "受力分析",
+        "计算题"
+      ],
+      "examples": [
+        {
+          "prompt": "物块在斜面上受拉力运动，求加速度和支持力。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ],
+          "common_traps": [
+            "没有先画过程图或受力/电路图就直接套公式。",
+            "把标量大小、矢量方向和正负号混在一起。",
+            "忽略临界状态、能量损失或单位换算。"
+          ],
+          "grading_points": [
+            "研究对象和物理过程划分清楚。",
+            "所用物理规律及适用条件准确。",
+            "方程、单位、方向和结论检查完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_physics",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_energy_momentum",
+      "name": "动量能量综合",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中力学",
+      "depth": 3,
+      "difficulty": 0.76,
+      "prerequisites": [
+        {
+          "id": "physics_junior_work_power",
+          "relation": "prerequisite",
+          "reason": "Energy-momentum synthesis builds on work, power, and kinetic-energy vocabulary.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "extends",
+          "reason": "physics_senior_energy_momentum uses physics_senior_circular_motion as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        },
+        {
+          "id": "physics_senior_work_energy_path",
+          "relation": "procedure_step",
+          "reason": "A common next step is choosing whether the process is easier by work-energy or momentum conservation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        },
+        {
+          "id": "physics_senior_momentum_collision",
+          "relation": "confusable",
+          "reason": "Energy conservation and momentum conservation are often mixed in collision and interaction tasks.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        },
+        {
+          "id": "physics_senior_mechanical_energy_loss",
+          "relation": "application",
+          "reason": "Energy-momentum reasoning is used to estimate losses in nonideal mechanical processes.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "牛顿运动与能量",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "综合应用",
+        "守恒思想"
+      ],
+      "examples": [
+        {
+          "prompt": "两个小球碰撞后进入轨道，判断用动量守恒还是机械能守恒。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ],
+          "common_traps": [
+            "没有先画过程图或受力/电路图就直接套公式。",
+            "把标量大小、矢量方向和正负号混在一起。",
+            "忽略临界状态、能量损失或单位换算。"
+          ],
+          "grading_points": [
+            "研究对象和物理过程划分清楚。",
+            "所用物理规律及适用条件准确。",
+            "方程、单位、方向和结论检查完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_physics",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_circular_motion",
+      "name": "圆周运动",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中力学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "physics_senior_force_decomposition",
+          "required_mastery": 0.6,
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.89,
+          "reason": "Circular-motion equations require resolving forces into radial and tangential directions before applying the centripetal-acceleration condition.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "mechanics_vector_trig_prerequisite",
+            "physics_use": "uses vector decomposition and trigonometric components to isolate the inward net force"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_electric_magnetic_field",
+          "relation": "extends",
+          "reason": "Practice 电场磁场综合 after 圆周运动; it is the next topic in the senior_high physics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_trig_definitions",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Resolve circular-motion position, velocity, and force components with sine and cosine definitions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "circular_motion_trig_components"
+          }
+        },
+        {
+          "id": "senior_vector_coordinate",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Represent radial and tangential directions in coordinates before writing centripetal-acceleration equations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "radial_tangential_vector_coordinates"
+          }
+        },
+        {
+          "id": "physics_senior_circular_critical",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Uniform circular motion and critical-condition circular motion use similar centripetal formulas but differ in boundary constraints such as just-contact or just-taut cases.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "uniform_circular_vs_critical_boundary",
+            "physics_use": "distinguishes steady centripetal-force setup from limiting-condition checks"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "牛顿运动与能量",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "模型分析",
+        "临界问题"
+      ],
+      "examples": [
+        {
+          "prompt": "小球过竖直圆轨道最高点，求不断轨的最小速度。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ],
+          "common_traps": [
+            "没有先画过程图或受力/电路图就直接套公式。",
+            "把标量大小、矢量方向和正负号混在一起。",
+            "忽略临界状态、能量损失或单位换算。"
+          ],
+          "grading_points": [
+            "研究对象和物理过程划分清楚。",
+            "所用物理规律及适用条件准确。",
+            "方程、单位、方向和结论检查完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_physics",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_electric_magnetic_field",
+      "name": "电场磁场综合",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中力学",
+      "depth": 3,
+      "difficulty": 0.78,
+      "prerequisites": [
+        {
+          "id": "physics_junior_circuit_recognition",
+          "relation": "prerequisite",
+          "reason": "Field topics still require basic charge, current, source, and circuit vocabulary.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "extends",
+          "reason": "physics_senior_electric_magnetic_field uses physics_senior_experiment_data as a extends link for physics practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ],
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        },
+        {
+          "id": "physics_senior_electric_field_force",
+          "relation": "procedure_step",
+          "reason": "Start field problems by translating the field into the force on a charge or current element.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        },
+        {
+          "id": "physics_senior_magnetic_force",
+          "relation": "confusable",
+          "reason": "Electric-field force direction is often confused with magnetic-force direction rules.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        },
+        {
+          "id": "physics_senior_composite_field",
+          "relation": "application",
+          "reason": "Electric and magnetic field basics are combined in composite-field trajectory problems.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中力学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "没有先确定研究对象和过程",
+        "公式套用时忽略方向、单位或能量损失",
+        "电路、力学图像和文字条件没有互相校验"
+      ],
+      "unit": "牛顿运动与能量",
+      "skills": [
+        "画出过程图或受力/电路/光路图",
+        "选择适合的物理规律并明确适用条件",
+        "用单位、数量级和极端情况检查答案"
+      ],
+      "question_types": [
+        "综合应用",
+        "轨迹分析"
+      ],
+      "examples": [
+        {
+          "prompt": "带电粒子进入匀强磁场，求半径、周期和偏转方向。",
+          "answer_outline": [
+            "明确研究对象、已知量、未知量和物理过程。",
+            "画出受力图、电路图、光路图或状态变化图。",
+            "选择公式并代入统一单位。",
+            "用单位、方向和实际意义检查结论。"
+          ],
+          "common_traps": [
+            "没有先画过程图或受力/电路图就直接套公式。",
+            "把标量大小、矢量方向和正负号混在一起。",
+            "忽略临界状态、能量损失或单位换算。"
+          ],
+          "grading_points": [
+            "研究对象和物理过程划分清楚。",
+            "所用物理规律及适用条件准确。",
+            "方程、单位、方向和结论检查完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_physics",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_experiment_data",
+      "name": "高中物理实验数据处理",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中实验",
+      "depth": 3,
+      "difficulty": 0.72,
+      "prerequisites": [
+        {
+          "id": "physics_senior_experiment_acceleration",
+          "relation": "prerequisite",
+          "reason": "Experiment data processing depends on reading raw measurements and uncertainty patterns from motion experiments.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "motion_experiment_data_foundation"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_ac_circuit_intro",
+          "relation": "extends",
+          "reason": "Practice 交变电流初步 after 高中物理实验数据处理; it is the next topic in the senior_high physics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "procedure_step",
+          "reason": "After collecting readings, students should plot variables and read slope or intercept before selecting a formula.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "experiment_data_graph_reading"
+          }
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "application",
+          "reason": "Linear fitting of experiment data applies straight-line graphs to estimate constants and check systematic error.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "linear_fit_experiment_data"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "研究对象不清",
+        "公式条件误用",
+        "单位方向遗漏"
+      ],
+      "unit": "数据处理",
+      "skills": [
+        "建立物理模型并画图",
+        "选择规律并统一单位",
+        "用方向单位和极端情况检验"
+      ],
+      "question_types": [
+        "实验探究",
+        "误差分析"
+      ],
+      "examples": [
+        {
+          "prompt": "用纸带数据求加速度，画 v-t 图并分析误差来源。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "没有先画过程图或受力/电路图就直接套公式。",
+            "把标量大小、矢量方向和正负号混在一起。",
+            "忽略临界状态、能量损失或单位换算。"
+          ],
+          "grading_points": [
+            "研究对象和物理过程划分清楚。",
+            "所用物理规律及适用条件准确。",
+            "方程、单位、方向和结论检查完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_physics",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_ac_circuit_intro",
+      "name": "交变电流初步",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "电磁学",
+      "depth": 3,
+      "difficulty": 0.7,
+      "prerequisites": [
+        {
+          "id": "physics_senior_electromagnetic_induction_law",
+          "relation": "prerequisite",
+          "reason": "AC source models rely on induction ideas and changing magnetic flux.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_ac_transformer",
+          "relation": "procedure_step",
+          "reason": "After reading AC period, frequency, and RMS values, transformer-ratio problems are the next practice step.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_dc_circuit_dynamic",
+          "relation": "confusable",
+          "reason": "AC effective values are often confused with transient DC circuit values.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_ac_transformer",
+          "relation": "application",
+          "reason": "AC basics are directly used in transformer voltage, current, and power calculations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "研究对象不清",
+        "公式条件误用",
+        "单位方向遗漏"
+      ],
+      "unit": "交变电流",
+      "skills": [
+        "建立物理模型并画图",
+        "选择规律并统一单位",
+        "用方向单位和极端情况检验"
+      ],
+      "question_types": [
+        "图像分析",
+        "计算题"
+      ],
+      "examples": [
+        {
+          "prompt": "根据正弦交流电图像求周期、频率、有效值和最大值。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ],
+          "common_traps": [
+            "没有先画过程图或受力/电路图就直接套公式。",
+            "把标量大小、矢量方向和正负号混在一起。",
+            "忽略临界状态、能量损失或单位换算。"
+          ],
+          "grading_points": [
+            "研究对象和物理过程划分清楚。",
+            "所用物理规律及适用条件准确。",
+            "方程、单位、方向和结论检查完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "subject_depth_boost",
+        "gaokao_style_example",
+        "senior_high_core",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "pep_high_school_physics",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_motion_graph_synthesis",
+      "name": "运动图像综合",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "直线运动与图像",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_newton_laws",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 牛顿运动定律综合 before 运动图像综合; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_newton_laws",
+          "relation": "co_occurs",
+          "reason": "Review 运动图像综合 together with 牛顿运动定律综合 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "co_occurs",
+          "reason": "Review 运动图像综合 together with 力的分解与正交分析 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Motion graph synthesis usually identifies velocity and acceleration before choosing a force-analysis model.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_acceleration",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Acceleration experiments rely on reading motion data and checking whether the graph matches the physical process.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_function_graph_analysis",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "运动图像综合会把函数图像分析中的斜率、面积和凹凸变化翻译为速度、位移和加速度信息。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "函数图像->运动图像",
+            "physics_use": "把 x-t、v-t、a-t 图像特征映射到运动过程"
+          }
+        },
+        {
+          "id": "college_derivative_definition",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.89,
+          "reason": "理解瞬时速度和瞬时加速度需要先理解导数作为瞬时变化率的定义。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "导数->速度/加速度",
+            "physics_use": "用变化率解释图像切线斜率"
+          }
+        },
+        {
+          "id": "college_derivative_calculation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "Motion graph synthesis applies derivatives when velocity is the rate of change of position and acceleration is the rate of change of velocity.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "kinematics_derivatives"
+          }
+        },
+        {
+          "id": "college_definite_integral",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Velocity-time and acceleration-time graph tasks apply definite integrals to recover displacement or velocity change from area.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "motion_graph_area_integral"
+          }
+        },
+        {
+          "id": "college_integral_application_interval",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Before using area under a motion graph, students must choose the time interval that matches the physical process.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "motion_graph_integral_interval"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "结合 x-t、v-t 图像判断运动过程、位移和加速度变化。",
+          "answer_outline": [
+            "先判断题目属于运动图像综合的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_force_decomposition",
+      "name": "力的分解与正交分析",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "受力分析",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 运动图像综合 before 力的分解与正交分析; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "co_occurs",
+          "reason": "Review 力的分解与正交分析 together with 运动图像综合 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_connected_body",
+          "relation": "co_occurs",
+          "reason": "Review 力的分解与正交分析 together with 连接体与整体隔离法 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_connected_body",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Connected-body problems normally start by decomposing forces on each object before writing linked equations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_friction_critical",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Friction threshold problems use force decomposition to compare components with maximum static friction.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_vector_coordinate",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "力的正交分解需要先会把向量投影到坐标轴，并用分量表示大小和方向。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "向量->力分解",
+            "physics_use": "建立沿斜面和垂直斜面的受力分量"
+          }
+        },
+        {
+          "id": "sine_cosine_tangent",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "斜面分解通常先定坐标轴，再用 sin、cos 把重力分解为平行斜面和垂直斜面的分量。",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "三角函数->斜面分解",
+            "procedure": [
+              "choose_axes",
+              "project_gravity",
+              "write_component_equations"
+            ]
+          }
+        },
+        {
+          "id": "senior_vector_linear_operation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Force decomposition applies vector linear operations by replacing one force with equivalent perpendicular components.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "force_decomposition_vector_operations"
+          }
+        },
+        {
+          "id": "senior_vector_dot_product",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Incline and pulling-force problems apply dot products to find the component of a force along a chosen direction.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "force_projection_dot_product"
+          }
+        },
+        {
+          "id": "sine_cosine_tangent",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "Inclined-plane force components apply sine and cosine ratios to connect angle geometry with parallel and normal components.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "incline_components_trig"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "斜面或连接体中建立坐标系并列平衡/动力学方程。",
+          "answer_outline": [
+            "先判断题目属于力的分解与正交分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_connected_body",
+      "name": "连接体与整体隔离法",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "牛顿运动定律",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_force_decomposition",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 力的分解与正交分析 before 连接体与整体隔离法; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "co_occurs",
+          "reason": "Review 连接体与整体隔离法 together with 力的分解与正交分析 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_friction_critical",
+          "relation": "co_occurs",
+          "reason": "Review 连接体与整体隔离法 together with 摩擦力临界问题 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_friction_critical",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "After linking the bodies, students often need to decide the friction regime before solving the equations.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.86,
+          "reason": "Connected-body scenarios provide a common application for choosing objects, axes, and decomposed force components.",
+          "use_cases": [
+            "diagnosis",
+            "review",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "用整体法和隔离法求连接体加速度、拉力或摩擦力。",
+          "answer_outline": [
+            "先判断题目属于连接体与整体隔离法的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_friction_critical",
+      "name": "摩擦力临界问题",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "牛顿运动定律",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_connected_body",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 连接体与整体隔离法 before 摩擦力临界问题; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_connected_body",
+          "relation": "co_occurs",
+          "reason": "Review 摩擦力临界问题 together with 连接体与整体隔离法 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "co_occurs",
+          "reason": "Review 摩擦力临界问题 together with 平抛与斜抛运动 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Critical friction analysis requires resolving normal force and tangential components before comparing limits.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_connected_body",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Connected bodies on rough surfaces are a standard application of static-friction threshold reasoning.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "判断静摩擦转动摩擦、临界加速度和临界外力。",
+          "answer_outline": [
+            "先判断题目属于摩擦力临界问题的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_projectile_motion",
+      "name": "平抛与斜抛运动",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "曲线运动",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_friction_critical",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 摩擦力临界问题 before 平抛与斜抛运动; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_friction_critical",
+          "relation": "co_occurs",
+          "reason": "Review 平抛与斜抛运动 together with 摩擦力临界问题 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_circular_critical",
+          "relation": "co_occurs",
+          "reason": "Review 平抛与斜抛运动 together with 圆周运动临界条件 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_motion_graph_synthesis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Projectile solutions split motion into horizontal and vertical components, then verify timing and velocity with graph reasoning.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_multistage_synthesis",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Projectile motion often appears as one segment inside multi-stage mechanics synthesis problems.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_trig_definitions",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Projectile initial velocity must be decomposed into horizontal and vertical components using trigonometric ratios.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "projectile_velocity_decomposition"
+          }
+        },
+        {
+          "id": "quadratic_function_concept",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Projectile trajectory y(x) is modeled as a quadratic function when air resistance is ignored.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "projectile_quadratic_trajectory"
+          }
+        },
+        {
+          "id": "senior_vector_coordinate",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Projectile motion applies vector coordinates by separating initial velocity and displacement into horizontal and vertical components.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "projectile_vector_components"
+          }
+        },
+        {
+          "id": "sine_cosine_tangent",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Oblique launch problems apply trigonometric ratios to convert launch speed and angle into component velocities.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "projectile_trig_components"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "分解平抛运动并求落点、时间或速度方向。",
+          "answer_outline": [
+            "先判断题目属于平抛与斜抛运动的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_circular_critical",
+      "name": "圆周运动临界条件",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "曲线运动",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_projectile_motion",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 平抛与斜抛运动 before 圆周运动临界条件; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "co_occurs",
+          "reason": "Review 圆周运动临界条件 together with 平抛与斜抛运动 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_work_energy_path",
+          "relation": "co_occurs",
+          "reason": "Review 圆周运动临界条件 together with 功和动能定理路径选择 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Critical circular-motion questions require radial force decomposition before applying the centripetal condition.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_gravitation_orbit",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "Orbit problems apply circular-motion critical ideas when gravity supplies the centripetal force.",
+          "use_cases": [
+            "learning_path",
+            "review",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "分析竖直圆周、轨道压力和恰好通过条件。",
+          "answer_outline": [
+            "先判断题目属于圆周运动临界条件的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_work_energy_path",
+      "name": "功和动能定理路径选择",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "功和能",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_circular_critical",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 圆周运动临界条件 before 功和动能定理路径选择; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_circular_critical",
+          "relation": "co_occurs",
+          "reason": "Review 功和动能定理路径选择 together with 圆周运动临界条件 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_mechanical_energy_loss",
+          "relation": "co_occurs",
+          "reason": "Review 功和动能定理路径选择 together with 机械能守恒与能量损失 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_mechanical_energy_loss",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "After choosing a work-energy path, students must account for nonconservative work and energy loss.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_multistage_synthesis",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Work-energy path selection is a common application in multi-stage mechanics problems with changing constraints.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_definite_integral",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "变力做功和 v-t 图像位移都需要先理解定积分表示连续累积量。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "积分->位移/功",
+            "physics_use": "用面积或累积量解释位移、功和能量变化"
+          }
+        },
+        {
+          "id": "college_integral_physics_application",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "功和动能定理路径选择可以作为定积分物理应用中的典型变力做功场景。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "功->定积分物理应用",
+            "math_use": "建立 W=∫F(x)dx 或面积累积模型"
+          }
+        },
+        {
+          "id": "college_integral_application",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Work-energy path selection applies integral modeling when work is accumulated from a changing force over a path.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "work_energy_integral_model"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "选择动能定理处理变力、摩擦和多过程问题。",
+          "answer_outline": [
+            "先判断题目属于功和动能定理路径选择的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_mechanical_energy_loss",
+      "name": "机械能守恒与能量损失",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "功和能",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_work_energy_path",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 功和动能定理路径选择 before 机械能守恒与能量损失; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_work_energy_path",
+          "relation": "co_occurs",
+          "reason": "Review 机械能守恒与能量损失 together with 功和动能定理路径选择 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_momentum_collision",
+          "relation": "co_occurs",
+          "reason": "Review 机械能守恒与能量损失 together with 碰撞与动量守恒 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_work_energy_path",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Energy-loss questions require identifying dissipative work before writing the work-energy relationship.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_energy",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Energy experiments use mechanical energy loss to explain deviations from ideal conservation.",
+          "use_cases": [
+            "diagnosis",
+            "review",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "判断系统机械能是否守恒并计算热损失或弹性势能。",
+          "answer_outline": [
+            "先判断题目属于机械能守恒与能量损失的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_momentum_collision",
+      "name": "碰撞与动量守恒",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "动量",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_mechanical_energy_loss",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 机械能守恒与能量损失 before 碰撞与动量守恒; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_mechanical_energy_loss",
+          "relation": "co_occurs",
+          "reason": "Review 碰撞与动量守恒 together with 机械能守恒与能量损失 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_impulse_graph",
+          "relation": "co_occurs",
+          "reason": "Review 碰撞与动量守恒 together with 冲量与力时图像 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_impulse_graph",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Collision analysis often moves from conservation statements to impulse-time information for force and duration.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_energy_momentum",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Momentum collision problems are a central application of combined momentum and energy reasoning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "判断碰撞类型并联立动量、能量或恢复系数关系。",
+          "answer_outline": [
+            "先判断题目属于碰撞与动量守恒的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_impulse_graph",
+      "name": "冲量与力时图像",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "动量",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_momentum_collision",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 碰撞与动量守恒 before 冲量与力时图像; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_momentum_collision",
+          "relation": "co_occurs",
+          "reason": "Review 冲量与力时图像 together with 碰撞与动量守恒 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_gravitation_orbit",
+          "relation": "co_occurs",
+          "reason": "Review 冲量与力时图像 together with 万有引力与天体运动 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_momentum_collision",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Impulse graphs are used to update momentum states before interpreting a collision or interaction outcome.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Force-time graph interpretation is a practical application of experiment data reading and area estimation.",
+          "use_cases": [
+            "diagnosis",
+            "review",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "由 F-t 图像求冲量并分析速度变化。",
+          "answer_outline": [
+            "先判断题目属于冲量与力时图像的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_gravitation_orbit",
+      "name": "万有引力与天体运动",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "万有引力",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_impulse_graph",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 冲量与力时图像 before 万有引力与天体运动; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_impulse_graph",
+          "relation": "co_occurs",
+          "reason": "Review 万有引力与天体运动 together with 冲量与力时图像 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "co_occurs",
+          "reason": "Review 万有引力与天体运动 together with 简谐运动图像 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Orbit problems should first convert gravity into the radial net force, then reuse circular-motion relations for speed, period, and radius.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "gravity_to_centripetal_procedure",
+            "physics_use": "maps inverse-square gravitation onto circular-motion equations step by step"
+          }
+        },
+        {
+          "id": "physics_senior_circular_critical",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Satellite and planet orbit tasks apply circular critical reasoning when checking escape, minimum speed, or stable-radius conditions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "orbital_boundary_application",
+            "physics_use": "uses centripetal boundary conditions to judge orbital feasibility"
+          }
+        },
+        {
+          "id": "physics_senior_projectile_motion",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "reason": "Near-Earth projectile motion and orbital motion both involve gravity, but the former treats g as nearly constant while the latter needs radius-dependent inverse-square force.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "constant_g_vs_inverse_square_gravity",
+            "physics_use": "prevents mixing local projectile approximations with orbital-scale models"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "比较轨道半径、周期、线速度和机械能。",
+          "answer_outline": [
+            "先判断题目属于万有引力与天体运动的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_simple_harmonic",
+      "name": "简谐运动图像",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "振动与波",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_gravitation_orbit",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 万有引力与天体运动 before 简谐运动图像; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_gravitation_orbit",
+          "relation": "co_occurs",
+          "reason": "Review 简谐运动图像 together with 万有引力与天体运动 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_wave_interference",
+          "relation": "co_occurs",
+          "reason": "Review 简谐运动图像 together with 机械波传播与干涉 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "senior_trig_graph",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "分析简谐运动 x-t 图像前，需要先熟悉正弦、余弦函数图像的周期、相位和振幅。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "三角函数->简谐运动",
+            "physics_use": "读取简谐运动的振幅、周期、相位和初始状态"
+          }
+        },
+        {
+          "id": "senior_function_periodicity",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Simple harmonic motion graph questions apply function periodicity to identify cycle length and repeated states.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "simple_harmonic_periodicity"
+          }
+        },
+        {
+          "id": "sine_cosine_tangent",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.87,
+          "reason": "Simple harmonic motion uses sine and cosine forms to connect displacement, phase, and initial state.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "simple_harmonic_trig_form"
+          }
+        },
+        {
+          "id": "physics_senior_wave_interference",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After extracting amplitude, period, and phase from simple harmonic motion, the next step is to transfer phase reasoning to wave propagation and interference.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "trig_graph_phase_to_wave_steps",
+            "physics_use": "connects sine-function graph features to phase difference and interference judgments"
+          }
+        },
+        {
+          "id": "college_physics_simple_harmonic_oscillation",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "High-school graph reading and college differential-equation modeling describe the same oscillation but use different evidence: image features versus restoring-force dynamics.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "graph_reading_vs_differential_equation_model",
+            "physics_use": "keeps visual period-amplitude extraction separate from equation-based derivation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "由振动图像判断周期、相位、能量转化和回复力。",
+          "answer_outline": [
+            "先判断题目属于简谐运动图像的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_wave_interference",
+      "name": "机械波传播与干涉",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理力学",
+      "unit": "振动与波",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_simple_harmonic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 简谐运动图像 before 机械波传播与干涉; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_simple_harmonic",
+          "relation": "co_occurs",
+          "reason": "Review 机械波传播与干涉 together with 简谐运动图像 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_electric_field_force",
+          "relation": "co_occurs",
+          "reason": "Review 机械波传播与干涉 together with 电场力与电势能 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "senior_trig_definitions",
+          "relation": "procedure_step",
+          "reason": "Wave interference solutions first express phase difference with sine or cosine relationships.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "wave_phase_trig_setup"
+          }
+        },
+        {
+          "id": "college_physics_interference_diffraction",
+          "relation": "application",
+          "reason": "Mechanical-wave interference prepares the same path-difference reasoning used in college interference and diffraction.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "wave_path_difference_transfer"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "根据波形图和传播方向求质点振动、波速和干涉条件。",
+          "answer_outline": [
+            "先判断题目属于机械波传播与干涉的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_electric_field_force",
+      "name": "电场力与电势能",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "静电场",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_wave_interference",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_electric_field_force uses physics_senior_wave_interference as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_wave_interference",
+          "relation": "co_occurs",
+          "reason": "physics_senior_electric_field_force uses physics_senior_wave_interference as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_electric_potential_graph",
+          "relation": "co_occurs",
+          "reason": "physics_senior_electric_field_force uses physics_senior_electric_potential_graph as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "senior_vector_linear_operation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Electric field force problems use vector addition to combine fields and forces from multiple charges.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "electric_force_vector_superposition",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_electric_potential_graph",
+          "relation": "procedure_step",
+          "reason": "After force direction is known, potential and field graphs help connect force, work, and energy changes.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_magnetic_force",
+          "relation": "confusable",
+          "reason": "Electric force can act on a stationary charge, unlike magnetic force that depends on velocity.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "分析带电粒子在电场中的运动和能量变化。",
+          "answer_outline": [
+            "先判断题目属于电场力与电势能的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_electric_potential_graph",
+      "name": "电势与场强图像",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "静电场",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_electric_field_force",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 电场力与电势能 before 电势与场强图像; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_electric_field_force",
+          "relation": "co_occurs",
+          "reason": "Review 电势与场强图像 together with 电场力与电势能 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_capacitor_dynamic",
+          "relation": "co_occurs",
+          "reason": "Review 电势与场强图像 together with 电容器动态分析 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "senior_derivative_tangent",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "The electric field direction and magnitude are read from the negative slope of the potential-position graph.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "potential_graph_slope_to_field"
+          }
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Students need graph-reading skill before extracting extrema, monotonic intervals, and slopes from potential graphs.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "potential_graph_information_reading"
+          }
+        },
+        {
+          "id": "physics_senior_electric_field_force",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "When reading a potential graph, first infer field magnitude and direction from the negative slope, then use the field to decide force and potential-energy change.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "potential_slope_to_field_force_steps",
+            "physics_use": "turns graph slope and direction into electric-field and force conclusions"
+          }
+        },
+        {
+          "id": "college_physics_electric_potential",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "Electric potential, electric potential energy, and electric field are easily interchanged; comparing graph tasks with college potential definitions separates scalar value, energy, and vector field.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "potential_energy_field_confusion",
+            "physics_use": "distinguishes scalar potential graphs from vector electric-field interpretation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "由 φ-x 或 E-x 图像判断场强方向、做功和电势能。",
+          "answer_outline": [
+            "先判断题目属于电势与场强图像的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_capacitor_dynamic",
+      "name": "电容器动态分析",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "静电场",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_electric_potential_graph",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_capacitor_dynamic uses physics_senior_electric_potential_graph as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_electric_potential_graph",
+          "relation": "co_occurs",
+          "reason": "physics_senior_capacitor_dynamic uses physics_senior_electric_potential_graph as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_dc_circuit_dynamic",
+          "relation": "co_occurs",
+          "reason": "physics_senior_capacitor_dynamic uses physics_senior_dc_circuit_dynamic as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_dc_circuit_dynamic",
+          "relation": "procedure_step",
+          "reason": "Capacitor charging and discharging feed into dynamic DC circuit analysis.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_power_extreme",
+          "relation": "application",
+          "reason": "Capacitor-state changes can constrain voltage, current, and power extrema in circuits.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_electric_potential_graph",
+          "relation": "confusable",
+          "reason": "Stored charge, voltage, and potential graph slope are often mixed without checking definitions.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "判断充放电、极板变化和电场能变化。",
+          "answer_outline": [
+            "先判断题目属于电容器动态分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_dc_circuit_dynamic",
+      "name": "闭合电路动态分析",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "恒定电流",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_capacitor_dynamic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_dc_circuit_dynamic uses physics_senior_capacitor_dynamic as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_capacitor_dynamic",
+          "relation": "co_occurs",
+          "reason": "physics_senior_dc_circuit_dynamic uses physics_senior_capacitor_dynamic as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_power_extreme",
+          "relation": "co_occurs",
+          "reason": "physics_senior_dc_circuit_dynamic uses physics_senior_power_extreme as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "senior_exponential_function",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Circuit transition problems apply exponential-function intuition to describe charging, discharging, and approach to a steady state.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "circuit_transition_exponential",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "college_first_order_linear_ode",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "RC and RL transition models apply first-order linear differential equations to connect rates of change with circuit state variables.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "circuit_transition_first_order_ode",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_power_extreme",
+          "relation": "procedure_step",
+          "reason": "After dynamic current or voltage is determined, power-extreme checks are a common next calculation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_ac_circuit_intro",
+          "relation": "confusable",
+          "reason": "Transient DC changes are often confused with sinusoidal AC variation.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "分析滑动变阻器变化导致的电流、电压和功率变化。",
+          "answer_outline": [
+            "先判断题目属于闭合电路动态分析的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_power_extreme",
+      "name": "电路功率极值",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "恒定电流",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_dc_circuit_dynamic",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 闭合电路动态分析 before 电路功率极值; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_dc_circuit_dynamic",
+          "relation": "co_occurs",
+          "reason": "Review 电路功率极值 together with 闭合电路动态分析 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_magnetic_force",
+          "relation": "co_occurs",
+          "reason": "Review 电路功率极值 together with 带电粒子在磁场中运动 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "quadratic_max_min",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Circuit power extreme questions apply quadratic maximum and minimum reasoning when power is written as a parameter function.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "circuit_power_quadratic_extreme"
+          }
+        },
+        {
+          "id": "senior_derivative_extrema",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Power optimization tasks apply derivative extrema methods when resistance or current is treated as a continuous variable.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "circuit_power_derivative_extreme"
+          }
+        },
+        {
+          "id": "physics_senior_dc_circuit_dynamic",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Power-extreme questions should first simplify the circuit and choose the variable resistance or current, then write power as a function before optimizing.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "circuit_simplification_to_optimization_steps",
+            "physics_use": "links circuit dynamic analysis to quadratic or derivative-based extreme-value solving"
+          }
+        },
+        {
+          "id": "physics_junior_electric_power",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "Formula substitution for electric power is not the same as optimizing output or load power; the latter requires tracking which quantity changes.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "power_formula_vs_power_extreme",
+            "physics_use": "prevents using P=UI or P=I^2R without checking the variable and constraint"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "用等效电路和函数关系求输出功率或效率极值。",
+          "answer_outline": [
+            "先判断题目属于电路功率极值的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_magnetic_force",
+      "name": "带电粒子在磁场中运动",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "磁场",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_power_extreme",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_magnetic_force uses physics_senior_power_extreme as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_power_extreme",
+          "relation": "co_occurs",
+          "reason": "physics_senior_magnetic_force uses physics_senior_power_extreme as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_composite_field",
+          "relation": "co_occurs",
+          "reason": "physics_senior_magnetic_force uses physics_senior_composite_field as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "senior_vector_dot_product",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Use vector perpendicularity and component checks before applying magnetic force direction rules.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "magnetic_force_vector_perpendicularity",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_composite_field",
+          "relation": "application",
+          "reason": "Magnetic force is used with electric force to analyze selected velocity and curved trajectories.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_electric_field_force",
+          "relation": "confusable",
+          "reason": "Magnetic force direction from the hand rule is often confused with electric-field force direction.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "由洛伦兹力建立圆周运动半径、周期和边界条件。",
+          "answer_outline": [
+            "先判断题目属于带电粒子在磁场中运动的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_composite_field",
+      "name": "复合场粒子运动",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "复合场",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_magnetic_force",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_composite_field uses physics_senior_magnetic_force as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_magnetic_force",
+          "relation": "co_occurs",
+          "reason": "physics_senior_composite_field uses physics_senior_magnetic_force as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_electromagnetic_induction_law",
+          "relation": "co_occurs",
+          "reason": "physics_senior_composite_field uses physics_senior_electromagnetic_induction_law as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "senior_vector_coordinate",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Composite field trajectories are easier to split by coordinate axes before matching electric and magnetic stages.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "composite_field_coordinate_decomposition",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_electromagnetic_induction_law",
+          "relation": "application",
+          "reason": "Composite-field reasoning prepares students to track magnetic effects in induction setups.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_magnetic_force",
+          "relation": "confusable",
+          "reason": "Students often use a single magnetic-force rule when a composite field also includes electric force.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "在电场、磁场和重力叠加下分段分析粒子轨迹。",
+          "answer_outline": [
+            "先判断题目属于复合场粒子运动的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_electromagnetic_induction_law",
+      "name": "法拉第电磁感应定律",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "电磁感应",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_composite_field",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_electromagnetic_induction_law uses physics_senior_composite_field as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_composite_field",
+          "relation": "co_occurs",
+          "reason": "physics_senior_electromagnetic_induction_law uses physics_senior_composite_field as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_induction_rod",
+          "relation": "co_occurs",
+          "reason": "physics_senior_electromagnetic_induction_law uses physics_senior_induction_rod as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "college_derivative_calculation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Faraday induction links induced emf to the rate of change of magnetic flux, a derivative calculation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "flux_rate_of_change_derivative",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_induction_rod",
+          "relation": "procedure_step",
+          "reason": "After applying Faraday law and Lenz direction, moving-rod induction is the standard calculation model.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_magnetic_force",
+          "relation": "confusable",
+          "reason": "Induced emf from changing flux is often confused with magnetic force on a moving charge.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "判断磁通量变化、感应电动势和感应电流方向。",
+          "answer_outline": [
+            "先判断题目属于法拉第电磁感应定律的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_induction_rod",
+      "name": "导体棒切割磁感线",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "电磁感应",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_electromagnetic_induction_law",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_induction_rod uses physics_senior_electromagnetic_induction_law as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_electromagnetic_induction_law",
+          "relation": "co_occurs",
+          "reason": "physics_senior_induction_rod uses physics_senior_electromagnetic_induction_law as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_ac_transformer",
+          "relation": "co_occurs",
+          "reason": "physics_senior_induction_rod uses physics_senior_ac_transformer as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_ac_transformer",
+          "relation": "procedure_step",
+          "reason": "Moving-rod induction strengthens flux-change reasoning before transformer models.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_ac_transformer",
+          "relation": "application",
+          "reason": "Induction-rod energy conversion prepares students for ideal transformer energy-transfer checks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_dc_circuit_dynamic",
+          "relation": "confusable",
+          "reason": "Induction-rod equivalent circuits are often confused with ordinary DC source circuits.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "联立受力、能量和电路关系分析导体棒运动。",
+          "answer_outline": [
+            "先判断题目属于导体棒切割磁感线的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_ac_transformer",
+      "name": "变压器与远距离输电",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理电磁学",
+      "unit": "交变电流",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_induction_rod",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "physics_senior_ac_transformer uses physics_senior_induction_rod as a prerequisite link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_induction_rod",
+          "relation": "co_occurs",
+          "reason": "physics_senior_ac_transformer uses physics_senior_induction_rod as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_experiment_vernier",
+          "relation": "co_occurs",
+          "reason": "physics_senior_ac_transformer uses physics_senior_experiment_vernier as a co occurs link for physics practice planning.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_ac_circuit_intro",
+          "relation": "procedure_step",
+          "reason": "Transformer problems should first read AC RMS, peak, frequency, and power assumptions.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_electromagnetic_induction_law",
+          "relation": "application",
+          "reason": "Transformer voltage ratios apply electromagnetic induction in coupled coils.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        },
+        {
+          "id": "physics_senior_ac_circuit_intro",
+          "relation": "confusable",
+          "reason": "Ideal transformer ratios are often confused with basic AC waveform quantities.",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "chapter_focus": "高中物理电磁学"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "分析理想变压器电压电流关系和输电损耗。",
+          "answer_outline": [
+            "先判断题目属于变压器与远距离输电的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_experiment_vernier",
+      "name": "游标卡尺与螺旋测微器读数",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理实验",
+      "unit": "基本仪器",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_ac_transformer",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 变压器与远距离输电 before 游标卡尺与螺旋测微器读数; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_ac_transformer",
+          "relation": "co_occurs",
+          "reason": "Review 游标卡尺与螺旋测微器读数 together with 变压器与远距离输电 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_acceleration",
+          "relation": "co_occurs",
+          "reason": "Review 游标卡尺与螺旋测微器读数 together with 探究加速度与力质量关系 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "procedure_step",
+          "reason": "Instrument reading should be recorded with resolution and uncertainty before data processing starts.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "instrument_reading_to_data_table"
+          }
+        },
+        {
+          "id": "physics_senior_experiment_acceleration",
+          "relation": "application",
+          "reason": "Accurate length and time readings support acceleration experiments and later uncertainty checks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "instrument_reading_in_motion_experiment"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "完成长度测量读数并处理有效数字。",
+          "answer_outline": [
+            "先判断题目属于游标卡尺与螺旋测微器读数的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_experiment_acceleration",
+      "name": "探究加速度与力质量关系",
+      "aliases": [
+        "速度和加速度",
+        "速度",
+        "加速度",
+        "加速度与力质量关系",
+        "加速度实验"
+      ],
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理实验",
+      "unit": "力学实验",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_experiment_vernier",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 游标卡尺与螺旋测微器读数 before 探究加速度与力质量关系; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_newton_laws",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "解释加速度变化时需要回到牛顿第二定律的力、质量、加速度关系。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_kinematics_calculus",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.88,
+          "reason": "速度描述位移变化率，加速度描述速度变化率，是运动学中最常混淆的一组概念。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_vernier",
+          "relation": "co_occurs",
+          "reason": "Review 探究加速度与力质量关系 together with 游标卡尺与螺旋测微器读数 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_energy",
+          "relation": "co_occurs",
+          "reason": "Review 探究加速度与力质量关系 together with 验证机械能守恒实验 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "The acceleration experiment applies data-processing skills by fitting a-F or a-1/m graphs and using scatter to judge systematic and random error.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "experiment_linear_fit_variance_error_application",
+            "physics_use": "uses variance, error analysis, and linear fitting to test Newton second-law relationships"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "设计控制变量并由图像求加速度和结论。",
+          "answer_outline": [
+            "先判断题目属于探究加速度与力质量关系的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_experiment_energy",
+      "name": "验证机械能守恒实验",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理实验",
+      "unit": "力学实验",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_experiment_acceleration",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 探究加速度与力质量关系 before 验证机械能守恒实验; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_experiment_acceleration",
+          "relation": "co_occurs",
+          "reason": "Review 验证机械能守恒实验 together with 探究加速度与力质量关系 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_resistance",
+          "relation": "co_occurs",
+          "reason": "Review 验证机械能守恒实验 together with 测电阻与伏安法选择 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_work_energy_path",
+          "relation": "procedure_step",
+          "reason": "Energy-conservation experiments first identify the work-energy path before comparing measured losses.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "energy_experiment_work_energy_setup"
+          }
+        },
+        {
+          "id": "physics_senior_energy_momentum",
+          "relation": "application",
+          "reason": "Measured kinetic and potential energy changes apply conservation reasoning in multistage mechanics tasks.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "energy_experiment_conservation_application"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "处理打点计时器数据并判断误差来源。",
+          "answer_outline": [
+            "先判断题目属于验证机械能守恒实验的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_experiment_resistance",
+      "name": "测电阻与伏安法选择",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理实验",
+      "unit": "电学实验",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_experiment_energy",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 验证机械能守恒实验 before 测电阻与伏安法选择; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_experiment_energy",
+          "relation": "co_occurs",
+          "reason": "Review 测电阻与伏安法选择 together with 验证机械能守恒实验 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_battery",
+          "relation": "co_occurs",
+          "reason": "Review 测电阻与伏安法选择 together with 测电源电动势和内阻 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_experiment_data",
+          "relation": "procedure_step",
+          "reason": "Resistance experiments require tabulating voltage-current pairs before choosing internal or external connection corrections.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "resistance_experiment_data_table"
+          }
+        },
+        {
+          "id": "college_physics_current_circuit",
+          "relation": "application",
+          "reason": "Volt-ampere measurement decisions prepare steady-current circuit modeling in college physics.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "resistance_measurement_to_current_circuit"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "根据内外接误差选择电路并计算电阻。",
+          "answer_outline": [
+            "先判断题目属于测电阻与伏安法选择的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_experiment_battery",
+      "name": "测电源电动势和内阻",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理实验",
+      "unit": "电学实验",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_experiment_resistance",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 测电阻与伏安法选择 before 测电源电动势和内阻; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_experiment_resistance",
+          "relation": "co_occurs",
+          "reason": "Review 测电源电动势和内阻 together with 测电阻与伏安法选择 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_model_boundary",
+          "relation": "co_occurs",
+          "reason": "Review 测电源电动势和内阻 together with 物理压轴边界条件 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "procedure_step",
+          "reason": "Battery experiments use the U-I graph intercept and slope before solving for emf and internal resistance.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "battery_ui_graph_reading"
+          }
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "application",
+          "reason": "The emf and internal-resistance model applies a linear graph where intercept and slope have physical meaning.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "battery_linear_model"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "由 U-I 图像求电动势、内阻并分析误差。",
+          "answer_outline": [
+            "先判断题目属于测电源电动势和内阻的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_model_boundary",
+      "name": "物理压轴边界条件",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理综合",
+      "unit": "压轴模型",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_experiment_battery",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 测电源电动势和内阻 before 物理压轴边界条件; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_experiment_battery",
+          "relation": "co_occurs",
+          "reason": "Review 物理压轴边界条件 together with 测电源电动势和内阻 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_multistage_synthesis",
+          "relation": "co_occurs",
+          "reason": "Review 物理压轴边界条件 together with 多过程综合建模 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_multistage_synthesis",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Boundary-condition problems should list contact, separation, velocity-zero, and direction-change constraints before splitting the problem into stages.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "boundary_conditions_to_multistage_steps",
+            "physics_use": "turns hidden limiting conditions into an ordered multi-process model"
+          }
+        },
+        {
+          "id": "physics_senior_connected_body",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Connected-body problems apply boundary-condition checks when tension, friction, or contact force reaches zero and the system model must change.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "boundary_conditions_in_connected_body_application",
+            "physics_use": "detects when an assumed constraint fails and a new mechanical stage begins"
+          }
+        },
+        {
+          "id": "physics_senior_multistage_synthesis",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "reason": "A boundary condition is the trigger for changing a model, while a multi-stage solution is the organized result after those triggers are identified.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "boundary_trigger_vs_multistage_solution",
+            "physics_use": "separates finding limiting events from executing the later process chain"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "在多过程题中识别恰好、最大、最小和脱离条件。",
+          "answer_outline": [
+            "先判断题目属于物理压轴边界条件的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "physics_senior_multistage_synthesis",
+      "name": "多过程综合建模",
+      "subject": "physics",
+      "stage": "senior_high",
+      "chapter": "高中物理综合",
+      "unit": "压轴模型",
+      "depth": 3,
+      "difficulty": 0.66,
+      "prerequisites": [
+        {
+          "id": "physics_senior_model_boundary",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 物理压轴边界条件 before 多过程综合建模; it supplies the foundation for this physics learning path.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "physics_senior_model_boundary",
+          "relation": "co_occurs",
+          "reason": "Review 多过程综合建模 together with 物理压轴边界条件 when diagnosing adjacent physics skills.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "physics_senior_model_boundary",
+          "relation": "procedure_step",
+          "reason": "Multistage synthesis starts by marking process boundaries before choosing laws for each segment.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "multistage_boundary_partition"
+          }
+        },
+        {
+          "id": "physics_senior_energy_momentum",
+          "relation": "application",
+          "reason": "Complex mechanics tasks often combine energy and momentum conservation across connected stages.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "multistage_energy_momentum_transfer"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只套公式但没有界定研究对象和过程",
+        "忽略方向、单位、符号或临界条件",
+        "图像、文字条件和物理模型没有互相校验"
+      ],
+      "skills": [
+        "抽象研究对象并画出关键过程图",
+        "选择适用规律并写明成立条件",
+        "用单位、方向、极端情况或守恒量检查结论"
+      ],
+      "question_types": [
+        "模型建构",
+        "计算推理"
+      ],
+      "examples": [
+        {
+          "prompt": "把力学、电磁学或能量动量过程拆成连续方程组。",
+          "answer_outline": [
+            "先判断题目属于多过程综合建模的哪一种设问。",
+            "提取题干中的限制条件、隐含关系和关键数据。",
+            "调用物理核心概念或题型步骤完成推理。",
+            "回到题干检查答案是否完整、规范且符合情境。"
+          ],
+          "common_traps": [
+            "只看到关键词就套固定结论。",
+            "漏掉题干中的限制条件或设问角度。"
+          ],
+          "grading_points": [
+            "核心概念或方法选择正确。",
+            "推理步骤完整，关键条件有回应。",
+            "答案表述符合该题型规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "senior_high",
+        "core_track",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "science_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school",
+        "pep_high_school_physics"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "gaokao_style",
+        "academic_level_exam"
+      ]
+    },
+    {
+      "id": "college_physics_vector_calculus",
+      "name": "矢量与物理量",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理基础",
+      "unit": "数学工具",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_vector_space",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 向量空间 before 矢量与物理量; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_vector_space",
+          "relation": "co_occurs",
+          "reason": "矢量与物理量 and 向量空间 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_kinematics_calculus",
+          "relation": "extends",
+          "reason": "Practice 质点运动学微积分表述 after 矢量与物理量; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_vector_linear_operation",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.88,
+          "reason": "理解位移、速度、加速度和力的矢量合成，需要先掌握向量加减和数乘的线性运算。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "向量运算->物理矢量",
+            "physics_use": "合成和分解位移、速度、加速度、力"
+          }
+        },
+        {
+          "id": "college_physics_kinematics_calculus",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "After defining displacement, velocity, acceleration, and force as vectors, the next procedure is to express motion with derivatives and integrals of vector quantities.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "vector_quantities_to_calculus_kinematics_steps",
+            "physics_use": "moves from vector definitions to calculus-based motion equations"
+          }
+        },
+        {
+          "id": "physics_senior_force_decomposition",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Vector physical quantities apply force-decomposition habits from mechanics, but extend them to displacement, velocity, acceleration, field, and flux directions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "mechanics_vectors_to_general_physical_vectors",
+            "physics_use": "uses vector components and directions across mechanics and electromagnetism"
+          }
+        },
+        {
+          "id": "physics_junior_work_power",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Work and power can look scalar even when force and displacement are vectors; this comparison prevents treating every physical quantity as directionless.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "scalar_vs_vector_physical_quantity_confusion",
+            "physics_use": "distinguishes scalar outputs such as work from vector inputs such as force and displacement"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用矢量分解描述位移、速度和力，并说明坐标系选择。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_kinematics_calculus",
+      "name": "质点运动学微积分表述",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理力学",
+      "unit": "质点运动学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_vector_calculus",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 矢量与物理量 before 质点运动学微积分表述; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_vector_calculus",
+          "relation": "co_occurs",
+          "reason": "质点运动学微积分表述 and 矢量与物理量 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_newton_laws_system",
+          "relation": "extends",
+          "reason": "Practice 牛顿定律与参考系 after 质点运动学微积分表述; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_derivative_calculation",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.92,
+          "reason": "质点运动学微积分表述通常先建立 x(t)，再求导得到 v(t)，继续求导得到 a(t)。",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "导数->速度/加速度",
+            "procedure": [
+              "model_position_function",
+              "differentiate_to_velocity",
+              "differentiate_to_acceleration"
+            ]
+          }
+        },
+        {
+          "id": "college_second_derivative_test",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "reason": "二阶导数在函数图像中常用于凹凸判断，在运动学中表示加速度，两个语境不能直接混用结论。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "加速度->二阶导数",
+            "confusion": "graph_curvature_vs_physical_acceleration"
+          }
+        },
+        {
+          "id": "college_derivative_calculation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.92,
+          "reason": "Particle kinematics applies derivative calculation to move from position functions to velocity and acceleration functions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "particle_kinematics_derivative_calculation"
+          }
+        },
+        {
+          "id": "college_definite_integral",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Particle kinematics applies definite integrals to reconstruct displacement or velocity change from time-dependent velocity or acceleration.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "particle_kinematics_definite_integral"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由位置函数求速度、加速度，并解释曲线运动中的切向/法向分量。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_newton_laws_system",
+      "name": "牛顿定律与参考系",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理力学",
+      "unit": "动力学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_kinematics_calculus",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 质点运动学微积分表述 before 牛顿定律与参考系; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_kinematics_calculus",
+          "relation": "co_occurs",
+          "reason": "牛顿定律与参考系 and 质点运动学微积分表述 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_work_energy_theorem",
+          "relation": "extends",
+          "reason": "Practice 功和动能定理 after 牛顿定律与参考系; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_work_energy_theorem",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "After drawing the system force diagram and choosing an inertial or non-inertial frame, the next step is to decide whether force equations or energy equations are shorter.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "newton_frame_to_energy_method_steps",
+            "physics_use": "connects reference-frame force balances to later work-energy method selection"
+          }
+        },
+        {
+          "id": "physics_senior_connected_body",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Newton-law system modeling applies directly to connected bodies by choosing system boundaries, internal forces, and external net forces.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "system_boundary_newton_application",
+            "physics_use": "uses whole-system and isolated-body equations for multi-object mechanics"
+          }
+        },
+        {
+          "id": "college_physics_momentum_center_mass",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "Newton external-force equations and center-of-mass momentum equations can both describe systems, but they answer different questions about acceleration and total momentum.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "force_system_vs_center_of_mass_momentum",
+            "physics_use": "separates net-force dynamics from momentum and center-of-mass descriptions"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "对非惯性参考系或多物体系统建立动力学方程。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_work_energy_theorem",
+      "name": "功和动能定理",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理力学",
+      "unit": "功和能",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_newton_laws_system",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 牛顿定律与参考系 before 功和动能定理; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_newton_laws_system",
+          "relation": "co_occurs",
+          "reason": "功和动能定理 and 牛顿定律与参考系 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_potential_energy_conservation",
+          "relation": "extends",
+          "reason": "Practice 势能与机械能守恒 after 功和动能定理; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_integral_application_integrand",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "用积分求功时，需要先把力随位移变化的函数建立为被积函数，再确定积分区间。",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "功->被积函数建立",
+            "procedure": [
+              "choose_displacement_variable",
+              "model_force_function",
+              "integrate_force_over_path"
+            ]
+          }
+        },
+        {
+          "id": "senior_vector_dot_product",
+          "relation": "application",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "恒力做功 W=Fs cosθ 可以用向量数量积解释力在位移方向上的有效分量。",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "功->向量数量积",
+            "math_use": "用点积解释方向夹角和有效分量"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "计算变力做功，并由动能定理判断速度变化。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_potential_energy_conservation",
+      "name": "势能与机械能守恒",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理力学",
+      "unit": "功和能",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_work_energy_theorem",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 功和动能定理 before 势能与机械能守恒; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_work_energy_theorem",
+          "relation": "co_occurs",
+          "reason": "势能与机械能守恒 and 功和动能定理 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_momentum_center_mass",
+          "relation": "extends",
+          "reason": "Practice 动量与质心运动 after 势能与机械能守恒; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_work_energy_theorem",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Before invoking mechanical-energy conservation, first split work into conservative and non-conservative parts using the work-energy theorem.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "work_energy_to_conservation_check_steps",
+            "physics_use": "checks whether potential energy can replace path-dependent work"
+          }
+        },
+        {
+          "id": "physics_senior_mechanical_energy_loss",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Potential-energy conservation applies to high-school mechanical-energy problems by identifying when friction or collision loss must be placed outside the conserved total.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "conservation_with_energy_loss_application",
+            "physics_use": "decides when E_k+E_p is conserved and when loss terms must be added"
+          }
+        },
+        {
+          "id": "college_physics_work_energy_theorem",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "The work-energy theorem always tracks net work, while mechanical-energy conservation only works after non-conservative work is absent or explicitly separated.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "net_work_vs_conserved_mechanical_energy",
+            "physics_use": "prevents applying conservation in systems with hidden dissipative work"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由保守力定义势能，并判断系统机械能守恒条件。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_momentum_center_mass",
+      "name": "动量与质心运动",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理力学",
+      "unit": "动量与质心",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_potential_energy_conservation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 势能与机械能守恒 before 动量与质心运动; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_potential_energy_conservation",
+          "relation": "co_occurs",
+          "reason": "动量与质心运动 and 势能与机械能守恒 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_rigid_body_rotation",
+          "relation": "extends",
+          "reason": "Practice 刚体定轴转动 after 动量与质心运动; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_rigid_body_rotation",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After finding total momentum and center-of-mass motion, the next procedure is to separate translation of the center of mass from rotation about it.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "center_of_mass_translation_to_rotation_steps",
+            "physics_use": "builds the bridge from particle systems to rigid-body motion"
+          }
+        },
+        {
+          "id": "physics_senior_momentum_collision",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Center-of-mass momentum methods apply to collision problems by tracking external impulse separately from internal interaction forces.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "collision_center_of_mass_application",
+            "physics_use": "uses conservation and center-of-mass velocity to simplify multi-body collisions"
+          }
+        },
+        {
+          "id": "college_physics_potential_energy_conservation",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "reason": "Momentum conservation depends on external impulse, while mechanical-energy conservation depends on non-conservative work; the two conditions are independent.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "momentum_vs_energy_conservation_conditions",
+            "physics_use": "separates impulse conditions from energy-loss conditions in system analysis"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用质心运动定理分析碰撞或爆炸问题。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_rigid_body_rotation",
+      "name": "刚体定轴转动",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理力学",
+      "unit": "刚体力学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_momentum_center_mass",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 动量与质心运动 before 刚体定轴转动; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_momentum_center_mass",
+          "relation": "co_occurs",
+          "reason": "刚体定轴转动 and 动量与质心运动 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_angular_momentum",
+          "relation": "extends",
+          "reason": "Practice 角动量守恒 after 刚体定轴转动; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_angular_momentum",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "After writing torque, moment of inertia, and angular acceleration for fixed-axis rotation, the next step is to formulate angular momentum and its conservation condition.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "rigid_rotation_to_angular_momentum_steps",
+            "physics_use": "extends rotational dynamics into angular-momentum conservation checks"
+          }
+        },
+        {
+          "id": "physics_senior_circular_motion",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Rigid-body rotation applies circular-motion ideas to every mass element while adding moment of inertia as the distribution-weighted factor.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "circular_motion_to_rigid_body_application",
+            "physics_use": "connects angular velocity and centripetal acceleration to extended bodies"
+          }
+        },
+        {
+          "id": "college_physics_vector_calculus",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.83,
+          "reason": "Angular quantities are axial vectors in many contexts, but fixed-axis rotation often uses signed scalars; confusing these representations causes sign and direction errors.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "angular_vector_vs_signed_scalar_confusion",
+            "physics_use": "keeps torque and angular velocity directions consistent with the chosen axis convention"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "建立转动惯量、角加速度和力矩之间的关系。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_angular_momentum",
+      "name": "角动量守恒",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理力学",
+      "unit": "刚体力学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_rigid_body_rotation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 刚体定轴转动 before 角动量守恒; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_rigid_body_rotation",
+          "relation": "co_occurs",
+          "reason": "角动量守恒 and 刚体定轴转动 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_simple_harmonic_oscillation",
+          "relation": "extends",
+          "reason": "Practice 简谐振动微分方程 after 角动量守恒; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_simple_harmonic_oscillation",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "After applying angular momentum conservation in rotation, students can proceed to oscillation models where conserved quantities and phase-space reasoning are compared.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "angular_momentum_to_oscillation_model_sequence",
+            "physics_use": "places rotational conservation before later periodic-motion modeling in the course chain"
+          }
+        },
+        {
+          "id": "college_physics_rigid_body_rotation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Angular momentum conservation applies to rigid-body rotation when external torque about the chosen axis is zero, such as spin-up or redistribution cases.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "zero_external_torque_application",
+            "physics_use": "uses torque checks to decide whether I omega remains constant"
+          }
+        },
+        {
+          "id": "college_physics_momentum_center_mass",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Linear momentum conservation and angular momentum conservation require different external quantities: impulse versus torque about a specified point or axis.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "linear_vs_angular_momentum_conservation",
+            "physics_use": "prevents using center-of-mass momentum rules for rotational conservation problems"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "判断外力矩是否为零，并用角动量守恒求角速度变化。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_simple_harmonic_oscillation",
+      "name": "简谐振动微分方程",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理振动与波",
+      "unit": "机械振动",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_angular_momentum",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 角动量守恒 before 简谐振动微分方程; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_angular_momentum",
+          "relation": "co_occurs",
+          "reason": "简谐振动微分方程 and 角动量守恒 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_damped_forced_oscillation",
+          "relation": "extends",
+          "reason": "Practice 阻尼与受迫振动 after 简谐振动微分方程; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_derivative_definition",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.87,
+          "reason": "建立简谐振动微分方程时，需要用二阶导数把位移函数和加速度联系起来。",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "math_to_physics",
+            "bridge_focus": "二阶导数->简谐振动",
+            "procedure": [
+              "define_displacement_function",
+              "differentiate_twice",
+              "relate_acceleration_to_displacement"
+            ]
+          }
+        },
+        {
+          "id": "senior_trig_graph",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "简谐振动微分方程的解通常写成正弦或余弦形式，三角函数图像帮助解释相位和周期。",
+          "use_cases": [
+            "hint_generation",
+            "learning_path",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "简谐振动方程->三角函数图像",
+            "math_use": "用三角函数图像解释通解参数"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由受力方程推出简谐振动方程并解释周期。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_damped_forced_oscillation",
+      "name": "阻尼与受迫振动",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理振动与波",
+      "unit": "机械振动",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_simple_harmonic_oscillation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 简谐振动微分方程 before 阻尼与受迫振动; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_simple_harmonic_oscillation",
+          "relation": "co_occurs",
+          "reason": "阻尼与受迫振动 and 简谐振动微分方程 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_mechanical_wave_equation",
+          "relation": "extends",
+          "reason": "Practice 机械波与波动方程 after 阻尼与受迫振动; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_exponential_function",
+          "relation": "application",
+          "priority": "core",
+          "context": "explanation",
+          "confidence": 0.86,
+          "reason": "Damped oscillation applies exponential-function intuition to describe amplitude decay envelopes.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "damping_exponential_envelope"
+          }
+        },
+        {
+          "id": "college_differential",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "explanation",
+          "confidence": 0.83,
+          "reason": "Damping models require translating small changes in displacement and velocity into differential-equation terms.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "damping_differential_modeling"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "比较欠阻尼、临界阻尼、过阻尼和共振条件。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_mechanical_wave_equation",
+      "name": "机械波与波动方程",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理振动与波",
+      "unit": "波动",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_damped_forced_oscillation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 阻尼与受迫振动 before 机械波与波动方程; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_damped_forced_oscillation",
+          "relation": "co_occurs",
+          "reason": "机械波与波动方程 and 阻尼与受迫振动 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_interference_diffraction",
+          "relation": "extends",
+          "reason": "Practice 干涉与衍射 after 机械波与波动方程; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_trig_definitions",
+          "relation": "procedure_step",
+          "reason": "Solving a wave equation starts by mapping phase, period, and wavelength to trigonometric form.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "wave_equation_phase_trig"
+          }
+        },
+        {
+          "id": "college_physics_interference_diffraction",
+          "relation": "application",
+          "reason": "The wave equation provides the amplitude and phase model used in interference and diffraction analysis.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "wave_equation_to_interference"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "根据波函数求振幅、波速、频率和质点速度。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_interference_diffraction",
+      "name": "干涉与衍射",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理振动与波",
+      "unit": "波动光学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_mechanical_wave_equation",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 机械波与波动方程 before 干涉与衍射; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_mechanical_wave_equation",
+          "relation": "co_occurs",
+          "reason": "干涉与衍射 and 机械波与波动方程 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_ideal_gas_state",
+          "relation": "extends",
+          "reason": "Practice 理想气体状态方程 after 干涉与衍射; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_mechanical_wave_equation",
+          "relation": "procedure_step",
+          "reason": "Interference and diffraction calculations first translate the physical setup into a wave phase relation.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "interference_wave_phase_setup"
+          }
+        },
+        {
+          "id": "college_physics_polarization",
+          "relation": "application",
+          "reason": "Wave-optics reasoning transfers to polarization when comparing light intensity and field direction effects.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "wave_optics_to_polarization"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "分析双缝干涉或单缝衍射条纹位置。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_ideal_gas_state",
+      "name": "理想气体状态方程",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理热学",
+      "unit": "气体动理论",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_interference_diffraction",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 干涉与衍射 before 理想气体状态方程; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_interference_diffraction",
+          "relation": "co_occurs",
+          "reason": "理想气体状态方程 and 干涉与衍射 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_thermo_first_law",
+          "relation": "extends",
+          "reason": "Practice 热力学第一定律 after 理想气体状态方程; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_thermo_first_law",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After using pV=nRT to identify gas states, the next procedure is to compute heat, work, and internal-energy change for the process path.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "state_equation_to_first_law_steps",
+            "physics_use": "moves from proportional gas-state relations to thermodynamic process accounting"
+          }
+        },
+        {
+          "id": "college_physics_thermo_first_law",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "The ideal-gas state equation applies inside first-law problems to connect pressure, volume, and temperature before calculating work or heat.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "ideal_gas_state_in_first_law_application",
+            "physics_use": "uses direct and inverse proportional relationships among p, V, and T during process analysis"
+          }
+        },
+        {
+          "id": "college_physics_thermo_first_law",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "A state equation relates equilibrium variables, while the first law relates energy transfer along a process; mixing them hides path dependence.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "state_relation_vs_process_energy_confusion",
+            "physics_use": "separates proportional state constraints from heat-work-energy bookkeeping"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用状态方程分析气体过程中的压强、体积和温度变化。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_thermo_first_law",
+      "name": "热力学第一定律",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理热学",
+      "unit": "热力学定律",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_ideal_gas_state",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 理想气体状态方程 before 热力学第一定律; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_ideal_gas_state",
+          "relation": "co_occurs",
+          "reason": "热力学第一定律 and 理想气体状态方程 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_thermo_second_law_entropy",
+          "relation": "extends",
+          "reason": "Practice 热力学第二定律与熵 after 热力学第一定律; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_thermo_second_law_entropy",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "After balancing heat, work, and internal energy with the first law, the next step is to test process direction and efficiency with entropy or second-law limits.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "first_law_accounting_to_entropy_steps",
+            "physics_use": "adds irreversibility and entropy checks after energy conservation"
+          }
+        },
+        {
+          "id": "college_physics_ideal_gas_state",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "First-law calculations apply the ideal-gas state equation to determine missing p, V, or T values before integrating work over a path.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "first_law_ideal_gas_application",
+            "physics_use": "combines state-variable proportionality with heat and work accounting"
+          }
+        },
+        {
+          "id": "college_physics_thermo_second_law_entropy",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "The first law permits any energy-balanced process, while the second law restricts which energy-balanced processes can actually occur.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "energy_conservation_vs_process_direction_confusion",
+            "physics_use": "distinguishes energy bookkeeping from entropy and feasibility constraints"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "区分吸热、做功和内能变化，并判断符号。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_thermo_second_law_entropy",
+      "name": "热力学第二定律与熵",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理热学",
+      "unit": "热力学定律",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_thermo_first_law",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 热力学第一定律 before 热力学第二定律与熵; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_thermo_first_law",
+          "relation": "co_occurs",
+          "reason": "热力学第二定律与熵 and 热力学第一定律 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_coulomb_field",
+          "relation": "extends",
+          "reason": "Practice 库仑定律与电场叠加 after 热力学第二定律与熵; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_thermo_first_law",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Entropy analysis should start from the first-law energy balance, then add reversibility, reservoir, and efficiency constraints.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "first_law_balance_before_entropy_steps",
+            "physics_use": "orders heat-work accounting before second-law direction tests"
+          }
+        },
+        {
+          "id": "college_physics_ideal_gas_state",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Second-law and entropy examples apply ideal-gas state changes when comparing isothermal, adiabatic, and cyclic processes.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "entropy_ideal_gas_process_application",
+            "physics_use": "uses gas-state relations to evaluate reversible and irreversible process paths"
+          }
+        },
+        {
+          "id": "college_physics_thermo_first_law",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "Entropy increase is not the same statement as energy conservation; a process can conserve energy and still be impossible by the second law.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "entropy_vs_energy_conservation_confusion",
+            "physics_use": "keeps feasibility reasoning separate from heat-work energy balance"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用熵变或不可逆性解释热机效率限制。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_coulomb_field",
+      "name": "库仑定律与电场叠加",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "静电场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_thermo_second_law_entropy",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 热力学第二定律与熵 before 库仑定律与电场叠加; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_thermo_second_law_entropy",
+          "relation": "co_occurs",
+          "reason": "库仑定律与电场叠加 and 热力学第二定律与熵 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_gauss_law",
+          "relation": "extends",
+          "reason": "Practice 高斯定理 after 库仑定律与电场叠加; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_vector_space",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Field superposition relies on vector-space operations before integrating or summing electric fields.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "field_superposition_vector_space"
+          }
+        },
+        {
+          "id": "senior_vector_linear_operation",
+          "relation": "procedure_step",
+          "reason": "Electric-field superposition starts by adding field vectors from each charge before applying symmetry.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "coulomb_field_vector_sum"
+          }
+        },
+        {
+          "id": "college_physics_gauss_law",
+          "relation": "application",
+          "reason": "Coulomb-field symmetry checks support choosing Gaussian surfaces in Gauss-law problems.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "coulomb_symmetry_to_gauss_law"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "计算点电荷系的电场并判断方向。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_gauss_law",
+      "name": "高斯定理",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "静电场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_coulomb_field",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 库仑定律与电场叠加 before 高斯定理; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_coulomb_field",
+          "relation": "co_occurs",
+          "reason": "高斯定理 and 库仑定律与电场叠加 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_electric_potential",
+          "relation": "extends",
+          "reason": "Practice 电势与电势能 after 高斯定理; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_integral_physics_application",
+          "relation": "procedure_step",
+          "reason": "Gauss-law problems require setting up flux as an integral over a closed surface before simplifying by symmetry.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "gauss_law_flux_integral"
+          }
+        },
+        {
+          "id": "college_physics_electric_potential",
+          "relation": "application",
+          "reason": "Fields found with Gauss law are often applied to potential-difference and energy calculations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "gauss_field_to_potential"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "选择高斯面求具有对称性的电场分布。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_electric_potential",
+      "name": "电势与电势能",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "静电场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_gauss_law",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 高斯定理 before 电势与电势能; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_gauss_law",
+          "relation": "co_occurs",
+          "reason": "电势与电势能 and 高斯定理 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_capacitance_dielectric",
+          "relation": "extends",
+          "reason": "Practice 电容与介质 after 电势与电势能; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_integral_physics_application",
+          "relation": "procedure_step",
+          "reason": "Potential calculations first convert electric field along a path into an integral with correct sign.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "electric_potential_path_integral"
+          }
+        },
+        {
+          "id": "college_physics_capacitance_dielectric",
+          "relation": "application",
+          "reason": "Potential difference is applied directly when deriving capacitance and stored energy of conductors.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "potential_to_capacitance"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由电场积分求电势差并解释电势能变化。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_capacitance_dielectric",
+      "name": "电容与介质",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "静电场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_electric_potential",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 电势与电势能 before 电容与介质; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_electric_potential",
+          "relation": "co_occurs",
+          "reason": "电容与介质 and 电势与电势能 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_current_circuit",
+          "relation": "extends",
+          "reason": "Practice 稳恒电流与电路 after 电容与介质; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_electric_potential",
+          "relation": "procedure_step",
+          "reason": "Capacitance modeling first relates charge to potential difference before adding dielectric effects.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "capacitance_from_potential_difference"
+          }
+        },
+        {
+          "id": "college_physics_current_circuit",
+          "relation": "application",
+          "reason": "Capacitors and dielectrics extend into transient and steady-current circuit reasoning.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "capacitance_to_circuit_application"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "分析插入介质或改变极板距离后的电容和能量变化。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_current_circuit",
+      "name": "稳恒电流与电路",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "稳恒电流",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_capacitance_dielectric",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 电容与介质 before 稳恒电流与电路; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_capacitance_dielectric",
+          "relation": "co_occurs",
+          "reason": "稳恒电流与电路 and 电容与介质 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_magnetic_field_biot_savart",
+          "relation": "extends",
+          "reason": "Practice 毕奥-萨伐尔定律 after 稳恒电流与电路; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "function_graph_reading",
+          "relation": "procedure_step",
+          "reason": "Circuit analysis often starts by reading I-V graphs and identifying slopes, intercepts, and operating points.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "current_circuit_iv_graph_reading"
+          }
+        },
+        {
+          "id": "college_physics_magnetic_field_biot_savart",
+          "relation": "application",
+          "reason": "Steady currents are the source model used when applying Biot-Savart magnetic-field calculations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "current_to_magnetic_field_source"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用基尔霍夫定律求复杂电路电流和电势差。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_magnetic_field_biot_savart",
+      "name": "毕奥-萨伐尔定律",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "磁场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_current_circuit",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 稳恒电流与电路 before 毕奥-萨伐尔定律; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_current_circuit",
+          "relation": "co_occurs",
+          "reason": "毕奥-萨伐尔定律 and 稳恒电流与电路 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_ampere_law",
+          "relation": "extends",
+          "reason": "Practice 安培环路定理 after 毕奥-萨伐尔定律; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_definite_integral",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Biot-Savart calculations accumulate infinitesimal magnetic-field contributions with definite integrals.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "biot_savart_definite_integral"
+          }
+        },
+        {
+          "id": "college_physics_ampere_law",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "After integrating current elements with Biot-Savart, the next procedure is to check symmetry and decide whether Ampere law gives a shorter field calculation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "field_integral_to_symmetry_law_steps",
+            "physics_use": "moves from direct magnetic-field integration to symmetry-based circulation methods"
+          }
+        },
+        {
+          "id": "college_physics_ampere_law",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Biot-Savart sums local current-element contributions, while Ampere law uses field circulation and symmetry; choosing the wrong tool leads to invalid shortcuts.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "biot_savart_vs_ampere_law_confusion",
+            "physics_use": "distinguishes direct integration from symmetry-dependent magnetic-field reasoning"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "计算载流导线在空间某点产生的磁感应强度。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_ampere_law",
+      "name": "安培环路定理",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "磁场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_magnetic_field_biot_savart",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 毕奥-萨伐尔定律 before 安培环路定理; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_magnetic_field_biot_savart",
+          "relation": "co_occurs",
+          "reason": "安培环路定理 and 毕奥-萨伐尔定律 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_lorentz_force",
+          "relation": "extends",
+          "reason": "Practice 洛伦兹力与带电粒子运动 after 安培环路定理; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_magnetic_field_biot_savart",
+          "relation": "procedure_step",
+          "reason": "Ampere-law use should be checked against the magnetic-field direction and symmetry learned from Biot-Savart.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "ampere_symmetry_check"
+          }
+        },
+        {
+          "id": "college_physics_lorentz_force",
+          "relation": "application",
+          "reason": "Magnetic fields obtained from Ampere-law symmetry are applied to Lorentz-force motion problems.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "ampere_field_to_lorentz_force"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "利用对称性和环路定理求磁场。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_lorentz_force",
+      "name": "洛伦兹力与带电粒子运动",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "磁场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_ampere_law",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 安培环路定理 before 洛伦兹力与带电粒子运动; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_ampere_law",
+          "relation": "co_occurs",
+          "reason": "洛伦兹力与带电粒子运动 and 安培环路定理 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_faraday_induction",
+          "relation": "extends",
+          "reason": "Practice 法拉第电磁感应定律 after 洛伦兹力与带电粒子运动; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_trig_definitions",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Lorentz force magnitude uses the sine of the angle between velocity and magnetic field.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "lorentz_force_angle_sine"
+          }
+        },
+        {
+          "id": "college_physics_faraday_induction",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "After determining magnetic force direction on a moving charge, the next step is to connect moving conductors and changing flux to induced emf.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "lorentz_force_to_induction_steps",
+            "physics_use": "links right-hand-rule force direction with motional-emf and flux-change reasoning"
+          }
+        },
+        {
+          "id": "physics_senior_magnetic_force",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Magnetic force on a charge, force on a current-carrying wire, and electric force use different direction rules and angle factors despite similar field notation.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "magnetic_force_direction_rule_confusion",
+            "physics_use": "prevents mixing Lorentz-force vector products with electric-field force rules"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "求带电粒子在匀强磁场中的半径、周期和轨迹。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_faraday_induction",
+      "name": "法拉第电磁感应定律",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "电磁感应",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_lorentz_force",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 洛伦兹力与带电粒子运动 before 法拉第电磁感应定律; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_lorentz_force",
+          "relation": "co_occurs",
+          "reason": "法拉第电磁感应定律 and 洛伦兹力与带电粒子运动 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_maxwell_equations_intro",
+          "relation": "extends",
+          "reason": "Practice 麦克斯韦方程组初步 after 法拉第电磁感应定律; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_integral_physics_application",
+          "relation": "procedure_step",
+          "reason": "Induction analysis starts by expressing magnetic flux through an area before evaluating its change.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "faraday_flux_integral_setup"
+          }
+        },
+        {
+          "id": "college_physics_maxwell_equations_intro",
+          "relation": "application",
+          "reason": "Faraday induction is one of the core field-change laws combined in Maxwell-equation form.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "faraday_to_maxwell_equations"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由磁通量变化求感应电动势并判断方向。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_maxwell_equations_intro",
+      "name": "麦克斯韦方程组初步",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理电磁学",
+      "unit": "电磁场",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_faraday_induction",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 法拉第电磁感应定律 before 麦克斯韦方程组初步; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_faraday_induction",
+          "relation": "co_occurs",
+          "reason": "麦克斯韦方程组初步 and 法拉第电磁感应定律 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_geometric_optics",
+          "relation": "extends",
+          "reason": "Practice 几何光学成像 after 麦克斯韦方程组初步; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_partial_derivative",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.86,
+          "reason": "Maxwell equations require partial derivatives to describe spatial and temporal changes of fields.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "maxwell_partial_derivatives"
+          }
+        },
+        {
+          "id": "college_gradient_directional_derivative",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Gradient and directional-derivative ideas help interpret how electromagnetic fields vary in space.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "field_variation_gradient"
+          }
+        },
+        {
+          "id": "college_physics_faraday_induction",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Before reading Maxwell equations as a coupled field system, trace Faraday induction from changing flux to circulating electric field.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "faraday_flux_to_maxwell_field_steps",
+            "physics_use": "connects integral laws, field circulation, and time-varying electromagnetic fields"
+          }
+        },
+        {
+          "id": "college_physics_gauss_law",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.85,
+          "reason": "Gauss law describes field flux from sources, while Faraday and Ampere-Maxwell laws describe circulation from changing fields; mixing flux and circulation is a common Maxwell-equation error.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "flux_law_vs_circulation_law_confusion",
+            "physics_use": "separates divergence-style source laws from curl-style changing-field laws"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "解释四个积分形式方程对应的物理含义。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_geometric_optics",
+      "name": "几何光学成像",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理光学",
+      "unit": "几何光学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_maxwell_equations_intro",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 麦克斯韦方程组初步 before 几何光学成像; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_maxwell_equations_intro",
+          "relation": "co_occurs",
+          "reason": "几何光学成像 and 麦克斯韦方程组初步 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_polarization",
+          "relation": "extends",
+          "reason": "Practice 光的偏振 after 几何光学成像; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_trig_definitions",
+          "relation": "procedure_step",
+          "reason": "Ray-tracing problems first use small-angle or triangle relations before applying lens and mirror equations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "geometric_optics_ray_triangle_setup"
+          }
+        },
+        {
+          "id": "similar_triangles",
+          "relation": "application",
+          "reason": "Geometric-optics ray diagrams use similar triangles to connect object height, image height, object distance, image distance, and magnification.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.97,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "geometric_optics_similar_triangle_magnification"
+          }
+        },
+        {
+          "id": "similarity_properties",
+          "relation": "procedure_step",
+          "reason": "Ray-tracing solutions first identify pairs of similar triangles, then use proportional sides to derive magnification or lens relations.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.96,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "ray_diagram_similarity_proportion"
+          }
+        },
+        {
+          "id": "inverse_function_graph",
+          "relation": "application",
+          "reason": "Thin-lens equations apply inverse-function reasoning when object distance and image distance vary reciprocally.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "lens_equation_inverse_relation"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用薄透镜成像公式求像距、放大率和成像性质。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_polarization",
+      "name": "光的偏振",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理光学",
+      "unit": "波动光学",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_geometric_optics",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 几何光学成像 before 光的偏振; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_geometric_optics",
+          "relation": "co_occurs",
+          "reason": "光的偏振 and 几何光学成像 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_special_relativity_postulates",
+          "relation": "extends",
+          "reason": "Practice 狭义相对论基本假设 after 光的偏振; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "senior_trig_definitions",
+          "relation": "procedure_step",
+          "reason": "Polarization intensity problems first resolve the angle between transmission axes before applying Malus-law form.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "polarization_axis_angle_setup"
+          }
+        },
+        {
+          "id": "senior_trig_graph",
+          "relation": "application",
+          "reason": "Malus-law intensity variation applies trigonometric graph behavior as the analyzer angle changes.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "malus_law_trig_graph"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用马吕斯定律分析偏振片后的光强变化。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_special_relativity_postulates",
+      "name": "狭义相对论基本假设",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理近代物理",
+      "unit": "相对论",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_polarization",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 光的偏振 before 狭义相对论基本假设; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_polarization",
+          "relation": "co_occurs",
+          "reason": "狭义相对论基本假设 and 光的偏振 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_photoelectric_effect",
+          "relation": "extends",
+          "reason": "Practice 光电效应 after 狭义相对论基本假设; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_physics_photoelectric_effect",
+          "relation": "procedure_step",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "After setting the light-speed postulate and inertial-frame rules, the course can proceed to modern-physics evidence where light also behaves as quantized energy.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "relativity_postulates_to_modern_physics_steps",
+            "physics_use": "places high-speed frame assumptions before photon-energy model building"
+          }
+        },
+        {
+          "id": "college_physics_de_broglie_atom",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.83,
+          "reason": "Relativity postulates apply as boundary checks in de Broglie and atomic models by clarifying when classical momentum, wave speed, or high-speed approximations are valid.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "relativity_boundary_in_quantum_models_application",
+            "physics_use": "uses modern-physics assumptions alongside inverse wavelength-momentum reasoning"
+          }
+        },
+        {
+          "id": "college_physics_de_broglie_atom",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Relativistic momentum limits and de Broglie inverse wavelength-momentum relations are related modern-physics ideas, but they answer different modeling questions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_direction": "physics_to_physics",
+            "bridge_focus": "relativity_vs_de_broglie_inverse_relation_confusion",
+            "physics_use": "keeps high-speed frame effects separate from matter-wave wavelength reasoning"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "用光速不变和相对性原理解释时间膨胀。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_photoelectric_effect",
+      "name": "光电效应",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理近代物理",
+      "unit": "量子物理",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_special_relativity_postulates",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 狭义相对论基本假设 before 光电效应; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_special_relativity_postulates",
+          "relation": "co_occurs",
+          "reason": "光电效应 and 狭义相对论基本假设 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "college_physics_de_broglie_atom",
+          "relation": "extends",
+          "reason": "Practice 德布罗意波与原子结构 after 光电效应; it is the next topic in this course sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "linear_function_graph",
+          "relation": "procedure_step",
+          "reason": "Photoelectric-effect data should be linearized as stopping voltage versus frequency before interpreting slope and intercept.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "photoelectric_linear_fit"
+          }
+        },
+        {
+          "id": "college_physics_de_broglie_atom",
+          "relation": "application",
+          "reason": "Photon quantization in the photoelectric effect prepares particle-wave reasoning for de Broglie and atomic models.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "photoelectric_to_quantum_atom"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "由截止频率和遏止电压求普朗克常量或逸出功。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    },
+    {
+      "id": "college_physics_de_broglie_atom",
+      "name": "德布罗意波与原子结构",
+      "subject": "physics",
+      "stage": "college",
+      "chapter": "大学物理近代物理",
+      "unit": "量子物理",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [
+        {
+          "id": "college_physics_photoelectric_effect",
+          "required_mastery": 0.58,
+          "relation": "prerequisite",
+          "reason": "Master 光电效应 before 德布罗意波与原子结构; it provides the foundation used by later steps.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        }
+      ],
+      "related": [
+        {
+          "id": "college_physics_photoelectric_effect",
+          "relation": "co_occurs",
+          "reason": "德布罗意波与原子结构 and 光电效应 are often studied together, so guidance can compare their conditions and usage.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "inverse_function_graph",
+          "relation": "procedure_step",
+          "reason": "De Broglie wavelength calculations first recognize wavelength as inverse to momentum.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "math",
+            "bridge_direction": "physics_to_math",
+            "bridge_focus": "de_broglie_inverse_momentum"
+          }
+        },
+        {
+          "id": "college_physics_photoelectric_effect",
+          "relation": "application",
+          "reason": "Matter-wave calculations extend the quantum energy and photon evidence introduced by the photoelectric effect.",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "physics",
+            "target_subject": "physics",
+            "bridge_focus": "matter_wave_quantum_evidence"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "把高中公式直接套到连续模型而不说明条件",
+        "忽略矢量方向、参考系或边界条件",
+        "只算结果不解释物理意义和量纲"
+      ],
+      "skills": [
+        "建立物理模型并明确近似条件",
+        "用微积分或矢量方法推导核心关系",
+        "结合单位、量纲和极限情形检查结论"
+      ],
+      "question_types": [
+        "概念推导",
+        "计算应用"
+      ],
+      "examples": [
+        {
+          "prompt": "计算物质波波长并解释能级跃迁。",
+          "answer_outline": [
+            "先识别题目考查的大学物理模型或概念。",
+            "列出关键变量、条件、公式或过程图。",
+            "按课程方法完成推导、计算或结构化解释。",
+            "检查结论的单位、边界条件和现实含义。"
+          ],
+          "common_traps": [
+            "把高中公式直接套到连续模型而不说明条件",
+            "忽略矢量方向、参考系或边界条件"
+          ],
+          "grading_points": [
+            "模型选择和核心概念准确。",
+            "推理步骤完整，关键条件有回应。",
+            "结论表达规范，并能解释结果含义。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "physics",
+        "college",
+        "college_course_track"
+      ],
+      "curriculum_version": [
+        "generic_college",
+        "college_physics"
+      ],
+      "exam_region": [
+        "college_course_generic"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "college_course_exam"
+      ],
+      "course_family": "physics"
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/static/knowledge_seeds/politics.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/politics.json
@@ -167,6 +167,9 @@
         {
           "id": "pol_junior_collective_responsibility",
           "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.79,
           "reason": "Practice 集体与责任 after 权利与义务; it is the next topic in the junior_high politics learning sequence.",
           "use_cases": [
             "learning_path",
@@ -434,6 +437,9 @@
         {
           "id": "pol_senior_political_participation",
           "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
           "reason": "Practice 人民民主与政治参与 after 市场机制与宏观调控; it is the next topic in the senior_high politics learning sequence.",
           "use_cases": [
             "learning_path",
@@ -912,6 +918,9 @@
         {
           "id": "pol_senior_culture_confidence",
           "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.79,
           "reason": "Practice 文化传承与文化自信 after 唯物辩证法; it is the next topic in the senior_high politics learning sequence.",
           "use_cases": [
             "learning_path",
@@ -1494,6 +1503,9 @@
         {
           "id": "pol_senior_logical_thinking",
           "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78,
           "reason": "Practice 逻辑与思维方法 after 国际关系与中国外交; it is the next topic in the senior_high politics learning sequence.",
           "use_cases": [
             "learning_path",

--- a/plugin/plugins/study_companion/static/knowledge_seeds/politics.json
+++ b/plugin/plugins/study_companion/static/knowledge_seeds/politics.json
@@ -1,0 +1,1768 @@
+{
+  "version": "1.0",
+  "subject": "politics",
+  "topics": [
+    {
+      "id": "pol_junior_rule_law",
+      "name": "规则与法治意识",
+      "subject": "politics",
+      "stage": "junior_high",
+      "chapter": "道德与法治",
+      "depth": 1,
+      "difficulty": 0.4,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_junior_rights_obligations",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "分析规则和法治案例时，通常先判断规则依据，再进入公民权利与义务边界的判断。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_junior_collective_responsibility",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "校园规则、公共秩序和法治意识常落实到集体生活中的责任承担。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rule_morality",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "学生容易把法律规范、校纪规则和道德要求混为一谈，需要在诊断中对比边界。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rights_obligations",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "reason": "Practice 权利与义务 after 规则与法治意识; it is the next topic in the junior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "成长与法治",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "材料题",
+        "观点说明"
+      ],
+      "examples": [
+        {
+          "prompt": "结合校园案例说明规则意识和法治意识的关系。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "pol_junior_rights_obligations",
+      "name": "权利与义务",
+      "subject": "politics",
+      "stage": "junior_high",
+      "chapter": "道德与法治",
+      "depth": 2,
+      "difficulty": 0.46,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_junior_rule_morality",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_collective_responsibility",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rule_law",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_junior_collective_responsibility",
+          "relation": "extends",
+          "reason": "Practice 集体与责任 after 权利与义务; it is the next topic in the junior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_senior_institution_change",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Rights and obligations help explain how institutional change redefines citizen-state boundaries.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "history",
+            "bridge_direction": "politics_to_history"
+          }
+        },
+        {
+          "id": "chinese_senior_text_answer_template",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Rights-obligations cases can be converted into point-by-point evidence and conclusion answers.",
+          "use_cases": [
+            "hint_generation",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "chinese",
+            "bridge_direction": "politics_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "成长与法治",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "概念辨析",
+        "材料分析"
+      ],
+      "examples": [
+        {
+          "prompt": "判断网络表达案例中公民权利和义务的边界。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ],
+      "aliases": [
+        "权利和义务",
+        "公民权利",
+        "公民义务",
+        "权利义务关系",
+        "权利和义务有什么关系",
+        "公民怎样正确行使权利履行义务"
+      ]
+    },
+    {
+      "id": "pol_junior_collective_responsibility",
+      "name": "集体与责任",
+      "subject": "politics",
+      "stage": "junior_high",
+      "chapter": "道德与法治",
+      "depth": 2,
+      "difficulty": 0.42,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_junior_rights_obligations",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "分析个人与集体关系题时，应先确认个人权利和应履行义务，再判断责任承担是否合理。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_junior_national_security",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "reason": "维护国家安全是个人责任、集体责任和社会责任在公共生活中的典型应用场景。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rule_law",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "学生容易把集体责任简化为服从规则，忽略规则背后的法治意识和责任边界。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_national_security",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.79,
+          "reason": "Practice 国家安全教育 after 集体与责任; it is the next topic in the junior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "成长与法治",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "价值判断",
+        "措施题"
+      ],
+      "examples": [
+        {
+          "prompt": "说明班级合作中个人责任和集体利益如何统一。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "junior_high",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "pol_senior_economy_market",
+      "name": "市场机制与宏观调控",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "高中政治",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_senior_political_participation",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_socialism_market",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_political_participation",
+          "relation": "extends",
+          "reason": "Practice 人民民主与政治参与 after 市场机制与宏观调控; it is the next topic in the senior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_micro_demand_supply",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.91,
+          "reason": "Market mechanism questions transfer directly to demand-supply shifts and equilibrium analysis.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "economics",
+            "bridge_direction": "politics_to_economics"
+          }
+        },
+        {
+          "id": "college_macro_fiscal_policy",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Macro-control materials often require fiscal-policy tools such as spending, taxation, and deficits.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "economics",
+            "bridge_direction": "politics_to_economics"
+          }
+        },
+        {
+          "id": "college_macro_monetary_policy",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "Macro-control also maps to monetary-policy levers that affect credit, rates, and aggregate demand.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "economics",
+            "bridge_direction": "politics_to_economics"
+          }
+        },
+        {
+          "id": "college_econ_policy_tradeoff",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.86,
+          "reason": "Policy evaluation in politics benefits from economics tradeoff language about goals, costs, and constraints.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "economics",
+            "bridge_direction": "politics_to_economics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "经济政治哲学",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "材料题",
+        "经济分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析价格变化、供需关系和政府调控措施。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ],
+      "aliases": [
+        "市场机制",
+        "宏观调控",
+        "市场机制和宏观调控",
+        "市场调节和宏观调控怎么区分",
+        "政府为什么要进行宏观调控"
+      ]
+    },
+    {
+      "id": "pol_senior_political_participation",
+      "name": "人民民主与政治参与",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "高中政治",
+      "depth": 2,
+      "difficulty": 0.6,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "政治参与材料通常要先识别参与主体和渠道，再用法治框架判断程序、权责和制度保障。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "application",
+          "priority": "core",
+          "context": "review",
+          "confidence": 0.82,
+          "reason": "基层治理、民主协商和监督参与常以法治化治理作为材料应用场景。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rights_obligations",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.77,
+          "reason": "政治参与中的民主权利容易被误答成一般公民权利义务，需要区分主体、渠道和制度层次。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.8,
+          "reason": "Practice 全面依法治国 after 人民民主与政治参与; it is the next topic in the senior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "经济政治哲学",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "材料题",
+        "主体分析"
+      ],
+      "examples": [
+        {
+          "prompt": "根据基层治理材料说明人民当家作主的制度优势。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "pol_senior_rule_of_law",
+      "name": "全面依法治国",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "高中政治",
+      "depth": 2,
+      "difficulty": 0.64,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_junior_rule_morality",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_political_participation",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rule_law",
+          "relation": "prerequisite",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "This topic should be understood first and is used for diagnosis and learning-path guidance.",
+          "use_cases": [
+            "diagnosis",
+            "learning_path",
+            "hint_generation"
+          ]
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "法治案例题需要界定主体和权责后，用规范逻辑组织原因、意义和措施链条。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_philosophy_dialectics",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.79,
+          "reason": "Practice 唯物辩证法 after 全面依法治国; it is the next topic in the senior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_senior_institution_change",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "Rule-of-law analysis connects to historical explanations of institutional change and state governance.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "history",
+            "bridge_direction": "politics_to_history"
+          }
+        },
+        {
+          "id": "chinese_senior_task_driven_writing",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.83,
+          "reason": "Rule-of-law materials support task-driven writing that balances standpoint, evidence, and action proposals.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "chinese",
+            "bridge_direction": "politics_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "经济政治哲学",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "法治分析",
+        "措施题"
+      ],
+      "examples": [
+        {
+          "prompt": "结合行政执法案例说明严格规范公正文明执法。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ],
+      "aliases": [
+        "依法治国",
+        "全面依法治国",
+        "法治材料题",
+        "依法治国材料题",
+        "全面依法治国材料题怎么答",
+        "法治政府和依法治国有什么关系"
+      ]
+    },
+    {
+      "id": "pol_senior_philosophy_dialectics",
+      "name": "唯物辩证法",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "高中政治",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.76,
+          "reason": "This edge marks a common confusion that guidance should contrast explicitly.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_culture_confidence",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.78,
+          "reason": "This edge points to a common application context for practice planning.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "This edge captures the next analysis or problem-solving step for the topic.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_culture_confidence",
+          "relation": "extends",
+          "reason": "Practice 文化传承与文化自信 after 唯物辩证法; it is the next topic in the senior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "chinese_senior_composition_argument_layer",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.9,
+          "reason": "Dialectical analysis maps to layered argumentative writing with thesis, contrast, development, and synthesis.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "chinese",
+            "bridge_direction": "politics_to_chinese"
+          }
+        },
+        {
+          "id": "chinese_senior_modern_argument_structure",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.87,
+          "reason": "Dialectical categories help identify claim hierarchy and relation logic in argumentative texts.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "chinese",
+            "bridge_direction": "politics_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "经济政治哲学",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "哲学分析",
+        "观点说明"
+      ],
+      "examples": [
+        {
+          "prompt": "用联系观和发展观分析科技创新与社会生活变化。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ],
+      "aliases": [
+        "唯物辩证法",
+        "辩证法",
+        "矛盾观",
+        "联系发展观点",
+        "唯物辩证法材料题怎么答",
+        "矛盾观点和联系发展观点怎么用"
+      ]
+    },
+    {
+      "id": "pol_senior_culture_confidence",
+      "name": "文化传承与文化自信",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "高中政治",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_senior_philosophy_dialectics",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "文化材料题通常先提取文化载体和变化过程，再用辩证方法分析传承、创新和自信。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_socialism_market",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.78,
+          "reason": "文化自信常应用于高质量发展、文化产业和社会价值引领等经济社会材料。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_philosophy_dialectics",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.76,
+          "reason": "学生容易把文化传承题泛化为哲学辩证法题，忽略文化主体、载体和价值认同。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_socialism_market",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78,
+          "reason": "Practice 社会主义市场经济体制 after 文化传承与文化自信; it is the next topic in the senior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背概念，不扣材料主体和设问角度",
+        "原因、意义、措施混答",
+        "答案缺少政治学科术语和逻辑层次"
+      ],
+      "unit": "经济政治哲学",
+      "skills": [
+        "识别材料对应的核心概念和主体关系",
+        "按设问类型组织原因、意义、措施或评析",
+        "用规范术语连接材料和教材观点"
+      ],
+      "question_types": [
+        "文化分析",
+        "材料题"
+      ],
+      "examples": [
+        {
+          "prompt": "结合传统节日创新传播材料说明文化自信。",
+          "answer_outline": [
+            "判断模块和设问类型：经济、政治、法治、哲学或文化。",
+            "圈出材料主体、行为、结果和关键词。",
+            "匹配教材概念并展开“材料+观点+分析”。",
+            "检查角度是否完整、术语是否规范。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "pol_junior_national_security",
+      "name": "国家安全教育",
+      "subject": "politics",
+      "stage": "junior_high",
+      "chapter": "道德与法治",
+      "depth": 2,
+      "difficulty": 0.44,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_junior_collective_responsibility",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "国家安全材料应先识别安全领域和风险行为，再落实到个人、集体和社会责任。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_junior_rule_law",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "reason": "维护国家安全常通过遵守法律、规则和公共秩序来考查法治意识的应用。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rights_obligations",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "学生容易只强调个人权利，忽略维护国家安全时权利行使和义务履行的边界。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_junior_rule_morality",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.77,
+          "reason": "Practice 道德与法律关系 after 国家安全教育; it is the next topic in the junior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背术语不扣材料",
+        "主体和角度错位",
+        "答案层次不清"
+      ],
+      "unit": "国家安全",
+      "skills": [
+        "识别材料主体、行为和设问类型",
+        "匹配教材核心概念并扣材料分析",
+        "按原因意义措施评析组织答案"
+      ],
+      "question_types": [
+        "材料题",
+        "价值判断"
+      ],
+      "examples": [
+        {
+          "prompt": "结合生活案例说明维护国家安全与青少年行为的关系。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "pol_junior_rule_morality",
+      "name": "道德与法律关系",
+      "subject": "politics",
+      "stage": "junior_high",
+      "chapter": "道德与法治",
+      "depth": 2,
+      "difficulty": 0.46,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_junior_rule_law",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "辨析道德和法律关系时，应先区分规范来源、约束方式和后果，再回到法治意识判断。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_junior_rights_obligations",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.8,
+          "reason": "公共生活中的权利行使和义务履行常同时涉及道德约束与法律规范。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_rule_of_law",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.78,
+          "reason": "道德与法律关系容易被误答成全面依法治国的制度措施题，需要区分初中辨析和高中法治体系层次。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        }
+      ],
+      "typical_misconceptions": [
+        "只背术语不扣材料",
+        "主体和角度错位",
+        "答案层次不清"
+      ],
+      "unit": "法治与德治",
+      "skills": [
+        "识别材料主体、行为和设问类型",
+        "匹配教材核心概念并扣材料分析",
+        "按原因意义措施评析组织答案"
+      ],
+      "question_types": [
+        "观点说明",
+        "材料分析"
+      ],
+      "examples": [
+        {
+          "prompt": "分析某公共事件中道德约束和法律规范的不同作用。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "junior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "zhongkao_regional_style"
+      ],
+      "curriculum_version": [
+        "generic_cn_junior",
+        "renjiao_junior",
+        "beishi_junior",
+        "sujiao_junior"
+      ],
+      "exam_region": [
+        "zhongkao_local_generic",
+        "zhongkao_beijing_style",
+        "zhongkao_shanghai_style",
+        "zhongkao_jiangsu_style"
+      ],
+      "exam_type": [
+        "daily_practice",
+        "unit_test",
+        "zhongkao_style"
+      ]
+    },
+    {
+      "id": "pol_senior_socialism_market",
+      "name": "社会主义市场经济体制",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "经济与社会",
+      "depth": 2,
+      "difficulty": 0.66,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_senior_economy_market",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.88,
+          "reason": "分析社会主义市场经济体制时，应先判断市场机制和宏观调控如何分别发挥作用。",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "pol_senior_international_relations",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.79,
+          "reason": "开放型经济、高质量发展和国际合作材料常用于考查社会主义市场经济体制的应用。",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_economy_market",
+          "relation": "confusable",
+          "priority": "core",
+          "context": "diagnosis",
+          "confidence": 0.84,
+          "reason": "学生容易把一般市场机制与社会主义市场经济体制混同，忽略制度优势和政府作用。",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ]
+        },
+        {
+          "id": "pol_senior_international_relations",
+          "relation": "extends",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.78,
+          "reason": "Practice 国际关系与中国外交 after 社会主义市场经济体制; it is the next topic in the senior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "college_econ_market_failure_synthesis",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "Socialist market economy materials often ask why market failure requires coordinated public action.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "economics",
+            "bridge_direction": "politics_to_economics"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背术语不扣材料",
+        "主体和角度错位",
+        "答案层次不清"
+      ],
+      "unit": "经济制度",
+      "skills": [
+        "识别材料主体、行为和设问类型",
+        "匹配教材核心概念并扣材料分析",
+        "按原因意义措施评析组织答案"
+      ],
+      "question_types": [
+        "经济分析",
+        "材料题"
+      ],
+      "examples": [
+        {
+          "prompt": "说明有效市场和有为政府如何共同促进高质量发展。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "pol_senior_international_relations",
+      "name": "国际关系与中国外交",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "当代国际政治",
+      "depth": 3,
+      "difficulty": 0.68,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "extends",
+          "reason": "Practice 逻辑与思维方法 after 国际关系与中国外交; it is the next topic in the senior_high politics learning sequence.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning"
+          ]
+        },
+        {
+          "id": "history_senior_globalization",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.89,
+          "reason": "International-relations materials connect to globalization, world markets, and historical interaction patterns.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "history",
+            "bridge_direction": "politics_to_history"
+          }
+        },
+        {
+          "id": "history_senior_modernization_comparison",
+          "relation": "application",
+          "priority": "useful",
+          "context": "review",
+          "confidence": 0.84,
+          "reason": "Foreign-policy analysis can be compared with historical modernization paths and changing power structures.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "history",
+            "bridge_direction": "politics_to_history"
+          }
+        },
+        {
+          "id": "geo_senior_regional_sustainability",
+          "relation": "application",
+          "priority": "useful",
+          "context": "practice",
+          "confidence": 0.82,
+          "reason": "International cooperation questions often require regional analysis of resources, development, and sustainability.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "geography",
+            "bridge_direction": "politics_to_geography"
+          }
+        },
+        {
+          "id": "pol_junior_national_security",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.8,
+          "reason": "International-relations prompts can be confused with domestic security prompts unless the actors, arena, and diplomacy are identified.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "politics",
+            "bridge_direction": "politics_internal"
+          }
+        },
+        {
+          "id": "pol_senior_logical_thinking",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.86,
+          "reason": "After identifying international actors and interests, students should test claims with premise, evidence, and conclusion checks.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "politics",
+            "bridge_direction": "politics_internal"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背术语不扣材料",
+        "主体和角度错位",
+        "答案层次不清"
+      ],
+      "unit": "国际关系",
+      "skills": [
+        "识别材料主体、行为和设问类型",
+        "匹配教材核心概念并扣材料分析",
+        "按原因意义措施评析组织答案"
+      ],
+      "question_types": [
+        "政治分析",
+        "材料题"
+      ],
+      "examples": [
+        {
+          "prompt": "结合国际合作材料分析国家利益、和平发展与人类命运共同体。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    },
+    {
+      "id": "pol_senior_logical_thinking",
+      "name": "逻辑与思维方法",
+      "subject": "politics",
+      "stage": "senior_high",
+      "chapter": "逻辑与思维",
+      "depth": 2,
+      "difficulty": 0.62,
+      "prerequisites": [],
+      "related": [
+        {
+          "id": "pol_senior_philosophy_dialectics",
+          "relation": "confusable",
+          "priority": "useful",
+          "context": "diagnosis",
+          "confidence": 0.82,
+          "reason": "Logical-thinking tasks are often confused with dialectics unless students distinguish formal inference from contradiction and development analysis.",
+          "use_cases": [
+            "diagnosis",
+            "hint_generation",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "politics",
+            "bridge_direction": "politics_internal"
+          }
+        },
+        {
+          "id": "pol_senior_international_relations",
+          "relation": "procedure_step",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.85,
+          "reason": "Logic methods should be applied to material questions by separating claims, reasons, assumptions, and policy conclusions.",
+          "use_cases": [
+            "learning_path",
+            "hint_generation",
+            "practice_planning"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "politics",
+            "bridge_direction": "politics_internal"
+          }
+        },
+        {
+          "id": "chinese_senior_composition_argument",
+          "relation": "application",
+          "priority": "core",
+          "context": "practice",
+          "confidence": 0.84,
+          "reason": "Formal argument checks transfer to composition tasks that require clear claims, valid reasoning, and evidence-based rebuttal.",
+          "use_cases": [
+            "learning_path",
+            "practice_planning",
+            "review"
+          ],
+          "metadata": {
+            "source_subject": "politics",
+            "target_subject": "chinese",
+            "bridge_direction": "politics_to_chinese"
+          }
+        }
+      ],
+      "typical_misconceptions": [
+        "只背术语不扣材料",
+        "主体和角度错位",
+        "答案层次不清"
+      ],
+      "unit": "科学思维",
+      "skills": [
+        "识别材料主体、行为和设问类型",
+        "匹配教材核心概念并扣材料分析",
+        "按原因意义措施评析组织答案"
+      ],
+      "question_types": [
+        "逻辑推理",
+        "观点辨析"
+      ],
+      "examples": [
+        {
+          "prompt": "判断一个三段论推理是否有效，并说明大项中项小项关系。",
+          "answer_outline": [
+            "判断题目材料和设问类型。",
+            "提取关键词、图表数据或实验条件。",
+            "调用对应概念、模型或方法分步分析。",
+            "检查结论是否扣题、规范且完整。"
+          ]
+        }
+      ],
+      "curriculum_tags": [
+        "multi_subject_seed",
+        "politics",
+        "senior_high",
+        "subject_depth_boost",
+        "curriculum_context",
+        "gaokao_regional_style",
+        "humanities_elective_track"
+      ],
+      "curriculum_version": [
+        "generic_cn_high_school",
+        "renjiao_high_school",
+        "beishi_high_school",
+        "sujiao_high_school"
+      ],
+      "exam_region": [
+        "new_gaokao_generic",
+        "new_gaokao_i",
+        "new_gaokao_ii",
+        "national_a",
+        "national_b"
+      ],
+      "exam_type": [
+        "school_exam",
+        "academic_level_exam",
+        "gaokao_style"
+      ]
+    }
+  ]
+}

--- a/plugin/plugins/study_companion/store_topics.py
+++ b/plugin/plugins/study_companion/store_topics.py
@@ -166,65 +166,65 @@ def upsert_topic(self, topic: dict[str, Any], *, commit: bool = True) -> None:
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
             ON CONFLICT(id) DO UPDATE SET
-                name = CASE WHEN topics.source = 'seed' THEN topics.name ELSE excluded.name END,
-                subject = CASE WHEN topics.source = 'seed' THEN topics.subject ELSE excluded.subject END,
-                chapter = CASE WHEN topics.source = 'seed' THEN topics.chapter ELSE excluded.chapter END,
+                name = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.name ELSE excluded.name END,
+                subject = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.subject ELSE excluded.subject END,
+                chapter = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.chapter ELSE excluded.chapter END,
                 stage = CASE
-                    WHEN topics.source = 'seed' AND topics.stage = '' AND excluded.stage != '' THEN excluded.stage
-                    WHEN topics.source = 'seed' THEN topics.stage
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.stage = '' AND excluded.stage != '' THEN excluded.stage
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.stage
                     ELSE excluded.stage
                 END,
                 unit = CASE
-                    WHEN topics.source = 'seed' AND (topics.unit = '' OR topics.unit = topics.chapter) AND excluded.unit != '' THEN excluded.unit
-                    WHEN topics.source = 'seed' THEN topics.unit
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND (topics.unit = '' OR topics.unit = topics.chapter) AND excluded.unit != '' THEN excluded.unit
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.unit
                     ELSE excluded.unit
                 END,
-                depth = CASE WHEN topics.source = 'seed' THEN topics.depth ELSE excluded.depth END,
-                difficulty = CASE WHEN topics.source = 'seed' THEN topics.difficulty ELSE excluded.difficulty END,
-                prerequisites = CASE WHEN topics.source = 'seed' THEN topics.prerequisites ELSE excluded.prerequisites END,
-                related = CASE WHEN topics.source = 'seed' THEN topics.related ELSE excluded.related END,
-                typical_misconceptions = CASE WHEN topics.source = 'seed' THEN topics.typical_misconceptions ELSE excluded.typical_misconceptions END,
+                depth = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.depth ELSE excluded.depth END,
+                difficulty = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.difficulty ELSE excluded.difficulty END,
+                prerequisites = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.prerequisites ELSE excluded.prerequisites END,
+                related = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.related ELSE excluded.related END,
+                typical_misconceptions = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.typical_misconceptions ELSE excluded.typical_misconceptions END,
                 skills = CASE
-                    WHEN topics.source = 'seed' AND topics.skills = '[]' AND excluded.skills != '[]' THEN excluded.skills
-                    WHEN topics.source = 'seed' THEN topics.skills
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.skills = '[]' AND excluded.skills != '[]' THEN excluded.skills
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.skills
                     ELSE excluded.skills
                 END,
                 question_types = CASE
-                    WHEN topics.source = 'seed' AND topics.question_types = '[]' AND excluded.question_types != '[]' THEN excluded.question_types
-                    WHEN topics.source = 'seed' THEN topics.question_types
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.question_types = '[]' AND excluded.question_types != '[]' THEN excluded.question_types
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.question_types
                     ELSE excluded.question_types
                 END,
                 examples = CASE
-                    WHEN topics.source = 'seed' AND topics.examples = '[]' AND excluded.examples != '[]' THEN excluded.examples
-                    WHEN topics.source = 'seed' THEN topics.examples
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.examples = '[]' AND excluded.examples != '[]' THEN excluded.examples
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.examples
                     ELSE excluded.examples
                 END,
                 course_family = CASE
-                    WHEN topics.source = 'seed' AND topics.course_family = '' AND excluded.course_family != '' THEN excluded.course_family
-                    WHEN topics.source = 'seed' THEN topics.course_family
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.course_family = '' AND excluded.course_family != '' THEN excluded.course_family
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.course_family
                     ELSE excluded.course_family
                 END,
                 curriculum_version = CASE
-                    WHEN topics.source = 'seed' AND topics.curriculum_version = '[]' AND excluded.curriculum_version != '[]' THEN excluded.curriculum_version
-                    WHEN topics.source = 'seed' THEN topics.curriculum_version
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.curriculum_version = '[]' AND excluded.curriculum_version != '[]' THEN excluded.curriculum_version
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.curriculum_version
                     ELSE excluded.curriculum_version
                 END,
                 exam_region = CASE
-                    WHEN topics.source = 'seed' AND topics.exam_region = '[]' AND excluded.exam_region != '[]' THEN excluded.exam_region
-                    WHEN topics.source = 'seed' THEN topics.exam_region
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.exam_region = '[]' AND excluded.exam_region != '[]' THEN excluded.exam_region
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.exam_region
                     ELSE excluded.exam_region
                 END,
                 exam_type = CASE
-                    WHEN topics.source = 'seed' AND topics.exam_type = '[]' AND excluded.exam_type != '[]' THEN excluded.exam_type
-                    WHEN topics.source = 'seed' THEN topics.exam_type
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.exam_type = '[]' AND excluded.exam_type != '[]' THEN excluded.exam_type
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.exam_type
                     ELSE excluded.exam_type
                 END,
                 aliases = CASE
-                    WHEN topics.source = 'seed' AND topics.aliases = '[]' AND excluded.aliases != '[]' THEN excluded.aliases
-                    WHEN topics.source = 'seed' THEN topics.aliases
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' AND topics.aliases = '[]' AND excluded.aliases != '[]' THEN excluded.aliases
+                    WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.aliases
                     ELSE excluded.aliases
                 END,
-                source = CASE WHEN topics.source = 'seed' THEN topics.source ELSE excluded.source END,
+                source = CASE WHEN topics.source = 'seed' AND excluded.source != 'seed' THEN topics.source ELSE excluded.source END,
                 updated_at = datetime('now')
             """,
             (

--- a/plugin/plugins/study_companion/ui_api.py
+++ b/plugin/plugins/study_companion/ui_api.py
@@ -144,7 +144,8 @@ def build_knowledge_map_payload(
         stage_counts[stage] = stage_counts.get(stage, 0) + 1
         subject_counts[subject] = subject_counts.get(subject, 0) + 1
         chapter_counts[chapter] = chapter_counts.get(chapter, 0) + 1
-        unit_counts[unit] = unit_counts.get(unit, 0) + 1
+        unit_key = f"{subject}:{unit}" if subject else unit
+        unit_counts[unit_key] = unit_counts.get(unit_key, 0) + 1
         mastery = mastery_by_topic.get(topic_id) or {}
         weak = topic_id in weak_topic_ids
         if weak:
@@ -162,9 +163,9 @@ def build_knowledge_map_payload(
                 "question_types": list(topic.get("question_types") or []),
                 "examples": list(topic.get("examples") or []),
                 "typical_misconceptions": list(
-                    topic.get("typical_misconceptions")
-                    or topic.get("misconceptions")
-                    or []
+                    topic["typical_misconceptions"]
+                    if isinstance(topic.get("typical_misconceptions"), list)
+                    else topic.get("misconceptions") or []
                 ),
                 "mastery": float(mastery.get("mastery") or 0.0),
                 "level": str(mastery.get("level") or ""),

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -1108,6 +1108,46 @@ def test_study_store_seed_topic_upsert_preserves_seed_metadata(tmp_path: Path) -
         store.close()
 
 
+def test_study_store_seed_topic_upsert_refreshes_seed_metadata(tmp_path: Path) -> None:
+    store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
+    store.open()
+    try:
+        store.upsert_topic(
+            {
+                "id": "seed_topic",
+                "name": "Old Seed Topic",
+                "subject": "math",
+                "chapter": "Old Chapter",
+                "prerequisites": [{"id": "old_pre"}],
+                "related": [{"id": "old_related", "relation": "next"}],
+                "source": "seed",
+            }
+        )
+        store.upsert_topic(
+            {
+                "id": "seed_topic",
+                "name": "New Seed Topic",
+                "subject": "math",
+                "chapter": "New Chapter",
+                "prerequisites": [{"id": "new_pre"}],
+                "related": [{"id": "new_related", "relation": "application"}],
+                "source": "seed",
+            }
+        )
+
+        topic = store.get_topic("seed_topic")
+        assert topic is not None
+        assert topic["name"] == "New Seed Topic"
+        assert topic["chapter"] == "New Chapter"
+        assert topic["prerequisites"] == [{"id": "new_pre"}]
+        assert topic["related"] == [
+            {"id": "new_related", "relation": "application"}
+        ]
+        assert topic["source"] == "seed"
+    finally:
+        store.close()
+
+
 def test_study_store_enforces_sqlite_foreign_keys(tmp_path: Path) -> None:
     store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
     store.open()
@@ -1520,6 +1560,33 @@ def test_knowledge_map_related_object_edges_use_topic_ids() -> None:
         }
     ]
     assert not any(str(edge["to"]).startswith("{") for edge in payload["edges"])
+
+
+def test_knowledge_map_keeps_subject_units_and_empty_misconceptions_distinct() -> None:
+    payload = build_knowledge_map_payload(
+        topics=[
+            {
+                "id": "math_unit",
+                "name": "Math Unit",
+                "subject": "math",
+                "unit": "综合应用",
+                "typical_misconceptions": [],
+                "misconceptions": ["legacy value"],
+            },
+            {
+                "id": "physics_unit",
+                "name": "Physics Unit",
+                "subject": "physics",
+                "unit": "综合应用",
+            },
+        ]
+    )
+
+    assert payload["summary"]["unit_counts"] == {
+        "math:综合应用": 1,
+        "physics:综合应用": 1,
+    }
+    assert payload["nodes"][0]["typical_misconceptions"] == []
 
 
 def test_build_tutor_payload_preserves_structured_summary() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
+++ b/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
@@ -18,7 +18,7 @@ from plugin.plugins.study_companion.knowledge_seed_validator import (
 pytestmark = pytest.mark.unit
 
 
-def test_bundled_legacy_seed_validates_with_quality_gaps() -> None:
+def test_bundled_seed_manifest_validates_all_topics() -> None:
     seed = (
         Path(__file__).resolve().parents[3]
         / "plugins"
@@ -30,7 +30,7 @@ def test_bundled_legacy_seed_validates_with_quality_gaps() -> None:
     result = validate_knowledge_seed_manifest(seed)
 
     assert result.is_valid
-    assert len(result.topics) == 457
+    assert len(result.topics) == 820
     assert result.report["schema_ready_topics"] == len(result.topics)
 
 

--- a/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
+++ b/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
@@ -44,6 +44,47 @@ def test_bundled_seed_manifest_validates_all_topics() -> None:
     assert result.report["schema_ready_topics"] == len(result.topics)
 
 
+def test_chinese_main_idea_bridge_extends_into_junior_narrative_reading() -> None:
+    seed = (
+        Path(__file__).resolve().parents[3]
+        / "plugins"
+        / "study_companion"
+        / "static"
+        / "knowledge_seeds"
+        / "chinese.json"
+    )
+    payload = json.loads(seed.read_text(encoding="utf-8"))
+    topics = payload["topics"]
+    main_idea = next(
+        topic
+        for topic in topics
+        if topic.get("id") == "chinese_primary_paragraph_main_idea"
+    )
+    narrative = next(
+        topic
+        for topic in topics
+        if topic.get("id") == "chinese_junior_narrative_reading"
+    )
+
+    edges = build_topic_edges([main_idea, narrative])
+    bridge = next(
+        edge
+        for edge in edges
+        if {
+            edge.get("from"),
+            edge.get("to"),
+        }
+        == {
+            "chinese_primary_paragraph_main_idea",
+            "chinese_junior_narrative_reading",
+        }
+    )
+
+    assert bridge["relation"] == "extends"
+    assert bridge["from"] == "chinese_primary_paragraph_main_idea"
+    assert bridge["to"] == "chinese_junior_narrative_reading"
+
+
 def test_compact_confusion_labels_use_related_topic_label() -> None:
     payload = build_knowledge_guidance_payload(
         topics=[

--- a/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
+++ b/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+import json
 from pathlib import Path
 
 import pytest
@@ -7,9 +9,16 @@ import pytest
 from plugin.plugins.study_companion.entry_tutor_context_support import (
     _TutorContextSupportMixin,
 )
+from plugin.plugins.study_companion.entry_knowledge_entries import _KnowledgeEntriesMixin
 from plugin.plugins.study_companion._graph_utils import topic_id, topic_label
 from plugin.plugins.study_companion.knowledge_graph_guidance import (
+    _build_diagnosis_questions,
+    build_topic_edges,
     build_knowledge_guidance_payload,
+    match_topics,
+)
+from plugin.plugins.study_companion.knowledge_retrieval_eval import (
+    evaluate_knowledge_retrieval_queries,
 )
 from plugin.plugins.study_companion.knowledge_seed_validator import (
     validate_knowledge_seed_manifest,
@@ -86,3 +95,197 @@ def test_knowledge_guidance_cache_can_be_invalidated() -> None:
     host._invalidate_knowledge_guidance_cache()
 
     assert host._knowledge_guidance_topics_cache == {}
+
+
+def test_related_prerequisite_edges_point_from_prerequisite_to_topic() -> None:
+    edges = build_topic_edges(
+        [
+            {
+                "id": "advanced",
+                "name": "Advanced",
+                "related": [
+                    {
+                        "id": "foundation",
+                        "relation": "prerequisite",
+                        "reason": "Foundation comes first.",
+                    }
+                ],
+            },
+            {"id": "foundation", "name": "Foundation", "related": []},
+        ]
+    )
+
+    assert [(edge["from"], edge["to"]) for edge in edges] == [
+        ("foundation", "advanced")
+    ]
+
+
+def test_topic_matching_has_no_implicit_math_bonus() -> None:
+    topics = [
+        {"id": "math_common", "name": "Common", "subject": "math"},
+        {"id": "history_common", "name": "Common", "subject": "history"},
+    ]
+
+    neutral = match_topics(topics, query="common", limit=2)
+    assert {item["score"] for item in neutral} == {neutral[0]["score"]}
+
+    hinted = match_topics(topics, query="history common", limit=2)
+    assert hinted[0]["id"] == "history_common"
+
+
+def test_prerequisite_question_cap_keeps_later_application_questions() -> None:
+    learning_path = [
+        {
+            "from": f"pre_{index}",
+            "to": "focus",
+            "from_label": f"Prerequisite {index}",
+            "to_label": "Focus",
+            "relation": "prerequisite",
+        }
+        for index in range(4)
+    ]
+    learning_path.append(
+        {
+            "from": "focus",
+            "to": "application",
+            "from_label": "Focus",
+            "to_label": "Application",
+            "relation": "application",
+        }
+    )
+
+    questions = _build_diagnosis_questions(
+        selected_id="focus",
+        selected_label="Focus",
+        learning_path=learning_path,
+        confusions=[],
+        next_practice=[],
+    )
+
+    assert sum(item["kind"] == "prerequisite_probe" for item in questions) == 3
+    assert any(item["kind"] == "application_practice" for item in questions)
+
+
+def test_nested_seed_manifests_are_expanded(tmp_path: Path) -> None:
+    seed_path = tmp_path / "seed.json"
+    child_manifest = tmp_path / "child.json"
+    root_manifest = tmp_path / "root.json"
+    seed_path.write_text(
+        json.dumps(
+            {
+                "subject": "art",
+                "topics": [
+                    {
+                        "id": "color",
+                        "name": "Color",
+                        "subject": "art",
+                        "stage": "primary",
+                        "chapter": "Basics",
+                        "unit": "Color",
+                        "prerequisites": [],
+                        "related": [],
+                        "skills": ["observe"],
+                        "question_types": ["identify"],
+                        "examples": [],
+                        "typical_misconceptions": ["tone equals hue"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    child_manifest.write_text(
+        json.dumps({"files": [{"path": seed_path.name}]}), encoding="utf-8"
+    )
+    root_manifest.write_text(
+        json.dumps({"files": [{"path": child_manifest.name}]}), encoding="utf-8"
+    )
+
+    result = validate_knowledge_seed_manifest(root_manifest)
+
+    assert result.is_valid
+    assert [topic.data["id"] for topic in result.topics] == ["color"]
+
+
+def test_related_prerequisites_participate_in_cycle_detection(tmp_path: Path) -> None:
+    def topic(current: str, prerequisite: str) -> dict[str, object]:
+        return {
+            "id": current,
+            "name": current,
+            "subject": "art",
+            "stage": "primary",
+            "chapter": "Cycle",
+            "unit": "Cycle",
+            "prerequisites": [],
+            "related": [
+                {
+                    "id": prerequisite,
+                    "relation": "prerequisite",
+                    "reason": "Cycle fixture.",
+                    "priority": "core",
+                    "context": "diagnosis",
+                    "confidence": 0.9,
+                    "use_cases": ["learning_path"],
+                }
+            ],
+            "skills": ["observe"],
+            "question_types": ["identify"],
+            "examples": [],
+            "typical_misconceptions": ["cycle"],
+        }
+
+    seed = tmp_path / "cycle.json"
+    seed.write_text(
+        json.dumps({"topics": [topic("a", "b"), topic("b", "a")]}),
+        encoding="utf-8",
+    )
+
+    result = validate_knowledge_seed_manifest(seed)
+
+    assert result.report["cycles_in_prerequisites"] == 2
+
+
+def test_cross_subject_expectation_is_part_of_eval_result() -> None:
+    report = evaluate_knowledge_retrieval_queries(
+        topics=[
+            {
+                "id": "biology",
+                "name": "Genetics",
+                "subject": "biology",
+                "stage": "senior_high",
+                "chapter": "Genetics",
+                "unit": "Genetics",
+                "prerequisites": [],
+                "related": [],
+            },
+            {
+                "id": "math",
+                "name": "Probability",
+                "subject": "math",
+                "stage": "senior_high",
+                "chapter": "Probability",
+                "unit": "Probability",
+                "prerequisites": [],
+                "related": [],
+            },
+        ],
+        cases=[
+            {
+                "topic_id": "biology",
+                "expected_topic_ids": ["biology"],
+                "expect_cross_subject": True,
+            }
+        ],
+    )
+
+    assert report["summary"]["failed_count"] == 1
+    assert report["results"][0]["passed"] is False
+    assert report["results"][0]["failure_reasons"] == [
+        "expected cross-subject edge was not returned"
+    ]
+
+
+def test_guidance_default_limit_covers_bundled_manifest() -> None:
+    signature = inspect.signature(_KnowledgeEntriesMixin.study_knowledge_guidance)
+
+    assert signature.parameters["limit"].default == 1000

--- a/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
+++ b/plugin/tests/unit/plugins/test_study_companion_knowledge_graph_infra.py
@@ -21,6 +21,7 @@ from plugin.plugins.study_companion.knowledge_retrieval_eval import (
     evaluate_knowledge_retrieval_queries,
 )
 from plugin.plugins.study_companion.knowledge_seed_validator import (
+    main as validate_knowledge_seed_main,
     validate_knowledge_seed_manifest,
 )
 
@@ -205,6 +206,137 @@ def test_nested_seed_manifests_are_expanded(tmp_path: Path) -> None:
 
     assert result.is_valid
     assert [topic.data["id"] for topic in result.topics] == ["color"]
+
+
+def test_nested_manifest_topic_count_includes_descendant_topics(
+    tmp_path: Path,
+) -> None:
+    seed_path = tmp_path / "seed.json"
+    child_manifest = tmp_path / "child.json"
+    root_manifest = tmp_path / "root.json"
+    seed_path.write_text(
+        json.dumps(
+            {
+                "subject": "art",
+                "topics": [
+                    {
+                        "id": "color",
+                        "name": "Color",
+                        "subject": "art",
+                        "stage": "primary",
+                        "chapter": "Basics",
+                        "unit": "Color",
+                        "prerequisites": [],
+                        "related": [],
+                        "skills": ["observe"],
+                        "question_types": ["identify"],
+                        "examples": [],
+                        "typical_misconceptions": ["tone equals hue"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    child_manifest.write_text(
+        json.dumps({"files": [{"path": seed_path.name, "topic_count": 1}]}),
+        encoding="utf-8",
+    )
+    root_manifest.write_text(
+        json.dumps({"files": [{"path": child_manifest.name, "topic_count": 1}]}),
+        encoding="utf-8",
+    )
+
+    result = validate_knowledge_seed_manifest(root_manifest)
+
+    assert result.is_valid
+    assert [topic.data["id"] for topic in result.topics] == ["color"]
+
+
+def test_nested_manifest_reports_invalid_references(tmp_path: Path) -> None:
+    child_manifest = tmp_path / "child.json"
+    invalid_json = tmp_path / "invalid.json"
+    root_manifest = tmp_path / "root.json"
+    child_manifest.write_text(
+        json.dumps({"files": [{"path": root_manifest.name}]}),
+        encoding="utf-8",
+    )
+    invalid_json.write_text("not json", encoding="utf-8")
+    root_manifest.write_text(
+        json.dumps(
+            {
+                "files": [
+                    {"path": child_manifest.name},
+                    {"path": child_manifest.name},
+                    {"path": "missing.json"},
+                    {},
+                    {"path": invalid_json.name},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = validate_knowledge_seed_manifest(root_manifest)
+    issue_codes = {issue.code for issue in result.issues}
+
+    assert {
+        "circular_manifest_reference",
+        "duplicate_manifest_file",
+        "missing_manifest_file",
+        "invalid_manifest_file",
+        "invalid_json",
+    } <= issue_codes
+
+
+def test_bundled_seed_uses_semantic_prerequisite_and_support_relations() -> None:
+    seed = (
+        Path(__file__).resolve().parents[3]
+        / "plugins"
+        / "study_companion"
+        / "static"
+        / "knowledge_graph_seed.json"
+    )
+    result = validate_knowledge_seed_manifest(seed)
+    topics = {str(topic.data["id"]): topic.data for topic in result.topics}
+
+    sentence_expansion = topics["chinese_primary_sentence_expansion"]
+    assert any(
+        ref["id"] == "chinese_primary_pinyin_character"
+        for ref in sentence_expansion["prerequisites"]
+    )
+    assert not any(
+        ref["id"] == "chinese_primary_pinyin_character"
+        and ref.get("relation") == "prerequisite"
+        for ref in sentence_expansion["related"]
+    )
+
+    industrial_location = topics["geo_senior_industrial_location"]
+    history_ref = next(
+        ref
+        for ref in industrial_location["related"]
+        if ref["id"] == "history_junior_industrial_revolution"
+    )
+    assert history_ref["relation"] == "co_occurs"
+
+
+def test_validator_cli_formats_bundled_report(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    seed = (
+        Path(__file__).resolve().parents[3]
+        / "plugins"
+        / "study_companion"
+        / "static"
+        / "knowledge_graph_seed.json"
+    )
+
+    exit_code = validate_knowledge_seed_main([str(seed)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Knowledge Seed Quality Report" in output
+    assert "validated 820 knowledge seed topics" in output
 
 
 def test_related_prerequisites_participate_in_cycle_detection(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## 改动概览

补齐多学科知识图谱 seed，恢复完整 manifest、评估用例和跨学科桥接关系。

## 为什么改

数学单学科 seed 只能验证局部结构。伴学知识图谱真正可用需要多学科节点、跨学科应用关系和整体一致性校验同时成立。

## 怎么改

- 增加各学科 seed 文件。
- 恢复完整知识图谱 manifest。
- 增加知识图谱评估用例。
- 恢复数学与其他学科之间的跨学科关系边。

## 为什么不继续拆

这一层的 manifest、跨学科边和全局 validator 结果互相绑定。如果按学科继续拆，会让大量边在中间 PR 中临时断开，反而更难审查整体一致性。

## 风险与边界

主要风险集中在数据质量和跨学科关系是否合理；代码逻辑变更已经放在前置基础设施 PR 中。

## 验证

- 知识图谱 validator 通过。
- 结果：820 个 topic，5016 条 typed edge，0 个 issue，0 个孤立节点，0 个过度连接节点，0 个前置依赖环。
- 全量 schema ready：820/820。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增知识图谱引导，可按主题、查询、阶段和课程筛选学习路径、关联知识、常见困惑及下一步练习。
  - 支持审核知识候选主题，批准或拒绝操作将同步更新候选状态。
  - 知识地图支持学科筛选，并展示更丰富的节点、关系与统计信息。
  - 扩展多学科知识库，覆盖英语、语文、物理、化学、生物、历史、地理、政治、计算机科学和经济学。

- **改进**
  - 概念讲解可结合知识图谱引导，提供更精准的学习上下文与诊断问题。
  - 增强知识数据校验、检索评估和数据库迁移兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->