### PR TITLE
perf: 前端静止态 CPU/GPU 降耗（Live2D 降帧 + rAF 空转循环治理）

### DIFF
--- a/frontend/react-neko-chat/src/FullChatSurface.tsx
+++ b/frontend/react-neko-chat/src/FullChatSurface.tsx
@@ -2142,8 +2142,6 @@ export default function FullChatSurface({
 
     const gap = 16;
     let frameId: number | null = null;
-    let trackingFrameId: number | null = null;
-    let disposed = false;
 
     const getDesktopPlacementSpace = (shellRect: DOMRect) => {
       const layout = (window as typeof window & {
@@ -2229,17 +2227,16 @@ export default function FullChatSurface({
       });
     };
 
-    const trackPlacement = () => {
-      if (disposed) return;
-      updatePlacement();
-      trackingFrameId = window.requestAnimationFrame(trackPlacement);
-    };
-
     schedulePlacementUpdate();
-    trackingFrameId = window.requestAnimationFrame(trackPlacement);
 
     const visualViewport = window.visualViewport;
     window.addEventListener('resize', schedulePlacementUpdate);
+    // Surface/desktop layout moves (avatar drag, window move, work-area change)
+    // have no element-level signal a ResizeObserver could catch, so listen for
+    // the host's layout-change events instead of polling every frame. Mirrors the
+    // event-driven compact placement effect in App.tsx (CompactChatApp).
+    window.addEventListener('neko:compact-surface-layout-change', schedulePlacementUpdate);
+    window.addEventListener('neko:desktop-compact-layout-change', schedulePlacementUpdate);
     visualViewport?.addEventListener('resize', schedulePlacementUpdate);
     visualViewport?.addEventListener('scroll', schedulePlacementUpdate);
 
@@ -2253,14 +2250,12 @@ export default function FullChatSurface({
     }
 
     return () => {
-      disposed = true;
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
       }
-      if (trackingFrameId !== null) {
-        window.cancelAnimationFrame(trackingFrameId);
-      }
       window.removeEventListener('resize', schedulePlacementUpdate);
+      window.removeEventListener('neko:compact-surface-layout-change', schedulePlacementUpdate);
+      window.removeEventListener('neko:desktop-compact-layout-change', schedulePlacementUpdate);
       visualViewport?.removeEventListener('resize', schedulePlacementUpdate);
       visualViewport?.removeEventListener('scroll', schedulePlacementUpdate);
       observer?.disconnect();

--- a/frontend/react-neko-chat/src/useFocusGlow.test.tsx
+++ b/frontend/react-neko-chat/src/useFocusGlow.test.tsx
@@ -1,0 +1,119 @@
+import { render, cleanup } from '@testing-library/react';
+import { useRef } from 'react';
+import { useFocusGlow } from './useFocusGlow';
+
+// Manual rAF + clock so we can assert the loop *idles* (stops scheduling frames)
+// once the glow has settled, instead of spinning rAF forever re-writing the same
+// --focus-glow value every frame.
+let now = 0;
+let rafMap: Map<number, FrameRequestCallback>;
+let nextRafId = 0;
+
+function frame(dtMs = 1000): void {
+  now += dtMs;
+  const callbacks = [...rafMap.values()];
+  rafMap.clear();
+  callbacks.forEach((cb) => cb(now));
+}
+
+function pendingFrames(): number {
+  return rafMap.size;
+}
+
+function settle(maxFrames = 120): void {
+  let guard = 0;
+  while (pendingFrames() > 0 && guard < maxFrames) {
+    frame(1000);
+    guard += 1;
+  }
+}
+
+function pushCharge(charge: number): void {
+  window.dispatchEvent(new CustomEvent('neko-focus-charge', { detail: { charge, atMs: now } }));
+}
+
+function GlowHost() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useFocusGlow(ref);
+  return <div ref={ref} data-testid="glow-host" />;
+}
+
+describe('useFocusGlow', () => {
+  beforeEach(() => {
+    now = 1_000_000;
+    rafMap = new Map();
+    nextRafId = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      const id = ++nextRafId;
+      rafMap.set(id, cb);
+      return id;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
+      rafMap.delete(id);
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('idles the rAF loop once an activated charge settles at the ENTER baseline', () => {
+    const { getByTestId } = render(<GlowHost />);
+    const host = getByTestId('glow-host');
+
+    // No charge yet: the loop idles on its first frame.
+    frame();
+    expect(pendingFrames()).toBe(0);
+
+    // Activated push (>= ENTER 0.6): glow appears, loop restarts.
+    pushCharge(0.7);
+    expect(pendingFrames()).toBe(1);
+
+    // While decaying 0.7 -> 0.6 (DECAY_ACTIVATED 0.01/s, ~10s) the loop keeps
+    // ticking and the intensity is still changing.
+    frame(1000);
+    expect(pendingFrames()).toBe(1);
+    expect(Number(host.style.getPropertyValue('--focus-glow'))).toBeGreaterThan(0.6);
+
+    // Past the settle window the loop must stop scheduling frames — this is the
+    // fix: no more per-frame rewrites of a now-constant value.
+    settle();
+    expect(pendingFrames()).toBe(0);
+    expect(host.style.getPropertyValue('--focus-glow')).toBe('0.600');
+    // Breathing is a pure CSS keyframe and stays on while the loop is idle.
+    expect(host.getAttribute('data-focus-breathing')).toBe('true');
+    expect(host.getAttribute('data-focus-glow')).toBe('true');
+  });
+
+  it('restarts the idled loop on the next charge push', () => {
+    render(<GlowHost />);
+    frame();
+
+    pushCharge(0.6); // exactly at ENTER -> settles immediately
+    settle();
+    expect(pendingFrames()).toBe(0);
+
+    pushCharge(0.9); // a fresh push must wake the loop back up
+    expect(pendingFrames()).toBe(1);
+  });
+
+  it('keeps fading a sub-ENTER charge all the way to 0 (no early idle at a floor)', () => {
+    const { getByTestId } = render(<GlowHost />);
+    const host = getByTestId('glow-host');
+    frame();
+
+    pushCharge(0.45); // between ONSET 0.3 and ENTER 0.6 -> must decay to 0, not floor
+    expect(pendingFrames()).toBe(1);
+
+    // Still ticking partway through the fade (does NOT idle at a floor).
+    frame(1000);
+    expect(pendingFrames()).toBe(1);
+
+    settle();
+    expect(pendingFrames()).toBe(0); // fully decayed -> idle
+    expect(host.style.getPropertyValue('--focus-glow')).toBe(''); // cleared at 0
+    expect(host.getAttribute('data-focus-glow')).toBeNull();
+  });
+});

--- a/frontend/react-neko-chat/src/useFocusGlow.ts
+++ b/frontend/react-neko-chat/src/useFocusGlow.ts
@@ -83,6 +83,15 @@ export function useFocusGlow(ref: RefObject<HTMLElement | null>): void {
         raf = 0; // fully decayed — stop until the next push
         return;
       }
+      // Activated glow floors at the ENTER baseline (its breathing is a pure CSS
+      // keyframe, not driven by rAF); once charge has decayed to that floor the
+      // intensity is constant, so idle the loop instead of re-writing the same
+      // --focus-glow every frame. onCharge() restarts it on the next push.
+      // Sub-ENTER charges keep decaying toward 0 and idle via render() above.
+      if (setpoint >= ENTER && charge <= ENTER) {
+        raf = 0;
+        return;
+      }
       raf = requestAnimationFrame(tick);
     };
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -394,6 +394,9 @@
     var mobileExpandClickGuard = null;
     var mobileExpandVisualGuardTimer = 0;
     var compactMinimizeBallFrame = 0;
+    // surface 锚点跟踪：拖拽/缩放会话每帧同步保证跟手，静止时降到 ~30fps 省 CPU（sync 幂等，降频零视觉代价）。
+    var compactSurfaceTrackingLastSyncTs = 0;
+    var COMPACT_SURFACE_IDLE_SYNC_INTERVAL_MS = 33;
     var compactSurfaceAnchorSnapshot = '';
     var compactDesktopSurfaceAnchorSnapshot = '';
     var compactInteractionGeometrySnapshot = '';
@@ -465,6 +468,8 @@
             compactSurfaceAnchorLocked = false;
             compactSurfaceAnchorSnapshot = '';
         }
+        // 桌面侧布局变化（窗口移动/跨屏等）：归零节流时钟，让下一帧立即重同步，不受静止节流延迟。
+        compactSurfaceTrackingLastSyncTs = 0;
         scheduleCompactMinimizeBallTracking();
     }
 
@@ -2054,13 +2059,30 @@
                 stopCompactMinimizeBallTracking();
                 return;
             }
-            syncCompactSurfaceAnchor();
-            syncCompactInteractionGeometry();
+            // 拖拽/缩放 surface 时每帧同步保证跟手；静止时按 ~30fps 节流，避免无谓的每帧
+            // getModelScreenBounds/getBoundingClientRect/序列化比较把 CPU 与 GPU 合成打满。
+            var trackingActive = !!(
+                (dragState && dragState.compactSurface) ||
+                compactSurfaceDesktopDragActive ||
+                compactSurfaceResizeSession ||
+                compactSurfaceDesktopResizeActive
+            );
+            var now = (window.performance && typeof window.performance.now === 'function')
+                ? window.performance.now()
+                : Date.now();
+            if (trackingActive || (now - compactSurfaceTrackingLastSyncTs) >= COMPACT_SURFACE_IDLE_SYNC_INTERVAL_MS) {
+                compactSurfaceTrackingLastSyncTs = now;
+                syncCompactSurfaceAnchor();
+                syncCompactInteractionGeometry();
+            }
             compactMinimizeBallFrame = window.requestAnimationFrame(loop);
         };
 
         syncCompactSurfaceAnchor();
         syncCompactInteractionGeometry();
+        compactSurfaceTrackingLastSyncTs = (window.performance && typeof window.performance.now === 'function')
+            ? window.performance.now()
+            : Date.now();
         compactMinimizeBallFrame = window.requestAnimationFrame(loop);
     }
 

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -9713,6 +9713,10 @@ async function destroyLive2DPreviewContext() {
             manager._displayChangeHandler = null;
         }
 
