### PR TITLE
修复模型切换后的头像根容器穿透污染

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1113,7 +1113,7 @@
                         live2dContainer2.classList.remove('hidden');
                         live2dContainer2.style.display = 'block';
                         live2dContainer2.style.visibility = 'visible';
-                        live2dContainer2.style.removeProperty('pointer-events');
+                        live2dContainer2.style.setProperty('pointer-events', 'none', 'important');
                     }
                     var live2dCanvas2 = document.getElementById('live2d-canvas');
                     if (live2dCanvas2) {
@@ -1176,7 +1176,7 @@
                                 if (!deferRevealPrepared) {
                                     live2dContainer2.style.removeProperty('opacity');
                                 }
-                                live2dContainer2.style.removeProperty('pointer-events');
+                                live2dContainer2.style.setProperty('pointer-events', 'none', 'important');
                             }
                             if (live2dCanvas2) {
                                 live2dCanvas2.style.display = 'block';

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -1208,6 +1208,13 @@
         });
     }
 
+    function keepAvatarRootContainerPassthrough(container) {
+        if (!container || !container.id || !container.style) return false;
+        if (container.id !== 'live2d-container' && container.id !== 'pngtuber-container') return false;
+        container.style.setProperty('pointer-events', 'none', 'important');
+        return true;
+    }
+
     function restoreLive2DDisplaySurface(reason) {
         const preserveAvatarCornerPeekOpacity = window.nekoYuiGuideAvatarCornerPeekActive === true;
         const preserveYuiGuidePreparing = shouldPreserveYuiGuideLive2DPreparing();
@@ -1237,7 +1244,7 @@
             } else if (!preserveAvatarCornerPeekOpacity) {
                 live2dContainer.style.removeProperty('opacity');
             }
-            live2dContainer.style.removeProperty('pointer-events');
+            keepAvatarRootContainerPassthrough(live2dContainer);
         }
 
         const live2dCanvas = document.getElementById('live2d-canvas');
