### PR TITLE
新手引导开始时的模型加载方案1，判定进入新手引导后先加载用户模型，然后淡出，再加载教程模型

### DIFF
--- a/static/tutorial/core/round-prelude-controller.js
+++ b/static/tutorial/core/round-prelude-controller.js
@@ -39,7 +39,7 @@
             this.warn = normalizedOptions.warn || noop;
             this.defaultDelayMs = Number.isFinite(normalizedOptions.delayMs)
                 ? Math.max(0, Math.round(normalizedOptions.delayMs))
-                : 1500;
+                : 0;
         }
 
         async play(day, options) {

--- a/static/yui-guide-round-prelude.test.cjs
+++ b/static/yui-guide-round-prelude.test.cjs
@@ -59,7 +59,7 @@ test('round prelude runs avatar override, visibility, delay, lifecycle and start
         'reveal',
         ['visible', 'avatar_floating_day4'],
         ['ready', 'avatar_floating_day4'],
-        ['sleep', 1500],
+        ['sleep', 0],
         ['takeover', 4, 'manual'],
         ['lifecycle', true],
         'skip',

--- a/tests/unit/test_avatar_floating_day1_round_contracts.py
+++ b/tests/unit/test_avatar_floating_day1_round_contracts.py
@@ -648,10 +648,17 @@ def test_avatar_floating_round_waits_after_tutorial_model_is_visible():
         "clearModelManagerTutorialRecheckTimer()",
         1,
     )[0]
+    default_delay_block = prelude_source.split(
+        "this.defaultDelayMs = Number.isFinite(normalizedOptions.delayMs)",
+        1,
+    )[1].split(
+        "        }",
+        1,
+    )[0]
 
     assert "await toPromise(() => this.sleep(delayMs));" in prelude_source
     assert "this.defaultDelayMs" in prelude_source
-    assert "1500" in prelude_source
+    assert ": 0;" in default_delay_block
     assert prelude_source.index("this.ensureVisible(sceneId, {") < prelude_source.index(
         "await toPromise(() => this.sleep(delayMs));"
     )


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 优化新手教程启动时的教程模型准备流程：

- 将头像浮窗教程 round prelude 的默认额外等待从 1500ms 调整为 0ms。
- 保留教程模型准备期隐藏逻辑，让第一个 scene 的入场演出负责揭开模型。
- 更新 round prelude 与头像浮窗教程合同测试，锁定“准备期隐藏 + 无额外空等”的启动语义。

这样可以减少用户模型淡出后到教程首个 scene 出现前的空白等待，同时避免教程模型先裸露出来再切入 scene 的中间态。

## 回归报告 / Regression Report

不适用。本 PR 未修改 app/、main_logic/、main_routers/ 或 memory/ 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 仅涉及 1 个计数文件和 2 个测试文件，范围集中在新手教程 prelude 等待时间。

## 测试 / Testing

- `node --test static/yui-guide-round-prelude.test.cjs`
- `.venv/bin/python -m pytest tests/unit/test_avatar_floating_day1_round_contracts.py -q -k test_avatar_floating_round_waits_after_tutorial_model_is_visible`
- `.venv/bin/python -m pytest tests/unit/test_universal_tutorial_manager_static.py -q -k test_tutorial_yui_teardown_clears_non_live2d_runtime_residue_before_replay`
- `.venv/bin/python -m pytest tests/test_agent_rewrite_regression.py -q -k test_home_yui_guide_avatar_override_does_not_persist_tutorial_model`
- `node --check static/tutorial/core/round-prelude-controller.js`
- `node --check static/tutorial/core/universal-manager.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 教程/引导开始前的默认等待时间已调整为 0，不再额外延迟约 1.5 秒。
  * 相关测试已更新，确保延迟行为与实际表现一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->