### PR TITLE
补充已合并第4天教程修复后的动画设置点击衔接

### DIFF
--- a/static/tutorial-settings-tour-flow.test.cjs
+++ b/static/tutorial-settings-tour-flow.test.cjs
@@ -213,7 +213,9 @@ test('SettingsTourFlow reuses day four animation panel from its anchor cursor cl
                 anchorButton.id,
                 previousSceneId
             ]);
-            options.onClickStart();
+            if (options && typeof options.onClickStart === 'function') {
+                options.onClickStart();
+            }
             return Promise.resolve(true);
         },
         ensureAvatarFloatingSettingsSidePanel(panelId) {
@@ -253,6 +255,7 @@ test('SettingsTourFlow reuses day four animation panel from its anchor cursor cl
         ['narration', 'day4_model_behavior', 'line', 'voice', 3200],
         ['delay', 220],
         ['cursor-click-anchor', 'day4_model_behavior_anchor_button', 'click', 620, 'animation-settings-button', 'day4_chat_settings'],
+        ['ensure-panel', 'animation-settings'],
         ['highlight', 'day4_model_behavior-animation-settings-panel', 'animation-settings-panel', 'settings-button'],
         ['delay', 3200],
         ['ellipse', 100, 100, 51.2, 60, 3200],
@@ -363,7 +366,12 @@ test('SettingsTourFlow stops day two panel tour if skip happens while opening si
 
 test('SettingsTourFlow owns linear day four gaze follow scene body', async () => {
     const calls = [];
-    const mouseTrackingToggle = { id: 'mouse-tracking-toggle' };
+    const mouseTrackingToggle = {
+        id: 'mouse-tracking-toggle',
+        click() {
+            calls.push(['target-click', 'mouse-tracking-toggle']);
+        }
+    };
     const settingsButton = { id: 'settings-button' };
     const director = {
         sceneRunId: 5,
@@ -399,6 +407,11 @@ test('SettingsTourFlow owns linear day four gaze follow scene body', async () =>
             calls.push(['move', element.id, durationMs]);
             return Promise.resolve(true);
         },
+        runActionWithCursorClick(durationMs, action) {
+            calls.push(['cursor-click', durationMs]);
+            action();
+            return Promise.resolve(true);
+        },
         finalizeScene(sceneRunId, options) {
             calls.push(['finalize', sceneRunId, options.index, options.total]);
             return Promise.resolve(true);
@@ -421,8 +434,415 @@ test('SettingsTourFlow owns linear day four gaze follow scene body', async () =>
         ['narration', 'day4_gaze_follow', 'line', 'voice'],
         ['delay', 220],
         ['move', 'mouse-tracking-toggle', 620],
+        ['cursor-click', 420],
+        ['target-click', 'mouse-tracking-toggle'],
+        ['delay', 1800],
         ['finalize', 5, 3, 8]
     ]);
+});
+
+test('SettingsTourFlow does not toggle off enabled day four gaze follow', async () => {
+    const calls = [];
+    const mouseTrackingToggle = {
+        id: 'mouse-tracking-toggle',
+        checked: true,
+        click() {
+            calls.push(['target-click', 'mouse-tracking-toggle']);
+        }
+    };
+    const settingsButton = { id: 'settings-button' };
+    const director = {
+        sceneRunId: 5,
+        currentStep: 'day4-gaze',
+        prepareNarration(scene) {
+            calls.push(['prepare', scene.id]);
+            return { text: 'line', voiceKey: 'voice', canHandleSceneButtons: false, actionWaitPromise: null };
+        },
+        getDay4SettingsButtonSpotlightTarget() {
+            return settingsButton;
+        },
+        getDay4MouseTrackingTarget() {
+            return mouseTrackingToggle;
+        },
+        applyGuideHighlights(config) {
+            calls.push(['highlight', config.key, config.primary.id, config.persistent.id]);
+        },
+        enableInterrupts(step) {
+            calls.push(['interrupts', step]);
+        },
+        createNarrationPromise(scene, text, voiceKey) {
+            calls.push(['narration', scene.id, text, voiceKey]);
+            return Promise.resolve();
+        },
+        waitForSceneDelay(delayMs) {
+            calls.push(['delay', delayMs]);
+            return Promise.resolve(true);
+        },
+        isStopping() {
+            return false;
+        },
+        moveCursorToElement(element, durationMs) {
+            calls.push(['move', element.id, durationMs]);
+            return Promise.resolve(true);
+        },
+        runActionWithCursorClick(durationMs, action) {
+            calls.push(['cursor-click', durationMs]);
+            action();
+            return Promise.resolve(true);
+        },
+        finalizeScene(sceneRunId, options) {
+            calls.push(['finalize', sceneRunId, options.index, options.total]);
+            return Promise.resolve(true);
+        }
+    };
+    const flow = new SettingsTourFlow(director);
+
+    const result = await flow.play({ id: 'day4_gaze_follow' }, {
+        sceneRunId: 5,
+        previousSceneId: 'day4_model_behavior',
+        index: 3,
+        total: 8
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(calls, [
+        ['prepare', 'day4_gaze_follow'],
+        ['highlight', 'day4_gaze_follow-mouse-tracking-toggle', 'mouse-tracking-toggle', 'settings-button'],
+        ['interrupts', 'day4-gaze'],
+        ['narration', 'day4_gaze_follow', 'line', 'voice'],
+        ['delay', 220],
+        ['move', 'mouse-tracking-toggle', 620],
+        ['cursor-click', 420],
+        ['delay', 1800],
+        ['finalize', 5, 3, 8]
+    ]);
+});
+
+test('SettingsTourFlow reads nested mouse tracking checkbox before stale wrapper state', async () => {
+    const calls = [];
+    const checkbox = { checked: false };
+    const mouseTrackingToggle = {
+        id: 'mouse-tracking-toggle',
+        getAttribute(name) {
+            return name === 'aria-checked' ? 'true' : null;
+        },
+        querySelector(selector) {
+            if (selector === 'input[type="checkbox"]') {
+                return checkbox;
+            }
+            return null;
+        },
+        click() {
+            checkbox.checked = true;
+            calls.push(['target-click', 'mouse-tracking-toggle']);
+        }
+    };
+    const settingsButton = { id: 'settings-button' };
+    const director = {
+        sceneRunId: 5,
+        currentStep: 'day4-gaze',
+        prepareNarration(scene) {
+            calls.push(['prepare', scene.id]);
+            return { text: 'line', voiceKey: 'voice', canHandleSceneButtons: false, actionWaitPromise: null };
+        },
+        getDay4SettingsButtonSpotlightTarget() {
+            return settingsButton;
+        },
+        getDay4MouseTrackingTarget() {
+            return mouseTrackingToggle;
+        },
+        applyGuideHighlights(config) {
+            calls.push(['highlight', config.key, config.primary.id, config.persistent.id]);
+        },
+        enableInterrupts(step) {
+            calls.push(['interrupts', step]);
+        },
+        createNarrationPromise(scene, text, voiceKey) {
+            calls.push(['narration', scene.id, text, voiceKey]);
+            return Promise.resolve();
+        },
+        waitForSceneDelay(delayMs) {
+            calls.push(['delay', delayMs]);
+            return Promise.resolve(true);
+        },
+        isStopping() {
+            return false;
+        },
+        moveCursorToElement(element, durationMs) {
+            calls.push(['move', element.id, durationMs]);
+            return Promise.resolve(true);
+        },
+        runActionWithCursorClick(durationMs, action) {
+            calls.push(['cursor-click', durationMs]);
+            action();
+            return Promise.resolve(true);
+        },
+        finalizeScene(sceneRunId, options) {
+            calls.push(['finalize', sceneRunId, options.index, options.total]);
+            return Promise.resolve(true);
+        }
+    };
+    const flow = new SettingsTourFlow(director);
+
+    const result = await flow.play({ id: 'day4_gaze_follow' }, {
+        sceneRunId: 5,
+        previousSceneId: 'day4_model_behavior',
+        index: 3,
+        total: 8
+    });
+
+    assert.equal(result, true);
+    assert.equal(checkbox.checked, true);
+    assert.deepEqual(calls, [
+        ['prepare', 'day4_gaze_follow'],
+        ['highlight', 'day4_gaze_follow-mouse-tracking-toggle', 'mouse-tracking-toggle', 'settings-button'],
+        ['interrupts', 'day4-gaze'],
+        ['narration', 'day4_gaze_follow', 'line', 'voice'],
+        ['delay', 220],
+        ['move', 'mouse-tracking-toggle', 620],
+        ['cursor-click', 420],
+        ['target-click', 'mouse-tracking-toggle'],
+        ['delay', 1800],
+        ['finalize', 5, 3, 8]
+    ]);
+});
+
+test('SettingsTourFlow hides day four privacy panels before and after closing settings', async () => {
+    const calls = [];
+    const settingsButton = { id: 'settings-button' };
+    const privacyButton = { id: 'privacy-toggle' };
+    const director = {
+        sceneRunId: 6,
+        currentStep: 'day4-privacy',
+        prepareNarration(scene) {
+            calls.push(['prepare', scene.id]);
+            return { text: 'line', voiceKey: 'voice', canHandleSceneButtons: false, actionWaitPromise: null };
+        },
+        getDay4SettingsButtonSpotlightTarget() {
+            return settingsButton;
+        },
+        getDay4PrivacyModeButtonTarget() {
+            return privacyButton;
+        },
+        collapseAvatarFloatingSidePanelsExcept(panel) {
+            calls.push(['collapse-except', panel]);
+        },
+        applyGuideHighlights(config) {
+            calls.push(['highlight', config.key, config.primary.id, config.persistent.id]);
+        },
+        enableInterrupts(step) {
+            calls.push(['interrupts', step]);
+        },
+        createNarrationPromise(scene, text, voiceKey) {
+            calls.push(['narration', scene.id, text, voiceKey]);
+            return Promise.resolve();
+        },
+        waitForSceneDelay(delayMs) {
+            calls.push(['delay', delayMs]);
+            return Promise.resolve(true);
+        },
+        isStopping() {
+            return false;
+        },
+        moveCursorToElement(element, durationMs) {
+            calls.push(['move', element.id, durationMs]);
+            return Promise.resolve(true);
+        },
+        closeSettingsPanel() {
+            calls.push(['close-settings']);
+            return Promise.resolve(true);
+        },
+        forceHideManagedPanel(panelId) {
+            calls.push(['force-hide', panelId]);
+        },
+        finalizeScene(sceneRunId, options) {
+            calls.push(['finalize', sceneRunId, options.index, options.total]);
+            return Promise.resolve(true);
+        }
+    };
+    const flow = new SettingsTourFlow(director);
+
+    const result = await flow.play({ id: 'day4_privacy_mode' }, {
+        sceneRunId: 6,
+        previousSceneId: 'day4_gaze_follow',
+        index: 4,
+        total: 8
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(calls, [
+        ['prepare', 'day4_privacy_mode'],
+        ['collapse-except', null],
+        ['highlight', 'day4_privacy_mode-privacy-mode-button', 'privacy-toggle', 'settings-button'],
+        ['interrupts', 'day4-privacy'],
+        ['narration', 'day4_privacy_mode', 'line', 'voice'],
+        ['delay', 220],
+        ['move', 'privacy-toggle', 620],
+        ['force-hide', 'settings'],
+        ['collapse-except', null],
+        ['close-settings'],
+        ['force-hide', 'settings'],
+        ['collapse-except', null],
+        ['finalize', 6, 4, 8]
+    ]);
+});
+
+test('SettingsTourFlow does not hide newer panel when day four privacy close becomes stale', async () => {
+    const calls = [];
+    const settingsButton = { id: 'settings-button' };
+    const privacyButton = { id: 'privacy-toggle' };
+    const director = {
+        sceneRunId: 6,
+        currentStep: 'day4-privacy',
+        prepareNarration(scene) {
+            calls.push(['prepare', scene.id]);
+            return { text: 'line', voiceKey: 'voice', canHandleSceneButtons: false, actionWaitPromise: null };
+        },
+        getDay4SettingsButtonSpotlightTarget() {
+            return settingsButton;
+        },
+        getDay4PrivacyModeButtonTarget() {
+            return privacyButton;
+        },
+        collapseAvatarFloatingSidePanelsExcept(panel) {
+            calls.push(['collapse-except', panel]);
+        },
+        applyGuideHighlights(config) {
+            calls.push(['highlight', config.key, config.primary.id, config.persistent.id]);
+        },
+        enableInterrupts(step) {
+            calls.push(['interrupts', step]);
+        },
+        createNarrationPromise(scene, text, voiceKey) {
+            calls.push(['narration', scene.id, text, voiceKey]);
+            return Promise.resolve();
+        },
+        waitForSceneDelay(delayMs) {
+            calls.push(['delay', delayMs]);
+            return Promise.resolve(true);
+        },
+        isStopping() {
+            return false;
+        },
+        moveCursorToElement(element, durationMs) {
+            calls.push(['move', element.id, durationMs]);
+            return Promise.resolve(true);
+        },
+        closeSettingsPanel() {
+            calls.push(['close-settings']);
+            this.sceneRunId = 7;
+            return Promise.resolve(true);
+        },
+        forceHideManagedPanel(panelId) {
+            calls.push(['force-hide', panelId]);
+        },
+        finalizeScene(sceneRunId, options) {
+            calls.push(['finalize', sceneRunId, options.index, options.total]);
+            return Promise.resolve(true);
+        }
+    };
+    const flow = new SettingsTourFlow(director);
+
+    const result = await flow.play({ id: 'day4_privacy_mode' }, {
+        sceneRunId: 6,
+        previousSceneId: 'day4_gaze_follow',
+        index: 4,
+        total: 8
+    });
+
+    assert.equal(result, false);
+    assert.deepEqual(calls, [
+        ['prepare', 'day4_privacy_mode'],
+        ['collapse-except', null],
+        ['highlight', 'day4_privacy_mode-privacy-mode-button', 'privacy-toggle', 'settings-button'],
+        ['interrupts', 'day4-privacy'],
+        ['narration', 'day4_privacy_mode', 'line', 'voice'],
+        ['delay', 220],
+        ['move', 'privacy-toggle', 620],
+        ['force-hide', 'settings'],
+        ['collapse-except', null],
+        ['close-settings']
+    ]);
+});
+
+test('SettingsTourFlow continues day four privacy cleanup when hide helpers throw', async () => {
+    const calls = [];
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => {
+        warnings.push(args);
+    };
+    const settingsButton = { id: 'settings-button' };
+    const privacyButton = { id: 'privacy-toggle' };
+    const director = {
+        sceneRunId: 6,
+        currentStep: 'day4-privacy',
+        prepareNarration(scene) {
+            calls.push(['prepare', scene.id]);
+            return { text: 'line', voiceKey: 'voice', canHandleSceneButtons: false, actionWaitPromise: null };
+        },
+        getDay4SettingsButtonSpotlightTarget() {
+            return settingsButton;
+        },
+        getDay4PrivacyModeButtonTarget() {
+            return privacyButton;
+        },
+        collapseAvatarFloatingSidePanelsExcept(panel) {
+            calls.push(['collapse-except', panel]);
+            if (calls.filter((call) => call[0] === 'collapse-except').length > 1) {
+                throw new Error('collapse failed');
+            }
+        },
+        applyGuideHighlights(config) {
+            calls.push(['highlight', config.key, config.primary.id, config.persistent.id]);
+        },
+        enableInterrupts(step) {
+            calls.push(['interrupts', step]);
+        },
+        createNarrationPromise(scene, text, voiceKey) {
+            calls.push(['narration', scene.id, text, voiceKey]);
+            return Promise.resolve();
+        },
+        waitForSceneDelay(delayMs) {
+            calls.push(['delay', delayMs]);
+            return Promise.resolve(true);
+        },
+        isStopping() {
+            return false;
+        },
+        moveCursorToElement(element, durationMs) {
+            calls.push(['move', element.id, durationMs]);
+            return Promise.resolve(true);
+        },
+        closeSettingsPanel() {
+            calls.push(['close-settings']);
+            return Promise.resolve(true);
+        },
+        forceHideManagedPanel(panelId) {
+            calls.push(['force-hide', panelId]);
+            throw new Error('hide failed');
+        },
+        finalizeScene(sceneRunId, options) {
+            calls.push(['finalize', sceneRunId, options.index, options.total]);
+            return Promise.resolve(true);
+        }
+    };
+    const flow = new SettingsTourFlow(director);
+
+    try {
+        const result = await flow.play({ id: 'day4_privacy_mode' }, {
+            sceneRunId: 6,
+            previousSceneId: 'day4_gaze_follow',
+            index: 4,
+            total: 8
+        });
+
+        assert.equal(result, true);
+        assert.equal(warnings.length, 4);
+        assert.equal(calls.at(-1)[0], 'finalize');
+    } finally {
+        console.warn = originalWarn;
+    }
 });
 
 test('SettingsTourFlow refreshes visible day five character panel before panic narration', async () => {
@@ -737,12 +1157,14 @@ test('SettingsTourFlow stops day four panel tour when anchor click makes scene s
             return false;
         },
         moveAvatarFloatingCursor(cursorScene, anchorButton, secondaryTarget, previousSceneId, options) {
-            options.onClickStart();
+            if (options && typeof options.onClickStart === 'function') {
+                options.onClickStart();
+            }
             this.sceneRunId = 15;
             return Promise.resolve(true);
         },
         ensureAvatarFloatingSettingsSidePanel(panelId, options) {
-            calls.push(['ensure', panelId, !!(options && options.shouldContinue)]);
+            calls.push(['ensure', panelId, !!(options && options.shouldContinue), !!(options && options.skipOpenSettingsPanel)]);
             return Promise.resolve(animationPanel);
         },
         getElementRect(target) {
@@ -760,7 +1182,8 @@ test('SettingsTourFlow stops day four panel tour when anchor click makes scene s
 
     assert.equal(result, false);
     assert.deepEqual(calls, [
-        ['highlight', 'day4_model_behavior-animation-settings-button']
+        ['highlight', 'day4_model_behavior-animation-settings-button'],
+        ['ensure', 'animation-settings', true, true]
     ]);
 });
 

--- a/static/tutorial/core/settings-tour-flow.js
+++ b/static/tutorial/core/settings-tour-flow.js
@@ -49,6 +49,7 @@
         })
     });
     const DEFAULT_CURSOR_CLICK_VISIBLE_MS = 420;
+    const DAY4_GAZE_FOLLOW_CHECKED_DISPLAY_MS = 1800;
 
     class SettingsTourFlow {
         constructor(director) {
@@ -232,7 +233,11 @@
                         cursorMoveDurationMs: normalizedSchema.cursorMoveDurationMs
                     }, anchorButton, null, previousSceneId, {
                         onClickStart: () => {
-                            openedPanelPromise = Promise.resolve(sidePanel);
+                            if (!this.isSceneStale(sceneRunId)) {
+                                openedPanelPromise = this.ensurePanelForScene(panelId, sceneRunId, scene, {
+                                    skipOpenSettingsPanel: true
+                                });
+                            }
                         }
                     });
                 } else {
@@ -313,10 +318,27 @@
             }
 
             if (mouseTrackingTarget) {
-                await director.moveCursorToElement(mouseTrackingTarget, 620);
+                const moved = await director.moveCursorToElement(mouseTrackingTarget, 620);
+                if (moved && typeof director.runActionWithCursorClick === 'function') {
+                    await director.runActionWithCursorClick(DEFAULT_CURSOR_CLICK_VISIBLE_MS, () => {
+                        if (
+                            this.shouldClickToggleToEnable(mouseTrackingTarget)
+                            && typeof mouseTrackingTarget.click === 'function'
+                        ) {
+                            mouseTrackingTarget.click();
+                        }
+                    });
+                    if (this.isSceneStale(sceneRunId)) {
+                        return false;
+                    }
+                    await director.waitForSceneDelay(DAY4_GAZE_FOLLOW_CHECKED_DISPLAY_MS);
+                }
             }
 
             await narrationPromise;
+            if (this.isSceneStale(sceneRunId)) {
+                return false;
+            }
             return this.finalizeNarration(sceneRunId, narration, normalizedContext);
         }
 
@@ -351,11 +373,14 @@
 
             await narrationPromise;
             if (!this.isSceneStale(sceneRunId)) {
+                this.safeHideSettingsPanels();
                 await director.closeSettingsPanel().catch((error) => {
                     console.warn('[YuiGuide] 第4天隐私模式结束后收起设置面板失败，继续流程:', error);
                 });
-                director.forceHideManagedPanel('settings');
-                director.collapseAvatarFloatingSidePanelsExcept(null);
+                if (this.isSceneStale(sceneRunId)) {
+                    return false;
+                }
+                this.safeHideSettingsPanels();
             }
             return this.finalizeNarration(sceneRunId, narration, normalizedContext);
         }
@@ -561,15 +586,93 @@
             return sceneId.indexOf('day4_') === 0;
         }
 
-        async ensurePanelForScene(panelId, sceneRunId, scene) {
+        shouldClickToggleToEnable(target) {
+            const checked = this.readToggleChecked(target);
+            return checked !== true;
+        }
+
+        readToggleChecked(target) {
+            if (!target) {
+                return null;
+            }
+            const candidates = [];
+            if (typeof target.querySelector === 'function') {
+                const nestedToggle = target.querySelector('input[type="checkbox"]');
+                if (nestedToggle && !candidates.includes(nestedToggle)) {
+                    candidates.push(nestedToggle);
+                }
+            }
+            if (!candidates.includes(target)) {
+                candidates.push(target);
+            }
+            if (typeof target.querySelector === 'function') {
+                const nestedToggle = target.querySelector('[role="switch"], [aria-checked]');
+                if (nestedToggle && !candidates.includes(nestedToggle)) {
+                    candidates.push(nestedToggle);
+                }
+            }
+            for (const candidate of candidates) {
+                if (!candidate) {
+                    continue;
+                }
+                if (typeof candidate.checked === 'boolean') {
+                    return !!candidate.checked;
+                }
+                if (typeof candidate.getAttribute === 'function') {
+                    const ariaChecked = candidate.getAttribute('aria-checked');
+                    if (ariaChecked === 'true') {
+                        return true;
+                    }
+                    if (ariaChecked === 'false') {
+                        return false;
+                    }
+                }
+                if (candidate.classList && typeof candidate.classList.contains === 'function') {
+                    if (
+                        candidate.classList.contains('is-checked')
+                        || candidate.classList.contains('checked')
+                        || candidate.classList.contains('active')
+                    ) {
+                        return true;
+                    }
+                }
+            }
+            return null;
+        }
+
+        safeHideSettingsPanels() {
+            const director = this.director;
+            try {
+                if (director && typeof director.forceHideManagedPanel === 'function') {
+                    director.forceHideManagedPanel('settings');
+                }
+            } catch (error) {
+                console.warn('[YuiGuide] 第4天隐私模式隐藏设置面板失败，继续流程:', error);
+            }
+            try {
+                if (director && typeof director.collapseAvatarFloatingSidePanelsExcept === 'function') {
+                    director.collapseAvatarFloatingSidePanelsExcept(null);
+                }
+            } catch (error) {
+                console.warn('[YuiGuide] 第4天隐私模式收起侧栏失败，继续流程:', error);
+            }
+        }
+
+        async ensurePanelForScene(panelId, sceneRunId, scene, options) {
             const director = this.director;
             if (this.isSceneStale(sceneRunId)) {
                 return null;
             }
-            const options = this.shouldGuardPanelFlow(scene)
+            const normalizedOptions = options || {};
+            const ensureOptions = this.shouldGuardPanelFlow(scene)
                 ? { shouldContinue: () => !this.isSceneStale(sceneRunId) }
                 : undefined;
-            return director.ensureAvatarFloatingSettingsSidePanel(panelId, options);
+            if (normalizedOptions.skipOpenSettingsPanel) {
+                return director.ensureAvatarFloatingSettingsSidePanel(panelId, Object.assign({}, ensureOptions, {
+                    skipOpenSettingsPanel: true
+                }));
+            }
+            return director.ensureAvatarFloatingSettingsSidePanel(panelId, ensureOptions);
         }
 
         async finalizeNarration(sceneRunId, narration, context) {

--- a/static/tutorial/yui-guide/days/day4-companion-guide.js
+++ b/static/tutorial/yui-guide/days/day4-companion-guide.js
@@ -89,6 +89,7 @@
                     target: 'settings-sidepanel:animation-settings',
                     cursorAction: 'tour',
                     operation: 'show-settings-sidepanel:animation-settings',
+                    deferSettingsSidePanelUntilCursorClick: true,
                     afterSceneDelayMs: 0
                 },
                 {
@@ -109,6 +110,7 @@
                     target: 'settings-sidepanel:animation-settings',
                     cursorAction: 'tour',
                     operation: 'show-settings-sidepanel:animation-settings',
+                    deferSettingsSidePanelUntilCursorClick: true,
                     afterSceneDelayMs: 0
                 },
                 {

--- a/static/tutorial/yui-guide/director.js
+++ b/static/tutorial/yui-guide/director.js
@@ -6136,14 +6136,20 @@
             const shouldContinue = options && typeof options.shouldContinue === 'function'
                 ? options.shouldContinue
                 : null;
+            const skipOpenSettingsPanel = !!(options && options.skipOpenSettingsPanel);
             if (shouldContinue && !shouldContinue()) {
                 return null;
             }
-            const opened = await this.openSettingsPanel();
-            if (!opened || this.isStopping()) {
+            if (!skipOpenSettingsPanel) {
+                const opened = await this.openSettingsPanel();
+                if (!opened) {
+                    return null;
+                }
+                this.positionManagedPanelNow('settings');
+            }
+            if (this.isStopping()) {
                 return null;
             }
-            this.positionManagedPanelNow('settings');
             const panel = await this.waitForElement(() => this.getAvatarFloatingSidePanel(type), 1200);
             if (!panel) {
                 return null;

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2090,6 +2090,9 @@ test('director registers settings side panels as pause tokens', () => {
     assert.match(sidebarControllerBlock, /data-yui-guide-sidebar-paused/);
     assert.match(constructorBlock, /this\.sidebarPauseController = new SidebarPauseController\(\{/);
     assert.match(constructorBlock, /this\.pauseCoordinator\.registerPauseToken\('sidebar',\s*this\.sidebarPauseController\.getPauseToken\(\)\);/);
+    assert.match(ensureSettingsBlock, /const skipOpenSettingsPanel = !!\(options && options\.skipOpenSettingsPanel\);/);
+    assert.match(ensureSettingsBlock, /if \(!skipOpenSettingsPanel\) \{[\s\S]*const opened = await this\.openSettingsPanel\(\);/);
+    assert.match(ensureSettingsBlock, /if \(!opened\) \{[\s\S]*return null;[\s\S]*if \(this\.isStopping\(\)\) \{[\s\S]*return null;/);
     assert.match(ensureSettingsBlock, /this\.sidebarPauseController\.trackPanel\(panel\);/);
     assert.match(
         ensureSettingsBlock,


### PR DESCRIPTION
## 改动概述 / Summary

优化新手教程第 4 天设置面板相关动画衔接，补充已合并第 4 天教程修复后的后续细节处理。

主要改动：
- 动画设置面板改为猫爪移动到入口并点击后，再展开并展示面板。
- 跟踪鼠标开关点击后保留勾选展示时间，避免界面一闪而过。
- 隐私模式段落关闭设置面板前后清理托管面板和侧栏状态，减少关闭时短暂闪现。
- 第 4 天 settings tour 的面板等待逻辑继续使用 scene guard，避免 stale scene 异步结果影响后续流程。
- 补充对应 settings tour 单元测试。

## 回归报告 / Regression Report

不适用。本 PR 未触碰 app/、main_logic/、memory/ 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。本 PR 计入上限的文件数未超过 20 个，且改动集中在第 4 天新手教程 settings tour 后续修复。

## 测试 / Testing

- `node static/tutorial-settings-tour-flow.test.cjs`
- `node --test --test-name-pattern 'settings tour flow owns' static/yui-guide-common.test.cjs`
- `node --check static/tutorial/core/settings-tour-flow.js && node --check static/tutorial/yui-guide/days/day4-companion-guide.js && node --check static/tutorial-settings-tour-flow.test.cjs`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化第 4 天设置引导：侧边栏在游标点击触发后再呈现，减少交互时机错乱。
  - 强化“凝视追随”：仅在光标移动成功且触发点击后才执行切换，并等待正确展示时长；场景过期会更可靠终止。
  - 改进隐私模式收尾：采用更稳妥的隐藏/收起与关闭顺序，避免前后面板状态不一致，并在隐藏失败时继续收尾。

- **Tests**
  - 扩展第 4 天相关用例与期望调用序列，补齐点击记录、stale/异常与面板隐藏断言覆盖面。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->