### PR TITLE
fix(chat): stop idle compact surface tracking loop

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -394,9 +394,10 @@
     var mobileExpandClickGuard = null;
     var mobileExpandVisualGuardTimer = 0;
     var compactMinimizeBallFrame = 0;
-    // surface 锚点跟踪：拖拽/缩放会话每帧同步保证跟手，静止时降到 ~30fps 省 CPU（sync 幂等，降频零视觉代价）。
-    var compactSurfaceTrackingLastSyncTs = 0;
-    var COMPACT_SURFACE_IDLE_SYNC_INTERVAL_MS = 33;
+    // surface 锚点跟踪：拖拽/缩放会话每帧同步保证跟手；静止时只做短暂 settle，
+    // 后续由 layout/avatar/resize/geometry 事件重新唤醒，避免 compact 打开后长期空转。
+    var COMPACT_SURFACE_IDLE_SETTLE_FRAME_COUNT = 3;
+    var compactSurfaceTrackingSettleFramesRemaining = 0;
     var compactSurfaceAnchorSnapshot = '';
     var compactDesktopSurfaceAnchorSnapshot = '';
     var compactInteractionGeometrySnapshot = '';
@@ -468,8 +469,7 @@
             compactSurfaceAnchorLocked = false;
             compactSurfaceAnchorSnapshot = '';
         }
-        // 桌面侧布局变化（窗口移动/跨屏等）：归零节流时钟，让下一帧立即重同步，不受静止节流延迟。
-        compactSurfaceTrackingLastSyncTs = 0;
+        // 桌面侧布局变化（窗口移动/跨屏等）：立即唤醒短 settle，避免静止态停帧后漏掉新 anchor。
         scheduleCompactMinimizeBallTracking();
     }
 
@@ -2040,8 +2040,18 @@
             window.cancelAnimationFrame(compactMinimizeBallFrame);
             compactMinimizeBallFrame = 0;
         }
+        compactSurfaceTrackingSettleFramesRemaining = 0;
         compactSurfacePendingModelOpen = false;
         clearCompactSurfaceAnchor();
+    }
+
+    function isCompactSurfaceTrackingActive() {
+        return !!(
+            (dragState && dragState.compactSurface) ||
+            compactSurfaceDesktopDragActive ||
+            compactSurfaceResizeSession ||
+            compactSurfaceDesktopResizeActive
+        );
     }
 
     function scheduleCompactMinimizeBallTracking() {
@@ -2049,6 +2059,7 @@
             stopCompactMinimizeBallTracking();
             return;
         }
+        compactSurfaceTrackingSettleFramesRemaining = COMPACT_SURFACE_IDLE_SETTLE_FRAME_COUNT;
         if (compactMinimizeBallFrame) {
             return;
         }
@@ -2059,30 +2070,22 @@
                 stopCompactMinimizeBallTracking();
                 return;
             }
-            // 拖拽/缩放 surface 时每帧同步保证跟手；静止时按 ~30fps 节流，避免无谓的每帧
-            // getModelScreenBounds/getBoundingClientRect/序列化比较把 CPU 与 GPU 合成打满。
-            var trackingActive = !!(
-                (dragState && dragState.compactSurface) ||
-                compactSurfaceDesktopDragActive ||
-                compactSurfaceResizeSession ||
-                compactSurfaceDesktopResizeActive
-            );
-            var now = (window.performance && typeof window.performance.now === 'function')
-                ? window.performance.now()
-                : Date.now();
-            if (trackingActive || (now - compactSurfaceTrackingLastSyncTs) >= COMPACT_SURFACE_IDLE_SYNC_INTERVAL_MS) {
-                compactSurfaceTrackingLastSyncTs = now;
-                syncCompactSurfaceAnchor();
-                syncCompactInteractionGeometry();
+            var trackingActive = isCompactSurfaceTrackingActive();
+            if (!trackingActive && compactSurfaceTrackingSettleFramesRemaining <= 0) {
+                return;
+            }
+            syncCompactSurfaceAnchor();
+            syncCompactInteractionGeometry();
+            if (trackingActive) {
+                compactSurfaceTrackingSettleFramesRemaining = COMPACT_SURFACE_IDLE_SETTLE_FRAME_COUNT;
+            } else {
+                compactSurfaceTrackingSettleFramesRemaining -= 1;
             }
             compactMinimizeBallFrame = window.requestAnimationFrame(loop);
         };
 
         syncCompactSurfaceAnchor();
         syncCompactInteractionGeometry();
