### PR TITLE
削弱Yui的救球能力

### DIFF
--- a/templates/badminton_demo.html
+++ b/templates/badminton_demo.html
@@ -1082,10 +1082,10 @@
   var YUI_RACKET_HIT_REACH_Y = 62;
   var YUI_RACKET_RESCUE_GATE_REACH_X = 38;
   var YUI_RACKET_RESCUE_GATE_REACH_Y = 54;
-  var YUI_RACKET_SAVE_REACH_X = 84;
-  var YUI_RACKET_SAVE_REACH_Y = 86;
-  var YUI_SHORT_DROP_SAVE_REACH_X = 96;
-  var YUI_SHORT_DROP_SAVE_REACH_Y = 118;
+  var YUI_RACKET_SAVE_REACH_X = 66;
+  var YUI_RACKET_SAVE_REACH_Y = 72;
+  var YUI_SHORT_DROP_SAVE_REACH_X = 72;
+  var YUI_SHORT_DROP_SAVE_REACH_Y = 92;
   var YUI_SHORT_DROP_SAVE_NET_WINDOW_PX = 112;
   var YUI_SHORT_DROP_SAVE_MAX_Z = 96;
   var YUI_SHORT_DROP_SAVE_MIN_Z = 4;
@@ -5923,14 +5923,15 @@
     var contact = incomingBall ? { x: incomingBall.x, y: incomingBall.y } : getRacketContactPoint(shooter);
     var racket = getRacketContactPoint(shooter);
     var contactError = incomingBall ? Math.sqrt(Math.pow(incomingBall.x - racket.x, 2) + Math.pow(incomingBall.y - racket.y, 2)) : 0;
-    var minTimingQuality = shooter === 'neko' ? 0.62 : 0.34;
+    var isSmash = !!swingOptions.smash;
+    var isSave = !!swingOptions.save && shooter === 'neko' && !isSmash;
+    var minTimingQuality = shooter === 'neko' ? (isSave ? 0.46 : 0.62) : 0.34;
     var timingQuality = incomingBall ? clamp(1 - contactError / 118, minTimingQuality, 1) : 1;
     var quality = clamp((powerQuality * 0.55 + angleQuality * 0.45) * timingQuality, 0, 1);
     var force = clamp(power, 0, 100) / 100;
     var incomingVx = incomingBall ? incomingBall.vx || 0 : 0;
     var incomingVy = incomingBall ? incomingBall.vy || 0 : 0;
     var incomingSpeed = Math.sqrt(incomingVx * incomingVx + incomingVy * incomingVy);
-    var isSmash = !!swingOptions.smash;
     var smashQuality = isSmash ? (shooter === 'neko' ? clamp(Number(swingOptions.smashQuality) || 0.72, 0, 1) : getPlayerSmashQuality(incomingBall)) : 0;
     if (isSmash && smashQuality <= 0) isSmash = false;
     var smashSpeedBonus = isSmash ? 130 + smashQuality * 150 : 0;
@@ -6084,7 +6085,7 @@
       shooter: shotShooter,
       angle: angle,
       power: power,
-      impulse: buildSwingImpulse(angle, power, shotShooter, incomingBall, { smash: smash, smashQuality: smashQuality }),
+      impulse: buildSwingImpulse(angle, power, shotShooter, incomingBall, { smash: smash, smashQuality: smashQuality, save: save }),
       save: save,
       forceScore: !!(options && options.forceScore)
     };

--- a/tests/e2e/test_badminton_demo.py
+++ b/tests/e2e/test_badminton_demo.py
@@ -745,19 +745,19 @@ def test_badminton_yui_saves_player_smash_just_outside_racket_hit_range(mock_pag
     setup = page.evaluate(
         """() => {
           const contact = window.BadmintonDemo._debugGetYuiRacketContactPoint();
-          const dx = contact.reachX + 32;
-          const dy = 10;
+          const dx = contact.reachX + 12;
+          const dy = 0;
           const courtY = contact.x + dx;
           const screenY = contact.y + dy;
           const id = window.BadmintonDemo._debugSetPlayerShuttleForYuiReturnBall({
             x: courtY,
-            prevX: courtY - 24,
+            prevX: courtY - 8,
             courtY,
-            prevCourtY: courtY - 24,
+            prevCourtY: courtY - 8,
             y: screenY,
             prevY: screenY,
-            vx: 78,
-            vCourtY: 78,
+            vx: 24,
+            vCourtY: 24,
             vy: 0,
             vz: 0,
             isSmash: true,
@@ -772,6 +772,8 @@ def test_badminton_yui_saves_player_smash_just_outside_racket_hit_range(mock_pag
           };
         }"""
     )
+    assert setup["contact"]["saveReachX"] == 66
+    assert setup["contact"]["saveReachY"] == 72
     assert setup["normalNormalized"] > 1
     assert setup["saveNormalized"] <= 1
 

--- a/tests/unit/test_badminton_improvement_contract.py
+++ b/tests/unit/test_badminton_improvement_contract.py
@@ -2879,7 +2879,8 @@ def test_badminton_racket_swing_applies_physics_to_shuttle():
 
     assert "function buildSwingImpulse(angle, power, shooter, incomingBall) {" in html
     assert "var contact = incomingBall ? { x: incomingBall.x, y: incomingBall.y } : getRacketContactPoint(shooter);" in html
-    assert "var minTimingQuality = shooter === 'neko' ? 0.62 : 0.34;" in html
+    assert "var isSave = !!swingOptions.save && shooter === 'neko' && !isSmash;" in html
+    assert "var minTimingQuality = shooter === 'neko' ? (isSave ? 0.46 : 0.62) : 0.34;" in html
     assert "var timingQuality = incomingBall ? clamp(1 - contactError / 118, minTimingQuality, 1) : 1;" in html
     assert "incomingSpeed: incomingSpeed," in html
     assert "incomingVx: incomingVx," in html
@@ -3387,10 +3388,10 @@ def test_badminton_yui_returns_incoming_shuttle_before_landing():
     assert "return getYuiRacketHitRangeState(incomingBall).normalized <= 1;" in html
     assert "function getYuiRacketRescueGateState(incomingBall) {" in html
     assert "return getYuiVisibleOrNeutralRacketRangeState(incomingBall, YUI_RACKET_RESCUE_GATE_REACH_X, YUI_RACKET_RESCUE_GATE_REACH_Y);" in html
-    assert "var YUI_RACKET_SAVE_REACH_X = 84;" in html
-    assert "var YUI_RACKET_SAVE_REACH_Y = 86;" in html
-    assert "var YUI_SHORT_DROP_SAVE_REACH_X = 96;" in html
-    assert "var YUI_SHORT_DROP_SAVE_REACH_Y = 118;" in html
+    assert "var YUI_RACKET_SAVE_REACH_X = 66;" in html
+    assert "var YUI_RACKET_SAVE_REACH_Y = 72;" in html
+    assert "var YUI_SHORT_DROP_SAVE_REACH_X = 72;" in html
+    assert "var YUI_SHORT_DROP_SAVE_REACH_Y = 92;" in html
     assert "var YUI_SHORT_DROP_SAVE_NET_WINDOW_PX = 112;" in html
     assert "var YUI_SHORT_DROP_SAVE_MAX_Z = 96;" in html
     assert "var YUI_SHORT_DROP_SAVE_MIN_Z = 4;" in html
@@ -3735,6 +3736,7 @@ def test_badminton_space_jump_enables_air_smash():
     ]
     assert "var swingOptions = arguments.length > 4 && arguments[4] ? arguments[4] : {};" in swing_section
     assert "var isSmash = !!swingOptions.smash;" in swing_section
