### PR TITLE
拆出几个 NEKO Live 小基础修复

### DIFF
--- a/plugin/plugins/neko_roast/core/event_bus.py
+++ b/plugin/plugins/neko_roast/core/event_bus.py
@@ -23,6 +23,7 @@ handler 可同步可异步：同步 handler 内联调用（沿用插件既有「
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -41,6 +42,9 @@ class EventBus:
         self._subs: dict[str, list[_Subscription]] = {}
         self._audit = audit
         self._tasks: set[asyncio.Task[Any]] = set()
+        self._last_publish_at: float = 0.0
+        self._last_event_type: str = ""
+        self._publish_count: int = 0
 
     def subscribe(self, event_type: str, handler: Callable[[Any], Any], *, owner: str = "") -> Callable[[], None]:
         """订阅某类直播事件。``owner``=归属模块 id（失败 audit 用）。返回取消订阅的句柄。"""
@@ -59,14 +63,26 @@ class EventBus:
 
     def publish(self, event_type: str, event: Any) -> None:
         """按类型逐订阅者隔离派发。无订阅者 = 静默丢弃。"""
-        for sub in list(self._subs.get(str(event_type), [])):
+        event_type = str(event_type)
+        if getattr(event, "schema_version", None) is not None and getattr(event, "type", ""):
+            self._last_publish_at = time.time()
+            self._last_event_type = event_type
+            self._publish_count += 1
+        for sub in list(self._subs.get(event_type, [])):
             try:
                 result = sub.handler(event)
             except Exception as exc:  # noqa: BLE001 — 单订阅者失败隔离，不波及其余
                 self._record_error(sub.owner, str(event_type), exc)
                 continue
             if asyncio.iscoroutine(result):
-                self._spawn_isolated(result, sub.owner, str(event_type))
+                self._spawn_isolated(result, sub.owner, event_type)
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "last_publish_at": self._last_publish_at,
+            "last_event_type": self._last_event_type,
+            "publish_count": self._publish_count,
+        }
 
     # —— 向后兼容的观测别名（runtime 的 sandbox_result / result 仍走这俩；无订阅者即 no-op）——
     def on(self, event: str, listener: Callable[[Any], Any]) -> Callable[[], None]:

--- a/plugin/plugins/neko_roast/core/event_bus.py
+++ b/plugin/plugins/neko_roast/core/event_bus.py
@@ -27,6 +27,8 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from .contracts import LiveEvent
+
 
 class _Subscription:
     __slots__ = ("event_type", "handler", "owner")
@@ -64,7 +66,7 @@ class EventBus:
     def publish(self, event_type: str, event: Any) -> None:
         """按类型逐订阅者隔离派发。无订阅者 = 静默丢弃。"""
         event_type = str(event_type)
-        if getattr(event, "schema_version", None) is not None and getattr(event, "type", ""):
+        if isinstance(event, LiveEvent):
             self._last_publish_at = time.time()
             self._last_event_type = event_type
             self._publish_count += 1

--- a/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
+++ b/plugin/plugins/neko_roast/modules/bili_live_ingest/__init__.py
@@ -50,13 +50,21 @@ class BiliLiveIngestModule(BaseModule):
         self._lookup_buvid3_ttl: float = 6 * 3600.0
         self._room_status_cache: "dict[int, tuple[LiveRoomStatus, float]]" = {}
         self._room_status_ttl: float = 60.0
+        self._last_event_at: float = 0.0
+        self._last_event_type: str = ""
 
     async def teardown(self) -> None:
         await self.stop_listening()
         await super().teardown()
 
     def status(self) -> dict[str, Any]:
-        return {"enabled": self.enabled, "listening": self.is_listening(), "room_id": self._room_id}
+        return {
+            "enabled": self.enabled,
+            "listening": self.is_listening(),
+            "room_id": self._room_id,
+            "last_event_at": self._last_event_at,
+            "last_event_type": self._last_event_type,
+        }
 
     def is_listening(self) -> bool:
         return self._listener is not None
