### PR TITLE
加长主人档案的显示宽度，防止i18n翻译过长或设定过长不方便编辑

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -11170,9 +11170,14 @@ function toggleMasterSection() {
         clearTimeout(content._masterProfileHideTimer);
         content._masterProfileHideTimer = null;
     }
+    if (content._masterProfileHideContent) {
+        content.removeEventListener('transitionend', content._masterProfileHideContent);
+        content._masterProfileHideContent = null;
+    }
 
     if (isOpening) {
         content.style.display = 'block';
+        content.style.setProperty('--master-profile-viewport-left', `${content.getBoundingClientRect().left}px`);
         content.getBoundingClientRect();
         content.classList.add('open');
         header.classList.add('open');
@@ -11195,9 +11200,13 @@ function toggleMasterSection() {
             clearTimeout(content._masterProfileHideTimer);
             content._masterProfileHideTimer = null;
         }
+        if (content._masterProfileHideContent === hideContent) {
+            content._masterProfileHideContent = null;
+        }
     };
 
     content.addEventListener('transitionend', hideContent);
+    content._masterProfileHideContent = hideContent;
     content._masterProfileHideTimer = setTimeout(hideContent, 280);
 }
 

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -11164,10 +11164,41 @@ function toggleMasterSection() {
     const content = document.getElementById('master-profile-content');
     const header = document.getElementById('master-profile-header');
     if (!content || !header) return;
-    const isHidden = content.style.display === 'none';
-    content.style.display = isHidden ? 'block' : 'none';
-    header.classList.toggle('open', isHidden);
-    header.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+    const isOpening = !content.classList.contains('open');
+
+    if (content._masterProfileHideTimer) {
+        clearTimeout(content._masterProfileHideTimer);
+        content._masterProfileHideTimer = null;
+    }
+
+    if (isOpening) {
+        content.style.display = 'block';
+        content.getBoundingClientRect();
+        content.classList.add('open');
+        header.classList.add('open');
+        header.setAttribute('aria-expanded', 'true');
+        return;
+    }
+
+    content.classList.remove('open');
+    header.classList.remove('open');
+    header.setAttribute('aria-expanded', 'false');
+
+    const hideContent = function (event) {
+        if (event && event.target !== content) return;
+        if (event && event.propertyName !== 'clip-path') return;
+        if (!content.classList.contains('open')) {
+            content.style.display = 'none';
+        }
+        content.removeEventListener('transitionend', hideContent);
+        if (content._masterProfileHideTimer) {
+            clearTimeout(content._masterProfileHideTimer);
+            content._masterProfileHideTimer = null;
+        }
+    };
+
+    content.addEventListener('transitionend', hideContent);
+    content._masterProfileHideTimer = setTimeout(hideContent, 280);
 }
 
 // ===================== 隐藏猫娘 =====================

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -128,8 +128,10 @@
         .master-profile-content {
             position: absolute;
             left: 0;
-            right: 0;
+            right: auto;
             top: 100%;
+            width: max(100%, 50vw);
+            max-width: calc(100vw - 40px);
             margin-top: 4px;
             padding: 10px 12px;
             background: #f0f8ff;
@@ -137,6 +139,33 @@
             border-radius: 16px;
             z-index: 20;
             box-shadow: 0 8px 24px rgba(64, 197, 241, 0.15);
+            opacity: 0;
+            transform: translateY(-8px) scaleX(0.92);
+            transform-origin: top left;
+            clip-path: inset(0 100% 0 0 round 16px);
+            pointer-events: none;
+            will-change: opacity, transform, clip-path;
+            transition:
+                opacity 0.18s ease,
+                transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1),
+                clip-path 0.24s cubic-bezier(0.2, 0.8, 0.2, 1);
+        }
+        .master-profile-content.open {
+            opacity: 1;
+            transform: translateY(0) scaleX(1);
+            clip-path: inset(0 0 0 0 round 16px);
+            pointer-events: auto;
+        }
+        @media (max-width: 900px) {
+            .master-profile-content {
+                width: 100%;
+                max-width: 100%;
+            }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .master-profile-content {
+                transition: none;
+            }
         }
         .master-profile-content .field-row-wrapper {
             display: flex;

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -131,7 +131,7 @@
             right: auto;
             top: 100%;
             width: max(100%, 50vw);
-            max-width: calc(100vw - 40px);
+            max-width: calc(100vw - var(--master-profile-viewport-left, 0px) - 20px);
             margin-top: 4px;
             padding: 10px 12px;
             background: #f0f8ff;


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

加长主人档案的显示宽度，防止i18n翻译过长或设定过长不方便编辑

## 测试 / Testing

手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * “我的档案”下拉面板支持更顺滑的展开与收起动画，展开/收起状态显示更一致。
  * 优化小屏设备上的面板宽度与适配，显示更贴合视口。
* **无障碍与体验优化**
  * 尊重“减少动态效果”偏好：开启后自动关闭动画过渡。
  * 展开/收起过程中的交互可用性与显示稳定性得到提升。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->