@@ -2699,7 +2706,9 @@
         container.style.opacity = hasReturnRect ? '0' : '1';
         container.style.transform = hasReturnRect ? getModelCatTransitionScaleTransform() : 'none';
         if (options.clearPointerEvents) {
-            container.style.removeProperty('pointer-events');
+            if (!keepAvatarRootContainerPassthrough(container)) {
+                container.style.removeProperty('pointer-events');
+            }
         }
         return true;
     }

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -1932,7 +1932,7 @@ class UniversalTutorialManager {
             if (!deferRevealPrepared) {
                 live2dContainer.style.removeProperty('opacity');
             }
-            live2dContainer.style.removeProperty('pointer-events');
+            live2dContainer.style.setProperty('pointer-events', 'none', 'important');
         }
         const live2dCanvas = document.getElementById('live2d-canvas');
         if (live2dCanvas) {
@@ -2380,7 +2380,7 @@ class UniversalTutorialManager {
             } else {
                 live2dContainer.style.setProperty('opacity', '1', 'important');
             }
-            live2dContainer.style.removeProperty('pointer-events');
+            live2dContainer.style.setProperty('pointer-events', 'none', 'important');
         }
 
         const live2dCanvas = document.getElementById('live2d-canvas');

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -2919,13 +2919,12 @@ class UniversalTutorialManager {
 
         const activePrefix = this.getActiveAvatarFloatingModelPrefix();
         const activeLocked = snapshot[activePrefix] === true;
-        [`${activePrefix}-canvas`, `${activePrefix}-container`].forEach(elementId => {
-            const element = document.getElementById(elementId);
-            if (!element) return;
-            const pointerKey = elementId.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
-            const hasSnapshotPointerEvents = snapshot.pointerEvents
-                && Object.prototype.hasOwnProperty.call(snapshot.pointerEvents, pointerKey);
-            const snapshotPointerEvents = hasSnapshotPointerEvents ? snapshot.pointerEvents[pointerKey] : null;
+        function restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix) {
+            const isActiveAvatarContainer = elementId === `${activePrefix}-container`;
+            if (isActiveAvatarContainer && (activePrefix === 'live2d' || activePrefix === 'pngtuber')) {
+                element.style.pointerEvents = 'none';
+                return;
+            }
             if (hasSnapshotPointerEvents && snapshotPointerEvents) {
                 element.style.pointerEvents = snapshotPointerEvents;
                 return;
@@ -2934,6 +2933,15 @@ class UniversalTutorialManager {
                 element.style.removeProperty('pointer-events');
                 element.style.pointerEvents = activeLocked ? 'none' : 'auto';
             }
+        }
+        [`${activePrefix}-canvas`, `${activePrefix}-container`].forEach(elementId => {
+            const element = document.getElementById(elementId);
+            if (!element) return;
+            const pointerKey = elementId.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+            const hasSnapshotPointerEvents = snapshot.pointerEvents
+                && Object.prototype.hasOwnProperty.call(snapshot.pointerEvents, pointerKey);
+            const snapshotPointerEvents = hasSnapshotPointerEvents ? snapshot.pointerEvents[pointerKey] : null;
+            restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix);
         });
         if (reason === 'tutorial-avatar-restored') {
             this._avatarFloatingModelLockSnapshot = null;

--- a/static/tutorial/core/universal-manager.js
+++ b/static/tutorial/core/universal-manager.js
@@ -2919,10 +2919,10 @@ class UniversalTutorialManager {
 
         const activePrefix = this.getActiveAvatarFloatingModelPrefix();
         const activeLocked = snapshot[activePrefix] === true;
-        function restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix) {
+        function restoreAvatarPointerEvents(element, elementId, snapshotPointerEvents, hasSnapshotPointerEvents) {
             const isActiveAvatarContainer = elementId === `${activePrefix}-container`;
             if (isActiveAvatarContainer && (activePrefix === 'live2d' || activePrefix === 'pngtuber')) {
-                element.style.pointerEvents = 'none';
+                element.style.setProperty('pointer-events', 'none', 'important');
                 return;
             }
             if (hasSnapshotPointerEvents && snapshotPointerEvents) {
@@ -2941,7 +2941,7 @@ class UniversalTutorialManager {
             const hasSnapshotPointerEvents = snapshot.pointerEvents
                 && Object.prototype.hasOwnProperty.call(snapshot.pointerEvents, pointerKey);
             const snapshotPointerEvents = hasSnapshotPointerEvents ? snapshot.pointerEvents[pointerKey] : null;
-            restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix);
+            restoreAvatarPointerEvents(element, elementId, snapshotPointerEvents, hasSnapshotPointerEvents);
         });
         if (reason === 'tutorial-avatar-restored') {
             this._avatarFloatingModelLockSnapshot = null;

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2308,7 +2308,13 @@ test('tutorial skip button reuses the manager tutorial end lifecycle', () => {
     assert.match(managerSource, /vrmCanvas: readPointerEvents\('vrm-canvas'\)/);
     assert.match(managerSource, /mmdCanvas: readPointerEvents\('mmd-canvas'\)/);
     assert.match(avatarInteractionRestoreBlock, /const hasSnapshotPointerEvents = snapshot\.pointerEvents/);
-    assert.match(avatarInteractionRestoreBlock, /element\.style\.pointerEvents = snapshot\.pointerEvents\[pointerKey\] \|\| '';/);
+    assert.match(avatarInteractionRestoreBlock, /const snapshotPointerEvents = hasSnapshotPointerEvents \? snapshot\.pointerEvents\[pointerKey\] : null;/);
+    assert.match(avatarInteractionRestoreBlock, /function restoreAvatarPointerEvents\(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix\)/);
+    assert.match(avatarInteractionRestoreBlock, /const isActiveAvatarContainer = elementId === `\$\{activePrefix\}-container`;/);
+    assert.match(avatarInteractionRestoreBlock, /if \(isActiveAvatarContainer && \(activePrefix === 'live2d' \|\| activePrefix === 'pngtuber'\)\) \{[\s\S]*?element\.style\.pointerEvents = 'none';[\s\S]*?return;/);
+    assert.match(avatarInteractionRestoreBlock, /element\.style\.pointerEvents = snapshotPointerEvents;/);
+    assert.match(avatarInteractionRestoreBlock, /restoreAvatarPointerEvents\(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix\);/);
+    assert.doesNotMatch(avatarInteractionRestoreBlock, /element\.style\.pointerEvents = snapshot\.pointerEvents\[pointerKey\] \|\| '';/);
     assert.match(avatarInteractionRestoreBlock, /activePrefix === 'live2d' \|\| activePrefix === 'pngtuber'/);
     assert.match(managerSource, /modelType === 'live3d'/);
     assert.match(managerSource, /live3d_sub_type/);

--- a/static/yui-guide-common.test.cjs
+++ b/static/yui-guide-common.test.cjs
@@ -2309,11 +2309,11 @@ test('tutorial skip button reuses the manager tutorial end lifecycle', () => {
     assert.match(managerSource, /mmdCanvas: readPointerEvents\('mmd-canvas'\)/);
     assert.match(avatarInteractionRestoreBlock, /const hasSnapshotPointerEvents = snapshot\.pointerEvents/);
     assert.match(avatarInteractionRestoreBlock, /const snapshotPointerEvents = hasSnapshotPointerEvents \? snapshot\.pointerEvents\[pointerKey\] : null;/);
-    assert.match(avatarInteractionRestoreBlock, /function restoreAvatarPointerEvents\(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix\)/);
+    assert.match(avatarInteractionRestoreBlock, /function restoreAvatarPointerEvents\(element, elementId, snapshotPointerEvents, hasSnapshotPointerEvents\)/);
     assert.match(avatarInteractionRestoreBlock, /const isActiveAvatarContainer = elementId === `\$\{activePrefix\}-container`;/);
-    assert.match(avatarInteractionRestoreBlock, /if \(isActiveAvatarContainer && \(activePrefix === 'live2d' \|\| activePrefix === 'pngtuber'\)\) \{[\s\S]*?element\.style\.pointerEvents = 'none';[\s\S]*?return;/);
+    assert.match(avatarInteractionRestoreBlock, /if \(isActiveAvatarContainer && \(activePrefix === 'live2d' \|\| activePrefix === 'pngtuber'\)\) \{[\s\S]*?element\.style\.setProperty\('pointer-events', 'none', 'important'\);[\s\S]*?return;/);
     assert.match(avatarInteractionRestoreBlock, /element\.style\.pointerEvents = snapshotPointerEvents;/);
-    assert.match(avatarInteractionRestoreBlock, /restoreAvatarPointerEvents\(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix\);/);
+    assert.match(avatarInteractionRestoreBlock, /restoreAvatarPointerEvents\(element, elementId, snapshotPointerEvents, hasSnapshotPointerEvents\);/);
     assert.doesNotMatch(avatarInteractionRestoreBlock, /element\.style\.pointerEvents = snapshot\.pointerEvents\[pointerKey\] \|\| '';/);
     assert.match(avatarInteractionRestoreBlock, /activePrefix === 'live2d' \|\| activePrefix === 'pngtuber'/);
     assert.match(managerSource, /modelType === 'live3d'/);

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1437,15 +1437,15 @@ def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     assert "mmdCanvas: readPointerEvents('mmd-canvas')" in tutorial_source
     assert "const hasSnapshotPointerEvents = snapshot.pointerEvents" in avatar_interaction_restore_block
     assert "const snapshotPointerEvents = hasSnapshotPointerEvents ? snapshot.pointerEvents[pointerKey] : null;" in avatar_interaction_restore_block
-    assert "function restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix)" in avatar_interaction_restore_block
+    assert "function restoreAvatarPointerEvents(element, elementId, snapshotPointerEvents, hasSnapshotPointerEvents)" in avatar_interaction_restore_block
     assert "if (hasSnapshotPointerEvents && snapshotPointerEvents) {" in avatar_interaction_restore_block
     assert "element.style.pointerEvents = snapshotPointerEvents;" in avatar_interaction_restore_block
     assert "element.style.pointerEvents = snapshot.pointerEvents[pointerKey] || '';" not in avatar_interaction_restore_block
     assert "activePrefix === 'live2d' || activePrefix === 'pngtuber'" in avatar_interaction_restore_block
     assert "const isActiveAvatarContainer = elementId === `${activePrefix}-container`;" in avatar_interaction_restore_block
     assert "if (isActiveAvatarContainer && (activePrefix === 'live2d' || activePrefix === 'pngtuber')) {" in avatar_interaction_restore_block
-    assert "element.style.pointerEvents = 'none';" in avatar_interaction_restore_block
-    assert "restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix);" in avatar_interaction_restore_block
+    assert "element.style.setProperty('pointer-events', 'none', 'important');" in avatar_interaction_restore_block
+    assert "restoreAvatarPointerEvents(element, elementId, snapshotPointerEvents, hasSnapshotPointerEvents);" in avatar_interaction_restore_block
     assert "element.style.removeProperty('pointer-events');" in avatar_interaction_restore_block
     assert "element.style.pointerEvents = activeLocked ? 'none' : 'auto';" in avatar_interaction_restore_block
     assert avatar_interaction_restore_block.index("const isActiveAvatarContainer = elementId === `${activePrefix}-container`;") < avatar_interaction_restore_block.index("if (hasSnapshotPointerEvents && snapshotPointerEvents) {")

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1437,12 +1437,18 @@ def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     assert "mmdCanvas: readPointerEvents('mmd-canvas')" in tutorial_source
     assert "const hasSnapshotPointerEvents = snapshot.pointerEvents" in avatar_interaction_restore_block
     assert "const snapshotPointerEvents = hasSnapshotPointerEvents ? snapshot.pointerEvents[pointerKey] : null;" in avatar_interaction_restore_block
+    assert "function restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix)" in avatar_interaction_restore_block
     assert "if (hasSnapshotPointerEvents && snapshotPointerEvents) {" in avatar_interaction_restore_block
     assert "element.style.pointerEvents = snapshotPointerEvents;" in avatar_interaction_restore_block
     assert "element.style.pointerEvents = snapshot.pointerEvents[pointerKey] || '';" not in avatar_interaction_restore_block
     assert "activePrefix === 'live2d' || activePrefix === 'pngtuber'" in avatar_interaction_restore_block
+    assert "const isActiveAvatarContainer = elementId === `${activePrefix}-container`;" in avatar_interaction_restore_block
+    assert "if (isActiveAvatarContainer && (activePrefix === 'live2d' || activePrefix === 'pngtuber')) {" in avatar_interaction_restore_block
+    assert "element.style.pointerEvents = 'none';" in avatar_interaction_restore_block
+    assert "restoreAvatarPointerEvents(element, elementId, activeLocked, snapshotPointerEvents, hasSnapshotPointerEvents, activePrefix);" in avatar_interaction_restore_block
     assert "element.style.removeProperty('pointer-events');" in avatar_interaction_restore_block
     assert "element.style.pointerEvents = activeLocked ? 'none' : 'auto';" in avatar_interaction_restore_block
+    assert avatar_interaction_restore_block.index("const isActiveAvatarContainer = elementId === `${activePrefix}-container`;") < avatar_interaction_restore_block.index("if (hasSnapshotPointerEvents && snapshotPointerEvents) {")
     assert "this.restoreAvatarFloatingModelInteractionState('teardown-early');" in tutorial_source
     assert ".then(() => this.clearTutorialYuiLive2dRuntimeResidue('tutorial-avatar-restored'))" in tutorial_source
     assert ".then(() => this.restoreAvatarFloatingModelInteractionState('tutorial-avatar-restored'))" in tutorial_source

--- a/tests/unit/test_app_character_static.py
+++ b/tests/unit/test_app_character_static.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 
 APP_CHARACTER_PATH = Path(__file__).resolve().parents[2] / "static" / "app-character.js"
+APP_INTERPAGE_PATH = Path(__file__).resolve().parents[2] / "static" / "app-interpage.js"
 APP_UI_PATH = Path(__file__).resolve().parents[2] / "static" / "app-ui.js"
+INDEX_CSS_PATH = Path(__file__).resolve().parents[2] / "static" / "css" / "index.css"
 
 
 def test_character_switch_resets_avatar_lock_after_successful_model_load():
@@ -63,3 +65,51 @@ def test_app_ui_exposes_shared_return_ball_hide_helper():
     assert "window.hideNekoReturnBallContainer = hideReturnBallContainer" in source
     assert "window.hideAllNekoReturnBallContainers = function(reason = 'return-ball-hide')" in source
     assert "ensureMultiWindowReturnBallDrag(null)" in source
+
+
+def test_character_switch_does_not_restore_full_container_pointer_events():
+    character_source = APP_CHARACTER_PATH.read_text(encoding="utf-8")
+    interpage_source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+    app_ui_source = APP_UI_PATH.read_text(encoding="utf-8")
+    css_source = INDEX_CSS_PATH.read_text(encoding="utf-8")
+
+    live2d_css = css_source[
+        css_source.index("#live2d-container {"):
+        css_source.index("#live2d-container.minimized")
+    ]
+    assert "pointer-events: none;" in live2d_css
+    assert "#live2d-canvas" in css_source
+
+    for source in (character_source, interpage_source, app_ui_source):
+        assert "live2dContainer.style.pointerEvents = 'auto';" not in source
+        assert 'live2dContainer.style.pointerEvents = "auto";' not in source
+        assert "live2dContainer2.style.pointerEvents = 'auto';" not in source
+        assert "l2dContainer.style.pointerEvents = 'auto';" not in source
+        assert "live2dContainer.style.setProperty('pointer-events', 'auto'" not in source
+
+    assert "live2dContainer2.style.setProperty('pointer-events', 'none', 'important');" in interpage_source
+    assert "live2dCanvas2.style.pointerEvents = 'auto';" in interpage_source
+    assert "live2dCanvas.style.setProperty('pointer-events', 'auto', 'important');" in app_ui_source
+
+
+def test_character_model_switch_repeated_paths_keep_only_model_entities_interactive():
+    source = APP_CHARACTER_PATH.read_text(encoding="utf-8")
+    interpage_source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+
+    assert "window.pngtuberManager.image.style.pointerEvents = 'auto';" in source
+    assert "live2dCanvas2.style.pointerEvents = 'auto';" in interpage_source
+    assert "vrmCanvas.style.pointerEvents = 'auto';" in interpage_source
+    assert "vrmContainer.style.removeProperty('pointer-events');" in interpage_source
+    assert "mmdContainerShow.style.removeProperty('pointer-events');" in source
+
+    for target in (
+        "live2dContainer.style.pointerEvents = 'auto';",
+        "live2dContainer2.style.pointerEvents = 'auto';",
+        "pngtuberContainer.style.pointerEvents = 'auto';",
+        "oldPngtuberContainer.style.pointerEvents = 'auto';",
+    ):
+        assert target not in source
+        assert target not in interpage_source
+
+    assert "oldPngtuberContainer.style.pointerEvents = 'none';" in interpage_source
+    assert "clearGoodbyeStateForCharacterSwitch();" in source

--- a/tests/unit/test_avatar_root_pointer_events_static.py
+++ b/tests/unit/test_avatar_root_pointer_events_static.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+APP_UI_PATH = PROJECT_ROOT / "static" / "app-ui.js"
+APP_INTERPAGE_PATH = PROJECT_ROOT / "static" / "app-interpage.js"
+UNIVERSAL_MANAGER_PATH = PROJECT_ROOT / "static" / "tutorial" / "core" / "universal-manager.js"
+
+
+def test_live2d_restore_keeps_root_container_passthrough():
+    source = APP_UI_PATH.read_text(encoding="utf-8")
+    helper_block = source[
+        source.index("function keepAvatarRootContainerPassthrough(container)"):
+        source.index("    function restoreLive2DDisplaySurface(reason)")
+    ]
+    restore_block = source[
+        source.index("function restoreLive2DDisplaySurface(reason)"):
+        source.index("    function activateLive2DRenderForDisplay(reason)")
+    ]
+    return_prepare_block = source[
+        source.index("function prepareModelReturnContainer(container, rect, options = {})"):
+        source.index("    function applyModelGoodbyeVisualFade(container")
+    ]
+
+    assert "container.id !== 'live2d-container' && container.id !== 'pngtuber-container'" in helper_block
+    assert "container.style.setProperty('pointer-events', 'none', 'important');" in helper_block
+    assert "keepAvatarRootContainerPassthrough(live2dContainer);" in restore_block
+    assert "live2dContainer.style.removeProperty('pointer-events');" not in restore_block
+    assert "if (!keepAvatarRootContainerPassthrough(container)) {" in return_prepare_block
+    assert "container.style.removeProperty('pointer-events');" in return_prepare_block
+
+
+def test_model_reload_live2d_restore_keeps_root_container_passthrough():
+    source = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
+    reload_block = source[
+        source.index("var live2dContainer2 = document.getElementById('live2d-container');"):
+        source.index("if (window.lanlan_config) {", source.index("var live2dContainer2 = document.getElementById('live2d-container');"))
+    ]
+
+    assert "live2dContainer2.style.setProperty('pointer-events', 'none', 'important');" in reload_block
+    assert "live2dContainer2.style.removeProperty('pointer-events');" not in reload_block
+    assert "live2dCanvas2.style.pointerEvents = 'auto';" in reload_block
+
+
+def test_tutorial_live2d_restore_keeps_root_container_passthrough():
+    source = UNIVERSAL_MANAGER_PATH.read_text(encoding="utf-8")
+    temporary_load_block = source[
+        source.index("async loadTemporaryTutorialLive2dModel("):
+        source.index("    isTutorialYuiLive2dActive()")
+    ]
+    restore_block = source[
+        source.index("restoreTutorialLive2dDisplayState(reason"):
+        source.index("    revealTutorialLive2dPrepared()")
+    ]
+
+    assert "live2dContainer.style.setProperty('pointer-events', 'none', 'important');" in temporary_load_block
+    assert "live2dContainer.style.removeProperty('pointer-events');" not in temporary_load_block
+    assert "live2dContainer.style.setProperty('pointer-events', 'none', 'important');" in restore_block
+    assert "live2dContainer.style.removeProperty('pointer-events');" not in restore_block
+    assert "live2dCanvas.style.setProperty('pointer-events', 'auto', 'important');" in restore_block


### PR DESCRIPTION
﻿## 背景

本 PR 是 PR-A 的 N.E.K.O 侧修复，目标是收敛猫猫/猫娘模型切换后可能残留的全屏透明 hit target。

问题表现是：Pet 作为全屏透明 Electron 窗口浮在游戏上方时，如果模型外层容器在切换/恢复后重新参与 DOM 命中，PC 侧可能把透明区域误判为真实交互目标，进而让 native mouse ignore 状态保持为不穿透。用户看到的结果是猫娘可见，但透明区域也可能挡住底层游戏点击。

## 根因

N.E.K.O 侧部分 Live2D / PngTuber 恢复路径会清理外层容器的 `pointer-events`，使 `live2d-container` / `pngtuber-container` 这类全屏容器重新成为可命中层。外层容器本身不应该承担交互，真正可交互的应该是模型 canvas/image、浮动按钮、返回按钮、拖拽热点等具体目标。

## 修复

- 保持 `live2d-container` / `pngtuber-container` 外层容器为 `pointer-events:none !important`。
- 保留真实模型实体和控制 UI 的 `pointer-events:auto`。
- 覆盖普通模型恢复、模型切换、教程临时 Live2D 恢复等路径。
- 增加静态合同测试，防止后续恢复路径再次把外层容器变成全屏 hit target。

## 验证

- `python -m pytest tests/unit/test_avatar_root_pointer_events_static.py tests/unit/test_app_character_static.py tests/unit/test_pngtuber_static_contracts.py tests/unit/test_live2d_interaction_static_contracts.py`
- 结果：28 passed
- GitNexus `detect_changes`：risk low，affected processes 0

## 风险边界

本 PR 不改 Electron native mouse ignore 逻辑；PC 侧 hitTest/native ignore 状态机修复在配套 PR 中完成。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复角色切换/Live2D 与教程模型切换后可能出现的交互穿透：在显示与恢复过程中，强制保持头像根容器为不可交互（`pointer-events: none !important`），避免意外可点击。
  * 优化显示准备与恢复逻辑，确保画布/容器指针事件状态在不同场景下正确回落。
* **Tests**
  * 更新并新增指针事件恢复的静态资源校验用例，覆盖活动容器（Live2D/pangtuber）与多次切换场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->