### PR TITLE
fix(avatar): show drag hint near adjacent display edge

### DIFF
--- a/static/avatar-multiscreen-drag-hint.js
+++ b/static/avatar-multiscreen-drag-hint.js
@@ -5,7 +5,7 @@
     const SNOOZE_MS = 3 * 24 * 60 * 60 * 1000;
     const MISS_WINDOW_MS = 30 * 1000;
     const REQUIRED_MISSES = 2;
-    const EDGE_RELEASE_THRESHOLD_PX = 36;
+    const EDGE_RELEASE_THRESHOLD_PX = 180;
     const MIN_EDGE_DRAG_DISTANCE_PX = 48;
 
     const FALLBACK_TEXT = {
@@ -17,6 +17,7 @@
 
     let isPromptVisible = false;
     let missRecordQueue = Promise.resolve();
+    let approachRecordQueue = Promise.resolve();
     let lastDisplaySwitchMissCall = null;
 
     function now() {
@@ -395,6 +396,17 @@
         return false;
     }
 
+    async function hasPointerAdjacentEdgeIntent(pointer) {
+        if (!hasDisplaySwitchBridge()) return false;
+        const displays = await window.electronScreen.getAllDisplays();
+        if (!Array.isArray(displays) || displays.length <= 1) return false;
+        const currentDisplay = normalizeDisplay(await window.electronScreen.getCurrentDisplay());
+        if (!currentDisplay) return false;
+        const edges = getPointerEdgeIntents(pointer, currentDisplay);
+        return edges.length > 0 &&
+            edges.some(edge => hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer));
+    }
+
     function wasDisplaySwitchMissRecordedSince(source, startedAt) {
         const since = Number(startedAt);
         if (!Number.isFinite(since)) return false;
@@ -410,21 +422,36 @@
 
     async function recordPointerEdgeRelease(source, pointer) {
         try {
-            if (!hasDisplaySwitchBridge()) return false;
-            const displays = await window.electronScreen.getAllDisplays();
-            if (!Array.isArray(displays) || displays.length <= 1) return false;
-            const currentDisplay = normalizeDisplay(await window.electronScreen.getCurrentDisplay());
-            if (!currentDisplay) return false;
-            const edges = getPointerEdgeIntents(pointer, currentDisplay);
-            if (!edges.length || !edges.some(edge => hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer))) {
-                return false;
-            }
+            if (!(await hasPointerAdjacentEdgeIntent(pointer))) return false;
             const startedAt = Number(pointer && pointer.startedAt);
             if (wasDisplaySwitchMissRecordedSince(source, startedAt)) return false;
             return recordDisplaySwitchMiss(source);
         } catch (_) {
             return false;
         }
+    }
+
+    async function recordPointerEdgeApproachNow(source, pointer) {
+        try {
+            const state = readState();
+            if (isSuppressed(state) || isPromptVisible) return false;
+            if (!(await hasPointerAdjacentEdgeIntent(pointer))) return false;
+            state.lastSource = normalizeSource(source);
+            state.lastMissAt = now();
+            writeState(state);
+            showPrompt();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    async function recordPointerEdgeApproach(source, pointer) {
+        const nextRecord = approachRecordQueue.then(function () {
+            return recordPointerEdgeApproachNow(source, pointer);
+        });
+        approachRecordQueue = nextRecord.catch(function () {});
+        return nextRecord;
     }
 
     async function recordDisplaySwitchMissNow(source) {
@@ -464,6 +491,34 @@
         }
     }
 
+    async function isModelCenterOnAnotherDisplay(model) {
+        try {
+            if (!hasDisplaySwitchBridge() || !isModelCenterOutsideCurrentWindow(model)) return false;
+            if (!model || typeof model.getBounds !== 'function') return false;
+            const bounds = model.getBounds();
+            if (!bounds) return false;
+            const centerX = (Number(bounds.left) + Number(bounds.right)) / 2;
+            const centerY = (Number(bounds.top) + Number(bounds.bottom)) / 2;
+            if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) return false;
+
+            const currentDisplay = normalizeDisplay(await window.electronScreen.getCurrentDisplay());
+            if (!currentDisplay) return false;
+            const screenX = currentDisplay.x + centerX;
+            const screenY = currentDisplay.y + centerY;
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!Array.isArray(displays) || displays.length <= 1) return false;
+
+            return displays.some(function (rawDisplay) {
+                const display = normalizeDisplay(rawDisplay);
+                return display && !isSameDisplay(display, currentDisplay) &&
+                    screenX >= display.x && screenX < display.right &&
+                    screenY >= display.y && screenY < display.bottom;
+            });
+        } catch (_) {
+            return false;
+        }
+    }
+
     function installLive2DDisplaySwitchMissHook() {
         const Manager = window.Live2DManager;
         const proto = Manager && Manager.prototype;
@@ -473,7 +528,7 @@
         const originalCheckAndSwitchDisplay = proto._checkAndSwitchDisplay;
         const wrappedCheckAndSwitchDisplay = async function (model) {
             const displaySwitched = await originalCheckAndSwitchDisplay.apply(this, arguments);
-            if (hasDisplaySwitchBridge() && !displaySwitched && isModelCenterOutsideCurrentWindow(model)) {
+            if (!displaySwitched && await isModelCenterOnAnotherDisplay(model)) {
                 recordDisplaySwitchMiss('live2d');
             }
             return displaySwitched;
@@ -503,6 +558,7 @@
 
     window.NekoAvatarMultiScreenDragHint = {
         recordDisplaySwitchMiss,
+        recordPointerEdgeApproach,
         recordPointerEdgeRelease,
         markDisplaySwitchSuccess,
         ackPrompt,

--- a/static/avatar-multiscreen-drag-hint.js
+++ b/static/avatar-multiscreen-drag-hint.js
@@ -17,9 +17,14 @@
 
     let isPromptVisible = false;
     let missRecordQueue = Promise.resolve();
+    let lastDisplaySwitchMissCall = null;
 
     function now() {
         return Date.now();
+    }
+
+    function normalizeSource(source) {
+        return source || 'avatar';
     }
 
     function translate(key, fallback) {
@@ -278,8 +283,13 @@
     }
 
     function recordDisplaySwitchMiss(source) {
+        const normalizedSource = normalizeSource(source);
+        lastDisplaySwitchMissCall = {
+            source: normalizedSource,
+            at: now()
+        };
         const nextRecord = missRecordQueue.then(function () {
-            return recordDisplaySwitchMissNow(source);
+            return recordDisplaySwitchMissNow(normalizedSource);
         });
         missRecordQueue = nextRecord.catch(function () {});
         return nextRecord;
@@ -303,14 +313,6 @@
         };
     }
 
-    function rangesOverlap(startA, endA, startB, endB) {
-        return Math.min(endA, endB) > Math.max(startA, startB);
-    }
-
-    function containsPoint(display, x, y) {
-        return display && x >= display.x && x < display.right && y >= display.y && y < display.bottom;
-    }
-
     function isSameDisplay(displayA, displayB) {
         if (!displayA || !displayB) return false;
         if (displayA.id !== undefined && displayB.id !== undefined) return displayA.id === displayB.id;
@@ -318,15 +320,15 @@
             displayA.width === displayB.width && displayA.height === displayB.height;
     }
 
-    function getPointerEdgeIntent(pointer, currentDisplay) {
-        if (!pointer || !currentDisplay) return null;
+    function getPointerEdgeIntents(pointer, currentDisplay) {
+        if (!pointer || !currentDisplay) return [];
         const startX = Number(pointer.startScreenX);
         const startY = Number(pointer.startScreenY);
         const releaseX = Number(pointer.screenX);
         const releaseY = Number(pointer.screenY);
         if (!Number.isFinite(startX) || !Number.isFinite(startY) ||
             !Number.isFinite(releaseX) || !Number.isFinite(releaseY)) {
-            return null;
+            return [];
         }
 
         const deltaX = releaseX - startX;
@@ -354,9 +356,28 @@
             }
         ].filter(candidate => candidate.near && candidate.distance >= MIN_EDGE_DRAG_DISTANCE_PX);
 
-        if (candidates.length === 0) return null;
+        if (candidates.length === 0) return [];
         candidates.sort((left, right) => right.distance - left.distance);
-        return candidates[0].edge;
+        return candidates.map(candidate => candidate.edge);
+    }
+
+    function touchesDisplayEdge(display, currentDisplay, edge) {
+        if (edge === 'right') return Math.abs(display.x - currentDisplay.right) <= 1;
+        if (edge === 'left') return Math.abs(display.right - currentDisplay.x) <= 1;
+        if (edge === 'bottom') return Math.abs(display.y - currentDisplay.bottom) <= 1;
+        if (edge === 'top') return Math.abs(display.bottom - currentDisplay.y) <= 1;
+        return false;
+    }
+
+    function releasePointMatchesDisplayEdge(display, edge, releaseX, releaseY) {
+        if (!Number.isFinite(releaseX) || !Number.isFinite(releaseY)) return false;
+        if (edge === 'right' || edge === 'left') {
+            return releaseY >= display.y && releaseY < display.bottom;
+        }
+        if (edge === 'bottom' || edge === 'top') {
+            return releaseX >= display.x && releaseX < display.right;
+        }
+        return false;
     }
 
     function hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer) {
@@ -366,29 +387,25 @@
         for (const rawDisplay of displays) {
             const display = normalizeDisplay(rawDisplay);
             if (!display || isSameDisplay(display, currentDisplay)) continue;
-
-            if (Number.isFinite(releaseX) && Number.isFinite(releaseY) && containsPoint(display, releaseX, releaseY)) {
-                return true;
-            }
-
-            if (edge === 'right' && display.x >= currentDisplay.right - 1 &&
-                rangesOverlap(display.y, display.bottom, currentDisplay.y, currentDisplay.bottom)) {
-                return true;
-            }
-            if (edge === 'left' && display.right <= currentDisplay.x + 1 &&
-                rangesOverlap(display.y, display.bottom, currentDisplay.y, currentDisplay.bottom)) {
-                return true;
-            }
-            if (edge === 'bottom' && display.y >= currentDisplay.bottom - 1 &&
-                rangesOverlap(display.x, display.right, currentDisplay.x, currentDisplay.right)) {
-                return true;
-            }
-            if (edge === 'top' && display.bottom <= currentDisplay.y + 1 &&
-                rangesOverlap(display.x, display.right, currentDisplay.x, currentDisplay.right)) {
+            if (touchesDisplayEdge(display, currentDisplay, edge) &&
+                releasePointMatchesDisplayEdge(display, edge, releaseX, releaseY)) {
                 return true;
             }
         }
         return false;
+    }
+
+    function wasDisplaySwitchMissRecordedSince(source, startedAt) {
+        const since = Number(startedAt);
+        if (!Number.isFinite(since)) return false;
+        const normalizedSource = normalizeSource(source);
+        if (lastDisplaySwitchMissCall &&
+            lastDisplaySwitchMissCall.source === normalizedSource &&
+            Number(lastDisplaySwitchMissCall.at) >= since) {
+            return true;
+        }
+        const state = readState();
+        return state.lastSource === normalizedSource && Number(state.lastMissAt) >= since;
     }
 
     async function recordPointerEdgeRelease(source, pointer) {
@@ -398,8 +415,12 @@
             if (!Array.isArray(displays) || displays.length <= 1) return false;
             const currentDisplay = normalizeDisplay(await window.electronScreen.getCurrentDisplay());
             if (!currentDisplay) return false;
-            const edge = getPointerEdgeIntent(pointer, currentDisplay);
-            if (!edge || !hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer)) return false;
+            const edges = getPointerEdgeIntents(pointer, currentDisplay);
+            if (!edges.length || !edges.some(edge => hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer))) {
+                return false;
+            }
+            const startedAt = Number(pointer && pointer.startedAt);
+            if (wasDisplaySwitchMissRecordedSince(source, startedAt)) return false;
             return recordDisplaySwitchMiss(source);
         } catch (_) {
             return false;

--- a/static/avatar-multiscreen-drag-hint.js
+++ b/static/avatar-multiscreen-drag-hint.js
@@ -18,6 +18,8 @@
     let isPromptVisible = false;
     let missRecordQueue = Promise.resolve();
     let approachRecordQueue = Promise.resolve();
+    let approachRecordPending = false;
+    let latestApproachRecord = null;
     let lastDisplaySwitchMissCall = null;
 
     function now() {
@@ -446,9 +448,35 @@
         }
     }
 
