### PR TITLE
新手教程模型加载时添加loading动画，并将用户模型推迟到新手引导结束后加载

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -63,6 +63,7 @@ _YUI_GUIDE_ASSET_VERSION_PATHS = (
     _PROJECT_ROOT / "static/tutorial/avatar/yui-stage.js",
     _PROJECT_ROOT / "static/tutorial/avatar/standin-controller.js",
     _PROJECT_ROOT / "static/tutorial/core/interaction-takeover.js",
+    _PROJECT_ROOT / "static/tutorial/core/avatar-floating-boot-predictor.js",
     _PROJECT_ROOT / "static/tutorial/core/skip-controller.js",
     _PROJECT_ROOT / "static/tutorial/avatar/reload-controller.js",
     _PROJECT_ROOT / "static/tutorial/core/round-prelude-controller.js",

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1127,7 +1127,9 @@
                         // Ensure Live2D manager is initialised
                         if (!window.live2dManager) {
                             console.log('[Model] Live2D 管理器未初始化，等待初始化完成');
-                            if (typeof initLive2DModel === 'function') {
+                            if (temporaryConfig && typeof window.Live2DManager === 'function') {
+                                window.live2dManager = new window.Live2DManager();
+                            } else if (typeof initLive2DModel === 'function') {
                                 await initLive2DModel();
                             }
                         }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -150,7 +150,15 @@ async function loadPageConfig() {
                 if (typeof window.hideOtherAvatarRuntimesForPNGTuber === 'function') {
                     window.hideOtherAvatarRuntimesForPNGTuber();
                 }
-                if (typeof window.loadPNGTuberAvatar === 'function') {
+                const shouldSkipPngtuberBoot = window.NekoAvatarFloatingBoot
+                    && typeof window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot === 'function'
+                    && window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot();
+                if (shouldSkipPngtuberBoot) {
+                    if (typeof window.NekoAvatarFloatingBoot.markUserModelBootSkipped === 'function') {
+                        window.NekoAvatarFloatingBoot.markUserModelBootSkipped('pngtuber-init');
+                    }
+                    console.log('[主页] 新手教程启动预测命中，跳过用户 PNGTuber 模型加载');
+                } else if (typeof window.loadPNGTuberAvatar === 'function') {
                     window.loadPNGTuberAvatar(lanlan_config.pngtuber || { idle_image: modelPath });
                 }
             } else if (modelType === 'live3d' || modelType === 'vrm') {

--- a/static/live2d-init.js
+++ b/static/live2d-init.js
@@ -51,6 +51,10 @@ function _nekoAwaitWithTimeout(thenable, ms) {
 // 仅对"本应显示 Live2D"的会话自愈；pngtuber/vrm/mmd 的空 cubism4Model 是正常态。
 function _nekoShouldSelfHealLive2D() {
     try {
+        if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot === 'function'
+            && window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()) {
+            return false;
+        }
         if (window.location && String(window.location.pathname || '').includes('model_manager')) return false;
         const mt = (window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
         const sub = (window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
@@ -410,6 +414,8 @@ async function initLive2DModel() {
     }
 }
 
+window.initLive2DModel = initLive2DModel;
+
 // 自动初始化函数（延迟执行，等待 cubism4Model 设置）
 async function _initLive2DModelInner() {
     const _preInitModelPath = (typeof cubism4Model !== 'undefined' ? cubism4Model : (window.cubism4Model || ''));
@@ -424,6 +430,15 @@ async function _initLive2DModelInner() {
             console.warn('[Live2D Init] 存储位置哨兵被拒绝，中止本次 Live2D 初始化');
             return;
         }
+    }
+
+    if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot === 'function'
+        && window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()) {
+        if (typeof window.NekoAvatarFloatingBoot.markUserModelBootSkipped === 'function') {
+            window.NekoAvatarFloatingBoot.markUserModelBootSkipped('live2d-init');
+        }
+        console.log('[Live2D Init] 新手教程启动预测命中，跳过用户 Live2D 模型加载');
+        return;
     }
 
     // 检查是否在 VRM/MMD 模式下，如果是则跳过 Live2D 初始化

--- a/static/mmd-init.js
+++ b/static/mmd-init.js
@@ -452,7 +452,7 @@
 })();
 
 // 模块加载完成后，若当前是 MMD 模式则自动初始化并加载模型
-(async function autoInitMMDOnMainPage() {
+async function autoInitMMDOnMainPage() {
     // 模型管理页面和角色卡导出页不自动加载
     if (window._cardExportPage) return;
     if (window.location.pathname.includes('model_manager') || document.querySelector('#vrm-model-select') !== null) return;
@@ -595,7 +595,10 @@
         console.error('[MMD Init] MMD 自动加载失败:', e);
         window.MMDLoadingOverlay.fail(loadingSessionId, { detail: e?.message || String(e) });
     }
-})();
+}
+
+window.autoInitMMDOnMainPage = autoInitMMDOnMainPage;
+autoInitMMDOnMainPage();
 
 // ── 主页面 MMD 待机动作轮换 ──────────────────────────────
 // 策略：优先在动画一轮播完（loop 事件）时切换，避免动作中途跳变；

--- a/static/mmd-init.js
+++ b/static/mmd-init.js
@@ -461,6 +461,15 @@
         await window.__nekoStorageLocationStartupBarrier;
     }
 
+    if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot === 'function'
+        && window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()) {
+        if (typeof window.NekoAvatarFloatingBoot.markUserModelBootSkipped === 'function') {
+            window.NekoAvatarFloatingBoot.markUserModelBootSkipped('mmd-init');
+        }
+        console.log('[MMD Init] 新手教程启动预测命中，跳过用户 MMD 模型加载');
+        return;
+    }
+
     // 等待页面配置加载完成
     if (window.pageConfigReady && typeof window.pageConfigReady.then === 'function') {
         await window.pageConfigReady;

--- a/static/tutorial/avatar/reload-controller.js
+++ b/static/tutorial/avatar/reload-controller.js
@@ -122,6 +122,7 @@
         beginOverride(options) {
             const normalizedOptions = options || {};
             const deferRevealPrepared = normalizedOptions.deferRevealPrepared === true;
+            const skipSourceModelFade = normalizedOptions.skipSourceModelFade === true;
             const host = this.host;
             if (!host) {
                 return Promise.reject(new Error('tutorial avatar reload host is required'));
@@ -182,9 +183,11 @@
                 this.override.proactiveSnapshot = snapshotProactiveState();
                 applyProactiveState(buildDisabledProactiveState());
 
-                await Promise.resolve(this.fadeOutCurrentModel({
-                    deferRevealPrepared
-                }));
+                if (!skipSourceModelFade) {
+                    await Promise.resolve(this.fadeOutCurrentModel({
+                        deferRevealPrepared
+                    }));
+                }
                 ensureOverrideActive();
                 this.setPreparing(true);
                 await this.reloadModel(currentName, tutorialModelPayload, {

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -328,6 +328,21 @@
         const modelType = String(window.lanlan_config && window.lanlan_config.model_type || 'live2d').toLowerCase();
         const subType = String(window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
         try {
+            const isPngtuberModel = modelType === 'pngtuber';
+            if (isPngtuberModel) {
+                if (typeof window.loadPNGTuberAvatar === 'function') {
+                    await window.loadPNGTuberAvatar(window.lanlan_config && window.lanlan_config.pngtuber || {});
+                    if (window.pngtuberManager && typeof window.pngtuberManager.show === 'function') {
+                        window.pngtuberManager.show();
+                    }
+                    return true;
+                }
+                if (typeof window.showCurrentModel === 'function') {
+                    await window.showCurrentModel();
+                    return true;
+                }
+                return false;
+            }
             const isMmdModel = modelType === 'live3d' && subType === 'mmd';
             if (isMmdModel) {
                 if (typeof window.autoInitMMDOnMainPage === 'function') {

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -210,11 +210,36 @@
         return overlaySequence;
     }
 
+    function isPcLoadingOverlayBridge(bridge) {
+        return !!(
+            bridge
+            && typeof bridge === 'object'
+            && typeof bridge.begin === 'function'
+            && typeof bridge.update === 'function'
+            && typeof bridge.clear === 'function'
+        );
+    }
+
     function getPcLoadingOverlayBridge() {
-        return window.nekoTutorialLoadingOverlay
-            && typeof window.nekoTutorialLoadingOverlay === 'object'
-            ? window.nekoTutorialLoadingOverlay
-            : null;
+        if (isPcLoadingOverlayBridge(window.nekoTutorialLoadingOverlay)) {
+            return window.nekoTutorialLoadingOverlay;
+        }
+        if (window.nekoTutorialOverlay && isPcLoadingOverlayBridge(window.nekoTutorialOverlay.loadingOverlay)) {
+            return window.nekoTutorialOverlay.loadingOverlay;
+        }
+        if (
+            window.nekoTutorialOverlay
+            && typeof window.nekoTutorialOverlay.beginLoading === 'function'
+            && typeof window.nekoTutorialOverlay.updateLoading === 'function'
+            && typeof window.nekoTutorialOverlay.clearLoading === 'function'
+        ) {
+            return {
+                begin: payload => window.nekoTutorialOverlay.beginLoading(payload),
+                update: payload => window.nekoTutorialOverlay.updateLoading(payload),
+                clear: payload => window.nekoTutorialOverlay.clearLoading(payload)
+            };
+        }
+        return null;
     }
 
     function beginDirectTutorialLoading(reason) {

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -1,0 +1,190 @@
+(function () {
+    'use strict';
+
+    const AVATAR_FLOATING_GUIDE_STORAGE_KEY = 'neko_avatar_floating_guide_v1';
+    const HOME_TUTORIAL_KEYS = ['neko_tutorial_home_yui_v1', 'neko_tutorial_home'];
+    const ROUND_COUNT = 7;
+
+    const state = {
+        predictedRound: null,
+        userModelBootSkipped: false,
+        directTutorialBootClaimed: false,
+        predictionSuppressed: false,
+        claimReason: ''
+    };
+
+    function getTodayLocalDate() {
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = String(now.getMonth() + 1).padStart(2, '0');
+        const day = String(now.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    }
+
+    function normalizeRound(value) {
+        const round = Number(value);
+        return Number.isInteger(round) && round >= 1 && round <= ROUND_COUNT ? round : null;
+    }
+
+    function normalizeRoundList(value) {
+        if (!Array.isArray(value)) {
+            return [];
+        }
+        return Array.from(new Set(
+            value
+                .map(item => Number(item))
+                .filter(item => Number.isInteger(item) && item >= 1 && item <= ROUND_COUNT)
+        )).sort((left, right) => left - right);
+    }
+
+    function loadGuideState() {
+        let parsed = {};
+        try {
+            const raw = window.localStorage && window.localStorage.getItem(AVATAR_FLOATING_GUIDE_STORAGE_KEY);
+            parsed = raw ? JSON.parse(raw) : {};
+        } catch (_) {
+            parsed = {};
+        }
+        return {
+            firstSeenDate: parsed.firstSeenDate || getTodayLocalDate(),
+            completedRounds: normalizeRoundList(parsed.completedRounds),
+            skippedRounds: normalizeRoundList(parsed.skippedRounds),
+            pendingRound: normalizeRound(parsed.pendingRound),
+            manualResetRound: normalizeRound(parsed.manualResetRound),
+            lastAutoShownDate: parsed.lastAutoShownDate || ''
+        };
+    }
+
+    function getDateDeltaDays(firstSeenDate, today) {
+        const matchFirst = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(firstSeenDate || ''));
+        const matchToday = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(today || ''));
+        if (!matchFirst || !matchToday) {
+            return 0;
+        }
+        const firstDate = new Date(Number(matchFirst[1]), Number(matchFirst[2]) - 1, Number(matchFirst[3]));
+        const todayDate = new Date(Number(matchToday[1]), Number(matchToday[2]) - 1, Number(matchToday[3]));
+        const diffMs = todayDate.getTime() - firstDate.getTime();
+        return Number.isFinite(diffMs) ? Math.max(0, Math.floor(diffMs / 86400000)) : 0;
+    }
+
+    function hasLegacyHomeTutorialSeen() {
+        try {
+            return HOME_TUTORIAL_KEYS.some(key => window.localStorage && window.localStorage.getItem(key) === 'true');
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function computePredictedRound() {
+        const guideState = loadGuideState();
+        const completed = new Set(guideState.completedRounds);
+        const skipped = new Set(guideState.skippedRounds);
+
+        if (!completed.has(1) && hasLegacyHomeTutorialSeen()) {
+            completed.add(1);
+        }
+
+        if (guideState.manualResetRound) {
+            return guideState.manualResetRound;
+        }
+        if (guideState.pendingRound && !completed.has(guideState.pendingRound) && !skipped.has(guideState.pendingRound)) {
+            return guideState.pendingRound;
+        }
+        if (!completed.has(1) && !skipped.has(1)) {
+            return 1;
+        }
+        if (guideState.lastAutoShownDate === getTodayLocalDate()) {
+            return null;
+        }
+
+        const maxDueRound = Math.min(ROUND_COUNT, getDateDeltaDays(guideState.firstSeenDate, getTodayLocalDate()) + 1);
+        for (let round = 2; round <= maxDueRound; round += 1) {
+            if (!completed.has(round) && !skipped.has(round)) {
+                return round;
+            }
+        }
+        return null;
+    }
+
+    function getPredictedRound() {
+        state.predictedRound = computePredictedRound();
+        return state.predictedRound;
+    }
+
+    function shouldBootIntoTutorial() {
+        if (state.predictionSuppressed) {
+            return false;
+        }
+        return !!getPredictedRound();
+    }
+
+    function shouldSkipUserModelBoot() {
+        return shouldBootIntoTutorial() || state.directTutorialBootClaimed === true;
+    }
+
+    function markUserModelBootSkipped(reason) {
+        state.userModelBootSkipped = true;
+        state.predictionSuppressed = false;
+        state.claimReason = reason || state.claimReason || 'user-model-boot-skipped';
+        return true;
+    }
+
+    function claimDirectTutorialBoot(round, reason) {
+        const normalizedRound = normalizeRound(round);
+        state.predictionSuppressed = false;
+        state.predictedRound = normalizedRound || getPredictedRound();
+        state.directTutorialBootClaimed = !!state.predictedRound;
+        state.claimReason = reason || 'direct-tutorial-boot';
+        return state.directTutorialBootClaimed;
+    }
+
+    function releaseDirectTutorialBoot(reason) {
+        state.directTutorialBootClaimed = false;
+        state.userModelBootSkipped = false;
+        state.claimReason = reason || '';
+    }
+
+    async function recoverUserModelBoot(reason) {
+        const shouldRecover = state.userModelBootSkipped || state.directTutorialBootClaimed;
+        if (!shouldRecover) {
+            return false;
+        }
+        state.predictionSuppressed = true;
+        releaseDirectTutorialBoot(reason || 'recover-user-model');
+        if (typeof window.showCurrentModel === 'function') {
+            await window.showCurrentModel();
+            return true;
+        }
+        const modelType = String(window.lanlan_config && window.lanlan_config.model_type || 'live2d').toLowerCase();
+        const subType = String(window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
+        if ((modelType === 'live3d' && subType === 'mmd') && typeof window.initMMDModel === 'function') {
+            await window.initMMDModel();
+            return true;
+        }
+        if ((modelType === 'vrm' || modelType === 'live3d') && typeof window.initVRMModel === 'function') {
+            await window.initVRMModel();
+            return true;
+        }
+        if (typeof window.initLive2DModel === 'function') {
+            await window.initLive2DModel();
+            return true;
+        }
+        return false;
+    }
+
+    window.NekoAvatarFloatingBoot = {
+        shouldBootIntoTutorial,
+        shouldSkipUserModelBoot,
+        getPredictedRound,
+        markUserModelBootSkipped,
+        claimDirectTutorialBoot,
+        releaseDirectTutorialBoot,
+        recoverUserModelBoot,
+        wasUserModelBootSkipped() {
+            return state.userModelBootSkipped === true;
+        },
+        isDirectTutorialBootClaimed() {
+            return state.directTutorialBootClaimed === true;
+        }
+    };
+})();

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -287,14 +287,13 @@
         const modelType = String(window.lanlan_config && window.lanlan_config.model_type || 'live2d').toLowerCase();
         const subType = String(window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
         try {
-            if (modelType === 'live3d' && subType === 'mmd') {
+            const isMmdModel = modelType === 'live3d' && subType === 'mmd';
+            if (isMmdModel) {
                 if (typeof window.initMMDModel === 'function') {
                     await window.initMMDModel();
                     return true;
                 }
-                return false;
-            }
-            if ((modelType === 'vrm' || modelType === 'live3d') && typeof window.initVRMModel === 'function') {
+            } else if ((modelType === 'vrm' || modelType === 'live3d') && typeof window.initVRMModel === 'function') {
                 await window.initVRMModel();
                 return true;
             }

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -3,6 +3,9 @@
 
     const AVATAR_FLOATING_GUIDE_STORAGE_KEY = 'neko_avatar_floating_guide_v1';
     const HOME_TUTORIAL_KEYS = ['neko_tutorial_home_yui_v1', 'neko_tutorial_home'];
+    const PC_OVERLAY_RUN_ID_STORAGE_KEY = 'yuiGuidePcOverlayRunId';
+    const PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence';
+    const PC_OVERLAY_LOADING_ICON = '/static/icons/emotion_model_icon.png';
     const ROUND_COUNT = 7;
 
     const state = {
@@ -10,8 +13,11 @@
         userModelBootSkipped: false,
         directTutorialBootClaimed: false,
         predictionSuppressed: false,
+        loadingActive: false,
         claimReason: ''
     };
+    let overlayRunId = '';
+    let overlaySequence = 0;
 
     function getTodayLocalDate() {
         const now = new Date();
@@ -144,12 +150,128 @@
         state.claimReason = reason || '';
     }
 
+    function createPcOverlayRunId() {
+        return 'yui-guide-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8);
+    }
+
+    function ensurePcOverlayRunId() {
+        if (overlayRunId) {
+            return overlayRunId;
+        }
+        try {
+            const stored = window.sessionStorage && window.sessionStorage.getItem(PC_OVERLAY_RUN_ID_STORAGE_KEY);
+            overlayRunId = stored || createPcOverlayRunId();
+            if (window.sessionStorage) {
+                window.sessionStorage.setItem(PC_OVERLAY_RUN_ID_STORAGE_KEY, overlayRunId);
+            }
+        } catch (_) {
+            overlayRunId = createPcOverlayRunId();
+        }
+        return overlayRunId;
+    }
+
+    function nextPcOverlaySequence() {
+        try {
+            const stored = window.sessionStorage && Number(window.sessionStorage.getItem(PC_OVERLAY_SEQUENCE_STORAGE_KEY));
+            if (Number.isFinite(stored) && stored > overlaySequence) {
+                overlaySequence = stored;
+            }
+        } catch (_) {}
+        overlaySequence += 1;
+        try {
+            if (window.sessionStorage) {
+                window.sessionStorage.setItem(PC_OVERLAY_SEQUENCE_STORAGE_KEY, String(overlaySequence));
+            }
+        } catch (_) {}
+        return overlaySequence;
+    }
+
+    function getPcLoadingOverlayBridge() {
+        return window.nekoTutorialLoadingOverlay
+            && typeof window.nekoTutorialLoadingOverlay === 'object'
+            ? window.nekoTutorialLoadingOverlay
+            : null;
+    }
+
+    function beginDirectTutorialLoading(reason) {
+        const bridge = getPcLoadingOverlayBridge();
+        if (!bridge || typeof bridge.begin !== 'function' || typeof bridge.update !== 'function') {
+            return false;
+        }
+        const tutorialRunId = ensurePcOverlayRunId();
+        const sequence = nextPcOverlaySequence();
+        state.loadingActive = true;
+        try {
+            const beginResult = bridge.begin({ tutorialRunId, reason: reason || 'direct-tutorial-loading' });
+            if (beginResult && typeof beginResult.catch === 'function') {
+                beginResult.catch(() => {
+                    state.loadingActive = false;
+                });
+            }
+            const updateResult = bridge.update({
+                tutorialRunId,
+                sequence,
+                payload: {
+                    loading: {
+                        visible: true,
+                        reason: reason || 'direct-tutorial-loading',
+                        emotionIconUrl: PC_OVERLAY_LOADING_ICON
+                    }
+                }
+            });
+            if (updateResult && typeof updateResult.catch === 'function') {
+                updateResult.catch(() => {
+                    state.loadingActive = false;
+                });
+            }
+            return true;
+        } catch (_) {
+            state.loadingActive = false;
+            return false;
+        }
+    }
+
+    function clearDirectTutorialLoading(reason) {
+        const bridge = getPcLoadingOverlayBridge();
+        if (!state.loadingActive && !overlayRunId) {
+            return false;
+        }
+        state.loadingActive = false;
+        if (!bridge) {
+            return false;
+        }
+        const tutorialRunId = ensurePcOverlayRunId();
+        const sequence = nextPcOverlaySequence();
+        try {
+            if (typeof bridge.update === 'function') {
+                const updateResult = bridge.update({
+                    tutorialRunId,
+                    sequence,
+                    payload: { loading: null, reason: reason || 'direct-tutorial-loading-clear' }
+                });
+                if (updateResult && typeof updateResult.catch === 'function') {
+                    updateResult.catch(() => {});
+                }
+            }
+        } catch (_) {}
+        try {
+            if (typeof bridge.clear === 'function') {
+                const clearResult = bridge.clear({ tutorialRunId, reason: reason || 'direct-tutorial-loading-clear' });
+                if (clearResult && typeof clearResult.catch === 'function') {
+                    clearResult.catch(() => {});
+                }
+            }
+        } catch (_) {}
+        return true;
+    }
+
     async function recoverUserModelBoot(reason) {
         const shouldRecover = state.userModelBootSkipped || state.directTutorialBootClaimed;
         if (!shouldRecover) {
             return false;
         }
         state.predictionSuppressed = true;
+        clearDirectTutorialLoading(reason || 'recover-user-model');
         releaseDirectTutorialBoot(reason || 'recover-user-model');
         if (typeof window.showCurrentModel === 'function') {
             await window.showCurrentModel();
@@ -179,6 +301,8 @@
         markUserModelBootSkipped,
         claimDirectTutorialBoot,
         releaseDirectTutorialBoot,
+        beginDirectTutorialLoading,
+        clearDirectTutorialLoading,
         recoverUserModelBoot,
         wasUserModelBootSkipped() {
             return state.userModelBootSkipped === true;

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -118,14 +118,25 @@
         return state.predictedRound;
     }
 
+    function isTutorialBootAvailable() {
+        return !(typeof window.innerWidth === 'number' && window.innerWidth <= 768);
+    }
+
     function shouldBootIntoTutorial() {
         if (state.predictionSuppressed) {
+            return false;
+        }
+        if (!isTutorialBootAvailable()) {
+            state.predictedRound = null;
             return false;
         }
         return !!getPredictedRound();
     }
 
     function shouldSkipUserModelBoot() {
+        if (!isTutorialBootAvailable()) {
+            return false;
+        }
         return shouldBootIntoTutorial() || state.directTutorialBootClaimed === true;
     }
 
@@ -137,6 +148,11 @@
     }
 
     function claimDirectTutorialBoot(round, reason) {
+        if (!isTutorialBootAvailable()) {
+            state.predictedRound = null;
+            state.directTutorialBootClaimed = false;
+            return false;
+        }
         const normalizedRound = normalizeRound(round);
         state.predictionSuppressed = false;
         state.predictedRound = normalizedRound || getPredictedRound();

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -94,14 +94,14 @@
         if (guideState.manualResetRound) {
             return guideState.manualResetRound;
         }
+        if (guideState.lastAutoShownDate === getTodayLocalDate()) {
+            return null;
+        }
         if (guideState.pendingRound && !completed.has(guideState.pendingRound) && !skipped.has(guideState.pendingRound)) {
             return guideState.pendingRound;
         }
         if (!completed.has(1) && !skipped.has(1)) {
             return 1;
-        }
-        if (guideState.lastAutoShownDate === getTodayLocalDate()) {
-            return null;
         }
 
         const maxDueRound = Math.min(ROUND_COUNT, getDateDeltaDays(guideState.firstSeenDate, getTodayLocalDate()) + 1);

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -227,6 +227,9 @@
         if (window.nekoTutorialOverlay && isPcLoadingOverlayBridge(window.nekoTutorialOverlay.loadingOverlay)) {
             return window.nekoTutorialOverlay.loadingOverlay;
         }
+        if (isPcLoadingOverlayBridge(window.nekoTutorialOverlay)) {
+            return window.nekoTutorialOverlay;
+        }
         if (
             window.nekoTutorialOverlay
             && typeof window.nekoTutorialOverlay.beginLoading === 'function'

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -305,10 +305,20 @@
         try {
             const isMmdModel = modelType === 'live3d' && subType === 'mmd';
             if (isMmdModel) {
+                if (typeof window.autoInitMMDOnMainPage === 'function') {
+                    await window.autoInitMMDOnMainPage();
+                    if (window.mmdManager && window.mmdManager.currentModel) {
+                        return true;
+                    }
+                }
                 if (typeof window.initMMDModel === 'function') {
                     await window.initMMDModel();
+                }
+                if (typeof window.showCurrentModel === 'function') {
+                    await window.showCurrentModel();
                     return true;
                 }
+                return false;
             } else if ((modelType === 'vrm' || modelType === 'live3d') && typeof window.initVRMModel === 'function') {
                 await window.initVRMModel();
                 return true;

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -10,6 +10,7 @@
 
     const state = {
         predictedRound: null,
+        userModelBootSkippedRound: null,
         userModelBootSkipped: false,
         directTutorialBootClaimed: false,
         predictionSuppressed: false,
@@ -130,7 +131,7 @@
 
     function markUserModelBootSkipped(reason) {
         state.userModelBootSkipped = true;
-        state.predictionSuppressed = false;
+        state.userModelBootSkippedRound = state.predictedRound || getPredictedRound();
         state.claimReason = reason || state.claimReason || 'user-model-boot-skipped';
         return true;
     }
@@ -144,9 +145,16 @@
         return state.directTutorialBootClaimed;
     }
 
-    function releaseDirectTutorialBoot(reason) {
+    function releaseDirectTutorialBoot(reason, options) {
+        const keepUserModelBootSkipped = options && options.keepUserModelBootSkipped === true;
+        if (options && options.suppressPrediction === true) {
+            state.predictionSuppressed = true;
+        }
         state.directTutorialBootClaimed = false;
-        state.userModelBootSkipped = false;
+        if (!keepUserModelBootSkipped) {
+            state.userModelBootSkipped = false;
+            state.userModelBootSkippedRound = null;
+        }
         state.claimReason = reason || '';
     }
 
@@ -272,32 +280,45 @@
         }
         state.predictionSuppressed = true;
         clearDirectTutorialLoading(reason || 'recover-user-model');
-        releaseDirectTutorialBoot(reason || 'recover-user-model');
-        if (typeof window.showCurrentModel === 'function') {
-            await window.showCurrentModel();
-            return true;
-        }
+        releaseDirectTutorialBoot(reason || 'recover-user-model', {
+            keepUserModelBootSkipped: true,
+            suppressPrediction: true
+        });
         const modelType = String(window.lanlan_config && window.lanlan_config.model_type || 'live2d').toLowerCase();
         const subType = String(window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
-        if ((modelType === 'live3d' && subType === 'mmd') && typeof window.initMMDModel === 'function') {
-            await window.initMMDModel();
-            return true;
+        try {
+            if (modelType === 'live3d' && subType === 'mmd') {
+                if (typeof window.initMMDModel === 'function') {
+                    await window.initMMDModel();
+                    return true;
+                }
+                return false;
+            }
+            if ((modelType === 'vrm' || modelType === 'live3d') && typeof window.initVRMModel === 'function') {
+                await window.initVRMModel();
+                return true;
+            }
+            if (typeof window.initLive2DModel === 'function') {
+                await window.initLive2DModel();
+                return true;
+            }
+            if (typeof window.showCurrentModel === 'function') {
+                await window.showCurrentModel();
+                return true;
+            }
+            return false;
+        } finally {
+            releaseDirectTutorialBoot(reason || 'recover-user-model');
         }
-        if ((modelType === 'vrm' || modelType === 'live3d') && typeof window.initVRMModel === 'function') {
-            await window.initVRMModel();
-            return true;
-        }
-        if (typeof window.initLive2DModel === 'function') {
-            await window.initLive2DModel();
-            return true;
-        }
-        return false;
     }
 
     window.NekoAvatarFloatingBoot = {
         shouldBootIntoTutorial,
         shouldSkipUserModelBoot,
         getPredictedRound,
+        getSkippedUserModelBootRound() {
+            return state.userModelBootSkippedRound;
+        },
         markUserModelBootSkipped,
         claimDirectTutorialBoot,
         releaseDirectTutorialBoot,

--- a/static/tutorial/core/round-prelude-controller.js
+++ b/static/tutorial/core/round-prelude-controller.js
@@ -50,9 +50,11 @@
                 : this.defaultDelayMs;
             const sceneId = 'avatar_floating_day' + day;
             const deferRevealPrepared = normalizedOptions.deferRevealPrepared === true;
+            const skipSourceModelFade = normalizedOptions.skipSourceModelFade === true;
 
             await toPromise(() => this.beginAvatarOverride({
-                deferRevealPrepared
+                deferRevealPrepared,
+                skipSourceModelFade
             })).catch((error) => {
                 this.warn('[Tutorial] 悬浮窗教程临时切换 YUI 失败，中止教程:', error);
                 return toPromise(() => this.revealPrepared()).then(() => {

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -743,6 +743,91 @@ class UniversalTutorialManager {
         return null;
     }
 
+    getAvatarFloatingBootHelper() {
+        return window.NekoAvatarFloatingBoot || null;
+    }
+
+    isDirectAvatarFloatingTutorialBoot(round) {
+        const helper = this.getAvatarFloatingBootHelper();
+        if (!helper) {
+            return false;
+        }
+        const normalizedRound = normalizeOptionalAvatarFloatingGuideRound(round);
+        const predictedRound = typeof helper.getPredictedRound === 'function'
+            ? normalizeOptionalAvatarFloatingGuideRound(helper.getPredictedRound())
+            : null;
+        const canBootDirect = typeof helper.shouldBootIntoTutorial === 'function'
+            ? helper.shouldBootIntoTutorial()
+            : !!predictedRound;
+        const skippedUserModel = typeof helper.wasUserModelBootSkipped === 'function'
+            && helper.wasUserModelBootSkipped();
+        return !!normalizedRound && ((canBootDirect && predictedRound === normalizedRound) || skippedUserModel);
+    }
+
+    claimDirectAvatarFloatingTutorialBoot(round, source) {
+        if (!window.NekoAvatarFloatingBoot || typeof window.NekoAvatarFloatingBoot.claimDirectTutorialBoot !== 'function') {
+            return false;
+        }
+        return window.NekoAvatarFloatingBoot.claimDirectTutorialBoot(round, source || 'avatar-floating-guide-start');
+    }
+
+    releaseDirectAvatarFloatingTutorialBoot(reason) {
+        if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot === 'function') {
+            window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot(reason || 'avatar-floating-guide-release');
+        }
+    }
+
+    async recoverUserModelAfterDirectTutorialBootFailure(reason) {
+        if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.recoverUserModelBoot === 'function') {
+            try {
+                return await window.NekoAvatarFloatingBoot.recoverUserModelBoot(reason || 'direct-tutorial-boot-failed');
+            } catch (error) {
+                console.warn('[Tutorial] direct tutorial boot 恢复用户模型失败:', reason || 'unknown', error);
+            }
+        }
+        if (typeof window.showCurrentModel === 'function') {
+            try {
+                await window.showCurrentModel();
+                return true;
+            } catch (error) {
+                console.warn('[Tutorial] showCurrentModel 恢复用户模型失败:', reason || 'unknown', error);
+            }
+        }
+        return false;
+    }
+
+    waitForTutorialModelHostReady(maxWaitTime = 12000) {
+        const hasHost = () => !!(
+            document.body
+            && document.getElementById('live2d-container')
+            && document.getElementById('live2d-canvas')
+        );
+        if (hasHost()) {
+            return Promise.resolve(true);
+        }
+        return new Promise((resolve) => {
+            let resolved = false;
+            const done = (result) => {
+                if (resolved) {
+                    return;
+                }
+                resolved = true;
+                clearTimeout(timer);
+                clearInterval(poller);
+                resolve(result);
+            };
+            const poller = setInterval(() => {
+                if (hasHost()) {
+                    done(true);
+                }
+            }, 50);
+            const timer = setTimeout(() => {
+                console.warn(`[Tutorial] 等待教程模型容器超时（${maxWaitTime / 1000}秒）`);
+                done(false);
+            }, maxWaitTime);
+        });
+    }
+
     async maybeStartAvatarFloatingGuideAutoRound(delayMs = 1200) {
         if (this.currentPage !== 'home' || this.isTutorialRunning || window.isInTutorial) {
             return false;
@@ -1389,6 +1474,7 @@ class UniversalTutorialManager {
                         page: this.currentPage,
                         reason: 'prompt-flow-active',
                     });
+                    this.recoverUserModelAfterDirectTutorialBootFailure('home-auto-start-suppressed');
                     this.dispatchStartupGreetingRelease('home-auto-start-suppressed');
                     return;
                 }
@@ -1397,11 +1483,13 @@ class UniversalTutorialManager {
                     const round = this.getHomeAvatarFloatingGuideStartRound();
                     if (!round) {
                         console.warn('[Tutorial] 首页每日教程 round 未注册，跳过启动');
+                        this.recoverUserModelAfterDirectTutorialBootFailure('no-home-avatar-floating-round');
                         this.dispatchStartupGreetingRelease('no-home-avatar-floating-round');
                         return;
                     }
                     this.startAvatarFloatingGuideRound(round, { source }).then((result) => {
                         if (result === false) {
+                            this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-round-start-skipped');
                             this.dispatchStartupGreetingRelease('avatar-floating-round-start-skipped', { day: round });
                         }
                     }).catch(error => {
@@ -2966,7 +3054,12 @@ class UniversalTutorialManager {
             }
 
             if (this.currentPage === 'home') {
-                await this.waitForFloatingButtons();
+                const round = this.getHomeAvatarFloatingGuideStartRound();
+                if (round && this.isDirectAvatarFloatingTutorialBoot(round)) {
+                    await this.waitForTutorialModelHostReady();
+                } else {
+                    await this.waitForFloatingButtons();
+                }
                 this.startTutorialWhenI18nReady(delayMs);
                 return true;
             }
@@ -3003,9 +3096,18 @@ class UniversalTutorialManager {
         if (this.currentPage !== 'home') {
             throw new Error('avatar_floating_guide_requires_home');
         }
-        const buttonsReady = await this.waitForFloatingButtons();
-        if (!buttonsReady) {
-            throw new Error('floating_buttons_not_ready');
+        const directTutorialBoot = this.isDirectAvatarFloatingTutorialBoot(round);
+        if (directTutorialBoot) {
+            const hostReady = await this.waitForTutorialModelHostReady();
+            if (!hostReady) {
+                await this.recoverUserModelAfterDirectTutorialBootFailure('tutorial-model-host-not-ready');
+                throw new Error('tutorial_model_host_not_ready');
+            }
+        } else {
+            const buttonsReady = await this.waitForFloatingButtons();
+            if (!buttonsReady) {
+                throw new Error('floating_buttons_not_ready');
+            }
         }
 
         this._isDestroyed = false;
@@ -3035,13 +3137,18 @@ class UniversalTutorialManager {
         this.syncYuiGuideCompactChatFixedLayout(true, 'avatar-floating-guide-start');
         this._tutorialModelPrefix = 'live2d';
         this.emitTutorialStarted('home', source);
+        if (directTutorialBoot) {
+            this.claimDirectAvatarFloatingTutorialBoot(round, source);
+        }
 
         try {
             const director = this.ensureYuiGuideDirector();
             if (!director || typeof director.playAvatarFloatingRound !== 'function') {
                 throw new Error('avatar_floating_director_unavailable');
             }
-            await this.playAvatarFloatingRoundPrelude(round, source, director);
+            await this.playAvatarFloatingRoundPrelude(round, source, director, {
+                skipSourceModelFade: directTutorialBoot
+            });
             const completed = await director.playAvatarFloatingRound(round, {
                 source,
                 surfaceReady: true,
@@ -3060,10 +3167,17 @@ class UniversalTutorialManager {
             return completed;
         } catch (error) {
             console.error('[Tutorial] 悬浮窗教程启动失败:', error);
+            if (directTutorialBoot) {
+                await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed');
+            }
             if (!this._tutorialEndHandled) {
                 await this.requestTutorialDestroy('destroy');
             }
             throw error;
+        } finally {
+            if (directTutorialBoot) {
+                this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-finished');
+            }
         }
     }
 
@@ -3081,7 +3195,7 @@ class UniversalTutorialManager {
         }
     }
 
-    async playAvatarFloatingRoundPrelude(round, source, director) {
+    async playAvatarFloatingRoundPrelude(round, source, director, options = {}) {
         const controller = this.ensureTutorialRoundPreludeController();
         if (!controller || typeof controller.play !== 'function') {
             throw new Error('tutorial_round_prelude_controller_unavailable');
@@ -3089,7 +3203,8 @@ class UniversalTutorialManager {
         return controller.play(round, {
             source: source,
             director: director || null,
-            deferRevealPrepared: true
+            deferRevealPrepared: true,
+            skipSourceModelFade: options && options.skipSourceModelFade === true
         });
     }
 
@@ -3112,6 +3227,20 @@ class UniversalTutorialManager {
 
         const storageKey = this.getStorageKey();
         const hasSeen = localStorage.getItem(storageKey);
+        if (this.currentPage === 'home') {
+            const directBootRound = this.getHomeAvatarFloatingGuideStartRound();
+            if (directBootRound && this.isDirectAvatarFloatingTutorialBoot(directBootRound)) {
+                const directBootState = loadAvatarFloatingGuideState();
+                if (directBootState.manualResetRound === directBootRound) {
+                    this.pendingTutorialStartSource = 'manual_reset';
+                }
+                if (!hasSeen) {
+                    this.setHomeTutorialPending(true);
+                }
+                this.startTutorialWhenI18nReady(1500);
+                return;
+            }
+        }
 
         if (!hasSeen && this.currentPage === 'home') {
             // 新手教程即将启动：先置 pending，让选人格门控在「模型加载/首句演出尚未上锁」这段窗口里

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -777,7 +777,41 @@ class UniversalTutorialManager {
         }
     }
 
+    beginDirectAvatarFloatingTutorialLoading(reason) {
+        if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.beginDirectTutorialLoading === 'function') {
+            window.NekoAvatarFloatingBoot.beginDirectTutorialLoading(reason || 'startup-direct-tutorial-predicted');
+        }
+    }
+
+    clearDirectAvatarFloatingTutorialLoading(reason) {
+        if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.clearDirectTutorialLoading === 'function') {
+            window.NekoAvatarFloatingBoot.clearDirectTutorialLoading(reason || 'avatar-floating-yui-ready');
+        }
+    }
+
+    dispatchAvatarFloatingTutorialInputRestored(reason = 'tutorial-avatar-restored') {
+        const detail = {
+            action: 'yui_guide_tutorial_input_restored',
+            reason,
+            page: this.getYuiGuidePageKey(),
+            runtimePage: this.currentPage,
+            timestamp: Date.now()
+        };
+        try {
+            window.dispatchEvent(new CustomEvent('neko:yui-guide:tutorial-input-restored', { detail }));
+        } catch (_) {}
+        try {
+            if (
+                window.nekoTutorialOverlay
+                && typeof window.nekoTutorialOverlay.relayToPet === 'function'
+            ) {
+                window.nekoTutorialOverlay.relayToPet(detail);
+            }
+        } catch (_) {}
+    }
+
     async recoverUserModelAfterDirectTutorialBootFailure(reason) {
+        this.clearDirectAvatarFloatingTutorialLoading(reason || 'direct-tutorial-boot-failed');
         if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.recoverUserModelBoot === 'function') {
             try {
                 return await window.NekoAvatarFloatingBoot.recoverUserModelBoot(reason || 'direct-tutorial-boot-failed');
@@ -2840,8 +2874,9 @@ class UniversalTutorialManager {
             const pointerKey = elementId.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
             const hasSnapshotPointerEvents = snapshot.pointerEvents
                 && Object.prototype.hasOwnProperty.call(snapshot.pointerEvents, pointerKey);
-            if (hasSnapshotPointerEvents) {
-                element.style.pointerEvents = snapshot.pointerEvents[pointerKey] || '';
+            const snapshotPointerEvents = hasSnapshotPointerEvents ? snapshot.pointerEvents[pointerKey] : null;
+            if (hasSnapshotPointerEvents && snapshotPointerEvents) {
+                element.style.pointerEvents = snapshotPointerEvents;
                 return;
             }
             if (activePrefix === 'live2d' || activePrefix === 'pngtuber') {
@@ -3149,6 +3184,9 @@ class UniversalTutorialManager {
             await this.playAvatarFloatingRoundPrelude(round, source, director, {
                 skipSourceModelFade: directTutorialBoot
             });
+            if (directTutorialBoot) {
+                this.clearDirectAvatarFloatingTutorialLoading('avatar-floating-yui-ready');
+            }
             const completed = await director.playAvatarFloatingRound(round, {
                 source,
                 surfaceReady: true,
@@ -3168,6 +3206,7 @@ class UniversalTutorialManager {
         } catch (error) {
             console.error('[Tutorial] 悬浮窗教程启动失败:', error);
             if (directTutorialBoot) {
+                this.clearDirectAvatarFloatingTutorialLoading('avatar-floating-start-failed');
                 await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed');
             }
             if (!this._tutorialEndHandled) {
@@ -3237,6 +3276,7 @@ class UniversalTutorialManager {
                 if (!hasSeen) {
                     this.setHomeTutorialPending(true);
                 }
+                this.beginDirectAvatarFloatingTutorialLoading('startup-direct-tutorial-predicted');
                 this.startTutorialWhenI18nReady(1500);
                 return;
             }
@@ -3741,6 +3781,9 @@ class UniversalTutorialManager {
             .then(() => this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored'))
             .catch(error => {
                 console.warn('[Tutorial] 拆除引导时恢复头像失败:', error);
+            })
+            .finally(() => {
+                this.dispatchAvatarFloatingTutorialInputRestored('tutorial-avatar-restored');
             })
             .finally(() => {
                 this._tutorialModelPrefix = null;

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -761,7 +761,33 @@ class UniversalTutorialManager {
             : !!predictedRound;
         const skippedUserModel = typeof helper.wasUserModelBootSkipped === 'function'
             && helper.wasUserModelBootSkipped();
-        return !!normalizedRound && ((canBootDirect && predictedRound === normalizedRound) || skippedUserModel);
+        const skippedRound = typeof helper.getSkippedUserModelBootRound === 'function'
+            ? normalizeOptionalAvatarFloatingGuideRound(helper.getSkippedUserModelBootRound())
+            : null;
+        return !!normalizedRound
+            && (
+                (canBootDirect && predictedRound === normalizedRound)
+                || (skippedUserModel && predictedRound === normalizedRound && skippedRound === normalizedRound)
+            );
+    }
+
+    getDirectAvatarFloatingTutorialBootRound() {
+        const helper = this.getAvatarFloatingBootHelper();
+        if (!helper || this.currentPage !== 'home') {
+            return null;
+        }
+        const predictedRound = typeof helper.getPredictedRound === 'function'
+            ? normalizeOptionalAvatarFloatingGuideRound(helper.getPredictedRound())
+            : null;
+        if (!predictedRound || !this.isAvatarFloatingGuideRoundRegistered(predictedRound)) {
+            return null;
+        }
+        return this.isDirectAvatarFloatingTutorialBoot(predictedRound) ? predictedRound : null;
+    }
+
+    getHomeAvatarFloatingGuideLaunchRound(options = {}) {
+        return this.getDirectAvatarFloatingTutorialBootRound()
+            || this.getHomeAvatarFloatingGuideStartRound(options);
     }
 
     claimDirectAvatarFloatingTutorialBoot(round, source) {
@@ -771,9 +797,9 @@ class UniversalTutorialManager {
         return window.NekoAvatarFloatingBoot.claimDirectTutorialBoot(round, source || 'avatar-floating-guide-start');
     }
 
-    releaseDirectAvatarFloatingTutorialBoot(reason) {
+    releaseDirectAvatarFloatingTutorialBoot(reason, options) {
         if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot === 'function') {
-            window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot(reason || 'avatar-floating-guide-release');
+            window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot(reason || 'avatar-floating-guide-release', options || {});
         }
     }
 
@@ -1514,7 +1540,7 @@ class UniversalTutorialManager {
                 }
                 if (this.shouldStartHomeAvatarFloatingGuideRound()) {
                     const source = this.consumeTutorialStartSource();
-                    const round = this.getHomeAvatarFloatingGuideStartRound();
+                    const round = this.getHomeAvatarFloatingGuideLaunchRound();
                     if (!round) {
                         console.warn('[Tutorial] 首页每日教程 round 未注册，跳过启动');
                         this.recoverUserModelAfterDirectTutorialBootFailure('no-home-avatar-floating-round');
@@ -1600,7 +1626,7 @@ class UniversalTutorialManager {
     }
 
     shouldStartHomeAvatarFloatingGuideRound() {
-        return !!this.getHomeAvatarFloatingGuideStartRound();
+        return !!this.getHomeAvatarFloatingGuideLaunchRound();
     }
 
     /**
@@ -3089,7 +3115,7 @@ class UniversalTutorialManager {
             }
 
             if (this.currentPage === 'home') {
-                const round = this.getHomeAvatarFloatingGuideStartRound();
+                const round = this.getHomeAvatarFloatingGuideLaunchRound();
                 if (round && this.isDirectAvatarFloatingTutorialBoot(round)) {
                     await this.waitForTutorialModelHostReady();
                 } else {
@@ -3200,6 +3226,11 @@ class UniversalTutorialManager {
                         || this.lifecycleStateStore.getEndRawReason()
                         || 'destroy'
                     );
+                if (directTutorialBoot) {
+                    this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {
+                        suppressPrediction: true
+                    });
+                }
                 await this.requestTutorialDestroy(endReason);
             }
             return completed;
@@ -3207,16 +3238,18 @@ class UniversalTutorialManager {
             console.error('[Tutorial] 悬浮窗教程启动失败:', error);
             if (directTutorialBoot) {
                 this.clearDirectAvatarFloatingTutorialLoading('avatar-floating-start-failed');
-                await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed');
+                this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {
+                    keepUserModelBootSkipped: true,
+                    suppressPrediction: true
+                });
             }
             if (!this._tutorialEndHandled) {
                 await this.requestTutorialDestroy('destroy');
             }
-            throw error;
-        } finally {
             if (directTutorialBoot) {
-                this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-finished');
+                await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed');
             }
+            throw error;
         }
     }
 
@@ -3267,7 +3300,7 @@ class UniversalTutorialManager {
         const storageKey = this.getStorageKey();
         const hasSeen = localStorage.getItem(storageKey);
         if (this.currentPage === 'home') {
-            const directBootRound = this.getHomeAvatarFloatingGuideStartRound();
+            const directBootRound = this.getDirectAvatarFloatingTutorialBootRound();
             if (directBootRound && this.isDirectAvatarFloatingTutorialBoot(directBootRound)) {
                 const directBootState = loadAvatarFloatingGuideState();
                 if (directBootState.manualResetRound === directBootRound) {
@@ -3389,7 +3422,7 @@ class UniversalTutorialManager {
         this.currentTutorialStartSource = this.consumeTutorialStartSource();
 
         if (this.currentPage === 'home') {
-            const round = this.getHomeAvatarFloatingGuideStartRound();
+            const round = this.getHomeAvatarFloatingGuideLaunchRound();
             if (!round) {
                 console.warn('[Tutorial] 首页每日教程 round 未注册，跳过启动');
                 return false;

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -3218,6 +3218,11 @@ class UniversalTutorialManager {
                 surfaceReady: true,
                 revealPrepared: () => this.revealTutorialLive2dPrepared()
             });
+            if (directTutorialBoot) {
+                this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {
+                    suppressPrediction: true
+                });
+            }
             if (!this._tutorialEndHandled) {
                 const endReason = completed
                     ? 'complete'
@@ -3226,11 +3231,6 @@ class UniversalTutorialManager {
                         || this.lifecycleStateStore.getEndRawReason()
                         || 'destroy'
                     );
-                if (directTutorialBoot) {
-                    this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {
-                        suppressPrediction: true
-                    });
-                }
                 await this.requestTutorialDestroy(endReason);
             }
             return completed;

--- a/static/vrm-init.js
+++ b/static/vrm-init.js
@@ -414,6 +414,14 @@ async function initVRMModel() {
         if (window.__nekoStorageLocationStartupBarrier && typeof window.__nekoStorageLocationStartupBarrier.then === 'function') {
             await window.__nekoStorageLocationStartupBarrier;
         }
+        if (window.NekoAvatarFloatingBoot && typeof window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot === 'function'
+            && window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()) {
+            if (typeof window.NekoAvatarFloatingBoot.markUserModelBootSkipped === 'function') {
+                window.NekoAvatarFloatingBoot.markUserModelBootSkipped('vrm-init');
+            }
+            console.log('[VRM Init] 新手教程启动预测命中，跳过用户 VRM 模型加载');
+            return;
+        }
         // 1. 等待配置加载完成
         if (window.pageConfigReady && typeof window.pageConfigReady.then === 'function') {
             await window.pageConfigReady;
@@ -624,6 +632,8 @@ async function initVRMModel() {
         window._isVRMLoading = false;
     }
 }
+
+window.initVRMModel = initVRMModel;
 
 // ── 主页面 VRM 待机动作轮换 ──────────────────────────────
 // 策略：优先在动画一轮播完（loop 事件）时切换，避免动作中途跳变；

--- a/templates/index.html
+++ b/templates/index.html
@@ -341,6 +341,7 @@
     <script src="/static/neko-tooltip.js?v={{ static_asset_version }}"></script>
     <script src="/static/common-ui-hud.js?v={{ static_asset_version }}"></script>
     <script src="/static/avatar-ui-drag.js?v={{ static_asset_version }}"></script>
+    <script src="/static/tutorial/core/avatar-floating-boot-predictor.js?v={{ static_asset_version }}"></script>
     <script src="/static/live2d-init.js?v={{ static_asset_version }}"></script>
 
     <!-- Three.js 核心库和importmap（用于ES6模块导入）-->

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1833,6 +1833,9 @@ def test_avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predict
     )[0]
     assert "window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()" in live2d_inner
     assert "window.NekoAvatarFloatingBoot.markUserModelBootSkipped('live2d-init')" in live2d_inner
+    assert "async function autoInitMMDOnMainPage()" in mmd_init_source
+    assert "window.autoInitMMDOnMainPage = autoInitMMDOnMainPage;" in mmd_init_source
+    assert "autoInitMMDOnMainPage();" in mmd_init_source
 
     self_heal_block = live2d_init_source.split("function _nekoShouldSelfHealLive2D()", 1)[1].split(
         "function scheduleLive2DConfigRetry",
@@ -1941,14 +1944,19 @@ def test_avatar_floating_direct_boot_does_not_wait_for_user_floating_buttons():
     assert "beginDirectTutorialLoading" not in claim_block
     assert "state.predictionSuppressed = false;" not in mark_skipped_block
     assert "await window.showCurrentModel();" in recovery_block
-    assert recovery_block.index("await window.initLive2DModel();") < recovery_block.index("await window.showCurrentModel();")
+    assert recovery_block.index("await window.initLive2DModel();") < recovery_block.rindex("await window.showCurrentModel();")
     assert "await window.initMMDModel();" in recovery_block
+    assert "await window.autoInitMMDOnMainPage();" in recovery_block
     assert "const isMmdModel = modelType === 'live3d' && subType === 'mmd';" in recovery_block
     mmd_branch = recovery_block.split("if (isMmdModel) {", 1)[1].split(
         "} else if ((modelType === 'vrm' || modelType === 'live3d')",
         1,
     )[0]
-    assert "return false;" not in mmd_branch
+    assert "return false;" not in mmd_branch.split("await window.showCurrentModel();", 1)[0]
+    assert "return true;" not in mmd_branch.split("await window.initMMDModel();", 1)[1].split(
+        "await window.showCurrentModel();",
+        1,
+    )[0]
     assert recovery_block.index("if (isMmdModel) {") < recovery_block.index("await window.showCurrentModel();")
 
 

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1515,7 +1515,7 @@ def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     )[0]
     assert "this.startTutorial();" in launch_block
     assert "this.shouldStartHomeAvatarFloatingGuideRound()" in launch_block
-    assert "const round = this.getHomeAvatarFloatingGuideStartRound();" in launch_block
+    assert "const round = this.getHomeAvatarFloatingGuideLaunchRound();" in launch_block
     assert "this.startAvatarFloatingGuideRound(round, { source })" in launch_block
     assert "shouldStartHomeAvatarFloatingGuideRound() {" in tutorial_source
     assert "getHomeAvatarFloatingGuideStartRound(options = {})" in tutorial_source
@@ -1525,8 +1525,8 @@ def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
         1,
     )[0]
     assert "this.currentPage === 'home'" in start_tutorial_block
-    assert "const round = this.getHomeAvatarFloatingGuideStartRound();" in start_tutorial_block
-    assert start_tutorial_block.index("const round = this.getHomeAvatarFloatingGuideStartRound();") < start_tutorial_block.index(
+    assert "const round = this.getHomeAvatarFloatingGuideLaunchRound();" in start_tutorial_block
+    assert start_tutorial_block.index("const round = this.getHomeAvatarFloatingGuideLaunchRound();") < start_tutorial_block.index(
         "if (!round) {"
     )
     assert start_tutorial_block.index("if (!round) {") < start_tutorial_block.index(
@@ -1794,6 +1794,7 @@ def test_avatar_floating_tutorial_boot_predictor_contract():
     assert "shouldBootIntoTutorial" in predictor_source
     assert "shouldSkipUserModelBoot" in predictor_source
     assert "getPredictedRound" in predictor_source
+    assert "getSkippedUserModelBootRound" in predictor_source
     assert "markUserModelBootSkipped" in predictor_source
     assert "claimDirectTutorialBoot" in predictor_source
     assert "releaseDirectTutorialBoot" in predictor_source
@@ -1835,7 +1836,7 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
 
     assert "isDirectAvatarFloatingTutorialBoot(round)" in tutorial_source
     assert "claimDirectAvatarFloatingTutorialBoot(round, source)" in tutorial_source
-    assert "releaseDirectAvatarFloatingTutorialBoot(reason)" in tutorial_source
+    assert "releaseDirectAvatarFloatingTutorialBoot(reason, options)" in tutorial_source
     assert "recoverUserModelAfterDirectTutorialBootFailure(reason)" in tutorial_source
     assert "waitForTutorialModelHostReady(maxWaitTime = 12000)" in tutorial_source
     assert "window.NekoAvatarFloatingBoot" in tutorial_source
@@ -1843,6 +1844,7 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     assert "window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot" in tutorial_source
     assert "window.NekoAvatarFloatingBoot.recoverUserModelBoot" in tutorial_source
     assert "window.NekoAvatarFloatingBoot.clearDirectTutorialLoading" in tutorial_source
+    assert "getDirectAvatarFloatingTutorialBootRound()" in tutorial_source
 
     start_round_block = tutorial_source.split("async startAvatarFloatingGuideRound(day, options = {})", 1)[1].split(
         "async playAvatarFloatingRoundPrelude",
@@ -1856,7 +1858,16 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     assert "skipSourceModelFade: directTutorialBoot" in start_round_block
     assert "this.clearDirectAvatarFloatingTutorialLoading('avatar-floating-yui-ready');" in start_round_block
     assert "await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed')" in start_round_block
-    assert "this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-finished');" in start_round_block
+    assert "this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {" in start_round_block
+    assert "keepUserModelBootSkipped: true" in start_round_block
+    assert "suppressPrediction: true" in start_round_block
+    assert start_round_block.index("this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {") < start_round_block.index(
+        "await this.requestTutorialDestroy(endReason);"
+    )
+    assert start_round_block.index("this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {") < start_round_block.index(
+        "await this.requestTutorialDestroy('destroy');"
+    )
+    assert "this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-finished');" not in start_round_block
 
     teardown_block = tutorial_source.split("_teardownTutorialUI() {", 1)[1].split(
         "async waitForTutorialTeardownSettled",
@@ -1893,18 +1904,38 @@ def test_avatar_floating_direct_boot_does_not_wait_for_user_floating_buttons():
         "function releaseDirectTutorialBoot",
         1,
     )[0]
+    direct_boot_gate_block = tutorial_source.split("isDirectAvatarFloatingTutorialBoot(round)", 1)[1].split(
+        "claimDirectAvatarFloatingTutorialBoot(round, source)",
+        1,
+    )[0]
+    recovery_block = predictor_source.split("async function recoverUserModelBoot(reason)", 1)[1].split(
+        "window.NekoAvatarFloatingBoot = {",
+        1,
+    )[0]
 
-    assert "const directBootRound = this.getHomeAvatarFloatingGuideStartRound();" in check_block
+    assert "const directBootRound = this.getDirectAvatarFloatingTutorialBootRound();" in check_block
     assert "this.isDirectAvatarFloatingTutorialBoot(directBootRound)" in check_block
+    assert "const round = this.getHomeAvatarFloatingGuideLaunchRound();" in check_block
     assert "this.beginDirectAvatarFloatingTutorialLoading('startup-direct-tutorial-predicted');" in check_block
     assert "this.pendingTutorialStartSource = 'manual_reset';" in check_block
     assert "this.startTutorialWhenI18nReady(1500);" in check_block
     assert check_block.index("this.isDirectAvatarFloatingTutorialBoot(directBootRound)") < check_block.index(
         "this.waitForFloatingButtons().then((found)"
     )
+    assert "predictedRound === normalizedRound" in direct_boot_gate_block
+    assert "skippedUserModel && predictedRound === normalizedRound" in direct_boot_gate_block
+    assert "getSkippedUserModelBootRound" in direct_boot_gate_block
     assert "beginDirectTutorialLoading" not in should_skip_block
     assert "beginDirectTutorialLoading" not in mark_skipped_block
     assert "beginDirectTutorialLoading" not in claim_block
+    assert "state.predictionSuppressed = false;" not in mark_skipped_block
+    assert "await window.showCurrentModel();" in recovery_block
+    assert recovery_block.index("await window.initLive2DModel();") < recovery_block.index("await window.showCurrentModel();")
+    assert "await window.initMMDModel();" in recovery_block
+    assert "return false;" in recovery_block.split("await window.initMMDModel();", 1)[1].split(
+        "if ((modelType === 'vrm' || modelType === 'live3d')",
+        1,
+    )[0]
 
 
 def test_tutorial_lifecycle_modules_export_reusable_controllers():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1932,10 +1932,13 @@ def test_avatar_floating_direct_boot_does_not_wait_for_user_floating_buttons():
     assert "await window.showCurrentModel();" in recovery_block
     assert recovery_block.index("await window.initLive2DModel();") < recovery_block.index("await window.showCurrentModel();")
     assert "await window.initMMDModel();" in recovery_block
-    assert "return false;" in recovery_block.split("await window.initMMDModel();", 1)[1].split(
-        "if ((modelType === 'vrm' || modelType === 'live3d')",
+    assert "const isMmdModel = modelType === 'live3d' && subType === 'mmd';" in recovery_block
+    mmd_branch = recovery_block.split("if (isMmdModel) {", 1)[1].split(
+        "} else if ((modelType === 'vrm' || modelType === 'live3d')",
         1,
     )[0]
+    assert "return false;" not in mmd_branch
+    assert recovery_block.index("if (isMmdModel) {") < recovery_block.index("await window.showCurrentModel();")
 
 
 def test_tutorial_lifecycle_modules_export_reusable_controllers():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1724,6 +1724,21 @@ def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     assert "await _waitForLive2DManagerIdle(30000);" in interpage_source
 
 
+def test_tutorial_temporary_model_reload_bootstraps_live2d_manager_without_user_model_init():
+    interpage_source = Path("static/app-interpage.js").read_text(encoding="utf-8")
+    live2d_branch = interpage_source.split("if (newModelPath) {", 1)[1].split(
+        "// Load the new model",
+        1,
+    )[0]
+
+    assert "if (temporaryConfig && typeof window.Live2DManager === 'function')" in live2d_branch
+    assert "window.live2dManager = new window.Live2DManager();" in live2d_branch
+    assert "await initLive2DModel();" in live2d_branch
+    assert live2d_branch.index("temporaryConfig && typeof window.Live2DManager === 'function'") < live2d_branch.index(
+        "await initLive2DModel();"
+    )
+
+
 def test_day1_round_activation_keeps_wakeup_after_step_registry_split():
     director_source = Path("static/tutorial/yui-guide/director.js").read_text(encoding="utf-8")
     activation_block = director_source.split("async playDay1IntroActivationRoundScene(sceneRunId)", 1)[1].split(
@@ -1749,6 +1764,109 @@ def test_day1_round_activation_keeps_wakeup_after_step_registry_split():
     assert "INTRO_ACTIVATION_REDUCED_MOTION_AUTO_ADVANCE_MS" in transition_block
     assert "return wait(waitMs);" in transition_block
     assert "wait(360)" not in transition_block
+
+
+def test_avatar_floating_tutorial_boot_predictor_loads_before_user_model_init():
+    index_source = Path("templates/index.html").read_text(encoding="utf-8")
+    pages_router_source = Path("main_routers/pages_router.py").read_text(encoding="utf-8")
+
+    predictor_script = "/static/tutorial/core/avatar-floating-boot-predictor.js"
+    assert predictor_script in index_source
+    assert index_source.index(predictor_script) < index_source.index("/static/live2d-init.js")
+    assert index_source.index(predictor_script) < index_source.index("/static/vrm-init.js")
+    assert index_source.index(predictor_script) < index_source.index("/static/mmd-init.js")
+    assert "static/tutorial/core/avatar-floating-boot-predictor.js" in pages_router_source
+
+
+def test_avatar_floating_tutorial_boot_predictor_contract():
+    predictor_source = Path("static/tutorial/core/avatar-floating-boot-predictor.js").read_text(encoding="utf-8")
+
+    assert "AVATAR_FLOATING_GUIDE_STORAGE_KEY = 'neko_avatar_floating_guide_v1'" in predictor_source
+    assert "manualResetRound" in predictor_source
+    assert "pendingRound" in predictor_source
+    assert "completedRounds" in predictor_source
+    assert "skippedRounds" in predictor_source
+    assert "lastAutoShownDate" in predictor_source
+    assert "window.NekoAvatarFloatingBoot" in predictor_source
+    assert "shouldBootIntoTutorial" in predictor_source
+    assert "shouldSkipUserModelBoot" in predictor_source
+    assert "getPredictedRound" in predictor_source
+    assert "markUserModelBootSkipped" in predictor_source
+    assert "claimDirectTutorialBoot" in predictor_source
+    assert "releaseDirectTutorialBoot" in predictor_source
+
+
+def test_avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predicted():
+    live2d_init_source = Path("static/live2d-init.js").read_text(encoding="utf-8")
+    vrm_init_source = Path("static/vrm-init.js").read_text(encoding="utf-8")
+    mmd_init_source = Path("static/mmd-init.js").read_text(encoding="utf-8")
+
+    for source in (live2d_init_source, vrm_init_source, mmd_init_source):
+        assert "window.NekoAvatarFloatingBoot" in source
+        assert "shouldSkipUserModelBoot" in source
+        assert "markUserModelBootSkipped" in source
+
+    live2d_inner = live2d_init_source.split("async function _initLive2DModelInner()", 1)[1].split(
+        "// 检查是否在 VRM/MMD 模式下",
+        1,
+    )[0]
+    assert "window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()" in live2d_inner
+    assert "window.NekoAvatarFloatingBoot.markUserModelBootSkipped('live2d-init')" in live2d_inner
+
+    self_heal_block = live2d_init_source.split("function _nekoShouldSelfHealLive2D()", 1)[1].split(
+        "function scheduleLive2DConfigRetry",
+        1,
+    )[0]
+    assert "window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()" in self_heal_block
+
+
+def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_model_fallback():
+    tutorial_source = Path("static/tutorial/core/universal-manager.js").read_text(encoding="utf-8")
+    avatar_reload_source = Path("static/tutorial/avatar/reload-controller.js").read_text(encoding="utf-8")
+
+    assert "isDirectAvatarFloatingTutorialBoot(round)" in tutorial_source
+    assert "claimDirectAvatarFloatingTutorialBoot(round, source)" in tutorial_source
+    assert "releaseDirectAvatarFloatingTutorialBoot(reason)" in tutorial_source
+    assert "recoverUserModelAfterDirectTutorialBootFailure(reason)" in tutorial_source
+    assert "waitForTutorialModelHostReady(maxWaitTime = 12000)" in tutorial_source
+    assert "window.NekoAvatarFloatingBoot" in tutorial_source
+    assert "window.NekoAvatarFloatingBoot.claimDirectTutorialBoot" in tutorial_source
+    assert "window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot" in tutorial_source
+    assert "window.NekoAvatarFloatingBoot.recoverUserModelBoot" in tutorial_source
+
+    start_round_block = tutorial_source.split("async startAvatarFloatingGuideRound(day, options = {})", 1)[1].split(
+        "async playAvatarFloatingRoundPrelude",
+        1,
+    )[0]
+    assert "const directTutorialBoot = this.isDirectAvatarFloatingTutorialBoot(round);" in start_round_block
+    assert "if (directTutorialBoot) {" in start_round_block
+    assert "await this.waitForTutorialModelHostReady()" in start_round_block
+    assert "await this.waitForFloatingButtons()" in start_round_block
+    assert "this.claimDirectAvatarFloatingTutorialBoot(round, source);" in start_round_block
+    assert "skipSourceModelFade: directTutorialBoot" in start_round_block
+    assert "await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed')" in start_round_block
+    assert "this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-finished');" in start_round_block
+
+    begin_block = avatar_reload_source.split("beginOverride(options)", 1)[1].split("restoreOverride()", 1)[0]
+    assert "const skipSourceModelFade = normalizedOptions.skipSourceModelFade === true;" in begin_block
+    assert "if (!skipSourceModelFade) {" in begin_block
+    assert "this.fadeOutCurrentModel({" in begin_block
+
+
+def test_avatar_floating_direct_boot_does_not_wait_for_user_floating_buttons():
+    tutorial_source = Path("static/tutorial/core/universal-manager.js").read_text(encoding="utf-8")
+    check_block = tutorial_source.split("async checkAndStartTutorial()", 1)[1].split(
+        "async waitForTutorialTeardownSettled",
+        1,
+    )[0]
+
+    assert "const directBootRound = this.getHomeAvatarFloatingGuideStartRound();" in check_block
+    assert "this.isDirectAvatarFloatingTutorialBoot(directBootRound)" in check_block
+    assert "this.pendingTutorialStartSource = 'manual_reset';" in check_block
+    assert "this.startTutorialWhenI18nReady(1500);" in check_block
+    assert check_block.index("this.isDirectAvatarFloatingTutorialBoot(directBootRound)") < check_block.index(
+        "this.waitForFloatingButtons().then((found)"
+    )
 
 
 def test_tutorial_lifecycle_modules_export_reusable_controllers():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1804,6 +1804,7 @@ def test_avatar_floating_tutorial_boot_predictor_contract():
     assert "window.nekoTutorialLoadingOverlay" in predictor_source
     assert "function isPcLoadingOverlayBridge(bridge)" in predictor_source
     assert "window.nekoTutorialOverlay.loadingOverlay" in predictor_source
+    assert "isPcLoadingOverlayBridge(window.nekoTutorialOverlay)" in predictor_source
     assert "window.nekoTutorialOverlay.beginLoading" in predictor_source
     assert "yuiGuidePcOverlayRunId" in predictor_source
     assert "emotion_model_icon.png" in predictor_source

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1802,7 +1802,9 @@ def test_avatar_floating_tutorial_boot_predictor_contract():
     assert "beginDirectTutorialLoading" in predictor_source
     assert "clearDirectTutorialLoading" in predictor_source
     assert "window.nekoTutorialLoadingOverlay" in predictor_source
-    assert "window.nekoTutorialOverlay" not in predictor_source
+    assert "function isPcLoadingOverlayBridge(bridge)" in predictor_source
+    assert "window.nekoTutorialOverlay.loadingOverlay" in predictor_source
+    assert "window.nekoTutorialOverlay.beginLoading" in predictor_source
     assert "yuiGuidePcOverlayRunId" in predictor_source
     assert "emotion_model_icon.png" in predictor_source
     assert "function isTutorialBootAvailable()" in predictor_source
@@ -1818,6 +1820,7 @@ def test_avatar_floating_tutorial_boot_predictor_contract():
 
 
 def test_avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predicted():
+    index_source = Path("static/js/index.js").read_text(encoding="utf-8")
     live2d_init_source = Path("static/live2d-init.js").read_text(encoding="utf-8")
     vrm_init_source = Path("static/vrm-init.js").read_text(encoding="utf-8")
     mmd_init_source = Path("static/mmd-init.js").read_text(encoding="utf-8")
@@ -1833,6 +1836,15 @@ def test_avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predict
     )[0]
     assert "window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()" in live2d_inner
     assert "window.NekoAvatarFloatingBoot.markUserModelBootSkipped('live2d-init')" in live2d_inner
+    pngtuber_block = index_source.split("if (modelType === 'pngtuber') {", 1)[1].split(
+        "} else if (modelType === 'live3d' || modelType === 'vrm')",
+        1,
+    )[0]
+    assert "window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()" in pngtuber_block
+    assert "window.NekoAvatarFloatingBoot.markUserModelBootSkipped('pngtuber-init')" in pngtuber_block
+    assert pngtuber_block.index("window.NekoAvatarFloatingBoot.shouldSkipUserModelBoot()") < pngtuber_block.index(
+        "window.loadPNGTuberAvatar("
+    )
     assert "async function autoInitMMDOnMainPage()" in mmd_init_source
     assert "window.autoInitMMDOnMainPage = autoInitMMDOnMainPage;" in mmd_init_source
     assert "autoInitMMDOnMainPage();" in mmd_init_source

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1959,7 +1959,15 @@ def test_avatar_floating_direct_boot_does_not_wait_for_user_floating_buttons():
     assert recovery_block.index("await window.initLive2DModel();") < recovery_block.rindex("await window.showCurrentModel();")
     assert "await window.initMMDModel();" in recovery_block
     assert "await window.autoInitMMDOnMainPage();" in recovery_block
+    assert "const isPngtuberModel = modelType === 'pngtuber';" in recovery_block
+    assert "await window.loadPNGTuberAvatar(window.lanlan_config && window.lanlan_config.pngtuber || {});" in recovery_block
+    assert recovery_block.index("if (isPngtuberModel) {") < recovery_block.index("await window.initLive2DModel();")
     assert "const isMmdModel = modelType === 'live3d' && subType === 'mmd';" in recovery_block
+    pngtuber_branch = recovery_block.split("if (isPngtuberModel) {", 1)[1].split(
+        "const isMmdModel = modelType === 'live3d' && subType === 'mmd';",
+        1,
+    )[0]
+    assert "await window.initLive2DModel();" not in pngtuber_branch
     mmd_branch = recovery_block.split("if (isMmdModel) {", 1)[1].split(
         "} else if ((modelType === 'vrm' || modelType === 'live3d')",
         1,
@@ -1969,7 +1977,9 @@ def test_avatar_floating_direct_boot_does_not_wait_for_user_floating_buttons():
         "await window.showCurrentModel();",
         1,
     )[0]
-    assert recovery_block.index("if (isMmdModel) {") < recovery_block.index("await window.showCurrentModel();")
+    assert mmd_branch.index("if (typeof window.initMMDModel === 'function')") < mmd_branch.index(
+        "await window.showCurrentModel();"
+    )
 
 
 def test_tutorial_lifecycle_modules_export_reusable_controllers():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1436,7 +1436,10 @@ def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     assert "vrmCanvas: readPointerEvents('vrm-canvas')" in tutorial_source
     assert "mmdCanvas: readPointerEvents('mmd-canvas')" in tutorial_source
     assert "const hasSnapshotPointerEvents = snapshot.pointerEvents" in avatar_interaction_restore_block
-    assert "element.style.pointerEvents = snapshot.pointerEvents[pointerKey] || '';" in avatar_interaction_restore_block
+    assert "const snapshotPointerEvents = hasSnapshotPointerEvents ? snapshot.pointerEvents[pointerKey] : null;" in avatar_interaction_restore_block
+    assert "if (hasSnapshotPointerEvents && snapshotPointerEvents) {" in avatar_interaction_restore_block
+    assert "element.style.pointerEvents = snapshotPointerEvents;" in avatar_interaction_restore_block
+    assert "element.style.pointerEvents = snapshot.pointerEvents[pointerKey] || '';" not in avatar_interaction_restore_block
     assert "activePrefix === 'live2d' || activePrefix === 'pngtuber'" in avatar_interaction_restore_block
     assert "element.style.removeProperty('pointer-events');" in avatar_interaction_restore_block
     assert "element.style.pointerEvents = activeLocked ? 'none' : 'auto';" in avatar_interaction_restore_block
@@ -1794,6 +1797,12 @@ def test_avatar_floating_tutorial_boot_predictor_contract():
     assert "markUserModelBootSkipped" in predictor_source
     assert "claimDirectTutorialBoot" in predictor_source
     assert "releaseDirectTutorialBoot" in predictor_source
+    assert "beginDirectTutorialLoading" in predictor_source
+    assert "clearDirectTutorialLoading" in predictor_source
+    assert "window.nekoTutorialLoadingOverlay" in predictor_source
+    assert "window.nekoTutorialOverlay" not in predictor_source
+    assert "yuiGuidePcOverlayRunId" in predictor_source
+    assert "emotion_model_icon.png" in predictor_source
 
 
 def test_avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predicted():
@@ -1833,6 +1842,7 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     assert "window.NekoAvatarFloatingBoot.claimDirectTutorialBoot" in tutorial_source
     assert "window.NekoAvatarFloatingBoot.releaseDirectTutorialBoot" in tutorial_source
     assert "window.NekoAvatarFloatingBoot.recoverUserModelBoot" in tutorial_source
+    assert "window.NekoAvatarFloatingBoot.clearDirectTutorialLoading" in tutorial_source
 
     start_round_block = tutorial_source.split("async startAvatarFloatingGuideRound(day, options = {})", 1)[1].split(
         "async playAvatarFloatingRoundPrelude",
@@ -1844,8 +1854,19 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     assert "await this.waitForFloatingButtons()" in start_round_block
     assert "this.claimDirectAvatarFloatingTutorialBoot(round, source);" in start_round_block
     assert "skipSourceModelFade: directTutorialBoot" in start_round_block
+    assert "this.clearDirectAvatarFloatingTutorialLoading('avatar-floating-yui-ready');" in start_round_block
     assert "await this.recoverUserModelAfterDirectTutorialBootFailure('avatar-floating-start-failed')" in start_round_block
     assert "this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-start-finished');" in start_round_block
+
+    teardown_block = tutorial_source.split("_teardownTutorialUI() {", 1)[1].split(
+        "async waitForTutorialTeardownSettled",
+        1,
+    )[0]
+    assert "this.dispatchAvatarFloatingTutorialInputRestored(" in tutorial_source
+    assert "neko:yui-guide:tutorial-input-restored" in tutorial_source
+    assert teardown_block.index("this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored')") < teardown_block.index(
+        "this.dispatchAvatarFloatingTutorialInputRestored("
+    )
 
     begin_block = avatar_reload_source.split("beginOverride(options)", 1)[1].split("restoreOverride()", 1)[0]
     assert "const skipSourceModelFade = normalizedOptions.skipSourceModelFade === true;" in begin_block
@@ -1855,18 +1876,35 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
 
 def test_avatar_floating_direct_boot_does_not_wait_for_user_floating_buttons():
     tutorial_source = Path("static/tutorial/core/universal-manager.js").read_text(encoding="utf-8")
+    predictor_source = Path("static/tutorial/core/avatar-floating-boot-predictor.js").read_text(encoding="utf-8")
     check_block = tutorial_source.split("async checkAndStartTutorial()", 1)[1].split(
         "async waitForTutorialTeardownSettled",
+        1,
+    )[0]
+    should_skip_block = predictor_source.split("function shouldSkipUserModelBoot()", 1)[1].split(
+        "function markUserModelBootSkipped",
+        1,
+    )[0]
+    mark_skipped_block = predictor_source.split("function markUserModelBootSkipped(reason)", 1)[1].split(
+        "function claimDirectTutorialBoot",
+        1,
+    )[0]
+    claim_block = predictor_source.split("function claimDirectTutorialBoot(round, reason)", 1)[1].split(
+        "function releaseDirectTutorialBoot",
         1,
     )[0]
 
     assert "const directBootRound = this.getHomeAvatarFloatingGuideStartRound();" in check_block
     assert "this.isDirectAvatarFloatingTutorialBoot(directBootRound)" in check_block
+    assert "this.beginDirectAvatarFloatingTutorialLoading('startup-direct-tutorial-predicted');" in check_block
     assert "this.pendingTutorialStartSource = 'manual_reset';" in check_block
     assert "this.startTutorialWhenI18nReady(1500);" in check_block
     assert check_block.index("this.isDirectAvatarFloatingTutorialBoot(directBootRound)") < check_block.index(
         "this.waitForFloatingButtons().then((found)"
     )
+    assert "beginDirectTutorialLoading" not in should_skip_block
+    assert "beginDirectTutorialLoading" not in mark_skipped_block
+    assert "beginDirectTutorialLoading" not in claim_block
 
 
 def test_tutorial_lifecycle_modules_export_reusable_controllers():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1818,6 +1818,16 @@ def test_avatar_floating_tutorial_boot_predictor_contract():
     )[0]
     assert "if (!isTutorialBootAvailable()) {" in should_skip_block
     assert "return false;" in should_skip_block.split("if (!isTutorialBootAvailable()) {", 1)[1].split("}", 1)[0]
+    compute_block = predictor_source.split("function computePredictedRound()", 1)[1].split(
+        "function getPredictedRound()",
+        1,
+    )[0]
+    assert compute_block.index("if (guideState.manualResetRound)") < compute_block.index(
+        "if (guideState.lastAutoShownDate === getTodayLocalDate())"
+    )
+    assert compute_block.index("if (guideState.lastAutoShownDate === getTodayLocalDate())") < compute_block.index(
+        "if (guideState.pendingRound"
+    )
 
 
 def test_avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predicted():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1889,6 +1889,9 @@ def test_avatar_floating_direct_tutorial_boot_uses_manager_recheck_and_user_mode
     assert "keepUserModelBootSkipped: true" in start_round_block
     assert "suppressPrediction: true" in start_round_block
     assert start_round_block.index("this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {") < start_round_block.index(
+        "if (!this._tutorialEndHandled) {"
+    )
+    assert start_round_block.index("this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {") < start_round_block.index(
         "await this.requestTutorialDestroy(endReason);"
     )
     assert start_round_block.index("this.releaseDirectAvatarFloatingTutorialBoot('avatar-floating-before-teardown', {") < start_round_block.index(

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1783,6 +1783,7 @@ def test_avatar_floating_tutorial_boot_predictor_loads_before_user_model_init():
 
 def test_avatar_floating_tutorial_boot_predictor_contract():
     predictor_source = Path("static/tutorial/core/avatar-floating-boot-predictor.js").read_text(encoding="utf-8")
+    manager_source = Path("static/tutorial/core/universal-manager.js").read_text(encoding="utf-8")
 
     assert "AVATAR_FLOATING_GUIDE_STORAGE_KEY = 'neko_avatar_floating_guide_v1'" in predictor_source
     assert "manualResetRound" in predictor_source
@@ -1804,6 +1805,16 @@ def test_avatar_floating_tutorial_boot_predictor_contract():
     assert "window.nekoTutorialOverlay" not in predictor_source
     assert "yuiGuidePcOverlayRunId" in predictor_source
     assert "emotion_model_icon.png" in predictor_source
+    assert "function isTutorialBootAvailable()" in predictor_source
+    assert "window.innerWidth <= 768" in predictor_source
+    assert "window.innerWidth <= 768" in manager_source
+
+    should_skip_block = predictor_source.split("function shouldSkipUserModelBoot()", 1)[1].split(
+        "function markUserModelBootSkipped",
+        1,
+    )[0]
+    assert "if (!isTutorialBootAvailable()) {" in should_skip_block
+    assert "return false;" in should_skip_block.split("if (!isTutorialBootAvailable()) {", 1)[1].split("}", 1)[0]
 
 
 def test_avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predicted():


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 实现新手引导启动时的模型加载方案 2：在页面早期判断本次启动是否会进入 7 天新手引导，如果命中 pending day / manual reset / 首日等状态，则先跳过用户模型初始化，直接准备 YUI 教程模型；新手引导结束或失败后，再恢复用户模型。

主要改动：
- 新增 `avatar-floating-boot-predictor.js`，在 Live2D / VRM / MMD 初始化前完成新手引导启动预测。
- Live2D、VRM、MMD 用户模型初始化在预测命中时跳过，并记录本次用户模型启动已延后。
- 新手引导直接启动时不再等待用户模型浮动按钮，避免“跳过用户模型后永远等不到按钮”的启动死锁。
- YUI 临时模型加载在 `temporaryConfig` 场景下可直接创建 `Live2DManager`，不再依赖会被用户模型闸门拦住的普通初始化。
- 教程接管支持跳过源模型淡出；教程启动失败、被抑制或容器不可用时 fallback 恢复用户模型。
- 更新静态资源版本路径，确保新增预测器和相关启动链路修改能刷新缓存。

## 回归报告 / Regression Report

改动了什么：
- `main_routers/pages_router.py` 新增 `static/tutorial/core/avatar-floating-boot-predictor.js` 到 YUI Guide 静态资源版本计算列表。
- 启动链路新增早期预测器，并调整主页教程启动、模型初始化、YUI 临时模型切换和教程恢复路径。

理由 / 必要性：
- 原流程会先加载用户模型，再淡出并切换到 YUI；重启新手引导时会出现用户模型先闪现、再切换教程模型的问题。
- 方案 2 要求判定足够早：如果本次启动确认会进入新手引导，就推迟用户模型加载，先直接加载 YUI。
- 手动重置后已有 `pendingRound` / `manualResetRound` 标记，可以在页面早期准确识别。

改动前后的表现对比：
- 改动前：启动时用户模型会先加载，教程开始后再淡出并切换到 YUI；手动重置后重启仍可能先走用户模型链路。
- 改动后：预测命中时 Live2D / VRM / MMD 用户模型初始化会先跳过；教程启动链路直接准备 YUI；教程结束或失败后再恢复用户模型。
- 修复过程中还补齐了两个死锁点：直接教程启动不能等待用户模型浮动按钮；YUI 临时模型加载不能依赖普通 `initLive2DModel()` 创建管理器。

潜在回归点：
- 正常非教程启动：预测器未命中时仍应按原 Live2D / VRM / MMD 用户模型初始化加载。
- 手动重置教程：`manualResetRound` 命中后应直接启动 YUI，且不被自动教程抑制逻辑拦截。
- 教程失败 / 启动被抑制：应恢复用户模型，不能留下空白模型区域。
- 静态资源缓存：新增预测器与 `app-interpage.js`、`live2d-init.js` 等启动链路变更应进入版本号计算，避免客户端继续使用旧资源。

## 不拆分理由 / Why Not Split

不适用。本 PR 计入拆分阈值的文件数未超过 20 个，且改动围绕同一条新手引导启动模型加载链路。

## 测试 / Testing

- `.venv/bin/python -m pytest tests/test_agent_rewrite_regression.py -k "temporary_model_reload_bootstraps_live2d_manager or direct_boot_does_not_wait_for_user_floating_buttons or day1_round_activation_keeps_wakeup or avatar_floating_tutorial_boot_predictor or avatar_model_initializers_skip_user_model or avatar_floating_direct_tutorial_boot"`
- `node --check static/tutorial/core/universal-manager.js && node --check static/app-interpage.js && node --check static/tutorial/core/avatar-floating-boot-predictor.js && node --check static/live2d-init.js && node --check static/vrm-init.js && node --check static/mmd-init.js && node --check static/tutorial/avatar/reload-controller.js && node --check static/tutorial/core/round-prelude-controller.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增头像浮动教程“启动预测”和“直达启动”，基于本地进度与声明状态决定是否跳过用户侧模型启动与恢复兜底。
  - 增强直达启动的加载覆盖层桥接能力，并支持对启动失败后的兜底处理；同时优化教程脚本加载顺序与静态资源版本注入。
- **Bug Fixes**
  - Live2D/VRM/PNGtuber/MMD 等启动流程在预测命中时跳过对应用户模型加载；并调整交互指针事件仅在快照为真时恢复。
- **Tests**
  - 扩展对直达启动、跳过/恢复、初始化顺序、以及交互恢复与加载覆盖契约的回归用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->