+        if (typeof manager._stopIdleFpsGovernor === 'function') {
+            manager._stopIdleFpsGovernor();
+        }
+
         if (manager.pixi_app && typeof manager.pixi_app.destroy === 'function') {
             try {
                 manager.pixi_app.destroy(true);

--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -55,8 +55,10 @@ const LIVE2D_BUBBLE_GEOMETRY_OVERRIDES = Object.freeze({});
 // 在稳定窗口后允许缓存自动刷新一次，避免“早期误识别被长期锁死”。
 const LIVE2D_BUBBLE_GEOMETRY_SETTLE_REFRESH_MS = 1800;
 const LIVE2D_LINUX_X11_DEFAULT_QUALITY = 'low';
-const LIVE2D_LINUX_X11_INTERACTIVE_FPS = 60;
-const LIVE2D_LINUX_X11_INTERACTIVE_FPS_HOLD_MS = 900;
+// 自适应帧率：无动作/说话/交互时降到地板省 CPU，活动时升回配置帧率（默认 60，全平台生效）。
+const LIVE2D_IDLE_FPS = 30;                         // 静止地板帧率
+const LIVE2D_INTERACTIVE_FPS_HOLD_MS = 900;         // 活动后维持满帧的窗口，过后衰减回地板
+const LIVE2D_IDLE_FPS_GOVERNOR_INTERVAL_MS = 300;   // 活动探测轮询间隔
 const LIVE2D_RETURN_BALL_VIEWPORT_MAX_SIZE = 200;
 
 function isDesktopLinuxX11Runtime() {
@@ -134,8 +136,8 @@ class Live2DManager {
         this._bubbleGeometryModelReadyAt = 0;
         this._bubbleGeometryRefreshPass = 0;
         this._linuxX11RendererProfileOptimized = false;
-        this._linuxX11FpsRestoreTimer = null;
-        this._linuxX11BaseTargetFps = null;
+        this._idleFpsRestoreTimer = null;
+        this._idleFpsGovernorTimer = null;
 
         // 常驻表情：使用官方 expression 播放并在清理后自动重放
         this.persistentExpressionNames = [];
@@ -300,6 +302,8 @@ class Live2DManager {
                 if (typeof window.targetFrameRate === 'number' && this.pixi_app.ticker) {
                     this.pixi_app.ticker.maxFPS = window.targetFrameRate;
                 }
+                // 启动自适应帧率守护：静止时降到地板（LIVE2D_IDLE_FPS），活动时升回配置帧率。
+                this._startIdleFpsGovernor();
 
                 // Resize 渲染器并等比调整模型坐标/尺寸
                 // 触发时机：
@@ -509,56 +513,84 @@ class Live2DManager {
      */
     setTargetFPS(fps) {
         if (this.pixi_app && this.pixi_app.ticker) {
-            if (this._linuxX11FpsRestoreTimer) {
-                clearTimeout(this._linuxX11FpsRestoreTimer);
-                this._linuxX11FpsRestoreTimer = null;
-                this._linuxX11BaseTargetFps = null;
+            if (this._idleFpsRestoreTimer) {
+                clearTimeout(this._idleFpsRestoreTimer);
+                this._idleFpsRestoreTimer = null;
             }
             this.pixi_app.ticker.maxFPS = fps;
             console.log(`[Live2D Core] 目标帧率设置为 ${fps === 0 ? 'VSync (无限制)' : fps + 'fps'}`);
         }
     }
 
-    boostLinuxX11InteractiveFPS(durationMs = LIVE2D_LINUX_X11_INTERACTIVE_FPS_HOLD_MS) {
-        if (!isDesktopLinuxX11Runtime()) return;
+    // 用户配置的目标帧率（活动时的上限），默认 60；0 表示不限帧（跟随 VSync）。
+    _resolveConfiguredTargetFps() {
+        const configured = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : 60;
+        return Number.isFinite(configured) ? configured : 60;
+    }
+
+    // 静止地板帧率：不超过用户配置；配置为 0（不限帧）时仍压到地板省 CPU。
+    _resolveIdleFps() {
+        const configured = this._resolveConfiguredTargetFps();
+        return configured === 0 ? LIVE2D_IDLE_FPS : Math.min(LIVE2D_IDLE_FPS, configured);
+    }
+
+    // 有渲染活动时升回配置帧率，并安排在 durationMs 后衰减回静止地板（全平台）。
+    boostInteractiveFPS(durationMs = LIVE2D_INTERACTIVE_FPS_HOLD_MS) {
         if (!this.pixi_app || !this.pixi_app.ticker) return;
-
         const ticker = this.pixi_app.ticker;
-        const configured = typeof window.targetFrameRate === 'number' ? window.targetFrameRate : 60;
-        const configuredFps = Number(configured);
-        if (configuredFps === 0) {
-            if (this._linuxX11FpsRestoreTimer) {
-                clearTimeout(this._linuxX11FpsRestoreTimer);
-                this._linuxX11FpsRestoreTimer = null;
-                this._linuxX11BaseTargetFps = null;
-            }
-            if (ticker.maxFPS !== 0) {
-                ticker.maxFPS = 0;
-            }
-            return;
+        const configured = this._resolveConfiguredTargetFps();
+        const activeFps = configured === 0 ? 0 : Math.max(LIVE2D_IDLE_FPS, configured);
+        if (ticker.maxFPS !== activeFps) {
+            ticker.maxFPS = activeFps;
         }
-
-        const baseFps = Math.max(1, Number.isFinite(configuredFps) ? configuredFps : 60);
-        const boostFps = Math.max(baseFps, LIVE2D_LINUX_X11_INTERACTIVE_FPS);
-        this._linuxX11BaseTargetFps = baseFps;
         const originalTicker = ticker;
-        if (ticker.maxFPS !== boostFps) {
-            ticker.maxFPS = boostFps;
+        if (this._idleFpsRestoreTimer) {
+            clearTimeout(this._idleFpsRestoreTimer);
         }
-        if (this._linuxX11FpsRestoreTimer) {
-            clearTimeout(this._linuxX11FpsRestoreTimer);
-        }
-        this._linuxX11FpsRestoreTimer = setTimeout(() => {
-            this._linuxX11FpsRestoreTimer = null;
-            const latestConfigured = typeof window.targetFrameRate === 'number' ? Number(window.targetFrameRate) : NaN;
-            const restoreFps = Number.isFinite(latestConfigured)
-                ? latestConfigured
-                : (Number.isFinite(this._linuxX11BaseTargetFps) ? this._linuxX11BaseTargetFps : 60);
-            this._linuxX11BaseTargetFps = null;
+        this._idleFpsRestoreTimer = setTimeout(() => {
+            this._idleFpsRestoreTimer = null;
             if (this.pixi_app && this.pixi_app.ticker === originalTicker) {
-                originalTicker.maxFPS = restoreFps;
+                originalTicker.maxFPS = this._resolveIdleFps();
             }
-        }, Math.max(100, Number(durationMs) || LIVE2D_LINUX_X11_INTERACTIVE_FPS_HOLD_MS));
+        }, Math.max(100, Number(durationMs) || LIVE2D_INTERACTIVE_FPS_HOLD_MS));
+    }
+
+    // 向后兼容旧调用名（live2d-interaction.js 的交互升帧），现已推广到全平台。
+    boostLinuxX11InteractiveFPS(durationMs) {
+        this.boostInteractiveFPS(durationMs);
+    }
+
+    // 是否有需要满帧的渲染活动：动作/表情播放、拖拽、光标聚焦跟踪、口型同步说话。
+    _hasRenderActivity() {
+        try {
+            if (typeof this.hasActiveMotionPlayback === 'function' && this.hasActiveMotionPlayback()) {
+                return true;
+            }
+        } catch (_) {}
+        if (this._isDraggingModel || this.isFocusing) return true;
+        const appState = window.appState;
+        if (appState && appState.lipSyncActive) return true;
+        return false;
+    }
+
+    // 自适应帧率守护：周期性探测活动状态，有活动就续命满帧，无活动时由衰减计时器回落到地板。
+    _startIdleFpsGovernor() {
+        this._stopIdleFpsGovernor();
+        // 启动即视为活动（加载/入场动画期间保持满帧），随后自动衰减。
+        this.boostInteractiveFPS();
+        this._idleFpsGovernorTimer = setInterval(() => {
+            if (!this.pixi_app || !this.pixi_app.ticker) return;
+            if (this._hasRenderActivity()) {
+                this.boostInteractiveFPS();
+            }
+        }, LIVE2D_IDLE_FPS_GOVERNOR_INTERVAL_MS);
+    }
+
+    _stopIdleFpsGovernor() {
+        if (this._idleFpsGovernorTimer) {
+            clearInterval(this._idleFpsGovernorTimer);
+            this._idleFpsGovernorTimer = null;
+        }
     }
 
     /**

--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -600,6 +600,12 @@ class Live2DManager {
                 this._stopIdleFpsGovernor();
                 return;
             }
+            // 暂停态（pauseRendering / 切到非 Live2D 角色时直接 ticker.stop() 但保留 pixi_app 复用）：
+            // ticker 已 stop，跳过升/降帧工作。不在此自终止——有多处直接 ticker.start() 的恢复路径
+            // （app-character / model_manager / app-ui / live2d-model 等）不走 resumeRendering，
+            // 自终止后无人重启会让 Live2D 失去 idle 节流；ticker 恢复 started 后本守护自动继续治理。
+            // 用 === false 安全降级：万一某 pixi 版本无 started 属性，守卫不触发即维持原行为。
+            if (this.pixi_app.ticker.started === false) return;
             if (this._hasRenderActivity()) {
                 this.boostInteractiveFPS();
             }

--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -593,7 +593,13 @@ class Live2DManager {
         // 启动即视为活动（加载/入场动画期间保持满帧），随后自动衰减。
         this.boostInteractiveFPS();
         this._idleFpsGovernorTimer = setInterval(() => {
-            if (!this.pixi_app || !this.pixi_app.ticker) return;
+            // 自终止：任何 teardown 路径（切 VRM/MMD、model_manager 销毁、manager.destroy 等）
+            // 销毁/置空 pixi_app 后，governor 在下一拍自动停掉并释放对 manager 的闭包引用——
+            // 不必每条销毁路径都手动清，避免遗漏与内存泄漏。
+            if (!this.pixi_app || !this.pixi_app.ticker) {
+                this._stopIdleFpsGovernor();
+                return;
+            }
             if (this._hasRenderActivity()) {
                 this.boostInteractiveFPS();
             }

--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -225,6 +225,7 @@ class Live2DManager {
         if (this.isInitialized && (!this.pixi_app || !this.pixi_app.stage)) {
             console.warn('Live2D 管理器标记为已初始化，但 pixi_app 或 stage 不存在，重置状态');
             if (this.pixi_app && this.pixi_app.destroy) {
+                this._stopIdleFpsGovernor();
                 if (this._screenChangeHandler) {
                     window.removeEventListener('resize', this._screenChangeHandler);
                     this._screenChangeHandler = null;
@@ -443,6 +444,7 @@ class Live2DManager {
                 this._displayChangeHandler = null;
             }
             if (this.pixi_app && this.pixi_app.destroy) {
+                this._stopIdleFpsGovernor();
                 try {
                     this.pixi_app.destroy(true);
                 } catch (e) {
@@ -476,6 +478,7 @@ class Live2DManager {
             this._displayChangeHandler = null;
         }
         if (this.pixi_app && this.pixi_app.destroy) {
+            this._stopIdleFpsGovernor();
             try {
                 this.pixi_app.destroy(true);
             } catch (e) {
@@ -512,14 +515,23 @@ class Live2DManager {
      * @param {number} fps - 目标帧率，0 表示不限帧（跟随 VSync）
      */
     setTargetFPS(fps) {
-        if (this.pixi_app && this.pixi_app.ticker) {
-            if (this._idleFpsRestoreTimer) {
-                clearTimeout(this._idleFpsRestoreTimer);
-                this._idleFpsRestoreTimer = null;
-            }
-            this.pixi_app.ticker.maxFPS = fps;
-            console.log(`[Live2D Core] 目标帧率设置为 ${fps === 0 ? 'VSync (无限制)' : fps + 'fps'}`);
+        if (!this.pixi_app || !this.pixi_app.ticker) return;
+        // setTargetFPS 是「目标帧率」配置的权威应用点：先同步配置源，确保 governor 的
+        // boost/restore 读到的是新值而非旧值（调用方一般已设过 window.targetFrameRate，这里兜底自洽）。
+        const resolved = Number(fps);
+        window.targetFrameRate = Number.isFinite(resolved) ? resolved : 60;
+        if (this._idleFpsRestoreTimer) {
+            clearTimeout(this._idleFpsRestoreTimer);
+            this._idleFpsRestoreTimer = null;
         }
+        // 立即按 governor 语义落地，不必等下一次活动周期：有渲染活动升回配置帧率，
+        // 否则直接压到静止地板，避免改完设置后空闲态停在未节流的值。
+        if (this._hasRenderActivity()) {
+            this.boostInteractiveFPS();
+        } else {
+            this.pixi_app.ticker.maxFPS = this._resolveIdleFps();
+        }
+        console.log(`[Live2D Core] 目标帧率设置为 ${window.targetFrameRate === 0 ? 'VSync (无限制)' : window.targetFrameRate + 'fps'}`);
     }
 
     // 用户配置的目标帧率（活动时的上限），默认 60；0 表示不限帧（跟随 VSync）。
@@ -539,7 +551,9 @@ class Live2DManager {
         if (!this.pixi_app || !this.pixi_app.ticker) return;
         const ticker = this.pixi_app.ticker;
         const configured = this._resolveConfiguredTargetFps();
-        const activeFps = configured === 0 ? 0 : Math.max(LIVE2D_IDLE_FPS, configured);
+        // 活动时升回用户配置上限（0=不限帧）。不再 Math.max(IDLE,...)，否则会把刻意设到
+        // 低于地板的配置（如低端机 24fps）反而抬到 30，超过用户上限。
+        const activeFps = configured === 0 ? 0 : configured;
         if (ticker.maxFPS !== activeFps) {
             ticker.maxFPS = activeFps;
         }
@@ -590,6 +604,11 @@ class Live2DManager {
         if (this._idleFpsGovernorTimer) {
             clearInterval(this._idleFpsGovernorTimer);
             this._idleFpsGovernorTimer = null;
+        }
+        // 一并清掉待触发的衰减计时器，避免销毁/重建失败路径留下后台 timer。
+        if (this._idleFpsRestoreTimer) {
+            clearTimeout(this._idleFpsRestoreTimer);
+            this._idleFpsRestoreTimer = null;
         }
     }
 

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -1880,8 +1880,9 @@ Live2DManager.prototype.setupUnloadCleanup = function () {
 Live2DManager.prototype.destroy = function () {
     console.log('[Live2D] 正在销毁 Live2DManager 实例...');
 
-    // 首先清理所有事件监听器
+    // 首先清理所有事件监听器与自适应帧率守护
     this.cleanupEventListeners();
+    this._stopIdleFpsGovernor();
 
     // 销毁当前模型
     if (this.currentModel) {


### PR DESCRIPTION
## 背景

CPU 诊断显示桌面 Electron 前端占用偏高，主因不是后端/主进程，而是**前端 renderer + GPU 合成**：几条「每帧自我重排」的 rAF 循环在桌宠**静止挂机**时也满帧空转。本 PR 对这些循环按性质分类治理——渲染本身只能降频，几何/动画轮询能降频或改事件驱动。

## 改动（3 个 commit）

### 1. Live2D 静止降帧 + compact surface 同步循环静止降频（`dee1d2d70`）
- **Live2D/Pixi ticker**：原本非 Linux 平台常驻 60fps。新增自适应帧率守护 `_startIdleFpsGovernor`（`static/live2d-core.js`），静止地板 `LIVE2D_IDLE_FPS=30`；有渲染活动（动作/表情播放、说话 `lipSyncActive`、拖拽、光标聚焦）升回配置帧率（默认 60），活动停止 900ms 后衰减回地板。原 Linux 专用的 `boostLinuxX11InteractiveFPS` 通用化为全平台 `boostInteractiveFPS`，保留旧名别名，交互调用点零改动。
- **compact surface 锚点同步 rAF**（`static/app-react-chat-window.js`）：`scheduleCompactMinimizeBallTracking` 主循环在拖拽/缩放 surface 时每帧同步保证跟手，静止时按 ~33ms（~30fps）节流。两个 sync 本身幂等，降频零视觉代价。

### 2. useFocusGlow 激活态 settle 后 idle rAF（`ae24bbe62`）
- 凝神边缘辉光的 rAF 循环（`frontend/react-neko-chat/src/useFocusGlow.ts`，compact 主聊天也用这个共享 hook）在 `charge >= ENTER(0.6)` 激活态下永不 idle：`liveCharge()` 地板锁 0.6 → `render()` 恒 true → 每帧重写**同一个常量** `--focus-glow`（呼吸是纯 CSS keyframe，不靠 rAF 驱动）。
- 修复：charge 衰减到 ENTER 地板后 idle rAF，`onCharge` 下次 push 再重启；sub-ENTER 仍照常衰减到 0。**无降级**（idle 期值恒定、呼吸由 CSS 续跑、无外部清除者）。新增 `useFocusGlow.test.tsx` 用手动接管 rAF + 时钟锁回归。

### 3. FullChatSurface choice 摆位改事件驱动（`0aa24ca02`）
- galgame 选项菜单 above/below 摆位删掉每帧 `trackPlacement` rAF 轮询，改 `resize`/`visualViewport` + `ResizeObserver` + `neko:compact-surface-layout-change`/`neko:desktop-compact-layout-change` 事件驱动，与 compact 主版 `App.tsx` 已有的事件驱动摆位 effect 对齐。FullChatSurface 属冻结 legacy 的 full 界面（默认 compact 不渲染），保留其自身 `appShellRef`，仅去掉每帧空转。

## 验证

- `tsc -b` 通过；React vitest **265 passed**（含 3 个新 useFocusGlow 测试）；pytest 前端静态契约测试无新增失败。
- React bundle（`static/react/neko-chat/*.{iife,es}.js`）是 gitignore 的 CI 构建产物，本 PR 只提交 TS 源，CI 重打包。
- ⚠️ 既有 flake：`App.test.tsx > expands the desktop hammer overlay on avatar range hover`（隔离单跑 10/10 过、仅并行全套约 1/7 偶发），与本 PR 无交集（既有 timer/rAF 并行基建 flake）。

## 影响面

纯前端、可灰度、易回滚。Live2D 静止 30fps 的 tradeoff：呼吸/idle 动画静止时 60→30（多数无感）；idle motion 播放期仍升回 60，故实际省幅小于理论一半。CPU 实测降幅建议用现有 profiler 复测确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 自适应帧率：空闲时降低帧率；检测到渲染活动后在保持窗口内提升上限，兼顾省电与流畅度。
* **Bug 修复**
  * 紧凑选择层/桌面布局摆放更新改为事件驱动，窗口与布局变化响应更及时。
  * 焦点发光衰减到基线后停止无效逐帧更新，后续达到门槛可重新唤醒。
  * 最小化球跟随与几何同步加入节流，非活跃时减少过度同步延迟。
* **测试**
  * 更新 `useFocusGlow` 的 rAF 调度覆盖用例。
* **维护**
  * Live2D 预览销毁时停止空闲帧率治理，避免残留回落逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->