### PR TITLE
延迟 goodbye 资源暂停并补齐恢复边界

### DIFF
--- a/frontend/plugin-manager/src/stores/metrics.ts
+++ b/frontend/plugin-manager/src/stores/metrics.ts
@@ -19,10 +19,13 @@ export const useMetricsStore = defineStore('metrics', () => {
   // 请求超时自动清理（防止请求堆积）
   const REQUEST_TIMEOUT = 15000 // 15秒
 
-  function isGoodbyeResourceSuspended() {
+  function isGoodbyeResourceSuspendingOrSuspended() {
     if (typeof window === 'undefined') return false
     try {
+      const helper = (window as any).isNekoGoodbyeResourceSuspendingOrSuspended
+      if (typeof helper === 'function' && helper()) return true
       if ((window as any).goodbyeResourceSuspended === true) return true
+      if ((window as any).__nekoGoodbyeResourceSuspendPending === true) return true
       return window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'
     } catch {
       return false
@@ -31,7 +34,7 @@ export const useMetricsStore = defineStore('metrics', () => {
 
   // 操作
   async function fetchAllMetrics() {
-    if (isGoodbyeResourceSuspended()) {
+    if (isGoodbyeResourceSuspendingOrSuspended()) {
       return { metrics: allMetrics.value }
     }
     // 如果已有请求正在进行，直接返回该请求的结果（防止请求堆积）
@@ -86,7 +89,7 @@ export const useMetricsStore = defineStore('metrics', () => {
       console.warn('[Metrics] fetchPluginMetrics called with empty pluginId')
       return
     }
-    if (isGoodbyeResourceSuspended()) {
+    if (isGoodbyeResourceSuspendingOrSuspended()) {
       return
     }
     
@@ -143,7 +146,7 @@ export const useMetricsStore = defineStore('metrics', () => {
     pluginId: string,
     params?: { limit?: number; start_time?: string; end_time?: string }
   ) {
-    if (isGoodbyeResourceSuspended()) {
+    if (isGoodbyeResourceSuspendingOrSuspended()) {
       return
     }
     try {

--- a/frontend/plugin-manager/src/stores/metrics.ts
+++ b/frontend/plugin-manager/src/stores/metrics.ts
@@ -19,8 +19,21 @@ export const useMetricsStore = defineStore('metrics', () => {
   // 请求超时自动清理（防止请求堆积）
   const REQUEST_TIMEOUT = 15000 // 15秒
 
+  function isGoodbyeResourceSuspended() {
+    if (typeof window === 'undefined') return false
+    try {
+      if ((window as any).goodbyeResourceSuspended === true) return true
+      return window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'
+    } catch {
+      return false
+    }
+  }
+
   // 操作
   async function fetchAllMetrics() {
+    if (isGoodbyeResourceSuspended()) {
+      return { metrics: allMetrics.value }
+    }
     // 如果已有请求正在进行，直接返回该请求的结果（防止请求堆积）
     if (pendingFetchAll) {
       return pendingFetchAll
@@ -71,6 +84,9 @@ export const useMetricsStore = defineStore('metrics', () => {
   async function fetchPluginMetrics(pluginId: string) {
     if (!pluginId) {
       console.warn('[Metrics] fetchPluginMetrics called with empty pluginId')
+      return
+    }
+    if (isGoodbyeResourceSuspended()) {
       return
     }
     
@@ -127,6 +143,9 @@ export const useMetricsStore = defineStore('metrics', () => {
     pluginId: string,
     params?: { limit?: number; start_time?: string; end_time?: string }
   ) {
+    if (isGoodbyeResourceSuspended()) {
+      return
+    }
     try {
       const response = await getPluginMetricsHistory(pluginId, params)
       metricsHistory.value[pluginId] = response.history || []
@@ -158,4 +177,3 @@ export const useMetricsStore = defineStore('metrics', () => {
     getHistory
   }
 })
-

--- a/frontend/plugin-manager/src/views/Dashboard.vue
+++ b/frontend/plugin-manager/src/views/Dashboard.vue
@@ -164,6 +164,7 @@ const serverInfoError = ref(false)
 const metricsLoading = ref(false)
 const globalMetrics = ref<GlobalMetrics | null>(null)
 let metricsTimer: number | null = null
+const GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY = 'neko-goodbye-resource-suspended'
 
 function isGoodbyeResourceSuspendingOrSuspended() {
   if (typeof window === 'undefined') return false
@@ -172,7 +173,7 @@ function isGoodbyeResourceSuspendingOrSuspended() {
     if (typeof helper === 'function' && helper()) return true
     if ((window as any).goodbyeResourceSuspended === true) return true
     if ((window as any).__nekoGoodbyeResourceSuspendPending === true) return true
-    return window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'
+    return window.localStorage.getItem(GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY) === 'true'
   } catch {
     return false
   }
@@ -442,6 +443,15 @@ function handleGoodbyeResourceState(event: Event) {
   }
 }
 
+function handleGoodbyeResourceStorage(event: StorageEvent) {
+  if (event.key !== null && event.key !== GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY) return
+  if (isGoodbyeResourceSuspendingOrSuspended()) {
+    stopAutoRefresh()
+  } else {
+    startAutoRefresh()
+  }
+}
+
 onMounted(async () => {
   await Promise.all([
     pluginStore.fetchPlugins(),
@@ -450,11 +460,13 @@ onMounted(async () => {
     fetchGlobalMetrics(),
   ])
   window.addEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
+  window.addEventListener('storage', handleGoodbyeResourceStorage)
   startAutoRefresh()
 })
 
 onUnmounted(() => {
   window.removeEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
+  window.removeEventListener('storage', handleGoodbyeResourceStorage)
   stopAutoRefresh()
 })
 </script>

--- a/frontend/plugin-manager/src/views/Dashboard.vue
+++ b/frontend/plugin-manager/src/views/Dashboard.vue
@@ -165,6 +165,19 @@ const metricsLoading = ref(false)
 const globalMetrics = ref<GlobalMetrics | null>(null)
 let metricsTimer: number | null = null
 
+function isGoodbyeResourceSuspendingOrSuspended() {
+  if (typeof window === 'undefined') return false
+  try {
+    const helper = (window as any).isNekoGoodbyeResourceSuspendingOrSuspended
+    if (typeof helper === 'function' && helper()) return true
+    if ((window as any).goodbyeResourceSuspended === true) return true
+    if ((window as any).__nekoGoodbyeResourceSuspendPending === true) return true
+    return window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'
+  } catch {
+    return false
+  }
+}
+
 // ── Computed stats ────────────────────────────────────────────────────
 
 const totalPlugins = computed(() => pluginStore.plugins.length)
@@ -402,8 +415,13 @@ function handleStartTutorial() {
 }
 
 function startAutoRefresh() {
+  if (isGoodbyeResourceSuspendingOrSuspended()) return
   stopAutoRefresh()
   metricsTimer = window.setInterval(() => {
+    if (isGoodbyeResourceSuspendingOrSuspended()) {
+      stopAutoRefresh()
+      return
+    }
     fetchGlobalMetrics()
   }, METRICS_REFRESH_INTERVAL)
 }
@@ -415,6 +433,15 @@ function stopAutoRefresh() {
   }
 }
 
+function handleGoodbyeResourceState(event: Event) {
+  const detail = (event as CustomEvent).detail || {}
+  if (detail.suspended || detail.pending || isGoodbyeResourceSuspendingOrSuspended()) {
+    stopAutoRefresh()
+  } else {
+    startAutoRefresh()
+  }
+}
+
 onMounted(async () => {
   await Promise.all([
     pluginStore.fetchPlugins(),
@@ -422,10 +449,12 @@ onMounted(async () => {
     fetchServerInfo(),
     fetchGlobalMetrics(),
   ])
+  window.addEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
   startAutoRefresh()
 })
 
 onUnmounted(() => {
+  window.removeEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
   stopAutoRefresh()
 })
 </script>

--- a/frontend/plugin-manager/src/views/Metrics.vue
+++ b/frontend/plugin-manager/src/views/Metrics.vue
@@ -39,6 +39,7 @@ const metrics = computed(() => metricsStore.allMetrics)
 const loading = computed(() => metricsStore.loading)
 
 let refreshTimer: number | null = null
+const GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY = 'neko-goodbye-resource-suspended'
 
 function isGoodbyeResourceSuspendingOrSuspended() {
   if (typeof window === 'undefined') return false
@@ -47,7 +48,7 @@ function isGoodbyeResourceSuspendingOrSuspended() {
     if (typeof helper === 'function' && helper()) return true
     if ((window as any).goodbyeResourceSuspended === true) return true
     if ((window as any).__nekoGoodbyeResourceSuspendPending === true) return true
-    return window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'
+    return window.localStorage.getItem(GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY) === 'true'
   } catch {
     return false
   }
@@ -87,14 +88,25 @@ function handleGoodbyeResourceState(event: Event) {
   }
 }
 
+function handleGoodbyeResourceStorage(event: StorageEvent) {
+  if (event.key !== null && event.key !== GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY) return
+  if (isGoodbyeResourceSuspendingOrSuspended()) {
+    stopAutoRefresh()
+  } else {
+    startAutoRefresh()
+  }
+}
+
 onMounted(async () => {
   await handleRefresh()
   window.addEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
+  window.addEventListener('storage', handleGoodbyeResourceStorage)
   startAutoRefresh()
 })
 
 onUnmounted(() => {
   window.removeEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
+  window.removeEventListener('storage', handleGoodbyeResourceStorage)
   stopAutoRefresh()
 })
 </script>

--- a/frontend/plugin-manager/src/views/Metrics.vue
+++ b/frontend/plugin-manager/src/views/Metrics.vue
@@ -40,12 +40,31 @@ const loading = computed(() => metricsStore.loading)
 
 let refreshTimer: number | null = null
 
+function isGoodbyeResourceSuspendingOrSuspended() {
+  if (typeof window === 'undefined') return false
+  try {
+    const helper = (window as any).isNekoGoodbyeResourceSuspendingOrSuspended
+    if (typeof helper === 'function' && helper()) return true
+    if ((window as any).goodbyeResourceSuspended === true) return true
+    if ((window as any).__nekoGoodbyeResourceSuspendPending === true) return true
+    return window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'
+  } catch {
+    return false
+  }
+}
+
 async function handleRefresh() {
   await metricsStore.fetchAllMetrics()
 }
 
 function startAutoRefresh() {
+  if (isGoodbyeResourceSuspendingOrSuspended()) return
+  stopAutoRefresh()
   refreshTimer = window.setInterval(async () => {
+    if (isGoodbyeResourceSuspendingOrSuspended()) {
+      stopAutoRefresh()
+      return
+    }
     if (!loading.value) {
       await handleRefresh()
     }
@@ -59,12 +78,23 @@ function stopAutoRefresh() {
   }
 }
 
+function handleGoodbyeResourceState(event: Event) {
+  const detail = (event as CustomEvent).detail || {}
+  if (detail.suspended || detail.pending || isGoodbyeResourceSuspendingOrSuspended()) {
+    stopAutoRefresh()
+  } else {
+    startAutoRefresh()
+  }
+}
+
 onMounted(async () => {
   await handleRefresh()
+  window.addEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
   startAutoRefresh()
 })
 
 onUnmounted(() => {
+  window.removeEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)
   stopAutoRefresh()
 })
 </script>
@@ -86,4 +116,3 @@ onUnmounted(() => {
   gap: 16px;
 }
 </style>
-

--- a/static/app-agent.js
+++ b/static/app-agent.js
@@ -1504,8 +1504,27 @@
     let agentTaskPollingInterval = null;
     let agentTaskTimeUpdateInterval = null;
 
+    function isGoodbyeAgentUiSuppressed() {
+        try {
+            if (typeof window.isNekoGoodbyeResourceSuspendingOrSuspended === 'function' &&
+                window.isNekoGoodbyeResourceSuspendingOrSuspended()) {
+                return true;
+            }
+            if (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive()) {
+                return true;
+            }
+        } catch (_) { /* ignore */ }
+        return false;
+    }
+
     window.startAgentTaskPolling = function () {
         console.trace('[App] startAgentTaskPolling');
+        if (isGoodbyeAgentUiSuppressed()) {
+            if (window.AgentHUD && window.AgentHUD.hideAgentTaskHUD) {
+                window.AgentHUD.hideAgentTaskHUD();
+            }
+            return;
+        }
         if (window.AgentHUD && window.AgentHUD.createAgentTaskHUD) {
             window.AgentHUD.createAgentTaskHUD();
             window.AgentHUD.showAgentTaskHUD();
@@ -1551,6 +1570,9 @@
     // updateTaskRunningTimes
     // ====================================================================
     function updateTaskRunningTimes() {
+        if (isGoodbyeAgentUiSuppressed()) {
+            return;
+        }
         const taskList = document.getElementById('agent-task-list');
         if (!taskList) {
             return;
@@ -1593,6 +1615,10 @@
     // checkAndToggleTaskHUD
     // ====================================================================
     function checkAndToggleTaskHUD() {
+        if (isGoodbyeAgentUiSuppressed()) {
+            window.stopAgentTaskPolling();
+            return;
+        }
         const getEl = (ids) => {
             for (let id of ids) {
                 const el = document.getElementById(id);

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -115,6 +115,7 @@
         if (type === 'live2d') return window.live2dManager;
         if (type === 'vrm') return window.vrmManager;
         if (type === 'mmd') return window.mmdManager;
+        if (type === 'pngtuber') return window.pngtuberManager;
         return null;
     }
 
@@ -127,11 +128,16 @@
         if (type === 'vrm' || type === 'mmd') {
             return !!manager._animationFrameId;
         }
+        if (type === 'pngtuber') {
+            const container = manager.container || document.getElementById('pngtuber-container');
+            return !!(container && container.style.display !== 'none' &&
+                !(container.classList && container.classList.contains('hidden')));
+        }
         return false;
     }
 
     function pauseModelRenderingForGoodbye(snapshot) {
-        ['live2d', 'vrm', 'mmd'].forEach((type) => {
+        ['live2d', 'vrm', 'mmd', 'pngtuber'].forEach((type) => {
             const manager = getModelManagerByType(type);
             if (!manager || typeof manager.pauseRendering !== 'function') return;
             if (!isModelRenderingActive(type, manager)) return;
@@ -146,7 +152,7 @@
 
     function resumeModelRenderingFromGoodbye(snapshot) {
         if (!snapshot || !snapshot.pausedByCat) return;
-        ['live2d', 'vrm', 'mmd'].forEach((type) => {
+        ['live2d', 'vrm', 'mmd', 'pngtuber'].forEach((type) => {
             if (!snapshot.pausedByCat[type]) return;
             const manager = getModelManagerByType(type);
             if (!manager || typeof manager.resumeRendering !== 'function') return;
@@ -228,7 +234,7 @@
             pending: true,
             suspended: false,
             activeModelType,
-            pausedByCat: { live2d: false, vrm: false, mmd: false },
+            pausedByCat: { live2d: false, vrm: false, mmd: false, pngtuber: false },
             subtitleWindowWasVisible: wasSubtitleVisibleBeforeGoodbyeSnapshot(),
             agentHudWasVisible: isAgentHudVisible(),
             subtitleWindowHiddenByCat: false,

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -298,6 +298,11 @@
 
     mod.restoreGoodbyeResourceSuspend = restoreGoodbyeResourceSuspend;
     mod.completeGoodbyeResourceSuspend = completeGoodbyeResourceSuspend;
+    window.addEventListener('neko:goodbye-state-cleared', (event) => {
+        const detail = event && event.detail ? event.detail : {};
+        const reason = detail.reason || 'goodbye-state-cleared';
+        restoreGoodbyeResourceSuspend(reason);
+    });
 
     // ================================================================
     //  1. Status toast  (app.js lines 86-145)

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -77,6 +77,8 @@
         }));
     }
 
+    publishGoodbyeResourceState(null, 'goodbye-resource-boot');
+
     window.isNekoGoodbyeResourceSuspended = function () {
         return !!(S && S.goodbyeResourceSuspended);
     };
@@ -137,10 +139,11 @@
     }
 
     function pauseModelRenderingForGoodbye(snapshot) {
+        const activeModelType = snapshot && snapshot.activeModelType;
         ['live2d', 'vrm', 'mmd', 'pngtuber'].forEach((type) => {
             const manager = getModelManagerByType(type);
             if (!manager || typeof manager.pauseRendering !== 'function') return;
-            if (!isModelRenderingActive(type, manager)) return;
+            if (activeModelType !== type && !isModelRenderingActive(type, manager)) return;
             try {
                 manager.pauseRendering();
                 snapshot.pausedByCat[type] = true;

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -45,6 +45,259 @@
     let nekoModelCatTransitionToken = 0;
     let nekoModelCatTransitionActive = null;
     let nekoModelCatRevealPlaybackToken = 0;
+    const GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY = 'neko-goodbye-resource-suspended';
+    let goodbyeResourceSuspendToken = 0;
+
+    function getGoodbyeResourceSnapshot() {
+        return S && S.goodbyeResourceSuspendSnapshot ? S.goodbyeResourceSuspendSnapshot : null;
+    }
+
+    function publishGoodbyeResourceState(snapshot, source) {
+        const suspended = !!(snapshot && snapshot.suspended);
+        const pending = !!(snapshot && snapshot.pending);
+        if (S) {
+            S.goodbyeResourceSuspended = suspended;
+            S.goodbyeResourceSuspendPending = pending;
+            S.goodbyeResourceSuspendSnapshot = snapshot || null;
+        }
+        window.goodbyeResourceSuspended = suspended;
+        window.__nekoGoodbyeResourceSuspendPending = pending;
+        window.__nekoGoodbyeResourceSuspendSnapshot = snapshot || null;
+        try {
+            localStorage.setItem(GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY, suspended ? 'true' : 'false');
+        } catch (_) { /* ignore */ }
+        window.dispatchEvent(new CustomEvent('neko:goodbye-resource-suspend-state', {
+            detail: {
+                suspended,
+                pending,
+                source: source || 'goodbye-resource',
+                token: snapshot ? snapshot.token : goodbyeResourceSuspendToken,
+                activeModelType: snapshot ? snapshot.activeModelType : ''
+            }
+        }));
+    }
+
+    window.isNekoGoodbyeResourceSuspended = function () {
+        return !!(S && S.goodbyeResourceSuspended);
+    };
+
+    window.isNekoGoodbyeResourceSuspendingOrSuspended = function () {
+        return !!(S && (S.goodbyeResourceSuspended || S.goodbyeResourceSuspendPending));
+    };
+
+    function isVisibleElement(el) {
+        if (!el) return false;
+        if (el.classList && el.classList.contains('hidden')) return false;
+        if (el.style && el.style.display === 'none') return false;
+        try {
+            const style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+            if (style && (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0')) {
+                return false;
+            }
+        } catch (_) { /* ignore */ }
+        return true;
+    }
+
+    function isElementVisibleById(id) {
+        return isVisibleElement(document.getElementById(id));
+    }
+
+    function getActiveGoodbyeModelType(fallbackType) {
+        if (fallbackType) return fallbackType;
+        if (isElementVisibleById('mmd-container')) return 'mmd';
+        if (isElementVisibleById('vrm-container')) return 'vrm';
+        const configured = (window.lanlan_config?.model_type || '').toLowerCase();
+        if (configured === 'pngtuber' && isElementVisibleById('pngtuber-container')) return 'pngtuber';
+        return 'live2d';
+    }
+
+    function getModelManagerByType(type) {
+        if (type === 'live2d') return window.live2dManager;
+        if (type === 'vrm') return window.vrmManager;
+        if (type === 'mmd') return window.mmdManager;
+        return null;
+    }
+
+    function isModelRenderingActive(type, manager) {
+        if (!manager) return false;
+        if (type === 'live2d') {
+            const ticker = manager.pixi_app && manager.pixi_app.ticker;
+            return !!(ticker && ticker.started !== false);
+        }
+        if (type === 'vrm' || type === 'mmd') {
+            return !!manager._animationFrameId;
+        }
+        return false;
+    }
+
+    function pauseModelRenderingForGoodbye(snapshot) {
+        ['live2d', 'vrm', 'mmd'].forEach((type) => {
+            const manager = getModelManagerByType(type);
+            if (!manager || typeof manager.pauseRendering !== 'function') return;
+            if (!isModelRenderingActive(type, manager)) return;
+            try {
+                manager.pauseRendering();
+                snapshot.pausedByCat[type] = true;
+            } catch (error) {
+                console.warn('[GoodbyeResource] pauseRendering failed:', type, error);
+            }
+        });
+    }
+
+    function resumeModelRenderingFromGoodbye(snapshot) {
+        if (!snapshot || !snapshot.pausedByCat) return;
+        ['live2d', 'vrm', 'mmd'].forEach((type) => {
+            if (!snapshot.pausedByCat[type]) return;
+            const manager = getModelManagerByType(type);
+            if (!manager || typeof manager.resumeRendering !== 'function') return;
+            try {
+                manager.resumeRendering();
+            } catch (error) {
+                console.warn('[GoodbyeResource] resumeRendering failed:', type, error);
+            }
+        });
+    }
+
+    function isSubtitleDisplayVisible() {
+        return isVisibleElement(document.getElementById('subtitle-display'));
+    }
+
+    function wasSubtitleVisibleBeforeGoodbyeSnapshot() {
+        try {
+            if (window.subtitleBridge && typeof window.subtitleBridge.wasVisibleBeforeGoodbye === 'function' &&
+                window.subtitleBridge.wasVisibleBeforeGoodbye()) {
+                return true;
+            }
+        } catch (_) { /* ignore */ }
+        return isSubtitleDisplayVisible();
+    }
+
+    function isAgentHudVisible() {
+        const hud = document.getElementById('agent-task-hud');
+        return !!(hud && hud.style.display !== 'none' && hud.style.opacity !== '0');
+    }
+
+    function hideSubtitleSettingsDomForGoodbye() {
+        const panel = document.getElementById('subtitle-settings-panel');
+        if (panel) {
+            panel.classList.add('hidden');
+            panel.style.opacity = '0';
+        }
+        const settingsBtn = document.getElementById('subtitle-settings-btn');
+        if (settingsBtn) {
+            settingsBtn.setAttribute('aria-expanded', 'false');
+        }
+    }
+
+    function hideGoodbyeAuxiliaryWindows(snapshot) {
+        try {
+            if (window.subtitleBridge && typeof window.subtitleBridge.suspendForGoodbye === 'function') {
+                window.subtitleBridge.suspendForGoodbye({ source: 'goodbye-resource-suspend' });
+            }
+        } catch (error) {
+            console.warn('[GoodbyeResource] subtitle suspend failed:', error);
+        }
+        hideSubtitleSettingsDomForGoodbye();
+        try {
+            if (window.nekoSubtitleWindow && typeof window.nekoSubtitleWindow.hide === 'function') {
+                window.nekoSubtitleWindow.hide();
+            }
+        } catch (_) { /* ignore */ }
+        try {
+            if (window.AgentHUD && typeof window.AgentHUD.hideAgentTaskHUD === 'function') {
+                window.AgentHUD.hideAgentTaskHUD();
+            }
+            if (typeof window.stopAgentTaskPolling === 'function') {
+                window.stopAgentTaskPolling({ source: 'goodbye-resource-suspend' });
+            }
+            if (window.nekoAgentHud && typeof window.nekoAgentHud.hide === 'function') {
+                window.nekoAgentHud.hide();
+            }
+        } catch (error) {
+            console.warn('[GoodbyeResource] Agent HUD suspend failed:', error);
+        }
+        snapshot.subtitleWindowHiddenByCat = true;
+        snapshot.agentHudHiddenByCat = true;
+    }
+
+    function beginGoodbyeResourceSuspend(options = {}) {
+        const token = ++goodbyeResourceSuspendToken;
+        const activeModelType = getActiveGoodbyeModelType(options.activeModelType);
+        const snapshot = {
+            token,
+            pending: true,
+            suspended: false,
+            activeModelType,
+            pausedByCat: { live2d: false, vrm: false, mmd: false },
+            subtitleWindowWasVisible: wasSubtitleVisibleBeforeGoodbyeSnapshot(),
+            agentHudWasVisible: isAgentHudVisible(),
+            subtitleWindowHiddenByCat: false,
+            agentHudHiddenByCat: false
+        };
+        publishGoodbyeResourceState(snapshot, 'goodbye-resource-pending');
+        return token;
+    }
+
+    function completeGoodbyeResourceSuspend(token) {
+        const snapshot = getGoodbyeResourceSnapshot();
+        if (!snapshot || snapshot.token !== token) return;
+        if (typeof window.isNekoGoodbyeModeActive === 'function' && !window.isNekoGoodbyeModeActive()) {
+            publishGoodbyeResourceState(null, 'goodbye-resource-stale');
+            return;
+        }
+        snapshot.pending = false;
+        snapshot.suspended = true;
+        publishGoodbyeResourceState(snapshot, 'goodbye-resource-suspended');
+        hideGoodbyeAuxiliaryWindows(snapshot);
+        pauseModelRenderingForGoodbye(snapshot);
+        publishGoodbyeResourceState(snapshot, 'goodbye-resource-paused');
+    }
+
+    function restoreGoodbyeResourceSuspend(reason) {
+        goodbyeResourceSuspendToken += 1;
+        const snapshot = getGoodbyeResourceSnapshot();
+        if (!snapshot) {
+            publishGoodbyeResourceState(null, reason || 'goodbye-resource-restore-empty');
+            return;
+        }
+        resumeModelRenderingFromGoodbye(snapshot);
+        publishGoodbyeResourceState(null, reason || 'goodbye-resource-restoring');
+        try {
+            if (window.subtitleBridge && typeof window.subtitleBridge.restoreAfterGoodbye === 'function') {
+                window.subtitleBridge.restoreAfterGoodbye({
+                    source: reason || 'goodbye-resource-restore',
+                    restoreWindow: true
+                });
+            }
+        } catch (error) {
+            console.warn('[GoodbyeResource] subtitle restore failed:', error);
+        }
+        if (snapshot.subtitleWindowWasVisible) {
+            try {
+                if (window.nekoSubtitleWindow && typeof window.nekoSubtitleWindow.show === 'function') {
+                    window.nekoSubtitleWindow.show();
+                }
+            } catch (_) { /* ignore */ }
+        }
+        if (snapshot.agentHudWasVisible) {
+            try {
+                if (window.AgentHUD && typeof window.AgentHUD.showAgentTaskHUD === 'function') {
+                    window.AgentHUD.showAgentTaskHUD();
+                }
+                if (typeof window.checkAndToggleTaskHUD === 'function') {
+                    window.checkAndToggleTaskHUD();
+                }
+                if (window.nekoAgentHud && typeof window.nekoAgentHud.show === 'function') {
+                    window.nekoAgentHud.show();
+                }
+            } catch (error) {
+                console.warn('[GoodbyeResource] Agent HUD restore failed:', error);
+            }
+        }
+    }
+
+    mod.restoreGoodbyeResourceSuspend = restoreGoodbyeResourceSuspend;
+    mod.completeGoodbyeResourceSuspend = completeGoodbyeResourceSuspend;
 
     // ================================================================
     //  1. Status toast  (app.js lines 86-145)
@@ -4509,6 +4762,12 @@
                 pngtuberContainer.style.display !== 'none' &&
                 !pngtuberContainer.classList.contains('hidden');
             console.log('[App] 判断当前模型类型 - isVrmActive:', isVrmActive, 'isMmdActive:', isMmdActive);
+            const activeGoodbyeModelType = isMmdActive
+                ? 'mmd'
+                : (isVrmActive ? 'vrm' : (isPngtuberActive ? 'pngtuber' : 'live2d'));
+            const goodbyeResourceToken = beginGoodbyeResourceSuspend({
+                activeModelType: activeGoodbyeModelType
+            });
 
             // VRM 也先仅禁用交互
             const vrmCanvas = document.getElementById('vrm-canvas');
@@ -4594,6 +4853,7 @@
                     pngtuberContainer.style.setProperty('visibility', 'hidden', 'important');
                     pngtuberContainer.style.setProperty('display', 'none', 'important');
                 }
+                completeGoodbyeResourceSuspend(goodbyeResourceToken);
             }, NEKO_MODEL_CAT_TRANSITION_DURATION_MS);
 
             // 隐藏所有浮动按钮和锁按钮
@@ -4904,7 +5164,6 @@
                 window._goodbyeHideTimerId = null;
                 console.log('[App] handleReturnClick: 已取消 goodbye 延迟隐藏定时器');
             }
-
             // 同步 window 中的设置值到状态
             if (typeof window.focusModeEnabled !== 'undefined') {
                 S.focusModeEnabled = window.focusModeEnabled;
@@ -4938,6 +5197,7 @@
 
             console.log('[App] 标志清除后 - live2dManager._goodbyeClicked:', window.live2dManager?._goodbyeClicked);
             console.log('[App] 标志清除后 - vrmManager._goodbyeClicked:', window.vrmManager?._goodbyeClicked);
+            restoreGoodbyeResourceSuspend('return-click');
 
             // 隐藏"请她回来"按钮
             const live2dReturnButtonContainer = document.getElementById('live2d-return-button-container');

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -54,6 +54,19 @@
     function screenshotButton()   { return $id('screenshotButton'); }
     function chatContainer()      { return $id('chatContainer'); }
 
+    function isGoodbyeUiSuppressed() {
+        try {
+            if (typeof window.isNekoGoodbyeResourceSuspendingOrSuspended === 'function' &&
+                window.isNekoGoodbyeResourceSuspendingOrSuspended()) {
+                return true;
+            }
+            if (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive()) {
+                return true;
+            }
+        } catch (_) { }
+        return false;
+    }
+
     async function releaseVoiceCaptureResources() {
         if (S.stream && typeof S.stream.getTracks === 'function') {
             S.stream.getTracks().forEach(function (track) {
@@ -1346,7 +1359,7 @@
                             running_count: tasks.filter(function (t) { return t.status === 'running'; }).length,
                             queued_count: tasks.filter(function (t) { return t.status === 'queued'; }).length,
                         });
-                        if (hasRunning && !window._agentTaskTimeUpdateInterval) {
+                        if (hasRunning && !window._agentTaskTimeUpdateInterval && !isGoodbyeUiSuppressed()) {
                             window._agentTaskTimeUpdateInterval = setInterval(function () {
                                 if (typeof window.updateTaskRunningTimes === 'function') window.updateTaskRunningTimes();
                             }, 1000);
@@ -2278,7 +2291,7 @@
                     try {
                         var masterOn = !!flags.agent_enabled;
                         var anyChildOn = !!(flags.computer_use_enabled || flags.browser_use_enabled || flags.user_plugin_enabled || flags.openclaw_enabled || flags.openfang_enabled);
-                        if (masterOn && anyChildOn && typeof window.startAgentTaskPolling === 'function') {
+                        if (masterOn && anyChildOn && typeof window.startAgentTaskPolling === 'function' && !isGoodbyeUiSuppressed()) {
                             window.startAgentTaskPolling();
                         }
                         var curName2 = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
@@ -2394,7 +2407,7 @@
                             if (typeof window.AgentHUD.showAgentTaskHUD === 'function') {
                                 window.AgentHUD.showAgentTaskHUD();
                             }
-                            if (hasRunning2 && !window._agentTaskTimeUpdateInterval) {
+                            if (hasRunning2 && !window._agentTaskTimeUpdateInterval && !isGoodbyeUiSuppressed()) {
                                 window._agentTaskTimeUpdateInterval = setInterval(function () {
                                     if (typeof window.updateTaskRunningTimes === 'function') window.updateTaskRunningTimes();
                                 }, 1000);

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -39,6 +39,20 @@ function isStandaloneAgentHudPage() {
     }
 }
 
+function isAgentHudSuppressedByGoodbye() {
+    if (isStandaloneAgentHudPage()) return false;
+    try {
+        if (typeof window.isNekoGoodbyeResourceSuspendingOrSuspended === 'function' &&
+            window.isNekoGoodbyeResourceSuspendingOrSuspended()) {
+            return true;
+        }
+        if (typeof window.isNekoGoodbyeModeActive === 'function' && window.isNekoGoodbyeModeActive()) {
+            return true;
+        }
+    } catch (_) { /* ignore */ }
+    return false;
+}
+
 function setAgentHudDraggingState(active) {
     try {
         if (document.body) {
@@ -771,6 +785,10 @@ window.AgentHUD._setupCollapseFunctionality = function (emptyState, collapseButt
 // 显示任务 HUD
 window.AgentHUD.showAgentTaskHUD = function () {
     console.log('[AgentHUD][TimeoutTrace] showAgentTaskHUD called. Current timeout ID:', this._hideTimeout);
+    if (isAgentHudSuppressedByGoodbye()) {
+        this.hideAgentTaskHUD();
+        return;
+    }
     
     // 清除任何正在进行的隐藏动画定时器，防止闪现后立刻消失
     if (this._hideTimeout) {
@@ -864,6 +882,14 @@ window.AgentHUD.hideAgentTaskHUD = function () {
 window.AgentHUD.updateAgentTaskHUD = function (tasksData) {
     // Cache latest snapshot so deferred re-render won't use stale closure data.
     this._latestTasksData = tasksData;
+    if (isAgentHudSuppressedByGoodbye()) {
+        if (this._updateRafId) {
+            cancelAnimationFrame(this._updateRafId);
+            this._updateRafId = null;
+        }
+        this.hideAgentTaskHUD();
+        return;
+    }
 
     // RAF throttle: coalesce rapid-fire WebSocket updates into a single frame
     if (this._updateRafId) return;
@@ -937,6 +963,10 @@ window.AgentHUD._markTasksCancelledLocally = function (taskIds, status) {
 
 // Internal: actual HUD update logic (called via RAF throttle)
 window.AgentHUD._doUpdateAgentTaskHUD = function () {
+    if (isAgentHudSuppressedByGoodbye()) {
+        this.hideAgentTaskHUD();
+        return;
+    }
     const tasksData = this._latestTasksData;
     if (!tasksData) return;
 

--- a/static/pngtuber-core.js
+++ b/static/pngtuber-core.js
@@ -153,6 +153,7 @@
             this.isLocked = false;
             this._lockIconElement = null;
             this._lockIconImages = null;
+            this._renderingPaused = false;
         }
 
         ensureContainer() {
@@ -304,6 +305,55 @@
             this.layeredBlinking = false;
         }
 
+        pauseRendering() {
+            this._renderingPaused = true;
+            this.clearLayeredTimers();
+            if (this.speakingMouthTimer) {
+                clearTimeout(this.speakingMouthTimer);
+                this.speakingMouthTimer = null;
+            }
+            if (this.returnIdleTimer) {
+                clearTimeout(this.returnIdleTimer);
+                this.returnIdleTimer = null;
+            }
+            if (this.clickTimer) {
+                clearTimeout(this.clickTimer);
+                this.clickTimer = null;
+            }
+            if (this.lipSyncFrame) {
+                cancelAnimationFrame(this.lipSyncFrame);
+                this.lipSyncFrame = null;
+            }
+            this.lipSyncMouthOpen = 0;
+            this.lipSyncMouthState = false;
+            this.lipSyncLastStateChangeAt = 0;
+            this.lipSyncNextPulseAt = 0;
+            this.lipSyncPulseCloseAt = 0;
+            this.speakingMouthOpen = false;
+            this.stopTalkingHopAnimation();
+            this.stopSpeakingBounceAnimation();
+        }
+
+        resumeRendering() {
+            if (!this._renderingPaused) return;
+            this._renderingPaused = false;
+            const container = this.container || document.getElementById(this.containerId);
+            if (!container || container.style.display === 'none' ||
+                (container.classList && container.classList.contains('hidden'))) {
+                return;
+            }
+            if (this.isLayeredActive()) {
+                this.drawLayeredState(this.state || 'idle');
+                if (!this.layeredBlinkTimer && !this.layeredBlinkEndTimer) {
+                    this.startLayeredBlinkLoop();
+                }
+                this.startLayeredAnimationLoop({ preserveTimeline: true });
+            }
+            if (this.isSpeaking) {
+                this.startSpeakingMouthAnimation();
+            }
+        }
+
         stopLayeredAnimationLoop() {
             if (this.layeredAnimationFrame) {
                 cancelAnimationFrame(this.layeredAnimationFrame);
@@ -405,6 +455,7 @@
         }
 
         playLayeredAnimation(target, options = {}) {
+            if (this._renderingPaused) return false;
             if (!this.isLayeredActive()) return false;
             return this.setLayeredStateIndex(this.resolveLayeredAnimationTarget(target), {
                 returnToDefaultAfterMs: options.returnToDefaultAfterMs,
@@ -654,6 +705,7 @@
         }
 
         startLayeredAnimationLoop(options = {}) {
+            if (this._renderingPaused) return;
             this.startLayeredBreathingLoop();
             if (this.layeredAnimationFrame) return;
             if (!this.isLayeredActive() || !this.hasMotionLayersForCurrentState()) return;
@@ -709,6 +761,7 @@
         }
 
         startLayeredBreathingLoop() {
+            if (this._renderingPaused) return;
             if (this.layeredBreathingFrame || !this.layeredBreathingEnabled()) return;
             this.layeredBreathingStart = this.layeredBreathingStart || performance.now();
             const tick = (timestamp) => {
@@ -1412,6 +1465,7 @@
         }
 
         startSpeakingBounceAnimation() {
+            if (this._renderingPaused) return;
             const config = this.speakingBounceConfig();
             if (!config) return;
             const now = performance.now();
@@ -1455,6 +1509,7 @@
         }
 
         startTalkingHopAnimation() {
+            if (this._renderingPaused) return;
             if (this.talkingHopFrame || !this.isSpeaking || !this.isLayeredActive()) return;
             this.talkingHopStart = performance.now();
             this.talkingHopAmplitude = 4.5;
@@ -1493,6 +1548,7 @@
         }
 
         startLipSync(analyser) {
+            if (this._renderingPaused) return false;
             if (!analyser || typeof analyser.getByteTimeDomainData !== 'function') {
                 this.startSpeakingMouthAnimation();
                 return false;
@@ -1566,6 +1622,7 @@
         }
 
         scheduleSpeakingMouthFrame() {
+            if (this._renderingPaused) return;
             if (!this.isSpeaking) return;
             if (this.lipSyncFrame) return;
             const nextDelay = this.speakingMouthOpen
@@ -1584,6 +1641,7 @@
         }
 
         startSpeakingMouthAnimation() {
+            if (this._renderingPaused) return;
             this.isSpeaking = true;
             this.startTalkingHopAnimation();
             if (this.lipSyncFrame) return;
@@ -1711,6 +1769,10 @@
         }
 
         setSpeaking(isSpeaking) {
+            if (this._renderingPaused) {
+                this.isSpeaking = !!isSpeaking;
+                return;
+            }
             if (this.returnIdleTimer) {
                 clearTimeout(this.returnIdleTimer);
                 this.returnIdleTimer = null;

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -46,6 +46,9 @@ let subtitleEnabled = initialSubtitleSettings
         ? window.appState.subtitleEnabled
         : localStorage.getItem('subtitleEnabled') === 'true');
 let subtitleSuppressedByGoodbye = false;
+let subtitleWasVisibleBeforeGoodbye = false;
+let subtitleWindowWasVisibleBeforeGoodbye = false;
+let subtitleDropCurrentTurnUntilNextStart = false;
 
 function isSubtitleTranslationOwner() {
     return !(window.__NEKO_MULTI_WINDOW__ &&
@@ -509,6 +512,42 @@ function isSubtitleTemporarilySuppressed() {
     return subtitleSuppressedByGoodbye;
 }
 
+function isGoodbyeResourceStateActive() {
+    try {
+        if (typeof window.isNekoGoodbyeResourceSuspendingOrSuspended === 'function' &&
+            window.isNekoGoodbyeResourceSuspendingOrSuspended()) {
+            return true;
+        }
+        return window.goodbyeResourceSuspended === true ||
+            window.__nekoGoodbyeResourceSuspendPending === true;
+    } catch (_) {
+        return false;
+    }
+}
+
+function isSubtitleDisplayCurrentlyVisible() {
+    const display = document.getElementById('subtitle-display');
+    if (!display) return false;
+    if (display.classList.contains('hidden')) return false;
+    if (display.style.display === 'none' || display.style.opacity === '0') return false;
+    try {
+        const style = window.getComputedStyle ? window.getComputedStyle(display) : null;
+        if (style && (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0')) {
+            return false;
+        }
+    } catch (_) { /* ignore */ }
+    return true;
+}
+
+function clearSubtitleTextOnly() {
+    const subtitleText = document.getElementById('subtitle-text');
+    if (subtitleText) {
+        subtitleText.textContent = '';
+        subtitleText.style.fontSize = '';
+    }
+    clearSubtitleDanmakuLayer();
+}
+
 /**
  * 设置用户语言并同步到 appState
  */
@@ -811,6 +850,7 @@ function resetIncrementalTranslationState() {
 }
 
 function cancelPendingSubtitleTranslations() {
+    currentTranslationRequestId += 1;
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
         currentTranslateAbortController = null;
@@ -930,6 +970,10 @@ function showSubtitleWithoutOriginalAndRestartCurrentTurn() {
         syncSubtitleRenderState('subtitle-non-owner-skip-show');
         return;
     }
+    if (isSubtitleTemporarilySuppressed() || subtitleDropCurrentTurnUntilNextStart) {
+        hideSubtitleDisplayOnly('subtitle-goodbye-drop-current-turn');
+        return;
+    }
 
     if (currentTurnIsStructured) {
         ensureSubtitleVisibleIfEnabled();
@@ -961,20 +1005,49 @@ function suppressSubtitleForGoodbye() {
     if (!isSubtitleTranslationOwner()) {
         return;
     }
+    if (!subtitleSuppressedByGoodbye) {
+        subtitleWasVisibleBeforeGoodbye = isSubtitleDisplayCurrentlyVisible();
+        subtitleWindowWasVisibleBeforeGoodbye = subtitleWasVisibleBeforeGoodbye;
+    }
     subtitleSuppressedByGoodbye = true;
+    subtitleDropCurrentTurnUntilNextStart = true;
+    cancelPendingSubtitleTranslations();
+    clearSubtitleTextOnly();
     hideSubtitleDisplayOnly('subtitle-goodbye-suppress');
+    try {
+        if (window.nekoSubtitleWindow && typeof window.nekoSubtitleWindow.hide === 'function') {
+            window.nekoSubtitleWindow.hide();
+        }
+    } catch (_) { /* ignore */ }
 }
 
-function restoreSubtitleAfterGoodbye() {
+function restoreSubtitleAfterGoodbye(options) {
     if (!subtitleSuppressedByGoodbye) {
         return;
     }
+    if (isGoodbyeResourceStateActive()) {
+        return;
+    }
     subtitleSuppressedByGoodbye = false;
-    if (subtitleEnabled) {
-        showSubtitleWithoutOriginalAndRestartCurrentTurn();
+    cancelPendingSubtitleTranslations();
+    clearSubtitleTextOnly();
+    const restoreWindow = !options || options.restoreWindow !== false;
+    const shouldRestoreVisible = subtitleEnabled && subtitleWasVisibleBeforeGoodbye;
+    if (shouldRestoreVisible) {
+        ensureSubtitleVisibleIfEnabled();
+        if (restoreWindow && subtitleWindowWasVisibleBeforeGoodbye) {
+            try {
+                if (window.nekoSubtitleWindow && typeof window.nekoSubtitleWindow.show === 'function') {
+                    window.nekoSubtitleWindow.show();
+                }
+            } catch (_) { /* ignore */ }
+        }
     } else {
         syncSubtitleRenderState('subtitle-goodbye-restore-disabled');
+        hideSubtitleDisplayOnly('subtitle-goodbye-restore-hidden');
     }
+    subtitleWasVisibleBeforeGoodbye = false;
+    subtitleWindowWasVisibleBeforeGoodbye = false;
 }
 
 function bindGoodbyeSubtitleVisibility() {
@@ -1002,6 +1075,7 @@ function bindGoodbyeSubtitleVisibility() {
 function updateSubtitleStreamingText(text) {
     if (isCurrentTurnFinalized) return;
     if (currentTurnIsStructured) return;
+    if (isSubtitleTemporarilySuppressed() || subtitleDropCurrentTurnUntilNextStart) return;
 
     var cleaned = (text || '').toString();
     currentTurnOriginalText = cleaned;
@@ -1032,6 +1106,7 @@ function updateSubtitleStreamingText(text) {
 function markSubtitleStructured() {
     if (isCurrentTurnFinalized) return;
     if (currentTurnIsStructured) return; // 已是结构化，幂等
+    if (isSubtitleTemporarilySuppressed() || subtitleDropCurrentTurnUntilNextStart) return;
     resetIncrementalTranslationState();
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
@@ -1050,6 +1125,12 @@ function markSubtitleStructured() {
  * 不发翻译请求。等价于 translateAndShowSubtitle 的结构化分支。
  */
 function finalizeSubtitleAsStructured() {
+    if (isSubtitleTemporarilySuppressed() || subtitleDropCurrentTurnUntilNextStart) {
+        isCurrentTurnFinalized = true;
+        cancelPendingSubtitleTranslations();
+        clearSubtitleTextOnly();
+        return;
+    }
     isCurrentTurnFinalized = true;
     currentTurnIsStructured = true;
     resetIncrementalTranslationState();
@@ -1094,6 +1175,7 @@ function resetSubtitleTurnState() {
  *   流式写入全部吞掉。
  */
 function beginSubtitleTurn(options) {
+    subtitleDropCurrentTurnUntilNextStart = isSubtitleTemporarilySuppressed();
     resetSubtitleTurnState();
     const skipLatch = !!(options && options.latch === false);
     turnBoundaryLatched = !skipLatch;
@@ -1106,6 +1188,7 @@ function beginSubtitleTurn(options) {
  *   - 反之（事件在没有前置 isNewMessage 的通道上独立到达）走完整复位路径。
  */
 function onAssistantTurnStart() {
+    subtitleDropCurrentTurnUntilNextStart = isSubtitleTemporarilySuppressed();
     if (turnBoundaryLatched) {
         turnBoundaryLatched = false;
         if (subtitleEnabled) {
@@ -1130,6 +1213,12 @@ function onAssistantTurnStart() {
  */
 async function translateAndShowSubtitle(text) {
     if (!text || !text.trim()) {
+        return;
+    }
+    if (isSubtitleTemporarilySuppressed() || subtitleDropCurrentTurnUntilNextStart) {
+        isCurrentTurnFinalized = true;
+        cancelPendingSubtitleTranslations();
+        clearSubtitleTextOnly();
         return;
     }
 
@@ -1389,7 +1478,20 @@ window.subtitleBridge = {
     /** 供 app-websocket.js 在结构化 turn 的 turn end 时调用（跳过翻译） */
     finalizeAsStructured: finalizeSubtitleAsStructured,
     /** 供 app-websocket.js 在 turn end 时调用 */
-    finalizeTurnWithTranslation: translateAndShowSubtitle
+    finalizeTurnWithTranslation: translateAndShowSubtitle,
+    suspendForGoodbye: function() {
+        suppressSubtitleForGoodbye();
+    },
+    restoreAfterGoodbye: function(options) {
+        restoreSubtitleAfterGoodbye(options || {});
+    },
+    cancelPendingTranslations: cancelPendingSubtitleTranslations,
+    isSuppressedByGoodbye: function() {
+        return subtitleSuppressedByGoodbye;
+    },
+    wasVisibleBeforeGoodbye: function() {
+        return subtitleWasVisibleBeforeGoodbye || subtitleWindowWasVisibleBeforeGoodbye;
+    }
 };
 
 // 向后兼容：保留全局函数名，但函数体已经精简

--- a/tests/unit/test_goodbye_resource_suspend_static.py
+++ b/tests/unit/test_goodbye_resource_suspend_static.py
@@ -10,6 +10,7 @@ APP_AGENT_PATH = REPO_ROOT / "static" / "app-agent.js"
 APP_UI_PATH = REPO_ROOT / "static" / "app-ui.js"
 APP_WEBSOCKET_PATH = REPO_ROOT / "static" / "app-websocket.js"
 COMMON_UI_HUD_PATH = REPO_ROOT / "static" / "common-ui-hud.js"
+PNGTUBER_PATH = REPO_ROOT / "static" / "pngtuber-core.js"
 PLUGIN_DASHBOARD_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "views" / "Dashboard.vue"
 PLUGIN_METRICS_VIEW_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "views" / "Metrics.vue"
 PLUGIN_METRICS_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "stores" / "metrics.ts"
@@ -28,6 +29,11 @@ def _js_function_block(source: str, function_name: str) -> str:
 def _js_assignment_function_block(source: str, name: str) -> str:
     marker = f"{name} = function"
     return _js_block_from_marker(source, marker, name)
+
+
+def _js_method_block(source: str, method_name: str) -> str:
+    marker = f"        {method_name}("
+    return _js_block_from_marker(source, marker, method_name)
 
 
 def _js_block_from_marker(source: str, marker: str, description: str) -> str:
@@ -112,7 +118,7 @@ def test_goodbye_resource_suspend_waits_for_cat_transition_and_uses_token_snapsh
     assert "const token = ++goodbyeResourceSuspendToken;" in begin_suspend
     assert "pending: true" in begin_suspend
     assert "suspended: false" in begin_suspend
-    assert "pausedByCat: { live2d: false, vrm: false, mmd: false }" in begin_suspend
+    assert "pausedByCat: { live2d: false, vrm: false, mmd: false, pngtuber: false }" in begin_suspend
     assert "subtitleWindowWasVisible: wasSubtitleVisibleBeforeGoodbyeSnapshot()" in begin_suspend
     assert "agentHudWasVisible: isAgentHudVisible()" in begin_suspend
 
@@ -132,21 +138,61 @@ def test_goodbye_resource_suspend_pauses_only_active_render_loops_and_restores_o
     is_rendering = _js_function_block(source, "isModelRenderingActive")
     pause_rendering = _js_function_block(source, "pauseModelRenderingForGoodbye")
     resume_rendering = _js_function_block(source, "resumeModelRenderingFromGoodbye")
+    get_manager = _js_function_block(source, "getModelManagerByType")
 
     assert "if (type === 'live2d')" in is_rendering
     assert "ticker && ticker.started !== false" in is_rendering
     assert "if (type === 'vrm' || type === 'mmd')" in is_rendering
     assert "return !!manager._animationFrameId;" in is_rendering
+    assert "if (type === 'pngtuber')" in is_rendering
+    assert "document.getElementById('pngtuber-container')" in is_rendering
+    assert "container.style.display !== 'none'" in is_rendering
 
-    assert "['live2d', 'vrm', 'mmd'].forEach" in pause_rendering
+    assert "if (type === 'pngtuber') return window.pngtuberManager;" in get_manager
+    assert "['live2d', 'vrm', 'mmd', 'pngtuber'].forEach" in pause_rendering
     assert "typeof manager.pauseRendering !== 'function'" in pause_rendering
     assert "if (!isModelRenderingActive(type, manager)) return;" in pause_rendering
     assert "manager.pauseRendering();" in pause_rendering
     assert "snapshot.pausedByCat[type] = true;" in pause_rendering
 
-    assert "['live2d', 'vrm', 'mmd'].forEach" in resume_rendering
+    assert "['live2d', 'vrm', 'mmd', 'pngtuber'].forEach" in resume_rendering
     assert "if (!snapshot.pausedByCat[type]) return;" in resume_rendering
     assert "manager.resumeRendering();" in resume_rendering
+
+
+@pytest.mark.unit
+def test_goodbye_resource_suspend_pauses_pngtuber_animation_loops():
+    source = _read(PNGTUBER_PATH)
+    pause_rendering = _js_method_block(source, "pauseRendering")
+    resume_rendering = _js_method_block(source, "resumeRendering")
+
+    assert "this._renderingPaused = false;" in source
+    assert "this._renderingPaused = true;" in pause_rendering
+    assert "this.clearLayeredTimers();" in pause_rendering
+    assert "clearTimeout(this.speakingMouthTimer);" in pause_rendering
+    assert "clearTimeout(this.returnIdleTimer);" in pause_rendering
+    assert "clearTimeout(this.clickTimer);" in pause_rendering
+    assert "cancelAnimationFrame(this.lipSyncFrame);" in pause_rendering
+    assert "this.stopTalkingHopAnimation();" in pause_rendering
+    assert "this.stopSpeakingBounceAnimation();" in pause_rendering
+
+    assert "if (!this._renderingPaused) return;" in resume_rendering
+    assert "this._renderingPaused = false;" in resume_rendering
+    assert "this.startLayeredAnimationLoop({ preserveTimeline: true });" in resume_rendering
+    assert "this.startSpeakingMouthAnimation();" in resume_rendering
+
+    for method_name in (
+        "playLayeredAnimation",
+        "startLayeredAnimationLoop",
+        "startLayeredBreathingLoop",
+        "startSpeakingBounceAnimation",
+        "startTalkingHopAnimation",
+        "startLipSync",
+        "scheduleSpeakingMouthFrame",
+        "startSpeakingMouthAnimation",
+        "setSpeaking",
+    ):
+        assert "this._renderingPaused" in _js_method_block(source, method_name)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_goodbye_resource_suspend_static.py
+++ b/tests/unit/test_goodbye_resource_suspend_static.py
@@ -99,6 +99,8 @@ def test_goodbye_resource_suspend_waits_for_cat_transition_and_uses_token_snapsh
     assert "window.__nekoGoodbyeResourceSuspendPending = pending;" in source
     assert "window.isNekoGoodbyeResourceSuspendingOrSuspended = function ()" in source
     assert "localStorage.setItem(GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY, suspended ? 'true' : 'false')" in source
+    assert "window.addEventListener('neko:goodbye-state-cleared'" in source
+    assert "restoreGoodbyeResourceSuspend(reason);" in source
 
     goodbye_handler_start = source.index("window.addEventListener('live2d-goodbye-click'")
     token_start = source.index("const goodbyeResourceToken = beginGoodbyeResourceSuspend", goodbye_handler_start)
@@ -220,10 +222,12 @@ def test_goodbye_agent_hud_and_websocket_ui_timers_are_suppressed_without_stoppi
     assert "!isGoodbyeUiSuppressed()" in websocket_source
     assert "window._agentTaskTimeUpdateInterval = setInterval" in websocket_source
 
-    assert "function isGoodbyeResourceSuspended()" in metrics_source
+    assert "function isGoodbyeResourceSuspendingOrSuspended()" in metrics_source
+    assert "isNekoGoodbyeResourceSuspendingOrSuspended" in metrics_source
     assert "(window as any).goodbyeResourceSuspended === true" in metrics_source
+    assert "(window as any).__nekoGoodbyeResourceSuspendPending === true" in metrics_source
     assert "window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'" in metrics_source
-    assert "if (isGoodbyeResourceSuspended())" in metrics_source
+    assert "if (isGoodbyeResourceSuspendingOrSuspended())" in metrics_source
 
     for view_source in (dashboard_source, metrics_view_source):
         assert "function isGoodbyeResourceSuspendingOrSuspended()" in view_source

--- a/tests/unit/test_goodbye_resource_suspend_static.py
+++ b/tests/unit/test_goodbye_resource_suspend_static.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_AGENT_PATH = REPO_ROOT / "static" / "app-agent.js"
+APP_UI_PATH = REPO_ROOT / "static" / "app-ui.js"
+APP_WEBSOCKET_PATH = REPO_ROOT / "static" / "app-websocket.js"
+COMMON_UI_HUD_PATH = REPO_ROOT / "static" / "common-ui-hud.js"
+PLUGIN_DASHBOARD_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "views" / "Dashboard.vue"
+PLUGIN_METRICS_VIEW_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "views" / "Metrics.vue"
+PLUGIN_METRICS_PATH = REPO_ROOT / "frontend" / "plugin-manager" / "src" / "stores" / "metrics.ts"
+SUBTITLE_PATH = REPO_ROOT / "static" / "subtitle.js"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _js_function_block(source: str, function_name: str) -> str:
+    marker = f"function {function_name}("
+    return _js_block_from_marker(source, marker, function_name)
+
+
+def _js_assignment_function_block(source: str, name: str) -> str:
+    marker = f"{name} = function"
+    return _js_block_from_marker(source, marker, name)
+
+
+def _js_block_from_marker(source: str, marker: str, description: str) -> str:
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing JS block {description}")
+    header_quote: str | None = None
+    header_escaped = False
+    paren_depth = 0
+    brace = -1
+    for index in range(start, len(source)):
+        char = source[index]
+        if header_quote:
+            if header_escaped:
+                header_escaped = False
+            elif char == "\\":
+                header_escaped = True
+            elif char == header_quote:
+                header_quote = None
+            continue
+        if char in {"'", '"', "`"}:
+            header_quote = char
+            continue
+        if char == "(":
+            paren_depth += 1
+        elif char == ")":
+            paren_depth = max(0, paren_depth - 1)
+        elif char == "{" and paren_depth == 0:
+            brace = index
+            break
+    if brace < 0:
+        raise AssertionError(f"missing opening brace for JS block {description}")
+
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index in range(brace, len(source)):
+        char = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated JS block {description}")
+
+
+@pytest.mark.unit
+def test_goodbye_resource_suspend_waits_for_cat_transition_and_uses_token_snapshot():
+    source = _read(APP_UI_PATH)
+    begin_suspend = _js_function_block(source, "beginGoodbyeResourceSuspend")
+    complete_suspend = _js_function_block(source, "completeGoodbyeResourceSuspend")
+    restore_suspend = _js_function_block(source, "restoreGoodbyeResourceSuspend")
+
+    assert "const NEKO_MODEL_CAT_TRANSITION_DURATION_MS = 850;" in source
+    assert "const GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY = 'neko-goodbye-resource-suspended';" in source
+    assert "window.goodbyeResourceSuspended = suspended;" in source
+    assert "window.__nekoGoodbyeResourceSuspendPending = pending;" in source
+    assert "window.isNekoGoodbyeResourceSuspendingOrSuspended = function ()" in source
+    assert "localStorage.setItem(GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY, suspended ? 'true' : 'false')" in source
+
+    goodbye_handler_start = source.index("window.addEventListener('live2d-goodbye-click'")
+    token_start = source.index("const goodbyeResourceToken = beginGoodbyeResourceSuspend", goodbye_handler_start)
+    hide_timer_start = source.index("window._goodbyeHideTimerId = setTimeout", token_start)
+    complete_start = source.index("completeGoodbyeResourceSuspend(goodbyeResourceToken);", hide_timer_start)
+    delay_start = source.index("NEKO_MODEL_CAT_TRANSITION_DURATION_MS", complete_start)
+
+    assert token_start < hide_timer_start < complete_start < delay_start
+    assert "const token = ++goodbyeResourceSuspendToken;" in begin_suspend
+    assert "pending: true" in begin_suspend
+    assert "suspended: false" in begin_suspend
+    assert "pausedByCat: { live2d: false, vrm: false, mmd: false }" in begin_suspend
+    assert "subtitleWindowWasVisible: wasSubtitleVisibleBeforeGoodbyeSnapshot()" in begin_suspend
+    assert "agentHudWasVisible: isAgentHudVisible()" in begin_suspend
+
+    assert "if (!snapshot || snapshot.token !== token) return;" in complete_suspend
+    assert "publishGoodbyeResourceState(snapshot, 'goodbye-resource-suspended');" in complete_suspend
+    assert complete_suspend.index("publishGoodbyeResourceState(snapshot, 'goodbye-resource-suspended');") < complete_suspend.index("hideGoodbyeAuxiliaryWindows(snapshot);")
+    assert complete_suspend.index("hideGoodbyeAuxiliaryWindows(snapshot);") < complete_suspend.index("pauseModelRenderingForGoodbye(snapshot);")
+
+    assert "goodbyeResourceSuspendToken += 1;" in restore_suspend
+    assert restore_suspend.index("resumeModelRenderingFromGoodbye(snapshot);") < restore_suspend.index("publishGoodbyeResourceState(null, reason || 'goodbye-resource-restoring');")
+    assert "restoreWindow: true" in restore_suspend
+
+
+@pytest.mark.unit
+def test_goodbye_resource_suspend_pauses_only_active_render_loops_and_restores_only_cat_paused_models():
+    source = _read(APP_UI_PATH)
+    is_rendering = _js_function_block(source, "isModelRenderingActive")
+    pause_rendering = _js_function_block(source, "pauseModelRenderingForGoodbye")
+    resume_rendering = _js_function_block(source, "resumeModelRenderingFromGoodbye")
+
+    assert "if (type === 'live2d')" in is_rendering
+    assert "ticker && ticker.started !== false" in is_rendering
+    assert "if (type === 'vrm' || type === 'mmd')" in is_rendering
+    assert "return !!manager._animationFrameId;" in is_rendering
+
+    assert "['live2d', 'vrm', 'mmd'].forEach" in pause_rendering
+    assert "typeof manager.pauseRendering !== 'function'" in pause_rendering
+    assert "if (!isModelRenderingActive(type, manager)) return;" in pause_rendering
+    assert "manager.pauseRendering();" in pause_rendering
+    assert "snapshot.pausedByCat[type] = true;" in pause_rendering
+
+    assert "['live2d', 'vrm', 'mmd'].forEach" in resume_rendering
+    assert "if (!snapshot.pausedByCat[type]) return;" in resume_rendering
+    assert "manager.resumeRendering();" in resume_rendering
+
+
+@pytest.mark.unit
+def test_goodbye_subtitles_cancel_active_work_and_do_not_replay_missed_turns():
+    source = _read(SUBTITLE_PATH)
+    cancel_pending = _js_function_block(source, "cancelPendingSubtitleTranslations")
+    suppress = _js_function_block(source, "suppressSubtitleForGoodbye")
+    restore = _js_function_block(source, "restoreSubtitleAfterGoodbye")
+    begin_turn = _js_function_block(source, "beginSubtitleTurn")
+    translate = _js_function_block(source, "translateAndShowSubtitle")
+
+    assert "let subtitleDropCurrentTurnUntilNextStart = false;" in source
+    assert "currentTranslationRequestId += 1;" in cancel_pending
+    assert "currentTranslateAbortController.abort();" in cancel_pending
+    assert "resetIncrementalTranslationState();" in cancel_pending
+
+    assert "subtitleWasVisibleBeforeGoodbye = isSubtitleDisplayCurrentlyVisible();" in suppress
+    assert "subtitleSuppressedByGoodbye = true;" in suppress
+    assert "subtitleDropCurrentTurnUntilNextStart = true;" in suppress
+    assert "cancelPendingSubtitleTranslations();" in suppress
+    assert "clearSubtitleTextOnly();" in suppress
+    assert "window.nekoSubtitleWindow.hide()" in suppress
+
+    assert "if (isGoodbyeResourceStateActive())" in restore
+    assert "subtitleSuppressedByGoodbye = false;" in restore
+    assert "cancelPendingSubtitleTranslations();" in restore
+    assert "clearSubtitleTextOnly();" in restore
+    assert "const shouldRestoreVisible = subtitleEnabled && subtitleWasVisibleBeforeGoodbye;" in restore
+    assert "window.nekoSubtitleWindow.show()" in restore
+    assert "translateAndShowSubtitle(currentTurnOriginalText)" not in restore
+    assert "resumeIncrementalTranslationQueue()" not in restore
+
+    assert "subtitleDropCurrentTurnUntilNextStart = isSubtitleTemporarilySuppressed();" in begin_turn
+    assert "if (isSubtitleTemporarilySuppressed() || subtitleDropCurrentTurnUntilNextStart)" in translate
+    assert "cancelPendingSubtitleTranslations();" in translate
+    assert "clearSubtitleTextOnly();" in translate
+
+    assert "suspendForGoodbye: function()" in source
+    assert "restoreAfterGoodbye: function(options)" in source
+    assert "cancelPendingTranslations: cancelPendingSubtitleTranslations" in source
+    assert "wasVisibleBeforeGoodbye: function()" in source
+
+
+@pytest.mark.unit
+def test_goodbye_agent_hud_and_websocket_ui_timers_are_suppressed_without_stopping_plugins():
+    agent_source = _read(APP_AGENT_PATH)
+    hud_source = _read(COMMON_UI_HUD_PATH)
+    websocket_source = _read(APP_WEBSOCKET_PATH)
+    dashboard_source = _read(PLUGIN_DASHBOARD_PATH)
+    metrics_source = _read(PLUGIN_METRICS_PATH)
+    metrics_view_source = _read(PLUGIN_METRICS_VIEW_PATH)
+    app_ui_source = _read(APP_UI_PATH)
+
+    agent_guard = _js_function_block(agent_source, "isGoodbyeAgentUiSuppressed")
+    start_polling = _js_assignment_function_block(agent_source, "window.startAgentTaskPolling")
+    update_times = _js_function_block(agent_source, "updateTaskRunningTimes")
+    check_hud = _js_function_block(agent_source, "checkAndToggleTaskHUD")
+
+    assert "window.isNekoGoodbyeResourceSuspendingOrSuspended()" in agent_guard
+    assert "window.isNekoGoodbyeModeActive()" in agent_guard
+    assert "if (isGoodbyeAgentUiSuppressed())" in start_polling
+    assert "hideAgentTaskHUD();" in start_polling
+    assert "if (isGoodbyeAgentUiSuppressed())" in update_times
+    assert "return;" in update_times
+    assert "window.stopAgentTaskPolling();" in check_hud
+
+    assert "function isAgentHudSuppressedByGoodbye()" in hud_source
+    assert "if (isAgentHudSuppressedByGoodbye())" in hud_source
+    assert "cancelAnimationFrame(this._updateRafId);" in hud_source
+    assert "this.hideAgentTaskHUD();" in hud_source
+
+    assert "function isGoodbyeUiSuppressed()" in websocket_source
+    assert "!isGoodbyeUiSuppressed()" in websocket_source
+    assert "window._agentTaskTimeUpdateInterval = setInterval" in websocket_source
+
+    assert "function isGoodbyeResourceSuspended()" in metrics_source
+    assert "(window as any).goodbyeResourceSuspended === true" in metrics_source
+    assert "window.localStorage.getItem('neko-goodbye-resource-suspended') === 'true'" in metrics_source
+    assert "if (isGoodbyeResourceSuspended())" in metrics_source
+
+    for view_source in (dashboard_source, metrics_view_source):
+        assert "function isGoodbyeResourceSuspendingOrSuspended()" in view_source
+        assert "(window as any).__nekoGoodbyeResourceSuspendPending === true" in view_source
+        assert "window.addEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)" in view_source
+        assert "window.removeEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)" in view_source
+        assert "if (isGoodbyeResourceSuspendingOrSuspended()) return" in view_source
+        assert "stopAutoRefresh()" in view_source
+
+    assert "stop_plugin" not in app_ui_source
+    assert "stop_plugin" not in agent_source
+    assert "stop_plugin" not in hud_source
+    assert "stop_plugin" not in websocket_source
+    assert "stop_plugin" not in metrics_source

--- a/tests/unit/test_goodbye_resource_suspend_static.py
+++ b/tests/unit/test_goodbye_resource_suspend_static.py
@@ -105,6 +105,7 @@ def test_goodbye_resource_suspend_waits_for_cat_transition_and_uses_token_snapsh
     assert "window.__nekoGoodbyeResourceSuspendPending = pending;" in source
     assert "window.isNekoGoodbyeResourceSuspendingOrSuspended = function ()" in source
     assert "localStorage.setItem(GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY, suspended ? 'true' : 'false')" in source
+    assert "publishGoodbyeResourceState(null, 'goodbye-resource-boot');" in source
     assert "window.addEventListener('neko:goodbye-state-cleared'" in source
     assert "restoreGoodbyeResourceSuspend(reason);" in source
 
@@ -149,9 +150,10 @@ def test_goodbye_resource_suspend_pauses_only_active_render_loops_and_restores_o
     assert "container.style.display !== 'none'" in is_rendering
 
     assert "if (type === 'pngtuber') return window.pngtuberManager;" in get_manager
+    assert "const activeModelType = snapshot && snapshot.activeModelType;" in pause_rendering
+    assert "if (activeModelType !== type && !isModelRenderingActive(type, manager)) return;" in pause_rendering
     assert "['live2d', 'vrm', 'mmd', 'pngtuber'].forEach" in pause_rendering
     assert "typeof manager.pauseRendering !== 'function'" in pause_rendering
-    assert "if (!isModelRenderingActive(type, manager)) return;" in pause_rendering
     assert "manager.pauseRendering();" in pause_rendering
     assert "snapshot.pausedByCat[type] = true;" in pause_rendering
 
@@ -280,6 +282,10 @@ def test_goodbye_agent_hud_and_websocket_ui_timers_are_suppressed_without_stoppi
         assert "(window as any).__nekoGoodbyeResourceSuspendPending === true" in view_source
         assert "window.addEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)" in view_source
         assert "window.removeEventListener('neko:goodbye-resource-suspend-state', handleGoodbyeResourceState)" in view_source
+        assert "function handleGoodbyeResourceStorage(event: StorageEvent)" in view_source
+        assert "window.addEventListener('storage', handleGoodbyeResourceStorage)" in view_source
+        assert "window.removeEventListener('storage', handleGoodbyeResourceStorage)" in view_source
+        assert "event.key !== GOODBYE_RESOURCE_SUSPEND_STORAGE_KEY" in view_source
         assert "if (isGoodbyeResourceSuspendingOrSuspended()) return" in view_source
         assert "stopAutoRefresh()" in view_source
 


### PR DESCRIPTION
﻿## 改动概述

这次改动把 goodbye 后的资源暂停从点击 goodbye 的瞬间后移到猫猫转场完成后执行，避免转场动画、字幕、Agent HUD 和插件管理面板在同一时间继续抢占渲染与请求资源。资源暂停状态拆成 pending 与 suspended 两段：pending 阶段用于提前通知插件管理面板停止发起新的指标请求，suspended 阶段才真正隐藏辅助窗口、暂停模型渲染循环，并把可跨窗口读取的状态写入本地存储。

字幕侧在 goodbye 期间会取消在途翻译、清空当前文本并丢弃当前 turn，恢复时只恢复可见性，不重放已经被丢弃的内容。Agent HUD 和 WebSocket 任务状态更新只在 UI 层短路，不停止插件或后端任务本身。插件管理的 Dashboard、Metrics 和 metrics store 都统一读取 goodbye 资源暂停状态，避免只在页面定时器入口拦截而漏掉直接调用 store 的路径。

## 风险与边界

本轮只处理 goodbye 结束后的前端资源收束与恢复边界，不改变插件运行生命周期，不停止后端任务，不调整轮询频率，也不把小闪烁问题转化成更高 CPU/GPU 负载。恢复路径覆盖 return ball 返回和角色切换触发的 goodbye 状态清理；角色切换会通过已有事件触发资源恢复，避免 return ball 被隐藏后状态残留。

主要回归风险集中在 Electron 多窗口环境：主窗口、字幕窗口、Agent HUD 窗口和插件管理窗口需要共享 goodbye 状态但各自有独立渲染路径。提交前已用静态契约测试和 plugin-manager 类型检查覆盖关键状态顺序、pending/suspended guard、HUD/字幕短路与恢复入口；真实 Electron 多窗口体验仍建议审查时重点手动确认 goodbye 完成后切角色、return ball 返回、插件指标请求抑制、字幕和 HUD 恢复这几条路径。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新 Features**
  * 新增“再见/资源挂起”状态联动：离开与返回时统一暂停并恢复字幕、任务 HUD 与页面自动刷新；同时抑制代理任务轮询与相关 UI 更新。
  * Goodbye 期间会暂停活动模型的渲染（含分层/说话相关动画），并在恢复后按原可见性与启用条件恢复显示。
* **Bug Fixes**
  * 挂起时仪表盘与指标拉取自动停止，避免后台继续请求与写入；恢复后恢复到原状态。
  * Goodbye 期间字幕翻译/渲染会正确跳过与失效处理，返回后不会重复、回放或错过内容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->