+    async function drainPointerEdgeApproaches(initialRecord) {
+        let currentRecord = initialRecord;
+        try {
+            while (currentRecord) {
+                const shown = await recordPointerEdgeApproachNow(
+                    currentRecord.source,
+                    currentRecord.pointer
+                );
+                if (shown) {
+                    latestApproachRecord = null;
+                    return true;
+                }
+                currentRecord = latestApproachRecord;
+                latestApproachRecord = null;
+            }
+            return false;
+        } finally {
+            approachRecordPending = false;
+        }
+    }
+
     async function recordPointerEdgeApproach(source, pointer) {
+        if (approachRecordPending) {
+            latestApproachRecord = { source, pointer };
+            return false;
+        }
+        approachRecordPending = true;
         const nextRecord = approachRecordQueue.then(function () {
-            return recordPointerEdgeApproachNow(source, pointer);
+            return drainPointerEdgeApproaches({ source, pointer });
         });
         approachRecordQueue = nextRecord.catch(function () {});
         return nextRecord;

--- a/static/avatar-multiscreen-drag-hint.js
+++ b/static/avatar-multiscreen-drag-hint.js
@@ -5,6 +5,8 @@
     const SNOOZE_MS = 3 * 24 * 60 * 60 * 1000;
     const MISS_WINDOW_MS = 30 * 1000;
     const REQUIRED_MISSES = 2;
+    const EDGE_RELEASE_THRESHOLD_PX = 36;
+    const MIN_EDGE_DRAG_DISTANCE_PX = 48;
 
     const FALLBACK_TEXT = {
         title: 'Move YUI to another screen',
@@ -58,6 +60,7 @@
         return Boolean(
             window.electronScreen &&
             typeof window.electronScreen.getAllDisplays === 'function' &&
+            typeof window.electronScreen.getCurrentDisplay === 'function' &&
             typeof window.electronScreen.moveWindowToDisplay === 'function'
         );
     }
@@ -282,6 +285,127 @@
         return nextRecord;
     }
 
