### PR TITLE
优化新手教程第 4 天的教程动画衔接与修复最后一段聊天框猫爪来回跳

### DIFF
--- a/static/tutorial-script-normalizer.test.cjs
+++ b/static/tutorial-script-normalizer.test.cjs
@@ -99,6 +99,26 @@ test('normalizeTutorialScene maps hold scenes to explicit cursor hold without mo
     assert.equal(scene.timeline.some((event) => event.command === 'operation.run'), false);
 });
 
+test('normalizeTutorialScene can freeze cursor after a move scene', () => {
+    const scene = normalizeTutorialScene({
+        id: 'day4_wrap',
+        voiceKey: 'avatar_floating_day4_wrap',
+        target: 'chat-input',
+        cursorAction: 'move',
+        freezeCursorAfterMove: true,
+        preserveExternalizedChatGuideTarget: true,
+        operation: 'cleanup'
+    });
+
+    const move = scene.timeline.find((event) => event.command === 'cursor.move');
+    const operation = scene.timeline.find((event) => event.command === 'operation.run');
+
+    assert.equal(move.target, 'chat-input');
+    assert.equal(move.freezePoint, true);
+    assert.equal(operation.preserveExternalizedChatGuideTarget, true);
+    assert.equal(scene.timeline.some((event) => event.command === 'cursor.hold'), false);
+});
+
 test('normalizeTutorialScene maps day3 galgame wheel rotation to a dedicated timeline command', () => {
     const scene = normalizeTutorialScene({
         id: 'day3_galgame_entry',

--- a/static/tutorial-settings-tour-flow.test.cjs
+++ b/static/tutorial-settings-tour-flow.test.cjs
@@ -28,9 +28,11 @@ test('SettingsTourFlow exposes declarative schemas for day four panel tours', ()
         anchorHighlightSuffix: 'chat-settings-button',
         panelHighlightSuffix: 'chat-settings-panel',
         cursorMoveDurationMs: 620,
+        panelEllipseDurationMs: 4200,
+        panelMinDurationMs: 4200,
         openWithSettingsCursor: true,
         settingsCursorIdSuffix: '_settings_button',
-        settingsCursorMoveDurationMs: 760,
+        settingsCursorMoveDurationMs: 560,
         openFailureMessage: '[YuiGuide] 第4天对话设置打开设置面板失败:'
     });
     assert.deepEqual(flow.getPanelTourSchema({ id: 'day4_model_behavior' }), {
@@ -40,7 +42,10 @@ test('SettingsTourFlow exposes declarative schemas for day four panel tours', ()
         anchorHighlightSuffix: 'animation-settings-button',
         panelHighlightSuffix: 'animation-settings-panel',
         cursorMoveDurationMs: 620,
-        collapseBeforeAnchorHighlight: true
+        collapseBeforeAnchorHighlight: true,
+        openWithAnchorCursor: true,
+        panelEllipseDurationMs: 3200,
+        panelMinDurationMs: 3200
     });
     assert.equal(flow.getPanelTourSchema({ id: 'day5_character_settings' }), null);
 });
@@ -148,6 +153,111 @@ test('SettingsTourFlow owns day two personalization detail scene body', async ()
         ['clear-action'],
         ['clear-persistent'],
         ['finalize', 11, true, 'wait', 2, 5]
+    ]);
+});
+
+test('SettingsTourFlow opens day four animation panel from its anchor cursor click', async () => {
+    const calls = [];
+    const settingsButton = { id: 'settings-button' };
+    const animationButton = { id: 'animation-settings-button' };
+    const animationPanel = {
+        id: 'animation-settings-panel',
+        _anchorElement: animationButton,
+        getBoundingClientRect() {
+            return { left: 20, top: 40, width: 160, height: 120 };
+        }
+    };
+    const director = {
+        sceneRunId: 14,
+        destroyed: false,
+        angryExitTriggered: false,
+        scenePausedForResistance: false,
+        currentStep: 'day4-model',
+        prepareNarration(scene) {
+            calls.push(['prepare', scene.id]);
+            return { text: 'line', voiceKey: 'voice', canHandleSceneButtons: true, actionWaitPromise: 'wait' };
+        },
+        getDay4SettingsButtonSpotlightTarget() {
+            return settingsButton;
+        },
+        getAvatarFloatingSidePanel(panelId) {
+            calls.push(['get-panel', panelId]);
+            return panelId === 'animation-settings' ? animationPanel : null;
+        },
+        collapseAvatarFloatingSidePanelsExcept(panel) {
+            calls.push(['collapse-except', panel]);
+        },
+        applyGuideHighlights(config) {
+            calls.push(['highlight', config.key, config.primary.id, config.persistent && config.persistent.id]);
+        },
+        enableInterrupts(step) {
+            calls.push(['interrupts', step]);
+        },
+        createNarrationPromise(scene, text, voiceKey, options) {
+            calls.push(['narration', scene.id, text, voiceKey, options && options.minDurationMs]);
+            return Promise.resolve();
+        },
+        waitForSceneDelay(durationMs) {
+            calls.push(['delay', durationMs]);
+            return Promise.resolve(true);
+        },
+        isStopping() {
+            return false;
+        },
+        moveAvatarFloatingCursor(cursorScene, anchorButton, secondaryTarget, previousSceneId, options) {
+            calls.push([
+                'cursor-click-anchor',
+                cursorScene.id,
+                cursorScene.cursorAction,
+                cursorScene.cursorMoveDurationMs,
+                anchorButton.id,
+                previousSceneId
+            ]);
+            options.onClickStart();
+            return Promise.resolve(true);
+        },
+        ensureAvatarFloatingSettingsSidePanel(panelId) {
+            calls.push(['ensure-panel', panelId]);
+            return Promise.resolve(animationPanel);
+        },
+        getElementRect(target) {
+            return target.getBoundingClientRect();
+        },
+        cursor: {
+            runPauseAwareEllipse(centerX, centerY, radiusX, radiusY, durationMs) {
+                calls.push(['ellipse', centerX, centerY, radiusX, radiusY, durationMs]);
+                return Promise.resolve(false);
+            }
+        },
+        finalizeScene(sceneRunId, options) {
+            calls.push(['finalize', sceneRunId, options.canHandleSceneButtons, options.actionWaitPromise, options.index, options.total]);
+            return Promise.resolve(true);
+        }
+    };
+    const flow = new SettingsTourFlow(director);
+
+    const result = await flow.play({ id: 'day4_model_behavior' }, {
+        sceneRunId: 14,
+        previousSceneId: 'day4_chat_settings',
+        index: 2,
+        total: 8
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(calls, [
+        ['prepare', 'day4_model_behavior'],
+        ['get-panel', 'animation-settings'],
+        ['collapse-except', null],
+        ['highlight', 'day4_model_behavior-animation-settings-button', 'animation-settings-button', 'settings-button'],
+        ['interrupts', 'day4-model'],
+        ['narration', 'day4_model_behavior', 'line', 'voice', 3200],
+        ['delay', 220],
+        ['cursor-click-anchor', 'day4_model_behavior_anchor_button', 'click', 620, 'animation-settings-button', 'day4_chat_settings'],
+        ['ensure-panel', 'animation-settings'],
+        ['highlight', 'day4_model_behavior-animation-settings-panel', 'animation-settings-panel', 'settings-button'],
+        ['delay', 3200],
+        ['ellipse', 100, 100, 51.2, 60, 3200],
+        ['finalize', 14, true, 'wait', 2, 8]
     ]);
 });
 
@@ -547,4 +657,42 @@ test('SettingsTourFlow runs pause-aware panel ellipse until narration settles', 
 
     assert.deepEqual(calls, [[60, 120, 36, 72, 1200]]);
     assert.equal(resumeWaits, 1);
+});
+
+test('SettingsTourFlow keeps panel ellipse alive for configured minimum duration', async () => {
+    const delays = [];
+    const panel = {
+        getBoundingClientRect() {
+            return { left: 10, top: 20, width: 100, height: 200 };
+        }
+    };
+    const director = {
+        sceneRunId: 4,
+        destroyed: false,
+        angryExitTriggered: false,
+        scenePausedForResistance: false,
+        isStopping() {
+            return false;
+        },
+        getElementRect(target) {
+            return target.getBoundingClientRect();
+        },
+        waitForSceneDelay(durationMs) {
+            delays.push(durationMs);
+            return Promise.resolve(true);
+        },
+        cursor: {
+            runPauseAwareEllipse() {
+                return Promise.resolve(false);
+            }
+        }
+    };
+    const flow = new SettingsTourFlow(director);
+
+    await flow.runPanelNarrationEllipse(4, panel, Promise.resolve(), {
+        durationMs: 1200,
+        minDurationMs: 900
+    });
+
+    assert.deepEqual(delays, [900]);
 });

--- a/static/tutorial-visual-runtime.test.cjs
+++ b/static/tutorial-visual-runtime.test.cjs
@@ -32,7 +32,12 @@ test('VisualRuntime registers timeline command handlers against director APIs', 
             return Promise.resolve(true);
         },
         runAvatarFloatingSceneOperation(scene, primaryTarget) {
-            calls.push(['operation', scene.operation, primaryTarget && primaryTarget.id]);
+            calls.push([
+                'operation',
+                scene.operation,
+                primaryTarget && primaryTarget.id,
+                scene.preserveExternalizedChatGuideTarget === true
+            ]);
             return Promise.resolve(true);
         },
         cursor: {
@@ -58,7 +63,12 @@ test('VisualRuntime registers timeline command handlers against director APIs', 
     await registry.dispatch({ command: 'cursor.move', target: 'chat-input', durationMs: 320 }, { director });
     await registry.dispatch({ command: 'cursor.click', effectDurationMs: 180 }, { director });
     await registry.dispatch({ command: 'cursor.wobble', durationMs: 120 }, { director });
-    await registry.dispatch({ command: 'operation.run', operation: 'cleanup', target: 'chat-input' }, {
+    await registry.dispatch({
+        command: 'operation.run',
+        operation: 'cleanup',
+        target: 'chat-input',
+        preserveExternalizedChatGuideTarget: true
+    }, {
         scene: { id: 'scene-a' },
         director
     });
@@ -74,7 +84,7 @@ test('VisualRuntime registers timeline command handlers against director APIs', 
         ['wobble', 120],
         ['delay', 120],
         ['resolve', 'chat-input'],
-        ['operation', 'cleanup', 'chat-input']
+        ['operation', 'cleanup', 'chat-input', true]
     ]);
 });
 
@@ -949,9 +959,12 @@ test('VisualRuntime routes day3 galgame wheel rotation command to the existing d
     ]);
 });
 