@@ -160,6 +168,8 @@ class BiliLiveIngestModule(BaseModule):
         if bus is None:
             return
         live_event = self._to_live_event(cmd, event)
+        self._last_event_at = live_event.ts or time.time()
+        self._last_event_type = live_event.type
         bus.publish(live_event.type, live_event)
 
     def _to_live_event(self, cmd: str, event: Any) -> LiveEvent:

--- a/plugin/plugins/neko_roast/stores/viewer_store.py
+++ b/plugin/plugins/neko_roast/stores/viewer_store.py
@@ -190,3 +190,13 @@ class ViewerStore:
         profiles = await self._load_all()
         ordered = sorted(profiles.values(), key=lambda item: str(item.get("last_seen_at") or ""), reverse=True)
         return [dict(item) for item in ordered[:limit]]
+
+    async def clear_profiles(self) -> dict[str, Any]:
+        async with self._lock:
+            profiles = await self._load_all()
+            cleared = len(profiles)
+            await self._save_all({})
+            file, _custom = self._resolve_file()
+            if self._active_fallback_file is not None:
+                file = self._active_fallback_file
+            return {"cleared": cleared, "path": str(file)}

--- a/plugin/plugins/neko_roast/stores/viewer_store.py
+++ b/plugin/plugins/neko_roast/stores/viewer_store.py
@@ -119,11 +119,11 @@ class ViewerStore:
                 return {str(k): dict(v) for k, v in data.items() if isinstance(v, dict)}
         return {}
 
-    async def _save_all(self, profiles: dict[str, dict[str, Any]]) -> None:
+    async def _save_all(self, profiles: dict[str, dict[str, Any]]) -> bool:
         file, custom = self._resolve_file()
         if await asyncio.to_thread(self._write_json, file, profiles):
             self._active_fallback_file = None
-            return
+            return True
         # 自定义目录写失败 → 回退默认目录（只告警一次，避免刷屏）。
         if custom:
             fallback = self._default_dir() / _STORE_FILE
@@ -132,8 +132,9 @@ class ViewerStore:
                 if not self._fallback_warned:
                     self._audit("viewer_store_fallback", f"自定义目录不可写，已回退默认目录：{fallback.parent}")
                     self._fallback_warned = True
-                return
+                return True
         self._audit("viewer_store_save_failed", f"档案写入失败：{file}")
+        return False
 
     # ── 公共 API（行为与原 KV 版一致，仅底层换成 JSON）──────────────
 
@@ -195,7 +196,9 @@ class ViewerStore:
         async with self._lock:
             profiles = await self._load_all()
             cleared = len(profiles)
-            await self._save_all({})
+            if not await self._save_all({}):
+                file, _custom = self._resolve_file()
+                raise OSError(f"failed to clear viewer profiles: {file}")
             file, _custom = self._resolve_file()
             if self._active_fallback_file is not None:
                 file = self._active_fallback_file

--- a/plugin/plugins/neko_roast/tests/test_event_bus.py
+++ b/plugin/plugins/neko_roast/tests/test_event_bus.py
@@ -124,3 +124,40 @@ def test_super_chat_jpn_routes_to_super_chat_bus_key():
     assert live_event.type == "super_chat"
     assert live_event.uid == "42"
     assert live_event.payload["raw_type"] == "SUPER_CHAT_MESSAGE_JPN"