+    function normalizeDisplay(display) {
+        if (!display || typeof display !== 'object') return null;
+        const x = Number.isFinite(display.screenX) ? display.screenX : (display.bounds && display.bounds.x);
+        const y = Number.isFinite(display.screenY) ? display.screenY : (display.bounds && display.bounds.y);
+        const width = Number.isFinite(display.width) ? display.width : (display.bounds && display.bounds.width);
+        const height = Number.isFinite(display.height) ? display.height : (display.bounds && display.bounds.height);
+        if (!Number.isFinite(x) || !Number.isFinite(y) || !(width > 0) || !(height > 0)) return null;
+        return {
+            id: display.id,
+            x,
+            y,
+            width,
+            height,
+            right: x + width,
+            bottom: y + height
+        };
+    }
+
+    function rangesOverlap(startA, endA, startB, endB) {
+        return Math.min(endA, endB) > Math.max(startA, startB);
+    }
+
+    function containsPoint(display, x, y) {
+        return display && x >= display.x && x < display.right && y >= display.y && y < display.bottom;
+    }
+
+    function isSameDisplay(displayA, displayB) {
+        if (!displayA || !displayB) return false;
+        if (displayA.id !== undefined && displayB.id !== undefined) return displayA.id === displayB.id;
+        return displayA.x === displayB.x && displayA.y === displayB.y &&
+            displayA.width === displayB.width && displayA.height === displayB.height;
+    }
+
+    function getPointerEdgeIntent(pointer, currentDisplay) {
+        if (!pointer || !currentDisplay) return null;
+        const startX = Number(pointer.startScreenX);
+        const startY = Number(pointer.startScreenY);
+        const releaseX = Number(pointer.screenX);
+        const releaseY = Number(pointer.screenY);
+        if (!Number.isFinite(startX) || !Number.isFinite(startY) ||
+            !Number.isFinite(releaseX) || !Number.isFinite(releaseY)) {
+            return null;
+        }
+
+        const deltaX = releaseX - startX;
+        const deltaY = releaseY - startY;
+        const candidates = [
+            {
+                edge: 'right',
+                distance: deltaX,
+                near: releaseX >= currentDisplay.right - EDGE_RELEASE_THRESHOLD_PX
+            },
+            {
+                edge: 'left',
+                distance: -deltaX,
+                near: releaseX <= currentDisplay.x + EDGE_RELEASE_THRESHOLD_PX
+            },
+            {
+                edge: 'bottom',
+                distance: deltaY,
+                near: releaseY >= currentDisplay.bottom - EDGE_RELEASE_THRESHOLD_PX
+            },
+            {
+                edge: 'top',
+                distance: -deltaY,
+                near: releaseY <= currentDisplay.y + EDGE_RELEASE_THRESHOLD_PX
+            }
+        ].filter(candidate => candidate.near && candidate.distance >= MIN_EDGE_DRAG_DISTANCE_PX);
+
+        if (candidates.length === 0) return null;
+        candidates.sort((left, right) => right.distance - left.distance);
+        return candidates[0].edge;
+    }
+
+    function hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer) {
+        if (!Array.isArray(displays) || !currentDisplay || !edge) return false;
+        const releaseX = Number(pointer && pointer.screenX);
+        const releaseY = Number(pointer && pointer.screenY);
+        for (const rawDisplay of displays) {
+            const display = normalizeDisplay(rawDisplay);
+            if (!display || isSameDisplay(display, currentDisplay)) continue;
+
+            if (Number.isFinite(releaseX) && Number.isFinite(releaseY) && containsPoint(display, releaseX, releaseY)) {
+                return true;
+            }
+
+            if (edge === 'right' && display.x >= currentDisplay.right - 1 &&
+                rangesOverlap(display.y, display.bottom, currentDisplay.y, currentDisplay.bottom)) {
+                return true;
+            }
+            if (edge === 'left' && display.right <= currentDisplay.x + 1 &&
+                rangesOverlap(display.y, display.bottom, currentDisplay.y, currentDisplay.bottom)) {
+                return true;
+            }
+            if (edge === 'bottom' && display.y >= currentDisplay.bottom - 1 &&
+                rangesOverlap(display.x, display.right, currentDisplay.x, currentDisplay.right)) {
+                return true;
+            }
+            if (edge === 'top' && display.bottom <= currentDisplay.y + 1 &&
+                rangesOverlap(display.x, display.right, currentDisplay.x, currentDisplay.right)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    async function recordPointerEdgeRelease(source, pointer) {
+        try {
+            if (!hasDisplaySwitchBridge()) return false;
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!Array.isArray(displays) || displays.length <= 1) return false;
+            const currentDisplay = normalizeDisplay(await window.electronScreen.getCurrentDisplay());
+            if (!currentDisplay) return false;
+            const edge = getPointerEdgeIntent(pointer, currentDisplay);
+            if (!edge || !hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer)) return false;
+            return recordDisplaySwitchMiss(source);
+        } catch (_) {
+            return false;
+        }
+    }
+
     async function recordDisplaySwitchMissNow(source) {
         const state = readState();
         if (isSuppressed(state) || isPromptVisible) return false;
@@ -358,6 +482,7 @@
 
     window.NekoAvatarMultiScreenDragHint = {
         recordDisplaySwitchMiss,
+        recordPointerEdgeRelease,
         markDisplaySwitchSuccess,
         ackPrompt,
         dismissForever,

--- a/static/avatar-multiscreen-drag-hint.test.cjs
+++ b/static/avatar-multiscreen-drag-hint.test.cjs
@@ -148,3 +148,60 @@ test('pointer edge release intent ignores movement away from the edge', async ()
     assert.equal(result, false);
     assert.equal(document.getElementById('avatar-multiscreen-drag-hint'), null);
 });
+
+test('pointer edge release intent ignores releases outside adjacent display span', async () => {
+    const { window, document } = createContext({
+        displays: [
+            twoDisplays[0],
+            { id: 2, screenX: 1000, screenY: 600, width: 900, height: 800 }
+        ]
+    });
+
+    const pointer = {
+        startScreenX: 820,
+        startScreenY: 100,
+        screenX: 998,
+        screenY: 100
+    };
+    const first = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('mmd', pointer);
+    const second = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('mmd', pointer);
+
+    assert.equal(first, false);
+    assert.equal(second, false);
+    assert.equal(document.getElementById('avatar-multiscreen-drag-hint'), null);
+});
+
+test('pointer edge release intent keeps secondary edge candidates at corners', async () => {
+    const { window, document } = createContext({ displays: twoDisplays });
+    const pointer = {
+        startScreenX: 900,
+        startScreenY: 600,
+        screenX: 998,
+        screenY: 799
+    };
+
+    const first = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('vrm', pointer);
+    const second = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('vrm', pointer);
+
+    assert.equal(first, false);
+    assert.equal(second, true);
+    assert.ok(document.getElementById('avatar-multiscreen-drag-hint'));
+});
+
+test('pointer edge release intent skips a miss already recorded during the same drag', async () => {
+    const { window, document } = createContext({ displays: twoDisplays });
+    const startedAt = Date.now();
+
+    const existingMiss = await window.NekoAvatarMultiScreenDragHint.recordDisplaySwitchMiss('vrm');
+    const edgeMiss = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('vrm', {
+        startedAt,
+        startScreenX: 820,
+        startScreenY: 400,
+        screenX: 998,
+        screenY: 400
+    });
+
+    assert.equal(existingMiss, false);
+    assert.equal(edgeMiss, false);
+    assert.equal(document.getElementById('avatar-multiscreen-drag-hint'), null);
+});

--- a/static/avatar-multiscreen-drag-hint.test.cjs
+++ b/static/avatar-multiscreen-drag-hint.test.cjs
@@ -121,6 +121,39 @@ test('pointer edge release intent shows the drag hint after repeated attempts', 
     assert.ok(document.getElementById('avatar-multiscreen-drag-hint'));
 });
 
+test('pointer edge approach shows the drag hint immediately on adjacent edge', async () => {
+    const { window, document } = createContext({ displays: twoDisplays });
+
+    const result = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeApproach('vrm', {
+        startScreenX: 620,
+        startScreenY: 400,
+        screenX: 860,
+        screenY: 400
+    });
+
+    assert.equal(result, true);
+    assert.ok(document.getElementById('avatar-multiscreen-drag-hint'));
+});
+
+test('pointer edge approach ignores edges without an adjacent display', async () => {
+    const { window, document } = createContext({
+        displays: [
+            twoDisplays[0],
+            { id: 2, screenX: 1000, screenY: 600, width: 900, height: 800 }
+        ]
+    });
+
+    const result = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeApproach('mmd', {
+        startScreenX: 620,
+        startScreenY: 100,
+        screenX: 860,
+        screenY: 100
+    });
+
+    assert.equal(result, false);
+    assert.equal(document.getElementById('avatar-multiscreen-drag-hint'), null);
+});
+
 test('pointer edge release intent ignores edge drags without an adjacent display', async () => {
     const { window, document } = createContext({ displays: [twoDisplays[0]] });
 

--- a/static/avatar-multiscreen-drag-hint.test.cjs
+++ b/static/avatar-multiscreen-drag-hint.test.cjs
@@ -1,0 +1,150 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, 'avatar-multiscreen-drag-hint.js'), 'utf8');
+
+function createElement(tagName, ownerDocument) {
+    const element = {
+        tagName: tagName.toUpperCase(),
+        children: [],
+        className: '',
+        id: '',
+        style: {},
+        textContent: '',
+        attributes: {},
+        classList: {
+            values: new Set(),
+            add(value) {
+                this.values.add(value);
+            },
+            contains(value) {
+                return this.values.has(value);
+            }
+        },
+        appendChild(child) {
+            this.children.push(child);
+            child.parentNode = this;
+            if (child.id) ownerDocument._elementsById.set(child.id, child);
+            return child;
+        },
+        remove() {
+            if (this.id) ownerDocument._elementsById.delete(this.id);
+            if (this.parentNode) {
+                this.parentNode.children = this.parentNode.children.filter(child => child !== this);
+            }
+        },
+        setAttribute(name, value) {
+            this.attributes[name] = value;
+        },
+        addEventListener() {}
+    };
+    return element;
+}
+
+function createDocument() {
+    const document = {
+        _elementsById: new Map(),
+        createElement(tagName) {
+            return createElement(tagName, document);
+        },
+        getElementById(id) {
+            return document._elementsById.get(id) || null;
+        }
+    };
+    document.head = createElement('head', document);
+    document.body = createElement('body', document);
+    return document;
+}
+
+function createContext({ displays }) {
+    const document = createDocument();
+    const storage = new Map();
+    const window = {
+        innerWidth: 1000,
+        innerHeight: 800,
+        localStorage: {
+            getItem(key) {
+                return storage.has(key) ? storage.get(key) : null;
+            },
+            setItem(key, value) {
+                storage.set(key, String(value));
+            }
+        },
+        electronScreen: {
+            async getAllDisplays() {
+                return displays;
+            },
+            async getCurrentDisplay() {
+                return displays[0];
+            },
+            async moveWindowToDisplay() {}
+        }
+    };
+    const context = vm.createContext({
+        window,
+        document,
+        Date,
+        JSON,
+        Number,
+        Promise,
+        setTimeout() {},
+        requestAnimationFrame(callback) {
+            callback();
+        }
+    });
+    vm.runInContext(source, context, { filename: 'avatar-multiscreen-drag-hint.js' });
+    return { window, document };
+}
+
+const twoDisplays = [
+    { id: 1, screenX: 0, screenY: 0, width: 1000, height: 800 },
+    { id: 2, screenX: 1000, screenY: 0, width: 900, height: 800 }
+];
+
+test('pointer edge release intent shows the drag hint after repeated attempts', async () => {
+    const { window, document } = createContext({ displays: twoDisplays });
+    const pointer = {
+        startScreenX: 820,
+        startScreenY: 400,
+        screenX: 998,
+        screenY: 400
+    };
+
+    const first = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('vrm', pointer);
+    const second = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('vrm', pointer);
+
+    assert.equal(first, false);
+    assert.equal(second, true);
+    assert.ok(document.getElementById('avatar-multiscreen-drag-hint'));
+});
+
+test('pointer edge release intent ignores edge drags without an adjacent display', async () => {
+    const { window, document } = createContext({ displays: [twoDisplays[0]] });
+
+    const result = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('mmd', {
+        startScreenX: 820,
+        startScreenY: 400,
+        screenX: 998,
+        screenY: 400
+    });
+
+    assert.equal(result, false);
+    assert.equal(document.getElementById('avatar-multiscreen-drag-hint'), null);
+});
+
+test('pointer edge release intent ignores movement away from the edge', async () => {
+    const { window, document } = createContext({ displays: twoDisplays });
+
+    const result = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeRelease('live2d', {
+        startScreenX: 998,
+        startScreenY: 400,
+        screenX: 900,
+        screenY: 400
+    });
+
+    assert.equal(result, false);
+    assert.equal(document.getElementById('avatar-multiscreen-drag-hint'), null);
+});

--- a/static/avatar-multiscreen-drag-hint.test.cjs
+++ b/static/avatar-multiscreen-drag-hint.test.cjs
@@ -59,9 +59,10 @@ function createDocument() {
     return document;
 }
 
-function createContext({ displays }) {
+function createContext({ displays, getCurrentDisplay } = {}) {
     const document = createDocument();
     const storage = new Map();
+    const currentDisplayGetter = getCurrentDisplay || (async () => displays[0]);
     const window = {
         innerWidth: 1000,
         innerHeight: 800,
@@ -78,7 +79,7 @@ function createContext({ displays }) {
                 return displays;
             },
             async getCurrentDisplay() {
-                return displays[0];
+                return currentDisplayGetter();
             },
             async moveWindowToDisplay() {}
         }
@@ -152,6 +153,49 @@ test('pointer edge approach ignores edges without an adjacent display', async ()
 
     assert.equal(result, false);
     assert.equal(document.getElementById('avatar-multiscreen-drag-hint'), null);
+});
+
+test('pointer edge approach coalesces in-flight checks to the latest pointer', async () => {
+    let resolveDisplay;
+    const displayReady = new Promise(resolve => {
+        resolveDisplay = resolve;
+    });
+    let currentDisplayCalls = 0;
+    const { window, document } = createContext({
+        displays: twoDisplays,
+        async getCurrentDisplay() {
+            currentDisplayCalls += 1;
+            await displayReady;
+            return twoDisplays[0];
+        }
+    });
+
+    const first = window.NekoAvatarMultiScreenDragHint.recordPointerEdgeApproach('vrm', {
+        startScreenX: 100,
+        startScreenY: 400,
+        screenX: 180,
+        screenY: 400
+    });
+    const stale = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeApproach('vrm', {
+        startScreenX: 120,
+        startScreenY: 400,
+        screenX: 240,
+        screenY: 400
+    });
+    const latest = await window.NekoAvatarMultiScreenDragHint.recordPointerEdgeApproach('vrm', {
+        startScreenX: 620,
+        startScreenY: 400,
+        screenX: 860,
+        screenY: 400
+    });
+
+    assert.equal(stale, false);
+    assert.equal(latest, false);
+    resolveDisplay();
+
+    assert.equal(await first, true);
+    assert.equal(currentDisplayCalls, 2);
+    assert.ok(document.getElementById('avatar-multiscreen-drag-hint'));
 });
 
 test('pointer edge release intent ignores edge drags without an adjacent display', async () => {

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -296,9 +296,30 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
     let clickStartTime = 0;
     let clickStartX = 0;
     let clickStartY = 0;
+    let dragHintStartPointer = null;
+    let dragHintLastPointer = null;
     let hasMoved = false;
     const CLICK_THRESHOLD_DISTANCE = 10; // 移动距离阈值（像素）
     const CLICK_THRESHOLD_TIME = 300; // 时间阈值（毫秒）
+
+    const captureDragHintPointer = (event) => {
+        const screenX = Number(event?.screenX);
+        const screenY = Number(event?.screenY);
+        if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) return null;
+        return { screenX, screenY };
+    };
+
+    const recordDragHintPointerEdgeRelease = async () => {
+        const helper = window.NekoAvatarMultiScreenDragHint;
+        if (!helper || typeof helper.recordPointerEdgeRelease !== 'function') return false;
+        if (!dragHintStartPointer || !dragHintLastPointer) return false;
+        return await helper.recordPointerEdgeRelease('live2d', {
+            startScreenX: dragHintStartPointer.screenX,
+            startScreenY: dragHintStartPointer.screenY,
+            screenX: dragHintLastPointer.screenX,
+            screenY: dragHintLastPointer.screenY
+        });
+    };
 
     // 使用 avatar-ui-drag.js 中的共享工具函数（按钮 pointer-events 管理）
     const disableButtonPointerEvents = () => {
@@ -353,6 +374,8 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
         clickStartTime = Date.now();
         clickStartX = globalPos.x;
         clickStartY = globalPos.y;
+        dragHintStartPointer = captureDragHintPointer(originalEvent);
+        dragHintLastPointer = dragHintStartPointer;
         hasMoved = false;
         this._touchSetPointerSeq = (this._touchSetPointerSeq || 0) + 1;
         this._lastTouchPointer = { x: clickStartX, y: clickStartY, time: clickStartTime, seq: this._touchSetPointerSeq };
@@ -368,11 +391,12 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
         disableButtonPointerEvents();
     });
 
-    const onDragEnd = async () => {
+    const onDragEnd = async (event) => {
         if (this._isDraggingModel) {
             this._isDraggingModel = false;
             document.getElementById('live2d-canvas').style.cursor = '';
             restoreButtonPointerEvents();
+            dragHintLastPointer = captureDragHintPointer(event) || dragHintLastPointer;
 
             if (!this._isModelReadyForInteraction) return;
 
@@ -412,15 +436,13 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
 
             // 如果没有发生屏幕切换，检测并执行自动吸附
             if (!displaySwitched) {
+                await recordDragHintPointerEdgeRelease();
                 // 执行自动吸附检测和动画
                 const snapped = await this._checkAndPerformSnap(model);
 
                 // 如果没有执行吸附，则正常保存位置
                 if (!snapped) {
                     await this._savePositionAfterInteraction();
-                } else if (window.NekoAvatarMultiScreenDragHint &&
-                    typeof window.NekoAvatarMultiScreenDragHint.recordEdgeBounce === 'function') {
-                    window.NekoAvatarMultiScreenDragHint.recordEdgeBounce('live2d');
                 }
                 // 如果执行了吸附，_checkAndPerformSnap 内部会保存位置
             }
@@ -455,6 +477,7 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
             // 这里假设 canvas 是全屏覆盖的
             const x = event.clientX;
             const y = event.clientY;
+            dragHintLastPointer = captureDragHintPointer(event) || dragHintLastPointer;
 
             // 检测是否移动超过阈值
             const moveDistance = Math.sqrt(

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -298,6 +298,7 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
     let clickStartY = 0;
     let dragHintStartPointer = null;
     let dragHintLastPointer = null;
+    let dragHintApproachShown = false;
     let hasMoved = false;
     const CLICK_THRESHOLD_DISTANCE = 10; // 移动距离阈值（像素）
     const CLICK_THRESHOLD_TIME = 300; // 时间阈值（毫秒）
@@ -320,6 +321,21 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
             screenX: dragHintLastPointer.screenX,
             screenY: dragHintLastPointer.screenY
         });
+    };
+
+    const recordDragHintPointerEdgeApproach = async () => {
+        const helper = window.NekoAvatarMultiScreenDragHint;
+        if (!helper || typeof helper.recordPointerEdgeApproach !== 'function') return false;
+        if (dragHintApproachShown || !dragHintStartPointer || !dragHintLastPointer) return false;
+        const shown = await helper.recordPointerEdgeApproach('live2d', {
+            startedAt: dragHintStartPointer.startedAt,
+            startScreenX: dragHintStartPointer.screenX,
+            startScreenY: dragHintStartPointer.screenY,
+            screenX: dragHintLastPointer.screenX,
+            screenY: dragHintLastPointer.screenY
+        });
+        if (shown) dragHintApproachShown = true;
+        return shown;
     };
 
     // 使用 avatar-ui-drag.js 中的共享工具函数（按钮 pointer-events 管理）
@@ -380,6 +396,7 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
             dragHintStartPointer.startedAt = Date.now();
         }
         dragHintLastPointer = dragHintStartPointer;
+        dragHintApproachShown = false;
         hasMoved = false;
         this._touchSetPointerSeq = (this._touchSetPointerSeq || 0) + 1;
         this._lastTouchPointer = { x: clickStartX, y: clickStartY, time: clickStartTime, seq: this._touchSetPointerSeq };
@@ -482,6 +499,7 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
             const x = event.clientX;
             const y = event.clientY;
             dragHintLastPointer = captureDragHintPointer(event) || dragHintLastPointer;
+            void recordDragHintPointerEdgeApproach();
 
             // 检测是否移动超过阈值
             const moveDistance = Math.sqrt(

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -314,6 +314,7 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
         if (!helper || typeof helper.recordPointerEdgeRelease !== 'function') return false;
         if (!dragHintStartPointer || !dragHintLastPointer) return false;
         return await helper.recordPointerEdgeRelease('live2d', {
+            startedAt: dragHintStartPointer.startedAt,
             startScreenX: dragHintStartPointer.screenX,
             startScreenY: dragHintStartPointer.screenY,
             screenX: dragHintLastPointer.screenX,
@@ -375,6 +376,9 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
         clickStartX = globalPos.x;
         clickStartY = globalPos.y;
         dragHintStartPointer = captureDragHintPointer(originalEvent);
+        if (dragHintStartPointer) {
+            dragHintStartPointer.startedAt = Date.now();
+        }
         dragHintLastPointer = dragHintStartPointer;
         hasMoved = false;
         this._touchSetPointerSeq = (this._touchSetPointerSeq || 0) + 1;

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -51,6 +51,9 @@ class MMDInteraction {
         this._orbitPivot = null;
         this._lastPanDragPointerScreen = null;
         this._panDragModelCenterOffset = null;
+        this._dragHintPanStartPointer = null;
+        this._dragHintPanLastPointer = null;
+        this._dragHintApproachShown = false;
     }
 
     // ═══════════════════ 射线检测 ═══════════════════
@@ -82,6 +85,56 @@ class MMDInteraction {
 
         return clientX >= bounds.minX && clientX <= bounds.maxX &&
                clientY >= bounds.minY && clientY <= bounds.maxY;
+    }
+
+    _captureDragHintPointer(event) {
+        const screenX = Number(event?.screenX);
+        const screenY = Number(event?.screenY);
+        if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) return null;
+        return { screenX, screenY };
+    }
+
+    _rememberDragHintPanPointer(event, { start = false } = {}) {
+        const pointer = this._captureDragHintPointer(event);
+        if (!pointer) return;
+        if (start) {
+            pointer.startedAt = Date.now();
+            this._dragHintPanStartPointer = pointer;
+        }
+        this._dragHintPanLastPointer = pointer;
+    }
+
+    async _recordDragHintPointerEdgeRelease(source) {
+        const helper = window.NekoAvatarMultiScreenDragHint;
+        if (!helper || typeof helper.recordPointerEdgeRelease !== 'function') return false;
+        const start = this._dragHintPanStartPointer;
+        const release = this._dragHintPanLastPointer;
+        if (!start || !release) return false;
+        return await helper.recordPointerEdgeRelease(source, {
+            startedAt: start.startedAt,
+            startScreenX: start.screenX,
+            startScreenY: start.screenY,
+            screenX: release.screenX,
+            screenY: release.screenY
+        });
+    }
+
+    async _recordDragHintPointerEdgeApproach(source) {
+        const helper = window.NekoAvatarMultiScreenDragHint;
+        if (!helper || typeof helper.recordPointerEdgeApproach !== 'function') return false;
+        if (this._dragHintApproachShown) return false;
+        const start = this._dragHintPanStartPointer;
+        const pointer = this._dragHintPanLastPointer;
+        if (!start || !pointer) return false;
+        const shown = await helper.recordPointerEdgeApproach(source, {
+            startedAt: start.startedAt,
+            startScreenX: start.screenX,
+            startScreenY: start.screenY,
+            screenX: pointer.screenX,
+            screenY: pointer.screenY
+        });
+        if (shown) this._dragHintApproachShown = true;
+        return shown;
     }
 
     /**
@@ -312,6 +365,8 @@ class MMDInteraction {
                 this.dragMode = 'pan';
                 this.previousMousePosition = { x: e.clientX, y: e.clientY };
                 this._rememberPanDragPointer(e, { captureOffset: true });
+                this._rememberDragHintPanPointer(e, { start: true });
+                this._dragHintApproachShown = false;
                 canvas.style.cursor = 'move';
                 e.preventDefault();
                 e.stopPropagation();
@@ -366,6 +421,8 @@ class MMDInteraction {
             const dy = e.clientY - this.previousMousePosition.y;
             if (this.dragMode === 'pan') {
                 this._rememberPanDragPointer(e);
+                this._rememberDragHintPanPointer(e);
+                void this._recordDragHintPointerEdgeApproach('mmd');
             }
             this.previousMousePosition = { x: e.clientX, y: e.clientY };
 
@@ -424,6 +481,7 @@ class MMDInteraction {
             if (this.isDragging) {
                 if (this.dragMode === 'pan') {
                     this._rememberPanDragPointer(e);
+                    this._rememberDragHintPanPointer(e);
                 }
                 // 保留本次拖拽类型再清状态，跨屏切换只对 pan 生效
                 // （orbit 是绕模型中心旋转朝向，不应触发多屏切换）
@@ -440,6 +498,9 @@ class MMDInteraction {
                     : false;
 
                 if (!displaySwitched) {
+                    if (wasPanDrag) {
+                        await this._recordDragHintPointerEdgeRelease('mmd');
+                    }
                     // 桌宠窗口与网页端统一：clampModelPosition 已按可见像素(200px)判定，
                     // 只有模型绝大部分出屏才回弹，贴边摆放不会被过度纠正。
                     const snapped = await this._snapModelIntoScreen({ animate: true });
@@ -692,7 +753,6 @@ class MMDInteraction {
                 }
             }
             if (!targetDisplay) {
-                recordDisplaySwitchMiss();
                 return false;
             }
 

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -307,21 +307,6 @@ class MMDInteraction {
         return true;
     }
 
-    async _waitForDisplaySwitchLayoutSettle() {
-        const nextFrame = () => new Promise(resolve => {
-            if (typeof requestAnimationFrame === 'function') {
-                requestAnimationFrame(resolve);
-            } else {
-                setTimeout(resolve, 0);
-            }
-        });
-
-        await nextFrame();
-        await nextFrame();
-        await new Promise(resolve => setTimeout(resolve, 140));
-        await nextFrame();
-    }
-
     // ═══════════════════ 锁定控制 ═══════════════════
 
     setLocked(locked) {
@@ -789,8 +774,9 @@ class MMDInteraction {
                 ? switchScreenY - targetDisplay.screenY + (Number(pointerOffset.y) || 0)
                 : modelScreenY - targetDisplay.screenY;
 
-            // 6. 等待 display-change 的延迟 resize 生效，再执行回弹与保存
-            await this._waitForDisplaySwitchLayoutSettle();
+            // 6. 等待新窗口尺寸生效，再执行回弹与保存
+            await new Promise(resolve => requestAnimationFrame(resolve));
+            await new Promise(resolve => requestAnimationFrame(resolve));
             this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);
 
             const snapped = useDragPointerForSwitch

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -307,6 +307,21 @@ class MMDInteraction {
         return true;
     }
 
+    async _waitForDisplaySwitchLayoutSettle() {
+        const nextFrame = () => new Promise(resolve => {
+            if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(resolve);
+            } else {
+                setTimeout(resolve, 0);
+            }
+        });
+
+        await nextFrame();
+        await nextFrame();
+        await new Promise(resolve => setTimeout(resolve, 140));
+        await nextFrame();
+    }
+
     // ═══════════════════ 锁定控制 ═══════════════════
 
     setLocked(locked) {
@@ -774,9 +789,8 @@ class MMDInteraction {
                 ? switchScreenY - targetDisplay.screenY + (Number(pointerOffset.y) || 0)
                 : modelScreenY - targetDisplay.screenY;
 
-            // 6. 等待新窗口尺寸生效，再执行回弹与保存
-            await new Promise(resolve => requestAnimationFrame(resolve));
-            await new Promise(resolve => requestAnimationFrame(resolve));
+            // 6. 等待 display-change 的延迟 resize 生效，再执行回弹与保存
+            await this._waitForDisplaySwitchLayoutSettle();
             this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);
 
             const snapped = useDragPointerForSwitch

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -62,6 +62,9 @@ class VRMInteraction {
         this._snapResolve = null;
         this._lastPanDragPointerScreen = null;
         this._panDragModelCenterOffset = null;
+        this._dragHintPanStartPointer = null;
+        this._dragHintPanLastPointer = null;
+        this._dragHintApproachShown = false;
     }
 
 
@@ -145,6 +148,56 @@ class VRMInteraction {
         } else {
             this._panDragModelCenterOffset = { x: 0, y: 0 };
         }
+    }
+
+    _captureDragHintPointer(event) {
+        const screenX = Number(event?.screenX);
+        const screenY = Number(event?.screenY);
+        if (!Number.isFinite(screenX) || !Number.isFinite(screenY)) return null;
+        return { screenX, screenY };
+    }
+
+    _rememberDragHintPanPointer(event, { start = false } = {}) {
+        const pointer = this._captureDragHintPointer(event);
+        if (!pointer) return;
+        if (start) {
+            pointer.startedAt = Date.now();
+            this._dragHintPanStartPointer = pointer;
+        }
+        this._dragHintPanLastPointer = pointer;
+    }
+
+    async _recordDragHintPointerEdgeRelease(source) {
+        const helper = window.NekoAvatarMultiScreenDragHint;
+        if (!helper || typeof helper.recordPointerEdgeRelease !== 'function') return false;
+        const start = this._dragHintPanStartPointer;
+        const release = this._dragHintPanLastPointer;
+        if (!start || !release) return false;
+        return await helper.recordPointerEdgeRelease(source, {
+            startedAt: start.startedAt,
+            startScreenX: start.screenX,
+            startScreenY: start.screenY,
+            screenX: release.screenX,
+            screenY: release.screenY
+        });
+    }
+
+    async _recordDragHintPointerEdgeApproach(source) {
+        const helper = window.NekoAvatarMultiScreenDragHint;
+        if (!helper || typeof helper.recordPointerEdgeApproach !== 'function') return false;
+        if (this._dragHintApproachShown) return false;
+        const start = this._dragHintPanStartPointer;
+        const pointer = this._dragHintPanLastPointer;
+        if (!start || !pointer) return false;
+        const shown = await helper.recordPointerEdgeApproach(source, {
+            startedAt: start.startedAt,
+            startScreenX: start.screenX,
+            startScreenY: start.screenY,
+            screenX: pointer.screenX,
+            screenY: pointer.screenY
+        });
+        if (shown) this._dragHintApproachShown = true;
+        return shown;
     }
 
     _moveModelCenterToWindowPoint(targetX, targetY) {
@@ -287,6 +340,8 @@ class VRMInteraction {
                 this.dragMode = 'pan';
                 this.previousMousePosition = { x: e.clientX, y: e.clientY };
                 this._rememberPanDragPointer(e, { captureOffset: true });
+                this._rememberDragHintPanPointer(e, { start: true });
+                this._dragHintApproachShown = false;
                 canvas.style.cursor = 'move';
                 e.preventDefault();
                 e.stopPropagation();
@@ -355,6 +410,8 @@ class VRMInteraction {
             const deltaY = e.clientY - this.previousMousePosition.y;
             if (this.dragMode === 'pan') {
                 this._rememberPanDragPointer(e);
+                this._rememberDragHintPanPointer(e);
+                void this._recordDragHintPointerEdgeApproach('vrm');
             }
 
             if (this.dragMode === 'pan' && this.manager.currentModel && this.manager.currentModel.scene) {
@@ -432,6 +489,7 @@ class VRMInteraction {
                 e.stopPropagation();
                 if (this.dragMode === 'pan') {
                     this._rememberPanDragPointer(e);
+                    this._rememberDragHintPanPointer(e);
                 }
                 // 保留本次拖拽类型再清状态，跨屏切换只对 pan 生效
                 // （orbit 绕包围盒中心原地转身，屏幕投影不位移，无需多屏切换）
@@ -450,6 +508,9 @@ class VRMInteraction {
                     : false;
 
                 if (!displaySwitched) {
+                    if (wasPanDrag) {
+                        await this._recordDragHintPointerEdgeRelease('vrm');
+                    }
                     // 拖拽结束后：若超出屏幕范围，执行回弹
                     await this._snapModelIntoScreen({ animate: true });
 
@@ -1122,7 +1183,6 @@ class VRMInteraction {
                 }
             }
             if (!targetDisplay) {
-                recordDisplaySwitchMiss();
                 return false;
             }
 

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -235,6 +235,21 @@ class VRMInteraction {
         return true;
     }
 
+    async _waitForDisplaySwitchLayoutSettle() {
+        const nextFrame = () => new Promise(resolve => {
+            if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(resolve);
+            } else {
+                setTimeout(resolve, 0);
+            }
+        });
+
+        await nextFrame();
+        await nextFrame();
+        await new Promise(resolve => setTimeout(resolve, 140));
+        await nextFrame();
+    }
+
     /**
      * 射线检测：判断屏幕坐标 (clientX, clientY) 是否命中 VRM 模型
      * @returns {boolean} 是否命中
@@ -1204,8 +1219,8 @@ class VRMInteraction {
                 ? switchScreenY - targetDisplay.screenY + (Number(pointerOffset.y) || 0)
                 : modelScreenY - targetDisplay.screenY;
 
-            // 6. 等待一帧让新窗口尺寸生效，再执行回弹与保存
-            await new Promise(resolve => requestAnimationFrame(resolve));
+            // 6. 等待 display-change 的延迟 resize 生效，再执行回弹与保存
+            await this._waitForDisplaySwitchLayoutSettle();
             this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);
 
             if (useDragPointerForSwitch) {

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -235,21 +235,6 @@ class VRMInteraction {
         return true;
     }
 
-    async _waitForDisplaySwitchLayoutSettle() {
-        const nextFrame = () => new Promise(resolve => {
-            if (typeof requestAnimationFrame === 'function') {
-                requestAnimationFrame(resolve);
-            } else {
-                setTimeout(resolve, 0);
-            }
-        });
-
-        await nextFrame();
-        await nextFrame();
-        await new Promise(resolve => setTimeout(resolve, 140));
-        await nextFrame();
-    }
-
     /**
      * 射线检测：判断屏幕坐标 (clientX, clientY) 是否命中 VRM 模型
      * @returns {boolean} 是否命中
@@ -1219,8 +1204,8 @@ class VRMInteraction {
                 ? switchScreenY - targetDisplay.screenY + (Number(pointerOffset.y) || 0)
                 : modelScreenY - targetDisplay.screenY;
 
-            // 6. 等待 display-change 的延迟 resize 生效，再执行回弹与保存
-            await this._waitForDisplaySwitchLayoutSettle();
+            // 6. 等待一帧让新窗口尺寸生效，再执行回弹与保存
+            await new Promise(resolve => requestAnimationFrame(resolve));
             this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);
 
             if (useDragPointerForSwitch) {

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -126,26 +126,6 @@ def test_model_interactions_report_display_switch_misses_and_success():
     assert "markDisplaySwitchSuccess('vrm')" in vrm
 
 
-def test_live3d_display_switch_waits_for_layout_settle_before_pointer_realign():
-    mmd = _source("static/mmd-interaction.js")
-    vrm = _source("static/vrm-interaction.js")
-
-    assert "_waitForDisplaySwitchLayoutSettle" in mmd
-    assert "_waitForDisplaySwitchLayoutSettle" in vrm
-    assert "setTimeout(resolve, 140)" in mmd
-    assert "setTimeout(resolve, 140)" in vrm
-
-    mmd_switch = mmd.split("const result = await window.electronScreen.moveWindowToDisplay", 1)[1]
-    assert mmd_switch.index("await this._waitForDisplaySwitchLayoutSettle();") < mmd_switch.index(
-        "this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);"
-    )
-
-    vrm_switch = vrm.split("const result = await window.electronScreen.moveWindowToDisplay", 1)[1]
-    assert vrm_switch.index("await this._waitForDisplaySwitchLayoutSettle();") < vrm_switch.index(
-        "this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);"
-    )
-
-
 def test_model_renderers_refresh_pixel_density_after_display_switch():
     live2d_core = _source("static/live2d-core.js")
     mmd_core = _source("static/mmd-core.js")

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -31,7 +31,8 @@ def test_multiscreen_drag_hint_counts_display_switch_misses_only_on_multiple_dis
     assert "function recordDisplaySwitchMiss(source)" in source
     assert "if (!(await hasMultipleDisplays())) return false;" in source
     assert "state.recentMissCount >= REQUIRED_MISSES" in source
-    assert "hasDisplaySwitchBridge() && !displaySwitched && isModelCenterOutsideCurrentWindow(model)" in source
+    assert "async function isModelCenterOnAnotherDisplay(model)" in source
+    assert "if (!displaySwitched && await isModelCenterOnAnotherDisplay(model))" in source
 
 
 def test_multiscreen_drag_hint_serializes_display_switch_miss_updates():
@@ -48,14 +49,16 @@ def test_multiscreen_drag_hint_serializes_display_switch_miss_updates():
 def test_multiscreen_drag_hint_records_pointer_edge_release_intent():
     source = _source("static/avatar-multiscreen-drag-hint.js")
 
-    assert "const EDGE_RELEASE_THRESHOLD_PX = 36;" in source
+    assert "const EDGE_RELEASE_THRESHOLD_PX = 180;" in source
     assert "const MIN_EDGE_DRAG_DISTANCE_PX = 48;" in source
     assert "function getPointerEdgeIntents(pointer, currentDisplay)" in source
     assert "function hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer)" in source
+    assert "async function recordPointerEdgeApproach(source, pointer)" in source
     assert "async function recordPointerEdgeRelease(source, pointer)" in source
     assert "edges.some(edge => hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer))" in source
     assert "wasDisplaySwitchMissRecordedSince(source, startedAt)" in source
     assert "window.electronScreen.getCurrentDisplay" in source
+    assert "recordPointerEdgeApproach," in source
     assert "recordPointerEdgeRelease," in source
 
 
@@ -99,10 +102,13 @@ def test_model_interactions_report_display_switch_misses_and_success():
     assert "_checkAndSwitchDisplay" in helper
     assert "recordDisplaySwitchMiss('live2d')" in helper
     assert "recordDisplaySwitchMiss('live2d')" not in live2d
+    assert "recordPointerEdgeApproach('live2d'" in live2d
     assert "recordPointerEdgeRelease('live2d'" in live2d
     assert "recordEdgeBounce('live2d')" not in live2d
     assert "markDisplaySwitchSuccess('live2d')" in live2d
     assert "recordDisplaySwitchMiss('mmd')" in mmd
+    assert "void this._recordDragHintPointerEdgeApproach('mmd');" in mmd
+    assert "if (!targetDisplay) {\n                return false;\n            }" in mmd
     mmd_release = mmd.split("if (!displaySwitched) {", 1)[1].split("// 鼠标离开", 1)[0]
     assert mmd_release.index("if (wasPanDrag) {") < mmd_release.index(
         "await this._recordDragHintPointerEdgeRelease('mmd');"
@@ -110,6 +116,8 @@ def test_model_interactions_report_display_switch_misses_and_success():
     assert "recordEdgeBounce('mmd')" not in mmd
     assert "markDisplaySwitchSuccess('mmd')" in mmd
     assert "recordDisplaySwitchMiss('vrm')" in vrm
+    assert "void this._recordDragHintPointerEdgeApproach('vrm');" in vrm
+    assert "if (!targetDisplay) {\n                return false;\n            }" in vrm
     vrm_release = vrm.split("if (!displaySwitched) {", 1)[1].split("// 5. 鼠标进入", 1)[0]
     assert vrm_release.index("if (wasPanDrag) {") < vrm_release.index(
         "await this._recordDragHintPointerEdgeRelease('vrm');"

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -23,6 +23,7 @@ def test_multiscreen_drag_hint_counts_display_switch_misses_only_on_multiple_dis
     assert "const MISS_WINDOW_MS = 30 * 1000;" in source
     assert "function hasDisplaySwitchBridge()" in source
     assert "typeof window.electronScreen.moveWindowToDisplay === 'function'" in source
+    assert "typeof window.electronScreen.getCurrentDisplay === 'function'" in source
     assert "async function hasMultipleDisplays()" in source
     assert "window.electronScreen.getAllDisplays" in source
     assert "if (!hasDisplaySwitchBridge()) return false;" in source
@@ -42,6 +43,18 @@ def test_multiscreen_drag_hint_serializes_display_switch_miss_updates():
     assert "return recordDisplaySwitchMissNow(source);" in source
     assert "missRecordQueue = nextRecord.catch(function () {});" in source
     assert "function recordDisplaySwitchMissNow(source)" in source
+
+
+def test_multiscreen_drag_hint_records_pointer_edge_release_intent():
+    source = _source("static/avatar-multiscreen-drag-hint.js")
+
+    assert "const EDGE_RELEASE_THRESHOLD_PX = 36;" in source
+    assert "const MIN_EDGE_DRAG_DISTANCE_PX = 48;" in source
+    assert "function getPointerEdgeIntent(pointer, currentDisplay)" in source
+    assert "function hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer)" in source
+    assert "async function recordPointerEdgeRelease(source, pointer)" in source
+    assert "window.electronScreen.getCurrentDisplay" in source
+    assert "recordPointerEdgeRelease," in source
 
 
 def test_multiscreen_drag_hint_can_be_disabled_or_suppressed_after_success():
@@ -84,11 +97,15 @@ def test_model_interactions_report_display_switch_misses_and_success():
     assert "_checkAndSwitchDisplay" in helper
     assert "recordDisplaySwitchMiss('live2d')" in helper
     assert "recordDisplaySwitchMiss('live2d')" not in live2d
+    assert "recordPointerEdgeRelease('live2d'" in live2d
+    assert "recordEdgeBounce('live2d')" not in live2d
     assert "markDisplaySwitchSuccess('live2d')" in live2d
     assert "recordDisplaySwitchMiss('mmd')" in mmd
+    assert "await this._recordDragHintPointerEdgeRelease('mmd');" in mmd
     assert "recordEdgeBounce('mmd')" not in mmd
     assert "markDisplaySwitchSuccess('mmd')" in mmd
     assert "recordDisplaySwitchMiss('vrm')" in vrm
+    assert "await this._recordDragHintPointerEdgeRelease('vrm');" in vrm
     assert "recordEdgeBounce('vrm')" not in vrm
     assert "markDisplaySwitchSuccess('vrm')" in vrm
 

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -40,7 +40,7 @@ def test_multiscreen_drag_hint_serializes_display_switch_miss_updates():
     assert "let missRecordQueue = Promise.resolve();" in source
     assert "function recordDisplaySwitchMiss(source) {" in source
     assert "const nextRecord = missRecordQueue.then(function () {" in source
-    assert "return recordDisplaySwitchMissNow(source);" in source
+    assert "return recordDisplaySwitchMissNow(normalizedSource);" in source
     assert "missRecordQueue = nextRecord.catch(function () {});" in source
     assert "function recordDisplaySwitchMissNow(source)" in source
 
@@ -50,9 +50,11 @@ def test_multiscreen_drag_hint_records_pointer_edge_release_intent():
 
     assert "const EDGE_RELEASE_THRESHOLD_PX = 36;" in source
     assert "const MIN_EDGE_DRAG_DISTANCE_PX = 48;" in source
-    assert "function getPointerEdgeIntent(pointer, currentDisplay)" in source
+    assert "function getPointerEdgeIntents(pointer, currentDisplay)" in source
     assert "function hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer)" in source
     assert "async function recordPointerEdgeRelease(source, pointer)" in source
+    assert "edges.some(edge => hasAdjacentDisplayForEdge(displays, currentDisplay, edge, pointer))" in source
+    assert "wasDisplaySwitchMissRecordedSince(source, startedAt)" in source
     assert "window.electronScreen.getCurrentDisplay" in source
     assert "recordPointerEdgeRelease," in source
 
@@ -101,11 +103,17 @@ def test_model_interactions_report_display_switch_misses_and_success():
     assert "recordEdgeBounce('live2d')" not in live2d
     assert "markDisplaySwitchSuccess('live2d')" in live2d
     assert "recordDisplaySwitchMiss('mmd')" in mmd
-    assert "await this._recordDragHintPointerEdgeRelease('mmd');" in mmd
+    mmd_release = mmd.split("if (!displaySwitched) {", 1)[1].split("// 鼠标离开", 1)[0]
+    assert mmd_release.index("if (wasPanDrag) {") < mmd_release.index(
+        "await this._recordDragHintPointerEdgeRelease('mmd');"
+    )
     assert "recordEdgeBounce('mmd')" not in mmd
     assert "markDisplaySwitchSuccess('mmd')" in mmd
     assert "recordDisplaySwitchMiss('vrm')" in vrm
-    assert "await this._recordDragHintPointerEdgeRelease('vrm');" in vrm
+    vrm_release = vrm.split("if (!displaySwitched) {", 1)[1].split("// 5. 鼠标进入", 1)[0]
+    assert vrm_release.index("if (wasPanDrag) {") < vrm_release.index(
+        "await this._recordDragHintPointerEdgeRelease('vrm');"
+    )
     assert "recordEdgeBounce('vrm')" not in vrm
     assert "markDisplaySwitchSuccess('vrm')" in vrm
 

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -126,6 +126,26 @@ def test_model_interactions_report_display_switch_misses_and_success():
     assert "markDisplaySwitchSuccess('vrm')" in vrm
 
 
+def test_live3d_display_switch_waits_for_layout_settle_before_pointer_realign():
+    mmd = _source("static/mmd-interaction.js")
+    vrm = _source("static/vrm-interaction.js")
+
+    assert "_waitForDisplaySwitchLayoutSettle" in mmd
+    assert "_waitForDisplaySwitchLayoutSettle" in vrm
+    assert "setTimeout(resolve, 140)" in mmd
+    assert "setTimeout(resolve, 140)" in vrm
+
+    mmd_switch = mmd.split("const result = await window.electronScreen.moveWindowToDisplay", 1)[1]
+    assert mmd_switch.index("await this._waitForDisplaySwitchLayoutSettle();") < mmd_switch.index(
+        "this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);"
+    )
+
+    vrm_switch = vrm.split("const result = await window.electronScreen.moveWindowToDisplay", 1)[1]
+    assert vrm_switch.index("await this._waitForDisplaySwitchLayoutSettle();") < vrm_switch.index(
+        "this._moveModelCenterToWindowPoint(desiredModelCenterX, desiredModelCenterY);"
+    )
+
+
 def test_model_renderers_refresh_pixel_density_after_display_switch():
     live2d_core = _source("static/live2d-core.js")
     mmd_core = _source("static/mmd-core.js")


### PR DESCRIPTION
## 改动概述 / Summary

- 修复多屏拖拽提示弹框难触发的问题：拖动过程中按住鼠标靠近“连接着另一块显示器”的屏幕边缘时，立即触发一次多屏拖动提示，不再等到释放后靠回弹/吸附失败间接触发。
- Live2D、MMD、VRM 三种模型拖动入口统一上报拖拽开始点和当前全局 `screenX/screenY`，由 `avatar-multiscreen-drag-hint.js` 统一判断当前边缘是否真实相邻另一块显示器。
- 避免无目标显示器边缘误弹：如果模型/鼠标靠近的是不能拖到另一块屏幕的位置，不再记录 display-switch miss。
- 保留既有跨屏成功标记、稍后提醒、永不提醒逻辑；释放后的边缘意图记录仍作为兜底。

## 回归报告 / Regression Report

不适用：未修改 `app/`、`main_logic/`、`main_routers/` 或 `memory/` 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用：计入上限的文件数未超过 20 个。

## 测试 / Testing

- `node --test static/avatar-multiscreen-drag-hint.test.cjs`
- `uv run pytest tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py tests/unit/test_mmd_interaction_static_contracts.py tests/unit/test_vrm_interaction_static_contracts.py`
- `node --check static/avatar-multiscreen-drag-hint.js && node --check static/avatar-multiscreen-drag-hint.test.cjs && node --check static/live2d-interaction.js && node --check static/mmd-interaction.js && node --check static/vrm-interaction.js`
- `git diff --check`
- 本地 PC 壳手测：拖到相邻屏连接边缘时按住即可弹提示；无相邻屏目标的边缘不再弹。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增强多屏拖拽提示：更精确识别“靠近边缘/释放边缘”意图，上报起止屏幕位置与时间信息；在直播互动、MMD、VRM中生效并避免重复展示。
* **Bug 修复**
  * 优化多屏切换失败与边缘释放判定：改进判断准确性与失败记录时机，减少误触发；无法确认切换目标时不再记录失败。
* **测试**
  * 更新并新增多屏拖拽提示静态契约与交互上报时序测试，覆盖提示创建与条件分支。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->