### PR TITLE
fix(tutorial): constrain icebreaker prompt lifecycle

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -2443,6 +2443,10 @@
                 if (isDuplicateMessage(data.action, data.timestamp)) return true;
                 clearYuiGuideChatMessages();
                 return true;
+            case 'yui_guide_set_chat_input_locked':
+                if (isDuplicateMessage(data.action, data.timestamp)) return true;
+                applyYuiGuideChatInputLocked(data.locked === true, data.reason || '');
+                return true;
             case 'tutorial_chat_identity_override':
                 if (isDuplicateMessage(data.action, data.timestamp)) return true;
                 applyTutorialChatIdentityOverride(data);

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -2542,6 +2542,10 @@
                     shouldOpenHost = true;
                 } else if (action.type === 'clear_prompt' && action.sessionId && typeof host.clearIcebreakerChoicePrompt === 'function') {
                     host.clearIcebreakerChoicePrompt(action.sessionId);
+                } else if (action.type === 'clear_prompt_source'
+                        && action.source === 'new_user_icebreaker'
+                        && typeof host.clearChoicePromptBySource === 'function') {
+                    host.clearChoicePromptBySource(action.source, action.reason || 'icebreaker-bridge');
                 }
             } catch (error) {
                 console.warn('[NewUserIcebreaker] Failed to apply bridge action:', action.type, error);
@@ -2569,6 +2573,16 @@
     function clearIcebreakerChoicePromptFromBroadcast(sessionId) {
         if (!isStandaloneChatPage()) return;
         queueIcebreakerBridgeAction({ type: 'clear_prompt', sessionId: String(sessionId || '') });
+    }
+
+    function clearIcebreakerChoicePromptSourceFromBroadcast(source, reason) {
+        if (!isStandaloneChatPage()) return;
+        if (String(source || '') !== 'new_user_icebreaker') return;
+        queueIcebreakerBridgeAction({
+            type: 'clear_prompt_source',
+            source: String(source || ''),
+            reason: String(reason || '')
+        });
     }
 
     // Also defined in new-user-icebreaker.js for the local chat host path.
@@ -2631,6 +2645,7 @@
         return action === 'icebreaker_append_chat_message'
             || action === 'icebreaker_set_choice_prompt'
             || action === 'icebreaker_clear_choice_prompt'
+            || action === 'icebreaker_clear_choice_prompt_source'
             || action === 'icebreaker_choice_selected'
             || action === 'icebreaker_free_text_submitted';
     }
@@ -2656,6 +2671,10 @@
             case 'icebreaker_clear_choice_prompt':
                 if (isDuplicateMessage(data.action, data.timestamp)) return true;
                 clearIcebreakerChoicePromptFromBroadcast(data.sessionId);
