### PR TITLE
把 NEKO Live 的 runtime 先拆开

### DIFF
--- a/plugin/plugins/neko_roast/core/active_topic_rules.py
+++ b/plugin/plugins/neko_roast/core/active_topic_rules.py
@@ -14,11 +14,39 @@ import re
 _ACTIVE_TOPIC_NORMALIZE_RE = re.compile(r"[\W_]+", re.UNICODE)
 _ACTIVE_TOPIC_SIMILARITY_THRESHOLD = 0.78
 _ACTIVE_TOPIC_MIN_NORMALIZED_CHARS = 6
+_ACTIVE_TOPIC_LOW_CONFIDENCE_TERMS = (
+    "\u6838\u7535",
+    "\u6838\u7535\u7ad9",
+    "\u6838\u8f90\u5c04",
+    "\u8f90\u5c04",
+    "\u7206\u7834",
+    "\u7206\u70b8",
+    "\u52b3\u6539",
+    "\u516c\u5f00\u793a\u4f17",
+    "\u793a\u4f17",
+    "\u5904\u5211",
+    "\u60e9\u7f5a",
+    "\u5ba1\u5224",
+    "\u653b\u7565",
+    "\u6559\u7a0b",
+    "\u4e13\u5bb6",
+    "\u61c2\u5f88\u591a",
+    "\u8dd1\u4ee3\u7801",
+    "\u903b\u8f91\u7535\u8def",
+    "\u6f0f\u52fa",
+    "nuclear",
+    "radiation",
+    "punish",
+    "trial",
+    "expert",
+)
 
 
 def _is_meaningful_active_topic_text(text: str) -> bool:
     compact = " ".join(str(text or "").strip().split())
     if not compact:
+        return False
+    if _is_low_confidence_active_topic_text(compact):
         return False
     lowered = compact.lower()
     if lowered in {"hi", "hello", "ok", "1", "?", "？", "好", "嗯", "啊", "草", "6"}:
@@ -71,7 +99,16 @@ def _is_meaningful_active_topic_text(text: str) -> bool:
         "\u4eca\u665a\u505a\u4ec0\u4e48",
         "\u60f3\u542c\u4ec0\u4e48",
         "\u6765\u70b9\u5f39\u5e55",
+        "\u8fd8\u5728\u5417",
+        "\u6709\u4eba\u5417",
+        "\u5728\u4e0d\u5728",
+        "\u5192\u4e2a\u6ce1",
+        "\u542d\u4e00\u58f0",
+        "\u7ed9\u70b9\u53cd\u5e94",
+        "\u63a5\u4e00\u53e5",
+        "\u53d1\u4e2a\u8a00",
         "\u62631",
+        "\u6263\u4e2a",
         "\u5f39\u5e55\u5237\u8d77\u6765",
         "\u60f3\u770b\u4ec0\u4e48",
         "\u60f3\u804a\u4ec0\u4e48",
@@ -147,6 +184,8 @@ def _active_topic_filter_reason(text: str) -> str:
     compact = " ".join(str(text or "").strip().split())
     if not compact:
         return "filtered_recent_danmaku"
+    if _is_low_confidence_active_topic_text(compact):
+        return "low_confidence_topic"
     lowered = compact.lower()
     dense_lowered = "".join(ch for ch in lowered if ch.isalnum() or "\u4e00" <= ch <= "\u9fff")
     if _is_viewer_to_viewer_mention_text(compact):
@@ -160,6 +199,61 @@ def _active_topic_filter_reason(text: str) -> str:
     if _is_reaction_only(dense_lowered):
         return "filtered_reaction"
     return "filtered_recent_danmaku"
+
+def _is_low_confidence_active_topic_text(text: str) -> bool:
+    compact = " ".join(str(text or "").strip().split())
+    if not compact:
+        return True
+    lowered = compact.casefold()
+    dense = "".join(ch for ch in lowered if ch.isalnum() or "\u4e00" <= ch <= "\u9fff")
+    if any(term.casefold() in lowered or term.casefold() in dense for term in _ACTIVE_TOPIC_LOW_CONFIDENCE_TERMS):
+        return True
+    # Active engagement should not spin highly specific game/wiki/news titles
+    # unless they expose a small, safe reply handle. Let danmaku_response handle
+    # those directly instead of forcing a weird A/B host question.
+    game_or_technical_markers = (
+        "\u6cf0\u62c9\u745e\u4e9a",
+        "\u6211\u7684\u4e16\u754c",
+        "\u661f\u9732\u8c37",
+        "\u660e\u65e5\u65b9\u821f",
+        "\u539f\u795e",
+        "\u5d29\u574f",
+        "\u7edd\u533a\u96f6",
+        "\u4ee3\u7801",
+        "\u7f16\u7a0b",
+        "\u7535\u8def",
+        "\u673a\u5236",
+        "\u914d\u88c5",
+        "\u914d\u65b9",
+        "terraria",
+        "minecraft",
+        "code",
+        "circuit",
+    )
+    if any(marker in lowered or marker in dense for marker in game_or_technical_markers):
+        return True
+    return False
+
+def _is_clean_live_material_text(text: str) -> bool:
+    compact = " ".join(str(text or "").strip().split())
+    if not compact:
+        return False
+    lowered = compact.casefold()
+    # Common mojibake markers from UTF-8 text decoded as a legacy codepage.
+    if any(marker in compact for marker in ("鐚", "灞", "绁", "姝", "鍍", "锛", "鈥", "�")):
+        return False
+    if compact.count('"') % 2:
+        return False
+    if _is_low_confidence_active_topic_text(compact):
+        return False
+    return not any(term.casefold() in lowered for term in ("public shaming", "labor camp", "punishment"))
+
+def _is_clean_live_material(material: dict | None) -> bool:
+    if not isinstance(material, dict):
+        return False
+    fields = ("title", "hint", "reply_affordance", "live_column")
+    values = [str(material.get(field) or "").strip() for field in fields]
+    return any(values) and all(_is_clean_live_material_text(value) for value in values if value)
 
 def _is_direct_neko_request_or_ack(dense_lowered: str) -> bool:
     if not any(target in dense_lowered for target in ("\u732b\u732b", "neko")):
@@ -432,6 +526,29 @@ def _active_topic_material_profile(title: str) -> dict[str, str]:
             "live_column": "NEKO tiny verdict",
             "reply_affordance": "viewer can tease NEKO or the topic back",
             "hint": "Turn this material into one tiny playful tease; do not make it a news recap.",
