### PR TITLE
修复 PNGTuber 导入菜单打开文件选择器时的 DOM 移除时序问题，避免 blur 期间重复移除节点导致 NotFoundError…

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -9068,12 +9068,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // 上传模型功能
     let pngtuberUploadChoiceMenu = null;
+    let pngtuberUploadChoiceOpeningPicker = false;
 
     function closePNGTuberUploadChoice() {
-        if (pngtuberUploadChoiceMenu) {
-            pngtuberUploadChoiceMenu.remove();
+        const menu = pngtuberUploadChoiceMenu;
+        if (menu) {
             pngtuberUploadChoiceMenu = null;
             document.removeEventListener('mousedown', handlePNGTuberUploadChoiceOutsideClick, true);
+            if (menu.parentNode) {
+                menu.parentNode.removeChild(menu);
+            }
         }
     }
 
@@ -9094,6 +9098,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     function handlePNGTuberUploadChoiceFocusout(event) {
         const nextTarget = event.relatedTarget;
         if (!pngtuberUploadChoiceMenu) return;
+        if (pngtuberUploadChoiceOpeningPicker) return;
         if (nextTarget && (pngtuberUploadChoiceMenu.contains(nextTarget) || uploadBtn.contains(nextTarget))) return;
         closePNGTuberUploadChoice();
     }
@@ -9105,8 +9110,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         item.tabIndex = 0;
         item.innerHTML = `<span class="dropdown-item-text" data-text="${label}">${label}</span>`;
         const select = () => {
-            closePNGTuberUploadChoice();
+            pngtuberUploadChoiceOpeningPicker = true;
             onSelect();
+            setTimeout(() => {
+                pngtuberUploadChoiceOpeningPicker = false;
+                closePNGTuberUploadChoice();
+            }, 0);
         };
         item.addEventListener('click', select);
         item.addEventListener('keydown', (event) => {

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -9111,11 +9111,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         item.innerHTML = `<span class="dropdown-item-text" data-text="${label}">${label}</span>`;
         const select = () => {
             pngtuberUploadChoiceOpeningPicker = true;
-            onSelect();
-            setTimeout(() => {
-                pngtuberUploadChoiceOpeningPicker = false;
-                closePNGTuberUploadChoice();
-            }, 0);
+            try {
+                onSelect();
+            } finally {
+                setTimeout(() => {
+                    pngtuberUploadChoiceOpeningPicker = false;
+                    closePNGTuberUploadChoice();
+                }, 0);
+            }
         };
         item.addEventListener('click', select);
         item.addEventListener('keydown', (event) => {

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -178,6 +178,11 @@ def test_model_manager_pngtuber_upload_supports_project_file_without_removing_fo
     assert "uploadPNGTuberFiles(Array.from(e.target.files));" in script
     assert "menu.addEventListener('keydown', handlePNGTuberUploadChoiceKeydown);" in script
     assert "menu.addEventListener('focusout', handlePNGTuberUploadChoiceFocusout);" in script
+    assert "let pngtuberUploadChoiceOpeningPicker = false;" in script
+    assert "if (pngtuberUploadChoiceOpeningPicker) return;" in script
+    assert "setTimeout(() => {" in script
+    assert "menu.parentNode.removeChild(menu);" in script
+    assert "pngtuberUploadChoiceMenu.remove();" not in script
     assert "event.key === 'Escape'" in script
     assert "window.t('live2d.pngtuberImportProjectFile')" in script
     assert "window.t('live2d.pngtuberImportFolder')" in script

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 
@@ -186,12 +187,12 @@ def test_model_manager_pngtuber_upload_supports_project_file_without_removing_fo
         script.index("function createPNGTuberUploadChoiceItem"):
         script.index("function showPNGTuberUploadChoice")
     ]
-    assert "try {\n                onSelect();" in choice_item_block
-    assert "} finally {\n                setTimeout(() => {" in choice_item_block
-    assert (
-        "pngtuberUploadChoiceOpeningPicker = false;\n"
-        "                    closePNGTuberUploadChoice();"
-    ) in choice_item_block
+    assert re.search(
+        r"try\s*\{\s*onSelect\(\);\s*\}\s*finally\s*\{\s*setTimeout\(\(\)\s*=>\s*\{\s*"
+        r"pngtuberUploadChoiceOpeningPicker\s*=\s*false;\s*closePNGTuberUploadChoice\(\);\s*"
+        r"\},\s*0\);\s*\}",
+        choice_item_block,
+    )
     assert "event.key === 'Escape'" in script
     assert "window.t('live2d.pngtuberImportProjectFile')" in script
     assert "window.t('live2d.pngtuberImportFolder')" in script

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -180,9 +180,18 @@ def test_model_manager_pngtuber_upload_supports_project_file_without_removing_fo
     assert "menu.addEventListener('focusout', handlePNGTuberUploadChoiceFocusout);" in script
     assert "let pngtuberUploadChoiceOpeningPicker = false;" in script
     assert "if (pngtuberUploadChoiceOpeningPicker) return;" in script
-    assert "setTimeout(() => {" in script
     assert "menu.parentNode.removeChild(menu);" in script
     assert "pngtuberUploadChoiceMenu.remove();" not in script
+    choice_item_block = script[
+        script.index("function createPNGTuberUploadChoiceItem"):
+        script.index("function showPNGTuberUploadChoice")
+    ]
+    assert "try {\n                onSelect();" in choice_item_block
+    assert "} finally {\n                setTimeout(() => {" in choice_item_block
+    assert (
+        "pngtuberUploadChoiceOpeningPicker = false;\n"
+        "                    closePNGTuberUploadChoice();"
+    ) in choice_item_block
     assert "event.key === 'Escape'" in script
     assert "window.t('live2d.pngtuberImportProjectFile')" in script
     assert "window.t('live2d.pngtuberImportFolder')" in script


### PR DESCRIPTION
…，并补充静态契约测试防止回归

<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

修复 PNGTuber 导入菜单打开文件选择器时的 DOM 移除时序问题

## 测试 / Testing

手动测试导入


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 PNGTuber 上传“选择菜单”的收起时机：在选择/切换过程中不会因焦点离开而被提前关闭。
  * 强化菜单关闭与清理：确保对应菜单节点被移除，降低误触发与重复打开。
* **Tests**
  * 增加针对选择菜单交互的静态契约校验，覆盖互斥打开保护与延迟清理/收尾流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->