+
+
+def test_publish_updates_status_for_runtime_health_rows():
+    bus = EventBus()
+
+    bus.publish("danmaku", LiveEvent(type="danmaku", uid="1"))
+
+    status = bus.status()
+    assert status["publish_count"] == 1
+    assert status["last_event_type"] == "danmaku"
+    assert status["last_publish_at"] > 0
+
+
+def test_observability_emit_does_not_overwrite_live_event_bus_health_status():
+    bus = EventBus()
+
+    bus.publish("danmaku", LiveEvent(type="danmaku", uid="1"))
+    bus.emit("result", {"status": "dry_run"})
+
+    status = bus.status()
+    assert status["publish_count"] == 1
+    assert status["last_event_type"] == "danmaku"
+
+
+def test_live_ingest_status_tracks_last_published_event_for_health_rows():
+    audit = _Audit()
+    bus = EventBus(audit)
+    module = BiliLiveIngestModule()
+    module.ctx = SimpleNamespace(audit=audit, event_bus=bus)
+    module._room_id = 100
+    event = SimpleNamespace(uid=42, nickname="User", text="hi", room_id=100, guard_level=0)
+
+    module._on_live_event("DANMU_MSG", event)
+
+    status = module.status()
+    assert status["last_event_type"] == "danmaku"
+    assert status["last_event_at"] > 0

--- a/plugin/plugins/neko_roast/tests/test_event_bus.py
+++ b/plugin/plugins/neko_roast/tests/test_event_bus.py
@@ -148,6 +148,17 @@ def test_observability_emit_does_not_overwrite_live_event_bus_health_status():
     assert status["last_event_type"] == "danmaku"
 
 
+def test_live_event_health_status_ignores_duck_typed_payloads():
+    bus = EventBus()
+
+    bus.publish("result", SimpleNamespace(type="result", schema_version=1))
+
+    status = bus.status()
+    assert status["publish_count"] == 0
+    assert status["last_event_type"] == ""
+    assert status["last_publish_at"] == 0
+
+
 def test_live_ingest_status_tracks_last_published_event_for_health_rows():
     audit = _Audit()
     bus = EventBus(audit)

--- a/plugin/plugins/neko_roast/tests/test_viewer_store_clear.py
+++ b/plugin/plugins/neko_roast/tests/test_viewer_store_clear.py
@@ -55,3 +55,16 @@ async def test_clear_profiles_resets_active_fallback_store(tmp_path, monkeypatch
     assert result["path"] == str(default / "viewer_profiles.json")
     assert await store.recent_profiles() == []
     assert json.loads((default / "viewer_profiles.json").read_text(encoding="utf-8")) == {}
+
+
+@pytest.mark.asyncio
+async def test_clear_profiles_raises_when_all_writes_fail(tmp_path, monkeypatch):
+    store = ViewerStore(_FakePlugin(tmp_path), audit=None)
+    await store.upsert_identity(ViewerIdentity(uid="9", nickname="blocked viewer"))
+    monkeypatch.setattr(store, "_write_json", lambda _file, _profiles: False)
+
+    with pytest.raises(OSError, match="failed to clear viewer profiles"):
+        await store.clear_profiles()
+
+    assert await store.has_roasted("9") is False
+    assert (await store.recent_profiles())[0]["uid"] == "9"

--- a/plugin/plugins/neko_roast/tests/test_viewer_store_clear.py
+++ b/plugin/plugins/neko_roast/tests/test_viewer_store_clear.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugin.plugins.neko_roast.core.contracts import ViewerIdentity
+from plugin.plugins.neko_roast.stores.viewer_store import ViewerStore
+
+
+class _FakePlugin:
+    def __init__(self, data_dir):
+        self._data_dir = data_dir
+
+    def data_path(self, *parts):
+        return self._data_dir.joinpath(*parts) if parts else self._data_dir
+
+
+@pytest.mark.asyncio
+async def test_clear_profiles_resets_current_store_file(tmp_path):
+    store = ViewerStore(_FakePlugin(tmp_path), audit=None)
+    await store.upsert_identity(ViewerIdentity(uid="1001", nickname="viewer"))
+    await store.mark_roasted("1001", "first roast")
+
+    result = await store.clear_profiles()
+
+    assert result["cleared"] == 1
+    assert result["path"] == str(tmp_path / "viewer_profiles.json")
+    assert await store.recent_profiles() == []
+    assert await store.has_roasted("1001") is False
+    data = json.loads((tmp_path / "viewer_profiles.json").read_text(encoding="utf-8"))
+    assert data == {}
+
+
+@pytest.mark.asyncio
+async def test_clear_profiles_resets_active_fallback_store(tmp_path, monkeypatch):
+    custom = tmp_path / "custom_here"
+    default = tmp_path / "default"
+    store = ViewerStore(_FakePlugin(default), audit=None, dir_provider=lambda: str(custom))
+    original_write_json = store._write_json
+
+    def _fail_custom(file, profiles):
+        if file.parent == custom:
+            return False
+        return original_write_json(file, profiles)
+
+    monkeypatch.setattr(store, "_write_json", _fail_custom)
+
+    await store.upsert_identity(ViewerIdentity(uid="8", nickname="fallback viewer"))
+    assert (default / "viewer_profiles.json").exists()
+
+    result = await store.clear_profiles()
+
+    assert result["cleared"] == 1
+    assert result["path"] == str(default / "viewer_profiles.json")
+    assert await store.recent_profiles() == []
+    assert json.loads((default / "viewer_profiles.json").read_text(encoding="utf-8")) == {}

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -198,8 +198,16 @@
             return 'mmd';
         }
 