-test('VisualRuntime routes settings tour command to SettingsTourFlow with scene context', async () => {
+test('VisualRuntime clears day four externalized chat cursor before settings tour playback', async () => {
     const calls = [];
     const director = {
+        clearExternalizedChatGuideTarget(options) {
+            calls.push(['clear-externalized-chat', options.clearCursor]);
+        },
         settingsTourFlow: {
             play(scene, context) {
                 calls.push([
@@ -995,7 +1008,44 @@ test('VisualRuntime routes settings tour command to SettingsTourFlow with scene 
 
     assert.equal(result, true);
     assert.deepEqual(calls, [
+        ['clear-externalized-chat', true],
         ['settings-tour', 'day4_chat_settings', 41, 'day4_intro_companion', 1, 6]
+    ]);
+});
+
+test('VisualRuntime leaves non-day-four settings tours externalized cursor state intact', async () => {
+    const calls = [];
+    const director = {
+        clearExternalizedChatGuideTarget(options) {
+            calls.push(['clear-externalized-chat', options.clearCursor]);
+        },
+        settingsTourFlow: {
+            play(scene, context) {
+                calls.push(['settings-tour', scene.id, context.sceneRunId]);
+                return Promise.resolve(true);
+            }
+        }
+    };
+    const registry = new CommandRegistry();
+    const runtime = createTutorialVisualRuntime(director);
+
+    runtime.registerCommands(registry);
+    const result = await registry.dispatch({
+        command: 'settingsTour.play'
+    }, {
+        scene: {
+            id: 'day5_character_settings',
+            legacyScene: {
+                id: 'day5_character_settings'
+            }
+        },
+        director,
+        sceneRunId: 51
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(calls, [
+        ['settings-tour', 'day5_character_settings', 51]
     ]);
 });
 

--- a/static/tutorial/core/scene-orchestrator.js
+++ b/static/tutorial/core/scene-orchestrator.js
@@ -493,6 +493,9 @@
                 if (Number.isFinite(scene.cursorWobbleDurationMs)) {
                     externalizedCursorOptions.effectDurationMs = Math.max(0, Math.floor(scene.cursorWobbleDurationMs));
                 }
+                if (scene.freezeCursorAfterMove === true) {
+                    externalizedCursorOptions.freezePoint = true;
+                }
                 const shouldPreferExternalizedPrimaryKind = !!(
                     scene
                     && typeof scene.cursorAction === 'string'

--- a/static/tutorial/core/script-normalizer.js
+++ b/static/tutorial/core/script-normalizer.js
@@ -139,7 +139,7 @@
                 pushIfCommand(timeline, settleHoldEvent);
             }
         } else if (cursorAction && cursorAction !== 'none') {
-            pushIfCommand(timeline, {
+            const moveEvent = {
                 id: sceneId + ':cursor-move',
                 at: cursorStartMs,
                 command: 'cursor.move',
@@ -147,7 +147,11 @@
                 target: cursorTarget,
                 secondary: typeof scene.secondary === 'string' ? scene.secondary : '',
                 durationMs: cursorMoveDurationMs
-            });
+            };
+            if (scene.freezeCursorAfterMove === true) {
+                moveEvent.freezePoint = true;
+            }
+            pushIfCommand(timeline, moveEvent);
             if (cursorAction === 'click') {
                 const clickEvent = {
                     id: sceneId + ':cursor-click',
@@ -157,14 +161,18 @@
                     effectDurationMs: numberOrDefault(scene.cursorClickDurationMs, 420)
                 };
                 if (scene.operation && !isGalgameWheelRotationOperation(scene)) {
-                    clickEvent.blocking = true;
-                    clickEvent.onStart = [{
+                    const operationEvent = {
                         id: sceneId + ':operation',
                         command: 'operation.run',
                         operation: scene.operation,
                         trigger: 'onClickStart',
                         blocking: true
-                    }];
+                    };
+                    if (scene.preserveExternalizedChatGuideTarget === true) {
+                        operationEvent.preserveExternalizedChatGuideTarget = true;
+                    }
+                    clickEvent.blocking = true;
+                    clickEvent.onStart = [operationEvent];
                 }
                 pushIfCommand(timeline, clickEvent);
             } else if (cursorAction === 'wobble' || cursorAction === 'tour') {
@@ -187,14 +195,18 @@
                 blocking: true
             });
         } else if (scene.operation && cursorAction !== 'click') {
-            pushIfCommand(timeline, {
+            const operationEvent = {
                 id: sceneId + ':operation',
                 at: cursorAction === 'click' ? cursorFollowupMs : cursorFollowupMs,
                 command: 'operation.run',
                 operation: scene.operation,
                 trigger: cursorAction === 'click' ? 'onClickStart' : 'afterCursorMove',
                 blocking: true
-            });
+            };
+            if (scene.preserveExternalizedChatGuideTarget === true) {
+                operationEvent.preserveExternalizedChatGuideTarget = true;
+            }
+            pushIfCommand(timeline, operationEvent);
         }
 
         if (scene.petalTransition === true) {

--- a/static/tutorial/core/settings-tour-flow.js
+++ b/static/tutorial/core/settings-tour-flow.js
@@ -28,9 +28,11 @@
             anchorHighlightSuffix: 'chat-settings-button',
             panelHighlightSuffix: 'chat-settings-panel',
             cursorMoveDurationMs: 620,
+            panelEllipseDurationMs: 4200,
+            panelMinDurationMs: 4200,
             openWithSettingsCursor: true,
             settingsCursorIdSuffix: '_settings_button',
-            settingsCursorMoveDurationMs: 760,
+            settingsCursorMoveDurationMs: 560,
             openFailureMessage: '[YuiGuide] 第4天对话设置打开设置面板失败:'
         }),
         day4_model_behavior: Object.freeze({
@@ -40,7 +42,10 @@
             anchorHighlightSuffix: 'animation-settings-button',
             panelHighlightSuffix: 'animation-settings-panel',
             cursorMoveDurationMs: 620,
-            collapseBeforeAnchorHighlight: true
+            collapseBeforeAnchorHighlight: true,
+            openWithAnchorCursor: true,
+            panelEllipseDurationMs: 3200,
+            panelMinDurationMs: 3200
         })
     });
     const DEFAULT_CURSOR_CLICK_VISIBLE_MS = 420;
@@ -160,6 +165,7 @@
             const narration = this.prepareNarration(scene);
             const settingsButton = director.getDay4SettingsButtonSpotlightTarget();
             let sidePanel = null;
+            let openedPanelPromise = null;
 
             if (normalizedSchema.waitForPanelBeforeOpening) {
                 sidePanel = director.getAvatarFloatingSidePanel(panelId);
@@ -194,7 +200,9 @@
             }
             director.enableInterrupts(director.currentStep);
 
-            const narrationPromise = this.createNarrationPromise(scene, narration);
+            const narrationPromise = this.createNarrationPromise(scene, narration, {
+                minDurationMs: normalizedSchema.panelMinDurationMs
+            });
 
             await director.waitForSceneDelay(220);
             if (this.isSceneStale(sceneRunId)) {
@@ -214,7 +222,22 @@
             } else if (!normalizedSchema.waitForPanelBeforeOpening) {
                 await director.openSettingsPanel();
             } else if (anchorButton) {
-                await director.moveCursorToElement(anchorButton, normalizedSchema.cursorMoveDurationMs);
+                if (
+                    normalizedSchema.openWithAnchorCursor
+                    && typeof director.moveAvatarFloatingCursor === 'function'
+                ) {
+                    await director.moveAvatarFloatingCursor({
+                        id: scene.id + '_anchor_button',
+                        cursorAction: 'click',
+                        cursorMoveDurationMs: normalizedSchema.cursorMoveDurationMs
+                    }, anchorButton, null, previousSceneId, {
+                        onClickStart: () => {
+                            openedPanelPromise = director.ensureAvatarFloatingSettingsSidePanel(panelId);
+                        }
+                    });
+                } else {
+                    await director.moveCursorToElement(anchorButton, normalizedSchema.cursorMoveDurationMs);
+                }
             }
             if (this.isSceneStale(sceneRunId)) {
                 return false;
@@ -241,11 +264,15 @@
                 return false;
             }
 
-            const touredPanel = await director.ensureAvatarFloatingSettingsSidePanel(panelId)
+            const openedPanel = openedPanelPromise ? await openedPanelPromise : null;
+            const touredPanel = openedPanel
+                || await director.ensureAvatarFloatingSettingsSidePanel(panelId)
                 || sidePanel;
             await this.tourPanel(scene, sceneRunId, touredPanel, narrationPromise, {
                 key: scene.id + '-' + normalizedSchema.panelHighlightSuffix,
-                persistent: settingsButton || null
+                persistent: settingsButton || null,
+                ellipseDurationMs: normalizedSchema.panelEllipseDurationMs,
+                minDurationMs: normalizedSchema.panelMinDurationMs
             });
 
             return this.finalizeNarration(sceneRunId, narration, normalizedContext);
@@ -549,7 +576,10 @@
                 if (Number.isFinite(normalizedOptions.cursorMoveDurationMs)) {
                     await director.moveCursorToElement(panel, normalizedOptions.cursorMoveDurationMs);
                 }
-                await this.runPanelNarrationEllipse(sceneRunId, panel, narrationPromise);
+                await this.runPanelNarrationEllipse(sceneRunId, panel, narrationPromise, {
+                    durationMs: normalizedOptions.ellipseDurationMs,
+                    minDurationMs: normalizedOptions.minDurationMs
+                });
                 return;
             }
             await (narrationPromise || Promise.resolve());
@@ -581,8 +611,24 @@
             const durationMs = Number.isFinite(normalizedOptions.durationMs)
                 ? Math.max(0, normalizedOptions.durationMs)
                 : 5600;
+            const minDurationMs = Number.isFinite(normalizedOptions.minDurationMs)
+                ? Math.max(0, normalizedOptions.minDurationMs)
+                : 0;
             let narrationDone = false;
-            const guardedNarrationPromise = resolvedNarrationPromise.finally(() => {
+            const minimumDisplayPromise = minDurationMs > 0
+                ? (typeof director.waitForSceneDelay === 'function'
+                    ? director.waitForSceneDelay(minDurationMs)
+                    : new Promise((resolve) => {
+                        const timerApi = typeof window !== 'undefined' && window.setTimeout
+                            ? window
+                            : globalThis;
+                        timerApi.setTimeout(resolve, minDurationMs);
+                    }))
+                : Promise.resolve();
+            const guardedNarrationPromise = Promise.all([
+                resolvedNarrationPromise,
+                minimumDisplayPromise
+            ]).finally(() => {
                 narrationDone = true;
             });
             const narrationSettledPromise = guardedNarrationPromise.catch(() => {});

--- a/static/tutorial/core/visual-runtime.js
+++ b/static/tutorial/core/visual-runtime.js
@@ -315,7 +315,8 @@
                 const cursorKind = director.getExternalizedChatCursorTargetKind(cursorScene);
                 if (cursorKind) {
                     director.setExternalizedChatCursorEffect(cursorKind, 'move', {
-                        durationMs
+                        durationMs,
+                        freezePoint: event.freezePoint === true
                     });
                     const waitMs = durationMs > 0 ? durationMs + 500 : undefined;
                     return await director.waitForExternalizedChatCursorMove(cursorScene.id || '', waitMs);
@@ -506,6 +507,9 @@
             const legacyScene = Object.assign({}, getLegacyScene(context), {
                 operation: event.operation || (getLegacyScene(context).operation || '')
             });
+            if (event.preserveExternalizedChatGuideTarget === true) {
+                legacyScene.preserveExternalizedChatGuideTarget = true;
+            }
             if (
                 event.trigger === 'afterCursorMove'
                 && typeof director.isHomeChatExternalized === 'function'
@@ -567,6 +571,14 @@
                 return false;
             }
             const legacyScene = getLegacyScene(context);
+            if (
+                legacyScene
+                && typeof legacyScene.id === 'string'
+                && legacyScene.id.indexOf('day4_') === 0
+                && typeof director.clearExternalizedChatGuideTarget === 'function'
+            ) {
+                director.clearExternalizedChatGuideTarget({ clearCursor: true });
+            }
             return await director.settingsTourFlow.play(legacyScene, {
                 sceneRunId: context ? context.sceneRunId : undefined,
                 previousSceneId: context ? context.previousSceneId : undefined,

--- a/static/tutorial/yui-guide/days/day4-companion-guide.js
+++ b/static/tutorial/yui-guide/days/day4-companion-guide.js
@@ -162,8 +162,13 @@
                     text: '真正舒服的陪伴才不是一刻不停地粘着你呢~ 而是懂得什么时候该悄悄靠近抓抓你的衣角撒个娇，什么时候该安安静静地趴在一旁，用目光默默守候着你喵~',
                     emotion: 'happy',
                     target: 'chat-input',
+                    cursorTarget: 'chat-capsule-input',
                     cursorAction: 'move',
+                    cursorMoveDurationMs: 900,
+                    freezeCursorAfterMove: true,
                     operation: 'cleanup',
+                    preserveExternalizedChatGuideTarget: true,
+                    spotlightVariant: 'plain-capsule',
                     petalTransition: true
                 }
             ]


### PR DESCRIPTION
## 改动概述 / Summary

本 PR 优化新手教程第 4 天的教程动画衔接与聊天框猫爪固定逻辑，解决设置面板展示阶段切换突兀、对话设置面板环绕缺失、以及最后猫爪在聊天框附近来回横跳的问题。

主要改动：
- 调整第 4 天最后一幕猫爪移动到聊天框胶囊输入区后的冻结逻辑。
- 修复 cleanup 后外置聊天框猫爪状态被清掉的问题。
- 优化对话设置和动画设置面板的环绕展示时长。
- 动画设置面板改为先移动到入口并点击后再展开。
- 增加对应单元测试覆盖。

## 回归报告 / Regression Report

不适用。本 PR 未改动 `app/`、`main_logic/`、`memory/` 任一 Python 模块。

## 不拆分理由 / Why Not Split

不适用。本 PR 计入拆分阈值的文件数未超过 20 个。

## 测试 / Testing

- `node static/tutorial-script-normalizer.test.cjs`
- `node static/tutorial-settings-tour-flow.test.cjs`
- `node static/tutorial-visual-runtime.test.cjs`
- `git diff --check`