### PR TITLE
教程期间禁用快捷键桥接

### DIFF
--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1364,6 +1364,11 @@
     window.stopGameVoiceSttGate = stopGameVoiceSttGate;
 
     window.toggleMicMute = function(showToast = true) {
+        if (typeof window.isNekoShortcutBlockedByTutorial === 'function'
+            && window.isNekoShortcutBlockedByTutorial()) {
+            console.log('[Electron Shortcut] toggleMicMute: blocked - tutorial active');
+            return S.isMicMuted;
+        }
         S.isMicMuted = !S.isMicMuted;
         if (S.isMicMuted) {
             stopSilenceDetection();

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1367,21 +1367,7 @@
         if (typeof window.isNekoShortcutBlockedByTutorial === 'function') {
             return window.isNekoShortcutBlockedByTutorial();
         }
-
-        const body = document.body;
-        const root = document.documentElement;
-        const hasClass = function (node, className) {
-            return !!(node && node.classList && node.classList.contains(className));
-        };
-
-        return window.isInTutorial === true
-            || hasClass(body, 'yui-guide-home-ui-suppressed')
-            || hasClass(body, 'yui-guide-input-shield-active')
-            || hasClass(body, 'yui-guide-standalone-input-shield-active')
-            || hasClass(body, 'yui-guide-chat-buttons-disabled')
-            || hasClass(body, 'yui-guide-compact-chat-fixed')
-            || hasClass(root, 'yui-guide-plugin-dashboard-running')
-            || hasClass(body, 'yui-guide-plugin-dashboard-running');
+        return window.isInTutorial === true;
     }
 
     window.toggleMicMute = function(showToast = true) {

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1363,9 +1363,29 @@
     window.startGameVoiceSttGate = startGameVoiceSttGate;
     window.stopGameVoiceSttGate = stopGameVoiceSttGate;
 
+    function isTutorialShortcutBlockedForMicMute() {
+        if (typeof window.isNekoShortcutBlockedByTutorial === 'function') {
+            return window.isNekoShortcutBlockedByTutorial();
+        }
+
+        const body = document.body;
+        const root = document.documentElement;
+        const hasClass = function (node, className) {
+            return !!(node && node.classList && node.classList.contains(className));
+        };
+
+        return window.isInTutorial === true
+            || hasClass(body, 'yui-guide-home-ui-suppressed')
+            || hasClass(body, 'yui-guide-input-shield-active')
+            || hasClass(body, 'yui-guide-standalone-input-shield-active')
+            || hasClass(body, 'yui-guide-chat-buttons-disabled')
+            || hasClass(body, 'yui-guide-compact-chat-fixed')
+            || hasClass(root, 'yui-guide-plugin-dashboard-running')
+            || hasClass(body, 'yui-guide-plugin-dashboard-running');
+    }
+
     window.toggleMicMute = function(showToast = true) {
-        if (typeof window.isNekoShortcutBlockedByTutorial === 'function'
-            && window.isNekoShortcutBlockedByTutorial()) {
+        if (isTutorialShortcutBlockedForMicMute()) {
             console.log('[Electron Shortcut] toggleMicMute: blocked - tutorial active');
             return S.isMicMuted;
         }

--- a/static/common_ui.js
+++ b/static/common_ui.js
@@ -1154,22 +1154,6 @@ if (chatContentWrapper) {
 // ========== Electron 全局快捷键接口 ==========
 // 以下接口供 Electron 主进程通过 IPC 调用，用于全局快捷键功能
 
-window.isNekoShortcutBlockedByTutorial = function () {
-    const body = document.body;
-    const root = document.documentElement;
-    const hasClass = function (node, className) {
-        return !!(node && node.classList && node.classList.contains(className));
-    };
-    return window.isInTutorial === true
-        || hasClass(body, 'yui-guide-home-ui-suppressed')
-        || hasClass(body, 'yui-guide-input-shield-active')
-        || hasClass(body, 'yui-guide-standalone-input-shield-active')
-        || hasClass(body, 'yui-guide-chat-buttons-disabled')
-        || hasClass(body, 'yui-guide-compact-chat-fixed')
-        || hasClass(root, 'yui-guide-plugin-dashboard-running')
-        || hasClass(body, 'yui-guide-plugin-dashboard-running');
-};
-
 function blockNekoShortcutDuringTutorial(actionName) {
     if (typeof window.isNekoShortcutBlockedByTutorial !== 'function'
         || !window.isNekoShortcutBlockedByTutorial()) {

--- a/static/common_ui.js
+++ b/static/common_ui.js
@@ -1154,10 +1154,6 @@ if (chatContentWrapper) {
 // ========== Electron 全局快捷键接口 ==========
 // 以下接口供 Electron 主进程通过 IPC 调用，用于全局快捷键功能
 
-/**
- * 切换语音会话状态（开始/结束）
- * Electron 调用此接口来触发语音按钮的切换
- */
 window.isNekoShortcutBlockedByTutorial = function () {
     const body = document.body;
     const root = document.documentElement;
@@ -1183,6 +1179,10 @@ function blockNekoShortcutDuringTutorial(actionName) {
     return true;
 }
 
+/**
+ * 切换语音会话状态（开始/结束）
+ * Electron 调用此接口来触发语音按钮的切换
+ */
 window.toggleVoiceSession = function () {
     if (blockNekoShortcutDuringTutorial('toggleVoiceSession')) return;
     // 获取浮动按钮的当前状态（Live2D / VRM / MMD）

--- a/static/common_ui.js
+++ b/static/common_ui.js
@@ -1158,7 +1158,33 @@ if (chatContentWrapper) {
  * 切换语音会话状态（开始/结束）
  * Electron 调用此接口来触发语音按钮的切换
  */
+window.isNekoShortcutBlockedByTutorial = function () {
+    const body = document.body;
+    const root = document.documentElement;
+    const hasClass = function (node, className) {
+        return !!(node && node.classList && node.classList.contains(className));
+    };
+    return window.isInTutorial === true
+        || hasClass(body, 'yui-guide-home-ui-suppressed')
+        || hasClass(body, 'yui-guide-input-shield-active')
+        || hasClass(body, 'yui-guide-standalone-input-shield-active')
+        || hasClass(body, 'yui-guide-chat-buttons-disabled')
+        || hasClass(body, 'yui-guide-compact-chat-fixed')
+        || hasClass(root, 'yui-guide-plugin-dashboard-running')
+        || hasClass(body, 'yui-guide-plugin-dashboard-running');
+};
+
+function blockNekoShortcutDuringTutorial(actionName) {
+    if (typeof window.isNekoShortcutBlockedByTutorial !== 'function'
+        || !window.isNekoShortcutBlockedByTutorial()) {
+        return false;
+    }
+    console.log('[Electron Shortcut] ' + actionName + ': blocked - tutorial active');
+    return true;
+}
+
 window.toggleVoiceSession = function () {
+    if (blockNekoShortcutDuringTutorial('toggleVoiceSession')) return;
     // 获取浮动按钮的当前状态（Live2D / VRM / MMD）
     const micButton = window.live2dManager?._floatingButtons?.mic?.button
         || window.vrmManager?._floatingButtons?.mic?.button
@@ -1179,6 +1205,7 @@ window.toggleVoiceSession = function () {
  * Electron 调用此接口来触发屏幕分享按钮的切换
  */
 window.toggleScreenShare = function () {
+    if (blockNekoShortcutDuringTutorial('toggleScreenShare')) return;
     // 获取浮动按钮的当前状态（Live2D / VRM / MMD）
     const screenBtn = window.live2dManager?._floatingButtons?.screen?.button
         || window.vrmManager?._floatingButtons?.screen?.button
@@ -1213,6 +1240,7 @@ window.toggleScreenShare = function () {
  * Electron 调用此接口来触发截图按钮点击
  */
 window.triggerScreenshot = function () {
+    if (blockNekoShortcutDuringTutorial('triggerScreenshot')) return;
     // 语音会话中禁止截图（文本框处于禁用态时意味着用户处于语音会话中）
     if (window.isRecording) {
         console.log('[Electron Shortcut] triggerScreenshot: blocked - in voice session');

--- a/static/tutorial/yui-guide/common.js
+++ b/static/tutorial/yui-guide/common.js
@@ -119,6 +119,31 @@
         return null;
     }
 
+    function isNekoShortcutBlockedByTutorial(options) {
+        const normalizedOptions = options || {};
+        const host = normalizedOptions.window || root || {};
+        const doc = normalizedOptions.document || host.document;
+        const body = doc && doc.body;
+        const rootElement = doc && doc.documentElement;
+        const hasClass = function (node, className) {
+            return !!(node && node.classList && node.classList.contains(className));
+        };
+        return host.isInTutorial === true
+            || hasClass(body, 'yui-guide-home-ui-suppressed')
+            || hasClass(body, 'yui-guide-input-shield-active')
+            || hasClass(body, 'yui-guide-standalone-input-shield-active')
+            || hasClass(body, 'yui-guide-chat-buttons-disabled')
+            || hasClass(body, 'yui-guide-compact-chat-fixed')
+            || hasClass(rootElement, 'yui-guide-plugin-dashboard-running')
+            || hasClass(body, 'yui-guide-plugin-dashboard-running');
+    }
+
+    if (root && typeof root.isNekoShortcutBlockedByTutorial !== 'function') {
+        root.isNekoShortcutBlockedByTutorial = function () {
+            return isNekoShortcutBlockedByTutorial({ window: root });
+        };
+    }
+
     const tutorialGuideHelpersApi = loadTutorialGuideHelpersApi();
     const tutorialScopedResourcesApi = loadTutorialScopedResourcesApi();
     const tutorialBridgeCommandBusApi = loadTutorialBridgeCommandBusApi();
@@ -316,6 +341,7 @@
         normalizeTutorialScene,
         createTutorialTimelineEngine,
         createTutorialVisualRuntime,
+        isNekoShortcutBlockedByTutorial,
         syncPcSystemCursorHidden
     };
 });

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -14,8 +14,10 @@ TUTORIAL_STYLES_PATH = Path(__file__).resolve().parents[2] / "static" / "css/tut
 ROUND_PRELUDE_CONTROLLER_PATH = (
     Path(__file__).resolve().parents[2] / "static" / "tutorial/core/round-prelude-controller.js"
 )
+YUI_GUIDE_COMMON_PATH = Path(__file__).resolve().parents[2] / "static" / "tutorial/yui-guide/common.js"
 COMMON_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "common_ui.js"
 APP_AUDIO_CAPTURE_PATH = Path(__file__).resolve().parents[2] / "static" / "app-audio-capture.js"
+CHAT_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "templates" / "chat.html"
 
 
 def _read_manager() -> str:
@@ -42,12 +44,20 @@ def _read_round_prelude() -> str:
     return ROUND_PRELUDE_CONTROLLER_PATH.read_text(encoding="utf-8")
 
 
+def _read_yui_guide_common() -> str:
+    return YUI_GUIDE_COMMON_PATH.read_text(encoding="utf-8")
+
+
 def _read_common_ui() -> str:
     return COMMON_UI_PATH.read_text(encoding="utf-8")
 
 
 def _read_app_audio_capture() -> str:
     return APP_AUDIO_CAPTURE_PATH.read_text(encoding="utf-8")
+
+
+def _read_chat_template() -> str:
+    return CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
 
 
 def test_universal_tutorial_manager_excludes_legacy_driver_tutorial_system():
@@ -694,14 +704,19 @@ def test_avatar_floating_guide_lifecycle_toggles_compact_chat_fixed_layout_class
 
 
 def test_electron_shortcut_bridges_are_blocked_during_tutorial():
+    yui_guide_common = _read_yui_guide_common()
     common_ui = _read_common_ui()
     audio_capture = _read_app_audio_capture()
+    chat_template = _read_chat_template()
 
-    assert "window.isNekoShortcutBlockedByTutorial = function ()" in common_ui
-    assert "window.isInTutorial === true" in common_ui
-    assert "yui-guide-standalone-input-shield-active" in common_ui
-    assert "yui-guide-chat-buttons-disabled" in common_ui
-    assert "yui-guide-compact-chat-fixed" in common_ui
+    assert "root.isNekoShortcutBlockedByTutorial = function ()" in yui_guide_common
+    assert "host.isInTutorial === true" in yui_guide_common
+    assert "yui-guide-standalone-input-shield-active" in yui_guide_common
+    assert "yui-guide-chat-buttons-disabled" in yui_guide_common
+    assert "yui-guide-compact-chat-fixed" in yui_guide_common
+    assert "isNekoShortcutBlockedByTutorial," in yui_guide_common
+    assert "/static/tutorial/yui-guide/common.js" in chat_template
+    assert '<script src="/static/common_ui.js' not in chat_template
 
     for action in ("toggleVoiceSession", "toggleScreenShare", "triggerScreenshot"):
         block = common_ui.split(f"window.{action} = function", 1)[1].split("};", 1)[0]
@@ -718,9 +733,6 @@ def test_electron_shortcut_bridges_are_blocked_during_tutorial():
     )[0]
     assert "window.isNekoShortcutBlockedByTutorial" in mic_guard_block
     assert "window.isInTutorial === true" in mic_guard_block
-    assert "yui-guide-standalone-input-shield-active" in mic_guard_block
-    assert "yui-guide-chat-buttons-disabled" in mic_guard_block
-    assert "yui-guide-compact-chat-fixed" in mic_guard_block
 
     mute_block = audio_capture.split("window.toggleMicMute = function", 1)[1].split("window.setMicMuted", 1)[0]
     assert "isTutorialShortcutBlockedForMicMute()" in mute_block

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -705,8 +705,15 @@ def test_electron_shortcut_bridges_are_blocked_during_tutorial():
 
     for action in ("toggleVoiceSession", "toggleScreenShare", "triggerScreenshot"):
         block = common_ui.split(f"window.{action} = function", 1)[1].split("};", 1)[0]
-        assert f"blockNekoShortcutDuringTutorial('{action}')" in block
+        guard = f"if (blockNekoShortcutDuringTutorial('{action}')) return;"
+        assert guard in block
+        if action == "triggerScreenshot":
+            assert block.index(guard) < block.index("screenshotButton.click()")
+        else:
+            assert block.index(guard) < block.index("window.dispatchEvent(event)")
 
     mute_block = audio_capture.split("window.toggleMicMute = function", 1)[1].split("window.setMicMuted", 1)[0]
     assert "window.isNekoShortcutBlockedByTutorial" in mute_block
     assert "blocked - tutorial active" in mute_block
+    assert "return S.isMicMuted;" in mute_block
+    assert mute_block.index("return S.isMicMuted;") < mute_block.index("S.isMicMuted = !S.isMicMuted;")

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -712,8 +712,18 @@ def test_electron_shortcut_bridges_are_blocked_during_tutorial():
         else:
             assert block.index(guard) < block.index("window.dispatchEvent(event)")
 
+    mic_guard_block = audio_capture.split("function isTutorialShortcutBlockedForMicMute()", 1)[1].split(
+        "window.toggleMicMute = function",
+        1,
+    )[0]
+    assert "window.isNekoShortcutBlockedByTutorial" in mic_guard_block
+    assert "window.isInTutorial === true" in mic_guard_block
+    assert "yui-guide-standalone-input-shield-active" in mic_guard_block
+    assert "yui-guide-chat-buttons-disabled" in mic_guard_block
+    assert "yui-guide-compact-chat-fixed" in mic_guard_block
+
     mute_block = audio_capture.split("window.toggleMicMute = function", 1)[1].split("window.setMicMuted", 1)[0]
-    assert "window.isNekoShortcutBlockedByTutorial" in mute_block
+    assert "isTutorialShortcutBlockedForMicMute()" in mute_block
     assert "blocked - tutorial active" in mute_block
     assert "return S.isMicMuted;" in mute_block
     assert mute_block.index("return S.isMicMuted;") < mute_block.index("S.isMicMuted = !S.isMicMuted;")

--- a/tests/unit/test_universal_tutorial_manager_static.py
+++ b/tests/unit/test_universal_tutorial_manager_static.py
@@ -14,6 +14,8 @@ TUTORIAL_STYLES_PATH = Path(__file__).resolve().parents[2] / "static" / "css/tut
 ROUND_PRELUDE_CONTROLLER_PATH = (
     Path(__file__).resolve().parents[2] / "static" / "tutorial/core/round-prelude-controller.js"
 )
+COMMON_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "common_ui.js"
+APP_AUDIO_CAPTURE_PATH = Path(__file__).resolve().parents[2] / "static" / "app-audio-capture.js"
 
 
 def _read_manager() -> str:
@@ -38,6 +40,14 @@ def _read_tutorial_styles() -> str:
 
 def _read_round_prelude() -> str:
     return ROUND_PRELUDE_CONTROLLER_PATH.read_text(encoding="utf-8")
+
+
+def _read_common_ui() -> str:
+    return COMMON_UI_PATH.read_text(encoding="utf-8")
+
+
+def _read_app_audio_capture() -> str:
+    return APP_AUDIO_CAPTURE_PATH.read_text(encoding="utf-8")
 
 
 def test_universal_tutorial_manager_excludes_legacy_driver_tutorial_system():
@@ -681,3 +691,22 @@ def test_avatar_floating_guide_lifecycle_toggles_compact_chat_fixed_layout_class
     assert "this.syncYuiGuideCompactChatFixedLayout(false, reason)" in clear_method_block
     assert "action: 'yui_guide_set_compact_chat_fixed_layout'" in source
     assert "window.nekoTutorialOverlay.relayToChat(message)" in source
+
+
+def test_electron_shortcut_bridges_are_blocked_during_tutorial():
+    common_ui = _read_common_ui()
+    audio_capture = _read_app_audio_capture()
+
+    assert "window.isNekoShortcutBlockedByTutorial = function ()" in common_ui
+    assert "window.isInTutorial === true" in common_ui
+    assert "yui-guide-standalone-input-shield-active" in common_ui
+    assert "yui-guide-chat-buttons-disabled" in common_ui
+    assert "yui-guide-compact-chat-fixed" in common_ui
+
+    for action in ("toggleVoiceSession", "toggleScreenShare", "triggerScreenshot"):
+        block = common_ui.split(f"window.{action} = function", 1)[1].split("};", 1)[0]
+        assert f"blockNekoShortcutDuringTutorial('{action}')" in block
+
+    mute_block = audio_capture.split("window.toggleMicMute = function", 1)[1].split("window.setMicMuted", 1)[0]
+    assert "window.isNekoShortcutBlockedByTutorial" in mute_block
+    assert "blocked - tutorial active" in mute_block


### PR DESCRIPTION
﻿## 改动
- 教程态下拦截 Electron 快捷键桥接入口：语音、屏幕共享、截图。
- 教程态下拦截麦克风静音快捷键桥接入口。
- 增加静态测试，防止这些入口后续绕过教程态检查。

## 原因
PC 侧快捷键 suppression 如果因为时序或 relay 漏掉一次，页面桥接函数原本会继续执行，导致教程期间能开启语音等功能并污染后续教程/破冰聊天状态。本 PR 在 N.E.K.O 前端补一层兜底，不改 N.E.K.O.-PC。

## 验证
- `uv run pytest tests/unit/test_universal_tutorial_manager_static.py::test_electron_shortcut_bridges_are_blocked_during_tutorial -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 教程进行中会更严格地拦截部分快捷键触发，避免误切换语音会话、屏幕共享或触发截图。
  * 麦克风静音切换在教程态下会先检测并阻断，避免静音状态被意外翻转。
* **Tests**
  * 新增测试覆盖教程模式下快捷键桥接的拦截逻辑，以及静音切换的阻断判定与执行顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->