+        }
+    if any(
+        marker in dense
+        for marker in (
+            "keyboard",
+            "screen",
+            "desk",
+            "snack",
+            "drink",
+            "\u952e\u76d8",
+            "\u5c4f\u5e55",
+            "\u684c\u9762",
+            "\u6c34\u676f",
+            "\u996e\u6599",
+            "\u96f6\u98df",
+        )
+    ):
+        return {
+            "preferred_shape": "tiny_tease",
+            "fun_axis": "object_scene",
+            "live_column": "NEKO room observation",
+            "reply_affordance": "viewer can answer with one small object or room detail",
+            "hint": "Turn this material into one tiny room observation; do not pretend to know details beyond the title.",
         }
     if any(
         marker in dense

--- a/plugin/plugins/neko_roast/core/active_topic_selector.py
+++ b/plugin/plugins/neko_roast/core/active_topic_selector.py
@@ -1,0 +1,444 @@
+"""Stateful active-engagement topic selection for solo stream hosting."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from typing import Any
+
+from . import active_topic_rules
+from .live_content import active_engagement_fallback_topic_candidates
+
+
+class ActiveTopicSelector:
+    """Selects and rotates active-engagement material for the runtime.
+
+    The selector owns selection behavior while the runtime still owns the
+    mutable deques/caches for backward-compatible tests and dashboard state.
+    """
+
+    def __init__(self, runtime: Any) -> None:
+        object.__setattr__(self, "_runtime", runtime)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._runtime, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "_runtime":
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._runtime, name, value)
+
+    async def select_topic(self) -> dict[str, Any]:
+        candidates = await self.topic_candidates()
+        fallback_candidates = self._runtime._active_engagement_fallback_topic_candidates()
+        fallback = fallback_candidates[0]
+        shape = self.next_shape()
+        chosen = fallback
+        exhausted_cached_topics = bool(candidates)
+        candidate = self.choose_candidate(candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
+        if candidate is None:
+            candidate = self.choose_candidate(candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
+        if candidate is None:
+            candidate = self.choose_candidate(candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
+        if candidate is not None:
+            chosen = candidate
+            exhausted_cached_topics = False
+        if exhausted_cached_topics:
+            self._active_engagement_topic_cache = []
+            self._active_engagement_topic_cache_at = 0.0
+            refreshed_candidates = await self.topic_candidates()
+            candidate = self.choose_candidate(refreshed_candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
+            if candidate is None:
+                candidate = self.choose_candidate(refreshed_candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
+            if candidate is None:
+                candidate = self.choose_candidate(refreshed_candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
+            if candidate is not None:
+                chosen = candidate
+                exhausted_cached_topics = False
+        if exhausted_cached_topics:
+            chosen = (
+                self.choose_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
+                or self.choose_candidate(fallback_candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
+                or self.choose_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
+                or self.choose_candidate(
+                    fallback_candidates,
+                    avoid_recent_fun_axis=False,
+                    avoid_recent_family=False,
+                    allow_similar_title=True,
+                )
+                or fallback
+            )
+        elif chosen is fallback:
+            chosen = (
+                self.choose_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
+                or self.choose_candidate(fallback_candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
+                or self.choose_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
+                or self.choose_candidate(
+                    fallback_candidates,
+                    avoid_recent_fun_axis=False,
+                    avoid_recent_family=False,
+                    allow_similar_title=True,
+                )
+                or fallback
+            )
+        preferred_shape = str(chosen.get("preferred_shape") or shape).strip() or shape
+        shape = self.guarded_shape(preferred_shape)
+        key = str(chosen.get("key") or chosen.get("title") or fallback["key"]).strip()
+        self._active_engagement_recent_topic_keys.append(key)
+        title = str(chosen.get("title") or fallback["title"]).strip()
+        if title:
+            self._active_engagement_recent_topic_titles.append(title)
+        intent = self.intent_text(shape)
+        hint = str(chosen.get("hint") or fallback["hint"]).strip()
+        if shape != preferred_shape:
+            hint = self.hint_text(shape)
+        topic = {
+            "source": str(chosen.get("source") or "fallback"),
+            "shape": shape,
+            "key": key,
+            "title": title,
+            "family": self.host_material_family(chosen),
+            "fun_axis": str(chosen.get("fun_axis") or "").strip() or self.fun_axis_text(shape),
+            "hook": self.hook_text(shape, title),
+            "pattern": self.pattern_text(shape),
+            "intent": intent,
+            "live_column": str(chosen.get("live_column") or "").strip(),
+            "topic_pack": self.topic_pack(chosen),
+            "reply_affordance": str(chosen.get("reply_affordance") or "").strip()
+            or self.reply_affordance_text(shape),
+            "hint": hint,
+        }
+        self._active_engagement_recent_topic_sources.append(str(topic["source"]))
+        if topic["fun_axis"]:
+            self._active_engagement_recent_fun_axes.append(str(topic["fun_axis"]))
+        if topic["family"]:
+            self._recent_host_material_families.append(str(topic["family"]))
+        self._active_engagement_recent_shapes.append(shape)
+        self._active_engagement_recent_intents.append(intent)
+        if topic["reply_affordance"]:
+            self._active_engagement_recent_reply_affordances.append(str(topic["reply_affordance"]))
+        skip_reason = str(self._active_engagement_recent_topic_skip_reason or "").strip()
+        if skip_reason:
+            topic["recent_topic_skip_reason"] = skip_reason
+        shape_guard_reason = str(self._active_engagement_shape_guard_reason or "").strip()
+        if shape_guard_reason:
+            topic["shape_guard_reason"] = shape_guard_reason
+        return topic
+
+    def choose_candidate(
+        self,
+        candidates: list[dict[str, Any]],
+        *,
+        avoid_recent_fun_axis: bool,
+        avoid_recent_family: bool,
+        allow_similar_title: bool = False,
+    ) -> dict[str, Any] | None:
+        recent_spent_families = self._runtime._recent_spent_output_families() if avoid_recent_family else set()
+        for candidate in candidates:
+            if not active_topic_rules._is_clean_live_material(candidate):
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = "unclean_topic_material"
+                continue
+            key = str(candidate.get("key") or candidate.get("title") or "").strip()
+            if not key or key in self._active_engagement_recent_topic_keys:
+                continue
+            title = str(candidate.get("title") or "").strip()
+            if (
+                not allow_similar_title
+                and title
+                and self.is_similar_title(title, self._active_engagement_recent_topic_titles)
+            ):
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = "similar_topic_title"
+                continue
+            axis = str(candidate.get("fun_axis") or "").strip()
+            if avoid_recent_fun_axis and axis and axis in self._active_engagement_recent_fun_axes:
+                continue
+            reply_affordance = str(candidate.get("reply_affordance") or "").strip()
+            if (
+                avoid_recent_fun_axis
+                and reply_affordance
+                and reply_affordance in self._active_engagement_recent_reply_affordances
+            ):
+                continue
+            family = self.host_material_family(candidate)
+            if avoid_recent_family and family:
+                if family in self._recent_host_material_families:
+                    if not self._active_engagement_recent_topic_skip_reason:
+                        self._active_engagement_recent_topic_skip_reason = "recent_host_family"
+                    continue
+                if family in recent_spent_families:
+                    if not self._active_engagement_recent_topic_skip_reason:
+                        self._active_engagement_recent_topic_skip_reason = "recent_spent_output_family"
+                    continue
+            return candidate
+        return None
+
+    @staticmethod
+    def fallback_topic_candidates() -> list[dict[str, Any]]:
+        return active_engagement_fallback_topic_candidates()
+
+    @staticmethod
+    def topic_pack(material: dict[str, Any] | None) -> str:
+        if not isinstance(material, dict):
+            return ""
+        explicit = str(material.get("topic_pack") or "").strip()
+        if explicit:
+            return explicit
+        live_column = str(material.get("live_column") or "").lower()
+        family = active_topic_rules._host_material_family(material)
+        combined = " ".join(
+            str(material.get(field) or "").lower()
+            for field in ("key", "title", "fun_axis", "preferred_shape", "shape", "reply_affordance")
+        )
+        if family in {"tease", "host_self_test"} or any(marker in live_column for marker in ("verdict", "court", "award", "score")):
+            return "neko_verdict"
+        if family == "short_callback" or any(marker in live_column for marker in ("callback", "password", "command")):
+            return "viewer_callback"
+        if family == "choice_vote" or any(marker in live_column for marker in ("poll", "vote", "choice", "button")):
+            return "micro_poll"
+        if family == "micro_challenge" or any(marker in live_column for marker in ("challenge", "mission")):
+            return "micro_challenge"
+        if family == "object_scene" or any(marker in live_column for marker in ("observation", "patrol", "detective")):
+            return "room_observation"
+        if family == "room_mood" or any(marker in live_column for marker in ("radio", "weather", "thermometer", "filter", "mood")):
+            return "room_mood"
+        if "stance" in combined:
+            return "neko_stance"
+        return family or "general"
+
+    async def topic_candidates(self) -> list[dict[str, Any]]:
+        recent = self.recent_danmaku_topic_candidates()
+        recent_skip_reason = str(self._active_engagement_recent_topic_skip_reason or "").strip()
+        trending = await self.bili_trending_topic_candidates()
+        trending_skip_reason = str(self._active_engagement_recent_topic_skip_reason or "").strip()
+        if recent:
+            self._active_engagement_recent_topic_skip_reason = ""
+        else:
+            self._active_engagement_recent_topic_skip_reason = recent_skip_reason or trending_skip_reason
+        return [*recent, *trending]
+
+    async def bili_trending_topic_candidates(self) -> list[dict[str, Any]]:
+        now = time.monotonic()
+        if self._active_engagement_topic_cache and now - self._active_engagement_topic_cache_at < 600.0:
+            return list(self._active_engagement_topic_cache)
+        fetcher = self._active_engagement_topic_fetcher
+        if fetcher is None:
+            try:
+                from utils.web_scraper import fetch_bilibili_trending
+
+                fetcher = fetch_bilibili_trending
+            except Exception:
+                fetcher = None
+        if not callable(fetcher):
+            return []
+        try:
+            try:
+                payload = await asyncio.wait_for(fetcher(limit=6), timeout=2.0)
+            except TypeError:
+                payload = await asyncio.wait_for(fetcher(), timeout=2.0)
+        except Exception:
+            return []
+        videos = []
+        if isinstance(payload, dict):
+            videos = payload.get("videos") or payload.get("video") or payload.get("items") or []
+        if not isinstance(videos, list):
+            return []
+        candidates: list[dict[str, Any]] = []
+        for item in videos:
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get("title") or "").strip()
+            if not title:
+                continue
+            if not self.is_meaningful_topic_text(title):
+                continue
+            key = str(item.get("bvid") or item.get("id") or title).strip()
+            compact_title = self._runtime._compact_context_text(title, limit=40)
+            profile = self.material_profile(compact_title)
+            if not profile:
+                self._active_engagement_recent_topic_skip_reason = "low_confidence_topic"
+                continue
+            candidate = {
+                "source": "bili_trending",
+                "key": f"bili:{key}",
+                "title": compact_title,
+                "hint": "Use this Bilibili topic only as a small safe hook; anchor the topic first, then ask one easy reply.",
+            }
+            candidate.update(profile)
+            candidates.append(candidate)
+            if len(candidates) >= 6:
+                break
+        self._active_engagement_topic_cache = candidates
+        self._active_engagement_topic_cache_at = now
+        return list(candidates)
+
+    def recent_danmaku_topic_candidates(self) -> list[dict[str, Any]]:
+        self._active_engagement_recent_topic_skip_reason = ""
+        if self.has_streak(self._active_engagement_recent_topic_sources, "recent_danmaku", 2):
+            self._active_engagement_recent_topic_skip_reason = "recent_danmaku_source_streak"
+            return []
+        recent_items: list[tuple[str, str]] = []
+        for result in reversed(self.recent_results):
+            if not isinstance(result, dict):
+                continue
+            event = result.get("event") if isinstance(result.get("event"), dict) else {}
+            if str(event.get("source") or "") != "live_danmaku":
+                continue
+            if str(result.get("status") or "") not in {"pushed", "dry_run"}:
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = "non_output_danmaku"
+                continue
+            route = self._runtime._route_from_result(result)
+            if route == "avatar_roast":
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = "avatar_roast_context"
+                continue
+            age = self._runtime._iso_age_sec(result.get("created_at"))
+            if age is not None and age > self._ACTIVE_ENGAGEMENT_RECENT_DANMAKU_TOPIC_MAX_AGE_SECONDS:
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = "stale_recent_danmaku"
+                continue
+            text = str(event.get("danmaku_text") or "").strip()
+            if not text:
+                continue
+            if self.is_viewer_to_viewer_mention_text(text):
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = "viewer_to_viewer_mention"
+                continue
+            if not self.is_meaningful_topic_text(text):
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = (
+                        self.topic_filter_reason(text) or "filtered_recent_danmaku"
+                    )
+                continue
+            compact = self._runtime._compact_context_text(text, limit=40)
+            uid = str(event.get("uid") or "").strip()
+            recent_items.append((uid, compact))
+            if len(recent_items) >= 6:
+                break
+        speaker_ids = {uid for uid, _ in recent_items if uid}
+        if len(recent_items) >= 3 and len(speaker_ids) == 1:
+            self._active_engagement_recent_topic_skip_reason = "single_viewer_flood"
+            return []
+        candidates: list[dict[str, Any]] = []
+        for _uid, compact in recent_items[:3]:
+            profile = self.material_profile(compact)
+            if not profile:
+                if not self._active_engagement_recent_topic_skip_reason:
+                    self._active_engagement_recent_topic_skip_reason = "low_confidence_topic"
+                continue
+            candidate = {
+                "source": "recent_danmaku",
+                "key": f"danmaku:{compact}",
+                "title": compact,
+                "hint": "Anchor this recent danmaku first, then make one small reply hook without pretending a new viewer spoke.",
+            }
+            candidate.update(profile)
+            candidates.append(candidate)
+            if len(candidates) >= 3:
+                break
+        if candidates:
+            self._active_engagement_recent_topic_skip_reason = ""
+        return candidates
+
+    @staticmethod
+    def is_meaningful_topic_text(text: str) -> bool:
+        return active_topic_rules._is_meaningful_active_topic_text(text)
+
+    @staticmethod
+    def topic_filter_reason(text: str) -> str:
+        return active_topic_rules._active_topic_filter_reason(text)
+
+    @staticmethod
+    def is_direct_neko_request_or_ack(dense_lowered: str) -> bool:
+        return active_topic_rules._is_direct_neko_request_or_ack(dense_lowered)
+
+    @staticmethod
+    def is_untargeted_request_or_reaction(dense_lowered: str) -> bool:
+        return active_topic_rules._is_untargeted_request_or_reaction(dense_lowered)
+
+    @staticmethod
+    def is_untargeted_request(dense_lowered: str) -> bool:
+        return active_topic_rules._is_untargeted_request(dense_lowered)
+
+    @staticmethod
+    def is_reaction_only(dense_lowered: str) -> bool:
+        return active_topic_rules._is_reaction_only(dense_lowered)
+
+    @staticmethod
+    def is_live_test_or_runtime_feedback(dense_lowered: str) -> bool:
+        return active_topic_rules._is_live_test_or_runtime_feedback(dense_lowered)
+
+    def next_shape(self) -> str:
+        shapes = ["either_or", "light_stance", "tiny_tease", "small_challenge"]
+        shape = shapes[self._active_engagement_shape_index % len(shapes)]
+        self._active_engagement_shape_index += 1
+        return shape
+
+    def guarded_shape(self, shape: str) -> str:
+        self._active_engagement_shape_guard_reason = ""
+        shapes = ["either_or", "light_stance", "tiny_tease", "small_challenge"]
+        normalized = shape if shape in shapes else shapes[0]
+        if not self.has_streak(self._active_engagement_recent_shapes, normalized, 2):
+            return normalized
+        self._active_engagement_shape_guard_reason = "recent_shape_streak"
+        for candidate in shapes:
+            if candidate != normalized and not self.has_streak(
+                self._active_engagement_recent_shapes, candidate, 1
+            ):
+                return candidate
+        for candidate in shapes:
+            if candidate != normalized:
+                return candidate
+        return normalized
+
+    @staticmethod
+    def has_streak(values: deque[str], value: str, count: int) -> bool:
+        return active_topic_rules._has_active_engagement_streak(values, value, count)
+
+    @staticmethod
+    def is_similar_title(title: str, recent_titles: deque[str]) -> bool:
+        return active_topic_rules._is_similar_active_topic_title(title, recent_titles)
+
+    @staticmethod
+    def host_material_family(material: dict[str, Any] | None) -> str:
+        return active_topic_rules._host_material_family(material)
+
+    @staticmethod
+    def material_profile(title: str) -> dict[str, str]:
+        return active_topic_rules._active_topic_material_profile(title)
+
+    @staticmethod
+    def is_viewer_to_viewer_mention_text(text: str) -> bool:
+        return active_topic_rules._is_viewer_to_viewer_mention_text(text)
+
+    @staticmethod
+    def is_neko_mention_target(name: str, lowered_aliases: set[str]) -> bool:
+        return active_topic_rules._is_neko_mention_target(name, lowered_aliases)
+
+    @staticmethod
+    def hook_text(shape: str, title: str) -> str:
+        return active_topic_rules._active_engagement_hook_text(shape, title)
+
+    @staticmethod
+    def pattern_text(shape: str) -> str:
+        return active_topic_rules._active_engagement_pattern_text(shape)
+
+    @staticmethod
+    def hint_text(shape: str) -> str:
+        return active_topic_rules._active_engagement_hint_text(shape)
+
+    @staticmethod
+    def intent_text(shape: str) -> str:
+        return active_topic_rules._active_engagement_intent_text(shape)
+
+    @staticmethod
+    def fun_axis_text(shape: str) -> str:
+        return active_topic_rules._active_engagement_fun_axis_text(shape)
+
+    @staticmethod
+    def reply_affordance_text(shape: str) -> str:
+        return active_topic_rules._active_engagement_reply_affordance_text(shape)

--- a/plugin/plugins/neko_roast/core/live_content.py
+++ b/plugin/plugins/neko_roast/core/live_content.py
@@ -165,13 +165,13 @@ def idle_hosting_beat_candidates() -> list[dict[str, Any]]:
             "reply_affordance": "viewer can pick raised tail or curled tail",
         },
         {
-            "key": "idle:pretend-expert",
+            "key": "idle:steady-three-sec",
             "live_column": "NEKO three-second challenge",
             "shape": "micro_challenge",
             "fun_axis": "micro_challenge",
-            "title": "猫猫三秒假装懂很多",
-            "hint": "Make one tiny self-challenge about pretending to be knowledgeable.",
-            "reply_affordance": "viewer can judge whether NEKO looked convincing",
+            "title": "猫猫三秒假装很稳",
+            "hint": "Make one tiny self-challenge about staying composed; do not explain anything.",
+            "reply_affordance": "viewer can judge whether NEKO stayed steady",
         },
         {
             "key": "idle:keyboard-patrol",

--- a/plugin/plugins/neko_roast/core/live_hosting_director.py
+++ b/plugin/plugins/neko_roast/core/live_hosting_director.py
@@ -1,0 +1,306 @@
+"""Idle/warmup hosting director for NEKO Live solo stream."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from . import active_topic_rules
+from .contracts import InteractionResult, PipelineStep, ViewerEvent
+from .live_content import idle_hosting_beat_candidates
+
+
+class LiveHostingDirector:
+    """Owns warmup/idle hosting gates, beat rotation, and the auto loop."""
+
+    def __init__(self, runtime: Any) -> None:
+        self.runtime = runtime
+
+    async def trigger_idle_hosting(self) -> InteractionResult:
+        live_connection = self.runtime.live_connection_snapshot()
+        live_status = self.runtime.live_status_summary(live_connection)
+        health_rows = self.runtime.runtime_health_rows()
+        live_state = self.runtime.live_state_summary(live_status, health_rows)
+        event = self.idle_hosting_event(live_state)
+
+        if self.runtime.config.live_mode != "solo_stream":
+            return self.record_idle_hosting_skip(event, "idle_hosting.not_solo_stream")
+        state = str(live_state.get("state") or "")
+        if state == "paused":
+            return self.record_idle_hosting_skip(event, "idle_hosting.paused")
+        if state == "blocked":
+            return self.record_idle_hosting_skip(event, "idle_hosting.blocked")
+        if state != "idle":
+            return self.record_idle_hosting_skip(event, "idle_hosting.not_idle")
+        if not bool(live_state.get("idle_hosting_candidate")):
+            return self.record_idle_hosting_skip(event, "idle_hosting.not_candidate")
+        return await self.runtime.pipeline.handle_event(event)
+
+    async def maybe_trigger_idle_hosting(self) -> InteractionResult | None:
+        if self.runtime._idle_hosting_consecutive_failures >= self.runtime._IDLE_HOSTING_FAILURE_LIMIT:
+            return None
+        now = float(self.runtime._idle_hosting_now())
+        if now - self.runtime._idle_hosting_last_attempt_at < self.runtime._idle_hosting_min_interval_seconds():
+            return None
+        live_connection = self.runtime.live_connection_snapshot()
+        live_status = self.runtime.live_status_summary(live_connection)
+        health_rows = self.runtime.runtime_health_rows()
+        live_state = self.runtime.live_state_summary(live_status, health_rows)
+        if not bool(live_state.get("idle_hosting_candidate")):
+            return None
+
+        self.runtime._idle_hosting_last_attempt_at = now
+        result = await self.trigger_idle_hosting()
+        if result.status == "failed":
+            self.runtime._idle_hosting_consecutive_failures += 1
+            if self.runtime._idle_hosting_consecutive_failures >= self.runtime._IDLE_HOSTING_FAILURE_LIMIT:
+                self.runtime.audit.record(
+                    "idle_hosting_auto_disabled",
+                    "idle hosting disabled after repeated failures",
+                    level="warning",
+                )
+        elif result.status in {"dry_run", "pushed"}:
+            self.runtime._idle_hosting_consecutive_failures = 0
+        return result
+
+    def idle_hosting_event(self, live_state: dict[str, Any]) -> ViewerEvent:
+        host_beat = self.next_idle_hosting_beat()
+        return ViewerEvent(
+            uid="__neko_idle__",
+            nickname="NEKO",
+            danmaku_text="",
+            source="idle_hosting",
+            live_mode=self.runtime.config.live_mode,
+            raw={
+                "trigger": "manual_idle_hosting",
+                "live_state": dict(live_state),
+                "host_beat": host_beat,
+            },
+        )
+
+    def next_idle_hosting_beat(self) -> dict[str, Any]:
+        candidates = self.runtime._idle_hosting_beat_candidates()
+        fallback = candidates[0]
+        chosen = fallback
+        chosen_offset: int | None = None
+        preferred_stage = self.runtime._idle_hosting_preferred_stage()
+        ordered_candidates = self.runtime._idle_hosting_stage_ordered_candidates(candidates, preferred_stage)
+        recent_spent_families = self.runtime._recent_spent_output_families()
+        for offset, candidate in enumerate(ordered_candidates):
+            key = str(candidate.get("key") or "").strip()
+            axis = str(candidate.get("fun_axis") or "").strip()
+            title = str(candidate.get("title") or "").strip()
+            family = self.runtime._host_material_family(candidate)
+            reply_affordance = str(candidate.get("reply_affordance") or "").strip()
+            if (
+                key
+                and key not in self.runtime._idle_hosting_recent_beat_keys
+                and axis
+                and axis not in self.runtime._idle_hosting_recent_beat_axes
+                and family
+                and family not in self.runtime._recent_host_material_families
+                and family not in recent_spent_families
+                and (
+                    not reply_affordance
+                    or reply_affordance not in self.runtime._idle_hosting_recent_reply_affordances
+                )
+                and not self.runtime._is_similar_idle_hosting_beat_title(title)
+            ):
+                chosen = candidate
+                chosen_offset = offset
+                break
+        else:
+            for offset, candidate in enumerate(ordered_candidates):
+                key = str(candidate.get("key") or "").strip()
+                title = str(candidate.get("title") or "").strip()
+                family = self.runtime._host_material_family(candidate)
+                if (
+                    key
+                    and key not in self.runtime._idle_hosting_recent_beat_keys
+                    and family
+                    and family not in self.runtime._recent_host_material_families
+                    and family not in recent_spent_families
+                    and not self.runtime._is_similar_idle_hosting_beat_title(title)
+                ):
+                    chosen = candidate
+                    chosen_offset = offset
+                    break
+            else:
+                for offset, candidate in enumerate(ordered_candidates):
+                    key = str(candidate.get("key") or "").strip()
+                    if key and key not in self.runtime._idle_hosting_recent_beat_keys:
+                        chosen = candidate
+                        chosen_offset = offset
+                        break
+        if chosen_offset is None:
+            self.runtime._idle_hosting_beat_index = (self.runtime._idle_hosting_beat_index + 1) % len(candidates)
+        else:
+            self.runtime._idle_hosting_beat_index = (self.runtime._idle_hosting_beat_index + chosen_offset + 1) % len(candidates)
+        key = str(chosen.get("key") or fallback["key"]).strip()
+        axis = str(chosen.get("fun_axis") or "").strip()
+        title = str(chosen.get("title") or "").strip()
+        family = self.runtime._host_material_family(chosen)
+        reply_affordance = str(chosen.get("reply_affordance") or "").strip()
+        self.runtime._idle_hosting_recent_beat_keys.append(key)
+        if axis:
+            self.runtime._idle_hosting_recent_beat_axes.append(axis)
+        if title:
+            self.runtime._idle_hosting_recent_beat_titles.append(title)
+        if family:
+            self.runtime._recent_host_material_families.append(family)
+        if reply_affordance:
+            self.runtime._idle_hosting_recent_reply_affordances.append(reply_affordance)
+        payload = dict(chosen)
+        if family:
+            payload["family"] = family
+        payload["idle_stage"] = self.idle_hosting_material_stage(payload)
+        return payload
+
+    @staticmethod
+    def idle_hosting_beat_candidates() -> list[dict[str, Any]]:
+        candidates = [
+            candidate
+            for candidate in idle_hosting_beat_candidates()
+            if active_topic_rules._is_clean_live_material(candidate)
+        ]
+        return candidates or idle_hosting_beat_candidates()[:1]
+
+    def idle_hosting_preferred_stage(self) -> str:
+        streak = self.runtime._recent_actual_route_streak_since_viewer_activity("idle_hosting")
+        if streak <= 0:
+            return "settle"
+        if streak == 1:
+            return "column"
+        return "callback"
+
+    def idle_hosting_stage_ordered_candidates(
+        self,
+        candidates: list[dict[str, Any]],
+        preferred_stage: str,
+    ) -> list[dict[str, Any]]:
+        if not candidates:
+            return []
+        rotated = [
+            candidates[(self.runtime._idle_hosting_beat_index + offset) % len(candidates)]
+            for offset in range(len(candidates))
+        ]
+        preferred = [candidate for candidate in rotated if self.idle_hosting_material_stage(candidate) == preferred_stage]
+        rest = [candidate for candidate in rotated if candidate not in preferred]
+        return [*preferred, *rest]
+
+    @staticmethod
+    def idle_hosting_material_stage(material: dict[str, Any] | None) -> str:
+        if not isinstance(material, dict):
+            return "settle"
+        explicit = str(material.get("idle_stage") or "").strip()
+        if explicit:
+            return explicit
+        shape = str(material.get("shape") or "").strip()
+        axis = str(material.get("fun_axis") or "").strip()
+        if shape in {"one_word_call", "micro_challenge"} or axis in {"viewer_callback", "micro_challenge"}:
+            return "callback"
+        if shape in {"tiny_choice", "light_tease"} or axis in {"choice", "tease"}:
+            return "column"
+        return "settle"
+
+    def is_similar_idle_hosting_beat_title(self, title: str) -> bool:
+        return bool(title) and active_topic_rules._is_similar_active_topic_title(
+            title,
+            self.runtime._idle_hosting_recent_beat_titles,
+        )
+
+    def record_idle_hosting_skip(self, event: ViewerEvent, reason: str) -> InteractionResult:
+        result = InteractionResult(
+            accepted=False,
+            status="skipped",
+            event=event,
+            reason=reason,
+            steps=[PipelineStep("idle_hosting_gate", "skipped", reason)],
+        )
+        self.runtime.audit.record("idle_hosting_skipped", reason, level="info", detail={"mode": self.runtime.config.live_mode})
+        self.runtime.record_result(result)
+        return result
+
+    async def trigger_warmup_hosting(self) -> InteractionResult:
+        live_connection = self.runtime.live_connection_snapshot()
+        live_status = self.runtime.live_status_summary(live_connection)
+        health_rows = self.runtime.runtime_health_rows()
+        live_state = self.runtime.live_state_summary(live_status, health_rows)
+        event = self.warmup_hosting_event(live_state)
+
+        if self.runtime.config.live_mode != "solo_stream":
+            return self.record_warmup_hosting_skip(event, "warmup_hosting.not_solo_stream")
+        state = str(live_state.get("state") or "")
+        if state == "paused":
+            return self.record_warmup_hosting_skip(event, "warmup_hosting.paused")
+        if state == "blocked":
+            return self.record_warmup_hosting_skip(event, "warmup_hosting.blocked")
+        if state != "warmup":
+            return self.record_warmup_hosting_skip(event, "warmup_hosting.not_warmup")
+        if not bool(live_state.get("warmup_hosting_candidate")):
+            return self.record_warmup_hosting_skip(event, "warmup_hosting.not_candidate")
+        return await self.runtime.pipeline.handle_event(event)
+
+    async def maybe_trigger_warmup_hosting(self) -> InteractionResult | None:
+        live_connection = self.runtime.live_connection_snapshot()
+        live_status = self.runtime.live_status_summary(live_connection)
+        health_rows = self.runtime.runtime_health_rows()
+        live_state = self.runtime.live_state_summary(live_status, health_rows)
+        if not bool(live_state.get("warmup_hosting_candidate")):
+            return None
+        return await self.trigger_warmup_hosting()
+
+    def warmup_hosting_event(self, live_state: dict[str, Any]) -> ViewerEvent:
+        return ViewerEvent(
+            uid="__neko_warmup__",
+            nickname="NEKO",
+            danmaku_text="",
+            source="warmup_hosting",
+            live_mode=self.runtime.config.live_mode,
+            raw={
+                "trigger": "auto_warmup_hosting",
+                "live_state": dict(live_state),
+            },
+        )
+
+    def record_warmup_hosting_skip(self, event: ViewerEvent, reason: str) -> InteractionResult:
+        result = InteractionResult(
+            accepted=False,
+            status="skipped",
+            event=event,
+            reason=reason,
+            steps=[PipelineStep("warmup_hosting_gate", "skipped", reason)],
+        )
+        self.runtime.audit.record("warmup_hosting_skipped", reason, level="info", detail={"mode": self.runtime.config.live_mode})
+        self.runtime.record_result(result)
+        return result
+
+    def start_loop(self) -> None:
+        task = self.runtime._idle_hosting_task
+        if task is not None and not task.done():
+            return
+        self.runtime._idle_hosting_task = asyncio.create_task(self.idle_hosting_loop())
+
+    async def stop_loop(self) -> None:
+        task = self.runtime._idle_hosting_task
+        self.runtime._idle_hosting_task = None
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def idle_hosting_loop(self) -> None:
+        while True:
+            await self.runtime._idle_hosting_sleep(self.runtime._IDLE_HOSTING_CHECK_INTERVAL_SECONDS)
+            try:
+                await self.maybe_trigger_warmup_hosting()
+                await self.runtime.maybe_trigger_active_engagement()
+                await self.maybe_trigger_idle_hosting()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                message = f"idle_hosting_loop_failed: {type(exc).__name__}"
+                self.runtime.audit.record("idle_hosting_loop_failed", message, level="warning")

--- a/plugin/plugins/neko_roast/core/live_status.py
+++ b/plugin/plugins/neko_roast/core/live_status.py
@@ -1,0 +1,637 @@
+"""Pure live status and director-state calculations for NEKO Live."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from . import recent_context
+
+
+def _activity_level(config: Any) -> str:
+    return str(getattr(config, "activity_level", "standard"))
+
+
+def active_engagement_min_interval_seconds(config: Any) -> float:
+    return {
+        "quiet": 300.0,
+        "active": 45.0,
+        "standard": 60.0,
+    }.get(_activity_level(config), 60.0)
+
+
+def active_engagement_after_danmaku_interval_seconds(config: Any) -> float:
+    return {
+        "quiet": 210.0,
+        "active": 30.0,
+        "standard": 45.0,
+    }.get(_activity_level(config), 45.0)
+
+
+def active_engagement_idle_grace_seconds(config: Any, default: float) -> float:
+    return {
+        "quiet": 45.0,
+        "active": 15.0,
+        "standard": float(default),
+    }.get(_activity_level(config), float(default))
+
+
+def idle_hosting_min_interval_seconds(config: Any) -> float:
+    return {
+        "quiet": 180.0,
+        "active": 45.0,
+        "standard": 90.0,
+    }.get(_activity_level(config), 90.0)
+
+
+def solo_warmup_timeout_seconds(config: Any, default: float) -> float:
+    return {
+        "quiet": 90.0,
+        "active": 30.0,
+        "standard": float(default),
+    }.get(_activity_level(config), float(default))
+
+
+def live_state_threshold_seconds(config: Any, default_engaged: float, default_idle: float) -> tuple[float, float]:
+    return {
+        "quiet": (90.0, 300.0),
+        "active": (30.0, 90.0),
+        "standard": (float(default_engaged), float(default_idle)),
+    }.get(_activity_level(config), (float(default_engaged), float(default_idle)))
+
+
+def age_sec(timestamp: Any) -> float | None:
+    try:
+        value = float(timestamp)
+    except (TypeError, ValueError):
+        return None
+    if value <= 0:
+        return None
+    return round(max(0.0, time.time() - value), 1)
+
+
+def iso_age_sec(value: Any) -> float | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return round(max(0.0, (datetime.now(timezone.utc) - parsed).total_seconds()), 1)
+
+
+IsoAgeFn = Callable[[Any], float | None]
+
+
+def recent_live_danmaku_output_age_sec(recent_results: Any, iso_age_fn: IsoAgeFn = iso_age_sec) -> float | None:
+    for result in reversed(list(recent_results or [])):
+        if not isinstance(result, dict):
+            continue
+        if str(result.get("status") or "") not in {"pushed", "dry_run"}:
+            continue
+        event = result.get("event") if isinstance(result.get("event"), dict) else {}
+        if str(event.get("source") or "") != "live_danmaku":
+            continue
+        route = recent_context.route_from_result(result)
+        if route not in {"avatar_roast", "danmaku_response", "live_danmaku"}:
+            continue
+        age = iso_age_fn(result.get("created_at"))
+        if age is not None:
+            return float(age)
+    return None
+
+
+def recent_live_danmaku_event_age_sec(recent_results: Any, iso_age_fn: IsoAgeFn = iso_age_sec) -> float | None:
+    for result in reversed(list(recent_results or [])):
+        if not isinstance(result, dict):
+            continue
+        event = result.get("event") if isinstance(result.get("event"), dict) else {}
+        if str(event.get("source") or "") != "live_danmaku":
+            continue
+        age = iso_age_fn(result.get("created_at"))
+        if age is not None:
+            return float(age)
+    return None
+
+
+def last_viewer_activity_age_sec(
+    rows: list[dict[str, Any]],
+    recent_results: Any = None,
+    iso_age_fn: IsoAgeFn = iso_age_sec,
+) -> float | None:
+    ages: list[float] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get("id") not in {"live_ingest", "event_bus", "selection"}:
+            continue
+        outcome = str(row.get("last_outcome") or "").strip()
+        if outcome not in {"danmaku", "live_danmaku"}:
+            continue
+        age = row.get("age_sec")
+        if age is None:
+            continue
+        try:
+            ages.append(float(age))
+        except (TypeError, ValueError):
+            continue
+    recent_age = recent_live_danmaku_event_age_sec(recent_results, iso_age_fn)
+    if recent_age is not None:
+        ages.append(float(recent_age))
+    return min(ages) if ages else None
+
+
+def last_output_age_sec(
+    rows: list[dict[str, Any]],
+    recent_results: Any = None,
+    iso_age_fn: IsoAgeFn = iso_age_sec,
+) -> float | None:
+    ages: list[float] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get("id") not in {"pipeline", "dispatcher"}:
+            continue
+        age = row.get("age_sec")
+        if age is None:
+            continue
+        try:
+            ages.append(float(age))
+        except (TypeError, ValueError):
+            continue
+    for result in reversed(list(recent_results or [])):
+        if not isinstance(result, dict):
+            continue
+        if str(result.get("status") or "") not in {"pushed", "dry_run"}:
+            continue
+        age = iso_age_fn(result.get("created_at"))
+        if age is not None:
+            ages.append(float(age))
+            break
+    return min(ages) if ages else None
+
+
+def live_status_summary(
+    *,
+    config: Any,
+    live_connection: dict[str, Any],
+    safety_status: str,
+    cooldown_remaining: float,
+    output_channel: dict[str, Any],
+) -> dict[str, Any]:
+    room_id = int(getattr(config, "live_room_id", 0) or live_connection.get("room_id") or 0)
+    connected = bool(live_connection.get("connected"))
+    output_channel_ready = bool(output_channel.get("ready"))
+    output_channel_reason = str(output_channel.get("reason") or "")
+    output_channel_detail = str(output_channel.get("detail") or "")
+
+    summary = "ready_to_stream"
+    reason = "ready"
+    can_output = True
+
+    if room_id <= 0:
+        summary = "cannot_stream"
+        reason = "room_not_configured"
+        can_output = False
+    elif not bool(getattr(config, "live_enabled", False)):
+        summary = "cannot_stream"
+        reason = "live_disabled"
+        can_output = False
+    elif not connected:
+        summary = "cannot_stream"
+        reason = "live_ingest_disconnected"
+        can_output = False
+    elif safety_status == "paused":
+        summary = "temporarily_not_speaking"
+        reason = "manual_paused"
+        can_output = False
+    elif safety_status == "tripped":
+        summary = "cannot_stream"
+        reason = "safety_tripped"
+        can_output = False
+    elif safety_status == "degraded":
+        summary = "temporarily_not_speaking"
+        reason = "safety_degraded"
+        can_output = False
+    elif bool(getattr(config, "dry_run", True)):
+        summary = "test_only"
+        reason = "dry_run"
+        can_output = False
+    elif not output_channel_ready:
+        summary = "cannot_stream"
+        reason = output_channel_reason or "output_channel_unavailable"
+        can_output = False
+    elif cooldown_remaining > 0:
+        summary = "temporarily_not_speaking"
+        reason = "cooldown"
+        can_output = False
+
+    return {
+        "summary": summary,
+        "reason": reason,
+        "can_output": can_output,
+        "room_id": room_id,
+        "connected": connected,
+        "dry_run": bool(getattr(config, "dry_run", True)),
+        "safety_status": safety_status,
+        "cooldown_remaining": round(float(cooldown_remaining or 0.0), 1),
+        "output_channel_ready": output_channel_ready,
+        "output_channel_reason": output_channel_reason,
+        "output_channel_detail": output_channel_detail,
+    }
+
+
+def live_state_summary(
+    *,
+    config: Any,
+    live_status: dict[str, Any],
+    health_rows: list[dict[str, Any]],
+    recent_results: Any,
+    warmup_observed: bool,
+    warmup_elapsed: float | None,
+    engaged_threshold: float,
+    idle_threshold: float,
+    warmup_timeout_seconds: float,
+    iso_age_fn: IsoAgeFn = iso_age_sec,
+) -> dict[str, Any]:
+    safety_status = str(live_status.get("safety_status") or "")
+    live_mode = str(getattr(config, "live_mode", "co_stream"))
+    mode_role = "solo_host" if live_mode == "solo_stream" else "companion"
+
+    state = "engaged"
+    reason = "recent_activity"
+    last_viewer_activity_age = last_viewer_activity_age_sec(health_rows, recent_results, iso_age_fn)
+    last_output_age = last_output_age_sec(health_rows, recent_results, iso_age_fn)
+    warmup_timeout = warmup_elapsed is not None and warmup_elapsed >= float(warmup_timeout_seconds)
+
+    if live_status.get("summary") == "cannot_stream" or safety_status in {"tripped", "degraded", "disconnected"}:
+        state = "blocked"
+        reason = "blocked_by_live_status"
+    elif safety_status == "paused":
+        state = "paused"
+        reason = "manual_paused"
+    elif (
+        last_viewer_activity_age is None
+        and live_mode == "solo_stream"
+        and not warmup_observed
+        and not warmup_timeout
+    ):
+        state = "warmup"
+        reason = "solo_stream_warmup"
+    elif last_viewer_activity_age is None or last_viewer_activity_age > idle_threshold:
+        state = "idle"
+        reason = "no_recent_activity"
+    elif last_viewer_activity_age > engaged_threshold:
+        state = "quiet"
+        reason = "quiet_activity_gap"
+
+    idle_hosting_candidate = (
+        live_mode == "solo_stream"
+        and state == "idle"
+        and live_status.get("summary") in {"ready_to_stream", "test_only"}
+        and float(live_status.get("cooldown_remaining") or 0.0) <= 0.0
+    )
+    warmup_hosting_candidate = (
+        live_mode == "solo_stream"
+        and state == "warmup"
+        and live_status.get("summary") in {"ready_to_stream", "test_only"}
+        and float(live_status.get("cooldown_remaining") or 0.0) <= 0.0
+    )
+
+    return {
+        "state": state,
+        "reason": reason,
+        "mode": live_mode,
+        "mode_role": mode_role,
+        "warmup_hosting_candidate": warmup_hosting_candidate,
+        "idle_hosting_candidate": idle_hosting_candidate,
+        "last_activity_age_sec": last_viewer_activity_age,
+        "last_viewer_activity_age_sec": last_viewer_activity_age,
+        "last_output_age_sec": last_output_age,
+        "engaged_threshold_seconds": float(engaged_threshold),
+        "idle_threshold_seconds": float(idle_threshold),
+        "warmup_elapsed_sec": warmup_elapsed,
+        "warmup_timeout_seconds": float(warmup_timeout_seconds),
+    }
+
+
+def idle_hosting_status(
+    *,
+    live_state: dict[str, Any],
+    now: float,
+    last_attempt_at: float,
+    min_interval_seconds: float,
+    consecutive_failures: int,
+    failure_limit: int,
+) -> dict[str, Any]:
+    elapsed = max(0.0, float(now) - float(last_attempt_at or 0.0))
+    cooldown_remaining = 0.0
+    if last_attempt_at > 0:
+        cooldown_remaining = round(max(0.0, float(min_interval_seconds) - elapsed), 1)
+
+    candidate = bool(live_state.get("idle_hosting_candidate"))
+    auto_disabled = int(consecutive_failures or 0) >= int(failure_limit)
+    eligible = candidate and cooldown_remaining <= 0.0 and not auto_disabled
+    reason = "eligible"
+    if auto_disabled:
+        reason = "auto_disabled"
+    elif not candidate:
+        reason = "not_candidate"
+    elif cooldown_remaining > 0.0:
+        reason = "minimum_interval"
+
+    return {
+        "eligible": eligible,
+        "reason": reason,
+        "candidate": candidate,
+        "cooldown_remaining": cooldown_remaining,
+        "min_interval_seconds": float(min_interval_seconds),
+        "consecutive_failures": int(consecutive_failures or 0),
+    }
+
+
+def idle_hosting_wait_remaining_for_quiet_state(
+    live_state: dict[str, Any],
+    *,
+    idle_threshold_fallback: float,
+) -> float | None:
+    if str(live_state.get("state") or "") != "quiet":
+        return None
+    viewer_age = live_state.get("last_viewer_activity_age_sec")
+    if viewer_age is None:
+        return None
+    try:
+        age = float(viewer_age)
+    except (TypeError, ValueError):
+        return None
+    idle_threshold = float(live_state.get("idle_threshold_seconds") or idle_threshold_fallback)
+    return round(max(0.0, idle_threshold - age), 1)
+
+
+def active_engagement_status(
+    *,
+    config: Any,
+    live_status: dict[str, Any],
+    live_state: dict[str, Any],
+    now: float,
+    last_attempt_at: float,
+    min_interval_seconds: float,
+    recent_danmaku_output_age: float | None,
+    recent_danmaku_wait_seconds: float,
+    idle_hosting_wait_remaining: float | None,
+    idle_grace_seconds: float,
+    idle_takeover_streak: int,
+) -> dict[str, Any]:
+    state_name = str(live_state.get("state") or "")
+    idle_takeover_candidate = state_name == "idle" and int(idle_takeover_streak or 0) > 0
+    live_mode = str(getattr(config, "live_mode", "co_stream"))
+    candidate = (
+        live_mode == "solo_stream"
+        and (state_name == "quiet" or idle_takeover_candidate)
+        and live_status.get("summary") in {"ready_to_stream", "test_only"}
+        and float(live_status.get("cooldown_remaining") or 0.0) <= 0.0
+    )
+    elapsed = max(0.0, float(now) - float(last_attempt_at or 0.0))
+    cooldown_remaining = 0.0
+    if last_attempt_at > 0:
+        cooldown_remaining = round(max(0.0, float(min_interval_seconds) - elapsed), 1)
+    minimum_interval_remaining = cooldown_remaining
+    recent_danmaku_cooldown = 0.0
+    if recent_danmaku_output_age is not None:
+        recent_danmaku_cooldown = round(max(0.0, float(recent_danmaku_wait_seconds) - recent_danmaku_output_age), 1)
+    eligible = bool(candidate)
+    reason = "eligible"
+    if live_mode != "solo_stream":
+        reason = "not_solo_stream"
+    elif state_name in {"paused", "blocked"}:
+        reason = state_name
+    elif state_name not in {"quiet", "idle"}:
+        reason = "not_quiet"
+    elif state_name == "idle" and not idle_takeover_candidate:
+        reason = "not_quiet"
+    elif live_status.get("summary") not in {"ready_to_stream", "test_only"}:
+        reason = str(live_status.get("reason") or "live_status_not_ready")
+    elif float(live_status.get("cooldown_remaining") or 0.0) > 0.0:
+        reason = "cooldown"
+    elif cooldown_remaining > 0.0:
+        reason = "minimum_interval"
+        eligible = False
+    elif recent_danmaku_cooldown > 0.0:
+        reason = "recent_danmaku_output"
+        cooldown_remaining = recent_danmaku_cooldown
+        eligible = False
+    elif idle_hosting_wait_remaining is not None and idle_hosting_wait_remaining <= float(idle_grace_seconds):
+        reason = "approaching_idle_hosting"
+        cooldown_remaining = idle_hosting_wait_remaining
+        eligible = False
+    elif idle_takeover_candidate:
+        reason = "idle_hosting_streak"
+    return {
+        "candidate": bool(candidate),
+        "eligible": eligible,
+        "reason": reason,
+        "cooldown_remaining": cooldown_remaining,
+        "minimum_interval_remaining": minimum_interval_remaining,
+        "recent_danmaku_cooldown_remaining": recent_danmaku_cooldown,
+        "idle_hosting_wait_remaining": idle_hosting_wait_remaining,
+        "minimum_interval_seconds": float(min_interval_seconds),
+        "min_interval_seconds": float(min_interval_seconds),
+    }
+
+
+def live_director_status(
+    *,
+    config: Any,
+    live_status: dict[str, Any],
+    live_state: dict[str, Any],
+    idle_hosting_status: dict[str, Any],
+    active_engagement_status: dict[str, Any],
+) -> dict[str, Any]:
+    mode = str(live_state.get("mode") or getattr(config, "live_mode", "co_stream"))
+    state_name = str(live_state.get("state") or "")
+
+    next_auto_action = "none"
+    eligible = False
+    reason = "waiting_for_viewer"
+    cooldown_remaining = 0.0
+    min_interval_seconds = 0.0
+
+    if mode != "solo_stream":
+        reason = "companion_mode"
+    elif state_name == "paused":
+        reason = "paused"
+    elif state_name == "blocked":
+        reason = "blocked"
+    elif state_name == "warmup":
+        next_auto_action = "warmup_hosting"
+        eligible = bool(live_state.get("warmup_hosting_candidate"))
+        reason = "solo_warmup" if eligible else "warmup_hosting_not_ready"
+    elif state_name == "quiet":
+        if str(active_engagement_status.get("reason") or "") == "approaching_idle_hosting":
+            next_auto_action = "idle_hosting"
+            eligible = False
+            reason = "approaching_idle_hosting"
+            cooldown_remaining = float(active_engagement_status.get("idle_hosting_wait_remaining") or 0.0)
+            min_interval_seconds = float(idle_hosting_status.get("min_interval_seconds") or 0.0)
+        else:
+            next_auto_action = "active_engagement"
+            eligible = bool(active_engagement_status.get("eligible"))
+            reason = "solo_quiet" if eligible else str(active_engagement_status.get("reason") or "active_engagement_not_ready")
+            cooldown_remaining = float(active_engagement_status.get("cooldown_remaining") or 0.0)
+            min_interval_seconds = float(active_engagement_status.get("min_interval_seconds") or 0.0)
+    elif state_name == "idle":
+        if str(active_engagement_status.get("reason") or "") == "idle_hosting_streak":
+            next_auto_action = "active_engagement"
+            eligible = bool(active_engagement_status.get("eligible"))
+            reason = "idle_hosting_streak" if eligible else str(active_engagement_status.get("reason") or "active_engagement_not_ready")
+            cooldown_remaining = float(active_engagement_status.get("cooldown_remaining") or 0.0)
+            min_interval_seconds = float(active_engagement_status.get("min_interval_seconds") or 0.0)
+        else:
+            next_auto_action = "idle_hosting"
+            eligible = bool(idle_hosting_status.get("eligible"))
+            reason = "solo_idle" if eligible else str(idle_hosting_status.get("reason") or "idle_hosting_not_ready")
+            cooldown_remaining = float(idle_hosting_status.get("cooldown_remaining") or 0.0)
+            min_interval_seconds = float(idle_hosting_status.get("min_interval_seconds") or 0.0)
+    elif state_name == "engaged":
+        reason = "recent_activity"
+
+    return {
+        "next_auto_action": next_auto_action,
+        "eligible": eligible,
+        "reason": reason,
+        "cooldown_remaining": round(max(0.0, cooldown_remaining), 1),
+        "min_interval_seconds": float(min_interval_seconds),
+        "mode": mode,
+        "live_state": state_name,
+    }
+
+
+def solo_test_readiness(
+    *,
+    config: Any,
+    live_status: dict[str, Any],
+    live_state: dict[str, Any],
+    live_director_status: dict[str, Any],
+    profile_count: int,
+    warmup_observed: bool,
+) -> dict[str, Any]:
+    mode = str(live_state.get("mode") or getattr(config, "live_mode", "co_stream"))
+    status_summary = str(live_status.get("summary") or "")
+    is_solo = mode == "solo_stream"
+    live_ready = status_summary in {"ready_to_stream", "test_only"}
+    ready = bool(is_solo and live_ready)
+    if not is_solo:
+        summary = "not_solo_stream"
+    elif not live_ready:
+        summary = "live_not_ready"
+    elif bool(live_status.get("dry_run")):
+        summary = "ready_for_test"
+    else:
+        summary = "ready_for_live_test"
+
+    blocked_status = "ready" if ready else "blocked"
+    items = [
+        {"id": "preflight", "status": "ready" if live_ready else "blocked", "reason": str(live_status.get("reason") or "")},
+        {
+            "id": "test_isolation",
+            "status": "warning" if int(profile_count or 0) > 0 else blocked_status,
+            "reason": "viewer_profiles_present" if int(profile_count or 0) > 0 else ("clean" if ready else summary),
+        },
+        {
+            "id": "warmup_hosting",
+            "status": "observed" if warmup_observed else blocked_status,
+            "reason": "observed" if warmup_observed else ("available" if ready else summary),
+        },
+        {"id": "avatar_roast", "status": blocked_status, "reason": "available" if ready else summary},
+        {"id": "danmaku_response", "status": blocked_status, "reason": "available" if ready else summary},
+        {
+            "id": "active_engagement",
+            "status": blocked_status,
+            "reason": str(live_director_status.get("reason") or "available") if ready else summary,
+        },
+        {"id": "idle_hosting", "status": blocked_status, "reason": "available" if ready else summary},
+        {"id": "pacing_control", "status": blocked_status, "reason": _activity_level(config)},
+    ]
+    return {
+        "ready": ready,
+        "summary": summary,
+        "mode": mode,
+        "dry_run": bool(live_status.get("dry_run")),
+        "profile_count": int(profile_count or 0),
+        "next_auto_action": str(live_director_status.get("next_auto_action") or "none"),
+        "items": items,
+    }
+
+
+def speech_explanation(
+    *,
+    live_status: dict[str, Any],
+    live_state: dict[str, Any],
+    latest_result: dict[str, Any] | None,
+    iso_age_fn: IsoAgeFn = iso_age_sec,
+) -> dict[str, Any]:
+    latest = latest_result if isinstance(latest_result, dict) else {}
+    latest_status = str(latest.get("status") or "")
+    latest_reason = str(latest.get("reason") or "")
+    latest_age = iso_age_fn(latest.get("created_at")) if latest else None
+    latest_latency = latest.get("response_latency_ms") if latest else None
+    latest_event = latest.get("event") if isinstance(latest.get("event"), dict) else {}
+    latest_source = str(latest_event.get("source") or "") if isinstance(latest_event, dict) else ""
+
+    status_summary = str(live_status.get("summary") or "cannot_stream")
+    status_reason = str(live_status.get("reason") or "room_not_configured")
+    state_name = str(live_state.get("state") or "")
+    state_reason = str(live_state.get("reason") or "")
+
+    summary = "ready"
+    reason = "ready"
+    if status_summary == "cannot_stream":
+        summary = "cannot_stream"
+        reason = status_reason
+    elif status_summary == "test_only":
+        summary = "test_only"
+        reason = status_reason
+    elif status_summary == "temporarily_not_speaking":
+        summary = "temporarily_not_speaking"
+        reason = status_reason
+    elif bool(live_state.get("warmup_hosting_candidate")):
+        summary = "waiting_for_activity"
+        reason = "solo_stream_warmup"
+    elif bool(live_state.get("idle_hosting_candidate")):
+        summary = "waiting_for_activity"
+        reason = "idle_hosting_candidate"
+    elif state_name in {"warmup", "quiet", "idle"}:
+        summary = "waiting_for_activity"
+        reason = state_reason or state_name
+    elif latest_status == "pushed":
+        summary = "recently_spoke"
+        reason = "recent_output"
+    elif latest_status == "skipped":
+        summary = "recently_skipped"
+        reason = "recently_skipped"
+    elif latest_status == "failed":
+        summary = "failed"
+        reason = "failed"
+    elif latest_status == "dry_run":
+        summary = "test_only"
+        reason = latest_reason or "dispatcher.dry_run"
+
+    return {
+        "summary": summary,
+        "reason": reason,
+        "live_status_summary": status_summary,
+        "live_status_reason": status_reason,
+        "live_state": state_name,
+        "live_state_reason": state_reason,
+        "cooldown_remaining": round(float(live_status.get("cooldown_remaining") or 0.0), 1),
+        "warmup_hosting_candidate": bool(live_state.get("warmup_hosting_candidate")),
+        "idle_hosting_candidate": bool(live_state.get("idle_hosting_candidate")),
+        "last_result_status": latest_status,
+        "last_result_reason": latest_reason,
+        "last_result_source": latest_source,
+        "last_result_age_sec": latest_age,
+        "last_result_latency_ms": latest_latency,
+    }

--- a/plugin/plugins/neko_roast/core/recent_context.py
+++ b/plugin/plugins/neko_roast/core/recent_context.py
@@ -1,0 +1,197 @@
+"""Helpers for compact live-context memory used by the roast runtime."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+_SPENT_OUTPUT_ASCII_WORD_RE = re.compile(r"[a-z0-9]+")
+_SPENT_OUTPUT_FAMILY_TOKENS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("surprise", ("surprise", "惊喜", "小惊喜")),
+    ("reward", ("reward", "present", "gift", "snack", "小鱼干", "鱼干", "奖励", "礼物")),
+    ("program_plan", ("plan", "program", "segment", "企划", "节目", "环节", "计划")),
+    (
+        "audience_prompt",
+        (
+            "chat",
+            "danmaku",
+            "viewer",
+            "audience",
+            "drop a 1",
+            "type 1",
+            "say hi",
+            "anyone here",
+            "still here",
+            "大家",
+            "你们",
+            "观众",
+            "弹幕",
+            "互动",
+            "接话",
+            "发言",
+            "发弹幕",
+            "发个1",
+            "扣1",
+            "想听",
+            "想看",
+            "聊点",
+            "聊什么",
+            "说点",
+            "来一句",
+            "扣个",
+            "扣个1",
+            "打个1",
+            "打个分",
+            "打个标签",
+            "吱一声",
+            "冒个泡",
+            "举个爪",
+            "给点反应",
+            "给猫猫一点反应",
+            "还在吗",
+            "有人吗",
+            "有人在吗",
+            "在不在",
+        ),
+    ),
+    ("host_self_test", ("host score", "主播力", "正经主播", "主持", "像主播")),
+    ("short_callback", ("one word", "password", "一个字", "一个词", "三字", "暗号", "打分")),
+    ("choice_vote", ("either_or", "a/b", "choice", "二选一", "选一个", "还是")),
+    ("room_mood", ("room mood", "气氛", "温度", "猫窝", "小电台", "晴天", "小雨")),
+    ("object_scene", ("desk", "screen", "keyboard", "桌面", "水杯", "零食", "屏幕", "键盘")),
+    ("tease", ("tease", "吐槽", "别笑", "被自己")),
+    ("micro_challenge", ("challenge", "task", "三秒", "挑战", "任务", "姿势")),
+    ("quiet_room", ("quiet", "idle", "冷场", "安静", "没人说话", "没弹幕")),
+)
+
+_SYNTHETIC_OUTPUT_PREFIXES = (
+    "queued_to_neko(",
+    "dry_run(",
+    "skipped_to_neko(",
+    "instructions_queued(",
+    "instructions_restored(",
+    "developer_instructions_queued(",
+    "developer_instructions_restored(",
+    "developer_mode_announced(",
+)
+
+_KNOWN_ROUTE_STEPS = {
+    "danmaku_response",
+    "avatar_roast",
+    "idle_hosting",
+    "active_engagement",
+    "warmup_hosting",
+    "gift_signal",
+    "super_chat_signal",
+}
+
+
+def _normalize_spent_output_family_text(value: str) -> str:
+    return "".join(str(value or "").casefold().split())
+
+
+def _spent_output_ascii_words(value: str) -> set[str]:
+    return set(_SPENT_OUTPUT_ASCII_WORD_RE.findall(str(value or "").casefold()))
+
+
+def _spent_output_family_token_matches(
+    *,
+    normalized_output: str,
+    ascii_words: set[str],
+    token: str,
+) -> bool:
+    token_text = str(token or "").strip()
+    normalized_token = _normalize_spent_output_family_text(token_text)
+    if not normalized_token:
+        return False
+    if token_text.isascii() and token_text.replace(" ", "").isalnum() and " " not in token_text:
+        return normalized_token in ascii_words
+    return normalized_token in normalized_output
+
+
+def spent_output_text(result: dict[str, Any]) -> str:
+    """Return real text NEKO said, excluding synthetic dispatcher markers."""
+    if str(result.get("status") or "") != "pushed":
+        return ""
+    output = str(result.get("output") or "").strip()
+    if not output:
+        return ""
+    if output.startswith(_SYNTHETIC_OUTPUT_PREFIXES):
+        return ""
+    return output
+
+
+def spent_output_families(output: str) -> list[str]:
+    normalized = _normalize_spent_output_family_text(output)
+    if not normalized:
+        return []
+    ascii_words = _spent_output_ascii_words(output)
+    families: list[str] = []
+    for family, tokens in _SPENT_OUTPUT_FAMILY_TOKENS:
+        if any(
+            _spent_output_family_token_matches(
+                normalized_output=normalized,
+                ascii_words=ascii_words,
+                token=token,
+            )
+            for token in tokens
+        ):
+            families.append(family)
+    return families
+
+
+def compact_context_text(value: str, *, limit: int = 80) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def route_from_result(result: dict[str, Any]) -> str:
+    response_module = str(result.get("response_module") or "")
+    if response_module:
+        return response_module
+    event = result.get("event") if isinstance(result.get("event"), dict) else {}
+    source = str(event.get("source") or "")
+    event_type = str(event.get("event_type") or "").strip().lower()
+    signal_route = signal_route_for_event_type(event_type)
+    if signal_route:
+        return signal_route
+    if source in {"idle_hosting", "active_engagement", "warmup_hosting"}:
+        return source
+    steps = result.get("steps") if isinstance(result.get("steps"), list) else []
+    for step in reversed(steps):
+        if not isinstance(step, dict):
+            continue
+        step_id = str(step.get("id") or "")
+        if step_id in _KNOWN_ROUTE_STEPS:
+            return step_id
+    return source or "unknown"
+
+
+def signal_route_for_event_type(event_type: str) -> str:
+    normalized = str(event_type or "").strip().lower()
+    if normalized in {"gift", "guard"}:
+        return "gift_signal"
+    if normalized in {"super_chat", "sc"}:
+        return "super_chat_signal"
+    return ""
+
+
+def event_signal_from_result(result: dict[str, Any]) -> str:
+    event = result.get("event") if isinstance(result.get("event"), dict) else {}
+    source = str(event.get("source") or "")
+    if source != "live_danmaku":
+        return source or "unknown"
+    event_type = str(event.get("event_type") or "").strip().lower()
+    if event_type in {"gift", "guard"}:
+        return "gift_signal"
+    if event_type in {"super_chat", "sc"}:
+        return "super_chat_signal"
+    text = str(event.get("danmaku_text") or "").strip().lower()
+    if any(token in text for token in ("粉丝团灯牌", "赠送", "送出", "礼物", "gift")):
+        return "gift_signal"
+    if any(token in text for token in ("super chat", "superchat", "醒目留言", "sc")):
+        return "super_chat_signal"
+    return "danmaku_signal"