+                return true;
+            case 'icebreaker_clear_choice_prompt_source':
+                if (isDuplicateMessage(data.action, data.timestamp)) return true;
+                clearIcebreakerChoicePromptSourceFromBroadcast(data.source, data.reason);
                 return true;
             case 'icebreaker_choice_selected':
                 if (isDuplicateMessage(data.action, data.timestamp)) return true;

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -3543,6 +3543,7 @@
         for (var i = msgs.length - 1; i >= 0 && collected.length < GALGAME_HISTORY_LIMIT; i--) {
             var m = msgs[i];
             if (!m) continue;
+            if (isYuiGuideChatMessage(m)) continue;
             if (m.role !== 'assistant' && m.role !== 'user') continue;
             var text = '';
             if (Array.isArray(m.blocks)) {
@@ -4113,6 +4114,21 @@
 
     function setIcebreakerChoicePrompt(payload) {
         setNewUserIcebreakerPrompt(payload);
+    }
+
+    function clearChoicePromptBySource(source, reason) {
+        var normalizedSource = String(source || '');
+        if (!normalizedSource) return false;
+        if (normalizedSource !== 'new_user_icebreaker') return false;
+        if (!state.choicePrompt || state.choicePrompt.source !== normalizedSource) return false;
+        state.choicePrompt = null;
+        if (choicePromptRevealTimer) {
+            window.clearTimeout(choicePromptRevealTimer);
+            choicePromptRevealTimer = null;
+        }
+        invalidatePendingGalgameRequest();
+        renderWindow();
+        return true;
     }
 
     function clearIcebreakerChoicePrompt(sessionId) {
@@ -6670,6 +6686,10 @@
             setGalgameModeTemporarilyDisabled(false);
         });
 
+        window.addEventListener('neko:new-user-icebreaker-reset', function () {
+            clearChoicePromptBySource('new_user_icebreaker', 'new-user-icebreaker-reset');
+        });
+
         // Refresh option list whenever an assistant turn finishes streaming.
         window.addEventListener('neko-assistant-turn-end', function () {
             if (!state.galgameModeEnabled) return;
@@ -7070,6 +7090,7 @@
         setMiniGameInvitePrompt: setMiniGameInvitePrompt,
         setIcebreakerChoicePrompt: setIcebreakerChoicePrompt,
         setChoicePrompt: setChoicePrompt,
+        clearChoicePromptBySource: clearChoicePromptBySource,
         setNewUserIcebreakerPrompt: setNewUserIcebreakerPrompt,
         clearIcebreakerChoicePrompt: clearIcebreakerChoicePrompt,
         // unified resolved handler：accept 兼 launch / decline / suppress 都通过

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -4121,6 +4121,9 @@
         if (!normalizedSource) return false;
         if (normalizedSource !== 'new_user_icebreaker') return false;
         if (!state.choicePrompt || state.choicePrompt.source !== normalizedSource) return false;
+        if (window.console && typeof window.console.debug === 'function') {
+            window.console.debug('[NewUserIcebreaker] clearChoicePromptBySource:', normalizedSource, reason || '');
+        }
         state.choicePrompt = null;
         if (choicePromptRevealTimer) {
             window.clearTimeout(choicePromptRevealTimer);

--- a/static/tutorial/core/bridge-command-bus.js
+++ b/static/tutorial/core/bridge-command-bus.js
@@ -18,6 +18,7 @@
         yui_guide_append_chat_message: true,
         yui_guide_update_chat_message: true,
         yui_guide_clear_chat_messages: true,
+        yui_guide_set_chat_input_locked: true,
         tutorial_chat_identity_override: true
     });
 

--- a/static/tutorial/core/interaction-takeover.js
+++ b/static/tutorial/core/interaction-takeover.js
@@ -494,6 +494,7 @@
             }
 
             this.setExternalizedChatButtonsDisabled(true);
+            this.setExternalizedChatInputLocked(true, 'external-chat-ready');
             if (
                 this.document.body
                 && this.document.body.classList.contains('yui-guide-compact-chat-fixed')

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -190,6 +190,7 @@
     function endIcebreakerRouteOnPageExit(reason) {
         var session = activeSession;
         if (!session || session.routeEnded || !session.sessionId) return;
+        clearChoicePrompt();
         session.routeEnded = true;
         var body = {
             lanlan_name: resolveLanlanName(),
@@ -428,6 +429,14 @@
         broadcastIcebreaker(null, {
             action: 'icebreaker_clear_choice_prompt',
             sessionId: sessionId
+        });
+    }
+
+    function broadcastIcebreakerClearChoicePromptSource(source, reason) {
+        broadcastIcebreaker(null, {
+            action: 'icebreaker_clear_choice_prompt_source',
+            source: source || SOURCE,
+            reason: reason || 'icebreaker_source_reset'
         });
     }
 
@@ -1282,6 +1291,9 @@
     });
     window.addEventListener('neko:icebreaker-free-text-submitted', function (event) {
         handleFreeText(event && event.detail);
+    });
+    window.addEventListener('neko:new-user-icebreaker-reset', function () {
+        broadcastIcebreakerClearChoicePromptSource(SOURCE, 'new-user-icebreaker-reset');
     });
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', bootstrapFromRecentEndState, { once: true });

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -683,6 +683,8 @@ test('app interpage sends external chat pet reports through the command bus', ()
     assert.match(source, /bus\.postToPet\(action,\s*payload,\s*options \|\| \{\}\)/);
     assert.match(bridgeDataBlock, /case 'tutorial_chat_identity_override':/);
     assert.match(bridgeDataBlock, /applyTutorialChatIdentityOverride\(data\)/);
+    assert.match(bridgeDataBlock, /case 'yui_guide_set_chat_input_locked':/);
+    assert.match(bridgeDataBlock, /applyYuiGuideChatInputLocked\(data\.locked === true,\s*data\.reason \|\| ''\)/);
     assert.match(requestIdentityBlock, /postYuiGuideMessageToChat\([\s\S]*'tutorial_chat_identity_override'/);
     assert.doesNotMatch(requestIdentityBlock, /nekoBroadcastChannel\.postMessage\(Object\.assign\(\{\s*action: 'tutorial_chat_identity_override'/);
     assert.match(requestAvatarBlock, /postYuiGuideMessageToChat\('avatar_updated'/);

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -932,19 +932,24 @@ def test_icebreaker_uses_broadcast_channel_for_desktop_chat_window():
     assert "case 'icebreaker_append_chat_message'" in interpage
     assert "case 'icebreaker_set_choice_prompt'" in interpage
     assert "case 'icebreaker_clear_choice_prompt'" in interpage
+    assert "case 'icebreaker_clear_choice_prompt_source'" in interpage
     assert "appendIcebreakerChatMessage(data.message)" in interpage
     assert "setIcebreakerChoicePromptFromBroadcast(data.prompt)" in interpage
     assert "clearIcebreakerChoicePromptFromBroadcast(data.sessionId)" in interpage
+    assert "clearIcebreakerChoicePromptSourceFromBroadcast(data.source, data.reason)" in interpage
     icebreaker_flush_block = interpage.split("function flushPendingIcebreakerBridgeActions()", 1)[1].split(
         "function appendIcebreakerChatMessage",
         1,
     )[0]
     assert "shouldOpenHost = true" in icebreaker_flush_block
     assert "host.openWindow()" in icebreaker_flush_block
+    assert "action.source === 'new_user_icebreaker'" in icebreaker_flush_block
     assert "case 'icebreaker_choice_selected'" in interpage
     assert "postIcebreakerBridgeEvent('icebreaker_choice_selected'" in interpage
     assert "case 'icebreaker_free_text_submitted'" in interpage
     assert "postIcebreakerBridgeEvent('icebreaker_free_text_submitted'" in interpage
+    assert "action: 'icebreaker_clear_choice_prompt_source'" in runtime
+    assert "window.addEventListener('neko:new-user-icebreaker-reset'" in runtime
     assert "nekoBroadcastChannel.postMessage(message)" in interpage
     assert "postInterpageMessage(message)" not in interpage
 
@@ -961,6 +966,30 @@ def test_icebreaker_desktop_bridge_has_storage_fallback():
     assert "postIcebreakerBridgeEvent" in interpage
     assert "handleIcebreakerStorageBridgeEvent" in interpage
     assert "yuiGuideInterpageResources.addEventListener(window, 'storage', handleIcebreakerStorageBridgeEvent)" in interpage
+
+
+def test_icebreaker_source_clear_bridge_cannot_clear_non_icebreaker_prompt():
+    interpage = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+
+    source_clear_block = interpage.split("function clearIcebreakerChoicePromptSourceFromBroadcast(source, reason)", 1)[1].split(
+        "function getIcebreakerMessageText",
+        1,
+    )[0]
+
+    assert "String(source || '') !== 'new_user_icebreaker'" in source_clear_block
+    assert "mini_game_invite" not in source_clear_block
+
+
+def test_icebreaker_page_exit_clears_choice_prompt_before_route_end():
+    runtime = RUNTIME_PATH.read_text(encoding="utf-8")
+
+    page_exit_block = runtime.split("function endIcebreakerRouteOnPageExit(reason)", 1)[1].split(
+        "var body = {",
+        1,
+    )[0]
+
+    assert "clearChoicePrompt();" in page_exit_block
+    assert page_exit_block.index("clearChoicePrompt();") < page_exit_block.index("session.routeEnded = true;")
 
 
 def test_yui_guide_chat_bridge_has_storage_queue_fallback():

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1371,6 +1371,7 @@ def test_icebreaker_reset_clears_prompt_by_source_without_session_match():
     )[0]
     assert "if (normalizedSource !== 'new_user_icebreaker') return false;" in reset_block
     assert "state.choicePrompt.source !== normalizedSource" in reset_block
+    assert "clearChoicePromptBySource:', normalizedSource, reason || ''" in reset_block
     assert "state.choicePrompt = null;" in reset_block
     assert "invalidatePendingGalgameRequest();" in reset_block
 
@@ -1389,8 +1390,15 @@ def test_externalized_tutorial_chat_ready_replays_input_lock():
     bridge_bus = (Path(__file__).resolve().parents[2] / "static" / "tutorial" / "core" / "bridge-command-bus.js").read_text(
         encoding="utf-8"
     )
+    interpage = (Path(__file__).resolve().parents[2] / "static" / "app-interpage.js").read_text(encoding="utf-8")
 
     assert "yui_guide_set_chat_input_locked: true" in bridge_bus
+    bridge_replay_block = interpage.split("function handleYuiGuideChatBridgeData(data)", 1)[1].split(
+        "function drainPendingYuiGuideChatBridgeQueue",
+        1,
+    )[0]
+    assert "case 'yui_guide_set_chat_input_locked':" in bridge_replay_block
+    assert "applyYuiGuideChatInputLocked(data.locked === true, data.reason || '')" in bridge_replay_block
     ready_block = takeover.split("onExternalChatReady()", 1)[1].split(
         "destroy()",
         1,

--- a/tests/unit/test_react_chat_window_static.py
+++ b/tests/unit/test_react_chat_window_static.py
@@ -1348,6 +1348,56 @@ def test_icebreaker_choice_prompt_reveal_delay_hides_buttons_not_state():
     assert "if (state.choicePrompt && state.choicePrompt.source === 'new_user_icebreaker') return;" in galgame_fetch_block
 
 
+def test_galgame_history_excludes_tutorial_guide_messages():
+    react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    history_block = react_host.split("function getRecentGalgameMessageHistory()", 1)[1].split(
+        "function pickAcceptLanguage",
+        1,
+    )[0]
+
+    assert "if (isYuiGuideChatMessage(m)) continue;" in history_block
+    assert "if (!m) continue;" in history_block
+    assert history_block.index("if (!m) continue;") < history_block.index("if (isYuiGuideChatMessage(m)) continue;")
+
+
+def test_icebreaker_reset_clears_prompt_by_source_without_session_match():
+    react_host = APP_REACT_CHAT_WINDOW_PATH.read_text(encoding="utf-8")
+
+    assert "function clearChoicePromptBySource(source, reason)" in react_host
+    reset_block = react_host.split("function clearChoicePromptBySource(source, reason)", 1)[1].split(
+        "function clearIcebreakerChoicePrompt",
+        1,
+    )[0]
+    assert "if (normalizedSource !== 'new_user_icebreaker') return false;" in reset_block
+    assert "state.choicePrompt.source !== normalizedSource" in reset_block
+    assert "state.choicePrompt = null;" in reset_block
+    assert "invalidatePendingGalgameRequest();" in reset_block
+
+    listeners_block = react_host.split("function bindBridgeEvents()", 1)[1].split(
+        "function init()",
+        1,
+    )[0]
+    assert "window.addEventListener('neko:new-user-icebreaker-reset'" in listeners_block
+    assert "clearChoicePromptBySource('new_user_icebreaker', 'new-user-icebreaker-reset')" in listeners_block
+
+
+def test_externalized_tutorial_chat_ready_replays_input_lock():
+    takeover = (Path(__file__).resolve().parents[2] / "static" / "tutorial" / "core" / "interaction-takeover.js").read_text(
+        encoding="utf-8"
+    )
+    bridge_bus = (Path(__file__).resolve().parents[2] / "static" / "tutorial" / "core" / "bridge-command-bus.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "yui_guide_set_chat_input_locked: true" in bridge_bus
+    ready_block = takeover.split("onExternalChatReady()", 1)[1].split(
+        "destroy()",
+        1,
+    )[0]
+    assert "this.setExternalizedChatInputLocked(true, 'external-chat-ready')" in ready_block
+
+
 def test_new_user_icebreaker_choice_listener_posts_context():
     script = (Path(__file__).resolve().parents[2] / "static" / "icebreaker/new-user-icebreaker.js").read_text(encoding="utf-8")
     choice_block = script.split("function completeFromChoice(detail)", 1)[1].split(


### PR DESCRIPTION
## 改动概述 / Summary

收紧新手教程与新用户破冰的选项生命周期边界，避免教程台词或拖拽流程被当作普通对话参与选项生成。

主要改动：
- Galgame 选项生成历史会过滤 `yui-guide-*` / `yui_guide` 教程消息，只保留真实聊天上下文。
- 新用户破冰 reset/reload 增加 source 级 prompt 清理，解决旧 session prompt 残留后点击无响应的问题。
- 破冰 source 清理在 bridge 接收端和 chat host 侧都硬限制为 `new_user_icebreaker`，避免影响 `mini_game_invite` 等其他 choice prompt 链路。
- NEKO-PC 独立 `/chat` 窗口 ready 后重放教程输入锁，降低教程期间输入/拖拽被当成普通聊天的风险。
- 增加静态契约测试覆盖教程消息过滤、破冰 source 清理、PC 教程输入锁重放和非破冰 prompt 隔离。

## 回归报告 / Regression Report

不适用

## 不拆分理由 / Why Not Split

不适用

## 测试 / Testing

- `.venv/bin/python -m pytest tests/unit/test_new_user_icebreaker_static_contracts.py::test_icebreaker_uses_broadcast_channel_for_desktop_chat_window tests/unit/test_new_user_icebreaker_static_contracts.py::test_icebreaker_source_clear_bridge_cannot_clear_non_icebreaker_prompt tests/unit/test_new_user_icebreaker_static_contracts.py::test_icebreaker_page_exit_clears_choice_prompt_before_route_end tests/unit/test_react_chat_window_static.py::test_galgame_history_excludes_tutorial_guide_messages tests/unit/test_react_chat_window_static.py::test_icebreaker_reset_clears_prompt_by_source_without_session_match tests/unit/test_react_chat_window_static.py::test_externalized_tutorial_chat_ready_replays_input_lock -q`：6 passed
- `bash build_frontend.sh`：通过
- Playwright 临时运行时验证：破冰 reset 可清旧破冰 prompt；`mini_game_invite` 不会被破冰 source clear 清掉；Galgame 请求 body 不包含教程拖拽/引导台词，只包含正常 assistant 文本
- `node static/yui-guide-common.test.cjs`：当前结果 56 passed / 6 failed；已在干净 `upstream/main` 对照，失败项一致，属于既有静态断言基线问题
- `.venv/bin/python -m pytest tests/unit/test_react_chat_window_static.py tests/unit/test_new_user_icebreaker_static_contracts.py -q`：当前结果 131 passed / 7 failed；失败项为 compact/spotlight/历史静态契约既有问题，非本 PR 引入

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化新用户引导“冰糖火花”跨窗口同步：按来源重置清理“选项揭示”提示，并支持外部触发统一清理。
  * 教程外置聊天输入在就绪时自动锁定，且桥接回放会同步应用输入锁定状态。
* **Bug 修复**
  * 最近对话历史过滤掉引导类消息，避免影响选项生成/推断上下文。
  * 页面退出时更早清理选项提示，减少路由结束后的残留状态。
* **测试**
  * 新增/扩展静态契约校验：覆盖源级提示清理、输入锁定桥接、历史过滤与退出顺序。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->