### PR TITLE
fix(tutorial): restore icebreaker subtitle translation

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -2538,6 +2538,7 @@
                         if (!result) return result;
                         return waitForIcebreakerChatHostMounted(host).then(function () {
                             syncIcebreakerAssistantCompactCaption(action.message);
+                            finalizeIcebreakerAssistantSubtitleTranslation(action.message);
                             return result;
                         });
                     }).catch(function (error) {
@@ -2625,6 +2626,29 @@
             }));
         } catch (error) {
             console.warn('[NewUserIcebreaker] compact caption sync failed:', error);
+        }
+    }
+
+    function finalizeIcebreakerAssistantSubtitleTranslation(message) {
+        if (!isStandaloneChatPage() || !message || message.role !== 'assistant') return;
+        var line = getIcebreakerMessageText(message);
+        if (!line) return;
+        try {
+            var bridge = window.subtitleBridge;
+            if (!bridge || typeof bridge.finalizeTurnWithTranslation !== 'function') {
+                return;
+            }
+            if (typeof bridge.beginTurn === 'function') {
+                bridge.beginTurn({ latch: false });
+            }
+            var result = bridge.finalizeTurnWithTranslation(line);
+            if (result && typeof result.catch === 'function') {
+                result.catch(function (error) {
+                    console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
+                });
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
         }
     }
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -769,6 +769,16 @@
         S.pendingTextTurnSubmitAt = 0;
     }
 
+    function isNewUserIcebreakerMirrorTurnEnd(response) {
+        var meta = response && response.meta;
+        if (!meta || typeof meta !== 'object') return false;
+        if (meta.source === 'new_user_icebreaker' || meta.kind === 'new_user_icebreaker') {
+            return true;
+        }
+        var event = meta.event;
+        return !!(event && typeof event === 'object' && event.source === 'new_user_icebreaker');
+    }
+
     // turn-end / turn end agent_callback 两条路径共用的 realistic/structured
     // buffer 收尾：标 bubble 为 sent、设 _geminiTurnEndSealed 让 adapter 在
     // 后续 chunk 来时新建气泡而非追加到封口气泡（封口气泡的 React
@@ -2673,7 +2683,14 @@
 
                     // Emotion analysis & subtitle on turn completion —— 与
                     // agent_callback 路径共用 finalizeAssistantTurn；正常轮启用 music。
-                    finalizeAssistantTurn(assistantTurnId);
+                    //
+                    // 破冰 mirror TTS 的 turn_end 只表示语音播报链路结束；破冰文案
+                    // 已在 icebreaker runtime 用 subtitleBridge 精确 finalize。这里
+                    // 若再走普通聊天 finalizeAssistantTurn，会用 Gemini buffer /
+                    // 当前聊天气泡的旧文本二次翻译，覆盖破冰字幕。
+                    if (!isNewUserIcebreakerMirrorTurnEnd(response)) {
+                        finalizeAssistantTurn(assistantTurnId);
+                    }
 
                     // AI turn_end 后只 reschedule，不 reset backoff。
                     // 理由：turn_end 无法区分"用户发话引发的 turn"和"proactive 自己引发的 turn"，

--- a/static/tutorial/icebreaker/new-user-icebreaker.js
+++ b/static/tutorial/icebreaker/new-user-icebreaker.js
@@ -641,6 +641,29 @@
         }
     }
 