+        var pngtuberContainer = document.getElementById('pngtuber-container');
+        if (pngtuberContainer && pngtuberContainer.style.display !== 'none' && !pngtuberContainer.classList.contains('hidden')) {
+            return 'pngtuber';
+        }
+
         var cfg = window.lanlan_config || {};
         var modelType = String(cfg.model_type || '').toLowerCase();
+        if (modelType === 'pngtuber') {
+            return 'pngtuber';
+        }
         if (modelType === 'live3d') {
             var subType = String(cfg.live3d_sub_type || '').toLowerCase();
             if (subType === 'vrm' || subType === 'mmd') {
@@ -662,6 +670,11 @@
                 console.log('[Audio] MMD 口型同步已停止');
             }
             S.lipSyncActive = false;
+        } else if (activeModelType === 'pngtuber' && window.pngtuberManager) {
+            if (typeof window.pngtuberManager.stopLipSync === 'function') {
+                window.pngtuberManager.stopLipSync();
+            }
+            S.lipSyncActive = false;
         } else if (window.LanLan1 && window.LanLan1.live2dModel) {
             stopLipSync(window.LanLan1.live2dModel);
         } else {
@@ -1054,6 +1067,12 @@
                                 window.mmdManager.animationModule.startLipSync(S.globalAnalyser);
                                 S.lipSyncActive = true;
                                 console.log('[Audio] MMD 口型同步已启动');
+                            }
+                        } else if (activeModelType === 'pngtuber' && window.pngtuberManager) {
+                            if (typeof window.pngtuberManager.startLipSync === 'function') {
+                                window.pngtuberManager.startLipSync(S.globalAnalyser);
+                                S.lipSyncActive = true;
+                                console.log('[Audio] PNGTuber lip sync started');
                             }
                         } else if (window.LanLan1 && window.LanLan1.live2dModel) {
                             startLipSync(window.LanLan1.live2dModel, S.globalAnalyser);

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -692,6 +692,7 @@
                 });
                 stopActiveLipSync();
                 S.isPlaying = false;
+                S.assistantTurnSettledId = normalizedTurnId;
                 dispatchAssistantSpeechEnd(normalizedTurnId);
                 return true;
             }

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -198,16 +198,8 @@
             return 'mmd';
         }
 
-        var pngtuberContainer = document.getElementById('pngtuber-container');
-        if (pngtuberContainer && pngtuberContainer.style.display !== 'none' && !pngtuberContainer.classList.contains('hidden')) {
-            return 'pngtuber';
-        }
-
         var cfg = window.lanlan_config || {};
         var modelType = String(cfg.model_type || '').toLowerCase();