+    assert "var isSave = !!swingOptions.save && shooter === 'neko' && !isSmash;" in swing_section
     assert "var smashQuality = isSmash ? (shooter === 'neko' ? clamp(Number(swingOptions.smashQuality) || 0.72, 0, 1) : getPlayerSmashQuality(incomingBall)) : 0;" in swing_section
     assert "if (isSmash && smashQuality <= 0) isSmash = false;" in swing_section
     assert "var smashSpeedBonus = isSmash ? 130 + smashQuality * 150 : 0;" in swing_section
@@ -3749,7 +3751,7 @@ def test_badminton_space_jump_enables_air_smash():
     assert "if (shotShooter === 'player') smash = smash || isPlayerSmashReady(incomingBall);" in queue_section
     assert "var save = !!(options && options.save) && shotShooter === 'neko' && !smash;" in queue_section
     assert "var smashQuality = options && typeof options.smashQuality === 'number' ? options.smashQuality : 0;" in queue_section
-    assert "impulse: buildSwingImpulse(angle, power, shotShooter, incomingBall, { smash: smash, smashQuality: smashQuality })," in queue_section
+    assert "impulse: buildSwingImpulse(angle, power, shotShooter, incomingBall, { smash: smash, smashQuality: smashQuality, save: save })," in queue_section
     assert "save: save," in queue_section
     assert "if (shotShooter === 'player') setPlayerAction('shooting', 460);" in queue_section
     assert "else setYuiAction(save ? 'saving' : (smash ? 'smashing' : 'shooting'), save ? 560 : (smash ? 520 : 420));" in queue_section


### PR DESCRIPTION
﻿## 摘要

这次调整羽毛球对战小游戏里 Yui 的救球能力。之前 Yui 的应急救球覆盖范围偏大，而且救到边缘球之后仍然使用和普通 AI 回球一样的 timing 质量下限，导致玩家的杀球和短吊经常被稳定救回，体感上很难打穿。

根因是 Yui 的 emergency save 判定窗口明显大于普通球拍命中窗口，同时 `buildSwingImpulse` 对所有 Yui 入球回击都给了 `0.62` 的 timing quality 下限。结果是即使 Yui 只是擦边救到球，回球物理也仍然比较稳定。

这次改动缩小了两个救球窗口，并把已有的 `save` 标记传入 `buildSwingImpulse`。现在只有 Yui 的 save 回球会使用更低的 `0.46` timing 下限；普通 Yui 回球、Yui smash 和玩家回球都保留原来的 timing 行为。

## 改动内容

- 将 Yui 杀球救球范围从 `84 x 86` 收窄到 `66 x 72`。
- 将 Yui 短吊救球范围从 `96 x 118` 收窄到 `72 x 92`。
- 增加 `isSave` timing 分支，只让 Yui save 回球使用 `0.46` 的较低 timing 下限。
- 更新 unit 契约和 e2e save 边界构造，使测试锁定新的救球范围。

## 验证

- `python -m pytest tests/unit/test_badminton_improvement_contract.py -q -k "racket_swing_applies_physics_to_shuttle or yui_returns_incoming_shuttle_before_landing or space_jump_enables_air_smash"` 通过，结果为 `3 passed`。
- `gitnexus detect_changes` 返回低风险：3 个变更文件，affected processes 为 0。

补充说明：完整 `test_badminton_improvement_contract.py` 目前仍有一个无关既有失败：`test_badminton_debug_voice_mode_allows_tts_when_debugging`。本地运行羽毛球 e2e save 测试时卡在 browser/fixture 生命周期并超时，因此 e2e 已同步更新但未在本机完整跑通。