+    function finalizeIcebreakerAssistantSubtitleTranslation(role, message) {
+        if (role !== 'assistant') return;
+        var line = getIcebreakerMessageText(message);
+        if (!line) return;
+        try {
+            var bridge = window.subtitleBridge;
+            if (!bridge || typeof bridge.finalizeTurnWithTranslation !== 'function') {
+                return;
+            }
+            if (typeof bridge.beginTurn === 'function') {
+                bridge.beginTurn({ latch: false });
+            }
+            var result = bridge.finalizeTurnWithTranslation(line);
+            if (result && typeof result.catch === 'function') {
+                result.catch(function (error) {
+                    console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
+                });
+            }
+        } catch (error) {
+            console.warn('[NewUserIcebreaker] subtitle translation failed:', error);
+        }
+    }
+
     function waitForIcebreakerChatHostMounted(host) {
         return new Promise(function (resolve) {
             var attempts = 0;
@@ -709,8 +732,10 @@
         broadcastIcebreakerAppendMessage(message);
         return appendLlmContext(role, messageText, meta || {}).then(function () {
             if (!shouldRenderIcebreakerOnLocalChatHost()) {
-                // The standalone /chat page applies both append and compact caption sync
-                // from the broadcast receiver in app-interpage.js.
+                // In desktop multi-window mode the standalone /chat page renders the
+                // bubble/caption, but the pet page remains the subtitle translation
+                // owner. Finalize here so the translation panel is populated.
+                finalizeIcebreakerAssistantSubtitleTranslation(role, message);
                 return message;
             }
             var chatHost = null;
@@ -724,6 +749,7 @@
                 if (!result) return result;
                 return waitForIcebreakerChatHostMounted(chatHost).then(function () {
                     syncIcebreakerAssistantCompactCaption(role, message);
+                    finalizeIcebreakerAssistantSubtitleTranslation(role, message);
                     return result;
                 });
             });

--- a/tests/unit/test_app_websocket_static.py
+++ b/tests/unit/test_app_websocket_static.py
@@ -149,6 +149,29 @@ def test_greeting_check_defers_until_new_user_icebreaker_ends():
     assert "function isHomeTutorialLockedForGreeting()" not in source
 
 
+def test_new_user_icebreaker_mirror_turn_end_skips_regular_subtitle_finalize():
+    source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
+
+    assert "function isNewUserIcebreakerMirrorTurnEnd(response)" in source
+    helper_block = source.split("function isNewUserIcebreakerMirrorTurnEnd(response)", 1)[1].split(
+        "// turn-end / turn end agent_callback",
+        1,
+    )[0]
+    assert "meta.source === 'new_user_icebreaker'" in helper_block
+    assert "meta.kind === 'new_user_icebreaker'" in helper_block
+    assert "event.source === 'new_user_icebreaker'" in helper_block
+
+    turn_end_block = source.split("// -------- system turn end --------", 1)[1].split(
+        "// AI turn_end 后只 reschedule",
+        1,
+    )[0]
+    assert "flushRealisticBufferOnTurnEnd();" in turn_end_block
+    assert "emitAssistantLifecycleEvent('neko-assistant-turn-end'" in turn_end_block
+    assert "clearPendingAssistantTurnStart();" in turn_end_block
+    assert "if (!isNewUserIcebreakerMirrorTurnEnd(response)) {" in turn_end_block
+    assert "finalizeAssistantTurn(assistantTurnId);" in turn_end_block
+
+
 def test_goodbye_blocks_stale_audio_session_started():
     source = APP_WEBSOCKET_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -595,7 +595,7 @@ def test_icebreaker_assistant_messages_update_compact_caption_like_normal_chat()
     assert "window.dispatchEvent(new CustomEvent('neko-assistant-turn-end'" not in interpage_compact_block
     interpage_subtitle_block = interpage_runtime.split(
         "function finalizeIcebreakerAssistantSubtitleTranslation(message)", 1
-    )[1].split("function isIcebreakerBridgeAction", 1)[0]
+    )[1].split("function waitForIcebreakerChatHostMounted(host)", 1)[0]
     assert "if (!isStandaloneChatPage() || !message || message.role !== 'assistant') return;" in interpage_subtitle_block
     assert "window.subtitleBridge" in interpage_subtitle_block
     assert "bridge.beginTurn({ latch: false });" in interpage_subtitle_block

--- a/tests/unit/test_new_user_icebreaker_static_contracts.py
+++ b/tests/unit/test_new_user_icebreaker_static_contracts.py
@@ -553,9 +553,10 @@ def test_icebreaker_assistant_messages_update_compact_caption_like_normal_chat()
     interpage_runtime = APP_INTERPAGE_PATH.read_text(encoding="utf-8")
 
     assert "function syncIcebreakerAssistantCompactCaption(role, message)" in runtime
+    assert "function finalizeIcebreakerAssistantSubtitleTranslation(role, message)" in runtime
     assert "function waitForIcebreakerChatHostMounted(host)" in runtime
     sync_block = runtime.split("function syncIcebreakerAssistantCompactCaption(role, message)", 1)[1].split(
-        "function appendChatMessage(role, text, meta)",
+        "function finalizeIcebreakerAssistantSubtitleTranslation(role, message)",
         1,
     )[0]
     assert "if (role !== 'assistant') return;" in sync_block
@@ -568,26 +569,49 @@ def test_icebreaker_assistant_messages_update_compact_caption_like_normal_chat()
     assert "openSubtitleTranslationForIcebreakerAssistantMessage()" not in sync_block
     assert "setSubtitleEnabled(true" not in sync_block
     assert "setTranslateEnabled(true" not in sync_block
-    assert "subtitleBridge" not in sync_block
-    assert "finalizeTurnWithTranslation" not in sync_block
+
+    subtitle_block = runtime.split("function finalizeIcebreakerAssistantSubtitleTranslation(role, message)", 1)[1].split(
+        "function waitForIcebreakerChatHostMounted(host)",
+        1,
+    )[0]
+    assert "if (role !== 'assistant') return;" in subtitle_block
+    assert "window.subtitleBridge" in subtitle_block
+    assert "bridge.beginTurn({ latch: false });" in subtitle_block
+    assert "bridge.finalizeTurnWithTranslation(line)" in subtitle_block
+    assert "console.warn('[NewUserIcebreaker] subtitle translation failed:'" in subtitle_block
+    assert "setSubtitleEnabled(true" not in subtitle_block
+    assert "setTranslateEnabled(true" not in subtitle_block
 
     assert "function syncIcebreakerAssistantCompactCaption(message)" in interpage_runtime
+    assert "function finalizeIcebreakerAssistantSubtitleTranslation(message)" in interpage_runtime
     assert "function waitForIcebreakerChatHostMounted(host)" in interpage_runtime
     interpage_compact_block = interpage_runtime.split(
         "function syncIcebreakerAssistantCompactCaption(message)", 1
-    )[1].split("function isIcebreakerBridgeAction", 1)[0]
+    )[1].split("function finalizeIcebreakerAssistantSubtitleTranslation(message)", 1)[0]
     assert "if (!isStandaloneChatPage() || !message || message.role !== 'assistant') return;" in interpage_compact_block
     assert "window.dispatchEvent(new CustomEvent('neko-assistant-turn-start'" in interpage_compact_block
     assert "window.dispatchEvent(new CustomEvent('neko-compact-caption-update'" in interpage_compact_block
     assert "window.dispatchEvent(new CustomEvent('neko-assistant-speech-unavailable'" not in interpage_compact_block
     assert "window.dispatchEvent(new CustomEvent('neko-assistant-turn-end'" not in interpage_compact_block
+    interpage_subtitle_block = interpage_runtime.split(
+        "function finalizeIcebreakerAssistantSubtitleTranslation(message)", 1
+    )[1].split("function isIcebreakerBridgeAction", 1)[0]
+    assert "if (!isStandaloneChatPage() || !message || message.role !== 'assistant') return;" in interpage_subtitle_block
+    assert "window.subtitleBridge" in interpage_subtitle_block
+    assert "bridge.beginTurn({ latch: false });" in interpage_subtitle_block
+    assert "bridge.finalizeTurnWithTranslation(line)" in interpage_subtitle_block
+    assert "setSubtitleEnabled(true" not in interpage_subtitle_block
+    assert "setTranslateEnabled(true" not in interpage_subtitle_block
     assert "return Promise.resolve(host.appendMessage(action.message)).then(function (result) {" in interpage_runtime
     assert "return waitForIcebreakerChatHostMounted(host).then(function () {" in interpage_runtime
     assert "syncIcebreakerAssistantCompactCaption(action.message);" in interpage_runtime
+    assert "finalizeIcebreakerAssistantSubtitleTranslation(action.message);" in interpage_runtime
     assert interpage_runtime.index("return Promise.resolve(host.appendMessage(action.message)).then(function (result) {") < interpage_runtime.index(
         "return waitForIcebreakerChatHostMounted(host).then(function () {"
     ) < interpage_runtime.index(
         "syncIcebreakerAssistantCompactCaption(action.message);"
+    ) < interpage_runtime.index(
+        "finalizeIcebreakerAssistantSubtitleTranslation(action.message);"
     )
     assert "icebreaker_assistant_subtitle" not in runtime
     assert "icebreaker_assistant_subtitle" not in interpage_runtime
@@ -608,28 +632,36 @@ def test_icebreaker_assistant_message_does_not_auto_open_subtitle_translation_pa
     assert "setSubtitleEnabled(true" not in start_block
     assert "setTranslateEnabled(true" not in start_block
 
-    sync_block = runtime.split("function syncIcebreakerAssistantCompactCaption(role, message)", 1)[1].split(
+    sync_block = runtime.split("function finalizeIcebreakerAssistantSubtitleTranslation(role, message)", 1)[1].split(
         "function appendChatMessage(role, text, meta)",
         1,
     )[0]
     assert "if (role !== 'assistant') return;" in sync_block
     assert "setSubtitleEnabled(true" not in sync_block
     assert "setTranslateEnabled(true" not in sync_block
-    assert "subtitleBridge" not in sync_block
-    assert "finalizeTurnWithTranslation" not in sync_block
+    assert "bridge.finalizeTurnWithTranslation(line)" in sync_block
 
     append_message_block = runtime.split("function appendChatMessage(role, text, meta)", 1)[1].split(
         "function speakViaProjectTts",
         1,
     )[0]
     assert "return appendLlmContext(role, messageText, meta || {}).then(function () {" in append_message_block
+    standalone_branch = append_message_block.split("if (!shouldRenderIcebreakerOnLocalChatHost()) {", 1)[1].split(
+        "var chatHost = null;",
+        1,
+    )[0]
+    assert "finalizeIcebreakerAssistantSubtitleTranslation(role, message);" in standalone_branch
+    assert "syncIcebreakerAssistantCompactCaption(role, message);" not in standalone_branch
     assert "return host.appendMessage(message);" in append_message_block
     assert "return waitForIcebreakerChatHostMounted(chatHost).then(function () {" in append_message_block
     assert "syncIcebreakerAssistantCompactCaption(role, message);" in append_message_block
+    assert "finalizeIcebreakerAssistantSubtitleTranslation(role, message);" in append_message_block
     assert append_message_block.index("return host.appendMessage(message);") < append_message_block.index(
         "return waitForIcebreakerChatHostMounted(chatHost).then(function () {"
     ) < append_message_block.rindex(
         "syncIcebreakerAssistantCompactCaption(role, message);"
+    ) < append_message_block.rindex(
+        "finalizeIcebreakerAssistantSubtitleTranslation(role, message);"
     )
 
 


### PR DESCRIPTION
## 改动概述 / Summary

- 修复 PC 多窗口模式下，破冰 assistant 文案已显示在聊天框/紧凑字幕里，但字幕翻译框仍显示“暂无翻译内容”的问题。
- 破冰文案复用已有 `subtitleBridge.finalizeTurnWithTranslation` 链路，由宠物主页面负责字幕翻译写入，`/chat` 独立窗口继续负责聊天气泡和紧凑字幕。
- 在 websocket 普通 `turn end` 收尾处识别 `new_user_icebreaker` mirror TTS 事件，避免它误走普通聊天字幕收尾并覆盖破冰字幕。
- 补充静态契约测试，固定破冰字幕翻译写入、非自动打开翻译框、以及破冰 TTS turn_end 不触发普通字幕 finalize 的行为。

## 回归报告 / Regression Report

不适用。本 PR 未修改 app/、main_logic/、main_routers/ 或 memory/ 下的 Python 文件。

## 不拆分理由 / Why Not Split

不适用。计入上限的改动文件数不超过 20 个。

## 测试 / Testing

- `node --check static/app-websocket.js`
- `node --check static/tutorial/icebreaker/new-user-icebreaker.js`
- `node --check static/app-interpage.js`
- `uv run pytest tests/unit/test_new_user_icebreaker_static_contracts.py tests/unit/test_app_websocket_static.py -q`
- `git diff --check`