### PR TITLE
优化扬声器音量滑条的 100% 标记线显示，使刻线更清晰但不遮挡滑块，并为 100% 位置增加轻微吸附手感

### DIFF
--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1547,6 +1547,8 @@
             // 非线性轨道：thumb 位置走 0..SPEAKER_SLIDER_TRACK_MAX（千分比精度），
             // 经膝点映射成 0-200% 音量，使常规的 0-100% 占满轨道前 3/4、100% 落在锚点处。
             var SPEAKER_SLIDER_TRACK_MAX = 1000;
+            var SPEAKER_SLIDER_THUMB_SIZE = 16;
+            var SPEAKER_VOLUME_SNAP_RADIUS = 18;
             var SPEAKER_VOLUME_NORMAL_COLOR = '#4f8cff';
             var SPEAKER_VOLUME_BOOST_COLOR = '#ff9f43';
 
@@ -1560,6 +1562,18 @@
                     pos / SPEAKER_SLIDER_TRACK_MAX, C.DEFAULT_SPEAKER_VOLUME, C.MAX_SPEAKER_VOLUME, C.SPEAKER_VOLUME_KNEE_RATIO
                 ));
             }
+            var speakerVolumeAnchorTrackPos = speakerTrackPosFromVolume(C.DEFAULT_SPEAKER_VOLUME);
+            function speakerThumbAlignedLeft(trackPos) {
+                var ratio = trackPos / SPEAKER_SLIDER_TRACK_MAX;
+                var halfThumb = SPEAKER_SLIDER_THUMB_SIZE / 2;
+                var thumbOffsetPx = halfThumb * (1 - 2 * ratio);
+                return 'calc(' + (ratio * 100) + '% + ' + thumbOffsetPx.toFixed(2) + 'px)';
+            }
+            function snapSpeakerTrackPos(pos) {
+                return Math.abs(pos - speakerVolumeAnchorTrackPos) <= SPEAKER_VOLUME_SNAP_RADIUS
+                    ? speakerVolumeAnchorTrackPos
+                    : pos;
+            }
 
             var speakerSlider = document.createElement('input');
             speakerSlider.type = 'range';
@@ -1568,7 +1582,7 @@
             speakerSlider.max = String(SPEAKER_SLIDER_TRACK_MAX);
             speakerSlider.step = '1';
             speakerSlider.value = String(speakerTrackPosFromVolume(S.speakerVolume));
-            Object.assign(speakerSlider.style, { width: '100%', height: '6px', borderRadius: '3px', cursor: 'pointer', accentColor: SPEAKER_VOLUME_NORMAL_COLOR });
+            Object.assign(speakerSlider.style, { width: '100%', height: '6px', borderRadius: '3px', cursor: 'pointer', accentColor: SPEAKER_VOLUME_NORMAL_COLOR, position: 'relative', zIndex: '2', margin: '0' });
 
             // 超过标准音量（>100%）时数值与轨道染暖色，把增强区从常规区里区分出来
             function applySpeakerVolumeVisual(vol) {
@@ -1580,7 +1594,13 @@
             applySpeakerVolumeVisual(S.speakerVolume);
 
             speakerSlider.addEventListener('input', function (e) {
-                var newVol = speakerVolumeFromTrackPos(parseInt(e.target.value, 10));
+                var trackPos = parseInt(e.target.value, 10);
+                if (isNaN(trackPos)) return;
+                var snappedTrackPos = snapSpeakerTrackPos(trackPos);
+                if (snappedTrackPos !== trackPos) {
+                    speakerSlider.value = String(snappedTrackPos);
+                }
+                var newVol = speakerVolumeFromTrackPos(snappedTrackPos);
                 S.speakerVolume = newVol;
                 applySpeakerVolumeVisual(newVol);
                 if (S.speakerGainNode) {
@@ -1593,12 +1613,12 @@
 
             // 用相对定位容器在轨道 75% 处画一条 100% 标准锚点，告诉用户「这条线以上是增强」
             var speakerSliderWrap = document.createElement('div');
-            Object.assign(speakerSliderWrap.style, { position: 'relative', width: '100%' });
+            Object.assign(speakerSliderWrap.style, { position: 'relative', width: '100%', height: '18px', display: 'flex', alignItems: 'center' });
             var speakerAnchorTick = document.createElement('div');
             Object.assign(speakerAnchorTick.style, {
-                position: 'absolute', left: (C.SPEAKER_VOLUME_KNEE_RATIO * 100) + '%', top: '50%',
-                width: '2px', height: '12px', transform: 'translate(-50%, -50%)',
-                backgroundColor: 'var(--neko-popup-text-sub)', opacity: '0.55', borderRadius: '1px', pointerEvents: 'none'
+                position: 'absolute', left: speakerThumbAlignedLeft(speakerVolumeAnchorTrackPos), top: '0', bottom: '0',
+                width: '2px', transform: 'translateX(-50%)',
+                backgroundColor: 'var(--neko-popup-text-sub)', opacity: '0.28', borderRadius: '1px', pointerEvents: 'none', zIndex: '0'
             });
             speakerSliderWrap.appendChild(speakerSlider);
             speakerSliderWrap.appendChild(speakerAnchorTick);

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1547,8 +1547,9 @@
             // 非线性轨道：thumb 位置走 0..SPEAKER_SLIDER_TRACK_MAX（千分比精度），
             // 经膝点映射成 0-200% 音量，使常规的 0-100% 占满轨道前 3/4、100% 落在锚点处。
             var SPEAKER_SLIDER_TRACK_MAX = 1000;
+            // Matches Chromium/Electron's native range thumb; the anchor tick is cosmetic.
             var SPEAKER_SLIDER_THUMB_SIZE = 16;
-            var SPEAKER_VOLUME_SNAP_RADIUS = 18;
+            var SPEAKER_VOLUME_SNAP_RADIUS = 1;
             var SPEAKER_VOLUME_NORMAL_COLOR = '#4f8cff';
             var SPEAKER_VOLUME_BOOST_COLOR = '#ff9f43';
 
@@ -1563,6 +1564,8 @@
                 ));
             }
             var speakerVolumeAnchorTrackPos = speakerTrackPosFromVolume(C.DEFAULT_SPEAKER_VOLUME);
+            var speakerSliderPointerActive = false;
+            var speakerSliderHadPointerInput = false;
             function speakerThumbAlignedLeft(trackPos) {
                 var ratio = trackPos / SPEAKER_SLIDER_TRACK_MAX;
                 var halfThumb = SPEAKER_SLIDER_THUMB_SIZE / 2;
@@ -1570,9 +1573,17 @@
                 return 'calc(' + (ratio * 100) + '% + ' + thumbOffsetPx.toFixed(2) + 'px)';
             }
             function snapSpeakerTrackPos(pos) {
-                return Math.abs(pos - speakerVolumeAnchorTrackPos) <= SPEAKER_VOLUME_SNAP_RADIUS
+                return Math.abs(speakerVolumeFromTrackPos(pos) - C.DEFAULT_SPEAKER_VOLUME) <= SPEAKER_VOLUME_SNAP_RADIUS
                     ? speakerVolumeAnchorTrackPos
                     : pos;
+            }
+            function applySpeakerTrackPos(trackPos) {
+                var newVol = speakerVolumeFromTrackPos(trackPos);
+                S.speakerVolume = newVol;
+                applySpeakerVolumeVisual(newVol);
+                if (S.speakerGainNode) {
+                    S.speakerGainNode.gain.setTargetAtTime(newVol / 100, S.speakerGainNode.context.currentTime, 0.05);
+                }
             }
 
             var speakerSlider = document.createElement('input');
@@ -1593,21 +1604,38 @@
             }
             applySpeakerVolumeVisual(S.speakerVolume);
 