--- a/plugin/plugins/neko_roast/core/runtime.py
+++ b/plugin/plugins/neko_roast/core/runtime.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import re
 import time
 from collections import deque
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -28,8 +26,10 @@ from ..stores.credential_store import CredentialStore
 from ..stores.viewer_store import ViewerStore
 from .contracts import InteractionResult, PipelineStep, RoastConfig, ViewerEvent, ViewerProfile, parse_room_id
 from .event_bus import EventBus
-from . import active_topic_rules
-from .live_content import active_engagement_fallback_topic_candidates, idle_hosting_beat_candidates
+from . import active_topic_rules, live_status as live_status_rules, recent_context
+from .active_topic_selector import ActiveTopicSelector
+from .live_hosting_director import LiveHostingDirector
+from .live_content import active_engagement_fallback_topic_candidates
 from .instructions import (
     NEKO_ROAST_CONTEXT_INSTRUCTIONS,
     NEKO_ROAST_DEVELOPER_ANNOUNCEMENT,
@@ -41,89 +41,6 @@ from .module_registry import ModuleRegistry
 from .permission_gate import PermissionGate
 from .pipeline import RoastPipeline
 from .safety_guard import SafetyGuard
-
-
-_SPENT_OUTPUT_ASCII_WORD_RE = re.compile(r"[a-z0-9]+")
-_SPENT_OUTPUT_FAMILY_TOKENS: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("surprise", ("surprise", "惊喜", "小惊喜")),
-    ("reward", ("reward", "present", "gift", "snack", "小鱼干", "鱼干", "奖励", "礼物")),
-    ("program_plan", ("plan", "program", "segment", "企划", "节目", "环节", "计划")),
-    (
-        "audience_prompt",
-        (
-            "chat",
-            "danmaku",
-            "viewer",
-            "audience",
-            "drop a 1",
-            "type 1",
-            "say hi",
-            "anyone here",
-            "still here",
-            "大家",
-            "你们",
-            "观众",
-            "弹幕",
-            "互动",
-            "接话",
-            "发言",
-            "发弹幕",
-            "发个1",
-            "扣1",
-            "想听",
-            "想看",
-            "聊点",
-            "聊什么",
-            "说点",
-            "来一句",
-            "扣个",
-            "扣个1",
-            "打个1",
-            "打个分",
-            "打个标签",
-            "吱一声",
-            "冒个泡",
-            "举个爪",
-            "给点反应",
-            "给猫猫一点反应",
-            "还在吗",
-            "有人吗",
-            "有人在吗",
-            "在不在",
-        ),
-    ),
-    ("host_self_test", ("host score", "主播力", "正经主播", "主持", "像主播")),
-    ("short_callback", ("one word", "password", "一个字", "一个词", "三字", "暗号", "打分")),
-    ("choice_vote", ("either_or", "a/b", "choice", "二选一", "选一个", "还是")),
-    ("room_mood", ("room mood", "气氛", "温度", "猫窝", "小电台", "晴天", "小雨")),
-    ("object_scene", ("desk", "screen", "keyboard", "桌面", "水杯", "零食", "屏幕", "键盘")),
-    ("tease", ("tease", "吐槽", "别笑", "被自己")),
-    ("micro_challenge", ("challenge", "task", "三秒", "挑战", "任务", "姿势")),
-    ("quiet_room", ("quiet", "idle", "冷场", "安静", "没人说话", "没弹幕")),
-)
-
-
-def _normalize_spent_output_family_text(value: str) -> str:
-    return "".join(str(value or "").casefold().split())
-
-
-def _spent_output_ascii_words(value: str) -> set[str]:
-    return set(_SPENT_OUTPUT_ASCII_WORD_RE.findall(str(value or "").casefold()))
-
-
-def _spent_output_family_token_matches(
-    *,
-    normalized_output: str,
-    ascii_words: set[str],
-    token: str,
-) -> bool:
-    token_text = str(token or "").strip()
-    normalized_token = _normalize_spent_output_family_text(token_text)
-    if not normalized_token:
-        return False
-    if token_text.isascii() and token_text.replace(" ", "").isalnum() and " " not in token_text:
-        return normalized_token in ascii_words
-    return normalized_token in normalized_output
 
 
 class RoastRuntime:
@@ -198,6 +115,8 @@ class RoastRuntime:
         self._active_engagement_recent_topic_skip_reason: str = ""
         self._active_engagement_shape_guard_reason: str = ""
         self._active_engagement_shape_index: int = 0
+        self.live_hosting_director = LiveHostingDirector(self)
+        self.active_topic_selector = ActiveTopicSelector(self)
         self._config_lock: asyncio.Lock | None = None
 
         self.bili_live_ingest = BiliLiveIngestModule()
@@ -618,251 +537,52 @@ class RoastRuntime:
         return await self.pipeline.handle_event(event)
 
     async def trigger_idle_hosting(self) -> InteractionResult:
-        live_connection = self.live_connection_snapshot()
-        live_status = self.live_status_summary(live_connection)
-        health_rows = self.runtime_health_rows()
-        live_state = self.live_state_summary(live_status, health_rows)
-        event = self._idle_hosting_event(live_state)
-
-        if self.config.live_mode != "solo_stream":
-            return self._record_idle_hosting_skip(event, "idle_hosting.not_solo_stream")
-        state = str(live_state.get("state") or "")
-        if state == "paused":
-            return self._record_idle_hosting_skip(event, "idle_hosting.paused")
-        if state == "blocked":
-            return self._record_idle_hosting_skip(event, "idle_hosting.blocked")
-        if state != "idle":
-            return self._record_idle_hosting_skip(event, "idle_hosting.not_idle")
-        if not bool(live_state.get("idle_hosting_candidate")):
-            return self._record_idle_hosting_skip(event, "idle_hosting.not_candidate")
-        return await self.pipeline.handle_event(event)
+        return await self.live_hosting_director.trigger_idle_hosting()
 
     async def maybe_trigger_idle_hosting(self) -> InteractionResult | None:
-        if self._idle_hosting_consecutive_failures >= self._IDLE_HOSTING_FAILURE_LIMIT:
-            return None
-        now = float(self._idle_hosting_now())
-        if now - self._idle_hosting_last_attempt_at < self._idle_hosting_min_interval_seconds():
-            return None
-        live_connection = self.live_connection_snapshot()
-        live_status = self.live_status_summary(live_connection)
-        health_rows = self.runtime_health_rows()
-        live_state = self.live_state_summary(live_status, health_rows)
-        if not bool(live_state.get("idle_hosting_candidate")):
-            return None
-
-        self._idle_hosting_last_attempt_at = now
-        result = await self.trigger_idle_hosting()
-        if result.status == "failed":
-            self._idle_hosting_consecutive_failures += 1
-            if self._idle_hosting_consecutive_failures >= self._IDLE_HOSTING_FAILURE_LIMIT:
-                self.audit.record("idle_hosting_auto_disabled", "idle hosting disabled after repeated failures", level="warning")
-        elif result.status in {"dry_run", "pushed"}:
-            self._idle_hosting_consecutive_failures = 0
-        return result
+        return await self.live_hosting_director.maybe_trigger_idle_hosting()
 
     def _idle_hosting_event(self, live_state: dict[str, Any]) -> ViewerEvent:
-        host_beat = self._next_idle_hosting_beat()
-        return ViewerEvent(
-            uid="__neko_idle__",
-            nickname="NEKO",
-            danmaku_text="",
-            source="idle_hosting",
-            live_mode=self.config.live_mode,
-            raw={
-                "trigger": "manual_idle_hosting",
-                "live_state": dict(live_state),
-                "host_beat": host_beat,
-            },
-        )
+        return self.live_hosting_director.idle_hosting_event(live_state)
 
     def _next_idle_hosting_beat(self) -> dict[str, Any]:
-        candidates = self._idle_hosting_beat_candidates()
-        fallback = candidates[0]
-        chosen = fallback
-        chosen_offset: int | None = None
-        preferred_stage = self._idle_hosting_preferred_stage()
-        ordered_candidates = self._idle_hosting_stage_ordered_candidates(candidates, preferred_stage)
-        recent_spent_families = self._recent_spent_output_families()
-        for offset, candidate in enumerate(ordered_candidates):
-            key = str(candidate.get("key") or "").strip()
-            axis = str(candidate.get("fun_axis") or "").strip()
-            title = str(candidate.get("title") or "").strip()
-            family = self._host_material_family(candidate)
-            reply_affordance = str(candidate.get("reply_affordance") or "").strip()
-            if (
-                key
-                and key not in self._idle_hosting_recent_beat_keys
-                and axis
-                and axis not in self._idle_hosting_recent_beat_axes
-                and family
-                and family not in self._recent_host_material_families
-                and family not in recent_spent_families
-                and (
-                    not reply_affordance
-                    or reply_affordance not in self._idle_hosting_recent_reply_affordances
-                )
-                and not self._is_similar_idle_hosting_beat_title(title)
-            ):
-                chosen = candidate
-                chosen_offset = offset
-                break
-        else:
-            for offset, candidate in enumerate(ordered_candidates):
-                key = str(candidate.get("key") or "").strip()
-                title = str(candidate.get("title") or "").strip()
-                family = self._host_material_family(candidate)
-                if (
-                    key
-                    and key not in self._idle_hosting_recent_beat_keys
-                    and family
-                    and family not in self._recent_host_material_families
-                    and family not in recent_spent_families
-                    and not self._is_similar_idle_hosting_beat_title(title)
-                ):
-                    chosen = candidate
-                    chosen_offset = offset
-                    break
-            else:
-                for offset, candidate in enumerate(ordered_candidates):
-                    key = str(candidate.get("key") or "").strip()
-                    if key and key not in self._idle_hosting_recent_beat_keys:
-                        chosen = candidate
-                        chosen_offset = offset
-                        break
-        if chosen_offset is None:
-            self._idle_hosting_beat_index = (self._idle_hosting_beat_index + 1) % len(candidates)
-        else:
-            self._idle_hosting_beat_index = (self._idle_hosting_beat_index + chosen_offset + 1) % len(candidates)
-        key = str(chosen.get("key") or fallback["key"]).strip()
-        axis = str(chosen.get("fun_axis") or "").strip()
-        title = str(chosen.get("title") or "").strip()
-        family = self._host_material_family(chosen)
-        reply_affordance = str(chosen.get("reply_affordance") or "").strip()
-        self._idle_hosting_recent_beat_keys.append(key)
-        if axis:
-            self._idle_hosting_recent_beat_axes.append(axis)
-        if title:
-            self._idle_hosting_recent_beat_titles.append(title)
-        if family:
-            self._recent_host_material_families.append(family)
-        if reply_affordance:
-            self._idle_hosting_recent_reply_affordances.append(reply_affordance)
-        payload = dict(chosen)
-        if family:
-            payload["family"] = family
-        payload["idle_stage"] = self._idle_hosting_material_stage(payload)
-        return payload
+        return self.live_hosting_director.next_idle_hosting_beat()
 
     @staticmethod
     def _idle_hosting_beat_candidates() -> list[dict[str, Any]]:
-        return idle_hosting_beat_candidates()
+        return LiveHostingDirector.idle_hosting_beat_candidates()
 
     def _idle_hosting_preferred_stage(self) -> str:
-        streak = self._recent_actual_route_streak_since_viewer_activity("idle_hosting")
-        if streak <= 0:
-            return "settle"
-        if streak == 1:
-            return "column"
-        return "callback"
+        return self.live_hosting_director.idle_hosting_preferred_stage()
 
     def _idle_hosting_stage_ordered_candidates(
         self,
         candidates: list[dict[str, Any]],
         preferred_stage: str,
     ) -> list[dict[str, Any]]:
-        if not candidates:
-            return []
-        rotated = [candidates[(self._idle_hosting_beat_index + offset) % len(candidates)] for offset in range(len(candidates))]
-        preferred = [candidate for candidate in rotated if self._idle_hosting_material_stage(candidate) == preferred_stage]
-        rest = [candidate for candidate in rotated if candidate not in preferred]
-        return [*preferred, *rest]
+        return self.live_hosting_director.idle_hosting_stage_ordered_candidates(candidates, preferred_stage)
 
     @staticmethod
     def _idle_hosting_material_stage(material: dict[str, Any] | None) -> str:
-        if not isinstance(material, dict):
-            return "settle"
-        explicit = str(material.get("idle_stage") or "").strip()
-        if explicit:
-            return explicit
-        shape = str(material.get("shape") or "").strip()
-        axis = str(material.get("fun_axis") or "").strip()
-        if shape in {"one_word_call", "micro_challenge"} or axis in {"viewer_callback", "micro_challenge"}:
-            return "callback"
-        if shape in {"tiny_choice", "light_tease"} or axis in {"choice", "tease"}:
-            return "column"
-        return "settle"
+        return LiveHostingDirector.idle_hosting_material_stage(material)
 
     def _is_similar_idle_hosting_beat_title(self, title: str) -> bool:
-        return bool(title) and active_topic_rules._is_similar_active_topic_title(
-            title,
-            self._idle_hosting_recent_beat_titles,
-        )
+        return self.live_hosting_director.is_similar_idle_hosting_beat_title(title)
 
     def _record_idle_hosting_skip(self, event: ViewerEvent, reason: str) -> InteractionResult:
-        result = InteractionResult(
-            accepted=False,
-            status="skipped",
-            event=event,
-            reason=reason,
-            steps=[PipelineStep("idle_hosting_gate", "skipped", reason)],
-        )
-        self.audit.record("idle_hosting_skipped", reason, level="info", detail={"mode": self.config.live_mode})
-        self.record_result(result)
-        return result
+        return self.live_hosting_director.record_idle_hosting_skip(event, reason)
 
     async def trigger_warmup_hosting(self) -> InteractionResult:
-        live_connection = self.live_connection_snapshot()
-        live_status = self.live_status_summary(live_connection)
-        health_rows = self.runtime_health_rows()
-        live_state = self.live_state_summary(live_status, health_rows)
-        event = self._warmup_hosting_event(live_state)
-
-        if self.config.live_mode != "solo_stream":
-            return self._record_warmup_hosting_skip(event, "warmup_hosting.not_solo_stream")
-        state = str(live_state.get("state") or "")
-        if state == "paused":
-            return self._record_warmup_hosting_skip(event, "warmup_hosting.paused")
-        if state == "blocked":
-            return self._record_warmup_hosting_skip(event, "warmup_hosting.blocked")
-        if state != "warmup":
-            return self._record_warmup_hosting_skip(event, "warmup_hosting.not_warmup")
-        if not bool(live_state.get("warmup_hosting_candidate")):
-            return self._record_warmup_hosting_skip(event, "warmup_hosting.not_candidate")
-        return await self.pipeline.handle_event(event)
+        return await self.live_hosting_director.trigger_warmup_hosting()
 
     async def maybe_trigger_warmup_hosting(self) -> InteractionResult | None:
-        live_connection = self.live_connection_snapshot()
-        live_status = self.live_status_summary(live_connection)
-        health_rows = self.runtime_health_rows()
-        live_state = self.live_state_summary(live_status, health_rows)
-        if not bool(live_state.get("warmup_hosting_candidate")):
-            return None
-        return await self.trigger_warmup_hosting()
+        return await self.live_hosting_director.maybe_trigger_warmup_hosting()
 
     def _warmup_hosting_event(self, live_state: dict[str, Any]) -> ViewerEvent:
-        return ViewerEvent(
-            uid="__neko_warmup__",
-            nickname="NEKO",
-            danmaku_text="",
-            source="warmup_hosting",
-            live_mode=self.config.live_mode,
-            raw={
-                "trigger": "auto_warmup_hosting",
-                "live_state": dict(live_state),
-            },
-        )
+        return self.live_hosting_director.warmup_hosting_event(live_state)
 
     def _record_warmup_hosting_skip(self, event: ViewerEvent, reason: str) -> InteractionResult:
-        result = InteractionResult(
-            accepted=False,
-            status="skipped",
-            event=event,
-            reason=reason,
-            steps=[PipelineStep("warmup_hosting_gate", "skipped", reason)],
-        )
-        self.audit.record("warmup_hosting_skipped", reason, level="info", detail={"mode": self.config.live_mode})
-        self.record_result(result)
-        return result
+        return self.live_hosting_director.record_warmup_hosting_skip(event, reason)
 
     async def trigger_active_engagement(self) -> InteractionResult:
         live_connection = self.live_connection_snapshot()
@@ -921,101 +641,7 @@ class RoastRuntime:
         )
 
     async def _select_active_engagement_topic(self) -> dict[str, Any]:
-        candidates = await self._active_engagement_topic_candidates()
-        fallback_candidates = self._active_engagement_fallback_topic_candidates()
-        fallback = fallback_candidates[0]
-        shape = self._next_active_engagement_shape()
-        chosen = fallback
-        exhausted_cached_topics = bool(candidates)
-        candidate = self._choose_active_engagement_candidate(candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
-        if candidate is None:
-            candidate = self._choose_active_engagement_candidate(candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
-        if candidate is None:
-            candidate = self._choose_active_engagement_candidate(candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
-        if candidate is not None:
-            chosen = candidate
-            exhausted_cached_topics = False
-        if exhausted_cached_topics:
-            self._active_engagement_topic_cache = []
-            self._active_engagement_topic_cache_at = 0.0
-            refreshed_candidates = await self._active_engagement_topic_candidates()
-            candidate = self._choose_active_engagement_candidate(refreshed_candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
-            if candidate is None:
-                candidate = self._choose_active_engagement_candidate(refreshed_candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
-            if candidate is None:
-                candidate = self._choose_active_engagement_candidate(refreshed_candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
-            if candidate is not None:
-                chosen = candidate
-                exhausted_cached_topics = False
-        if exhausted_cached_topics:
-            chosen = (
-                self._choose_active_engagement_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
-                or self._choose_active_engagement_candidate(fallback_candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
-                or self._choose_active_engagement_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
-                or self._choose_active_engagement_candidate(
-                    fallback_candidates,
-                    avoid_recent_fun_axis=False,
-                    avoid_recent_family=False,
-                    allow_similar_title=True,
-                )
-                or fallback
-            )
-        elif chosen is fallback:
-            chosen = (
-                self._choose_active_engagement_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=True)
-                or self._choose_active_engagement_candidate(fallback_candidates, avoid_recent_fun_axis=False, avoid_recent_family=True)
-                or self._choose_active_engagement_candidate(fallback_candidates, avoid_recent_fun_axis=True, avoid_recent_family=False)
-                or self._choose_active_engagement_candidate(
-                    fallback_candidates,
-                    avoid_recent_fun_axis=False,
-                    avoid_recent_family=False,
-                    allow_similar_title=True,
-                )
-                or fallback
-            )
-        preferred_shape = str(chosen.get("preferred_shape") or shape).strip() or shape
-        shape = self._active_engagement_guarded_shape(preferred_shape)
-        key = str(chosen.get("key") or chosen.get("title") or fallback["key"]).strip()
-        self._active_engagement_recent_topic_keys.append(key)
-        title = str(chosen.get("title") or fallback["title"]).strip()
-        if title:
-            self._active_engagement_recent_topic_titles.append(title)
-        intent = self._active_engagement_intent_text(shape)
-        hint = str(chosen.get("hint") or fallback["hint"]).strip()
-        if shape != preferred_shape:
-            hint = self._active_engagement_hint_text(shape)
-        topic = {
-            "source": str(chosen.get("source") or "fallback"),
-            "shape": shape,
-            "key": key,
-            "title": title,
-            "family": self._host_material_family(chosen),
-            "fun_axis": str(chosen.get("fun_axis") or "").strip() or self._active_engagement_fun_axis_text(shape),
-            "hook": self._active_engagement_hook_text(shape, title),
-            "pattern": self._active_engagement_pattern_text(shape),
-            "intent": intent,
-            "live_column": str(chosen.get("live_column") or "").strip(),
-            "topic_pack": self._active_engagement_topic_pack(chosen),
-            "reply_affordance": str(chosen.get("reply_affordance") or "").strip()
-            or self._active_engagement_reply_affordance_text(shape),
-            "hint": hint,
-        }
-        self._active_engagement_recent_topic_sources.append(str(topic["source"]))
-        if topic["fun_axis"]:
-            self._active_engagement_recent_fun_axes.append(str(topic["fun_axis"]))
-        if topic["family"]:
-            self._recent_host_material_families.append(str(topic["family"]))
-        self._active_engagement_recent_shapes.append(shape)
-        self._active_engagement_recent_intents.append(intent)
-        if topic["reply_affordance"]:
-            self._active_engagement_recent_reply_affordances.append(str(topic["reply_affordance"]))
-        skip_reason = str(self._active_engagement_recent_topic_skip_reason or "").strip()
-        if skip_reason:
-            topic["recent_topic_skip_reason"] = skip_reason
-        shape_guard_reason = str(self._active_engagement_shape_guard_reason or "").strip()
-        if shape_guard_reason:
-            topic["shape_guard_reason"] = shape_guard_reason
-        return topic
+        return await self.active_topic_selector.select_topic()
 
     def _choose_active_engagement_candidate(
         self,
@@ -1025,42 +651,12 @@ class RoastRuntime:
         avoid_recent_family: bool,
         allow_similar_title: bool = False,
     ) -> dict[str, Any] | None:
-        recent_spent_families = self._recent_spent_output_families() if avoid_recent_family else set()
-        for candidate in candidates:
-            key = str(candidate.get("key") or candidate.get("title") or "").strip()
-            if not key or key in self._active_engagement_recent_topic_keys:
-                continue
-            title = str(candidate.get("title") or "").strip()
-            if (
-                not allow_similar_title
-                and title
-                and self._is_similar_active_topic_title(title, self._active_engagement_recent_topic_titles)
-            ):
-                if not self._active_engagement_recent_topic_skip_reason:
-                    self._active_engagement_recent_topic_skip_reason = "similar_topic_title"
-                continue
-            axis = str(candidate.get("fun_axis") or "").strip()
-            if avoid_recent_fun_axis and axis and axis in self._active_engagement_recent_fun_axes:
-                continue
-            reply_affordance = str(candidate.get("reply_affordance") or "").strip()
-            if (
-                avoid_recent_fun_axis
-                and reply_affordance
-                and reply_affordance in self._active_engagement_recent_reply_affordances
-            ):
-                continue
-            family = self._host_material_family(candidate)
-            if avoid_recent_family and family:
-                if family in self._recent_host_material_families:
-                    if not self._active_engagement_recent_topic_skip_reason:
-                        self._active_engagement_recent_topic_skip_reason = "recent_host_family"
-                    continue
-                if family in recent_spent_families:
-                    if not self._active_engagement_recent_topic_skip_reason:
-                        self._active_engagement_recent_topic_skip_reason = "recent_spent_output_family"
-                    continue
-            return candidate
-        return None
+        return self.active_topic_selector.choose_candidate(
+            candidates,
+            avoid_recent_fun_axis=avoid_recent_fun_axis,
+            avoid_recent_family=avoid_recent_family,
+            allow_similar_title=allow_similar_title,
+        )
 
     @staticmethod
     def _active_engagement_fallback_topic_candidates() -> list[dict[str, Any]]:
@@ -1068,156 +664,16 @@ class RoastRuntime:
 
     @staticmethod
     def _active_engagement_topic_pack(material: dict[str, Any] | None) -> str:
-        if not isinstance(material, dict):
-            return ""
-        explicit = str(material.get("topic_pack") or "").strip()
-        if explicit:
-            return explicit
-        live_column = str(material.get("live_column") or "").lower()
-        family = active_topic_rules._host_material_family(material)
-        combined = " ".join(
-            str(material.get(field) or "").lower()
-            for field in ("key", "title", "fun_axis", "preferred_shape", "shape", "reply_affordance")
-        )
-        if family in {"tease", "host_self_test"} or any(marker in live_column for marker in ("verdict", "court", "award", "score")):
-            return "neko_verdict"
-        if family == "short_callback" or any(marker in live_column for marker in ("callback", "password", "command")):
-            return "viewer_callback"
-        if family == "choice_vote" or any(marker in live_column for marker in ("poll", "vote", "choice", "button")):
-            return "micro_poll"
-        if family == "micro_challenge" or any(marker in live_column for marker in ("challenge", "mission")):
-            return "micro_challenge"
-        if family == "object_scene" or any(marker in live_column for marker in ("observation", "patrol", "detective")):
-            return "room_observation"
-        if family == "room_mood" or any(marker in live_column for marker in ("radio", "weather", "thermometer", "filter", "mood")):
-            return "room_mood"
-        if "stance" in combined:
-            return "neko_stance"
-        return family or "general"
+        return ActiveTopicSelector.topic_pack(material)
 
     async def _active_engagement_topic_candidates(self) -> list[dict[str, Any]]:
-        recent = self._recent_danmaku_topic_candidates()
-        trending = await self._bili_trending_topic_candidates()
-        return [*recent, *trending]
+        return await self.active_topic_selector.topic_candidates()
 
     async def _bili_trending_topic_candidates(self) -> list[dict[str, Any]]:
-        now = time.monotonic()
-        if self._active_engagement_topic_cache and now - self._active_engagement_topic_cache_at < 600.0:
-            return list(self._active_engagement_topic_cache)
-        fetcher = self._active_engagement_topic_fetcher
-        if fetcher is None:
-            try:
-                from utils.web_scraper import fetch_bilibili_trending
-
-                fetcher = fetch_bilibili_trending
-            except Exception:
-                fetcher = None
-        if not callable(fetcher):
-            return []
-        try:
-            try:
-                payload = await asyncio.wait_for(fetcher(limit=6), timeout=2.0)
-            except TypeError:
-                payload = await asyncio.wait_for(fetcher(), timeout=2.0)
-        except Exception:
-            return []
-        videos = []
-        if isinstance(payload, dict):
-            videos = payload.get("videos") or payload.get("video") or payload.get("items") or []
-        if not isinstance(videos, list):
-            return []
-        candidates: list[dict[str, Any]] = []
-        for item in videos:
-            if not isinstance(item, dict):
-                continue
-            title = str(item.get("title") or "").strip()
-            if not title:
-                continue
-            if not self._is_meaningful_active_topic_text(title):
-                continue
-            key = str(item.get("bvid") or item.get("id") or title).strip()
-            compact_title = self._compact_context_text(title, limit=40)
-            profile = self._active_topic_material_profile(compact_title)
-            candidate = {
-                "source": "bili_trending",
-                "key": f"bili:{key}",
-                "title": compact_title,
-                "hint": "Use this Bilibili topic as material for one playful live-room line; do not read it like news.",
-            }
-            if profile:
-                candidate.update(profile)
-            candidates.append(candidate)
-            if len(candidates) >= 6:
-                break
-        self._active_engagement_topic_cache = candidates
-        self._active_engagement_topic_cache_at = now
-        return list(candidates)
+        return await self.active_topic_selector.bili_trending_topic_candidates()
 
     def _recent_danmaku_topic_candidates(self) -> list[dict[str, Any]]:
-        self._active_engagement_recent_topic_skip_reason = ""
-        if self._has_active_engagement_streak(self._active_engagement_recent_topic_sources, "recent_danmaku", 2):
-            self._active_engagement_recent_topic_skip_reason = "recent_danmaku_source_streak"
-            return []
-        recent_items: list[tuple[str, str]] = []
-        for result in reversed(self.recent_results):
-            if not isinstance(result, dict):
-                continue
-            event = result.get("event") if isinstance(result.get("event"), dict) else {}
-            if str(event.get("source") or "") != "live_danmaku":
-                continue
-            if str(result.get("status") or "") not in {"pushed", "dry_run"}:
-                if not self._active_engagement_recent_topic_skip_reason:
-                    self._active_engagement_recent_topic_skip_reason = "non_output_danmaku"
-                continue
-            route = self._route_from_result(result)
-            if route == "avatar_roast":
-                if not self._active_engagement_recent_topic_skip_reason:
-                    self._active_engagement_recent_topic_skip_reason = "avatar_roast_context"
-                continue
-            age = self._iso_age_sec(result.get("created_at"))
-            if age is not None and age > self._ACTIVE_ENGAGEMENT_RECENT_DANMAKU_TOPIC_MAX_AGE_SECONDS:
-                if not self._active_engagement_recent_topic_skip_reason:
-                    self._active_engagement_recent_topic_skip_reason = "stale_recent_danmaku"
-                continue
-            text = str(event.get("danmaku_text") or "").strip()
-            if not text:
-                continue
-            if self._is_viewer_to_viewer_mention_text(text):
-                if not self._active_engagement_recent_topic_skip_reason:
-                    self._active_engagement_recent_topic_skip_reason = "viewer_to_viewer_mention"
-                continue
-            if not self._is_meaningful_active_topic_text(text):
-                if not self._active_engagement_recent_topic_skip_reason:
-                    self._active_engagement_recent_topic_skip_reason = (
-                        self._active_topic_filter_reason(text) or "filtered_recent_danmaku"
-                    )
-                continue
-            compact = self._compact_context_text(text, limit=40)
-            uid = str(event.get("uid") or "").strip()
-            recent_items.append((uid, compact))
-            if len(recent_items) >= 6:
-                break
-        speaker_ids = {uid for uid, _ in recent_items if uid}
-        if len(recent_items) >= 3 and len(speaker_ids) == 1:
-            self._active_engagement_recent_topic_skip_reason = "single_viewer_flood"
-            return []
-        candidates: list[dict[str, Any]] = []
-        for _uid, compact in recent_items[:3]:
-            profile = self._active_topic_material_profile(compact)
-            candidate = {
-                "source": "recent_danmaku",
-                "key": f"danmaku:{compact}",
-                "title": compact,
-                "hint": "Extend this recent danmaku into one small live-room hook without pretending a new viewer spoke.",
-            }
-            if profile:
-                candidate.update(profile)
-            candidates.append(candidate)
-            if len(candidates) >= 3:
-                break
-        if candidates:
-            self._active_engagement_recent_topic_skip_reason = ""
-        return candidates
+        return self.active_topic_selector.recent_danmaku_topic_candidates()
 
     @staticmethod
     def _is_meaningful_active_topic_text(text: str) -> bool:
@@ -1248,27 +704,10 @@ class RoastRuntime:
         return active_topic_rules._is_live_test_or_runtime_feedback(dense_lowered)
 
     def _next_active_engagement_shape(self) -> str:
-        shapes = ["either_or", "light_stance", "tiny_tease", "small_challenge"]
-        shape = shapes[self._active_engagement_shape_index % len(shapes)]
-        self._active_engagement_shape_index += 1
-        return shape
+        return self.active_topic_selector.next_shape()
 
     def _active_engagement_guarded_shape(self, shape: str) -> str:
-        self._active_engagement_shape_guard_reason = ""
-        shapes = ["either_or", "light_stance", "tiny_tease", "small_challenge"]
-        normalized = shape if shape in shapes else shapes[0]
-        if not self._has_active_engagement_streak(self._active_engagement_recent_shapes, normalized, 2):
-            return normalized
-        self._active_engagement_shape_guard_reason = "recent_shape_streak"
-        for candidate in shapes:
-            if candidate != normalized and not self._has_active_engagement_streak(
-                self._active_engagement_recent_shapes, candidate, 1
-            ):
-                return candidate
-        for candidate in shapes:
-            if candidate != normalized:
-                return candidate
-        return normalized
+        return self.active_topic_selector.guarded_shape(shape)
 
     @staticmethod
     def _has_active_engagement_streak(values: deque[str], value: str, count: int) -> bool:
@@ -1331,34 +770,13 @@ class RoastRuntime:
         return result
 
     def _start_idle_hosting_loop(self) -> None:
-        task = self._idle_hosting_task
-        if task is not None and not task.done():
-            return
-        self._idle_hosting_task = asyncio.create_task(self._idle_hosting_loop())
+        self.live_hosting_director.start_loop()
 
     async def _stop_idle_hosting_loop(self) -> None:
-        task = self._idle_hosting_task
-        self._idle_hosting_task = None
-        if task is None or task.done():
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        await self.live_hosting_director.stop_loop()
 
     async def _idle_hosting_loop(self) -> None:
-        while True:
-            await self._idle_hosting_sleep(self._IDLE_HOSTING_CHECK_INTERVAL_SECONDS)
-            try:
-                await self.maybe_trigger_warmup_hosting()
-                await self.maybe_trigger_active_engagement()
-                await self.maybe_trigger_idle_hosting()
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                message = f"idle_hosting_loop_failed: {type(exc).__name__}"
-                self.audit.record("idle_hosting_loop_failed", message, level="warning")
+        await self.live_hosting_director.idle_hosting_loop()
 
     async def dashboard_state(self) -> dict[str, Any]:
         profiles = await self.viewer_store.recent_profiles(self.config.recent_limit)
@@ -1398,69 +816,13 @@ class RoastRuntime:
 
     def live_status_summary(self, live_connection: dict[str, Any] | None = None) -> dict[str, Any]:
         connection = live_connection or self.live_connection_snapshot()
-        room_id = int(self.config.live_room_id or connection.get("room_id") or 0)
-        connected = bool(connection.get("connected"))
-        safety_status = self.safety_guard.status()
-        cooldown_remaining = round(float(self.safety_guard.output_cooldown_remaining()), 1)
-        output_channel = self.dispatcher.output_channel_status()
-        output_channel_ready = bool(output_channel.get("ready"))
-        output_channel_reason = str(output_channel.get("reason") or "")
-        output_channel_detail = str(output_channel.get("detail") or "")
-
-        summary = "ready_to_stream"
-        reason = "ready"
-        can_output = True
-
-        if room_id <= 0:
-            summary = "cannot_stream"
-            reason = "room_not_configured"
-            can_output = False
-        elif not self.config.live_enabled:
-            summary = "cannot_stream"
-            reason = "live_disabled"
-            can_output = False
-        elif not connected:
-            summary = "cannot_stream"
-            reason = "live_ingest_disconnected"
-            can_output = False
-        elif safety_status == "paused":
-            summary = "temporarily_not_speaking"
-            reason = "manual_paused"
-            can_output = False
-        elif safety_status == "tripped":
-            summary = "cannot_stream"
-            reason = "safety_tripped"
-            can_output = False
-        elif safety_status == "degraded":
-            summary = "temporarily_not_speaking"
-            reason = "safety_degraded"
-            can_output = False
-        elif self.config.dry_run:
-            summary = "test_only"
-            reason = "dry_run"
-            can_output = False
-        elif not output_channel_ready:
-            summary = "cannot_stream"
-            reason = output_channel_reason or "output_channel_unavailable"
-            can_output = False
-        elif cooldown_remaining > 0:
-            summary = "temporarily_not_speaking"
-            reason = "cooldown"
-            can_output = False
-
-        return {
-            "summary": summary,
-            "reason": reason,
-            "can_output": can_output,
-            "room_id": room_id,
-            "connected": connected,
-            "dry_run": bool(self.config.dry_run),
-            "safety_status": safety_status,
-            "cooldown_remaining": cooldown_remaining,
-            "output_channel_ready": output_channel_ready,
-            "output_channel_reason": output_channel_reason,
-            "output_channel_detail": output_channel_detail,
-        }
+        return live_status_rules.live_status_summary(
+            config=self.config,
+            live_connection=connection,
+            safety_status=self.safety_guard.status(),
+            cooldown_remaining=round(float(self.safety_guard.output_cooldown_remaining()), 1),
+            output_channel=self.dispatcher.output_channel_status(),
+        )
 
     def live_state_summary(
         self,
@@ -1469,99 +831,30 @@ class RoastRuntime:
     ) -> dict[str, Any]:
         status = live_status or self.live_status_summary()
         rows = health_rows if health_rows is not None else self.runtime_health_rows()
-        safety_status = str(status.get("safety_status") or self.safety_guard.status())
-        mode_role = "solo_host" if self.config.live_mode == "solo_stream" else "companion"
         engaged_threshold, idle_threshold = self._live_state_threshold_seconds()
-
-        state = "engaged"
-        reason = "recent_activity"
-        last_viewer_activity_age_sec = self._last_viewer_activity_age_sec(rows)
-        last_output_age_sec = self._last_output_age_sec(rows)
-        warmup_observed = self._has_recent_response_module("warmup_hosting")
-        warmup_elapsed = self._solo_warmup_elapsed_seconds()
-        warmup_timeout = (
-            warmup_elapsed is not None
-            and warmup_elapsed >= self._solo_warmup_timeout_seconds()
+        return live_status_rules.live_state_summary(
+            config=self.config,
+            live_status=status,
+            health_rows=rows,
+            recent_results=self.recent_results,
+            warmup_observed=self._has_recent_response_module("warmup_hosting"),
+            warmup_elapsed=self._solo_warmup_elapsed_seconds(),
+            engaged_threshold=engaged_threshold,
+            idle_threshold=idle_threshold,
+            warmup_timeout_seconds=self._solo_warmup_timeout_seconds(),
+            iso_age_fn=self._iso_age_sec,
         )
-
-        if status.get("summary") == "cannot_stream" or safety_status in {"tripped", "degraded", "disconnected"}:
-            state = "blocked"
-            reason = "blocked_by_live_status"
-        elif safety_status == "paused":
-            state = "paused"
-            reason = "manual_paused"
-        elif (
-            last_viewer_activity_age_sec is None
-            and self.config.live_mode == "solo_stream"
-            and not warmup_observed
-            and not warmup_timeout
-        ):
-            state = "warmup"
-            reason = "solo_stream_warmup"
-        elif last_viewer_activity_age_sec is None or last_viewer_activity_age_sec > idle_threshold:
-            state = "idle"
-            reason = "no_recent_activity"
-        elif last_viewer_activity_age_sec > engaged_threshold:
-            state = "quiet"
-            reason = "quiet_activity_gap"
-
-        idle_hosting_candidate = (
-            self.config.live_mode == "solo_stream"
-            and state == "idle"
-            and status.get("summary") in {"ready_to_stream", "test_only"}
-            and float(status.get("cooldown_remaining") or 0.0) <= 0.0
-        )
-        warmup_hosting_candidate = (
-            self.config.live_mode == "solo_stream"
-            and state == "warmup"
-            and status.get("summary") in {"ready_to_stream", "test_only"}
-            and float(status.get("cooldown_remaining") or 0.0) <= 0.0
-        )
-
-        return {
-            "state": state,
-            "reason": reason,
-            "mode": self.config.live_mode,
-            "mode_role": mode_role,
-            "warmup_hosting_candidate": warmup_hosting_candidate,
-            "idle_hosting_candidate": idle_hosting_candidate,
-            "last_activity_age_sec": last_viewer_activity_age_sec,
-            "last_viewer_activity_age_sec": last_viewer_activity_age_sec,
-            "last_output_age_sec": last_output_age_sec,
-            "engaged_threshold_seconds": float(engaged_threshold),
-            "idle_threshold_seconds": float(idle_threshold),
-            "warmup_elapsed_sec": warmup_elapsed,
-            "warmup_timeout_seconds": self._solo_warmup_timeout_seconds(),
-        }
 
     def idle_hosting_status(self, live_state: dict[str, Any] | None = None) -> dict[str, Any]:
         state = live_state or self.live_state_summary()
-        now = float(self._idle_hosting_now())
-        min_interval = self._idle_hosting_min_interval_seconds()
-        elapsed = max(0.0, now - float(self._idle_hosting_last_attempt_at or 0.0))
-        cooldown_remaining = 0.0
-        if self._idle_hosting_last_attempt_at > 0:
-            cooldown_remaining = round(max(0.0, min_interval - elapsed), 1)
-
-        candidate = bool(state.get("idle_hosting_candidate"))
-        auto_disabled = self._idle_hosting_consecutive_failures >= self._IDLE_HOSTING_FAILURE_LIMIT
-        eligible = candidate and cooldown_remaining <= 0.0 and not auto_disabled
-        reason = "eligible"
-        if auto_disabled:
-            reason = "auto_disabled"
-        elif not candidate:
-            reason = "not_candidate"
-        elif cooldown_remaining > 0.0:
-            reason = "minimum_interval"
-
-        return {
-            "eligible": eligible,
-            "reason": reason,
-            "candidate": candidate,
-            "cooldown_remaining": cooldown_remaining,
-            "min_interval_seconds": float(min_interval),
-            "consecutive_failures": int(self._idle_hosting_consecutive_failures),
-        }
+        return live_status_rules.idle_hosting_status(
+            live_state=state,
+            now=float(self._idle_hosting_now()),
+            last_attempt_at=float(self._idle_hosting_last_attempt_at or 0.0),
+            min_interval_seconds=self._idle_hosting_min_interval_seconds(),
+            consecutive_failures=int(self._idle_hosting_consecutive_failures),
+            failure_limit=self._IDLE_HOSTING_FAILURE_LIMIT,
+        )
 
     def active_engagement_status(
         self,
@@ -1570,67 +863,24 @@ class RoastRuntime:
     ) -> dict[str, Any]:
         status = live_status or self.live_status_summary()
         state = live_state or self.live_state_summary(status)
-        state_name = str(state.get("state") or "")
-        idle_takeover_candidate = state_name == "idle" and self._recent_actual_route_streak_since_viewer_activity(
-            "idle_hosting"
-        ) >= self._IDLE_HOSTING_STREAK_FOR_ACTIVE_TAKEOVER
-        candidate = (
-            self.config.live_mode == "solo_stream"
-            and (state_name == "quiet" or idle_takeover_candidate)
-            and status.get("summary") in {"ready_to_stream", "test_only"}
-            and float(status.get("cooldown_remaining") or 0.0) <= 0.0
+        idle_takeover_streak = self._recent_actual_route_streak_since_viewer_activity("idle_hosting")
+        return live_status_rules.active_engagement_status(
+            config=self.config,
+            live_status=status,
+            live_state=state,
+            now=float(self._active_engagement_now()),
+            last_attempt_at=float(self._active_engagement_last_attempt_at or 0.0),
+            min_interval_seconds=self._active_engagement_min_interval_seconds(),
+            recent_danmaku_output_age=self._recent_live_danmaku_output_age_sec(),
+            recent_danmaku_wait_seconds=self._active_engagement_after_danmaku_interval_seconds(),
+            idle_hosting_wait_remaining=self._idle_hosting_wait_remaining_for_quiet_state(state),
+            idle_grace_seconds=self._active_engagement_idle_grace_seconds(),
+            idle_takeover_streak=(
+                idle_takeover_streak
+                if idle_takeover_streak >= self._IDLE_HOSTING_STREAK_FOR_ACTIVE_TAKEOVER
+                else 0
+            ),
         )
-        now = float(self._active_engagement_now())
-        min_interval = self._active_engagement_min_interval_seconds()
-        elapsed = max(0.0, now - float(self._active_engagement_last_attempt_at or 0.0))
-        cooldown_remaining = 0.0
-        if self._active_engagement_last_attempt_at > 0:
-            cooldown_remaining = round(max(0.0, min_interval - elapsed), 1)
-        minimum_interval_remaining = cooldown_remaining
-        recent_danmaku_output_age = self._recent_live_danmaku_output_age_sec()
-        recent_danmaku_wait = self._active_engagement_after_danmaku_interval_seconds()
-        recent_danmaku_cooldown = 0.0
-        if recent_danmaku_output_age is not None:
-            recent_danmaku_cooldown = round(max(0.0, recent_danmaku_wait - recent_danmaku_output_age), 1)
-        idle_hosting_wait_remaining = self._idle_hosting_wait_remaining_for_quiet_state(state)
-        eligible = bool(candidate)
-        reason = "eligible"
-        if self.config.live_mode != "solo_stream":
-            reason = "not_solo_stream"
-        elif state_name in {"paused", "blocked"}:
-            reason = state_name
-        elif state_name not in {"quiet", "idle"}:
-            reason = "not_quiet"
-        elif state_name == "idle" and not idle_takeover_candidate:
-            reason = "not_quiet"
-        elif status.get("summary") not in {"ready_to_stream", "test_only"}:
-            reason = str(status.get("reason") or "live_status_not_ready")
-        elif float(status.get("cooldown_remaining") or 0.0) > 0.0:
-            reason = "cooldown"
-        elif cooldown_remaining > 0.0:
-            reason = "minimum_interval"
-            eligible = False
-        elif recent_danmaku_cooldown > 0.0:
-            reason = "recent_danmaku_output"
-            cooldown_remaining = recent_danmaku_cooldown
-            eligible = False
-        elif idle_hosting_wait_remaining is not None and idle_hosting_wait_remaining <= self._active_engagement_idle_grace_seconds():
-            reason = "approaching_idle_hosting"
-            cooldown_remaining = idle_hosting_wait_remaining
-            eligible = False
-        elif idle_takeover_candidate:
-            reason = "idle_hosting_streak"
-        return {
-            "candidate": bool(candidate),
-            "eligible": eligible,
-            "reason": reason,
-            "cooldown_remaining": cooldown_remaining,
-            "minimum_interval_remaining": minimum_interval_remaining,
-            "recent_danmaku_cooldown_remaining": recent_danmaku_cooldown,
-            "idle_hosting_wait_remaining": idle_hosting_wait_remaining,
-            "minimum_interval_seconds": float(min_interval),
-            "min_interval_seconds": float(min_interval),
-        }
 
     def live_director_status(
         self,
@@ -1643,63 +893,13 @@ class RoastRuntime:
         state = live_state or self.live_state_summary(status)
         idle_status = idle_hosting_status or self.idle_hosting_status(state)
         active_status = active_engagement_status or self.active_engagement_status(status, state)
-        mode = str(state.get("mode") or self.config.live_mode)
-        state_name = str(state.get("state") or "")
-
-        next_auto_action = "none"
-        eligible = False
-        reason = "waiting_for_viewer"
-        cooldown_remaining = 0.0
-        min_interval_seconds = 0.0
-
-        if mode != "solo_stream":
-            reason = "companion_mode"
-        elif state_name == "paused":
-            reason = "paused"
-        elif state_name == "blocked":
-            reason = "blocked"
-        elif state_name == "warmup":
-            next_auto_action = "warmup_hosting"
-            eligible = bool(state.get("warmup_hosting_candidate"))
-            reason = "solo_warmup" if eligible else "warmup_hosting_not_ready"
-        elif state_name == "quiet":
-            if str(active_status.get("reason") or "") == "approaching_idle_hosting":
-                next_auto_action = "idle_hosting"
-                eligible = False
-                reason = "approaching_idle_hosting"
-                cooldown_remaining = float(active_status.get("idle_hosting_wait_remaining") or 0.0)
-                min_interval_seconds = float(idle_status.get("min_interval_seconds") or 0.0)
-            else:
-                next_auto_action = "active_engagement"
-                eligible = bool(active_status.get("eligible"))
-                reason = "solo_quiet" if eligible else str(active_status.get("reason") or "active_engagement_not_ready")
-                cooldown_remaining = float(active_status.get("cooldown_remaining") or 0.0)
-                min_interval_seconds = float(active_status.get("min_interval_seconds") or 0.0)
-        elif state_name == "idle":
-            if str(active_status.get("reason") or "") == "idle_hosting_streak":
-                next_auto_action = "active_engagement"
-                eligible = bool(active_status.get("eligible"))
-                reason = "idle_hosting_streak" if eligible else str(active_status.get("reason") or "active_engagement_not_ready")
-                cooldown_remaining = float(active_status.get("cooldown_remaining") or 0.0)
-                min_interval_seconds = float(active_status.get("min_interval_seconds") or 0.0)
-            else:
-                next_auto_action = "idle_hosting"
-                eligible = bool(idle_status.get("eligible"))
-                reason = "solo_idle" if eligible else str(idle_status.get("reason") or "idle_hosting_not_ready")
-                cooldown_remaining = float(idle_status.get("cooldown_remaining") or 0.0)
-                min_interval_seconds = float(idle_status.get("min_interval_seconds") or 0.0)
-        elif state_name == "engaged":
-            reason = "recent_activity"
-
-        return {
-            "next_auto_action": next_auto_action,
-            "eligible": eligible,
-            "reason": reason,
-            "cooldown_remaining": round(max(0.0, cooldown_remaining), 1),
-            "min_interval_seconds": float(min_interval_seconds),
-            "mode": mode,
-            "live_state": state_name,
-        }
+        return live_status_rules.live_director_status(
+            config=self.config,
+            live_status=status,
+            live_state=state,
+            idle_hosting_status=idle_status,
+            active_engagement_status=active_status,
+        )
 
     def solo_test_readiness(
         self,
@@ -1711,73 +911,14 @@ class RoastRuntime:
         status = live_status or self.live_status_summary()
         state = live_state or self.live_state_summary(status)
         director = live_director_status or self.live_director_status(status, state)
-        mode = str(state.get("mode") or self.config.live_mode)
-        status_summary = str(status.get("summary") or "")
-        is_solo = mode == "solo_stream"
-        live_ready = status_summary in {"ready_to_stream", "test_only"}
-        ready = bool(is_solo and live_ready)
-        if not is_solo:
-            summary = "not_solo_stream"
-        elif not live_ready:
-            summary = "live_not_ready"
-        elif bool(status.get("dry_run")):
-            summary = "ready_for_test"
-        else:
-            summary = "ready_for_live_test"
-
-        blocked_status = "ready" if ready else "blocked"
-        warmup_observed = self._has_recent_response_module("warmup_hosting")
-        items = [
-            {
-                "id": "preflight",
-                "status": "ready" if live_ready else "blocked",
-                "reason": str(status.get("reason") or ""),
-            },
-            {
-                "id": "test_isolation",
-                "status": "warning" if int(profile_count or 0) > 0 else blocked_status,
-                "reason": "viewer_profiles_present" if int(profile_count or 0) > 0 else ("clean" if ready else summary),
-            },
-            {
-                "id": "warmup_hosting",
-                "status": "observed" if warmup_observed else blocked_status,
-                "reason": "observed" if warmup_observed else ("available" if ready else summary),
-            },
-            {
-                "id": "avatar_roast",
-                "status": blocked_status,
-                "reason": "available" if ready else summary,
-            },
-            {
-                "id": "danmaku_response",
-                "status": blocked_status,
-                "reason": "available" if ready else summary,
-            },
-            {
-                "id": "active_engagement",
-                "status": blocked_status,
-                "reason": str(director.get("reason") or "available") if ready else summary,
-            },
-            {
-                "id": "idle_hosting",
-                "status": blocked_status,
-                "reason": "available" if ready else summary,
-            },
-            {
-                "id": "pacing_control",
-                "status": blocked_status,
-                "reason": str(getattr(self.config, "activity_level", "standard")),
-            },
-        ]
-        return {
-            "ready": ready,
-            "summary": summary,
-            "mode": mode,
-            "dry_run": bool(status.get("dry_run")),
-            "profile_count": int(profile_count or 0),
-            "next_auto_action": str(director.get("next_auto_action") or "none"),
-            "items": items,
-        }
+        return live_status_rules.solo_test_readiness(
+            config=self.config,
+            live_status=status,
+            live_state=state,
+            live_director_status=director,
+            profile_count=profile_count,
+            warmup_observed=self._has_recent_response_module("warmup_hosting"),
+        )
 
     def _has_recent_response_module(self, module_id: str) -> bool:
         target = str(module_id)
@@ -1809,49 +950,25 @@ class RoastRuntime:
         return streak
 
     def _active_engagement_min_interval_seconds(self) -> float:
-        return {
-            "quiet": 300.0,
-            "active": 45.0,
-            "standard": 60.0,
-        }.get(str(getattr(self.config, "activity_level", "standard")), 60.0)
+        return live_status_rules.active_engagement_min_interval_seconds(self.config)
 
     def _active_engagement_after_danmaku_interval_seconds(self) -> float:
-        return {
-            "quiet": 210.0,
-            "active": 30.0,
-            "standard": 45.0,
-        }.get(
-            str(getattr(self.config, "activity_level", "standard")),
-            45.0,
-        )
+        return live_status_rules.active_engagement_after_danmaku_interval_seconds(self.config)
 
     def _active_engagement_idle_grace_seconds(self) -> float:
-        return {
-            "quiet": 45.0,
-            "active": 15.0,
-            "standard": float(self._ACTIVE_ENGAGEMENT_IDLE_GRACE_SECONDS),
-        }.get(str(getattr(self.config, "activity_level", "standard")), float(self._ACTIVE_ENGAGEMENT_IDLE_GRACE_SECONDS))
+        return live_status_rules.active_engagement_idle_grace_seconds(
+            self.config,
+            float(self._ACTIVE_ENGAGEMENT_IDLE_GRACE_SECONDS),
+        )
 
     def _idle_hosting_wait_remaining_for_quiet_state(self, live_state: dict[str, Any]) -> float | None:
-        if str(live_state.get("state") or "") != "quiet":
-            return None
-        viewer_age = live_state.get("last_viewer_activity_age_sec")
-        if viewer_age is None:
-            return None
-        try:
-            age = float(viewer_age)
-        except (TypeError, ValueError):
-            return None
-        idle_threshold = float(live_state.get("idle_threshold_seconds") or self._live_state_threshold_seconds()[1])
-        remaining = round(max(0.0, idle_threshold - age), 1)
-        return remaining
+        return live_status_rules.idle_hosting_wait_remaining_for_quiet_state(
+            live_state,
+            idle_threshold_fallback=self._live_state_threshold_seconds()[1],
+        )
 
     def _idle_hosting_min_interval_seconds(self) -> float:
-        return {
-            "quiet": 180.0,
-            "active": 45.0,
-            "standard": 90.0,
-        }.get(str(getattr(self.config, "activity_level", "standard")), 90.0)
+        return live_status_rules.idle_hosting_min_interval_seconds(self.config)
 
     def _solo_warmup_elapsed_seconds(self) -> float | None:
         if self._live_listener_started_at <= 0:
@@ -1859,20 +976,16 @@ class RoastRuntime:
         return max(0.0, float(self._live_state_now()) - float(self._live_listener_started_at))
 
     def _solo_warmup_timeout_seconds(self) -> float:
-        return {
-            "quiet": 90.0,
-            "active": 30.0,
-            "standard": float(self._SOLO_WARMUP_TIMEOUT_SECONDS),
-        }.get(str(getattr(self.config, "activity_level", "standard")), float(self._SOLO_WARMUP_TIMEOUT_SECONDS))
+        return live_status_rules.solo_warmup_timeout_seconds(
+            self.config,
+            float(self._SOLO_WARMUP_TIMEOUT_SECONDS),
+        )
 
     def _live_state_threshold_seconds(self) -> tuple[float, float]:
-        return {
-            "quiet": (90.0, 300.0),
-            "active": (30.0, 90.0),
-            "standard": (float(self._LIVE_STATE_ENGAGED_SECONDS), float(self._LIVE_STATE_IDLE_SECONDS)),
-        }.get(
-            str(getattr(self.config, "activity_level", "standard")),
-            (float(self._LIVE_STATE_ENGAGED_SECONDS), float(self._LIVE_STATE_IDLE_SECONDS)),
+        return live_status_rules.live_state_threshold_seconds(
+            self.config,
+            float(self._LIVE_STATE_ENGAGED_SECONDS),
+            float(self._LIVE_STATE_IDLE_SECONDS),
         )
 
     def speech_explanation(
@@ -1882,68 +995,12 @@ class RoastRuntime:
     ) -> dict[str, Any]:
         status = live_status or self.live_status_summary()
         state = live_state or self.live_state_summary(status)
-        latest = self.recent_results[-1] if self.recent_results else {}
-        latest_status = str(latest.get("status") or "") if isinstance(latest, dict) else ""
-        latest_reason = str(latest.get("reason") or "") if isinstance(latest, dict) else ""
-        latest_age = self._iso_age_sec(latest.get("created_at")) if isinstance(latest, dict) else None
-        latest_latency = latest.get("response_latency_ms") if isinstance(latest, dict) else None
-        latest_event = latest.get("event") if isinstance(latest, dict) else {}
-        latest_source = str(latest_event.get("source") or "") if isinstance(latest_event, dict) else ""
-
-        status_summary = str(status.get("summary") or "cannot_stream")
-        status_reason = str(status.get("reason") or "room_not_configured")
-        state_name = str(state.get("state") or "")
-        state_reason = str(state.get("reason") or "")
-
-        summary = "ready"
-        reason = "ready"
-        if status_summary == "cannot_stream":
-            summary = "cannot_stream"
-            reason = status_reason
-        elif status_summary == "test_only":
-            summary = "test_only"
-            reason = status_reason
-        elif status_summary == "temporarily_not_speaking":
-            summary = "temporarily_not_speaking"
-            reason = status_reason
-        elif bool(state.get("warmup_hosting_candidate")):
-            summary = "waiting_for_activity"
-            reason = "solo_stream_warmup"
-        elif bool(state.get("idle_hosting_candidate")):
-            summary = "waiting_for_activity"
-            reason = "idle_hosting_candidate"
-        elif state_name in {"warmup", "quiet", "idle"}:
-            summary = "waiting_for_activity"
-            reason = state_reason or state_name
-        elif latest_status == "pushed":
-            summary = "recently_spoke"
-            reason = "recent_output"
-        elif latest_status == "skipped":
-            summary = "recently_skipped"
-            reason = "recently_skipped"
-        elif latest_status == "failed":
-            summary = "failed"
-            reason = "failed"
-        elif latest_status == "dry_run":
-            summary = "test_only"
-            reason = latest_reason or "dispatcher.dry_run"
-
-        return {
-            "summary": summary,
-            "reason": reason,
-            "live_status_summary": status_summary,
-            "live_status_reason": status_reason,
-            "live_state": state_name,
-            "live_state_reason": state_reason,
-            "cooldown_remaining": round(float(status.get("cooldown_remaining") or 0.0), 1),
-            "warmup_hosting_candidate": bool(state.get("warmup_hosting_candidate")),
-            "idle_hosting_candidate": bool(state.get("idle_hosting_candidate")),
-            "last_result_status": latest_status,
-            "last_result_reason": latest_reason,
-            "last_result_source": latest_source,
-            "last_result_age_sec": latest_age,
-            "last_result_latency_ms": latest_latency,
-        }
+        return live_status_rules.speech_explanation(
+            live_status=status,
+            live_state=state,
+            latest_result=self.recent_results[-1] if self.recent_results else None,
+            iso_age_fn=self._iso_age_sec,
+        )
 
     def recent_interaction_context(self, *, limit: int = 3) -> list[str]:
         lines: list[str] = []
@@ -2040,43 +1097,11 @@ class RoastRuntime:
 
     @staticmethod
     def _spent_output_text(result: dict[str, Any]) -> str:
-        if str(result.get("status") or "") != "pushed":
-            return ""
-        output = str(result.get("output") or "").strip()
-        if not output:
-            return ""
-        synthetic_prefixes = (
-            "queued_to_neko(",
-            "dry_run(",
-            "skipped_to_neko(",
-            "instructions_queued(",
-            "instructions_restored(",
-            "developer_instructions_queued(",
-            "developer_instructions_restored(",
-            "developer_mode_announced(",
-        )
-        if output.startswith(synthetic_prefixes):
-            return ""
-        return output
+        return recent_context.spent_output_text(result)
 
     @staticmethod
     def _spent_output_families(output: str) -> list[str]:
-        normalized = _normalize_spent_output_family_text(output)
-        if not normalized:
-            return []
-        ascii_words = _spent_output_ascii_words(output)
-        families: list[str] = []
-        for family, tokens in _SPENT_OUTPUT_FAMILY_TOKENS:
-            if any(
-                _spent_output_family_token_matches(
-                    normalized_output=normalized,
-                    ascii_words=ascii_words,
-                    token=token,
-                )
-                for token in tokens
-            ):
-                families.append(family)
-        return families
+        return recent_context.spent_output_families(output)
 
     def _recent_spent_output_families(self, *, limit: int = 12) -> set[str]:
         families: set[str] = set()
@@ -2099,165 +1124,39 @@ class RoastRuntime:
 
     @staticmethod
     def _compact_context_text(value: str, *, limit: int = 80) -> str:
-        text = " ".join(str(value).split())
-        if len(text) <= limit:
-            return text
-        return text[: max(0, limit - 3)].rstrip() + "..."
+        return recent_context.compact_context_text(value, limit=limit)
 
     @staticmethod
     def _route_from_result(result: dict[str, Any]) -> str:
-        response_module = str(result.get("response_module") or "")
-        if response_module:
-            return response_module
-        event = result.get("event") if isinstance(result.get("event"), dict) else {}
-        source = str(event.get("source") or "")
-        event_type = str(event.get("event_type") or "").strip().lower()
-        signal_route = RoastRuntime._signal_route_for_event_type(event_type)
-        if signal_route:
-            return signal_route
-        if source in {"idle_hosting", "active_engagement", "warmup_hosting"}:
-            return source
-        steps = result.get("steps") if isinstance(result.get("steps"), list) else []
-        for step in reversed(steps):
-            if not isinstance(step, dict):
-                continue
-            step_id = str(step.get("id") or "")
-            if step_id in {
-                "danmaku_response",
-                "avatar_roast",
-                "idle_hosting",
-                "active_engagement",
-                "warmup_hosting",
-                "gift_signal",
-                "super_chat_signal",
-            }:
-                return step_id
-        return source or "unknown"
+        return recent_context.route_from_result(result)
 
     @staticmethod
     def _signal_route_for_event_type(event_type: str) -> str:
-        normalized = str(event_type or "").strip().lower()
-        if normalized in {"gift", "guard"}:
-            return "gift_signal"
-        if normalized in {"super_chat", "sc"}:
-            return "super_chat_signal"
-        return ""
+        return recent_context.signal_route_for_event_type(event_type)
 
     @staticmethod
     def _event_signal_from_result(result: dict[str, Any]) -> str:
-        event = result.get("event") if isinstance(result.get("event"), dict) else {}
-        source = str(event.get("source") or "")
-        if source != "live_danmaku":
-            return source or "unknown"
-        event_type = str(event.get("event_type") or "").strip().lower()
-        if event_type in {"gift", "guard"}:
-            return "gift_signal"
-        if event_type in {"super_chat", "sc"}:
-            return "super_chat_signal"
-        text = str(event.get("danmaku_text") or "").strip().lower()
-        if any(token in text for token in ("粉丝团灯牌", "赠送", "送出", "礼物", "gift")):
-            return "gift_signal"
-        if any(token in text for token in ("super chat", "superchat", "醒目留言", "sc")):
-            return "super_chat_signal"
-        return "danmaku_signal"
+        return recent_context.event_signal_from_result(result)
 
     def _recent_live_danmaku_output_age_sec(self) -> float | None:
-        for result in reversed(self.recent_results):
-            if not isinstance(result, dict):
-                continue
-            if str(result.get("status") or "") not in {"pushed", "dry_run"}:
-                continue
-            event = result.get("event") if isinstance(result.get("event"), dict) else {}
-            if str(event.get("source") or "") != "live_danmaku":
-                continue
-            route = self._route_from_result(result)
-            if route not in {"avatar_roast", "danmaku_response", "live_danmaku"}:
-                continue
-            age = self._iso_age_sec(result.get("created_at"))
-            if age is not None:
-                return float(age)
-        return None
+        return live_status_rules.recent_live_danmaku_output_age_sec(self.recent_results, self._iso_age_sec)
 
     def _last_viewer_activity_age_sec(self, rows: list[dict[str, Any]]) -> float | None:
-        ages: list[float] = []
-        for row in rows:
-            if not isinstance(row, dict):
-                continue
-            if row.get("id") not in {"live_ingest", "event_bus", "selection"}:
-                continue
-            outcome = str(row.get("last_outcome") or "").strip()
-            if outcome not in {"danmaku", "live_danmaku"}:
-                continue
-            age = row.get("age_sec")
-            if age is None:
-                continue
-            try:
-                ages.append(float(age))
-            except (TypeError, ValueError):
-                continue
-        recent_age = self._recent_live_danmaku_event_age_sec()
-        if recent_age is not None:
-            ages.append(float(recent_age))
-        return min(ages) if ages else None
+        return live_status_rules.last_viewer_activity_age_sec(rows, self.recent_results, self._iso_age_sec)
 
     def _last_output_age_sec(self, rows: list[dict[str, Any]]) -> float | None:
-        ages: list[float] = []
-        for row in rows:
-            if not isinstance(row, dict):
-                continue
-            if row.get("id") not in {"pipeline", "dispatcher"}:
-                continue
-            age = row.get("age_sec")
-            if age is None:
-                continue
-            try:
-                ages.append(float(age))
-            except (TypeError, ValueError):
-                continue
-        for result in reversed(self.recent_results):
-            if not isinstance(result, dict):
-                continue
-            if str(result.get("status") or "") not in {"pushed", "dry_run"}:
-                continue
-            age = self._iso_age_sec(result.get("created_at"))
-            if age is not None:
-                ages.append(float(age))
-                break
-        return min(ages) if ages else None
+        return live_status_rules.last_output_age_sec(rows, self.recent_results, self._iso_age_sec)
 
     def _recent_live_danmaku_event_age_sec(self) -> float | None:
-        for result in reversed(self.recent_results):
-            if not isinstance(result, dict):
-                continue
-            event = result.get("event") if isinstance(result.get("event"), dict) else {}
-            if str(event.get("source") or "") != "live_danmaku":
-                continue
-            age = self._iso_age_sec(result.get("created_at"))
-            if age is not None:
-                return float(age)
-        return None
+        return live_status_rules.recent_live_danmaku_event_age_sec(self.recent_results, self._iso_age_sec)
 
     @staticmethod
     def _age_sec(timestamp: Any) -> float | None:
-        try:
-            value = float(timestamp)
-        except (TypeError, ValueError):
-            return None
-        if value <= 0:
-            return None
-        return round(max(0.0, time.time() - value), 1)
+        return live_status_rules.age_sec(timestamp)
 
     @staticmethod
     def _iso_age_sec(value: Any) -> float | None:
-        if not value:
-            return None
-        try:
-            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        except ValueError:
-            return None
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return round(max(0.0, (datetime.now(timezone.utc) - parsed).total_seconds()), 1)
+        return live_status_rules.iso_age_sec(value)
 
     @staticmethod
     def _status_from_outcome(outcome: str) -> str:

--- a/plugin/plugins/neko_roast/modules/_prompt_context.py
+++ b/plugin/plugins/neko_roast/modules/_prompt_context.py
@@ -6,12 +6,59 @@ from typing import Any
 
 
 SHORT_REPLY_CONTRACT = "Hard length limit: one sentence, no paragraph, at most 14 Chinese characters or 8 English words."
+HOST_REPLY_CONTRACT = (
+    "Default host length: one compact sentence; occasional two short sentences are allowed for a fun host beat."
+)
 RECENT_CONTEXT_DEFAULT_LIMIT = 12
 RECENT_CONTEXT_LINE_LIMIT = 56
 VIEWER_CONTEXT_LINE_LIMIT = 44
 NEKO_ALREADY_SAID_MARKER = " / NEKO already said: "
 REPLY_PATH_MARKER = " / reply: "
 SPENT_OUTPUT_FAMILY_MARKER = " / spent_output_family="
+
+
+def live_output_quality_rules(*, kind: str = "reply") -> list[str]:
+    shared = [
+        "If the draft needs hidden context, expert knowledge, or a guessed viewer intention, replace it with a simpler surface reaction.",
+        "Do not invent a dilemma, punishment, report, trial, labor-camp, public-shaming, or real-person moral judgment.",
+        "Forbidden words: \u516c\u5f00\u793a\u4f17, \u52b3\u6539, \u5ba1\u5224, \u5904\u5211, \u60e9\u7f5a.",
+        "Do not force a technical, game-specific, guide, tutorial, or news title into a fake expert question.",
+        "If the topic is unfamiliar, mention only the visible surface anchor and make one small NEKO reaction.",
+        "Never output an unfinished choice; do not end with \u8fd8\u662f, \u6216\u8005, or or.",
+        "Avoid unclear abstract choices; each option must be ordinary, complete, and immediately understandable.",
+    ]
+    if kind == "host":
+        return [
+            *shared,
+            "For host beats, prefer a safe room observation over a clever but unclear question.",
+            "If the host hook feels strained, output one tiny stance instead of asking viewers to choose.",
+        ]
+    return [
+        *shared,
+        "For danmaku replies, answer the current danmaku before adding any joke.",
+        "If the danmaku itself is unclear, say one tiny reaction instead of inventing its meaning.",
+    ]
+
+
+def sustained_charm_rules(*, kind: str = "reply") -> list[str]:
+    shared = [
+        "Keep NEKO's presence cumulative: each line should feel like the same live cat host, not a reset template.",
+        "Use tiny recurring motifs sparingly, such as paw, tail, nest, desk, room weather, stamp, patrol, or password.",
+        "Switch motif when recent material already used the same tiny scene, object, or callback shape.",
+        "Prefer a fresh micro-scene over abstract hosting language.",
+    ]
+    if kind == "host":
+        return [
+            *shared,
+            "For host beats, make it feel like one bead in a tiny live column: room image, verdict, patrol, weather, password, or challenge.",
+            "Do not announce the column name; let the format show through the line.",
+            "After a callback-style host beat, leave space for viewer answers instead of adding a second prompt.",
+        ]
+    return [
+        *shared,
+        "If the current danmaku clearly answers a recent tiny hook, acknowledge the answer first without repeating the old prompt.",
+        "Carry only a tiny emotional echo from recent host material; do not continue old wording or topic by default.",
+    ]
 
 
 def _compact_context_line(value: Any, *, limit: int) -> str:
@@ -62,24 +109,30 @@ def _compact_plain(text: str, *, limit: int) -> str:
 
 def short_reply_rules(*, kind: str = "reply") -> list[str]:
     shared = [
-        SHORT_REPLY_CONTRACT,
-        "One breath only: no more than 20 Chinese chars or 10 English words when the idea still works.",
+        "The line must be complete; never end mid-word, mid-clause, or with an unfinished choice.",
         "Prefer a compact live punchline over explanation, setup, or follow-up commentary.",
         "Do not turn a reply into a host script, segment intro, plan, or audience survey.",
-        "Do not chain multiple clauses with commas; if the draft has a comma, cut one side.",
+        "Avoid comma chains; if the draft has too many clauses, cut the weakest side.",
         "Avoid phrases like special plan, everyone look, next let's, what should we talk about, or tell me what you want.",
-        "Avoid repeated presence checks like anyone here, still here, 有人吗, 还在吗, or 在不在; use a concrete tiny beat instead.",
+        "Avoid repeated presence checks like anyone here, still here, \u6709\u4eba\u5417, \u8fd8\u5728\u5417, or \u5728\u4e0d\u5728; use a concrete tiny beat instead.",
+        "Avoid empty praise like interesting, has a vibe, has a joke, \u6709\u70b9\u610f\u601d, \u6709\u70b9\u4e1c\u897f, or \u5f88\u6709\u6897; make one tiny concrete judgment instead.",
+        "Do not use \u55b5 as the whole punchline or default ending; the line must still have a real live-room point.",
     ]
     if kind == "host":
         return [
+            HOST_REPLY_CONTRACT,
             *shared,
-            "If the room is quiet, keep the line even smaller.",
-            "One small host beat only; if asking, ask one concrete low-pressure question.",
-            "If recent context was longer than this host beat, shrink the line instead of matching it.",
-            "No explanation, no setup, no second sentence, no extra follow-up after the concrete hook.",
+            "Usually keep the host beat within 36 Chinese chars; a rare flavorful beat may reach about 60.",
+            "If the room is quiet, keep the line smaller unless the material itself is especially fun.",
+            "One host beat only; if asking, ask one concrete low-pressure question.",
+            "If recent context was longer than this host beat, do not match its length by default.",
+            "No explanation, no setup, no extra follow-up after the concrete hook.",
         ]
     return [
+        SHORT_REPLY_CONTRACT,
+        "One breath only: no more than 20 Chinese chars or 10 English words when the idea still works.",
         *shared,
+        "Do not chain multiple clauses with commas; if the draft has a comma, cut one side.",
         "If the viewer's danmaku is short, answer even shorter.",
         "For one-word or very short danmaku, answer with a tiny reaction.",
         "If recent context was longer than the current danmaku, shrink the reply instead of matching it.",

--- a/plugin/plugins/neko_roast/modules/active_engagement/__init__.py
+++ b/plugin/plugins/neko_roast/modules/active_engagement/__init__.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from ...core.contracts import InteractionRequest, ViewerEvent, ViewerIdentity, ViewerProfile
 from .._base import BaseModule
-from .._prompt_context import anti_repeat_rules, recent_context_block, short_reply_rules
+from .._prompt_context import (
+    anti_repeat_rules,
+    live_output_quality_rules,
+    recent_context_block,
+    short_reply_rules,
+    sustained_charm_rules,
+)
 
 
 class ActiveEngagementModule(BaseModule):
@@ -57,14 +63,20 @@ class ActiveEngagementModule(BaseModule):
             "NEKO is the only host on stage in solo_stream.",
             "Create exactly one small live-room engagement beat as NEKO.",
             "Make it specific enough that a viewer can naturally reply, without begging for comments.",
+            "Start from a clear anchor: mention the concrete thing NEKO noticed before asking anything.",
             "Use the topic material as raw material only; transform it into NEKO's own live-room line.",
+            "If the topic is technical, game-specific, or unfamiliar, do not pretend expertise; make a light surface reaction instead.",
             "If a NEKO live column is provided, use it as the tiny engagement format without announcing a formal segment.",
             "Follow the requested topic shape when present: either_or, light_stance, tiny_tease, or small_challenge.",
             "Every active engagement line must give viewers one concrete reply handle.",
             "Use the provided viewer reply path as the only reply handle; do not add a second question.",
             "Use the provided fun axis as the line's purpose; do not drift into generic hosting.",
             "The reply handle must be an A/B choice, one-word answer, tiny stance, or playful yes/no-with-a-side.",
+            "Only use A/B when both sides are obvious, ordinary, and complete; otherwise make one tiny stance instead.",
             "Prefer one tiny observation over a plan, segment, or open-ended topic survey.",
+            "The final line must be a complete sentence; never end with an unfinished word or dangling 'or'.",
+            "Do not use punishment, public-shaming, trial, labor-camp, or real-person judgment language.",
+            "Do not say \u516c\u5f00\u793a\u4f17, \u52b3\u6539, \u5ba1\u5224, \u5904\u5211, or \u60e9\u7f5a.",
             "Do not use generic host slogans like 'everyone interact' or 'say something in chat'.",
             "Never address the whole room with broad audience-bait openings like everyone, anyone, chat, 大家, or 你们.",
             "Do not use generic Chinese host lines equivalent to 'everyone interact', 'start sending danmaku', or 'come chat'.",
@@ -76,6 +88,8 @@ class ActiveEngagementModule(BaseModule):
             "Do not mention silence, metrics, cooldowns, queues, dry_run, or system state.",
             "Do not pretend a viewer sent a message.",
             "Do not invent or hard-code streamer relationship labels; use profile memory if available, otherwise avoid naming the streamer.",
+            *live_output_quality_rules(kind="host"),
+            *sustained_charm_rules(kind="host"),
             "Keep one short TTS-friendly line.",
             *anti_repeat_rules(kind="host"),
             *short_reply_rules(kind="host"),
@@ -140,7 +154,7 @@ class ActiveEngagementModule(BaseModule):
     @staticmethod
     def _shape_task_text(shape: str) -> str:
         return {
-            "either_or": "turn the title into one A/B choice; make both options concrete and avoid yes/no questions.",
+            "either_or": "turn the title into one A/B choice only if both options are obvious and ordinary; otherwise use a tiny stance.",
             "light_stance": "give one small NEKO-flavored stance that viewers can agree or disagree with quickly.",
             "tiny_tease": "make one tiny playful tease about the topic without attacking viewers or sounding hostile.",
             "small_challenge": "offer one tiny low-pressure challenge that viewers can answer in a few words.",

--- a/plugin/plugins/neko_roast/modules/avatar_roast/__init__.py
+++ b/plugin/plugins/neko_roast/modules/avatar_roast/__init__.py
@@ -6,7 +6,14 @@ from typing import Any
 
 from ...core.contracts import InteractionRequest, ViewerEvent, ViewerIdentity, ViewerProfile
 from .._base import BaseModule
-from .._prompt_context import anti_repeat_rules, recent_context_block, short_reply_rules, viewer_session_context_block
+from .._prompt_context import (
+    anti_repeat_rules,
+    live_output_quality_rules,
+    recent_context_block,
+    short_reply_rules,
+    sustained_charm_rules,
+    viewer_session_context_block,
+)
 
 
 class AvatarRoastModule(BaseModule):
@@ -103,12 +110,17 @@ class AvatarRoastModule(BaseModule):
             "Use the host beat reply_affordance as the only reply hook; do not add a second question.",
             "Use the host beat fun_axis as the line's purpose; do not drift into generic hosting.",
             "Make it feel like a spontaneous host beat, with a little NEKO personality and no formal opening.",
+            "The final line must be a complete sentence; never end with an unfinished word or dangling choice.",
+            "Do not use punishment, public-shaming, trial, labor-camp, or real-person judgment language.",
+            "Do not say \u516c\u5f00\u793a\u4f17, \u52b3\u6539, \u5ba1\u5224, \u5904\u5211, or \u60e9\u7f5a.",
             "Do not pretend a viewer sent a message.",
             "Do not announce that nobody is talking or that the room is silent.",
             "Do not use generic welcome slogans, direct interaction requests, or attendance-check lines.",
             "Do not mention viewer absence, silence metrics, queues, timing controls, dry_run, or system state.",
             "Do not invent or hard-code streamer relationship labels; use profile memory if available, otherwise avoid naming the streamer.",
             "Keep it natural, low-pressure, and specific enough to avoid template-hosting.",
+            *live_output_quality_rules(kind="host"),
+            *sustained_charm_rules(kind="host"),
             *anti_repeat_rules(kind="host"),
             *short_reply_rules(kind="host"),
             "Output only the line NEKO should say.",
@@ -208,6 +220,8 @@ class AvatarRoastModule(BaseModule):
             "Current danmaku wins over any previous reply.",
             "Do not invent or hard-code streamer relationship labels; use profile memory if available, otherwise avoid naming the streamer.",
             f"Tone: {strength_hint}. Pacing: {pace}",
+            *live_output_quality_rules(),
+            *sustained_charm_rules(),
             "Output only NEKO's one-line first-appearance roast. No explanation, no prefix, no suffix, no rule recap.",
         ]
         return (

--- a/plugin/plugins/neko_roast/modules/danmaku_response/__init__.py
+++ b/plugin/plugins/neko_roast/modules/danmaku_response/__init__.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+import re
+
 from ...core import active_topic_rules
 from ...core.contracts import InteractionRequest, ViewerEvent, ViewerIdentity, ViewerProfile
-from .._prompt_context import anti_repeat_rules, recent_context_block, short_reply_rules, viewer_session_context_block
+from .._prompt_context import (
+    anti_repeat_rules,
+    live_output_quality_rules,
+    recent_context_block,
+    short_reply_rules,
+    sustained_charm_rules,
+    viewer_session_context_block,
+)
 from .._base import BaseModule
 
 
@@ -49,6 +58,7 @@ class DanmakuResponseModule(BaseModule):
         nickname = identity.nickname or identity.uid or "this viewer"
         danmaku = (event.danmaku_text or "").strip()
         danmaku_profile = DanmakuResponseModule._danmaku_profile(danmaku)
+        anchor_hint = DanmakuResponseModule._anchor_hint(danmaku)
         mode_contract = DanmakuResponseModule._mode_contract(event.live_mode)
         strength_hint = {
             "gentle": "soft, warm, and companionable",
@@ -64,10 +74,14 @@ class DanmakuResponseModule(BaseModule):
             "Only continue an old thread if the current danmaku explicitly continues that exact thread.",
             "Do not answer @other-viewer messages as a call to NEKO unless NEKO is the mentioned target.",
             "Do not repeat first-appearance, avatar, ID, or entrance-roast templates.",
-            "Only mention avatar or nickname if the current danmaku itself makes that relevant.",
+            "Make the target legible: keep one visible anchor from the current danmaku, such as the viewer nickname, a 2-6 character quote, or a concrete noun from the danmaku.",
+            "Do not make every reply start with the nickname; use the nickname only when the line would otherwise be ambiguous.",
+            "Only mention avatar if the current danmaku itself makes that relevant.",
             "Do not invent or hard-code streamer relationship labels; use profile memory if available, otherwise avoid naming the streamer.",
             "Do not launch a new show segment, special plan, topic poll, reward bit, or audience-suggestion prompt.",
             "Keep one short TTS-friendly line.",
+            *live_output_quality_rules(),
+            *sustained_charm_rules(),
             *DanmakuResponseModule._profile_rules(danmaku_profile["kind"]),
             *anti_repeat_rules(),
             *short_reply_rules(),
@@ -83,6 +97,7 @@ class DanmakuResponseModule(BaseModule):
             f"danmaku_profile: {danmaku_profile['kind']}\n"
             f"reply_target: {danmaku_profile['reply_target']}\n"
             f"reply_shape: {danmaku_profile['reply_shape']}\n"
+            f"anchor_hint: {anchor_hint or '(none)'}\n"
             f"mode_contract: {mode_contract}\n"
             f"tone: {strength_hint}\n\n"
             + recent_context
@@ -154,7 +169,23 @@ class DanmakuResponseModule(BaseModule):
             "danmaku_profile": profile["kind"],
             "danmaku_reply_target": profile["reply_target"],
             "danmaku_reply_shape": profile["reply_shape"],
+            "danmaku_anchor_hint": DanmakuResponseModule._anchor_hint(event.danmaku_text or ""),
         }
+
+    @staticmethod
+    def _anchor_hint(danmaku: str) -> str:
+        text = str(danmaku or "").strip()
+        first_clause = re.split(r"[\s，,。.!！?？、；;：:]+", text, maxsplit=1)[0] if text else ""
+        dense = DanmakuResponseModule._dense_text(first_clause or text)
+        if not dense or active_topic_rules._is_reaction_only(dense):
+            return ""
+        if len(dense) <= 6:
+            return dense
+        for start in range(0, min(len(dense), 10), 2):
+            candidate = dense[start : start + 6]
+            if len(candidate) >= 2 and not active_topic_rules._is_reaction_only(candidate):
+                return candidate
+        return dense[:6]
 
     @staticmethod
     def _profile_rules(kind: str) -> list[str]:

--- a/plugin/plugins/neko_roast/modules/warmup_hosting/__init__.py
+++ b/plugin/plugins/neko_roast/modules/warmup_hosting/__init__.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from ...core.contracts import InteractionRequest, ViewerEvent, ViewerIdentity, ViewerProfile
 from .._base import BaseModule
-from .._prompt_context import anti_repeat_rules, recent_context_block, short_reply_rules
+from .._prompt_context import (
+    anti_repeat_rules,
+    live_output_quality_rules,
+    recent_context_block,
+    short_reply_rules,
+    sustained_charm_rules,
+)
 
 
 class WarmupHostingModule(BaseModule):
@@ -51,6 +57,8 @@ class WarmupHostingModule(BaseModule):
             "Do not mention silence, metrics, cooldowns, queues, dry_run, or system state.",
             "Do not invent or hard-code streamer relationship labels; use profile memory if available, otherwise avoid naming the streamer.",
             "Keep it TTS-friendly and easy to continue from.",
+            *live_output_quality_rules(kind="host"),
+            *sustained_charm_rules(kind="host"),
             *anti_repeat_rules(kind="host"),
             *short_reply_rules(kind="host"),
             "Output only NEKO's line.",

--- a/plugin/plugins/neko_roast/tests/test_active_topic_selector.py
+++ b/plugin/plugins/neko_roast/tests/test_active_topic_selector.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+import pytest
+
+from plugin.plugins.neko_roast.core.active_topic_selector import ActiveTopicSelector
+
+
+class FakeRuntime:
+    _ACTIVE_ENGAGEMENT_RECENT_DANMAKU_TOPIC_MAX_AGE_SECONDS = 360.0
+
+    def __init__(self) -> None:
+        self.recent_results: deque[dict[str, Any]] = deque()
+        self._recent_host_material_families: deque[str] = deque(maxlen=12)
+        self._active_engagement_topic_fetcher = self._empty_topic_fetcher
+        self._active_engagement_topic_cache: list[dict[str, Any]] = []
+        self._active_engagement_topic_cache_at = 0.0
+        self._active_engagement_recent_topic_keys: deque[str] = deque(maxlen=12)
+        self._active_engagement_recent_topic_titles: deque[str] = deque(maxlen=8)
+        self._active_engagement_recent_topic_sources: deque[str] = deque(maxlen=6)
+        self._active_engagement_recent_fun_axes: deque[str] = deque(maxlen=6)
+        self._active_engagement_recent_shapes: deque[str] = deque(maxlen=6)
+        self._active_engagement_recent_intents: deque[str] = deque(maxlen=6)
+        self._active_engagement_recent_reply_affordances: deque[str] = deque(maxlen=6)
+        self._active_engagement_recent_topic_skip_reason = ""
+        self._active_engagement_shape_guard_reason = ""
+        self._active_engagement_shape_index = 0
+
+    def _recent_spent_output_families(self) -> set[str]:
+        return set()
+
+    @staticmethod
+    def _compact_context_text(value: str, *, limit: int = 80) -> str:
+        text = " ".join(str(value).split())
+        return text if len(text) <= limit else text[: limit - 3].rstrip() + "..."
+
+    @staticmethod
+    def _route_from_result(result: dict[str, Any]) -> str:
+        return str(result.get("response_module") or "")
+
+    @staticmethod
+    def _iso_age_sec(_value: Any) -> float | None:
+        return 0.0
+
+    @staticmethod
+    def _active_engagement_fallback_topic_candidates() -> list[dict[str, Any]]:
+        return [
+            {
+                "source": "fallback",
+                "key": "custom:desk-choice",
+                "title": "desk choice",
+                "preferred_shape": "either_or",
+                "fun_axis": "choice",
+                "live_column": "NEKO micro poll",
+                "reply_affordance": "viewer can pick one concrete side",
+                "hint": "Make one tiny A/B choice.",
+            }
+        ]
+
+    @staticmethod
+    async def _empty_topic_fetcher(limit: int = 6) -> dict[str, Any]:
+        return {"success": True, "videos": []}
+
+
+@pytest.mark.asyncio
+async def test_active_topic_selector_uses_runtime_fallback_and_records_rotation_state():
+    runtime = FakeRuntime()
+    selector = ActiveTopicSelector(runtime)
+
+    topic = await selector.select_topic()
+
+    assert topic["key"] == "custom:desk-choice"
+    assert topic["shape"] == "either_or"
+    assert topic["reply_affordance"] == "viewer can pick one concrete side"
+    assert list(runtime._active_engagement_recent_topic_keys) == ["custom:desk-choice"]
+    assert list(runtime._active_engagement_recent_fun_axes) == ["choice"]
+
+
+def test_active_topic_selector_choose_candidate_avoids_recent_family():
+    runtime = FakeRuntime()
+    runtime._recent_host_material_families.append("choice_vote")
+    selector = ActiveTopicSelector(runtime)
+
+    candidate = selector.choose_candidate(
+        [
+            {
+                "key": "used-choice",
+                "title": "cat choice A or B",
+                "fun_axis": "choice",
+                "reply_affordance": "viewer can pick one concrete side",
+            },
+            {
+                "key": "fresh-object",
+                "title": "keyboard patrol",
+                "fun_axis": "object_scene",
+                "reply_affordance": "viewer can answer with one small object",
+            },
+        ],
+        avoid_recent_fun_axis=False,
+        avoid_recent_family=True,
+    )
+
+    assert candidate is not None
+    assert candidate["key"] == "fresh-object"
+    assert runtime._active_engagement_recent_topic_skip_reason == "recent_host_family"
+
+
+def test_active_topic_selector_topic_pack_classifies_reply_path():
+    assert ActiveTopicSelector.topic_pack({"live_column": "NEKO micro poll", "title": "cup or keyboard"}) == "micro_poll"
+    assert ActiveTopicSelector.topic_pack({"live_column": "room observation", "title": "keyboard patrol"}) == "room_observation"

--- a/plugin/plugins/neko_roast/tests/test_config_contracts.py
+++ b/plugin/plugins/neko_roast/tests/test_config_contracts.py
@@ -5,6 +5,7 @@ import pytest
 
 from plugin.plugins.neko_roast.adapters.bili_auth_service import BiliAuthService
 from plugin.plugins.neko_roast.adapters.neko_dispatcher import NekoDispatcher
+from plugin.plugins.neko_roast.core import active_topic_rules
 from plugin.plugins.neko_roast.core.contracts import (
     InteractionRequest,
     InteractionResult,
@@ -67,6 +68,31 @@ def test_danmaku_response_prompt_is_not_avatar_roast_template():
     assert "Do not repeat first-appearance" in request.prompt_text
     assert "avatar" in request.prompt_text
     assert "only host on stage" in request.prompt_text
+
+
+def test_danmaku_response_prompt_requires_visible_target_anchor():
+    module = DanmakuResponseModule()
+    module.ctx = SimpleNamespace(config=RoastConfig(roast_strength="normal", dry_run=True))
+    event = ViewerEvent(
+        uid="42",
+        nickname="方块km",
+        danmaku_text="别怀疑啦，就是你想的那样",
+        source="live_danmaku",
+        live_mode="solo_stream",
+    )
+
+    request = module.build_request(
+        event,
+        ViewerIdentity(uid="42", nickname="方块km"),
+        ViewerProfile(uid="42", nickname="方块km", roast_count=1),
+    )
+
+    assert "Make the target legible" in request.prompt_text
+    assert "viewer nickname, a 2-6 character quote, or a concrete noun" in request.prompt_text
+    assert "anchor_hint: 别怀疑啦" in request.prompt_text
+    assert request.metadata["danmaku_anchor_hint"] == "别怀疑啦"
+    assert "Do not make every reply start with the nickname" in request.prompt_text
+    assert "Only mention avatar if the current danmaku itself makes that relevant." in request.prompt_text
 
 
 def test_danmaku_response_prompt_profiles_tiny_reactions():
@@ -374,6 +400,7 @@ def test_live_interaction_prompts_share_short_reply_contract():
     identity = ViewerIdentity(uid="42", nickname="viewer")
     profile = ViewerProfile(uid="42", nickname="viewer", roast_count=1)
     short_contract = "Hard length limit: one sentence, no paragraph, at most 14 Chinese characters or 8 English words."
+    host_contract = "Default host length: one compact sentence; occasional two short sentences are allowed for a fun host beat."
 
     danmaku = DanmakuResponseModule()
     danmaku.ctx = SimpleNamespace(config=RoastConfig(roast_strength="normal", dry_run=True))
@@ -413,24 +440,44 @@ def test_live_interaction_prompts_share_short_reply_contract():
     )
 
     common_rules = [
-        short_contract,
-        "One breath only: no more than 20 Chinese chars or 10 English words when the idea still works.",
         "Prefer a compact live punchline over explanation, setup, or follow-up commentary.",
         "Do not turn a reply into a host script, segment intro, plan, or audience survey.",
-        "Do not chain multiple clauses with commas",
+        "Avoid comma chains; if the draft has too many clauses, cut the weakest side.",
         "Avoid repeated presence checks like anyone here, still here, 有人吗, 还在吗, or 在不在",
+        "Avoid empty praise like interesting, has a vibe, has a joke, 有点意思, 有点东西, or 很有梗",
+        "Do not use 喵 as the whole punchline or default ending",
+        "If the draft needs hidden context, expert knowledge, or a guessed viewer intention",
+        "Do not invent a dilemma, punishment, report, trial, labor-camp, public-shaming",
+        "Forbidden words: 公开示众, 劳改, 审判, 处刑, 惩罚.",
+        "Do not force a technical, game-specific, guide, tutorial, or news title into a fake expert question.",
+        "Never output an unfinished choice; do not end with 还是, 或者, or or.",
+        "Avoid unclear abstract choices; each option must be ordinary, complete, and immediately understandable.",
+        "Keep NEKO's presence cumulative: each line should feel like the same live cat host, not a reset template.",
+        "Use tiny recurring motifs sparingly, such as paw, tail, nest, desk, room weather, stamp, patrol, or password.",
+        "Switch motif when recent material already used the same tiny scene, object, or callback shape.",
+        "Prefer a fresh micro-scene over abstract hosting language.",
     ]
     reply_rules = [
+        short_contract,
+        "One breath only: no more than 20 Chinese chars or 10 English words when the idea still works.",
+        "Do not chain multiple clauses with commas; if the draft has a comma, cut one side.",
         "If the viewer's danmaku is short, answer even shorter.",
         "For one-word or very short danmaku, answer with a tiny reaction.",
         "If recent context was longer than the current danmaku, shrink the reply instead of matching it.",
         "No explanation, no setup, no second sentence, no follow-up question unless the current danmaku asks one.",
+        "If the current danmaku clearly answers a recent tiny hook, acknowledge the answer first without repeating the old prompt.",
+        "Carry only a tiny emotional echo from recent host material; do not continue old wording or topic by default.",
     ]
     host_rules = [
-        "If the room is quiet, keep the line even smaller.",
-        "One small host beat only; if asking, ask one concrete low-pressure question.",
-        "If recent context was longer than this host beat, shrink the line instead of matching it.",
-        "No explanation, no setup, no second sentence, no extra follow-up after the concrete hook.",
+        host_contract,
+        "Usually keep the host beat within 36 Chinese chars; a rare flavorful beat may reach about 60.",
+        "If the room is quiet, keep the line smaller unless the material itself is especially fun.",
+        "One host beat only; if asking, ask one concrete low-pressure question.",
+        "If recent context was longer than this host beat, do not match its length by default.",
+        "No explanation, no setup, no extra follow-up after the concrete hook.",
+        "For host beats, make it feel like one bead in a tiny live column: room image, verdict, patrol, weather, password, or challenge.",
+        "Do not announce the column name; let the format show through the line.",
+        "After a callback-style host beat, leave space for viewer answers instead of adding a second prompt.",
     ]
 
     for request in [danmaku_request, avatar_request, idle_request, warmup_request, active_request]:
@@ -440,11 +487,13 @@ def test_live_interaction_prompts_share_short_reply_contract():
     for request in [danmaku_request, avatar_request]:
         for rule in reply_rules:
             assert rule in request.prompt_text
-        assert "One small host beat only; if asking, ask one concrete low-pressure question." not in request.prompt_text
+        assert host_contract not in request.prompt_text
+        assert "One host beat only; if asking, ask one concrete low-pressure question." not in request.prompt_text
 
     for request in [idle_request, warmup_request, active_request]:
         for rule in host_rules:
             assert rule in request.prompt_text
+        assert short_contract not in request.prompt_text
         assert "If the viewer's danmaku is short, answer even shorter." not in request.prompt_text
         assert (
             "No explanation, no setup, no second sentence, no follow-up question unless the current danmaku asks one."
@@ -722,7 +771,9 @@ def test_active_engagement_prompt_turns_shape_into_concrete_task():
     assert "NEKO live column: NEKO micro poll" in request.prompt_text
     assert "topic pack: micro_poll" in request.prompt_text
     assert "viewer reply path: viewer can answer with one side" in request.prompt_text
-    assert "avoid yes/no questions" in request.prompt_text
+    assert "both options are obvious and ordinary" in request.prompt_text
+    assert "Start from a clear anchor" in request.prompt_text
+    assert "The final line must be a complete sentence" in request.prompt_text
 
 
 def test_active_engagement_prompt_blocks_broad_engagement_bait():
@@ -739,6 +790,39 @@ def test_active_engagement_prompt_blocks_broad_engagement_bait():
     assert "Do not ask viewers to choose the stream topic for NEKO" in request.prompt_text
     assert "Do not say get the chat moving" in request.prompt_text
     assert "Do not say 大家快来互动, 弹幕刷起来, 接下来我们, or 特别企划." in request.prompt_text
+
+
+def test_active_engagement_rejects_low_confidence_weird_topics():
+    assert not active_topic_rules._is_meaningful_active_topic_text("\u770b\u8fd9\u4e2a\u6838\u7535\u7ad9\u653b\u7565")
+    assert active_topic_rules._active_topic_filter_reason("\u770b\u8fd9\u4e2a\u6838\u7535\u7ad9\u653b\u7565") == "low_confidence_topic"
+    assert not active_topic_rules._is_meaningful_active_topic_text("\u6cf0\u62c9\u745e\u4e9a\u91cc\u9020\u7535\u8111")
+    assert not active_topic_rules._is_meaningful_active_topic_text("\u732b\u732b\u5047\u88c5\u4e13\u5bb6\u61c2\u5f88\u591a")
+    assert active_topic_rules._active_topic_filter_reason("\u732b\u732b\u5047\u88c5\u4e13\u5bb6\u61c2\u5f88\u591a") == "low_confidence_topic"
+    assert active_topic_rules._active_topic_material_profile("\u6cf0\u62c9\u745e\u4e9a\u91cc\u9020\u7535\u8111") == {}
+
+
+def test_live_material_filter_rejects_mojibake_and_judgment_language():
+    assert not active_topic_rules._is_clean_live_material(
+        {
+            "title": "鐚尗涓夌鍋囪鎳傚緢澶?",
+            "hint": "Make one tiny line.",
+            "reply_affordance": "viewer can reply",
+        }
+    )
+    assert not active_topic_rules._is_clean_live_material(
+        {
+            "title": "\u628a\u8fd9\u79cd\u4eba\u516c\u5f00\u793a\u4f17\u8fd8\u662f\u9001\u53bb\u52b3\u6539",
+            "hint": "Make one tiny line.",
+            "reply_affordance": "viewer can reply",
+        }
+    )
+    assert active_topic_rules._is_clean_live_material(
+        {
+            "title": "\u732b\u732b\u7ed9\u7a7a\u6c14\u76d6\u4e00\u679a\u5b89\u9759\u7ae0",
+            "hint": "Make one tiny mood-stamp line.",
+            "reply_affordance": "viewer can answer with one stamp word",
+        }
+    )
 
 
 def test_warmup_hosting_prompt_is_opening_not_idle_filler():
@@ -961,6 +1045,32 @@ async def test_dispatcher_marks_live_requests_with_short_reply_contract():
     assert plugin.metadata["live_reply_contract"] == "short_tts_line"
     assert plugin.metadata["max_reply_chars"] == 28
     assert plugin.metadata["response_module_hint"] == "avatar_roast"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_allows_longer_host_reply_contracts():
+    class Plugin:
+        def __init__(self):
+            self.metadata = None
+
+        def push_message(self, **kwargs):
+            self.metadata = kwargs["metadata"]
+
+    plugin = Plugin()
+    request = InteractionRequest(
+        event=ViewerEvent(uid="__neko_active__", nickname="NEKO", source="active_engagement", live_mode="solo_stream"),
+        identity=ViewerIdentity(uid="__neko_active__", nickname="NEKO"),
+        profile=ViewerProfile(uid="__neko_active__", nickname="NEKO"),
+        prompt_text="reply",
+        live_mode="solo_stream",
+        strength="normal",
+    )
+
+    await NekoDispatcher(plugin).push_roast(request)
+
+    assert plugin.metadata["live_reply_contract"] == "short_tts_line"
+    assert plugin.metadata["max_reply_chars"] == 72
+    assert plugin.metadata["response_module_hint"] == "active_engagement"
 
 
 @pytest.mark.asyncio

--- a/plugin/plugins/neko_roast/tests/test_live_hosting_director.py
+++ b/plugin/plugins/neko_roast/tests/test_live_hosting_director.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+from typing import Any
+
+from plugin.plugins.neko_roast.core.live_hosting_director import LiveHostingDirector
+
+
+class Audit:
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str]] = []
+
+    def record(self, event: str, message: str, **_kwargs: Any) -> None:
+        self.rows.append((event, message))
+
+
+class FakeRuntime:
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(live_mode="solo_stream")
+        self.audit = Audit()
+        self.recorded: list[dict[str, Any]] = []
+        self._idle_hosting_recent_beat_keys: deque[str] = deque(maxlen=10)
+        self._idle_hosting_recent_beat_axes: deque[str] = deque(maxlen=5)
+        self._idle_hosting_recent_beat_titles: deque[str] = deque(maxlen=10)
+        self._idle_hosting_recent_reply_affordances: deque[str] = deque(maxlen=5)
+        self._recent_host_material_families: deque[str] = deque(maxlen=12)
+        self._idle_hosting_beat_index = 0
+        self._beats = [
+            {
+                "key": "old-choice",
+                "title": "old choice",
+                "fun_axis": "choice",
+                "shape": "tiny_choice",
+                "reply_affordance": "viewer can pick one concrete side",
+            },
+            {
+                "key": "fresh-room",
+                "title": "keyboard patrol",
+                "fun_axis": "object_scene",
+                "shape": "light_tease",
+                "reply_affordance": "viewer can answer with one small object",
+            },
+        ]
+
+    def _idle_hosting_beat_candidates(self) -> list[dict[str, Any]]:
+        return list(self._beats)
+
+    @staticmethod
+    def _idle_hosting_preferred_stage() -> str:
+        return "column"
+
+    @staticmethod
+    def _idle_hosting_material_stage(material: dict[str, Any] | None) -> str:
+        return LiveHostingDirector.idle_hosting_material_stage(material)
+
+    @staticmethod
+    def _idle_hosting_stage_ordered_candidates(candidates: list[dict[str, Any]], _stage: str) -> list[dict[str, Any]]:
+        return candidates
+
+    @staticmethod
+    def _host_material_family(material: dict[str, Any] | None) -> str:
+        return "choice_vote" if material and "choice" in str(material.get("key") or "") else "object_scene"
+
+    @staticmethod
+    def _recent_spent_output_families() -> set[str]:
+        return set()
+
+    @staticmethod
+    def _is_similar_idle_hosting_beat_title(_title: str) -> bool:
+        return False
+
+    def record_result(self, result: Any) -> None:
+        self.recorded.append(result)
+
+
+def test_live_hosting_director_rotates_idle_beats_away_from_recent_family():
+    runtime = FakeRuntime()
+    runtime._recent_host_material_families.append("choice_vote")
+    director = LiveHostingDirector(runtime)
+
+    beat = director.next_idle_hosting_beat()
+
+    assert beat["key"] == "fresh-room"
+    assert beat["family"] == "object_scene"
+    assert beat["idle_stage"] == "column"
+    assert list(runtime._idle_hosting_recent_beat_keys) == ["fresh-room"]
+
+
+def test_live_hosting_director_records_idle_skip_through_runtime():
+    runtime = FakeRuntime()
+    director = LiveHostingDirector(runtime)
+    event = director.idle_hosting_event({"state": "idle"})
+
+    result = director.record_idle_hosting_skip(event, "idle_hosting.not_idle")
+
+    assert result.status == "skipped"
+    assert runtime.recorded[-1].reason == "idle_hosting.not_idle"
+    assert runtime.audit.rows[-1] == ("idle_hosting_skipped", "idle_hosting.not_idle")

--- a/plugin/plugins/neko_roast/tests/test_live_status.py
+++ b/plugin/plugins/neko_roast/tests/test_live_status.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from plugin.plugins.neko_roast.core import live_status
+from plugin.plugins.neko_roast.core.contracts import RoastConfig
+
+
+def test_live_status_summary_blocks_until_stream_is_connected_and_output_ready():
+    config = RoastConfig(live_room_id=42, live_enabled=True, live_mode="solo_stream", dry_run=False)
+
+    disconnected = live_status.live_status_summary(
+        config=config,
+        live_connection={"connected": False, "room_id": 42},
+        safety_status="running",
+        cooldown_remaining=0.0,
+        output_channel={"ready": True},
+    )
+    output_blocked = live_status.live_status_summary(
+        config=config,
+        live_connection={"connected": True, "room_id": 42},
+        safety_status="running",
+        cooldown_remaining=0.0,
+        output_channel={"ready": False, "reason": "output_channel_unavailable"},
+    )
+
+    assert disconnected["summary"] == "cannot_stream"
+    assert disconnected["reason"] == "live_ingest_disconnected"
+    assert output_blocked["summary"] == "cannot_stream"
+    assert output_blocked["reason"] == "output_channel_unavailable"
+
+
+def test_live_state_summary_marks_solo_warmup_before_first_viewer_activity():
+    config = RoastConfig(live_room_id=42, live_enabled=True, live_mode="solo_stream", dry_run=True)
+
+    state = live_status.live_state_summary(
+        config=config,
+        live_status={"summary": "test_only", "safety_status": "running", "cooldown_remaining": 0.0},
+        health_rows=[],
+        recent_results=[],
+        warmup_observed=False,
+        warmup_elapsed=10.0,
+        engaged_threshold=60.0,
+        idle_threshold=120.0,
+        warmup_timeout_seconds=45.0,
+    )
+
+    assert state["state"] == "warmup"
+    assert state["warmup_hosting_candidate"] is True
+    assert state["idle_hosting_candidate"] is False
+
+
+def test_active_engagement_status_defers_when_idle_hosting_is_approaching():
+    config = RoastConfig(live_room_id=42, live_enabled=True, live_mode="solo_stream", dry_run=False)
+
+    status = live_status.active_engagement_status(
+        config=config,
+        live_status={"summary": "ready_to_stream", "cooldown_remaining": 0.0},
+        live_state={"state": "quiet"},
+        now=100.0,
+        last_attempt_at=0.0,
+        min_interval_seconds=60.0,
+        recent_danmaku_output_age=None,
+        recent_danmaku_wait_seconds=45.0,
+        idle_hosting_wait_remaining=5.0,
+        idle_grace_seconds=15.0,
+        idle_takeover_streak=0,
+    )
+
+    assert status["candidate"] is True
+    assert status["eligible"] is False
+    assert status["reason"] == "approaching_idle_hosting"
+    assert status["cooldown_remaining"] == 5.0
+
+
+def test_live_director_status_routes_idle_takeover_to_active_engagement():
+    config = RoastConfig(live_room_id=42, live_enabled=True, live_mode="solo_stream", dry_run=False)
+
+    director = live_status.live_director_status(
+        config=config,
+        live_status={"summary": "ready_to_stream"},
+        live_state={"state": "idle", "mode": "solo_stream"},
+        idle_hosting_status={"eligible": True, "cooldown_remaining": 0.0, "min_interval_seconds": 90.0},
+        active_engagement_status={
+            "eligible": True,
+            "reason": "idle_hosting_streak",
+            "cooldown_remaining": 0.0,
+            "min_interval_seconds": 60.0,
+        },
+    )
+
+    assert director["next_auto_action"] == "active_engagement"
+    assert director["eligible"] is True
+    assert director["reason"] == "idle_hosting_streak"

--- a/plugin/plugins/neko_roast/tests/test_recent_context.py
+++ b/plugin/plugins/neko_roast/tests/test_recent_context.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from plugin.plugins.neko_roast.core import recent_context
+
+
+def test_spent_output_text_ignores_synthetic_dispatch_markers():
+    assert (
+        recent_context.spent_output_text(
+            {
+                "status": "pushed",
+                "output": "queued_to_neko(avatar_roast)",
+            }
+        )
+        == ""
+    )
+    assert recent_context.spent_output_text({"status": "dry_run", "output": "猫猫正在营业"}) == ""
+    assert recent_context.spent_output_text({"status": "pushed", "output": "猫猫正在营业"}) == "猫猫正在营业"
+
+
+def test_spent_output_families_detects_repeat_prone_hosting_patterns():
+    families = recent_context.spent_output_families("大家还在吗，给猫猫一点反应，顺便打个1")
+
+    assert "audience_prompt" in families
+    assert "short_callback" in recent_context.spent_output_families("用一个字给今晚打分")
+
+
+def test_route_from_result_prefers_explicit_response_module_then_steps():
+    assert recent_context.route_from_result({"response_module": "danmaku_response"}) == "danmaku_response"
+    assert (
+        recent_context.route_from_result(
+            {
+                "event": {"source": "live_danmaku"},
+                "steps": [
+                    {"id": "avatar_roast"},
+                    {"id": "danmaku_response"},
+                ],
+            }
+        )
+        == "danmaku_response"
+    )
+
+
+def test_live_event_signal_classifies_signal_only_events():
+    gift_result = {
+        "event": {
+            "source": "live_danmaku",
+            "event_type": "danmaku",
+            "danmaku_text": "感谢赠送礼物",
+        }
+    }
+    super_chat_result = {
+        "event": {
+            "source": "live_danmaku",
+            "event_type": "super_chat",
+            "danmaku_text": "醒目留言",
+        }
+    }
+
+    assert recent_context.signal_route_for_event_type("guard") == "gift_signal"
+    assert recent_context.event_signal_from_result(gift_result) == "gift_signal"
+    assert recent_context.event_signal_from_result(super_chat_result) == "super_chat_signal"

--- a/plugin/plugins/neko_roast/tests/test_runtime_live_controls.py
+++ b/plugin/plugins/neko_roast/tests/test_runtime_live_controls.py
@@ -2035,7 +2035,7 @@ async def test_active_engagement_ignores_non_output_danmaku_as_topic_material(ru
         return {
             "success": True,
             "videos": [
-                {"title": "neutral topic after skipped danmaku", "bvid": "BV_AFTER_SKIPPED"},
+                {"title": "room mood after skipped danmaku", "bvid": "BV_AFTER_SKIPPED"},
             ],
         }
 
@@ -2068,7 +2068,7 @@ async def test_active_engagement_labels_filtered_recent_danmaku_skip_reason(runt
         return {
             "success": True,
             "videos": [
-                {"title": "neutral topic after filtered danmaku", "bvid": "BV_AFTER_FILTERED"},
+                {"title": "room mood after filtered danmaku", "bvid": "BV_AFTER_FILTERED"},
             ],
         }
 
@@ -2100,7 +2100,7 @@ async def test_active_engagement_labels_reaction_topic_skip_reason(runtime: Roas
         return {
             "success": True,
             "videos": [
-                {"title": "neutral topic after reaction", "bvid": "BV_AFTER_REACTION"},
+                {"title": "room mood after reaction", "bvid": "BV_AFTER_REACTION"},
             ],
         }
 
@@ -2132,7 +2132,7 @@ async def test_active_engagement_labels_runtime_feedback_topic_skip_reason(runti
         return {
             "success": True,
             "videos": [
-                {"title": "neutral topic after runtime feedback", "bvid": "BV_AFTER_RUNTIME_FEEDBACK"},
+                {"title": "room mood after runtime feedback", "bvid": "BV_AFTER_RUNTIME_FEEDBACK"},
             ],
         }
 
@@ -2166,7 +2166,7 @@ async def test_active_engagement_does_not_label_non_danmaku_skips_as_danmaku_top
         return {
             "success": True,
             "videos": [
-                {"title": "neutral topic after skipped active beat", "bvid": "BV_AFTER_ACTIVE_SKIP"},
+                {"title": "room mood after skipped active beat", "bvid": "BV_AFTER_ACTIVE_SKIP"},
             ],
         }
 
@@ -2194,7 +2194,7 @@ async def test_active_engagement_ignores_tiny_recent_danmaku_as_topic_material(r
         return {
             "success": True,
             "videos": [
-                {"title": "useful trending fallback", "bvid": "BV_USEFUL"},
+                {"title": "useful desk snack choice", "bvid": "BV_USEFUL"},
             ],
         }
 
@@ -2211,7 +2211,7 @@ async def test_active_engagement_ignores_tiny_recent_danmaku_as_topic_material(r
     topic = await runtime._select_active_engagement_topic()
 
     assert topic["source"] == "bili_trending"
-    assert topic["title"] == "useful trending fallback"
+    assert topic["title"] == "useful desk snack choice"
 
 
 @pytest.mark.asyncio
@@ -3151,7 +3151,7 @@ async def test_active_engagement_ignores_tiny_trending_titles_as_topic_material(
             "success": True,
             "videos": [
                 {"title": "ok", "bvid": "BV_TINY"},
-                {"title": "useful concrete trending fallback", "bvid": "BV_USEFUL"},
+                {"title": "useful desk snack choice", "bvid": "BV_USEFUL"},
             ],
         }
 
@@ -3161,7 +3161,7 @@ async def test_active_engagement_ignores_tiny_trending_titles_as_topic_material(
 
     assert topic["source"] == "bili_trending"
     assert topic["key"] == "bili:BV_USEFUL"
-    assert topic["title"] == "useful concrete trending fallback"
+    assert topic["title"] == "useful desk snack choice"
 
 
 @pytest.mark.asyncio
@@ -3426,6 +3426,39 @@ async def test_active_engagement_ignores_chinese_generic_host_prompt_topics(runt
 
 
 @pytest.mark.asyncio
+async def test_active_engagement_ignores_presence_check_host_bait_topics(runtime: RoastRuntime) -> None:
+    async def fetch_topics(limit: int = 6) -> dict:
+        return {
+            "success": True,
+            "videos": [
+                {"title": "还在吗吱一声给点反应", "bvid": "BV_PRESENCE_CHECK_CN"},
+                {"title": "猫猫深夜桌面物件投票", "bvid": "BV_USEFUL_PRESENCE_FILTER"},
+            ],
+        }
+
+    runtime._active_engagement_topic_fetcher = fetch_topics
+    runtime.record_result(
+        InteractionResult(
+            accepted=True,
+            status="pushed",
+            event=ViewerEvent(
+                uid="42",
+                nickname="viewer",
+                danmaku_text="在不在冒个泡接一句",
+                source="live_danmaku",
+            ),
+            steps=[PipelineStep("danmaku_response", "ok"), PipelineStep("neko_dispatcher", "ok")],
+        )
+    )
+
+    topic = await runtime._select_active_engagement_topic()
+
+    assert topic["source"] == "bili_trending"
+    assert topic["key"] == "bili:BV_USEFUL_PRESENCE_FILTER"
+    assert topic["title"] == "猫猫深夜桌面物件投票"
+
+
+@pytest.mark.asyncio
 async def test_active_engagement_ignores_spaced_chinese_generic_host_prompt_topics(runtime: RoastRuntime) -> None:
     async def fetch_topics(limit: int = 6) -> dict:
         return {
@@ -3497,7 +3530,7 @@ async def test_active_engagement_uses_fallback_instead_of_repeating_recent_singl
         return {
             "success": True,
             "videos": [
-                {"title": "单一直播话题", "bvid": "BV_ONLY"},
+                {"title": "late night room mood choice", "bvid": "BV_ONLY"},
             ],
         }
 
@@ -3766,6 +3799,13 @@ def test_proactive_material_avoids_generic_host_bait(runtime: RoastRuntime) -> N
         "\u60f3\u804a\u4ec0\u4e48",
         "\u6ca1\u4eba\u8bf4\u8bdd",
         "\u51b7\u573a",
+        "\u61c2\u5f88\u591a",
+        "\u4e13\u5bb6",
+        "\u653b\u7565",
+        "\u6559\u7a0b",
+        "expert",
+        "guide",
+        "tutorial",
     )
     materials = [*runtime._active_engagement_fallback_topic_candidates(), *runtime._idle_hosting_beat_candidates()]
 


### PR DESCRIPTION
﻿## 改了什么

把 `neko_roast` 的 live runtime 先拆出几块核心能力：

- 最近上下文整理
- live 状态/冷场/主动营业 eligibility
- 主动营业 topic 选择
- warmup / idle hosting director

同时补了一轮独播话术约束：弹幕回应要带清楚锚点，主动营业更少模板感，host beat 可以偶尔稍长一点。

## 为什么

前一个 PR 先把 NEKO Live 独播能力接进主分支，这个 PR 主要降低 runtime 的阅读和维护压力，后续修主动营业、冷场、状态诊断时不用继续往一个大文件里堆。

## 验证

后续 stack 顶层已跑：

- `uv run pytest plugin/plugins/neko_roast/tests -q` → 432 passed
- `uv run pytest tests/unit/test_core_game_route_memory_contract.py -q -k "neko_live or send_lanlan_response or mirror_assistant_speech"` → 56 passed
- `uv run pytest tests/unit/test_callback_instruction_origin.py -q` → 28 passed
- `uv run python -m plugin.neko_plugin_cli.cli check plugin/plugins/neko_roast` → 0 errors
- `git diff --check` → passed