-        if (modelType === 'pngtuber') {
-            return 'pngtuber';
-        }
         if (modelType === 'live3d') {
             var subType = String(cfg.live3d_sub_type || '').toLowerCase();
             if (subType === 'vrm' || subType === 'mmd') {
@@ -670,11 +662,6 @@
                 console.log('[Audio] MMD 口型同步已停止');
             }
             S.lipSyncActive = false;
-        } else if (activeModelType === 'pngtuber' && window.pngtuberManager) {
-            if (typeof window.pngtuberManager.stopLipSync === 'function') {
-                window.pngtuberManager.stopLipSync();
-            }
-            S.lipSyncActive = false;
         } else if (window.LanLan1 && window.LanLan1.live2dModel) {
             stopLipSync(window.LanLan1.live2dModel);
         } else {
@@ -693,6 +680,21 @@
             logAudioLifecycle('maybeFinalizeAssistantSpeech:skip_completion_mismatch', {
                 requestedTurnId: normalizedTurnId
             });
+            if (normalizedTurnId &&
+                normalizeAssistantTurnId(S.assistantSpeechActiveTurnId) === normalizedTurnId &&
+                isAssistantTurnPlaybackDrained(normalizedTurnId)) {
+                // Playback is the contract the backend gate cares about. If
+                // turn-end/completion is late or dropped after the browser has
+                // already drained audio, release the voice_play gate now; the
+                // later turn-end path can still settle turn bookkeeping.
+                logAudioLifecycle('maybeFinalizeAssistantSpeech:playback_drained_before_completion', {
+                    requestedTurnId: normalizedTurnId
+                });
+                stopActiveLipSync();
+                S.isPlaying = false;
+                dispatchAssistantSpeechEnd(normalizedTurnId);
+                return true;
+            }
             return false;
         }
         if (!isAssistantTurnPlaybackDrained(normalizedTurnId)) {
@@ -1051,12 +1053,6 @@
                                 window.mmdManager.animationModule.startLipSync(S.globalAnalyser);
                                 S.lipSyncActive = true;
                                 console.log('[Audio] MMD 口型同步已启动');
-                            }
-                        } else if (activeModelType === 'pngtuber' && window.pngtuberManager) {
-                            if (typeof window.pngtuberManager.startLipSync === 'function') {
-                                window.pngtuberManager.startLipSync(S.globalAnalyser);
-                                S.lipSyncActive = true;
-                                console.log('[Audio] PNGTuber lip sync started');
                             }
                         } else if (window.LanLan1 && window.LanLan1.live2dModel) {
                             startLipSync(window.LanLan1.live2dModel, S.globalAnalyser);

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -689,6 +689,12 @@
         logAudioLifecycle('maybeFinalizeAssistantSpeech:enter', {
             requestedTurnId: normalizedTurnId
         });
+        if (normalizedTurnId && S.assistantTurnSettledId === normalizedTurnId) {
+            logAudioLifecycle('maybeFinalizeAssistantSpeech:skip_already_settled', {
+                requestedTurnId: normalizedTurnId
+            });
+            return true;
+        }
         if (!normalizedTurnId || S.assistantTurnCompletedId !== normalizedTurnId) {
             logAudioLifecycle('maybeFinalizeAssistantSpeech:skip_completion_mismatch', {
                 requestedTurnId: normalizedTurnId

--- a/tests/unit/test_app_audio_playback_static.py
+++ b/tests/unit/test_app_audio_playback_static.py
@@ -21,5 +21,6 @@ def test_playback_gate_opens_when_audio_drains_before_turn_completion():
     mismatch_block = source[mismatch_start:drained_guard_start]
 
     assert "isAssistantTurnPlaybackDrained(normalizedTurnId)" in mismatch_block
+    assert "S.assistantTurnSettledId = normalizedTurnId" in mismatch_block
     assert "dispatchAssistantSpeechEnd(normalizedTurnId)" in mismatch_block
     assert "return true" in mismatch_block

--- a/tests/unit/test_app_audio_playback_static.py
+++ b/tests/unit/test_app_audio_playback_static.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+APP_AUDIO_PLAYBACK_PATH = PROJECT_ROOT / "static" / "app-audio-playback.js"
+
+
+def _source() -> str:
+    return APP_AUDIO_PLAYBACK_PATH.read_text(encoding="utf-8")
+
+
+def test_playback_gate_opens_when_audio_drains_before_turn_completion():
+    source = _source()
+    mismatch_start = source.index(
+        "if (!normalizedTurnId || S.assistantTurnCompletedId !== normalizedTurnId)"
+    )
+    drained_guard_start = source.index(
+        "if (!isAssistantTurnPlaybackDrained(normalizedTurnId))",
+        mismatch_start,
+    )
+    mismatch_block = source[mismatch_start:drained_guard_start]
+
+    assert "isAssistantTurnPlaybackDrained(normalizedTurnId)" in mismatch_block
+    assert "dispatchAssistantSpeechEnd(normalizedTurnId)" in mismatch_block
+    assert "return true" in mismatch_block

--- a/tests/unit/test_app_audio_playback_static.py
+++ b/tests/unit/test_app_audio_playback_static.py
@@ -24,3 +24,19 @@ def test_playback_gate_opens_when_audio_drains_before_turn_completion():
     assert "S.assistantTurnSettledId = normalizedTurnId" in mismatch_block
     assert "dispatchAssistantSpeechEnd(normalizedTurnId)" in mismatch_block
     assert "return true" in mismatch_block
+
+
+def test_late_turn_completion_does_not_reschedule_already_settled_turn():
+    source = _source()
+    settled_guard_start = source.index(
+        "if (normalizedTurnId && S.assistantTurnSettledId === normalizedTurnId)"
+    )
+    mismatch_start = source.index(
+        "if (!normalizedTurnId || S.assistantTurnCompletedId !== normalizedTurnId)",
+        settled_guard_start,
+    )
+    settled_guard_block = source[settled_guard_start:mismatch_start]
+
+    assert "maybeFinalizeAssistantSpeech:skip_already_settled" in settled_guard_block
+    assert "return true" in settled_guard_block
+    assert "scheduleProactiveChat" not in settled_guard_block


### PR DESCRIPTION
﻿## 改了什么

从 NEKO Live 大拆分里先独立拿出几块小基础设施修复，避免它们继续混在大 PR 里：

- 修语音播放早释放路径：音频已耗尽但 turn-end 晚到/丢失时，也同步标记 `assistantTurnSettledId`
- 给 `EventBus` 增加最近直播事件状态，方便 runtime health row 观测
- 让 `BiliLiveIngestModule.status()` 暴露最近事件时间和类型
- 给 `ViewerStore` 增加 `clear_profiles()`，并覆盖 fallback store 清空路径

这些改动彼此小、可独立验证，不需要 NEKO Live runtime/pipeline 大链路一起进来。

## 验证

- `uv run pytest tests/unit/test_app_audio_playback_static.py plugin/plugins/neko_roast/tests/test_viewer_store_clear.py plugin/plugins/neko_roast/tests/test_event_bus.py -q` → 15 passed
- `git diff --check` → passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化语音播放结束与兜底收尾逻辑，避免少数情况下状态停留。
  * 当音频在 turn 完成前排空时，更可靠地停止口型并派发播放结束。
  * 调整口型同步启停策略，移除特定模型分支，提升一致性。
* **New Features**
  * 增加运行观测状态：可查询事件总线最近事件时间/类型与累计发布次数。
  * 直播摄取状态输出最近事件类型与时间；新增查看器资料一键清理功能。
* **Tests**
  * 新增/补强静态脚本与单元测试，覆盖音频排空开闸与健康状态观测。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->