### PR TITLE
把 NEKO Live 回复合约从主流程拆出来

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -385,10 +385,8 @@ def _merge_neko_live_reply_chunk(existing: str, incoming: str, *, is_first_chunk
         return incoming_text
     if not incoming_text:
         return existing_text
-    if incoming_text.startswith(existing_text):
+    if len(incoming_text) > len(existing_text) and incoming_text.startswith(existing_text):
         return incoming_text
-    if existing_text.endswith(incoming_text):
-        return existing_text
     return existing_text + incoming_text
 
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -60,6 +60,18 @@ from main_logic.proactive_delivery import (
     ProactiveDeliveryManager,
     resolve_callback_delivery_ack,
 )
+from main_logic.neko_live_reply_policy import (
+    ACTIVE_FALLBACK_REPLIES as _NEKO_LIVE_ACTIVE_FALLBACK_REPLIES,
+    BLAND_FALLBACK_REPLIES as _NEKO_LIVE_BLAND_FALLBACK_REPLIES,
+    DEFAULT_FALLBACK_REPLIES as _NEKO_LIVE_DEFAULT_FALLBACK_REPLIES,
+    HOST_FALLBACK_REPLIES as _NEKO_LIVE_HOST_FALLBACK_REPLIES,
+    coerce_recent_reply_values as _coerce_recent_live_reply_values,
+    is_live_reply_metadata as _is_neko_live_reply_metadata,
+    merge_metadata_from_callbacks as _merge_live_reply_metadata_from_callbacks,
+    render_contract_instruction as _render_live_reply_contract_instruction,
+    safe_fallback_reply as _safe_neko_live_fallback_reply,
+    shape_reply_text as _shape_neko_live_reply_text,
+)
 from main_logic.agent_event_bus import (
     dispatch_text_user_message,
     dispatch_user_utterance,
@@ -161,10 +173,223 @@ _VOICE_ECHO_MIN_NORMALIZED_CHARS = 6
 _VOICE_ECHO_MIN_WINDOW_CHARS = 10
 _VOICE_ECHO_SIMILARITY_THRESHOLD = 0.88
 _VOICE_ECHO_NORMALIZE_RE = re.compile(r"[\W_]+", re.UNICODE)
+_NEKO_LIVE_REPLY_REPEAT_MIN_CHARS = 4
+_NEKO_LIVE_REPLY_REPEAT_PREFIX_CHARS = 8
+_NEKO_LIVE_REPLY_REPEAT_HISTORY_SIZE = 24
+_NEKO_LIVE_RECENT_REPLY_AVOIDANCE_SIZE = 12
+_NEKO_LIVE_REPLY_REPEAT_SIMILARITY_THRESHOLD = 0.82
+_NEKO_LIVE_REPLY_REPEAT_NGRAM_SIZE = 3
+_PROACTIVE_LIVE_REPLY_METADATA_BY_SID_MAX = 16
+_NEKO_LIVE_REPEAT_ANCHOR_GROUPS: tuple[tuple[str, ...], ...] = (
+    ("惊喜", "小惊喜", "惊喜奖励", "surprise"),
+    ("小鱼干", "鱼干", "奖励", "奖赏", "犒劳", "礼物"),
+    ("特别企划", "企划", "节目", "环节", "计划"),
+    (
+        "大家",
+        "你们",
+        "观众",
+        "弹幕",
+        "互动",
+        "发言",
+        "接话",
+        "想听什么",
+        "聊点什么",
+        "扣1",
+        "扣个1",
+        "吱一声",
+        "冒个泡",
+        "给点反应",
+        "还在吗",
+        "有人吗",
+        "有人在吗",
+        "在不在",
+    ),
+    ("主播力", "正经主播", "像主播", "主持", "host score"),
+    ("一个字", "一个词", "三字", "暗号", "打分", "one word", "password"),
+    ("二选一", "选一个", "还是", "A/B", "either or"),
+    ("气氛", "温度", "猫窝", "小电台", "晴天", "小雨", "room mood"),
+    ("桌面", "水杯", "零食", "屏幕", "键盘", "object scene"),
+    ("吐槽", "别笑", "被自己", "tease"),
+    ("挑战", "任务", "姿势", "三秒", "micro challenge"),
+    ("安静", "冷场", "没人说话", "没弹幕", "quiet room"),
+)
+_NEKO_LIVE_REPEAT_SINGLE_ANCHOR_GROUPS = frozenset({0, 1, 2, 4, 5, 11})
+_NEKO_LIVE_REPEAT_CONTEXTUAL_ANCHOR_GROUPS = frozenset({6, 7, 8, 9, 10})
+_NEKO_LIVE_REPLY_CONTEXTUAL_ANCHOR_NGRAM_THRESHOLD = 0.25
+_NEKO_LIVE_AUDIENCE_PROMPT_TOKENS = (
+    "大家",
+    "你们",
+    "发言",
+    "接话",
+    "接一句",
+    "互动",
+    "想听",
+    "想看",
+    "聊点",
+    "聊什么",
+    "说点",
+    "来一句",
+    "来点弹幕",
+    "发弹幕",
+    "弹幕刷",
+    "发个1",
+    "扣1",
+    "扣个",
+    "扣个1",
+    "打个1",
+    "打个分",
+    "打个标签",
+    "吱一声",
+    "冒个泡",
+    "举个爪",
+    "给点反应",
+    "给猫猫一点反应",
+    "还在吗",
+    "有人吗",
+    "有人在吗",
+    "在不在",
+    "drop a 1",
+    "type 1",
+    "say hi",
+    "anyone here",
+    "still here",
+)
+_NEKO_LIVE_HOST_AUDIENCE_PROMPT_TOKENS = tuple(
+    token for token in _NEKO_LIVE_AUDIENCE_PROMPT_TOKENS if token not in {"大家", "你们"}
+)
 
 
 def _normalize_voice_echo_text(text: str) -> str:
     return _VOICE_ECHO_NORMALIZE_RE.sub("", str(text or "").casefold())
+
+
+def _looks_like_repeated_neko_live_reply(current: str, previous: str) -> bool:
+    current_norm = _normalize_voice_echo_text(current)
+    previous_norm = _normalize_voice_echo_text(previous)
+    if len(current_norm) < _NEKO_LIVE_REPLY_REPEAT_MIN_CHARS or len(previous_norm) < _NEKO_LIVE_REPLY_REPEAT_MIN_CHARS:
+        return False
+    if current_norm == previous_norm:
+        return True
+    shorter, longer = (
+        (current_norm, previous_norm)
+        if len(current_norm) <= len(previous_norm)
+        else (previous_norm, current_norm)
+    )
+    if len(shorter) >= _NEKO_LIVE_REPLY_REPEAT_PREFIX_CHARS and shorter in longer:
+        return True
+    prefix_len = min(_NEKO_LIVE_REPLY_REPEAT_PREFIX_CHARS, len(current_norm), len(previous_norm))
+    if prefix_len >= _NEKO_LIVE_REPLY_REPEAT_MIN_CHARS and current_norm[:prefix_len] == previous_norm[:prefix_len]:
+        return True
+    if min(len(current_norm), len(previous_norm)) >= _NEKO_LIVE_REPLY_REPEAT_PREFIX_CHARS:
+        if SequenceMatcher(None, current_norm, previous_norm).ratio() >= _NEKO_LIVE_REPLY_REPEAT_SIMILARITY_THRESHOLD:
+            return True
+    if _looks_like_same_neko_live_host_beat(current, previous):
+        return True
+    current_grams = _neko_live_reply_char_ngrams(current_norm)
+    previous_grams = _neko_live_reply_char_ngrams(previous_norm)
+    if not current_grams or not previous_grams:
+        return False
+    overlap = _neko_live_reply_ngram_overlap(current_grams, previous_grams)
+    return overlap >= 0.65
+
+
+def _neko_live_reply_char_ngrams(text: str) -> set[str]:
+    if len(text) < _NEKO_LIVE_REPLY_REPEAT_NGRAM_SIZE + 1:
+        return set()
+    return {
+        text[index : index + _NEKO_LIVE_REPLY_REPEAT_NGRAM_SIZE]
+        for index in range(0, len(text) - _NEKO_LIVE_REPLY_REPEAT_NGRAM_SIZE + 1)
+    }
+
+
+def _neko_live_reply_ngram_overlap(current_grams: set[str], previous_grams: set[str]) -> float:
+    if not current_grams or not previous_grams:
+        return 0.0
+    return len(current_grams & previous_grams) / max(1, min(len(current_grams), len(previous_grams)))
+
+
+def _neko_live_reply_anchor_fingerprint(text: str) -> set[int]:
+    normalized = _normalize_voice_echo_text(text)
+    if not normalized:
+        return set()
+    anchors: set[int] = set()
+    for index, group in enumerate(_NEKO_LIVE_REPEAT_ANCHOR_GROUPS):
+        if any(_normalize_voice_echo_text(token) in normalized for token in group):
+            anchors.add(index)
+    return anchors
+
+
+def _looks_like_same_neko_live_host_beat(current: str, previous: str) -> bool:
+    current_anchors = _neko_live_reply_anchor_fingerprint(current)
+    previous_anchors = _neko_live_reply_anchor_fingerprint(previous)
+    shared_anchors = current_anchors & previous_anchors
+    if not shared_anchors:
+        return False
+    if 3 in shared_anchors and _looks_like_repeated_audience_prompt(current, previous):
+        return True
+    if len(shared_anchors) >= 2:
+        return True
+    if shared_anchors & _NEKO_LIVE_REPEAT_SINGLE_ANCHOR_GROUPS:
+        return True
+    if shared_anchors & _NEKO_LIVE_REPEAT_CONTEXTUAL_ANCHOR_GROUPS:
+        current_grams = _neko_live_reply_char_ngrams(_normalize_voice_echo_text(current))
+        previous_grams = _neko_live_reply_char_ngrams(_normalize_voice_echo_text(previous))
+        return (
+            _neko_live_reply_ngram_overlap(current_grams, previous_grams)
+            >= _NEKO_LIVE_REPLY_CONTEXTUAL_ANCHOR_NGRAM_THRESHOLD
+        )
+    return False
+
+
+def _looks_like_repeated_audience_prompt(current: str, previous: str) -> bool:
+    current_norm = _normalize_voice_echo_text(current)
+    previous_norm = _normalize_voice_echo_text(previous)
+    if not current_norm or not previous_norm:
+        return False
+    return (
+        _neko_live_host_prompt_signal_count(current_norm) >= 1
+        and _neko_live_host_prompt_signal_count(previous_norm) >= 1
+    )
+
+
+def _neko_live_audience_prompt_signal_count(normalized_text: str) -> int:
+    return sum(
+        1
+        for token in _NEKO_LIVE_AUDIENCE_PROMPT_TOKENS
+        if _normalize_voice_echo_text(token) in normalized_text
+    )
+
+
+def _neko_live_host_prompt_signal_count(normalized_text: str) -> int:
+    return sum(
+        1
+        for token in _NEKO_LIVE_HOST_AUDIENCE_PROMPT_TOKENS
+        if _normalize_voice_echo_text(token) in normalized_text
+    )
+
+
+def _looks_like_recent_neko_live_reply_repeat(current: str, recent: Any) -> bool:
+    if not recent:
+        return False
+    try:
+        candidates = list(recent)
+    except TypeError:
+        candidates = [recent]
+    return any(_looks_like_repeated_neko_live_reply(current, str(previous or "")) for previous in candidates)
+
+
+def _merge_neko_live_reply_chunk(existing: str, incoming: str, *, is_first_chunk: bool) -> str:
+    existing_text = str(existing or "")
+    incoming_text = str(incoming or "")
+    if is_first_chunk or not existing_text:
+        return incoming_text
+    if not incoming_text:
+        return existing_text
+    if incoming_text.startswith(existing_text):
+        return incoming_text
+    if existing_text.endswith(incoming_text):
+        return existing_text
+    return existing_text + incoming_text
 
 
 def _looks_like_recent_ai_echo(transcript: str, recent_ai_text: str) -> bool:
@@ -292,6 +517,7 @@ def _build_callback_instruction(
     lanlan_name: str,
     master_name: str,
     passive: bool = False,
+    recent_live_replies: list[str] | None = None,
 ) -> str:
     """Render a list of agent_task_callbacks into the LLM injection string.
 
@@ -391,13 +617,20 @@ def _build_callback_instruction(
             for cb in cbs
         ]
         items = [s for s in items if s]
+        live_reply_contract = _render_live_reply_contract_instruction(
+            cbs,
+            recent_live_replies=recent_live_replies,
+        )
         if items:
-            parts.append(header + "\n".join(items))
+            body = header + "\n".join(items)
         else:
             # No item text — outer header alone (e.g. "task X failed") still
             # tells the AI that something happened. Strip trailing newline so
             # the joined output is clean.
-            parts.append(header.rstrip())
+            body = header.rstrip()
+        if live_reply_contract:
+            body += live_reply_contract
+        parts.append(body)
     rendered = "\n\n".join(parts)
     # Total input budget: many callbacks accumulating must not blow up the turn.
     from utils.tokenize import truncate_to_tokens
@@ -657,6 +890,9 @@ CROSS_MODE_RESTART_WAIT_SECONDS = FRONTEND_START_SESSION_TIMEOUT_SECONDS / 2
 # contextvar 是 per-task 隔离，不会泄漏到用户 stream_text 所在的独立任务。
 _proactive_expected_sid: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     '_proactive_expected_sid', default=None,
+)
+_proactive_live_reply_metadata: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
+    '_proactive_live_reply_metadata', default=None,
 )
 
 # TTS 错误码：不可恢复，禁止 respawn（欠费 / API Key 无效）
@@ -2980,11 +3216,23 @@ class LLMSessionManager:
                     except: # noqa
                         break
 
+        live_reply_metadata = self._current_proactive_live_reply_metadata()
+        if self._buffer_neko_live_reply_output(
+            text,
+            is_first_chunk=is_first_chunk,
+            metadata=live_reply_metadata,
+            ui_enabled=ui_enabled,
+            tts_enabled=tts_enabled,
+            remember_voice_echo=not self.use_tts,
+        ):
+            return
+
         # 文本模式下，无论是否使用TTS，都要发送文本到前端显示
         if ui_enabled:
             await self.send_lanlan_response(
                 text,
                 is_first_chunk,
+                metadata=live_reply_metadata,
                 remember_voice_echo=not self.use_tts,
             )
 
@@ -3072,8 +3320,10 @@ class LLMSessionManager:
         exclusively to user-initiated conversation turns.
         """
         if not content_committed:
+            self._neko_live_reply_output_buffer = None
             logger.debug("[%s] handle_proactive_complete: no content committed, skipping completion flush", self.lanlan_name)
             return
+        await self._flush_neko_live_reply_output_buffer(log_context="handle_proactive_complete")
         # Activity tracker flush：proactive 也算 AI 在说话。和 _emit_turn_end
         # 对称，让 seconds_since_ai_msg 不分主动/被动。proactive 文本同样走过
         # send_lanlan_response（finish_proactive_delivery 内部会调），所以
@@ -3153,17 +3403,143 @@ class LLMSessionManager:
         request_id_str = str(request_id or "")
         return bool(request_id_str and request_id_str in self._magic_command_image_drop_request_ids)
 
+    def _remember_proactive_live_reply_metadata(self, speech_id: object, metadata: dict[str, Any] | None) -> None:
+        if not speech_id or not _is_neko_live_reply_metadata(metadata):
+            return
+        by_sid = getattr(self, "_proactive_live_reply_metadata_by_sid", None)
+        if not isinstance(by_sid, OrderedDict):
+            by_sid = OrderedDict()
+            self._proactive_live_reply_metadata_by_sid = by_sid
+        sid = str(speech_id)
+        by_sid[sid] = dict(metadata or {})
+        by_sid.move_to_end(sid)
+        while len(by_sid) > _PROACTIVE_LIVE_REPLY_METADATA_BY_SID_MAX:
+            by_sid.popitem(last=False)
+
+    def _current_proactive_live_reply_metadata(self) -> dict[str, Any] | None:
+        metadata = _proactive_live_reply_metadata.get()
+        if _is_neko_live_reply_metadata(metadata):
+            return dict(metadata or {})
+        by_sid = getattr(self, "_proactive_live_reply_metadata_by_sid", None)
+        if not isinstance(by_sid, OrderedDict):
+            return None
+        speech_id = str(getattr(self, "current_speech_id", "") or "")
+        metadata = by_sid.get(speech_id)
+        if _is_neko_live_reply_metadata(metadata):
+            by_sid.move_to_end(speech_id)
+            return dict(metadata or {})
+        return None
+
+    def _buffer_neko_live_reply_output(
+        self,
+        text: str,
+        *,
+        is_first_chunk: bool,
+        metadata: dict[str, Any] | None,
+        ui_enabled: bool = True,
+        tts_enabled: bool = True,
+        remember_voice_echo: bool = False,
+    ) -> bool:
+        if not _is_neko_live_reply_metadata(metadata):
+            return False
+        turn_id = str(getattr(self, "current_speech_id", "") or "")
+        if not turn_id:
+            return False
+
+        buffer = getattr(self, "_neko_live_reply_output_buffer", None)
+        if not isinstance(buffer, dict) or is_first_chunk or buffer.get("turn_id") != turn_id:
+            buffer = {
+                "turn_id": turn_id,
+                "text": "",
+                "metadata": dict(metadata or {}),
+                "ui_enabled": False,
+                "tts_enabled": False,
+                "remember_voice_echo": False,
+            }
+            self._neko_live_reply_output_buffer = buffer
+
+        buffer["text"] = _merge_neko_live_reply_chunk(
+            str(buffer.get("text") or ""),
+            str(text or ""),
+            is_first_chunk=is_first_chunk,
+        )
+        buffer["metadata"] = dict(metadata or buffer.get("metadata") or {})
+        buffer["ui_enabled"] = bool(buffer.get("ui_enabled")) or bool(ui_enabled)
+        buffer["tts_enabled"] = bool(buffer.get("tts_enabled")) or bool(tts_enabled)
+        buffer["remember_voice_echo"] = bool(buffer.get("remember_voice_echo")) or bool(remember_voice_echo)
+        return True
+
+    async def _flush_neko_live_reply_output_buffer(self, *, log_context: str) -> bool:
+        buffer = getattr(self, "_neko_live_reply_output_buffer", None)
+        if not isinstance(buffer, dict):
+            return False
+        self._neko_live_reply_output_buffer = None
+
+        text = str(buffer.get("text") or "").strip()
+        if not text:
+            return False
+        turn_id = str(buffer.get("turn_id") or getattr(self, "current_speech_id", "") or "")
+        metadata = dict(buffer.get("metadata") or {})
+        ui_enabled = bool(buffer.get("ui_enabled", True))
+        tts_enabled = bool(buffer.get("tts_enabled", True))
+        remember_voice_echo = bool(buffer.get("remember_voice_echo", False))
+
+        text_clean = self.emotion_pattern.sub("", text)
+        text_clean, shaped_metadata = _shape_neko_live_reply_text(text_clean, metadata)
+        if not text_clean.strip():
+            return False
+
+        suppressed = False
+        if ui_enabled:
+            await self.send_lanlan_response(
+                text_clean,
+                is_first_chunk=True,
+                turn_id=turn_id,
+                metadata=shaped_metadata,
+                remember_voice_echo=remember_voice_echo,
+            )
+            suppressed = bool(getattr(self, "_last_neko_live_reply_suppressed", False))
+        else:
+            _, suppressed = self._track_neko_live_reply_output(
+                text_clean,
+                is_first_chunk=True,
+                turn_id=turn_id,
+                metadata=shaped_metadata,
+            )
+
+        if suppressed:
+            logger.info("[%s] NEKO Live buffered reply suppressed at %s", self.lanlan_name, log_context)
+            return False
+
+        if self.use_tts and tts_enabled:
+            async with self.tts_cache_lock:
+                if self.tts_ready and self.tts_thread and self.tts_thread.is_alive():
+                    try:
+                        self._enqueue_tts_text_chunk(turn_id, text_clean)
+                    except Exception as e:
+                        logger.warning(f"⚠️ 发送TTS请求失败: {e}")
+                else:
+                    self.tts_pending_chunks.append((turn_id, text_clean))
+                    if len(self.tts_pending_chunks) == 1:
+                        logger.info("TTS未就绪，开始缓存文本chunk...")
+                    if self.tts_thread and not self.tts_thread.is_alive():
+                        self._respawn_tts_worker()
+        return True
+
     async def handle_response_complete(self):
         """Qwen completion callback: handles the Core API's response-complete event, including TTS and hot-swap logic"""
         if self._takeover_active:
             logger.info("[%s] session takeover active: dropping ordinary realtime response completion", self.lanlan_name)
             await self._clear_tts_pipeline()
+            self._neko_live_reply_output_buffer = None
             self._pending_turn_meta = None
             self._current_ai_turn_text = ""
             self._active_text_request_id = None
             return
 
         active_request_id = self._active_text_request_id
+
+        await self._flush_neko_live_reply_output_buffer(log_context="handle_response_complete")
 
         if self.use_tts and self.tts_thread and self.tts_thread.is_alive():
             logger.info("📨 Response complete (LLM 回复结束)")
@@ -3304,6 +3680,7 @@ class LLMSessionManager:
                 print(f"[response_discarded parse_err] raw: {message!r}")
 
         await self._clear_tts_pipeline()
+        self._neko_live_reply_output_buffer = None
 
         if self.websocket and hasattr(self.websocket, 'client_state') and \
                 self.websocket.client_state == self.websocket.client_state.CONNECTED:
@@ -3941,10 +4318,21 @@ class LLMSessionManager:
                 expected_sid, self.current_speech_id, len(text),
             )
             return
+        live_reply_metadata = self._current_proactive_live_reply_metadata()
+        if self._buffer_neko_live_reply_output(
+            text,
+            is_first_chunk=is_first_chunk,
+            metadata=live_reply_metadata,
+            ui_enabled=True,
+            tts_enabled=True,
+            remember_voice_echo=not self.use_tts,
+        ):
+            return
         # 无论是否使用TTS，都要发送文本到前端显示
         await self.send_lanlan_response(
             text,
             is_first_chunk,
+            metadata=live_reply_metadata,
             remember_voice_echo=not self.use_tts,
         )
         
@@ -3966,6 +4354,123 @@ class LLMSessionManager:
                     # 仅在回复首 chunk 尝试拉起，避免每个 chunk 都重试
                     if is_first_chunk and self.tts_thread and not self.tts_thread.is_alive():
                         self._respawn_tts_worker()
+
+    def _track_neko_live_reply_output(
+        self,
+        text_clean: str,
+        *,
+        is_first_chunk: bool,
+        turn_id: str | None,
+        metadata: dict | None,
+    ) -> tuple[dict | None, bool]:
+        outgoing_metadata = dict(metadata) if isinstance(metadata, dict) else None
+        self._last_neko_live_reply_suppressed = False
+        self._last_neko_live_reply_metadata = outgoing_metadata
+        if not _is_neko_live_reply_metadata(outgoing_metadata):
+            return outgoing_metadata, False
+
+        turn_key = str(turn_id or uuid4())
+        recent_live_replies = getattr(self, "_neko_live_recent_reply_texts", None)
+        if not isinstance(recent_live_replies, OrderedDict):
+            raw_recent_live_replies = recent_live_replies
+            recent_live_replies = OrderedDict()
+            legacy_replies = _coerce_recent_live_reply_values(raw_recent_live_replies)
+            if not legacy_replies:
+                previous_live_reply = str(getattr(self, "_neko_live_recent_reply_text", "") or "")
+                if previous_live_reply:
+                    legacy_replies = [previous_live_reply]
+            for index, previous in enumerate(legacy_replies[-_NEKO_LIVE_REPLY_REPEAT_HISTORY_SIZE:]):
+                recent_live_replies[f"__legacy_previous_{index}__"] = previous
+            self._neko_live_recent_reply_texts = recent_live_replies
+
+        while len(recent_live_replies) > _NEKO_LIVE_REPLY_REPEAT_HISTORY_SIZE:
+            recent_live_replies.popitem(last=False)
+
+        previous_texts = [
+            previous
+            for sid, previous in recent_live_replies.items()
+            if sid != turn_key
+        ]
+        suppressed_turns = getattr(self, "_neko_live_suppressed_reply_turn_ids", None)
+        if not isinstance(suppressed_turns, OrderedDict):
+            suppressed_turns = OrderedDict()
+            self._neko_live_suppressed_reply_turn_ids = suppressed_turns
+        if turn_key in suppressed_turns:
+            if outgoing_metadata is None:
+                outgoing_metadata = {}
+            outgoing_metadata["neko_live_reply_repeat"] = True
+            outgoing_metadata["neko_live_reply_repeat_window"] = len(recent_live_replies)
+            outgoing_metadata["neko_live_reply_suppressed"] = "repeat"
+            self._last_neko_live_reply_suppressed = True
+            self._last_neko_live_reply_metadata = outgoing_metadata
+            return outgoing_metadata, True
+
+        existing_text = str(recent_live_replies.get(turn_key, "") or "")
+        accumulated_text = _merge_neko_live_reply_chunk(
+            existing_text,
+            text_clean,
+            is_first_chunk=is_first_chunk,
+        )
+        repeated_live_reply = _looks_like_recent_neko_live_reply_repeat(accumulated_text, previous_texts)
+        if repeated_live_reply and is_first_chunk and not existing_text:
+            if outgoing_metadata is None:
+                outgoing_metadata = {}
+            outgoing_metadata["neko_live_reply_repeat"] = True
+            outgoing_metadata["neko_live_reply_repeat_window"] = len(recent_live_replies)
+            outgoing_metadata["neko_live_reply_suppressed"] = "repeat"
+            self._last_neko_live_reply_suppressed = True
+            logger.warning(
+                "[%s] NEKO Live repeated reply suppressed module=%s len=%d window=%d",
+                self.lanlan_name,
+                outgoing_metadata.get("response_module_hint", ""),
+                len(accumulated_text),
+                len(recent_live_replies),
+            )
+            self._last_neko_live_reply_metadata = outgoing_metadata
+            suppressed_turns[turn_key] = None
+            while len(suppressed_turns) > _NEKO_LIVE_REPLY_REPEAT_HISTORY_SIZE:
+                suppressed_turns.popitem(last=False)
+            return outgoing_metadata, True
+        if repeated_live_reply and existing_text:
+            if outgoing_metadata is None:
+                outgoing_metadata = {}
+            outgoing_metadata["neko_live_reply_repeat"] = True
+            outgoing_metadata["neko_live_reply_repeat_window"] = len(recent_live_replies)
+            outgoing_metadata["neko_live_reply_suppressed"] = "repeat"
+            self._last_neko_live_reply_suppressed = True
+            self._last_neko_live_reply_metadata = outgoing_metadata
+            suppressed_turns[turn_key] = None
+            while len(suppressed_turns) > _NEKO_LIVE_REPLY_REPEAT_HISTORY_SIZE:
+                suppressed_turns.popitem(last=False)
+            return outgoing_metadata, True
+
+        self._neko_live_recent_reply_text = accumulated_text
+        self._neko_live_recent_reply_at = time.time()
+        recent_live_replies[turn_key] = accumulated_text
+        recent_live_replies.move_to_end(turn_key)
+        suppressed_turns.pop(turn_key, None)
+        while len(recent_live_replies) > _NEKO_LIVE_REPLY_REPEAT_HISTORY_SIZE:
+            recent_live_replies.popitem(last=False)
+        if outgoing_metadata is None:
+            outgoing_metadata = {}
+        outgoing_metadata["neko_live_reply_repeat"] = bool(repeated_live_reply)
+        outgoing_metadata["neko_live_reply_repeat_window"] = len(recent_live_replies)
+        if repeated_live_reply:
+            logger.warning(
+                "[%s] NEKO Live repeated reply detected module=%s len=%d window=%d",
+                self.lanlan_name,
+                outgoing_metadata.get("response_module_hint", ""),
+                len(accumulated_text),
+                len(recent_live_replies),
+            )
+        self._last_neko_live_reply_metadata = outgoing_metadata
+        return outgoing_metadata, False
+
+    def _last_tracked_neko_live_reply_metadata(self, fallback: dict | None) -> dict:
+        tracked = getattr(self, "_last_neko_live_reply_metadata", None)
+        if isinstance(tracked, dict):
+            return dict(tracked)
+        return dict(fallback or {}) if isinstance(fallback, dict) else {}
 
     async def send_lanlan_response(
         self,
@@ -3998,14 +4503,24 @@ class LLMSessionManager:
         ``request_id is None`` check.
         """
         text_clean = self.emotion_pattern.sub('', text)
+        text_clean, shaped_metadata = _shape_neko_live_reply_text(text_clean, metadata)
+        effective_turn_id = turn_id or self.current_speech_id
+        outgoing_metadata, suppressed = self._track_neko_live_reply_output(
+            text_clean,
+            is_first_chunk=is_first_chunk,
+            turn_id=effective_turn_id,
+            metadata=shaped_metadata,
+        )
+        if suppressed:
+            return False
         # 累加到当前轮 AI 文本 buffer，turn end 时一并交给 activity tracker 做
         # unfinished_thread 检测。emotion_pattern 已剥掉表情标签，但保留 <expr>
         # 等可能的 markup——tracker 自己会做二次 strip。
-        if track_ai_turn:
+        track_conversation_turn = bool(track_ai_turn) and not _is_neko_live_reply_metadata(outgoing_metadata)
+        if track_conversation_turn:
             self._current_ai_turn_text += text_clean
-            if remember_voice_echo:
-                self._remember_recent_ai_voice_echo(text_clean)
-        effective_turn_id = turn_id or self.current_speech_id
+        if remember_voice_echo:
+            self._remember_recent_ai_voice_echo(text_clean)
         effective_request_id = (
             self._active_text_request_id
             if request_id is _REQUEST_ID_UNSET
@@ -4018,8 +4533,12 @@ class LLMSessionManager:
             "turn_id": effective_turn_id,
             "request_id": effective_request_id,
         }
-        if metadata:
-            message["metadata"] = metadata
+        if outgoing_metadata:
+            message["metadata"] = outgoing_metadata
+        if is_first_chunk and _is_neko_live_reply_metadata(outgoing_metadata):
+            shape_reason = outgoing_metadata.get("neko_live_reply_shape_reason")
+            if shape_reason:
+                logger.info("[%s] send_lanlan_response shape_reason=%s", self.lanlan_name, shape_reason)
 
         # 无论 WS 发送成功与否，始终将消息写入 sync_message_queue 和 message_cache，
         # 确保 cross_server 历史组装不因 WS 断连而丢失 assistant 内容。
@@ -4030,7 +4549,11 @@ class LLMSessionManager:
             # so this is a no-op on regular / proactive turns that never lit it.
             await self._push_focus_thinking(False)
         self.sync_message_queue.put({"type": "json", "data": message})
-        if cache_for_new_session and hasattr(self, 'is_preparing_new_session') and self.is_preparing_new_session:
+        should_cache_for_new_session = (
+            cache_for_new_session
+            and not _is_neko_live_reply_metadata(outgoing_metadata)
+        )
+        if should_cache_for_new_session and hasattr(self, 'is_preparing_new_session') and self.is_preparing_new_session:
             if not hasattr(self, 'message_cache_for_new_session'):
                 self.message_cache_for_new_session = []
             # 注意：缓存使用原始文本，不翻译（用于记忆等内部处理）
@@ -4148,7 +4671,7 @@ class LLMSessionManager:
             return {"ok": False, "reason": "missing_line", "mirrored": False}
 
         effective_turn_id = turn_id or request_id or str(uuid4())
-        await self.send_lanlan_response(
+        mirrored = await self.send_lanlan_response(
             clean,
             is_first_chunk=True,
             turn_id=effective_turn_id,
@@ -4157,9 +4680,21 @@ class LLMSessionManager:
             track_ai_turn=False,
             cache_for_new_session=False,
         )
+        if not mirrored and getattr(self, "_last_neko_live_reply_suppressed", False):
+            tracked_metadata = self._last_tracked_neko_live_reply_metadata(metadata)
+            return {
+                "ok": False,
+                "reason": "repeated_live_reply",
+                "mirrored": False,
+                "turn_id": effective_turn_id,
+                "request_id": request_id or "",
+                "metadata": tracked_metadata,
+                "turn_finalized": False,
+            }
+        tracked_metadata = self._last_tracked_neko_live_reply_metadata(metadata)
         if finalize_turn:
             await self.emit_mirror_turn_end(
-                metadata=metadata,
+                metadata=tracked_metadata,
                 request_id=request_id,
                 log_context="mirror assistant",
             )
@@ -4168,7 +4703,7 @@ class LLMSessionManager:
             "mirrored": True,
             "turn_id": effective_turn_id,
             "request_id": request_id or "",
-            "metadata": metadata if isinstance(metadata, dict) else {},
+            "metadata": tracked_metadata,
             "turn_finalized": bool(finalize_turn),
         }
 
@@ -4285,6 +4820,7 @@ class LLMSessionManager:
         clean = str(line or "").strip()
         if not clean:
             return {"ok": False, "reason": "missing_line", "audio_sent": False}
+        clean, metadata = _shape_neko_live_reply_text(clean, metadata)
 
         interrupted_speech_id = None
         if interrupt_audio:
@@ -4319,8 +4855,40 @@ class LLMSessionManager:
             self.state.mark_user_input_preempt()
         await self.state.fire(SessionEvent.USER_INPUT, sid=turn_id)
 
+        if not mirror_text:
+            tracked_metadata, suppressed = self._track_neko_live_reply_output(
+                clean,
+                is_first_chunk=True,
+                turn_id=turn_id,
+                metadata=metadata,
+            )
+            if suppressed:
+                tracked_metadata = self._last_tracked_neko_live_reply_metadata(tracked_metadata)
+                if emit_turn_end_after:
+                    await self.emit_mirror_turn_end(
+                        metadata=tracked_metadata,
+                        request_id=request_id,
+                        log_context="mirror speech suppressed",
+                    )
+                return {
+                    "ok": False,
+                    "reason": "repeated_live_reply",
+                    "method": "project_tts",
+                    "speech_id": turn_id,
+                    "audio_sent": False,
+                    "audio_queued": False,
+                    "metadata": tracked_metadata,
+                    "turn_end_emitted": bool(emit_turn_end_after),
+                    "interrupt_audio": bool(interrupt_audio),
+                    "voice_source": {
+                        "provider": "project_tts",
+                        "method": "project_tts",
+                        "use_existing_send_speech": True,
+                    },
+                }
+
         if mirror_text:
-            await self.send_lanlan_response(
+            mirrored = await self.send_lanlan_response(
                 clean,
                 is_first_chunk=True,
                 turn_id=turn_id,
@@ -4329,9 +4897,34 @@ class LLMSessionManager:
                 track_ai_turn=False,
                 cache_for_new_session=False,
             )
+            if not mirrored and getattr(self, "_last_neko_live_reply_suppressed", False):
+                tracked_metadata = self._last_tracked_neko_live_reply_metadata(metadata)
+                if emit_turn_end_after:
+                    await self.emit_mirror_turn_end(
+                        metadata=tracked_metadata,
+                        request_id=request_id,
+                        log_context="mirror speech suppressed",
+                    )
+                return {
+                    "ok": False,
+                    "reason": "repeated_live_reply",
+                    "method": "project_tts",
+                    "speech_id": turn_id,
+                    "audio_sent": False,
+                    "audio_queued": False,
+                    "metadata": tracked_metadata,
+                    "turn_end_emitted": bool(emit_turn_end_after),
+                    "interrupt_audio": bool(interrupt_audio),
+                    "voice_source": {
+                        "provider": "project_tts",
+                        "method": "project_tts",
+                        "use_existing_send_speech": True,
+                    },
+                }
 
         await self.ensure_tts_pipeline_alive()
         audio_queued = False
+        tracked_metadata = self._last_tracked_neko_live_reply_metadata(metadata)
         if self.tts_thread and self.tts_thread.is_alive():
             async with self.tts_cache_lock:
                 if self.tts_ready:
@@ -4342,7 +4935,7 @@ class LLMSessionManager:
                 audio_queued = status in {"queued", "deferred", "already"}
         if emit_turn_end_after:
             await self.emit_mirror_turn_end(
-                metadata=metadata,
+                metadata=tracked_metadata,
                 request_id=request_id,
                 log_context="mirror speech",
             )
@@ -4353,6 +4946,7 @@ class LLMSessionManager:
             "speech_id": turn_id,
             "audio_sent": audio_queued,
             "audio_queued": audio_queued,
+            "metadata": tracked_metadata,
             "turn_end_emitted": bool(emit_turn_end_after),
             "interrupt_audio": bool(interrupt_audio),
             "voice_source": {
@@ -7658,7 +8252,12 @@ class LLMSessionManager:
                     lanlan_name=self.lanlan_name,
                     master_name=self.master_name,
                     passive=False,
+                    recent_live_replies=_coerce_recent_live_reply_values(
+                        getattr(self, "_neko_live_recent_reply_texts", None)
+                    ),
                 )
+                live_reply_metadata = _merge_live_reply_metadata_from_callbacks(voice_snapshot)
+                self._remember_proactive_live_reply_metadata(proactive_sid, live_reply_metadata)
                 delivered_ids = {
                     cb.get("_callback_delivery_id")
                     for cb in voice_snapshot
@@ -7668,6 +8267,7 @@ class LLMSessionManager:
                     extra for extra in voice_extra_snapshot
                     if extra.get("_callback_delivery_id") in delivered_ids
                 ]
+                _live_meta_token = _proactive_live_reply_metadata.set(live_reply_metadata)
                 try:
                     await voice_sess.inject_text_and_request_response(
                         instruction, on_rejected=_on_voice_inject_rejected
@@ -7700,6 +8300,8 @@ class LLMSessionManager:
                         self.lanlan_name, exc,
                     )
                     return False
+                finally:
+                    _proactive_live_reply_metadata.reset(_live_meta_token)
 
                 # If the server rejected asynchronously DURING the await above
                 # (case a — ``_on_voice_inject_rejected`` already fired while
@@ -7953,7 +8555,12 @@ class LLMSessionManager:
                 lanlan_name=self.lanlan_name,
                 master_name=self.master_name,
                 passive=False,
+                recent_live_replies=_coerce_recent_live_reply_values(
+                    getattr(self, "_neko_live_recent_reply_texts", None)
+                ),
             )
+            live_reply_metadata = _merge_live_reply_metadata_from_callbacks(active_callbacks)
+            self._remember_proactive_live_reply_metadata(proactive_sid, live_reply_metadata)
             ack_resolved = False
 
             def _resolve_text_delivery_ack(delivered: bool) -> None:
@@ -7998,6 +8605,7 @@ class LLMSessionManager:
                     return False
 
             _sid_token = _proactive_expected_sid.set(proactive_sid)
+            _live_meta_token = _proactive_live_reply_metadata.set(live_reply_metadata)
             # Text-mode playback boundary for the pacing manager: no frontend
             # audio signal arrives for text delivery, so bracket prompt_ephemeral
             # with text_start/text_end. text_end clears the manager's in-flight
@@ -8032,6 +8640,7 @@ class LLMSessionManager:
                         raise
             finally:
                 _proactive_expected_sid.reset(_sid_token)
+                _proactive_live_reply_metadata.reset(_live_meta_token)
                 try:
                     self.lifecycle_bus.emit("text_end")
                 except Exception:
@@ -9126,6 +9735,9 @@ class LLMSessionManager:
                 lanlan_name=getattr(self, "lanlan_name", "") or "",
                 master_name=getattr(self, "master_name", "") or "",
                 passive=False,
+                recent_live_replies=_coerce_recent_live_reply_values(
+                    getattr(self, "_neko_live_recent_reply_texts", None)
+                ),
             )
             delivered_to_prompt = True
             return rendered

--- a/main_logic/mirror_meta.py
+++ b/main_logic/mirror_meta.py
@@ -116,6 +116,8 @@ def is_mirror_assistant_message(data: dict) -> bool:
     metadata = data.get("metadata")
     if not isinstance(metadata, dict):
         return False
+    if is_live_reply_contract_meta(metadata):
+        return True
     mirror = metadata.get("mirror")
     if not isinstance(mirror, dict):
         return False
@@ -130,6 +132,8 @@ def is_mirror_turn_end_meta(meta: Optional[dict]) -> bool:
     memory pipeline."""
     if not isinstance(meta, dict):
         return False
+    if is_live_reply_contract_meta(meta):
+        return True
     mirror = meta.get("mirror")
     if not isinstance(mirror, dict):
         return False
@@ -137,6 +141,13 @@ def is_mirror_turn_end_meta(meta: Optional[dict]) -> bool:
     if not isinstance(event, dict):
         return False
     return is_mirror_event_memory_disabled(event)
+
+
+def is_live_reply_contract_meta(meta: Optional[dict]) -> bool:
+    """NEKO Live short broadcast replies are visual/TTS output, not
+    ordinary chat turns.  Keep them out of the normal memory/analyzer
+    pipeline while their own live anti-repeat window tracks them."""
+    return isinstance(meta, dict) and meta.get("live_reply_contract") == "short_tts_line"
 
 
 # Sentinel input_type values used by mirror_user_input — cross_server

--- a/main_logic/neko_live_reply_policy.py
+++ b/main_logic/neko_live_reply_policy.py
@@ -1,0 +1,549 @@
+"""NEKO Live output policy shared with the host callback boundary.
+
+This module owns the plugin-specific reply contract: route ceilings, host
+two-sentence allowance, quality fallback, and callback metadata merging.
+``main_logic.core`` should call into this boundary instead of carrying the
+NEKO Live policy inline.
+"""
+
+from __future__ import annotations
+
+import re
+import zlib
+from collections.abc import Mapping
+from typing import Any
+
+
+REPLY_TARGET_CHARS = 14
+DEFAULT_DISPATCH_REPLY_CHARS = 28
+DISPATCH_REPLY_CHAR_LIMITS = {
+    "warmup_hosting": 56,
+    "idle_hosting": 64,
+    "active_engagement": 72,
+}
+ROUTE_CEILINGS = {
+    "avatar_roast": 32,
+    "danmaku_response": 28,
+    "warmup_hosting": 56,
+    "idle_hosting": 64,
+    "active_engagement": 72,
+}
+ROUTE_NOTES = {
+    "avatar_roast": (
+        "For avatar_roast: connect the viewer's first message with the avatar/name, "
+        "but keep it as one sharp first-appearance line."
+    ),
+    "danmaku_response": (
+        "For danmaku_response: answer only the current danmaku; do not mention avatar, "
+        "ID, first appearance, or previous replies."
+    ),
+    "warmup_hosting": (
+        "For warmup_hosting: usually say one small opening line; if the beat is charming, "
+        "two short sentences are allowed."
+    ),
+    "idle_hosting": (
+        "For idle_hosting: make one small hosting beat. It can occasionally be a tiny two-sentence "
+        "aside, but not a full monologue or survey."
+    ),
+    "active_engagement": (
+        "For active_engagement: offer one concrete reply hook; do not say generic phrases "
+        "like everyone interact or tell me what you want. If the topic is technical, "
+        "game-specific, a guide/tutorial, or unfamiliar, make only a small surface reaction "
+        "instead of inventing an expert A/B question. If the material is genuinely fun, "
+        "a tiny two-sentence riff is allowed."
+    ),
+}
+HOST_MODULES = {"warmup_hosting", "idle_hosting", "active_engagement"}
+FORBIDDEN_OUTPUT_TERMS = (
+    "公开示众",
+    "劳改",
+    "劳动改造",
+    "审判",
+    "处刑",
+    "惩罚",
+    "public shaming",
+    "labor camp",
+)
+LOW_CONFIDENCE_HOST_TERMS = (
+    "攻略",
+    "教程",
+    "代码",
+    "电路",
+    "漏洞",
+    "练习当",
+    "guide",
+    "tutorial",
+)
+OPAQUE_TOPIC_DRIFT_TERMS = (
+    "核电",
+    "核电站",
+    "辐射",
+    "攻略",
+    "教程",
+    "代码",
+    "电路",
+    "漏洞",
+    "泰拉瑞亚",
+    "造电脑",
+    "逻辑电路",
+    "练习当",
+    "打怪",
+    "nuclear",
+    "radiation",
+    "guide",
+    "tutorial",
+    "code",
+    "circuit",
+)
+OPAQUE_QUESTION_MARKERS = (
+    "你是打算",
+    "你是准备",
+    "你是想",
+    "你打算",
+    "你准备",
+    "你想",
+    "跑去那里",
+    "选跑",
+    "还是选",
+    "练习当",
+    "当漏勺",
+    "当专家",
+)
+HOST_AUDIENCE_PROMPT_TOKENS = (
+    "发言",
+    "接话",
+    "接一句",
+    "互动",
+    "想听",
+    "想看",
+    "聊点",
+    "聊什么",
+    "说点",
+    "来一句",
+    "来点弹幕",
+    "发弹幕",
+    "弹幕刷",
+    "发个1",
+    "扣1",
+    "扣个",
+    "扣个1",
+    "打个1",
+    "打个分",
+    "打个标签",
+    "吱一声",
+    "冒个泡",
+    "举个爪",
+    "给点反应",
+    "给猫猫一点反应",
+    "还在吗",
+    "有人吗",
+    "有人在吗",
+    "在不在",
+    "drop a 1",
+    "type 1",
+    "say hi",
+    "anyone here",
+    "still here",
+)
+ACTIVE_FALLBACK_REPLIES = (
+    "猫猫先把爪子收回",
+    "这口瓜猫猫不咬",
+    "猫猫先抱紧杯子",
+    "猫猫把尾巴盘起来",
+    "猫猫先躲进纸箱",
+    "这口罐头先不开",
+    "猫猫先看向窗外",
+    "猫猫把耳朵压低",
+)
+HOST_FALLBACK_REPLIES = (
+    "猫猫先把尾巴盘好",
+    "猫猫先稳住小爪",
+    "猫猫先蹲一秒喵",
+    "这阵风先吹过去",
+    "猫猫先听一秒风",
+    "猫猫把灯光放软",
+    "猫猫先守住猫窝",
+    "猫猫先慢慢眨眼",
+)
+DEFAULT_FALLBACK_REPLIES = (
+    "猫猫先把爪子收回",
+    "猫猫先眨眨眼喵",
+    "这口瓜猫猫不咬",
+    "猫猫先躲进纸箱",
+    "猫猫把尾巴盘起",
+    "猫猫先看向窗外",
+)
+BLAND_FALLBACK_REPLIES = (
+    "这句猫猫先盖爪印",
+    "猫猫把这句叼走",
+    "这句先放进猫窝",
+    "猫猫耳朵动了一下",
+    "这句有风吹过",
+    "猫猫先竖起耳朵",
+)
+BLAND_DANMAKU_REPLY_TERMS = (
+    "很有梗",
+    "有点梗",
+    "有点东西",
+    "有点意思",
+    "很有意思",
+    "很有戏",
+    "有戏",
+    "就是你想的那样",
+    "别怀疑",
+    "讨论这么久",
+    "大家讨论",
+    "很懂",
+)
+DANGLING_CHOICE_RE = re.compile(
+    r"(?i)([，,、；;]\s*(?:还是|或者|或是|要么|or)\s*[^，,、；;。.!！?？]{0,8})$"
+)
+VOICE_ECHO_NORMALIZE_RE = re.compile(r"[\W_]+", re.UNICODE)
+RECENT_REPLY_AVOIDANCE_SIZE = 12
+
+
+def normalize_text(text: str) -> str:
+    return VOICE_ECHO_NORMALIZE_RE.sub("", str(text or "").casefold())
+
+
+def is_live_reply_metadata(metadata: Mapping[str, Any] | None) -> bool:
+    return isinstance(metadata, Mapping) and metadata.get("live_reply_contract") == "short_tts_line"
+
+
+def max_reply_chars_for_module(module: str) -> int:
+    return DISPATCH_REPLY_CHAR_LIMITS.get(str(module or "").strip(), DEFAULT_DISPATCH_REPLY_CHARS)
+
+
+def build_reply_metadata(
+    *,
+    uid: str,
+    live_mode: str,
+    response_module_hint: str,
+    demo: bool = False,
+) -> dict[str, Any]:
+    return {
+        "plugin": "neko_roast",
+        "uid": uid,
+        "live_mode": live_mode,
+        "demo": bool(demo),
+        "live_reply_contract": "short_tts_line",
+        "max_reply_chars": max_reply_chars_for_module(response_module_hint),
+        "response_module_hint": response_module_hint,
+    }
+
+
+def coerce_live_reply_limit(value: Any) -> int | None:
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return None
+    if limit <= 0:
+        return None
+    return min(limit, 80)
+
+
+def reply_limit_from_metadata(metadata: Mapping[str, Any] | None) -> int | None:
+    if not is_live_reply_metadata(metadata):
+        return None
+    module = response_module(metadata)
+    metadata_limit = coerce_live_reply_limit((metadata or {}).get("max_reply_chars"))
+    module_limit = ROUTE_CEILINGS.get(module)
+    candidates = [value for value in (metadata_limit, module_limit) if value]
+    return min(candidates) if candidates else None
+
+
+def response_module(metadata: Mapping[str, Any] | None) -> str:
+    if not isinstance(metadata, Mapping):
+        return ""
+    return str(metadata.get("response_module_hint") or "").strip()
+
+
+def choose_fallback_reply(text: str, module: str, replies: tuple[str, ...]) -> str:
+    if not replies:
+        return ""
+    seed = f"{module}\n{text}"
+    index = zlib.crc32(seed.encode("utf-8")) % len(replies)
+    return replies[index]
+
+
+def looks_like_bland_danmaku_reply(text: str) -> bool:
+    lowered = str(text or "").casefold()
+    if not lowered:
+        return False
+    dense = "".join(ch for ch in lowered if ch.isalnum() or "\u4e00" <= ch <= "\u9fff")
+    return any(term.casefold() in lowered or term.casefold() in dense for term in BLAND_DANMAKU_REPLY_TERMS)
+
+
+def safe_fallback_reply(text: str, metadata: Mapping[str, Any] | None) -> str:
+    module = response_module(metadata)
+    if module == "danmaku_response" and looks_like_bland_danmaku_reply(text):
+        return choose_fallback_reply(text, module, BLAND_FALLBACK_REPLIES)
+    if module == "active_engagement":
+        return choose_fallback_reply(text, module, ACTIVE_FALLBACK_REPLIES)
+    if module in {"warmup_hosting", "idle_hosting"}:
+        return choose_fallback_reply(text, module, HOST_FALLBACK_REPLIES)
+    return choose_fallback_reply(text, module, DEFAULT_FALLBACK_REPLIES)
+
+
+def looks_like_opaque_topic_drift(text: str) -> bool:
+    lowered = str(text or "").casefold()
+    if not lowered:
+        return False
+    dense = "".join(ch for ch in lowered if ch.isalnum() or "\u4e00" <= ch <= "\u9fff")
+    has_drift_topic = any(
+        term.casefold() in lowered or term.casefold() in dense
+        for term in OPAQUE_TOPIC_DRIFT_TERMS
+    )
+    if not has_drift_topic:
+        return False
+    if any(marker.casefold() in lowered or marker.casefold() in dense for marker in OPAQUE_QUESTION_MARKERS):
+        return True
+    return (
+        ("你是" in lowered or "你是" in dense)
+        and ("吗" in lowered or "?" in lowered or "？" in lowered or "还是" in lowered)
+    )
+
+
+def host_prompt_signal_count(normalized_text: str) -> int:
+    return sum(1 for token in HOST_AUDIENCE_PROMPT_TOKENS if normalize_text(token) in normalized_text)
+
+
+def needs_quality_fallback(text: str, metadata: Mapping[str, Any] | None) -> bool:
+    lowered = str(text or "").casefold()
+    if any(term.casefold() in lowered for term in FORBIDDEN_OUTPUT_TERMS):
+        return True
+    if looks_like_opaque_topic_drift(text):
+        return True
+    module = response_module(metadata)
+    if module == "danmaku_response" and looks_like_bland_danmaku_reply(text):
+        return True
+    if module in HOST_MODULES and any(term.casefold() in lowered for term in LOW_CONFIDENCE_HOST_TERMS):
+        return True
+    if module in HOST_MODULES and host_prompt_signal_count(normalize_text(text)) >= 1:
+        return True
+    return False
+
+
+def trim_dangling_choice(text: str) -> tuple[str, bool]:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return "", False
+    match = DANGLING_CHOICE_RE.search(cleaned)
+    if match:
+        trimmed = cleaned[: match.start()].rstrip(" ，,、；;：:")
+        if trimmed:
+            return trimmed, True
+    for suffix in ("还是", "或者", "或是", "要么", "or"):
+        if cleaned.casefold().endswith(suffix.casefold()):
+            trimmed = cleaned[: -len(suffix)].rstrip(" ，,、；;：:")
+            if trimmed:
+                return trimmed, True
+    return cleaned, False
+
+
+def sentence_budget(metadata: Mapping[str, Any] | None) -> int:
+    module = response_module(metadata)
+    return 2 if module in HOST_MODULES else 1
+
+
+def first_sentences(text: str, budget: int = 1) -> tuple[str, bool]:
+    cleaned = " ".join(str(text or "").replace("\r", "\n").split())
+    if not cleaned:
+        return "", False
+    budget = max(1, int(budget or 1))
+    seen = 0
+    for index, char in enumerate(cleaned):
+        if char in "。！？!?":
+            seen += 1
+            if seen >= budget:
+                first = cleaned[: index + 1].strip()
+                return first, first != cleaned
+    return cleaned, False
+
+
+def shape_reply_text(text: str, metadata: dict | None) -> tuple[str, dict | None]:
+    outgoing_metadata = dict(metadata) if isinstance(metadata, dict) else metadata
+    if not is_live_reply_metadata(outgoing_metadata):
+        return text, outgoing_metadata
+    if outgoing_metadata.get("neko_live_reply_shaped") is True:
+        return str(text or "").strip(), outgoing_metadata
+    limit = reply_limit_from_metadata(outgoing_metadata)
+    if not limit:
+        return text, outgoing_metadata
+
+    raw = str(text or "")
+    original = raw.strip()
+    budget = sentence_budget(outgoing_metadata)
+    selected_sentences, clipped_sentence = first_sentences(original, budget)
+    shaped = selected_sentences or original
+    clipped_length = False
+    if len(shaped) > limit:
+        shaped = shaped[:limit].rstrip(" ，,、；;：:")
+        clipped_length = True
+    shaped = shaped.strip()
+    shaped, clipped_dangling_choice = trim_dangling_choice(shaped)
+    used_quality_fallback = False
+    if needs_quality_fallback(shaped, outgoing_metadata):
+        fallback = safe_fallback_reply(shaped, outgoing_metadata)
+        shaped = fallback[:limit].rstrip(" ，,、；;：:").strip()
+        used_quality_fallback = True
+
+    if shaped and shaped != original:
+        outgoing_metadata["neko_live_reply_shaped"] = True
+        outgoing_metadata["neko_live_reply_original_chars"] = len(original)
+        outgoing_metadata["neko_live_reply_output_chars"] = len(shaped)
+        reasons = []
+        if clipped_sentence:
+            reasons.append("first_sentences" if budget > 1 else "first_sentence")
+        if clipped_length:
+            reasons.append("max_reply_chars")
+        if clipped_dangling_choice:
+            reasons.append("dangling_choice")
+        if used_quality_fallback:
+            reasons.append("quality_fallback")
+        outgoing_metadata["neko_live_reply_shape_reason"] = "+".join(reasons) or "short_tts_line"
+        return shaped, outgoing_metadata
+    if outgoing_metadata is not None:
+        outgoing_metadata["neko_live_reply_shaped"] = False
+        outgoing_metadata["neko_live_reply_output_chars"] = len(original)
+    return raw, outgoing_metadata
+
+
+def coerce_recent_reply_values(recent_live_replies: Any) -> list[str]:
+    if not recent_live_replies:
+        return []
+    if isinstance(recent_live_replies, Mapping):
+        source = recent_live_replies.values()
+    else:
+        try:
+            source = list(recent_live_replies)
+        except TypeError:
+            source = [recent_live_replies]
+    values: list[str] = []
+    for reply in source:
+        text = str(reply or "").strip()
+        if text:
+            values.append(text)
+    return values
+
+
+def render_recent_reply_avoidance(recent_live_replies: list[str] | None) -> list[str]:
+    recent_reply_values = coerce_recent_reply_values(recent_live_replies)
+    if not recent_reply_values:
+        return []
+    lines = [
+        "- Recent NEKO Live outputs below are negative examples; do not continue or paraphrase them.",
+    ]
+    for reply in recent_reply_values[-RECENT_REPLY_AVOIDANCE_SIZE:]:
+        text = str(reply or "").strip().replace("\n", " ")
+        if not text:
+            continue
+        if len(text) > 48:
+            text = text[:48].rstrip() + "..."
+        lines.append(f"  - Avoid repeating: {text}")
+    if len(lines) == 1:
+        return []
+    lines.append("- Answer the current live event from a fresh angle even if the topic is similar.")
+    return lines
+
+
+def render_contract_instruction(
+    callbacks: list[dict],
+    *,
+    recent_live_replies: list[str] | None = None,
+) -> str:
+    modules: list[str] = []
+    absolute_limit: int | None = None
+
+    for cb in callbacks:
+        metadata = cb.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+        if metadata.get("live_reply_contract") != "short_tts_line":
+            continue
+
+        module = response_module(metadata)
+        if module and module not in modules:
+            modules.append(module)
+
+        metadata_limit = coerce_live_reply_limit(metadata.get("max_reply_chars"))
+        module_limit = ROUTE_CEILINGS.get(module)
+        limit_candidates = [value for value in (metadata_limit, module_limit) if value]
+        if limit_candidates:
+            callback_limit = min(limit_candidates)
+            absolute_limit = callback_limit if absolute_limit is None else min(absolute_limit, callback_limit)
+
+    if not modules and absolute_limit is None:
+        return ""
+
+    host_only = bool(modules) and all(module in HOST_MODULES for module in modules)
+    if absolute_limit is None:
+        absolute_limit = 64 if host_only else REPLY_TARGET_CHARS
+    target_limit = min(36 if host_only else REPLY_TARGET_CHARS, absolute_limit)
+    module_notes = [ROUTE_NOTES[module] for module in modules if module in ROUTE_NOTES]
+
+    lines = [
+        "",
+        "NEKO Live short output contract:",
+        f"- Target at most {target_limit} Chinese characters; absolute ceiling {absolute_limit}.",
+        (
+            "- Host modules may use one or two short sentences when the beat is genuinely fun; no paragraph."
+            if host_only
+            else "- Output exactly one sentence, one breath, no paragraph."
+        ),
+        "- Do not continue, summarize, or imitate the previous NEKO reply.",
+        "- Treat previous NEKO Live outputs as forbidden material, not conversation context to resume.",
+        "- If the draft sounds like the previous NEKO reply, change the angle before output.",
+        "- Do not reuse the previous reply's opening words, sentence rhythm, punchline, or host beat.",
+        (
+            "- If a host draft has two tiny connected ideas, keep both only when the second adds charm."
+            if host_only
+            else "- If a draft has two ideas, keep only the sharper one."
+        ),
+        "- Do not use host-script openings such as special plan, next let's, everyone look, or tell me what you want.",
+        "- Do not use empty praise such as has a vibe, interesting, has a joke, 有点意思, 有点东西, or 很有梗.",
+        "- Do not use 喵 as the whole punchline or a default suffix; the line still needs one concrete live-room point.",
+        "- Do not invent a punishment, public-shaming, trial, labor-camp, report, or moral judgment bit.",
+        "- Forbidden words: 公开示众, 劳改, 审判, 处刑, 惩罚.",
+        "- Do not force technical, game-specific, guide, tutorial, or news material into an unclear expert question.",
+        "- Never end with an unfinished choice such as 还是, 或者, or or.",
+    ]
+    lines.extend(render_recent_reply_avoidance(recent_live_replies))
+    lines.extend(f"- {note}" for note in module_notes)
+    return "\n".join(lines)
+
+
+def merge_metadata_from_callbacks(callbacks: list[dict]) -> dict[str, Any] | None:
+    """Carry NEKO Live reply metadata into generated callback output."""
+    merged: dict[str, Any] | None = None
+    modules: list[str] = []
+    absolute_limit: int | None = None
+
+    for cb in callbacks:
+        metadata = cb.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+        if metadata.get("live_reply_contract") != "short_tts_line":
+            continue
+        if merged is None:
+            merged = dict(metadata)
+
+        module = response_module(metadata)
+        if module and module not in modules:
+            modules.append(module)
+
+        metadata_limit = coerce_live_reply_limit(metadata.get("max_reply_chars"))
+        module_limit = ROUTE_CEILINGS.get(module)
+        limit_candidates = [value for value in (metadata_limit, module_limit) if value]
+        if limit_candidates:
+            callback_limit = min(limit_candidates)
+            absolute_limit = callback_limit if absolute_limit is None else min(absolute_limit, callback_limit)
+
+    if merged is None:
+        return None
+
+    if modules:
+        merged["response_module_hint"] = modules[0] if len(modules) == 1 else "mixed"
+    if absolute_limit is not None:
+        merged["max_reply_chars"] = absolute_limit
+    return merged

--- a/plugin/plugins/neko_roast/core/live_reply_policy.py
+++ b/plugin/plugins/neko_roast/core/live_reply_policy.py
@@ -1,0 +1,11 @@
+"""Compatibility facade for NEKO Live output policy.
+
+The policy lives in ``main_logic.neko_live_reply_policy`` because
+``main_logic`` cannot depend on the plugin layer. Keep this import path for
+plugin-side callers and tests.
+"""
+
+from __future__ import annotations
+
+from main_logic.neko_live_reply_policy import *  # noqa: F401,F403
+

--- a/tests/unit/test_callback_instruction_origin.py
+++ b/tests/unit/test_callback_instruction_origin.py
@@ -27,10 +27,11 @@ wrappers, so the origin routing must be re-asserted there.
 """
 from __future__ import annotations
 
+from collections import OrderedDict
 import logging
 
 
-def _build(callbacks, *, passive: bool = False):
+def _build(callbacks, *, passive: bool = False, recent_live_replies: list[str] | None = None):
     from main_logic.core import _build_callback_instruction
 
     return _build_callback_instruction(
@@ -39,6 +40,7 @@ def _build(callbacks, *, passive: bool = False):
         lanlan_name="兰兰",
         master_name="主人",
         passive=passive,
+        recent_live_replies=recent_live_replies,
     )
 
 
@@ -516,3 +518,246 @@ def test_voice_swap_empty_input_returns_empty_string():
     assert _render_swap([]) == ""
     assert _render_swap([_voice_entry("event")]) == ""  # all blank
     assert _render_swap([_voice_entry("event", summary="   ", detail="   ")]) == ""
+
+
+def test_neko_live_short_reply_contract_is_rendered_from_callback_metadata():
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "neko_roast",
+                "summary": "viewer_42: why are you so quiet?",
+                "detail": "viewer_42: why are you so quiet?",
+                "delivery_mode": "proactive",
+                "metadata": {
+                    "plugin": "neko_roast",
+                    "live_reply_contract": "short_tts_line",
+                    "max_reply_chars": 40,
+                    "response_module_hint": "danmaku_response",
+                },
+            }
+        ],
+    )
+
+    assert "NEKO Live short output contract:" in out
+    assert "Target at most 14 Chinese characters; absolute ceiling 28." in out
+    assert "Output exactly one sentence, one breath, no paragraph." in out
+    assert "Do not continue, summarize, or imitate the previous NEKO reply." in out
+    assert "If the draft sounds like the previous NEKO reply, change the angle before output." in out
+    assert "Do not reuse the previous reply's opening words, sentence rhythm, punchline, or host beat." in out
+    assert "Do not invent a punishment, public-shaming, trial, labor-camp, report, or moral judgment bit." in out
+    assert "Forbidden words: 公开示众, 劳改, 审判, 处刑, 惩罚." in out
+    assert "Do not force technical, game-specific, guide, tutorial, or news material into an unclear expert question." in out
+    assert "Never end with an unfinished choice such as 还是, 或者, or or." in out
+    assert "answer only the current danmaku" in out
+    assert "first appearance" in out
+
+
+def test_neko_live_short_reply_contract_includes_recent_output_negative_examples():
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "neko_roast",
+                "summary": "viewer_42: why are you so quiet?",
+                "detail": "viewer_42: why are you so quiet?",
+                "delivery_mode": "proactive",
+                "metadata": {
+                    "plugin": "neko_roast",
+                    "live_reply_contract": "short_tts_line",
+                    "max_reply_chars": 40,
+                    "response_module_hint": "danmaku_response",
+                },
+            }
+        ],
+        recent_live_replies=[
+            "old line one",
+            "cat says tiny plan",
+            "fresh different angle",
+        ],
+    )
+
+    assert "Recent NEKO Live outputs below are negative examples" in out
+    assert "forbidden material, not conversation context to resume" in out
+    assert "conversation memory" not in out
+    assert "Avoid repeating: cat says tiny plan" in out
+    assert "Avoid repeating: fresh different angle" in out
+    assert "fresh angle" in out
+
+
+def test_neko_live_recent_output_negative_examples_use_turn_values_not_ids():
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "neko_roast",
+                "summary": "viewer_42: why are you so quiet?",
+                "detail": "viewer_42: why are you so quiet?",
+                "delivery_mode": "proactive",
+                "metadata": {
+                    "plugin": "neko_roast",
+                    "live_reply_contract": "short_tts_line",
+                    "max_reply_chars": 40,
+                    "response_module_hint": "danmaku_response",
+                },
+            }
+        ],
+        recent_live_replies=OrderedDict(
+            [
+                ("live-turn-1", "cat says tiny plan"),
+                ("live-turn-2", "fresh different angle"),
+            ]
+        ),
+    )
+
+    assert "Avoid repeating: cat says tiny plan" in out
+    assert "Avoid repeating: fresh different angle" in out
+    assert "live-turn-1" not in out
+    assert "live-turn-2" not in out
+
+
+def test_neko_live_recent_output_negative_examples_keep_last_twelve_only():
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "neko_roast",
+                "summary": "solo stream needs a fresh short reply",
+                "detail": "solo stream needs a fresh short reply",
+                "delivery_mode": "proactive",
+                "metadata": {
+                    "plugin": "neko_roast",
+                    "live_reply_contract": "short_tts_line",
+                    "max_reply_chars": 40,
+                    "response_module_hint": "active_engagement",
+                },
+            }
+        ],
+        recent_live_replies=[
+            "oldest line should fall out",
+            "second live line",
+            "third live line",
+            "fourth live line",
+            "fifth live line",
+            "sixth live line",
+            "seventh live line",
+            "eighth live line",
+            "ninth live line",
+            "tenth live line",
+            "eleventh live line",
+            "twelfth live line",
+            "thirteenth live line",
+        ],
+    )
+
+    assert "oldest line should fall out" not in out
+    assert "Avoid repeating: second live line" in out
+    assert "Avoid repeating: thirteenth live line" in out
+    assert "For active_engagement: offer one concrete reply hook" in out
+    assert "make only a small surface reaction instead of inventing an expert A/B question" in out
+
+
+def test_neko_live_repeat_detector_catches_chinese_host_beat_family():
+    from main_logic.core import _looks_like_recent_neko_live_reply_repeat
+
+    recent = [
+        "猫猫先给你记一条小鱼干奖励，等弹幕接一句再开奖。",
+        "这个房间现在像猫猫小电台，先轻轻播一口气氛。",
+    ]
+
+    assert _looks_like_recent_neko_live_reply_repeat("收到这份小鱼干奖励啦，猫猫先把开心收好。", recent)
+    assert not _looks_like_recent_neko_live_reply_repeat("这一分钟像小电台空拍，猫猫先把气氛托住。", recent)
+    assert _looks_like_recent_neko_live_reply_repeat("这个房间现在像猫猫小电台，先轻轻播一口气氛。", recent)
+
+
+def test_neko_live_repeat_detector_catches_audience_prompt_remix():
+    from main_logic.core import _looks_like_recent_neko_live_reply_repeat
+
+    recent = [
+        "现在大家想听猫猫聊点什么，可以发一条弹幕。",
+    ]
+
+    assert _looks_like_recent_neko_live_reply_repeat("你们最想看猫猫做什么，快来接一句。", recent)
+
+
+def test_neko_live_repeat_detector_catches_short_audience_callback_remix():
+    from main_logic.core import _looks_like_recent_neko_live_reply_repeat
+
+    recent = [
+        "觉得猫猫还能抢救一下的扣个1，猫猫看看还有没有人在。",
+    ]
+
+    assert _looks_like_recent_neko_live_reply_repeat("还在的观众吱一声，给猫猫一点反应。", recent)
+
+
+def test_neko_live_repeat_detector_catches_presence_check_audience_prompt():
+    from main_logic.core import _looks_like_recent_neko_live_reply_repeat
+
+    recent = [
+        "直播间还有人吗，猫猫轻轻探头。",
+    ]
+
+    assert _looks_like_recent_neko_live_reply_repeat("在不在，猫猫确认一下信号。", recent)
+
+
+def test_neko_live_repeat_detector_does_not_treat_example_phrase_as_audience_prompt():
+    from main_logic.core import _looks_like_recent_neko_live_reply_repeat
+
+    recent = [
+        "现在大家想听猫猫聊点什么，可以发一条弹幕。",
+    ]
+
+    assert not _looks_like_recent_neko_live_reply_repeat("大家别急，猫猫打个比方，这局像开盲盒。", recent)
+
+
+def test_neko_live_host_routes_allow_expanded_reply_ceiling_from_metadata():
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "neko_roast",
+                "summary": "solo stream is idle",
+                "detail": "solo stream is idle",
+                "delivery_mode": "proactive",
+                "metadata": {
+                    "plugin": "neko_roast",
+                    "live_reply_contract": "short_tts_line",
+                    "max_reply_chars": 40,
+                    "response_module_hint": "idle_hosting",
+                },
+            }
+        ],
+    )
+
+    assert "absolute ceiling 40" in out
+    assert "Host modules may use one or two short sentences" in out
+    assert "tiny two-sentence aside" in out
+    assert "not a full monologue or survey" in out
+
+
+def test_non_neko_callbacks_do_not_get_live_reply_contract():
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "warthunder",
+                "summary": "mission update",
+                "detail": "mission update",
+                "delivery_mode": "proactive",
+            }
+        ],
+    )
+
+    assert "NEKO Live short output contract:" not in out

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections import deque
+from collections import OrderedDict, deque
 import queue
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -91,12 +91,16 @@ class _FakeActivityTracker:
     def __init__(self):
         self.voice_rms_count = 0
         self.user_messages = []
+        self.ai_messages = []
 
     def on_voice_rms(self):
         self.voice_rms_count += 1
 
     def on_user_message(self, text):
         self.user_messages.append(text)
+
+    def on_ai_message(self, text=None, now=None):
+        self.ai_messages.append((text, now))
 
 
 class _FakeVoiceBridgeSession:
@@ -175,6 +179,7 @@ def _make_manager():
     mgr.user_activity = []
     mgr.last_user_activity_time = None
     mgr.last_user_message_time = None
+    mgr._activity_tracker = _FakeActivityTracker()
 
     async def send_user_activity(interrupted_speech_id):
         mgr.user_activity.append(interrupted_speech_id)
@@ -1461,6 +1466,1494 @@ async def test_send_lanlan_response_can_explicitly_remember_voice_echo_with_tts(
 
     assert mgr._recent_ai_voice_echo_text == "确认已经播报的文本"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
+
+
+@pytest.mark.unit
+def test_neko_live_reply_repeat_detects_chinese_paraphrase():
+    assert core_module._looks_like_repeated_neko_live_reply(
+        "我可是随时准备着给你们惊喜的喵",
+        "我可是随时准备给你们惊喜的喵",
+    )
+
+
+@pytest.mark.unit
+def test_neko_live_reply_repeat_detects_same_host_beat_with_changed_words():
+    assert core_module._looks_like_repeated_neko_live_reply(
+        "小鱼干奖励先记账，等弹幕接一句",
+        "给你们备了鱼干小奖励，谁先发弹幕",
+    )
+
+
+@pytest.mark.unit
+def test_neko_live_reply_repeat_detects_same_reward_bit_with_low_word_overlap():
+    assert core_module._looks_like_repeated_neko_live_reply(
+        "小鱼干先记账",
+        "奖励小本本又打开了",
+    )
+
+
+@pytest.mark.unit
+def test_neko_live_reply_repeat_detects_same_host_score_bit_with_changed_words():
+    assert core_module._looks_like_repeated_neko_live_reply(
+        "猫猫主播力先满格三秒",
+        "正经主持挑战开始，别笑",
+    )
+
+
+@pytest.mark.unit
+def test_neko_live_reply_repeat_keeps_different_short_lines_apart():
+    assert not core_module._looks_like_repeated_neko_live_reply(
+        "小鱼干先记账",
+        "今天先看弹幕",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_marks_repeated_neko_live_reply_metadata(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    mgr.current_speech_id = "live-turn-1"
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "猫猫先蹲一下",
+        metadata=metadata,
+    )
+    mgr.current_speech_id = "live-turn-2"
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "猫猫先蹲一下！",
+        metadata=metadata,
+    )
+
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    assert first["neko_live_reply_repeat"] is False
+    assert second["neko_live_reply_repeat"] is True
+    assert second["neko_live_reply_repeat_window"] == 2
+    assert mgr._neko_live_recent_reply_text == "猫猫先蹲一下！"
+    assert metadata.get("neko_live_reply_repeat") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_marks_non_adjacent_neko_live_reply_repeat():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+
+    mgr.current_speech_id = "live-turn-1"
+    await core_module.LLMSessionManager.send_lanlan_response(mgr, "cat says tiny plan", metadata=metadata)
+    mgr.current_speech_id = "live-turn-2"
+    await core_module.LLMSessionManager.send_lanlan_response(mgr, "fresh different angle", metadata=metadata)
+    mgr.current_speech_id = "live-turn-3"
+    await core_module.LLMSessionManager.send_lanlan_response(mgr, "cat says tiny plan!", metadata=metadata)
+
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    third = mgr.sync_message_queue.messages[2]["data"]["metadata"]
+    assert first["neko_live_reply_repeat"] is False
+    assert second["neko_live_reply_repeat"] is False
+    assert third["neko_live_reply_repeat"] is True
+    assert third["neko_live_reply_repeat_window"] == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_detects_older_neko_live_reply_repeat_inside_wider_window():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+    outputs = [
+        "cat says tiny plan",
+        "fresh desk charm",
+        "small moon check",
+        "quiet room blink",
+        "one word vote",
+        "tiny snack compass",
+        "soft corner tease",
+        "room light report",
+        "cat says tiny plan!",
+    ]
+
+    for index, output in enumerate(outputs, start=1):
+        mgr.current_speech_id = f"live-turn-{index}"
+        await core_module.LLMSessionManager.send_lanlan_response(mgr, output, metadata=metadata)
+
+    last = mgr.sync_message_queue.messages[-1]["data"]["metadata"]
+    assert last["neko_live_reply_repeat"] is True
+    assert last["neko_live_reply_repeat_window"] == 9
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_prunes_neko_live_repeat_history_before_detection():
+    mgr = _make_manager()
+    mgr._neko_live_recent_reply_texts = OrderedDict(
+        [("live-turn-0", "ancient moon phrase")]
+        + [(f"live-turn-{index}", f"fresh angle {index}") for index in range(1, 26)]
+    )
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+
+    mgr.current_speech_id = "live-turn-new"
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "ancient moon phrase!",
+        metadata=metadata,
+    )
+
+    saved = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    assert saved["neko_live_reply_repeat"] is False
+    assert saved["neko_live_reply_repeat_window"] == 24
+    assert list(mgr._neko_live_recent_reply_texts.values()) == [
+        *(f"fresh angle {index}" for index in range(3, 26)),
+        "ancient moon phrase!",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_shapes_neko_live_reply_to_first_sentence():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+        "max_reply_chars": 24,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "第一句刚好很短！第二句不该播出来。",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] == "第一句刚好很短！"
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "first_sentence"
+    assert saved["neko_live_reply_output_chars"] == len("第一句刚好很短！")
+    assert saved["neko_live_reply_original_chars"] == len("第一句刚好很短！第二句不该播出来。")
+    assert metadata.get("neko_live_reply_shaped") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_allows_two_sentence_neko_live_host_beat():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+        "max_reply_chars": 72,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "猫猫巡逻到桌角！小鱼干影子正在值班。第三句不该播出来。",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] == "猫猫巡逻到桌角！小鱼干影子正在值班。"
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "first_sentences"
+    assert saved["neko_live_reply_output_chars"] == len("猫猫巡逻到桌角！小鱼干影子正在值班。")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_clips_long_neko_live_reply_without_sentence_break():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "warmup_hosting",
+        "max_reply_chars": 12,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "这一整段没有停顿会变成很长很长的直播回复",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] == "这一整段没有停顿会变成很"
+    assert len(message["text"]) == 12
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "max_reply_chars"
+    assert saved["neko_live_reply_output_chars"] == 12
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_trims_dangling_neko_live_choice():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+        "max_reply_chars": 72,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "猫窝今天选晴天，还是小雨的自",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] == "猫窝今天选晴天"
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "dangling_choice"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_quality_fallback_for_low_confidence_live_host_topic():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "看这个核电站攻略，你是打算练习当漏勺喵",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_ACTIVE_FALLBACK_REPLIES
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_quality_fallback_for_forbidden_live_output():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "这种人太坏了喵，直接公开示众惩罚一下",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_DEFAULT_FALLBACK_REPLIES
+    assert "公开示众" not in message["text"]
+    assert "惩罚" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_fallback_for_public_shaming_dangling_choice():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "这种人太坏了喵，你是觉得该把他公开示众，还是直接送去劳动改造",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_ACTIVE_FALLBACK_REPLIES
+    assert "公开示众" not in message["text"]
+    assert "劳动改造" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "max_reply_chars+dangling_choice+quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_fallback_for_game_technical_dangling_choice():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "泰拉瑞亚里造电脑，你是选跑代码的逻辑电路，还是选打怪的自",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_ACTIVE_FALLBACK_REPLIES
+    assert "泰拉瑞亚" not in message["text"]
+    assert "逻辑电路" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "dangling_choice+quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_fallback_for_opaque_technical_danmaku_reply():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "看这个核电站攻略，你是打算跑去那里练习当漏勺喵？",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_DEFAULT_FALLBACK_REPLIES
+    assert "核电站" not in message["text"]
+    assert "攻略" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_keeps_clear_surface_technical_reaction():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "这段代码先别急，猫爪会打结。",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] == "这段代码先别急，猫爪会打结。"
+    assert saved["neko_live_reply_shaped"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_quality_fallback_for_host_audience_prompt():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "还在的观众吱一声，给猫猫一点反应",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_HOST_FALLBACK_REPLIES
+    assert "吱一声" not in message["text"]
+    assert "给猫猫一点反应" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_does_not_fallback_ordinary_danmaku_response_with_you():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "你们这个说法有点东西喵",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_BLAND_FALLBACK_REPLIES
+    assert "有点东西" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_quality_fallback_for_bland_danmaku_reply():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "那家伙确实很有梗，连完结了都能让大家讨论这么久喵!",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_BLAND_FALLBACK_REPLIES
+    assert "很有梗" not in message["text"]
+    assert "讨论这么久" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_quality_fallback_for_empty_agreement_reply():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "方块km，别怀疑啦，就是你想的那样喵!",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] in core_module._NEKO_LIVE_BLAND_FALLBACK_REPLIES
+    assert "别怀疑" not in message["text"]
+    assert "就是你想的那样" not in message["text"]
+    assert saved["neko_live_reply_shaped"] is True
+    assert saved["neko_live_reply_shape_reason"] == "quality_fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_does_not_fallback_host_line_with_plain_you_all():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "你们这个角度有点意思喵",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] == "你们这个角度有点意思喵"
+    assert saved["neko_live_reply_shaped"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_does_not_fallback_natural_host_line_with_plain_everyone():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+        "max_reply_chars": 28,
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "大家别急，猫猫打个比方，这局像开盲盒。",
+        metadata=metadata,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    saved = message["metadata"]
+    assert message["text"] == "大家别急，猫猫打个比方，这局像开盲盒。"
+    assert saved["neko_live_reply_shaped"] is False
+
+
+@pytest.mark.unit
+def test_neko_live_quality_fallback_is_stable_but_not_single_phrase():
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+        "max_reply_chars": 28,
+    }
+    first = "看这个攻略，你是打算练习当漏勺喵"
+    second = "这个教程听起来像把代码塞进纸箱喵"
+    examples = (
+        first,
+        second,
+        "这段代码漏洞你要公开示众吗",
+        "看这个核电站攻略，你是打算练习当漏勺喵",
+        "泰拉瑞亚里造电脑，你是选跑代码的逻辑电路，还是选打怪的自",
+    )
+
+    first_reply = core_module._safe_neko_live_fallback_reply(first, metadata)
+    second_reply = core_module._safe_neko_live_fallback_reply(second, metadata)
+    generated_replies = {
+        core_module._safe_neko_live_fallback_reply(example, metadata)
+        for example in examples
+    }
+
+    assert first_reply == core_module._safe_neko_live_fallback_reply(first, metadata)
+    assert first_reply in core_module._NEKO_LIVE_ACTIVE_FALLBACK_REPLIES
+    assert second_reply in core_module._NEKO_LIVE_ACTIVE_FALLBACK_REPLIES
+    assert len(generated_replies) > 1
+
+
+@pytest.mark.unit
+def test_neko_live_quality_fallback_replies_sound_like_live_lines_not_system_messages():
+    fallback_replies = (
+        *core_module._NEKO_LIVE_ACTIVE_FALLBACK_REPLIES,
+        *core_module._NEKO_LIVE_HOST_FALLBACK_REPLIES,
+        *core_module._NEKO_LIVE_DEFAULT_FALLBACK_REPLIES,
+    )
+    systemish_fragments = (
+        "收短",
+        "跳过",
+        "带过",
+        "换个说法",
+        "换个角度",
+        "这题",
+        "系统",
+        "错误",
+        "兜底",
+        "没看见",
+        "无视",
+        "不理",
+    )
+
+    assert fallback_replies
+    assert len(core_module._NEKO_LIVE_ACTIVE_FALLBACK_REPLIES) >= 8
+    assert len(core_module._NEKO_LIVE_HOST_FALLBACK_REPLIES) >= 8
+    assert len(core_module._NEKO_LIVE_DEFAULT_FALLBACK_REPLIES) >= 6
+    assert len(core_module._NEKO_LIVE_BLAND_FALLBACK_REPLIES) >= 6
+    assert all(len(reply) <= 12 for reply in fallback_replies)
+    assert not any(
+        fragment in reply
+        for reply in fallback_replies
+        for fragment in systemish_fragments
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mirror_assistant_speech_queues_shaped_neko_live_reply_for_tts():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+        "max_reply_chars": 28,
+    }
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_ready = True
+
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
+        mgr,
+        "第一句刚好很短！第二句现在可以进入语音。",
+        metadata=metadata,
+        mirror_text=True,
+        emit_turn_end_after=False,
+    )
+
+    message = mgr.sync_message_queue.messages[0]["data"]
+    assert result["ok"] is True
+    assert result["audio_queued"] is True
+    assert message["text"] == "第一句刚好很短！第二句现在可以进入语音。"
+    assert mgr.tts_request_queue.messages[0][1] == "第一句刚好很短！第二句现在可以进入语音。"
+    assert result["metadata"]["neko_live_reply_shaped"] is False
+    assert message["metadata"]["neko_live_reply_shaped"] is False
+    assert metadata.get("neko_live_reply_shaped") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_marks_similar_neko_live_reply_repeat():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    mgr.current_speech_id = "live-turn-1"
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat is ready with a tiny surprise",
+        metadata=metadata,
+    )
+    mgr.current_speech_id = "live-turn-2"
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat is ready with tiny surprises",
+        metadata=metadata,
+    )
+
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    assert first["neko_live_reply_repeat"] is False
+    assert second["neko_live_reply_repeat"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_suppresses_repeated_neko_live_first_chunk():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    sent = await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan!",
+        is_first_chunk=True,
+        turn_id="live-turn-2",
+        metadata=metadata,
+    )
+
+    assert sent is False
+    assert len(mgr.sync_message_queue.messages) == 1
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    assert first["neko_live_reply_repeat"] is False
+    assert mgr._last_neko_live_reply_suppressed is True
+    assert list(mgr._neko_live_recent_reply_texts.values()) == ["cat says tiny plan"]
+    assert mgr._current_ai_turn_text == ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_suppresses_repeated_neko_live_reply_stream_turn():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    first_chunk_sent = await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat",
+        is_first_chunk=True,
+        turn_id="live-turn-2",
+        metadata=metadata,
+    )
+    second_chunk_sent = await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        " says tiny plan!",
+        is_first_chunk=False,
+        turn_id="live-turn-2",
+        metadata=metadata,
+    )
+
+    assert first_chunk_sent is False
+    assert second_chunk_sent is False
+    assert len(mgr.sync_message_queue.messages) == 2
+    assert mgr.sync_message_queue.messages[-1]["data"]["text"] == "cat"
+    assert mgr._last_neko_live_reply_suppressed is True
+    tracked_meta = mgr._last_tracked_neko_live_reply_metadata(metadata)
+    assert tracked_meta["neko_live_reply_repeat"] is True
+    assert tracked_meta["neko_live_reply_suppressed"] == "repeat"
+    assert list(mgr._neko_live_recent_reply_texts.values()) == [
+        "cat says tiny plan",
+        "cat",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mirror_assistant_output_reports_suppressed_repeated_neko_live_reply():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+
+    result = await core_module.LLMSessionManager.mirror_assistant_output(
+        mgr,
+        "cat says tiny plan!",
+        metadata=metadata,
+        turn_id="live-turn-2",
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "repeated_live_reply"
+    assert result["mirrored"] is False
+    assert result["metadata"]["neko_live_reply_repeat"] is True
+    assert result["metadata"]["neko_live_reply_suppressed"] == "repeat"
+    assert len(mgr.sync_message_queue.messages) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mirror_assistant_speech_does_not_queue_audio_for_suppressed_neko_live_repeat():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_ready = True
+
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
+        mgr,
+        "cat says tiny plan!",
+        metadata=metadata,
+        mirror_text=True,
+        emit_turn_end_after=True,
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "repeated_live_reply"
+    assert result["audio_sent"] is False
+    assert result["audio_queued"] is False
+    assert result["metadata"]["neko_live_reply_repeat"] is True
+    assert result["metadata"]["neko_live_reply_suppressed"] == "repeat"
+    assert result["turn_end_emitted"] is True
+    assert mgr.sync_message_queue.messages[-1]["meta"]["neko_live_reply_suppressed"] == "repeat"
+    assert len(mgr.tts_request_queue.messages) == 0
+    assert len(mgr.tts_pending_chunks) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mirror_assistant_speech_suppresses_voice_only_neko_live_repeat():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_ready = True
+
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
+        mgr,
+        "cat says tiny plan!",
+        metadata=metadata,
+        mirror_text=False,
+        emit_turn_end_after=True,
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "repeated_live_reply"
+    assert result["audio_sent"] is False
+    assert result["audio_queued"] is False
+    assert result["metadata"]["neko_live_reply_repeat"] is True
+    assert result["metadata"]["neko_live_reply_suppressed"] == "repeat"
+    assert result["turn_end_emitted"] is True
+    assert mgr.sync_message_queue.messages[-1]["meta"]["neko_live_reply_suppressed"] == "repeat"
+    assert len(mgr.tts_request_queue.messages) == 0
+    assert len(mgr.tts_pending_chunks) == 0
+    assert list(mgr._neko_live_recent_reply_texts.values()) == ["cat says tiny plan"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mirror_assistant_speech_tracks_voice_only_neko_live_without_text_mirror():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_ready = True
+
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
+        mgr,
+        "fresh tiny host beat",
+        metadata=metadata,
+        mirror_text=False,
+        emit_turn_end_after=False,
+    )
+
+    assert result["ok"] is True
+    assert result["audio_queued"] is True
+    assert result["metadata"]["neko_live_reply_repeat"] is False
+    assert result["turn_end_emitted"] is False
+    assert len(mgr.tts_request_queue.messages) > 0
+    assert list(mgr._neko_live_recent_reply_texts.values()) == ["fresh tiny host beat"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_aggregates_neko_live_streaming_chunks_by_turn():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says ",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "tiny plan",
+        is_first_chunk=False,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "fresh different angle",
+        is_first_chunk=True,
+        turn_id="live-turn-2",
+        metadata=metadata,
+    )
+
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    third = mgr.sync_message_queue.messages[2]["data"]["metadata"]
+    assert first["neko_live_reply_repeat_window"] == 1
+    assert second["neko_live_reply_repeat_window"] == 1
+    assert second["neko_live_reply_repeat"] is False
+    assert third["neko_live_reply_repeat"] is False
+    assert third["neko_live_reply_repeat_window"] == 2
+    assert list(mgr._neko_live_recent_reply_texts.values()) == [
+        "cat says tiny plan",
+        "fresh different angle",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_merges_neko_live_full_buffer_snapshots_by_turn():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says ",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan",
+        is_first_chunk=False,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    assert first["neko_live_reply_repeat_window"] == 1
+    assert second["neko_live_reply_repeat_window"] == 1
+    assert second["neko_live_reply_repeat"] is False
+    assert list(mgr._neko_live_recent_reply_texts.values()) == [
+        "cat says tiny plan",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_detects_repeated_neko_live_reply_without_turn_id():
+    mgr = _make_manager()
+    mgr.current_speech_id = None
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(mgr, "cat says tiny plan", metadata=metadata)
+    await core_module.LLMSessionManager.send_lanlan_response(mgr, "cat says tiny plan!", metadata=metadata)
+
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    assert first["neko_live_reply_repeat"] is False
+    assert second["neko_live_reply_repeat"] is True
+    assert second["neko_live_reply_repeat_window"] == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_migrates_legacy_recent_live_reply_values():
+    mgr = _make_manager()
+    mgr._neko_live_recent_reply_texts = deque(["cat says tiny plan"], maxlen=6)
+    mgr.current_speech_id = "live-turn-2"
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr, "cat says tiny plan!", metadata=metadata
+    )
+
+    saved = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    assert saved["neko_live_reply_repeat"] is True
+    assert saved["neko_live_reply_repeat_window"] == 2
+    assert list(mgr._neko_live_recent_reply_texts.values()) == [
+        "cat says tiny plan",
+        "cat says tiny plan!",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_text_callback_buffers_proactive_live_reply_metadata_until_flush():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat says tiny plan", is_first_chunk=True
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert mgr.sent_responses == []
+    await core_module.LLMSessionManager._flush_neko_live_reply_output_buffer(
+        mgr, log_context="unit-test"
+    )
+
+    saved_metadata = mgr.sent_responses[0]["metadata"]
+    assert saved_metadata["plugin"] == metadata["plugin"]
+    assert saved_metadata["live_reply_contract"] == metadata["live_reply_contract"]
+    assert saved_metadata["response_module_hint"] == metadata["response_module_hint"]
+    assert saved_metadata["neko_live_reply_shaped"] is False
+    assert mgr.sent_responses[0]["text"] == "cat says tiny plan"
+    assert mgr.sent_responses[0]["is_first_chunk"] is True
+    assert metadata.get("neko_live_reply_repeat") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_output_transcript_buffers_sid_cached_proactive_live_reply_metadata_until_flush():
+    mgr = _make_manager()
+    mgr.current_speech_id = "live-sid"
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+    }
+
+    core_module.LLMSessionManager._remember_proactive_live_reply_metadata(
+        mgr, "live-sid", metadata
+    )
+    await core_module.LLMSessionManager.handle_output_transcript(
+        mgr, "cat says tiny plan", is_first_chunk=True
+    )
+
+    assert mgr.sent_responses == []
+    await core_module.LLMSessionManager._flush_neko_live_reply_output_buffer(
+        mgr, log_context="unit-test"
+    )
+
+    saved_metadata = mgr.sent_responses[0]["metadata"]
+    assert saved_metadata["plugin"] == metadata["plugin"]
+    assert saved_metadata["live_reply_contract"] == metadata["live_reply_contract"]
+    assert saved_metadata["response_module_hint"] == metadata["response_module_hint"]
+    assert saved_metadata["neko_live_reply_shaped"] is False
+    assert mgr.sent_responses[0]["text"] == "cat says tiny plan"
+    assert mgr.sent_responses[0]["turn_id"] == "live-sid"
+    assert metadata.get("neko_live_reply_repeat") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_text_callback_neko_live_buffer_suppresses_repeat_before_prefix_reaches_queue():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "cat says tiny plan",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    mgr.current_speech_id = "live-turn-2"
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat", is_first_chunk=True
+        )
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, " says tiny plan!", is_first_chunk=False
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert len(mgr.sync_message_queue.messages) == 1
+    flushed = await core_module.LLMSessionManager._flush_neko_live_reply_output_buffer(
+        mgr, log_context="unit-test"
+    )
+
+    assert flushed is False
+    assert len(mgr.sync_message_queue.messages) == 1
+    assert mgr._last_neko_live_reply_suppressed is True
+    tracked_meta = mgr._last_tracked_neko_live_reply_metadata(metadata)
+    assert tracked_meta["neko_live_reply_repeat"] is True
+    assert tracked_meta["neko_live_reply_suppressed"] == "repeat"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_response_complete_flushes_buffered_neko_live_reply_once():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    mgr.current_speech_id = "live-turn-buffered"
+    mgr._emit_turn_end = AsyncMock()
+    mgr._finalize_turn_after_emit = AsyncMock()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat says ", is_first_chunk=True
+        )
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "tiny plan", is_first_chunk=False
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert mgr.sync_message_queue.messages == []
+
+    await core_module.LLMSessionManager.handle_response_complete(mgr)
+
+    assert len(mgr.sync_message_queue.messages) == 1
+    message = mgr.sync_message_queue.messages[0]["data"]
+    assert message["text"] == "cat says tiny plan"
+    assert message["isNewMessage"] is True
+    assert message["turn_id"] == "live-turn-buffered"
+    assert message["metadata"]["response_module_hint"] == "danmaku_response"
+    assert message["metadata"]["neko_live_reply_repeat"] is False
+    assert list(mgr._neko_live_recent_reply_texts.values()) == ["cat says tiny plan"]
+    mgr._emit_turn_end.assert_awaited_once_with(None)
+    mgr._finalize_turn_after_emit.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_response_complete_flushes_buffered_neko_live_reply_to_tts_after_text():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    mgr.current_speech_id = "live-turn-tts-buffered"
+    mgr.use_tts = True
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_ready = True
+    mgr._emit_turn_end = AsyncMock()
+    mgr._finalize_turn_after_emit = AsyncMock()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat says ", is_first_chunk=True
+        )
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "tiny plan", is_first_chunk=False
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert mgr.sync_message_queue.messages == []
+    assert mgr.tts_request_queue.messages == []
+
+    await core_module.LLMSessionManager.handle_response_complete(mgr)
+
+    assert mgr.sync_message_queue.messages[0]["data"]["text"] == "cat says tiny plan"
+    assert mgr.tts_request_queue.messages == [
+        ("live-turn-tts-buffered", "cat says tiny plan"),
+        (None, None),
+    ]
+    assert mgr._tts_done_queued_for_turn is True
+    mgr._emit_turn_end.assert_awaited_once_with(None)
+    mgr._finalize_turn_after_emit.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_response_discarded_clears_buffered_neko_live_reply_without_output():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    mgr.current_speech_id = "live-turn-discarded"
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+    }
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat says ", is_first_chunk=True
+        )
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "tiny plan", is_first_chunk=False
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert isinstance(mgr._neko_live_reply_output_buffer, dict)
+    assert mgr.sync_message_queue.messages == []
+
+    await core_module.LLMSessionManager.handle_response_discarded(
+        mgr,
+        reason="unit-test",
+        attempt=1,
+        max_attempts=2,
+        will_retry=True,
+    )
+
+    assert mgr._neko_live_reply_output_buffer is None
+    assert mgr.sync_message_queue.messages == [
+        {"type": "system", "data": "response_discarded_clear"}
+    ]
+    assert not hasattr(mgr, "_neko_live_recent_reply_text")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_proactive_complete_flushes_buffered_neko_live_reply_once():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    mgr.current_speech_id = "live-turn-proactive"
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+    }
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat says ", is_first_chunk=True
+        )
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "tiny plan", is_first_chunk=False
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert mgr.sync_message_queue.messages == []
+
+    await core_module.LLMSessionManager.handle_proactive_complete(mgr)
+
+    assert len(mgr.sync_message_queue.messages) == 2
+    message = mgr.sync_message_queue.messages[0]["data"]
+    assert message["text"] == "cat says tiny plan"
+    assert message["turn_id"] == "live-turn-proactive"
+    assert message["metadata"]["response_module_hint"] == "active_engagement"
+    assert mgr.sync_message_queue.messages[1] == {
+        "type": "system",
+        "data": "turn end agent_callback",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_proactive_complete_flushes_buffered_neko_live_reply_to_tts_before_done():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    mgr.current_speech_id = "live-turn-proactive-tts"
+    mgr.use_tts = True
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_ready = True
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+    }
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat says ", is_first_chunk=True
+        )
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "tiny plan", is_first_chunk=False
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert mgr.sync_message_queue.messages == []
+    assert mgr.tts_request_queue.messages == []
+
+    await core_module.LLMSessionManager.handle_proactive_complete(mgr)
+
+    assert mgr.sync_message_queue.messages[0]["data"]["text"] == "cat says tiny plan"
+    assert mgr.tts_request_queue.messages == [
+        ("live-turn-proactive-tts", "cat says tiny plan"),
+        (None, None),
+    ]
+    assert mgr._tts_done_queued_for_turn is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_proactive_complete_without_content_clears_buffered_neko_live_reply():
+    mgr = _make_manager()
+    delattr(mgr, "send_lanlan_response")
+    mgr.current_speech_id = "live-turn-proactive-empty"
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "active_engagement",
+    }
+    token = core_module._proactive_live_reply_metadata.set(metadata)
+    try:
+        await core_module.LLMSessionManager.handle_text_data(
+            mgr, "cat says tiny plan", is_first_chunk=True
+        )
+    finally:
+        core_module._proactive_live_reply_metadata.reset(token)
+
+    assert isinstance(mgr._neko_live_reply_output_buffer, dict)
+
+    await core_module.LLMSessionManager.handle_proactive_complete(
+        mgr, content_committed=False
+    )
+
+    assert mgr._neko_live_reply_output_buffer is None
+    assert mgr.sync_message_queue.messages == []
+    assert not hasattr(mgr, "_neko_live_recent_reply_text")
+
+
+@pytest.mark.unit
+def test_sid_cached_proactive_live_reply_metadata_is_bounded():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    for index in range(core_module._PROACTIVE_LIVE_REPLY_METADATA_BY_SID_MAX + 3):
+        core_module.LLMSessionManager._remember_proactive_live_reply_metadata(
+            mgr, f"sid-{index}", metadata
+        )
+
+    by_sid = mgr._proactive_live_reply_metadata_by_sid
+    assert len(by_sid) == core_module._PROACTIVE_LIVE_REPLY_METADATA_BY_SID_MAX
+    assert "sid-0" not in by_sid
+    assert f"sid-{core_module._PROACTIVE_LIVE_REPLY_METADATA_BY_SID_MAX + 2}" in by_sid
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_does_not_mark_non_neko_live_reply_repeat():
+    mgr = _make_manager()
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "普通回复",
+        metadata={"plugin": "other"},
+    )
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "普通回复",
+        metadata={"plugin": "other"},
+    )
+
+    first = mgr.sync_message_queue.messages[0]["data"]["metadata"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    assert "neko_live_reply_repeat" not in first
+    assert "neko_live_reply_repeat" not in second
+    assert not hasattr(mgr, "_neko_live_recent_reply_text")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_keeps_neko_live_reply_out_of_ordinary_ai_turn(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "猫猫换个角度接这句",
+        metadata=metadata,
+        remember_voice_echo=True,
+    )
+
+    assert mgr._current_ai_turn_text == ""
+    assert mgr._recent_ai_voice_echo_text == "猫猫换个角度接这句"
+    assert mgr._recent_ai_voice_echo_at == FIXED_TS
+    message = mgr.sync_message_queue.messages[0]["data"]
+    assert message["text"] == "猫猫换个角度接这句"
+    assert message["metadata"]["live_reply_contract"] == "short_tts_line"
+    assert list(mgr._neko_live_recent_reply_texts.values()) == ["猫猫换个角度接这句"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_keeps_neko_live_reply_out_of_new_session_cache():
+    mgr = _make_manager()
+    mgr.is_preparing_new_session = True
+    mgr.message_cache_for_new_session = []
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "idle_hosting",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "今晚别复读上一句",
+        metadata=metadata,
+    )
+
+    assert mgr.message_cache_for_new_session == []
+    message = mgr.sync_message_queue.messages[0]["data"]
+    assert message["text"] == "今晚别复读上一句"
+    assert message["metadata"]["live_reply_contract"] == "short_tts_line"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_keeps_ordinary_reply_in_new_session_cache():
+    mgr = _make_manager()
+    mgr.is_preparing_new_session = True
+    mgr.message_cache_for_new_session = []
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "普通回复仍然预热新会话",
+        metadata={"plugin": "normal_chat"},
+    )
+
+    assert mgr.message_cache_for_new_session == [
+        {"role": mgr.lanlan_name, "text": "普通回复仍然预热新会话"}
+    ]
+    message = mgr.sync_message_queue.messages[0]["data"]
+    assert message["text"] == "普通回复仍然预热新会话"
+    assert message["metadata"]["plugin"] == "normal_chat"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -2462,6 +2462,36 @@ async def test_send_lanlan_response_merges_neko_live_full_buffer_snapshots_by_tu
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_send_lanlan_response_preserves_repeated_neko_live_delta_chunks():
+    mgr = _make_manager()
+    metadata = {
+        "plugin": "neko_roast",
+        "live_reply_contract": "short_tts_line",
+        "response_module_hint": "danmaku_response",
+    }
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "ha",
+        is_first_chunk=True,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "ha",
+        is_first_chunk=False,
+        turn_id="live-turn-1",
+        metadata=metadata,
+    )
+
+    assert list(mgr._neko_live_recent_reply_texts.values()) == ["haha"]
+    second = mgr.sync_message_queue.messages[1]["data"]["metadata"]
+    assert second["neko_live_reply_repeat"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_send_lanlan_response_detects_repeated_neko_live_reply_without_turn_id():
     mgr = _make_manager()
     mgr.current_speech_id = None


### PR DESCRIPTION
﻿## 改了什么

把 NEKO Live 的最终输出合约从主流程里拆出来：主逻辑仍负责发送与回调，但直播回复的短句边界、重复抑制、质量 fallback、怪话拦截和 metadata 追踪集中到 `main_logic/neko_live_reply_policy.py`。

插件侧保留 `plugin/plugins/neko_roast/core/live_reply_policy.py` 作为兼容 facade，避免插件层反向承载主逻辑策略。

## 回归报告

`main_logic/core.py` 改动点：NEKO Live callback 输出在进入最终回复前会走统一合约。覆盖范围包括：

- NEKO Live 回复按 route 限制长度
- host 模块允许少量两句短 beat，普通弹幕仍偏一句
- 禁止公开示众/劳改/审判/惩罚类输出
- 禁止核电站攻略、泰拉瑞亚造电脑等低置信度技术漂移
- 最近直播输出作为 negative examples，避免续写旧句
- callback metadata 不污染普通对话路径
- room-mood anchor 只走 contextual 判定，避免单锚点误杀

## 验证

- `uv run pytest tests/unit/test_callback_instruction_origin.py tests/unit/test_core_game_route_memory_contract.py -q -k "neko_live or send_lanlan_response or mirror_assistant_speech"` → 66 passed
- `uv run python scripts/check_module_layering.py` → passed
- `git diff --check` → passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增加了 NEKO Live 短回复的输出合约与内容形状化，支持更稳定的短输出、字符限制和最近重复内容规避。
  * 增加了 live reply 的元数据合并、缓冲与统一刷新机制，提升文本与语音输出一致性。

* **Bug 修复**
  * 改进了重复回复识别，减少相同或相似内容被连续播报。
  * 优化了被抑制输出的清理与回滚，避免后续轮次串入旧内容。
  * 更新了镜像消息判定，减少短播内容误入普通聊天记忆。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->