+            speakerSlider.addEventListener('pointerdown', function () {
+                speakerSliderPointerActive = true;
+                speakerSliderHadPointerInput = true;
+            });
+            speakerSlider.addEventListener('pointerup', function () {
+                speakerSliderPointerActive = false;
+            });
+            speakerSlider.addEventListener('pointercancel', function () {
+                speakerSliderPointerActive = false;
+            });
             speakerSlider.addEventListener('input', function (e) {
                 var trackPos = parseInt(e.target.value, 10);
                 if (isNaN(trackPos)) return;
-                var snappedTrackPos = snapSpeakerTrackPos(trackPos);
-                if (snappedTrackPos !== trackPos) {
-                    speakerSlider.value = String(snappedTrackPos);
+                if (speakerSliderPointerActive) {
+                    var snappedTrackPos = snapSpeakerTrackPos(trackPos);
+                    if (snappedTrackPos !== trackPos) {
+                        trackPos = snappedTrackPos;
+                        speakerSlider.value = String(snappedTrackPos);
+                    }
                 }
-                var newVol = speakerVolumeFromTrackPos(snappedTrackPos);
-                S.speakerVolume = newVol;
-                applySpeakerVolumeVisual(newVol);
-                if (S.speakerGainNode) {
-                    S.speakerGainNode.gain.setTargetAtTime(newVol / 100, S.speakerGainNode.context.currentTime, 0.05);
-                }
+                applySpeakerTrackPos(trackPos);
             });
-            speakerSlider.addEventListener('change', function () {
+            speakerSlider.addEventListener('change', function (e) {
+                var trackPos = parseInt(e.target.value, 10);
+                if (!isNaN(trackPos) && speakerSliderHadPointerInput) {
+                    var snappedTrackPos = snapSpeakerTrackPos(trackPos);
+                    if (snappedTrackPos !== trackPos) {
+                        speakerSlider.value = String(snappedTrackPos);
+                        applySpeakerTrackPos(snappedTrackPos);
+                    }
+                }
+                speakerSliderHadPointerInput = false;
                 if (typeof window.saveSpeakerVolumeSetting === 'function') window.saveSpeakerVolumeSetting();
             });
 


### PR DESCRIPTION
<!--
下面两节是项目硬性规范，CI 会校验（scripts/check_pr_report.py）：
  · 改动了 app/ | main_logic/ | memory/ 任一 *.py → 必须填「回归报告」
  · 单个 PR 改动计入上限的文件 > 20 个 → 必须填「不拆分理由」
    （新增文件、i18n locale 文件、测试文件不计入）
不触发的那一节，写「不适用」或直接删除即可。
维护者可对纯重命名/批量格式化/生成代码等打 `report-exempt` 标签豁免。
-->

## 改动概述 / Summary

优化扬声器音量滑条的 100% 标记线显示，使刻线更清晰但不遮挡滑块，并为 100% 位置增加轻微吸附手感

## 测试 / Testing

手动测试


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化麦克风配置弹窗“扬声器音量”滑块交互：靠近默认音量阈值时更容易自动贴合/吸附到锚点位置。
  * 调整滑块拇指与轨道相关计算与对齐方式，使拖动后音量值变化更直观。
  * 更新滑块刻度显示与布局（含“100% 标准锚点”刻度），让刻度与滑块视觉位置关系更一致、更清晰。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->