### PR TITLE
fix(tutorial): 将启动教程 loading 限定到主屏

### DIFF
--- a/static/avatar-floating-boot-predictor.test.cjs
+++ b/static/avatar-floating-boot-predictor.test.cjs
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const predictorSource = fs.readFileSync(
+    path.join(__dirname, 'tutorial/core/avatar-floating-boot-predictor.js'),
+    'utf-8'
+);
+
+function createStorage() {
+    const values = new Map();
+    return {
+        getItem(key) {
+            return values.has(key) ? values.get(key) : null;
+        },
+        setItem(key, value) {
+            values.set(key, String(value));
+        }
+    };
+}
+
+function loadPredictor(bridge) {
+    const window = {
+        innerWidth: 1280,
+        localStorage: createStorage(),
+        sessionStorage: createStorage(),
+        nekoTutorialLoadingOverlay: bridge
+    };
+    const context = vm.createContext({ window, console, Date, Math });
+    vm.runInContext(predictorSource, context);
+    return window;
+}
+
+test('direct tutorial startup loading is scoped to the primary display', () => {
+    const begins = [];
+    const updates = [];
+    const clears = [];
+    const window = loadPredictor({
+        begin(payload) {
+            begins.push(payload);
+        },
+        update(payload) {
+            updates.push(payload);
+        },
+        clear(payload) {
+            clears.push(payload);
+        }
+    });
+
+    assert.equal(window.NekoAvatarFloatingBoot.beginDirectTutorialLoading('startup-direct-tutorial-predicted'), true);
+
+    assert.equal(begins.length, 1);
+    assert.equal(begins[0].reason, 'startup-direct-tutorial-predicted');
+    assert.equal(begins[0].displayScope, 'primary');
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].payload.loading.visible, true);
+    assert.equal(updates[0].payload.loading.reason, 'startup-direct-tutorial-predicted');
+    assert.equal(updates[0].payload.loading.displayScope, 'primary');
+
+    assert.equal(window.NekoAvatarFloatingBoot.clearDirectTutorialLoading('avatar-floating-yui-ready'), true);
+    assert.equal(updates[1].payload.loading, null);
+    assert.equal(updates[1].payload.reason, 'avatar-floating-yui-ready');
+    assert.equal(updates[1].payload.displayScope, 'primary');
+    assert.equal(clears.length, 1);
+    assert.equal(clears[0].reason, 'avatar-floating-yui-ready');
+    assert.equal(clears[0].displayScope, 'primary');
+});

--- a/static/tutorial/core/avatar-floating-boot-predictor.js
+++ b/static/tutorial/core/avatar-floating-boot-predictor.js
@@ -6,6 +6,7 @@
     const PC_OVERLAY_RUN_ID_STORAGE_KEY = 'yuiGuidePcOverlayRunId';
     const PC_OVERLAY_SEQUENCE_STORAGE_KEY = 'yuiGuidePcOverlaySequence';
     const PC_OVERLAY_LOADING_ICON = '/static/icons/emotion_model_icon.png';
+    const PC_OVERLAY_LOADING_DISPLAY_SCOPE = 'primary';
     const ROUND_COUNT = 7;
 
     const state = {
@@ -254,7 +255,11 @@
         const sequence = nextPcOverlaySequence();
         state.loadingActive = true;
         try {
-            const beginResult = bridge.begin({ tutorialRunId, reason: reason || 'direct-tutorial-loading' });
+            const beginResult = bridge.begin({
+                tutorialRunId,
+                reason: reason || 'direct-tutorial-loading',
+                displayScope: PC_OVERLAY_LOADING_DISPLAY_SCOPE
+            });
             if (beginResult && typeof beginResult.catch === 'function') {
                 beginResult.catch(() => {
                     state.loadingActive = false;
@@ -263,10 +268,12 @@
             const updateResult = bridge.update({
                 tutorialRunId,
                 sequence,
+                displayScope: PC_OVERLAY_LOADING_DISPLAY_SCOPE,
                 payload: {
                     loading: {
                         visible: true,
                         reason: reason || 'direct-tutorial-loading',
+                        displayScope: PC_OVERLAY_LOADING_DISPLAY_SCOPE,
                         emotionIconUrl: PC_OVERLAY_LOADING_ICON
                     }
                 }
@@ -299,7 +306,12 @@
                 const updateResult = bridge.update({
                     tutorialRunId,
                     sequence,
-                    payload: { loading: null, reason: reason || 'direct-tutorial-loading-clear' }
+                    displayScope: PC_OVERLAY_LOADING_DISPLAY_SCOPE,
+                    payload: {
+                        loading: null,
+                        reason: reason || 'direct-tutorial-loading-clear',
+                        displayScope: PC_OVERLAY_LOADING_DISPLAY_SCOPE
+                    }
                 });
                 if (updateResult && typeof updateResult.catch === 'function') {
                     updateResult.catch(() => {});
@@ -308,7 +320,11 @@
         } catch (_) {}
         try {
             if (typeof bridge.clear === 'function') {
-                const clearResult = bridge.clear({ tutorialRunId, reason: reason || 'direct-tutorial-loading-clear' });
+                const clearResult = bridge.clear({
+                    tutorialRunId,
+                    reason: reason || 'direct-tutorial-loading-clear',
+                    displayScope: PC_OVERLAY_LOADING_DISPLAY_SCOPE
+                });
                 if (clearResult && typeof clearResult.catch === 'function') {
                     clearResult.catch(() => {});
                 }


### PR DESCRIPTION
## 改动概述 / Summary

- 为新手教程启动前 loading 的 PC 桥接请求补充 `displayScope: primary`。
- 覆盖 begin、update、clear 三个阶段，避免多屏环境下所有屏幕都显示启动前教程 loading。
- 新增 boot predictor 合约测试，固定主屏显示语义。

## 回归报告 / Regression Report

不适用。本 PR 未修改 app/、main_logic/、main_routers/ 或 memory/ 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。计入上限的改动文件数不超过 20 个。

## 测试 / Testing

- `node --test static/avatar-floating-boot-predictor.test.cjs`
- `node --check static/tutorial/core/avatar-floating-boot-predictor.js`
- `node --check static/avatar-floating-boot-predictor.test.cjs`
- `/Users/mac/Code/N.E.K.O/.venv/bin/python -m pytest tests/test_agent_rewrite_regression.py -k "avatar_floating_tutorial_boot_predictor or avatar_model_initializers_skip_user_model_when_tutorial_boot_is_predicted or avatar_floating_direct"`