-        compactSurfaceTrackingLastSyncTs = (window.performance && typeof window.performance.now === 'function')
-            ? window.performance.now()
-            : Date.now();
         compactMinimizeBallFrame = window.requestAnimationFrame(loop);
     }
 
@@ -6232,6 +6235,9 @@
 
         shell.classList.add('is-dragging');
         document.body.classList.add('react-chat-window-dragging');
+        if (compactSurface) {
+            scheduleCompactMinimizeBallTracking();
+        }
     }
 
     function updateDrag(clientX, clientY) {

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1612,6 +1612,32 @@ def test_desktop_compact_layout_change_resets_anchor_only_when_base_surface_chan
     assert "compactSurfaceAnchorSnapshot = '';" not in listener_block
 
 
+def test_compact_surface_tracking_stops_idle_raf_but_keeps_active_sessions():
+    script = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    tracking_block = script.split("function scheduleCompactMinimizeBallTracking()", 1)[1].split(
+        "function revealPendingCompactSurfaceOpen",
+        1,
+    )[0]
+    drag_start_block = script.split("function startDrag(clientX, clientY, options)", 1)[1].split(
+        "function updateDrag",
+        1,
+    )[0]
+
+    assert "var COMPACT_SURFACE_IDLE_SETTLE_FRAME_COUNT = 3;" in script
+    assert "var compactSurfaceTrackingSettleFramesRemaining = 0;" in script
+    assert "function isCompactSurfaceTrackingActive()" in script
+    assert "(dragState && dragState.compactSurface)" in script
+    assert "compactSurfaceDesktopDragActive" in script
+    assert "compactSurfaceResizeSession" in script
+    assert "compactSurfaceDesktopResizeActive" in script
+    assert "compactSurfaceTrackingSettleFramesRemaining = COMPACT_SURFACE_IDLE_SETTLE_FRAME_COUNT;" in tracking_block
+    assert "if (!trackingActive && compactSurfaceTrackingSettleFramesRemaining <= 0) {\n                return;\n            }" in tracking_block
+    assert "compactMinimizeBallFrame = window.requestAnimationFrame(loop);" in tracking_block
+    assert "COMPACT_SURFACE_IDLE_SYNC_INTERVAL_MS" not in script
+    assert "if (compactSurface) {\n            scheduleCompactMinimizeBallTracking();\n        }" in drag_start_block
+
+
 def test_electron_compact_chat_retires_full_surface_chrome():
     template = CHAT_TEMPLATE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 改动概述 / Summary

将 compact surface tracking 从空闲常驻 `requestAnimationFrame` 循环改为事件唤醒后的短帧 settle。

这样 compact 聊天条/最小化球在静止状态下不再长期空转同步，降低 NEKO-PC 和 NEKO compact 状态下的无意义布局读取与渲染压力；同时保留拖拽、缩放、桌面 layout 变化等活跃场景的逐帧同步，避免影响 compact geometry、命中区域和桌面布局链路。

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `.venv/bin/python -m pytest tests/unit/test_react_chat_window_static.py::test_compact_surface_tracking_stops_idle_raf_but_keeps_active_sessions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了迷你浮窗在拖拽、缩放和自动同步时的跟随表现，减少空闲状态下不必要的刷新。
  * 在开始拖拽时会更及时地触发同步，提升位置与几何信息的一致性。
  * 布局变化时改为使用新的同步策略，避免旧逻辑带来的节流不稳定问题。

* **Tests**
  * 新增覆盖，验证空闲跟踪会在合适时机停止，同时保持活跃交互期间持续同步。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->